### PR TITLE
Import default service ports from localstack-client

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -1,4 +1,5 @@
 import os
+import localstack_client.config
 
 # LocalStack version
 VERSION = '0.8.1'
@@ -14,24 +15,6 @@ REGION_LOCAL = 'local'
 # dev environment
 ENV_DEV = 'dev'
 
-# infra service ports (counting up from 4567)
-DEFAULT_PORT_APIGATEWAY = 4567
-DEFAULT_PORT_KINESIS = 4568
-DEFAULT_PORT_DYNAMODB = 4569
-DEFAULT_PORT_DYNAMODBSTREAMS = 4570
-DEFAULT_PORT_ELASTICSEARCH = 4571
-DEFAULT_PORT_S3 = 4572
-DEFAULT_PORT_FIREHOSE = 4573
-DEFAULT_PORT_LAMBDA = 4574
-DEFAULT_PORT_SNS = 4575
-DEFAULT_PORT_SQS = 4576
-DEFAULT_PORT_REDSHIFT = 4577
-DEFAULT_PORT_ES = 4578
-DEFAULT_PORT_SES = 4579
-DEFAULT_PORT_ROUTE53 = 4580
-DEFAULT_PORT_CLOUDFORMATION = 4581
-DEFAULT_PORT_CLOUDWATCH = 4582
-DEFAULT_PORT_SSM = 4583
 # backend service ports, for services that are behind a proxy (counting down from 4566)
 DEFAULT_PORT_APIGATEWAY_BACKEND = 4566
 DEFAULT_PORT_KINESIS_BACKEND = 4565
@@ -46,26 +29,8 @@ DEFAULT_PORT_WEB_UI = 8080
 
 LOCALHOST = 'localhost'
 
-# map of default service APIs and ports to be spun up
-DEFAULT_SERVICE_PORTS = {
-    'es': DEFAULT_PORT_ES,
-    'elasticsearch': DEFAULT_PORT_ELASTICSEARCH,
-    's3': DEFAULT_PORT_S3,
-    'sns': DEFAULT_PORT_SNS,
-    'sqs': DEFAULT_PORT_SQS,
-    'apigateway': DEFAULT_PORT_APIGATEWAY,
-    'dynamodb': DEFAULT_PORT_DYNAMODB,
-    'dynamodbstreams': DEFAULT_PORT_DYNAMODBSTREAMS,
-    'firehose': DEFAULT_PORT_FIREHOSE,
-    'lambda': DEFAULT_PORT_LAMBDA,
-    'kinesis': DEFAULT_PORT_KINESIS,
-    'redshift': DEFAULT_PORT_REDSHIFT,
-    'route53': DEFAULT_PORT_ROUTE53,
-    'ses': DEFAULT_PORT_SES,
-    'cloudformation': DEFAULT_PORT_CLOUDFORMATION,
-    'cloudwatch': DEFAULT_PORT_CLOUDWATCH,
-    'ssm': DEFAULT_PORT_SSM
-}
+# map of default service APIs and ports to be spun up (fetch map from localstack_client)
+DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
 
 # host to bind to when starting the services
 BIND_HOST = '0.0.0.0'

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -460,9 +460,10 @@ class ProxyListenerS3(ProxyListener):
             # we need to un-pretty-print the XML, otherwise we run into this issue with Spark:
             # https://github.com/jserver/mock-s3/pull/9/files
             # https://github.com/localstack/localstack/issues/183
+            # Note: yet, we need to make sure we have a newline after the first line: <?xml ...>\n
             if response_content_str and response_content_str.startswith('<'):
                 is_bytes = isinstance(response._content, six.binary_type)
-                response._content = re.sub(r'>\n\s*<', '><', response_content_str, flags=re.MULTILINE)
+                response._content = re.sub(r'([^\?])>\n\s*<', r'\1><', response_content_str, flags=re.MULTILINE)
                 if is_bytes:
                     response._content = to_bytes(response._content)
                 response.headers['content-length'] = len(response._content)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -410,16 +410,14 @@ def load_file(file_path, default=None, mode=None):
 
 
 def to_str(obj, encoding=DEFAULT_ENCODING, errors='strict'):
-    """If ``obj`` is an instance of ``binary_type``, return
-    ``obj.decode(encoding, errors)``, otherwise return ``obj``
-    """
+    """ If ``obj`` is an instance of ``binary_type``, return
+    ``obj.decode(encoding, errors)``, otherwise return ``obj`` """
     return obj.decode(encoding, errors) if isinstance(obj, six.binary_type) else obj
 
 
 def to_bytes(obj, encoding=DEFAULT_ENCODING, errors='strict'):
     """ If ``obj`` is an instance of ``text_type``, return
-    ``obj.encode(encoding, errors)``, otherwise return ``obj``
-    """
+    ``obj.encode(encoding, errors)``, otherwise return ``obj`` """
     return obj.encode(encoding, errors) if isinstance(obj, six.text_type) else obj
 
 
@@ -431,6 +429,13 @@ def cleanup(files=True, env=ENV_DEV, quiet=True):
 def cleanup_threads_and_processes(quiet=True):
     for t in TMP_THREADS:
         t.stop(quiet=quiet)
+    # clear list
+    clear_list(TMP_THREADS)
+
+
+def clear_list(l):
+    while len(l):
+        del l[0]
 
 
 def cleanup_tmp_files():

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -9,8 +9,8 @@ import logging
 from six.moves import queue as Queue
 from six.moves.urllib.parse import urlparse
 from amazon_kclpy import kcl
-from localstack.constants import (LOCALSTACK_VENV_FOLDER, LOCALSTACK_ROOT_FOLDER,
-    REGION_LOCAL, DEFAULT_REGION, DEFAULT_PORT_KINESIS, DEFAULT_PORT_DYNAMODB)
+from localstack.constants import (LOCALSTACK_VENV_FOLDER, LOCALSTACK_ROOT_FOLDER, REGION_LOCAL, DEFAULT_REGION)
+from localstack import config
 from localstack.config import HOSTNAME, USE_SSL
 from localstack.utils.common import run, TMP_THREADS, TMP_FILES, save_file, now, retry, short_uid
 from localstack.utils.kinesis import kclipy_helper
@@ -259,7 +259,7 @@ def get_stream_info(stream_name, log_file=None, shards=None, env=None, endpoint_
     if env.region == REGION_LOCAL:
         stream_info['conn_kwargs'] = {
             'host': HOSTNAME,
-            'port': DEFAULT_PORT_KINESIS,
+            'port': config.PORT_KINESIS,
             'is_secure': bool(USE_SSL)
         }
     if endpoint_url:
@@ -313,8 +313,8 @@ def start_kcl_client_process(stream_name, listener_script, log_file=None, env=No
     }
     # set parameters for local connection
     if env.region == REGION_LOCAL:
-        kwargs['kinesisEndpoint'] = '%s:%s' % (HOSTNAME, DEFAULT_PORT_KINESIS)
-        kwargs['dynamodbEndpoint'] = '%s:%s' % (HOSTNAME, DEFAULT_PORT_DYNAMODB)
+        kwargs['kinesisEndpoint'] = '%s:%s' % (HOSTNAME, config.PORT_KINESIS)
+        kwargs['dynamodbEndpoint'] = '%s:%s' % (HOSTNAME, config.PORT_DYNAMODB)
         kwargs['kinesisProtocol'] = 'http%s' % ('s' if USE_SSL else '')
         kwargs['dynamodbProtocol'] = 'http%s' % ('s' if USE_SSL else '')
         kwargs['disableCertChecking'] = 'true'

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ flask-cors==3.0.3
 flask_swagger==0.2.12
 jsonpath-rw==1.4.0
 localstack-ext
+localstack-client==0.4
 moto-ext==1.1.21
 nose==1.3.7
 psutil==5.2.0

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -27,7 +27,7 @@ TEST_LAMBDA_NAME_ENV = 'test_lambda_env'
 TEST_LAMBDA_JAR_URL = ('https://repo.maven.apache.org/maven2/cloud/localstack/' +
     'localstack-utils/0.1.6/localstack-utils-0.1.6-tests.jar')
 
-TEST_LAMBDA_LIBS = ['localstack', 'requests', 'psutil', 'urllib3', 'chardet', 'certifi', 'idna']
+TEST_LAMBDA_LIBS = ['localstack', 'localstack_client', 'requests', 'psutil', 'urllib3', 'chardet', 'certifi', 'idna']
 
 
 def test_upload_lambda_from_s3():


### PR DESCRIPTION
* Import default service ports from [localstack-client](https://github.com/localstack/localstack-python-client). This way we can avoid duplication and maintain the default service ports in a single place. 
* This PR also contains a minor fix to return a missing newline in the responses returned by the S3 service.