### PR TITLE
Implementation of docker container reuse and expiration

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -28,7 +28,7 @@ from localstack import config
 from localstack.services import generic_proxy
 from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR
 from localstack.utils.common import (to_str, load_file, save_file, TMP_FILES,
-    unzip, is_zip_file, run, short_uid, cp_r, is_jar_archive, timestamp, TIMESTAMP_FORMAT_MILLIS)
+    unzip, is_zip_file, run, short_uid, is_jar_archive, timestamp, TIMESTAMP_FORMAT_MILLIS)
 from localstack.utils.aws import aws_stack, aws_responses
 from localstack.utils.analytics import event_publisher
 from localstack.utils.cloudwatch.cloudwatch_util import cloudwatched
@@ -77,6 +77,7 @@ docker_container_lock = threading.RLock()
 
 # keeps track of each function arn and the last time it was invoked
 function_invoke_times = {}
+
 
 # holds information about an existing container.
 class ContainerInfo:

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -150,11 +150,12 @@ def test_lambda_environment():
 
 def test_prime_and_destroy_containers():
     lambda_api.DO_USE_DOCKER = True
+    func_name = 'test_prime_and_destroy_containers'
 
     # create a new lambda
     lambda_client = aws_stack.connect_to_service('lambda')
 
-    func_arn = lambda_api.func_arn(TEST_LAMBDA_NAME_ENV)
+    func_arn = lambda_api.func_arn(func_name)
 
     # make sure existing containers are gone
     lambda_api.destroy_existing_docker_containers()
@@ -163,7 +164,7 @@ def test_prime_and_destroy_containers():
     # deploy and invoke lambda without Docker
     zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_ENV), get_content=True,
                                               libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
-    testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_ENV,
+    testutil.create_lambda_function(func_name=func_name,
                                     zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
 
     assert len(lambda_api.get_all_container_names()) == 0
@@ -179,7 +180,7 @@ def test_prime_and_destroy_containers():
             prev_invoke_time = lambda_api.function_invoke_times[func_arn]
 
         start_time = time.time()
-        lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_ENV, Payload=b'{}')
+        lambda_client.invoke(FunctionName=func_name, Payload=b'{}')
         duration = time.time() - start_time
 
         assert len(lambda_api.get_all_container_names()) == 1
@@ -210,11 +211,12 @@ def test_prime_and_destroy_containers():
 
 def test_destroy_idle_containers():
     lambda_api.DO_USE_DOCKER = True
+    func_name = 'test_destroy_idle_containers'
 
     # create a new lambda
     lambda_client = aws_stack.connect_to_service('lambda')
 
-    func_arn = lambda_api.func_arn(TEST_LAMBDA_NAME_ENV)
+    func_arn = lambda_api.func_arn(func_name)
 
     # make sure existing containers are gone
     lambda_api.destroy_existing_docker_containers()
@@ -223,12 +225,12 @@ def test_destroy_idle_containers():
     # deploy and invoke lambda without Docker
     zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_ENV), get_content=True,
                                               libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
-    testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_ENV,
+    testutil.create_lambda_function(func_name=func_name,
                                     zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
 
     assert len(lambda_api.get_all_container_names()) == 0
 
-    lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_ENV, Payload=b'{}')
+    lambda_client.invoke(FunctionName=func_name, Payload=b'{}')
     assert len(lambda_api.get_all_container_names()) == 1
 
     # try to destroy idle containers.

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -112,7 +112,7 @@ def test_lambda_runtimes():
                                   Payload=b'{"Records": [{"Kinesis": {"Data": "data", "PartitionKey": "partition"}}]}')
     assert result['StatusCode'] == 200
     result_data = result['Payload'].read()
-    # assert 'KinesisEvent' in to_str(result_data)
+    assert 'KinesisEvent' in to_str(result_data)
 
     # deploy and invoke lambda - Java with stream handler
     testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_JAVA_STREAM, zip_file=zip_file,

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -148,25 +148,94 @@ def test_lambda_environment():
     assert json.load(result_data) == {'Hello': 'World'}
 
 
-def test_lamba_multiple_invokes():
+def test_prime_and_destroy_containers():
+    lambda_api.DO_USE_DOCKER = True
+
+    # create a new lambda
     lambda_client = aws_stack.connect_to_service('lambda')
+
+    func_arn = lambda_api.func_arn(TEST_LAMBDA_NAME_ENV)
+
+    # make sure existing containers are gone
+    lambda_api.destroy_existing_docker_containers()
+    assert len(lambda_api.get_all_container_names()) == 0
 
     # deploy and invoke lambda without Docker
     zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_ENV), get_content=True,
                                               libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
-
-    start_time = time.time()
     testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_ENV,
                                     zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
-    duration = time.time() - start_time
-    print('Function created in %f seconds.' % duration)
 
-    # Reusing the container.
-    for i in range(0, 3):
+    assert len(lambda_api.get_all_container_names()) == 0
+
+    assert lambda_api.function_invoke_times == {}
+
+    # invoke a few times.
+    durations = []
+
+    for i in range(0, 4):
+        prev_invoke_time = None
+        if i > 0:
+            prev_invoke_time = lambda_api.function_invoke_times[func_arn]
+
         start_time = time.time()
-        result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_ENV, Payload=b'{}')
+        lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_ENV, Payload=b'{}')
         duration = time.time() - start_time
-        print('Function ran in %f seconds.' % duration)
-        assert result['StatusCode'] == 200
-        result_data = result['Payload']
-        assert json.load(result_data) == {'Hello': 'World'}
+
+        assert len(lambda_api.get_all_container_names()) == 1
+
+        # ensure the last invoke time is being updated properly.
+        if i > 0:
+            assert lambda_api.function_invoke_times[func_arn] > prev_invoke_time
+        else:
+            assert lambda_api.function_invoke_times[func_arn] > 0
+
+        print('Invoke Duration%d: %f' % (i, duration))
+        durations.append(duration)
+
+    # the first call would have created the container. subsequent calls would reuse and be faster.
+    assert durations[1] < durations[0]
+    assert durations[2] < durations[0]
+    assert durations[3] < durations[0]
+
+    status = lambda_api.get_docker_container_status(func_arn)
+    assert status == 1
+
+    lambda_api.destroy_existing_docker_containers()
+    status = lambda_api.get_docker_container_status(func_arn)
+    assert status == 0
+
+    assert len(lambda_api.get_all_container_names()) == 0
+
+
+def test_destroy_idle_containers():
+    lambda_api.DO_USE_DOCKER = True
+
+    # create a new lambda
+    lambda_client = aws_stack.connect_to_service('lambda')
+
+    func_arn = lambda_api.func_arn(TEST_LAMBDA_NAME_ENV)
+
+    # make sure existing containers are gone
+    lambda_api.destroy_existing_docker_containers()
+    assert len(lambda_api.get_all_container_names()) == 0
+
+    # deploy and invoke lambda without Docker
+    zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_ENV), get_content=True,
+                                              libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
+    testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_ENV,
+                                    zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
+
+    assert len(lambda_api.get_all_container_names()) == 0
+
+    lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_ENV, Payload=b'{}')
+    assert len(lambda_api.get_all_container_names()) == 1
+
+    # try to destroy idle containers.
+    lambda_api.idle_container_destroyer()
+    assert len(lambda_api.get_all_container_names()) == 1
+
+    # simulate an idle container
+    lambda_api.function_invoke_times[func_arn] = time.time() - 610
+    lambda_api.idle_container_destroyer()
+    assert len(lambda_api.get_all_container_names()) == 0

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -197,6 +197,10 @@ class TestLambdaAPI(unittest.TestCase):
             self.assertEqual(self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
                              result['message'])
 
+    def test_get_container_name(self):
+        name = lambda_api.get_container_name('arn:aws:lambda:us-east-1:00000000:function:my_function_name')
+        self.assertEqual(name, 'localstack_lambda_arn_aws_lambda_us-east-1_00000000_function_my_function_name')
+
     def _create_function(self, function_name):
         arn = lambda_api.func_arn(function_name)
         lambda_api.arn_to_lambda[arn] = LambdaFunction(arn)


### PR DESCRIPTION
fixes #421 

The current architecture creates. runs and removes a container each time a lambda is ran. This adds a fair amount of overhead to the the execution process. 

This PR will create lasting docker containers for each invoked function and expire that container if it's hasn't been invokes for 10 minutes. The performance impact can be seen in the integration tests. The first invoke takes between 700 and 1500 milliseconds to run. Subsequent calls take 100 milliseconds.

All the tests run well with one exception. In tests/integration/test_lambda.py:115. For some reason, the result is always empty for kinesis events. If I comment out line 115, I can get the integration tests to run.

Thoughts?