### PR TITLE
Mark f'strings' as noqa to silence linters on Python < 3.6

### DIFF
--- a/tests/integration/lambdas/lambda_python3.py
+++ b/tests/integration/lambdas/lambda_python3.py
@@ -3,6 +3,6 @@
 
 
 def handler(event, context):
-    # the following line is Python 3 specific
-    msg = f'Successfully processed {event}'
+    # the following line is Python 3.6+ specific
+    msg = f'Successfully processed {event}'  # noqa This code is Python 3.6+ only
     return event


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
