### PR TITLE
Fixed usage of deploy_template for deploying cloudformation stack

### DIFF
--- a/localstack/services/cloudformation/cloudformation_listener.py
+++ b/localstack/services/cloudformation/cloudformation_listener.py
@@ -98,7 +98,7 @@ def execute_change_set(req_data):
             TemplateBody=template)
 
     # now run the actual deployment
-    template_deployer.deploy_template(template)
+    template_deployer.deploy_template(template, stack_name)
 
     response = make_response('ExecuteChangeSet')
     return response


### PR DESCRIPTION
Fixes error when deploying cloudformation stack:
TypeError: deploy_template() takes exactly 2 arguments (1 given)