### PR TITLE
If http_proxy is set, the mock server health check fails, so bypass the proxy for internal requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,8 @@ builder.withPathStyleAccessEnabled(true);
 
 * If you are deploying within OpenShift, please be aware: the pod must run as `root`, and the user must have capabilities added to the running pod, in order to allow Elasticsearch to be run as the non-root `localstack` user.
 
-* The environment variables `http_proxy` and `https_proxy` are ignored by *LocalStack*. In other
-words, you can use these variables in your application environemt but they will not have an effect
-on how LocalStack services interact with each other (internal requests will go straight via
-localhost, bypassing any proxy configuration).
+* The environment variable `no_proxy` is rewritten by *LocalStack*.
+(Internal requests will go straight via localhost, bypassing any proxy configuration).
 
 ## Developing
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -69,10 +69,14 @@ for folder in [DATA_DIR, TMP_FOLDER]:
             # multiple processes in parallel. Should be safe to ignore
             pass
 
-# unset variables http(s)_proxy, i.e., run internal service calls directly instead of via a proxy
-for var_name in ('http_proxy', 'https_proxy'):
-    if os.environ.get(var_name):
-        os.environ[var_name] = ''
+# set variables no_proxy, i.e., run internal service calls directly
+no_proxy = ','.join([HOSTNAME, LOCALHOST, '127.0.0.1', '[::1]'])
+if os.environ.get('no_proxy'):
+    os.environ['no_proxy'] += ',' + no_proxy
+elif os.environ.get('NO_PROXY'):
+    os.environ['NO_PROXY'] += ',' + no_proxy
+else:
+    os.environ['no_proxy'] = no_proxy
 
 # additional CLI commands, can be set by plugins
 CLI_COMMANDS = {}


### PR DESCRIPTION
set no_proxy insted of ignore proxy, this is better solution for issue #239.