### PR TITLE
Refactor install script and put java libs into a single jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ publish:           ## Publish the library to the central PyPi repository
 	($(VENV_RUN) && ./setup.py sdist upload)
 
 publish-maven:     ## Publish artifacts to Maven Central
-	(cd localstack/ext/java/; mvn clean javadoc:jar source:jar deploy)
+	(cd localstack/ext/java/; mvn -Pfatjar clean javadoc:jar source:jar package deploy)
 
 coveralls:         ## Publish coveralls metrics
 	($(VENV_RUN); coveralls)

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ localstack web
 
 ## Change Log
 
+* v0.7.3: Extract proxy listeners into (sub-)classes; put java libs into a single "fat" jar; fix issue with non-daemonized threads; refactor code to start flask services
 * v0.7.2: Fix DATA_DIR config when running in Docker; fix Maven dependencies; return 'ConsumedCapacity' from DynamoDB get-item; use Queue ARN instead of URL for S3 bucket notifications
 * v0.7.1: Fix S3 API to GET bucket notifications; release Java artifacts to Maven Central; fix S3 file access from Spark; create DDB stream on UpdateTable; remove AUI dependency, optimize size of Docker image
 * v0.7.0: Support for Kinesis in CloudFormation; extend and integrate Java tests in CI; publish Docker image under new name; update READMEs and license agreements

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # LocalStack version
-VERSION = '0.7.2'
+VERSION = '0.7.3'
 
 # default AWS region
 if 'DEFAULT_REGION' not in os.environ:

--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -5,7 +5,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>
@@ -105,6 +105,19 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>fatjar</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-java-sdk</artifactId>
+                    <version>1.11.86</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -115,22 +128,10 @@
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
             </plugin>
-            <!-- <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.0.0</version>
-                <configuration>
-                    <minimizeJar>true</minimizeJar>
-                    <outputFile>${project.artifactId}-${project.version}-shaded</outputFile>
-                    <finalName>${project.artifactId}-${project.version}-shaded</finalName>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <relocations>
-                        <relocation>
-                            <pattern>com.amazonaws</pattern>
-                            <shadedPattern>shaded.com.amazonaws</shadedPattern>
-                        </relocation>
-                    </relocations>
-                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -139,7 +140,28 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> -->
+                <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>fat</shadedClassifierName>
+                    <artifactSet>
+                        <includes>
+                            <include>com.amazonaws:aws-java-sdk-lambda</include>
+                            <include>com.amazonaws:aws-lambda-java-events</include>
+                            <include>com.amazonaws:aws-lambda-java-core</include>
+                            <include>commons-*:*</include>
+                            <include>net.*:*</include>
+                            <include>org.*:*</include>
+                            <include>junit:junit</include>
+                            <include>com.fasterxml.*:*</include>
+                            <include>joda-time:*</include>
+                            <include>com.jayway.*:*</include>
+                            <include>software.*:*</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -170,7 +192,6 @@
                         </goals>
                     </execution>
                 </executions>
-
             </plugin>
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>

--- a/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -28,7 +28,7 @@ public class LambdaExecutor {
 	public static void main(String[] args) throws Exception {
 		if(args.length < 2) {
 			System.err.println("Usage: java " + LambdaExecutor.class.getSimpleName() +
-					"<lambdaClass> <recordsFilePath>");
+					" <lambdaClass> <recordsFilePath>");
 			System.exit(1);
 		}
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -22,7 +22,7 @@ from flask import Flask, Response, jsonify, request, make_response
 from localstack import config
 from localstack.constants import *
 from localstack.services import generic_proxy
-from localstack.services.install import M2_HOME, JAR_DEPENDENCIES, INSTALL_PATH_LOCALSTACK_JAR
+from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR
 from localstack.utils.common import *
 from localstack.utils.aws import aws_stack
 from localstack.utils.analytics import event_publisher
@@ -34,7 +34,7 @@ PATH_ROOT = '/2015-03-31'
 ARCHIVE_FILE_PATTERN = '%s/lambda.handler.*.jar' % config.TMP_FOLDER
 EVENT_FILE_PATTERN = '%s/lambda.event.*.json' % config.TMP_FOLDER
 LAMBDA_SCRIPT_PATTERN = '%s/lambda_script_*.py' % config.TMP_FOLDER
-LAMBDA_EXECUTOR_JAR = INSTALL_PATH_LOCALSTACK_JAR
+LAMBDA_EXECUTOR_JAR = INSTALL_PATH_LOCALSTACK_FAT_JAR
 LAMBDA_EXECUTOR_CLASS = 'cloud.localstack.LambdaExecutor'
 
 LAMBDA_RUNTIME_PYTHON27 = 'python2.7'
@@ -430,9 +430,6 @@ def set_function_code(code, lambda_name):
             TMP_FILES.append(event_file)
             class_name = lambda_arn_to_handler[arn].split('::')[0]
             classpath = '%s:%s' % (LAMBDA_EXECUTOR_JAR, main_file)
-            for jar in JAR_DEPENDENCIES:
-                jar_path = '%s/repository/%s' % (M2_HOME, jar)
-                classpath += ':%s' % (jar_path)
             cmd = 'java -cp %s %s %s %s' % (classpath, LAMBDA_EXECUTOR_CLASS, class_name, event_file)
             result, log_output = run_lambda_executor(cmd)
             LOG.info('Lambda output: %s' % log_output.replace('\n', '\n> '))


### PR DESCRIPTION
Refactor install script, put Java libs into a single jar file. This should make the first-time installation faster and more reliable, and actually removes the dependency to Maven for installing LocalStack.