### PR TITLE
Set right request data in GenericProxyHandler

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -102,6 +102,8 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
         content_length = self.headers.get('Content-Length')
         if content_length:
             self.data_bytes = self.rfile.read(int(content_length))
+        else:
+            self.data_bytes = None
         self.forward('GET')
 
     def do_PUT(self):
@@ -115,10 +117,12 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
         self.forward('POST')
 
     def do_DELETE(self):
+        self.data_bytes = None
         self.method = requests.delete
         self.forward('DELETE')
 
     def do_HEAD(self):
+        self.data_bytes = None
         self.method = requests.head
         self.forward('HEAD')
 
@@ -128,6 +132,7 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
         self.forward('PATCH')
 
     def do_OPTIONS(self):
+        self.data_bytes = None
         self.method = requests.options
         self.forward('OPTIONS')
 


### PR DESCRIPTION
GenericProxyHandler does not always send the correct data when
forwarding requests. self.data_bytes is not properly cleaned up on all
request types.

This commit resets self.data_bytes in the following cases:

- DELETE, HEAD and OPTIONS requests
- GET requests lacking content-length header