### PR TITLE
Added custom environment variable support for Lambda run under Docker

### DIFF
--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -103,7 +103,8 @@ def create_zip_file(file_path, include='*', get_content=False):
 
 
 def create_lambda_function(func_name, zip_file, event_source_arn=None, handler=LAMBDA_DEFAULT_HANDLER,
-        starting_position=LAMBDA_DEFAULT_STARTING_POSITION, runtime=LAMBDA_DEFAULT_RUNTIME):
+        starting_position=LAMBDA_DEFAULT_STARTING_POSITION, runtime=LAMBDA_DEFAULT_RUNTIME,
+        envvars={}):
     """Utility method to create a new function via the Lambda API"""
 
     client = aws_stack.connect_to_service('lambda')
@@ -116,7 +117,8 @@ def create_lambda_function(func_name, zip_file, event_source_arn=None, handler=L
         Code={
             'ZipFile': zip_file
         },
-        Timeout=LAMBDA_DEFAULT_TIMEOUT
+        Timeout=LAMBDA_DEFAULT_TIMEOUT,
+        Environment=dict(Variables=envvars)
     )
     # create event source mapping
     if event_source_arn:

--- a/tests/integration/lambdas/lambda_environment.py
+++ b/tests/integration/lambdas/lambda_environment.py
@@ -1,0 +1,7 @@
+import os
+
+
+def handler(event, context):
+    '''
+    '''
+    return {'Hello': os.environ.get('Hello')}

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -14,11 +14,13 @@ TEST_LAMBDA_PYTHON3 = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_python3.py')
 TEST_LAMBDA_NODEJS = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_integration.js')
 TEST_LAMBDA_JAVA = os.path.join(LOCALSTACK_ROOT_FOLDER, 'localstack', 'ext', 'java', 'target',
     'localstack-utils-tests.jar')
+TEST_LAMBDA_ENV = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_environment.py')
 
 TEST_LAMBDA_NAME_PY = 'test_lambda_py'
 TEST_LAMBDA_NAME_PY3 = 'test_lambda_py3'
 TEST_LAMBDA_NAME_JS = 'test_lambda_js'
 TEST_LAMBDA_NAME_JAVA = 'test_lambda_java'
+TEST_LAMBDA_NAME_ENV = 'test_lambda_env'
 
 TEST_LAMBDA_JAR_URL = ('https://repo.maven.apache.org/maven2/cloud/localstack/' +
     'localstack-utils/0.1.1/localstack-utils-0.1.1-tests.jar')
@@ -104,3 +106,18 @@ def test_lambda_runtimes():
         assert result['StatusCode'] == 200
         result_data = result['Payload'].read()
         assert to_str(result_data).strip() == '{}'
+
+
+def test_lambda_environment():
+
+    lambda_client = aws_stack.connect_to_service('lambda')
+
+    # deploy and invoke lambda without Docker
+    zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_ENV), get_content=True,
+        libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
+    response = testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_ENV,
+        zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
+    result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_ENV, Payload=b'{}')
+    assert result['StatusCode'] == 200
+    result_data = result['Payload']
+    assert json.load(result_data) == {"Hello": "World"}


### PR DESCRIPTION
Adds custom environment variables for Lambda invocations when `LAMBDA_EXECUTOR=docker` is used. Part of https://github.com/localstack/localstack/issues/187.

- [x] Include environment vars [when invoked without Docker](https://github.com/migurski/localstack/blob/00d5bc08e47e5c434bfcafdb7b245f808dd503ed/localstack/services/awslambda/lambda_api.py#L289-L303) or when [executed under Python directly](https://github.com/migurski/localstack/blob/00d5bc08e47e5c434bfcafdb7b245f808dd503ed/localstack/services/awslambda/lambda_api.py#L448-L449).
- [x] Add tests.

I’ll expand on this if it’s a workable direction?