### PR TITLE
Check for "boundary" parameter before assuming it exists

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -258,6 +258,10 @@ def expand_multipart_filename(data, headers):
         http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
     '''
     _, params = cgi.parse_header(headers.get('Content-Type'))
+
+    if 'boundary' not in params:
+        return data
+
     boundary = params['boundary'].encode('ascii')
     data_bytes = to_bytes(data)
 


### PR DESCRIPTION
If no "boundary" is found, proceed as before. Closes #310.