### PR TITLE
DynamoDBStreams Now Returns Valid ShardIDs.

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -126,7 +126,7 @@ def stream_name_from_stream_arn(stream_arn):
     return get_kinesis_stream_name(table_name)
 
 
-def random_id(stream_arn, kinesis_shard_id, n=16):
+def random_id(stream_arn, kinesis_shard_id):
     namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn.encode('utf-8')).digest()[:16])
     return uuid.uuid5(namespace, kinesis_shard_id.encode('utf-8')).hex
 

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -1,4 +1,6 @@
 import json
+import uuid
+import hashlib
 from flask import Flask, jsonify, request, make_response
 from localstack.services import generic_proxy
 from localstack.utils.aws import aws_stack
@@ -67,15 +69,22 @@ def post_request():
                 stream_details = kinesis.describe_stream(StreamName=stream_name)
                 table_details = dynamodb.describe_table(TableName=table_name)
                 stream['KeySchema'] = table_details['Table']['KeySchema']
-                stream['Shards'] = stream_details['StreamDescription']['Shards']
+
+                # Replace Kinesis ShardIDs with ones that mimic actual
+                # DynamoDBStream ShardIDs.
+                stream_shards = stream_details['StreamDescription']['Shards']
+                for shard in stream_shards:
+                    shard['ShardId'] = shard_id(stream_name, shard['ShardId'])
+                stream['Shards'] = stream_shards
                 break
         if not result:
             return error_response('Requested resource not found', error_type='ResourceNotFoundException')
     elif action == '%s.GetShardIterator' % ACTION_HEADER_PREFIX:
         # forward request to Kinesis API
         stream_name = stream_name_from_stream_arn(data['StreamArn'])
+        stream_shard_id = kinesis_shard_id(data['ShardId'])
         result = kinesis.get_shard_iterator(StreamName=stream_name,
-            ShardId=data['ShardId'], ShardIteratorType=data['ShardIteratorType'])
+            ShardId=stream_shard_id, ShardIteratorType=data['ShardIteratorType'])
     elif action == '%s.GetRecords' % ACTION_HEADER_PREFIX:
         kinesis_records = kinesis.get_records(**data)
         result = {'Records': []}
@@ -115,6 +124,19 @@ def table_name_from_stream_arn(stream_arn):
 def stream_name_from_stream_arn(stream_arn):
     table_name = table_name_from_stream_arn(stream_arn)
     return get_kinesis_stream_name(table_name)
+
+
+def random_id(stream_arn, kinesis_shard_id, n=16):
+    namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn.encode('utf-8')).digest()[:16])
+    return uuid.uuid5(namespace, kinesis_shard_id.encode('utf-8')).hex
+
+
+def shard_id(stream_arn, kinesis_shard_id):
+    return '-'.join([kinesis_shard_id, random_id(stream_arn, kinesis_shard_id)])
+
+
+def kinesis_shard_id(dynamodbstream_shard_id):
+    return dynamodbstream_shard_id.rsplit('-', 1)[0]
 
 
 def serve(port, quiet=True):


### PR DESCRIPTION
ShardIDs returned from the DynamoDBStreams emulator now mimic ShardIDs
in the production service.  Namely, they comply with the length requirements
in botocore.  Each returned ShardID is > 28 characters in length.

As ShardIDs from Kinesis are appended with `-$UUID5`.  The UUID5 value
generated is relative to the Kinesis stream name as well as the Kinesis
ShardID, ensuring that the value is consistent across multiple calls to
`describe_stream`.  Before ShardID values are passed through to
Kinesis, they are unwrapped to the original Kinesis value.

**Please refer to the contribution guidelines in the README when submitting PRs.**
