### PR TITLE
Create parent directories for download files

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -345,6 +345,8 @@ def download(url, path, verify_ssl=True):
     r = s.get(url, stream=True, verify=verify_ssl)
     total = 0
     try:
+        if not os.path.exists(os.path.dirname(path)):
+            os.makedirs(os.path.dirname(path))
         LOGGER.debug('Starting download from %s to %s (%s bytes)' % (url, path, r.headers.get('content-length')))
         with open(path, 'wb') as f:
             for chunk in r.iter_content(DOWNLOAD_CHUNK_SIZE):

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,6 @@ package_data = {
         'dashboard/web/img/*',
         'dashboard/web/js/*',
         'dashboard/web/views/*',
-        'infra/*/*.jar',
-        'infra/*.jar',
         'ext/java/*.*',
         'ext/java/src/main/java/com/atlassian/localstack/*.*',
         'utils/kinesis/java/com/atlassian/*.*'

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ package_data = {
         'dashboard/web/img/*',
         'dashboard/web/js/*',
         'dashboard/web/views/*',
+        'infra/*/*.jar',
+        'infra/*.jar',
         'ext/java/*.*',
         'ext/java/src/main/java/com/atlassian/localstack/*.*',
         'utils/kinesis/java/com/atlassian/*.*'


### PR DESCRIPTION
Adds call to `os.makedirs()` in `localstack.utils.common.download()` to ensure that downloaded files are created in new directories.

Closes https://github.com/localstack/localstack/issues/292