### PR TITLE
 test(persistence): unit tests for persistence.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 airspeed==0.5.5.dev20160812
 amazon-kclpy==1.4.5 #extended-lib
 awscli==1.11.125
+backports.tempfile==1.0
 boto==2.46.1
 boto3==1.4.4
 coverage==4.0.3

--- a/tests/unit/test_persistence.py
+++ b/tests/unit/test_persistence.py
@@ -1,0 +1,49 @@
+import unittest
+
+from backports.tempfile import TemporaryDirectory
+from nose.tools import assert_true, assert_false, assert_equal
+
+from localstack.utils import persistence
+
+
+class TestPersistence(unittest.TestCase):
+    temp_dir = None
+
+    # just in case tests run in parallel, we want to only
+    # create the temp_dir once
+    @classmethod
+    def setup_class(cls):
+        cls.temp_dir = TemporaryDirectory()
+        persistence.DATA_DIR = cls.temp_dir.name
+
+    @classmethod
+    def teardown_class(cls):
+        cls.temp_dir.cleanup()
+        persistence.DATA_DIR = None
+
+    def test_should_record(self):
+        assert_true(persistence.should_record('s3', 'PUT', None, None, None))
+        assert_true(persistence.should_record('s3', 'POST', None, None, None))
+        assert_true(persistence.should_record('s3', 'DELETE', None, None, None))
+
+        assert_false(persistence.should_record('s3', 'GET', None, None, None))
+        assert_false(persistence.should_record('s3', 'FAKE_METHOD', None, None, None))
+        assert_false(persistence.should_record('not_s3', 'PUT', None, None, None))
+        assert_false(persistence.should_record(None, None, None, None, None))
+
+    def test_record(self):
+        persistence.record(
+            's3', 'POST', 'path',
+            {'data': 'data_val'},
+            {'header1': 'header_val'},
+        )
+
+    def test_get_file_path(self):
+        assert_equal(
+            persistence.get_file_path('s3', create=True),
+            persistence.DATA_DIR + '/s3_api_calls.json'
+        )
+
+        assert_false(
+            persistence.get_file_path('invalid_api', create=False)
+        )


### PR DESCRIPTION
Added a few unit tests to improve coverage in persistence.py, using TemporaryDirectory() to generate a data directory which will be auto-deleted after the tests. Also added the `backports.tempfile` backport for Py2 compatibility.