### PR TITLE
Fix config code to get service endpoints in Java

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -29,6 +29,9 @@ DEFAULT_PORT_WEB_UI = 8080
 
 LOCALHOST = 'localhost'
 
+# version of the Maven dependency with Java utility code
+LOCALSTACK_MAVEN_VERSION = '0.1.7'
+
 # map of default service APIs and ports to be spun up (fetch map from localstack_client)
 DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
 

--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -5,7 +5,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -6,7 +6,8 @@ import glob
 import shutil
 import logging
 import tempfile
-from localstack.constants import DEFAULT_SERVICE_PORTS, ELASTICSEARCH_JAR_URL, DYNAMODB_JAR_URL
+from localstack.constants import (DEFAULT_SERVICE_PORTS,
+    ELASTICSEARCH_JAR_URL, DYNAMODB_JAR_URL, LOCALSTACK_MAVEN_VERSION)
 from localstack.utils.common import download, parallelize, run, mkdir, save_file, unzip, rm_rf
 
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -26,7 +27,7 @@ TMP_ARCHIVE_ELASTICMQ = os.path.join(tempfile.gettempdir(), 'elasticmq-server.ja
 URL_STS_JAR = 'http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 URL_ELASTICMQ_JAR = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.8.jar'
 URL_LOCALSTACK_FAT_JAR = ('http://central.maven.org/maven2/' +
-    'cloud/localstack/localstack-utils/0.1.6/localstack-utils-0.1.6-fat.jar')
+    'cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar').format(v=LOCALSTACK_MAVEN_VERSION)
 
 # set up logger
 LOGGER = logging.getLogger(__name__)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -1,7 +1,7 @@
 import os
 import json
 from io import BytesIO
-from localstack.constants import LOCALSTACK_ROOT_FOLDER
+from localstack.constants import LOCALSTACK_ROOT_FOLDER, LOCALSTACK_MAVEN_VERSION
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid, load_file, to_str, mkdir, download
@@ -25,7 +25,7 @@ TEST_LAMBDA_NAME_JAVA_STREAM = 'test_lambda_java_stream'
 TEST_LAMBDA_NAME_ENV = 'test_lambda_env'
 
 TEST_LAMBDA_JAR_URL = ('https://repo.maven.apache.org/maven2/cloud/localstack/' +
-    'localstack-utils/0.1.6/localstack-utils-0.1.6-tests.jar')
+    'localstack-utils/{version}/localstack-utils-{version}-tests.jar').format(version=LOCALSTACK_MAVEN_VERSION)
 
 TEST_LAMBDA_LIBS = ['localstack', 'localstack_client', 'requests', 'psutil', 'urllib3', 'chardet', 'certifi', 'idna']
 


### PR DESCRIPTION
Fix config code to get service endpoints in Java.

Background: Our most recent build on master has failed because we removed the `DEFAULT_*` port configurations from `constants.py`, but the Java code was still relying on these variables to be available. (btw, we expect this PR build to fail initially, until the new Maven library has propagated to Maven Central)