### PR TITLE
Map external port for SQS queue URLs

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -9,6 +9,7 @@ import collections
 import six
 from six import iteritems
 from six.moves.urllib import parse as urlparse
+import botocore.config
 from requests.models import Response, Request
 from localstack.constants import DEFAULT_REGION
 from localstack.utils import persistence
@@ -146,7 +147,9 @@ def send_notifications(method, bucket_name, object_path):
                         LOGGER.warning('Unable to send notification for S3 bucket "%s" to SNS topic "%s".' %
                             (bucket_name, config['Topic']))
                 if config.get('CloudFunction'):
-                    lambda_client = aws_stack.connect_to_service('lambda')
+                    # make sure we don't run into a socket timeout
+                    config = botocore.config.Config(read_timeout=300)
+                    lambda_client = aws_stack.connect_to_service('lambda', config=config)
                     try:
                         lambda_client.invoke(FunctionName=config['CloudFunction'], Payload=message)
                     except Exception as e:

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -139,7 +139,7 @@ def get_local_service_url(service_name):
     return os.environ['TEST_%s_URL' % (service_name.upper().replace('-', '_'))]
 
 
-def connect_to_service(service_name, client=True, env=None, region_name=None, endpoint_url=None):
+def connect_to_service(service_name, client=True, env=None, region_name=None, endpoint_url=None, config=None):
     """
     Generic method to obtain an AWS service client using boto3, based on environment, region, or custom endpoint_url.
     """
@@ -152,7 +152,7 @@ def connect_to_service(service_name, client=True, env=None, region_name=None, en
             endpoint_url = get_local_service_url(service_name)
             verify = False
     region = env.region if env.region != REGION_LOCAL else get_local_region()
-    return method(service_name, region_name=region, endpoint_url=endpoint_url, verify=verify)
+    return method(service_name, region_name=region, endpoint_url=endpoint_url, verify=verify, config=config)
 
 
 class VelocityInput:


### PR DESCRIPTION
* Map external port for SQS queue URLs. Addresses #394
* Allow specifying `config` for boto3 clients, and increase `read_timeout` on the boto3 client used for S3->Lambda integration (discussed in #408)