### PR TITLE
Add missing amazon-kclpy package to requirements (updated PR)

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -26,7 +26,7 @@ URL_LOCALSTACK_JAR = ('https://bitbucket.org/atlassian/localstack/raw/mvn/releas
     'com/atlassian/localstack-utils/1.0-SNAPSHOT/localstack-utils-1.0-SNAPSHOT.jar')
 
 # list of additional pip packages to install
-EXTENDED_PIP_LIBS = ['amazon_kclpy==1.4.4']
+EXTENDED_PIP_LIBS = ['amazon-kclpy==1.4.5']
 
 # set up logger
 LOGGER = logging.getLogger(os.path.basename(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 airspeed==0.5.5.dev20160812
+amazon-kclpy==1.4.5
 awscli==1.11.86
 boto==2.46.1
 boto3==1.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
+# Lines annotated with "#extended-lib" are excluded
+# from the dependencies when we build the pip package
+
 airspeed==0.5.5.dev20160812
-amazon-kclpy==1.4.5
+amazon-kclpy==1.4.5 #extended-lib
 awscli==1.11.86
 boto==2.46.1
 boto3==1.4.4

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ import sys
 import re
 from setuptools import find_packages, setup
 
+# marker for extended/ignored libs in requirements.txt
+IGNORED_LIB_MARKER = '#extended-lib'
+
 # parameter variables
 install_requires = []
 dependency_links = []
@@ -26,7 +29,7 @@ for line in re.split('\n', requirements):
     if line and line[0] == '#' and '#egg=' in line:
         line = re.search(r'#\s*(.*)', line).group(1)
     if line and line[0] != '#':
-        if '://' not in line:
+        if '://' not in line and IGNORED_LIB_MARKER not in line:
             install_requires.append(line)
 
 


### PR DESCRIPTION
This PR adds the missing `amazon-kclpy` package to requirements (local tests currently fail without the package). The PR also adds an exclusion marker to the package because we don't want it to be included in the localstack pip package.

Supersedes https://github.com/localstack/localstack/pull/180