### PR TITLE
Workaround to allow dots in SQS queue names

### DIFF
--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -19,8 +19,8 @@ from localstack.config import (USE_SSL, PORT_ROUTE53, PORT_S3,
     PORT_DYNAMODBSTREAMS, PORT_SES, PORT_ES, PORT_CLOUDFORMATION, PORT_APIGATEWAY,
     PORT_SSM)
 from localstack.utils import common, persistence
-from localstack.utils.common import (run, TMP_THREADS, in_ci,
-    TIMESTAMP_FORMAT, FuncThread, ShellCommandThread)
+from localstack.utils.common import (run, TMP_THREADS, in_ci, run_cmd_safe,
+    TIMESTAMP_FORMAT, FuncThread, ShellCommandThread, mkdir)
 from localstack.utils.analytics import event_publisher
 from localstack.services import generic_proxy, install
 from localstack.services.firehose import firehose_api
@@ -423,7 +423,9 @@ def start_infra_in_docker():
             config.HOST_TMP_FOLDER, image_name, cmd
     )
 
-    run('mkdir -p "{folder}"; chmod -R 777 "{folder}";'.format(folder=config.TMP_FOLDER))
+    mkdir(config.TMP_FOLDER)
+    run_cmd_safe('chmod -R 777 "%s"' % config.TMP_FOLDER)
+
     print(docker_cmd)
     t = ShellCommandThread(docker_cmd, outfile=subprocess.PIPE)
     t.start()

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -552,6 +552,10 @@ def run_safe(_python_lambda, print_error=True, **kwargs):
             print('Unable to execute function: %s' % e)
 
 
+def run_cmd_safe(**kwargs):
+    return run_safe(run, print_error=False, **kwargs)
+
+
 def run(cmd, cache_duration_secs=0, print_error=True, async=False, stdin=False,
         stderr=subprocess.STDOUT, outfile=None, env_vars=None, inherit_cwd=False):
     # don't use subprocess module as it is not thread-safe

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ boto3==1.4.4
 coverage==4.0.3
 docopt==0.6.2
 elasticsearch==5.3.0
+flake8>=3.4.1
 flask==0.10.1
 flask-cors==3.0.3
 flask_swagger==0.2.12
@@ -16,7 +17,6 @@ jsonpath-rw==1.4.0
 localstack-ext
 moto-ext==1.1.5
 nose==1.3.7
-flake8==3.4.1
 psutil==5.2.0
 pyOpenSSL==17.0.0
 python-coveralls==2.7.0

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -21,6 +21,14 @@ def receive_assert_delete(queue_url, assertions, sqs_client=None):
         sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=message['ReceiptHandle'])
 
 
+def test_sqs_queue_names():
+    sqs_client = aws_stack.connect_to_service('sqs')
+    queue_name = '%s.fifo' % short_uid()
+    # make sure we can create *.fifo queues
+    queue_url = sqs_client.create_queue(QueueName=queue_name)['QueueUrl']
+    sqs_client.delete_queue(QueueUrl=queue_url)
+
+
 def test_sns_to_sqs():
     sqs_client = aws_stack.connect_to_service('sqs')
     sns_client = aws_stack.connect_to_service('sns')


### PR DESCRIPTION
Workaround to allow dots in SQS queue names. This is a temporary workaround to allow creation of fifo queues (currently not supported directly by ElasticMQ) - See #335