### PR TITLE
Use native Python code to unzip archives

### DIFF
--- a/localstack/dashboard/infra.py
+++ b/localstack/dashboard/infra.py
@@ -261,7 +261,8 @@ def get_lambda_code(func_name, retries=1, cache_time=None, env=None):
         if not os.path.isfile(archive):
             download(loc, archive, verify_ssl=False)
         if len(os.listdir(folder)) <= 1:
-            run("cd %s && unzip -o %s" % (folder, filename))
+            zip_path = os.path.join(folder, filename)
+            unzip(zip_path, folder)
     except Exception as e:
         print("WARN: %s" % e)
         rm_rf(archive)

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -401,8 +401,7 @@ def set_function_code(code, lambda_name):
     # check if this is a ZIP file
     is_zip = is_zip_file(zip_file_content)
     if is_zip:
-
-        run('cd %s && unzip %s' % (tmp_dir, LAMBDA_ZIP_FILE_NAME))
+        unzip(tmp_file, tmp_dir)
         main_file = '%s/%s' % (tmp_dir, handler_file)
         if not os.path.isfile(main_file):
             # check if this is a zip file that contains a single JAR file

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -7,7 +7,7 @@ import shutil
 import logging
 from localstack.config import *
 from localstack.constants import DEFAULT_SERVICE_PORTS, ELASTICSEARCH_JAR_URL, DYNAMODB_JAR_URL
-from localstack.utils.common import download, parallelize, run, mkdir, save_file
+from localstack.utils.common import download, parallelize, run, mkdir, save_file, unzip, rm_rf
 
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = os.path.realpath(os.path.join(THIS_PATH, '..'))
@@ -36,10 +36,10 @@ def install_elasticsearch():
     if not os.path.exists(INSTALL_DIR_ES):
         LOGGER.info('Downloading and installing local Elasticsearch server. This may take some time.')
         run('mkdir -p %s' % INSTALL_DIR_INFRA)
-        if not os.path.exists(TMP_ARCHIVE_ES):
-            download(ELASTICSEARCH_JAR_URL, TMP_ARCHIVE_ES)
-        cmd = 'cd %s && cp %s es.zip && unzip -q es.zip && mv elasticsearch* elasticsearch && rm es.zip'
-        run(cmd % (INSTALL_DIR_INFRA, TMP_ARCHIVE_ES))
+        # download and extract archive
+        download_and_extract_with_retry(ELASTICSEARCH_JAR_URL, TMP_ARCHIVE_ES, INSTALL_DIR_INFRA)
+        run('cd %s && mv elasticsearch* elasticsearch' % (INSTALL_DIR_INFRA))
+
         for dir_name in ('data', 'logs', 'modules', 'plugins', 'config/scripts'):
             cmd = 'cd %s && mkdir -p %s && chmod -R 777 %s'
             run(cmd % (INSTALL_DIR_ES, dir_name, dir_name))
@@ -52,22 +52,13 @@ def install_kinesalite():
         run('cd "%s" && npm install' % ROOT_PATH)
 
 
-def is_alpine():
-    try:
-        run('cat /etc/issue | grep Alpine', print_error=False)
-        return True
-    except Exception as e:
-        return False
-
-
 def install_dynamodb_local():
     if not os.path.exists(INSTALL_DIR_DDB):
         LOGGER.info('Downloading and installing local DynamoDB server. This may take some time.')
         mkdir(INSTALL_DIR_DDB)
-        if not os.path.exists(TMP_ARCHIVE_DDB):
-            download(DYNAMODB_JAR_URL, TMP_ARCHIVE_DDB)
-        cmd = 'cd %s && cp %s ddb.zip && unzip -q ddb.zip && rm ddb.zip'
-        run(cmd % (INSTALL_DIR_DDB, TMP_ARCHIVE_DDB))
+        # download and extract archive
+        download_and_extract_with_retry(DYNAMODB_JAR_URL, TMP_ARCHIVE_DDB, INSTALL_DIR_DDB)
+
     # fix for Alpine, otherwise DynamoDBLocal fails with:
     # DynamoDBLocal_lib/libsqlite4java-linux-amd64.so: __memcpy_chk: symbol not found
     if is_alpine():
@@ -128,6 +119,35 @@ def install_components(names):
 
 def install_all_components():
     install_components(DEFAULT_SERVICE_PORTS.keys())
+
+
+# -----------------
+# HELPER FUNCTIONS
+# -----------------
+
+
+def is_alpine():
+    try:
+        run('cat /etc/issue | grep Alpine', print_error=False)
+        return True
+    except Exception as e:
+        return False
+
+
+def download_and_extract_with_retry(archive_url, tmp_archive, target_dir):
+
+    def download_and_extract():
+        if not os.path.exists(tmp_archive):
+            download(archive_url, tmp_archive)
+        unzip(tmp_archive, target_dir)
+
+    try:
+        download_and_extract()
+    except Exception as e:
+        # try deleting and re-downloading the zip file
+        LOGGER.info('Unable to extract file, re-downloading ZIP archive: %s' % tmp_archive)
+        rm_rf(tmp_archive)
+        download_and_extract()
 
 
 if __name__ == '__main__':

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -16,6 +16,7 @@ import decimal
 import logging
 import tempfile
 import requests
+import zipfile
 from io import BytesIO
 from contextlib import closing
 from datetime import datetime
@@ -434,9 +435,18 @@ def is_ip_address(addr):
 
 
 def is_zip_file(content):
-    import zipfile
     stream = BytesIO(content)
     return zipfile.is_zipfile(stream)
+
+
+def unzip(path, target_dir):
+    try:
+        zip_ref = zipfile.ZipFile(path, 'r')
+    except Exception as e:
+        LOGGER.warning('Unable to open zip file: %s: %s' % (path, e))
+        raise e
+    zip_ref.extractall(target_dir)
+    zip_ref.close()
 
 
 def is_jar_archive(content):


### PR DESCRIPTION
Use native Python code to unzip archives (eliminates the dependency to the `unzip` command).