### PR TITLE
S3 lifecycle support

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/LocalstackTestRunner.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LocalstackTestRunner.java
@@ -36,7 +36,7 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 	private static final String TMP_INSTALL_DIR = System.getProperty("java.io.tmpdir") +
 			File.separator + "localstack_install_dir";
 	private static final String ADDITIONAL_PATH = "/usr/local/bin/";
-	private static final String LOCALSTACK_REPO_URL = "https://github.com/localstack/localstack";
+	private static final String LOCALSTACK_REPO_URL = "https://github.com/ataylor284/localstack";
 
 	public static final String ENV_CONFIG_USE_SSL = "USE_SSL";
 	private static final String ENV_LOCALSTACK_PROCESS_GROUP = "ENV_LOCALSTACK_PROCESS_GROUP";

--- a/localstack/ext/java/src/main/java/cloud/localstack/LocalstackTestRunner.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LocalstackTestRunner.java
@@ -36,7 +36,7 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 	private static final String TMP_INSTALL_DIR = System.getProperty("java.io.tmpdir") +
 			File.separator + "localstack_install_dir";
 	private static final String ADDITIONAL_PATH = "/usr/local/bin/";
-	private static final String LOCALSTACK_REPO_URL = "https://github.com/ataylor284/localstack";
+	private static final String LOCALSTACK_REPO_URL = "https://github.com/localstack/localstack";
 
 	public static final String ENV_CONFIG_USE_SSL = "USE_SSL";
 	private static final String ENV_LOCALSTACK_PROCESS_GROUP = "ENV_LOCALSTACK_PROCESS_GROUP";

--- a/localstack/ext/java/src/test/java/cloud/localstack/S3LifecycleTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/S3LifecycleTest.java
@@ -1,0 +1,56 @@
+package cloud.localstack;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.UUID;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.entity.ContentType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
+import com.amazonaws.services.s3.model.Tag;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleFilter;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleFilterPredicate;
+import com.amazonaws.services.s3.model.lifecycle.LifecycleTagPredicate;
+
+/**
+ * Test that S3 bucket lifecycle settings can be set and read.
+ */
+@RunWith(LocalstackTestRunner.class)
+public class S3LifecycleTest {
+
+	@Test
+	public void testSetBucketLifecycle() throws Exception {
+		AmazonS3 client = TestUtils.getClientS3();
+
+		String bucketName = UUID.randomUUID().toString();
+		client.createBucket(bucketName);
+
+		BucketLifecycleConfiguration.Rule rule = new BucketLifecycleConfiguration.Rule()
+			.withId("expirationRule")
+			.withFilter(new LifecycleFilter(new LifecycleTagPredicate(new Tag("deleted", "true"))))
+			.withExpirationInDays(3)
+			.withStatus(BucketLifecycleConfiguration.ENABLED);
+
+		BucketLifecycleConfiguration bucketLifecycleConfiguration = new BucketLifecycleConfiguration()
+			.withRules(rule);
+
+		client.setBucketLifecycleConfiguration(bucketName, bucketLifecycleConfiguration);
+
+		bucketLifecycleConfiguration = client.getBucketLifecycleConfiguration(bucketName);
+
+		assertNotNull(bucketLifecycleConfiguration);
+		assertEquals(bucketLifecycleConfiguration.getRules().get(0).getId(), "expirationRule");
+
+		client.deleteBucket(bucketName);
+	}
+}

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -23,6 +23,9 @@ S3_NOTIFICATIONS = {}
 # mappings for bucket CORS settings
 BUCKET_CORS = {}
 
+# mappings for bucket lifecycle settings
+BUCKET_LIFECYCLE = {}
+
 # set up logger
 LOGGER = logging.getLogger(__name__)
 
@@ -204,6 +207,30 @@ def append_cors_headers(bucket_name, request_method, request_headers, response):
                 if origin in allowed or re.match(allowed.replace('*', '.*'), origin):
                     response.headers['Access-Control-Allow-Origin'] = origin
                     break
+
+
+def get_lifecycle(bucket_name):
+    response = Response()
+    lifecycle = BUCKET_LIFECYCLE.get(bucket_name)
+    if not lifecycle:
+        # TODO: check if bucket exists, otherwise return 404-like error
+        lifecycle = {
+            'LifecycleConfiguration': []
+        }
+    body = xmltodict.unparse(lifecycle)
+    response._content = body
+    response.status_code = 200
+    return response
+
+
+def set_lifecycle(bucket_name, lifecycle):
+    # TODO: check if bucket exists, otherwise return 404-like error
+    if isinstance(to_str(lifecycle), six.string_types):
+        lifecycle = xmltodict.parse(lifecycle)
+    BUCKET_LIFECYCLE[bucket_name] = lifecycle
+    response = Response()
+    response.status_code = 200
+    return response
 
 
 def strip_chunk_signatures(data):
@@ -426,6 +453,12 @@ class ProxyListenerS3(ProxyListener):
             if method == 'DELETE':
                 return delete_cors(bucket)
 
+        if query == 'lifecycle' or 'lifecycle' in query_map:
+            if method == 'GET':
+                return get_lifecycle(bucket)
+            if method == 'PUT':
+                return set_lifecycle(bucket, data)
+
         if modified_data:
             return Request(data=modified_data, headers=headers, method=method)
         return True
@@ -452,7 +485,7 @@ class ProxyListenerS3(ProxyListener):
             if len(path[1:].split('/')[1]) > 0:
                 parts = parsed.path[1:].split('/', 1)
                 # ignore bucket notification configuration requests
-                if parsed.query != 'notification':
+                if parsed.query != 'notification' and parsed.query != 'lifecycle':
                     object_path = parts[1] if parts[1][0] == '/' else '/%s' % parts[1]
                     send_notifications(method, bucket_name, object_path)
 


### PR DESCRIPTION
This PR adds some simple stubs to accept and store S3 lifecycle configurations.  In particular, the s3 client can PUT a lifecycle configuration and have it echoed back with a GET.

The lifecycle rules are not actually enforced.

This allows stacks that contain S3 lifecycle rules to set up against localstack without failing.