### PR TITLE
Use flask's test_client to test lambda API posts

### DIFF
--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -1,6 +1,5 @@
 import unittest
 import json
-import flask
 from localstack.services.awslambda import lambda_api
 from localstack.utils.aws.aws_models import LambdaFunction
 
@@ -24,7 +23,9 @@ class TestLambdaAPI(unittest.TestCase):
     def setUp(self):
         lambda_api.cleanup()
         self.maxDiff = None
-        self.app = flask.Flask(__name__)
+        self.app = lambda_api.app
+        self.app.testing = True
+        self.client = self.app.test_client()
 
     def test_delete_event_source_mapping(self):
         with self.app.test_request_context():
@@ -95,20 +96,17 @@ class TestLambdaAPI(unittest.TestCase):
                              result['message'])
 
     def test_create_alias(self):
-        with self.app.test_request_context():
-            self._create_function(self.FUNCTION_NAME)
-            lambda_api.publish_version(self.FUNCTION_NAME)
+        self._create_function(self.FUNCTION_NAME)
+        self.client.post('{0}/functions/{1}/versions'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
 
-            flask.request.data = json.dumps({
-                'Name': self.ALIAS_NAME,
-                'FunctionVersion': '1',
-                'Description': ''
-            })
-            result = json.loads(lambda_api.create_alias(self.FUNCTION_NAME).get_data())
+        response = self.client.post('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME),
+                         data=json.dumps({'Name': self.ALIAS_NAME, 'FunctionVersion': '1',
+                             'Description': ''}))
+        result = json.loads(response.get_data())
 
-            expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
-                               'FunctionVersion': '1', 'Description': '', 'Name': self.ALIAS_NAME}
-            self.assertDictEqual(expected_result, result)
+        expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
+                           'FunctionVersion': '1', 'Description': '', 'Name': self.ALIAS_NAME}
+        self.assertDictEqual(expected_result, result)
 
     def test_create_alias_on_non_existant_function_returns_error(self):
         with self.app.test_request_context():
@@ -118,43 +116,36 @@ class TestLambdaAPI(unittest.TestCase):
                              result['message'])
 
     def test_create_alias_returns_error_if_already_exists(self):
-        with self.app.test_request_context():
-            self._create_function(self.FUNCTION_NAME)
-            lambda_api.publish_version(self.FUNCTION_NAME)
-            flask.request.data = json.dumps({
-                'Name': self.ALIAS_NAME,
-                'FunctionVersion': '1',
-                'Description': ''
-            })
+        self._create_function(self.FUNCTION_NAME)
+        self.client.post('{0}/functions/{1}/versions'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
+        data = json.dumps({'Name': self.ALIAS_NAME, 'FunctionVersion': '1', 'Description': ''})
+        self.client.post('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME), data=data)
 
-            lambda_api.create_alias(self.FUNCTION_NAME).get_data()
-            result = json.loads(lambda_api.create_alias(self.FUNCTION_NAME).get_data())
-            alias_arn = lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME
-            self.assertEqual(self.ALIASEXISTS_EXCEPTION, result['__type'])
-            self.assertEqual(self.ALIASEXISTS_MESSAGE % alias_arn,
-                             result['message'])
+        response = self.client.post('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME),
+                                    data=data)
+        result = json.loads(response.get_data())
+
+        alias_arn = lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME
+        self.assertEqual(self.ALIASEXISTS_EXCEPTION, result['__type'])
+        self.assertEqual(self.ALIASEXISTS_MESSAGE % alias_arn,
+                         result['message'])
 
     def test_update_alias(self):
-        with self.app.test_request_context():
-            self._create_function(self.FUNCTION_NAME)
-            lambda_api.publish_version(self.FUNCTION_NAME)
-            flask.request.data = json.dumps({
-                'Name': self.ALIAS_NAME,
-                'FunctionVersion': '1',
-                'Description': ''
-            })
-            lambda_api.create_alias(self.FUNCTION_NAME).get_data()
+        self._create_function(self.FUNCTION_NAME)
+        self.client.post('{0}/functions/{1}/versions'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
+        self.client.post('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME),
+                         data=json.dumps({
+                             'Name': self.ALIAS_NAME, 'FunctionVersion': '1', 'Description': ''}))
 
-            flask.request.data = json.dumps({
-                'FunctionVersion': '$LATEST',
-                'Description': 'Test-Description'
-            })
-            result = json.loads(lambda_api.update_alias(self.FUNCTION_NAME, self.ALIAS_NAME).get_data())
+        response = self.client.put('{0}/functions/{1}/aliases/{2}'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME,
+                                                                          self.ALIAS_NAME),
+                                   data=json.dumps({'FunctionVersion': '$LATEST', 'Description': 'Test-Description'}))
+        result = json.loads(response.get_data())
 
-            expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
-                               'FunctionVersion': '$LATEST', 'Description': 'Test-Description',
-                               'Name': self.ALIAS_NAME}
-            self.assertDictEqual(expected_result, result)
+        expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
+                           'FunctionVersion': '$LATEST', 'Description': 'Test-Description',
+                           'Name': self.ALIAS_NAME}
+        self.assertDictEqual(expected_result, result)
 
     def test_update_alias_on_non_existant_function_returns_error(self):
         with self.app.test_request_context():
@@ -172,38 +163,32 @@ class TestLambdaAPI(unittest.TestCase):
             self.assertEqual(self.ALIASNOTFOUND_MESSAGE % alias_arn, result['message'])
 
     def test_list_aliases(self):
-        with self.app.test_request_context():
-            self._create_function(self.FUNCTION_NAME)
-            lambda_api.publish_version(self.FUNCTION_NAME)
-            flask.request.data = json.dumps({
-                'Name': self.ALIAS2_NAME,
-                'FunctionVersion': '$LATEST'
-            })
-            lambda_api.create_alias(self.FUNCTION_NAME).get_data()
-            flask.request.data = json.dumps({
-                'Name': self.ALIAS_NAME,
+        self._create_function(self.FUNCTION_NAME)
+        self.client.post('{0}/functions/{1}/versions'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
+
+        self.client.post('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME),
+                         data=json.dumps({'Name': self.ALIAS2_NAME, 'FunctionVersion': '$LATEST'}))
+        self.client.post('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME),
+                         data=json.dumps({'Name': self.ALIAS_NAME, 'FunctionVersion': '1',
+                                          'Description': self.ALIAS_NAME}))
+
+        response = self.client.get('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
+        result = json.loads(response.get_data())
+        expected_result = {'Aliases': [
+            {
+                'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
                 'FunctionVersion': '1',
+                'Name': self.ALIAS_NAME,
                 'Description': self.ALIAS_NAME
-            })
-            lambda_api.create_alias(self.FUNCTION_NAME).get_data()
-
-            result = json.loads(lambda_api.list_aliases(self.FUNCTION_NAME).get_data())
-
-            expected_result = {'Aliases': [
-                {
-                    'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
-                    'FunctionVersion': '1',
-                    'Name': self.ALIAS_NAME,
-                    'Description': self.ALIAS_NAME
-                },
-                {
-                    'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS2_NAME,
-                    'FunctionVersion': '$LATEST',
-                    'Name': self.ALIAS2_NAME,
-                    'Description': ''
-                }
-            ]}
-            self.assertDictEqual(expected_result, result)
+            },
+            {
+                'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS2_NAME,
+                'FunctionVersion': '$LATEST',
+                'Name': self.ALIAS2_NAME,
+                'Description': ''
+            }
+        ]}
+        self.assertDictEqual(expected_result, result)
 
     def test_list_non_existant_function_aliases_returns_error(self):
         with self.app.test_request_context():


### PR DESCRIPTION
What do you think about this way of testing @whummer. Uses the test_client instead of calling directly methods when there is request data.
