### PR TITLE
Set default AWS settings via config file rather than environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,14 @@ RUN mkdir -p /.npm && \
 ENV MAVEN_CONFIG=/opt/code/localstack \
     USER=localstack
 
+# set test AWS credentials and default region in config file
+RUN mkdir -p /root/.aws && \
+    echo '[default]' > /root/.aws/config && \
+    echo 'region = us-east-1' >> /root/.aws/config && \
+    echo '[default]' > /root/.aws/credentials && \
+    echo 'aws_access_key_id = foobar' >> /root/.aws/credentials && \
+    echo 'aws_secret_access_key = foobar' >> /root/.aws/credentials
+
 # expose service & web dashboard ports
 EXPOSE 4567-4583 8080
 
@@ -60,7 +68,4 @@ ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]
 
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
-RUN AWS_ACCESS_KEY_ID=foobar \
-    AWS_SECRET_ACCESS_KEY=foobar \
-    AWS_DEFAULT_REGION=us-east-1 \
-    make test
+RUN make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,7 @@ RUN mkdir -p /.npm && \
     ln -s `pwd` /tmp/localstack_install_dir
 
 # expose default environment (required for aws-cli to work)
-ENV AWS_ACCESS_KEY_ID=foobar \
-    AWS_SECRET_ACCESS_KEY=foobar \
-    AWS_DEFAULT_REGION=us-east-1 \
-    MAVEN_CONFIG=/opt/code/localstack \
+ENV MAVEN_CONFIG=/opt/code/localstack \
     USER=localstack
 
 # expose service & web dashboard ports
@@ -63,4 +60,7 @@ ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]
 
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
-RUN make test
+RUN AWS_ACCESS_KEY_ID=foobar \
+    AWS_SECRET_ACCESS_KEY=foobar \
+    AWS_DEFAULT_REGION=us-east-1 \
+    make test

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -146,7 +146,7 @@ def connect_to_service(service_name, client=True, env=None, region_name=None, en
         if env.region == REGION_LOCAL:
             endpoint_url = get_local_service_url(service_name)
             verify = False
-    region = env.region if env.region != REGION_LOCAL else DEFAULT_REGION
+    region = env.region if env.region != REGION_LOCAL else None
     return method(service_name, region_name=region, endpoint_url=endpoint_url, verify=verify)
 
 


### PR DESCRIPTION
This PR supersedes #277 . Set default AWS settings via config file rather than environment variables.