### PR TITLE
Ignore bucket notification configuration requests when sending s3 bucket notifications

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -431,8 +431,10 @@ class ProxyListenerS3(ProxyListener):
             # a put bucket request with a path like this: /bucket_name/
             if len(path[1:].split('/')[1]) > 0:
                 parts = parsed.path[1:].split('/', 1)
-                object_path = parts[1] if parts[1][0] == '/' else '/%s' % parts[1]
-                send_notifications(method, bucket_name, object_path)
+                # ignore bucket notification configuration requests
+                if parsed.query != 'notification':
+                    object_path = parts[1] if parts[1][0] == '/' else '/%s' % parts[1]
+                    send_notifications(method, bucket_name, object_path)
         # publish event for creation/deletion of buckets:
         if method in ('PUT', 'DELETE') and ('/' not in path[1:] or len(path[1:].split('/')[1]) <= 0):
             event_type = (event_publisher.EVENT_S3_CREATE_BUCKET if method == 'PUT'


### PR DESCRIPTION
Bucket notifications configuration requests were failing for a while, as they were picked up as file upload/download requests.