### PR TITLE
Add support for Kinesis streams in CloudFormation templates

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -145,6 +145,19 @@ RESOURCE_TO_FUNCTION = {
                 'description': 'Description'
             }
         }
+    },
+    'Kinesis::Stream': {
+        'create': {
+            'boto_client': 'client',
+            'function': 'create_stream',
+            'parameters': {
+                'Name': 'Name',
+                'ShardCount': 'ShardCount'
+            },
+            'defaults': {
+                'ShardCount': 1
+            }
+        }
     }
 }
 
@@ -265,6 +278,9 @@ def retrieve_resource_details(resource_id, resource_status, resources, stack_nam
         if resource_type == 'AWS::Logs::LogGroup':
             # TODO implement
             raise Exception('ResourceNotFound')
+        if resource_type == 'AWS::Kinesis::Stream':
+            stream_name = resolve_refs_recursively(stack_name, resource_props['Name'], resources)
+            return aws_stack.connect_to_service('kinesis', client=True).describe_stream(StreamName=stream_name)
         if is_deployable_resource(resource):
             LOGGER.warning('Unexpected resource type %s when resolving references' % resource_type)
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ flask-cors==3.0.3
 flask_swagger==0.2.12
 jsonpath-rw==1.4.0
 localstack-ext
-moto-ext==1.0.1.4
+moto-ext==1.0.1.5
 nose==1.3.7
 pep8==1.7.0
 psutil==5.2.0

--- a/tests/integration/templates/template1.yaml
+++ b/tests/integration/templates/template1.yaml
@@ -10,3 +10,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: cf-test-queue-1
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      Name: cf-test-stream-1

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -17,7 +17,6 @@ def bucket_exists(name):
     for bucket in buckets['Buckets']:
         if bucket['Name'] == name:
             return True
-    return False
 
 
 def queue_exists(name):
@@ -26,7 +25,12 @@ def queue_exists(name):
     for queue_url in queues['QueueUrls']:
         if queue_url.endswith('/%s' % name):
             return True
-    return False
+
+
+def stream_exists(name):
+    kinesis_client = aws_stack.connect_to_service('kinesis')
+    streams = kinesis_client.list_streams()
+    return name in streams['StreamNames']
 
 
 def get_stack_details(stack_name):
@@ -35,7 +39,6 @@ def get_stack_details(stack_name):
     for stack in stacks['Stacks']:
         if stack['StackName'] == stack_name:
             return stack
-    return None
 
 
 def test_apply_template():
@@ -54,9 +57,10 @@ def test_apply_template():
 
     # assert that bucket has been created
     assert bucket_exists('cf-test-bucket-1')
-
     # assert that queue has been created
     assert queue_exists('cf-test-queue-1')
+    # assert that stream has been created
+    assert stream_exists('cf-test-stream-1')
 
 
 def test_validate_template():


### PR DESCRIPTION
Add support for Kinesis streams in CloudFormation templates. This PR builds on the original commit by @justinm and adds a simple test case. Also, it turned out that we needed to patch and bump the version of `moto` to get this working.