### PR TITLE
adds test cases for >128k and <128k Java S3 uploads

### DIFF
--- a/localstack/ext/java/src/test/java/cloud/localstack/S3UploadTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/S3UploadTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.apache.commons.codec.binary.Base64;
@@ -24,19 +25,39 @@ import com.amazonaws.services.s3.model.S3Object;
 @RunWith(LocalstackTestRunner.class)
 public class S3UploadTest {
 
+	/**
+	 * Test based on https://github.com/localstack/localstack/issues/359
+	 */
 	@Test
-	public void testUpload() throws Exception {
-		/*
-		 * Test based on https://github.com/localstack/localstack/issues/359
-		 */
+	public void testTrival() throws Exception  {
+		testUpload("{}"); // Some JSON content, just an example
+	}
 
+	/**
+	 * Tests greater than 128k uploads
+	 * @throws Exception
+	 */
+	@Test
+	public void testGreaterThan128k() throws Exception  {
+		testUpload(String.join("", Collections.nCopies(13108, "abcdefghij"))); // Just slightly more than 2^17 bytes
+	}
+
+	/**
+	 * Tests less than 128k uploads
+	 * @throws Exception
+	 */
+	@Test
+	public void testLessThan128k() throws Exception  {
+		testUpload(String.join("", Collections.nCopies(13107, "abcdefghij"))); // Just slightly less than 2^17 bytes
+	}
+
+	private void testUpload(final String dataString) throws Exception {
 		AmazonS3 client = TestUtils.getClientS3();
 
 		String bucketName = UUID.randomUUID().toString();
 		String keyName = UUID.randomUUID().toString();
 		client.createBucket(bucketName);
 
-		String dataString = "{}"; // Some JSON content, just an example
 		byte[] dataBytes = dataString.getBytes(StandardCharsets.UTF_8);
 
 		ObjectMetadata metaData = new ObjectMetadata();


### PR DESCRIPTION
See comment for details: https://github.com/localstack/localstack/issues/359#issuecomment-337758803

It seems there is an issue that uploads over >128k do not work with the same error as being reported here. I get a message such as:
```
Unable to verify integrity of data upload.  Client calculated content hash (contentMD5: 8eET31STItFmGOd/IrNlCA== in base 64) didn't match hash (etag: 7eebd4a71c4c983bd38c1a227c22b236 in hex) calculated by Amazon S3.  You may need to delete the data stored in Amazon S3. (metadata.contentMD5: 8eET31STItFmGOd/IrNlCA==, md5DigestStream: null, bucketName: 4d52e9a7-8666-4149-9ff8-70d22e035782, key: 187c0368-1f2b-4062-883a-cf40ccfff568)

```
Additionally if I suppress the exception and continue anyway the assert on the lengths of the returned object differs... so it would appear uploads over 128k are indeed getting corrupted:
``` 
java.lang.AssertionError: array lengths differed, expected.length=156482 actual.length=156478
	at org.junit.Assert.fail(Assert.java:88)
       ...
```

This does seem to be a Java SDK specific issue. Or at least I have no problem uploading >128k objects using the AWS CLI.
