### PR TITLE
Execute lambdas asynchronously if the source is a topic -Issue #373

### DIFF
--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -99,7 +99,6 @@ def cloudwatched(ns):
     def wrapping(func):
         def wrapped(*args, **kwargs):
             time_before = now_utc()
-            result = None
             try:
                 result = func(*args, **kwargs)
                 publish_result(ns, time_before, result, kwargs)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -104,7 +104,7 @@ def test_lambda_runtimes():
                                   Payload=b'{"Records": [{"Sns": {"Message": "{}"}}]}')
     assert result['StatusCode'] == 200
     result_data = result['Payload'].read()
-    assert 'SNSEvent' in to_str(result_data)
+    assert to_str(result_data).strip() == '{"async": "True"}'
 
     # test KinesisEvent
     result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA,

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -100,7 +100,7 @@ def test_lambda_runtimes():
     assert 'LinkedHashMap' in to_str(result_data)
 
     # test SNSEvent
-    result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA,
+    result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA, InvocationType='Event',
                                   Payload=b'{"Records": [{"Sns": {"Message": "{}"}}]}')
     assert result['StatusCode'] == 200
     result_data = result['Payload'].read()


### PR DESCRIPTION
https://github.com/localstack/localstack/issues/373

I did not add `invoke-async` support as it's depreciated and `invoke` with `InvocationType` = `Event` should be used. See http://docs.aws.amazon.com/lambda/latest/dg/API_InvokeAsync.html