### PR TITLE
Support unicode names for S3

### DIFF
--- a/bin/localstack
+++ b/bin/localstack
@@ -105,6 +105,7 @@ if __name__ == "__main__":
             t.start()
             time.sleep(2)
             t.process.wait()
+            sys.exit(t.process.returncode)
         else:
             infra.start_infra()
     elif args['web']:

--- a/localstack/ext/java/src/test/java/cloud/localstack/BasicFunctionalityTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/BasicFunctionalityTest.java
@@ -27,8 +27,6 @@ import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 
-import cloud.localstack.LocalstackTestRunner;
-import cloud.localstack.TestUtils;
 import cloud.localstack.sample.S3Sample;
 
 /**
@@ -44,6 +42,10 @@ public class BasicFunctionalityTest {
 		 * https://github.com/mhart/kinesalite/blob/master/README.md#cbor-protocol-issues-with-the-java-sdk
 		 */
 		TestUtils.setEnv("AWS_CBOR_DISABLE", "1");
+		/* Disable SSL certificate checks for local testing */
+		if (LocalstackTestRunner.useSSL()) {
+			TestUtils.disableSslCertChecking();
+		}
 	}
 
 	@Test

--- a/localstack/ext/java/src/test/java/cloud/localstack/SQSMessagingTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/SQSMessagingTest.java
@@ -47,6 +47,11 @@ public class SQSMessagingTest {
         CreateQueueRequest createQueueRequest = new CreateQueueRequest(QUEUE_NAME).withAttributes(attributeMap);
         CreateQueueResult result = client.createQueue(createQueueRequest);
         Assert.assertNotNull(result);
+
+		/* Disable SSL certificate checks for local testing */
+		if (LocalstackTestRunner.useSSL()) {
+			TestUtils.disableSslCertChecking();
+		}
     }
 
     @Test

--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -1,5 +1,9 @@
+import re
 import xmltodict
 from six.moves.urllib import parse as urlparse
+from requests.models import Response
+from localstack import config
+from localstack.utils.common import to_str
 from localstack.utils.analytics import event_publisher
 from localstack.services.generic_proxy import ProxyListener
 
@@ -23,7 +27,16 @@ class ProxyListenerSQS(ProxyListener):
             if event_type:
                 event_publisher.fire_event(event_type, payload={'u': event_publisher.get_hash(queue_url)})
 
-        return True
+            # patch the response and return https://... if we're supposed to use SSL
+            if config.USE_SSL and action in ('CreateQueue', 'GetQueueUrl'):
+                content_str = to_str(response.content)
+                if '<QueueUrl>http://' in content_str:
+                    new_response = Response()
+                    new_response.status_code = response.status_code
+                    new_response.headers = response.headers
+                    new_response._content = re.sub(r'<QueueUrl>\s*http://', '<QueueUrl>https://', content_str)
+                    new_response.headers['content-length'] = len(new_response._content)
+                    return new_response
 
 
 # instantiate listener

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ flask-cors==3.0.3
 flask_swagger==0.2.12
 jsonpath-rw==1.4.0
 localstack-ext
-moto-ext==1.0.1.6
+moto-ext==1.0.1.7
 nose==1.3.7
 pep8==1.7.0
 psutil==5.2.0


### PR DESCRIPTION
* Support unicode names for S3 (see https://github.com/localstack/localstack/issues/142)
* Fix SQS Java tests using SSL