### PR TITLE
Adding subject to the SNS request for http requests

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -56,7 +56,9 @@ class ProxyListenerSNS(ProxyListener):
 
             elif req_action == 'Publish':
                 message = req_data['Message'][0]
-                subject = req_data.get('Subject')[0]
+                subject = ""
+                if req_data.get('Subject') is not None:
+               	    subject = req_data.get('Subject')[0]
                 sqs_client = aws_stack.connect_to_service('sqs')
                 for subscriber in SNS_SUBSCRIPTIONS[topic_arn]:
                     if subscriber['Protocol'] == 'sqs':

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -58,7 +58,7 @@ class ProxyListenerSNS(ProxyListener):
                 message = req_data['Message'][0]
                 subject = ""
                 if req_data.get('Subject') is not None:
-               	    subject = req_data.get('Subject')[0]
+                    subject = req_data.get('Subject')[0]
                 sqs_client = aws_stack.connect_to_service('sqs')
                 for subscriber in SNS_SUBSCRIPTIONS[topic_arn]:
                     if subscriber['Protocol'] == 'sqs':

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -81,7 +81,7 @@ class ProxyListenerSNS(ProxyListener):
                             },
                             data=json.dumps({
                                 'Type': 'Notification',
-				'Subject': subject,
+                                'Subject': subject,
                                 'Message': message,
                             })
                         )

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -56,6 +56,7 @@ class ProxyListenerSNS(ProxyListener):
 
             elif req_action == 'Publish':
                 message = req_data['Message'][0]
+                subject = req_data.get('Subject')[0]
                 sqs_client = aws_stack.connect_to_service('sqs')
                 for subscriber in SNS_SUBSCRIPTIONS[topic_arn]:
                     if subscriber['Protocol'] == 'sqs':
@@ -80,6 +81,7 @@ class ProxyListenerSNS(ProxyListener):
                             },
                             data=json.dumps({
                                 'Type': 'Notification',
+				'Subject': subject,
                                 'Message': message,
                             })
                         )


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**

The subject is empty for http endpoints. This is an easy fix that adds the subject to the message.