### PR TITLE
feat/testcontainers-integration-test into master

### DIFF
--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -103,6 +103,18 @@
             <type>jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/localstack/ext/java/src/test/java/cloud/localstack/testcontainers/TestContainersSqsTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/testcontainers/TestContainersSqsTest.java
@@ -116,7 +116,6 @@ public class TestContainersSqsTest {
 
         genericContainer = new GenericContainer(DOCKER_IMAGE_NAME)
                 .withExposedPorts(SQS_PORT)
-                .withFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", READ_WRITE)
                 .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Ready\\.\n"));
 
         genericContainer.start();

--- a/localstack/ext/java/src/test/java/cloud/localstack/testcontainers/TestContainersSqsTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/testcontainers/TestContainersSqsTest.java
@@ -1,0 +1,124 @@
+package cloud.localstack.testcontainers;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.CreateQueueResult;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.LogMessageWaitStrategy;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.testcontainers.containers.BindMode.READ_WRITE;
+
+/**
+ * <p>
+ * This test is used to ensure that the bug of <a href="https://github.com/localstack/localstack/issues/308">#308</a> is fixed.
+ * </p>
+ * <p>
+ * In this test the localstack docker images will be started by the <a href="https://www.testcontainers.org">testcontainers</a> framework.
+ * SQS will then be used to send some messages.
+ * </p>
+ * <p>
+ * The goal of this test is to check that the random port mapping of testcontainers is working with localstack.
+ * </p>
+ */
+public class TestContainersSqsTest {
+
+    private static final String DOCKER_IMAGE_NAME = "localstack/localstack:latest";
+
+    private static final int SQS_PORT = 4576;
+
+    private AmazonSQS amazonSQS;
+
+    private GenericContainer genericContainer;
+
+    @Before
+    public void before() {
+
+        startDockerImage();
+        createSqsClient();
+
+    }
+
+    private void createSqsClient() {
+
+        /*
+         * get the randomly generated SQS port
+         */
+        final Integer mappedPort = genericContainer.getMappedPort(SQS_PORT);
+
+        /*
+         * create the SQS client
+         */
+        final AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(
+                "http://localhost:" + mappedPort,
+                "us-east-1");
+
+        final AWSStaticCredentialsProvider awsStaticCredentialsProvider = new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials("accesskey", "secretkey"));
+
+        amazonSQS = AmazonSQSClientBuilder
+                .standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(awsStaticCredentialsProvider)
+                .build();
+    }
+
+    @Test
+    public void sendAndReceiveMessageTest() {
+
+        /*
+         * create the queue
+         */
+        final CreateQueueResult queue = amazonSQS.createQueue("test-queue");
+        final String queueUrl = queue.getQueueUrl();
+
+        /*
+         * send a message to the queue
+         */
+        final String messageBody = "test-message";
+        final SendMessageResult sendMessageResult = amazonSQS.sendMessage(queueUrl, messageBody);
+        assertNotNull(sendMessageResult);
+
+        final String messageId = sendMessageResult.getMessageId();
+        assertNotNull(messageId);
+
+        /*
+         * receive the message from the queue
+         */
+        final ReceiveMessageResult messageResult = amazonSQS.receiveMessage(queueUrl);
+        assertNotNull(messageResult);
+
+        /*
+         * compare results
+         */
+        final List<Message> messages = messageResult.getMessages();
+        assertNotNull(messages);
+        assertEquals(1, messages.size());
+
+        final Message message = messages.get(0);
+        assertEquals(messageId, message.getMessageId());
+        assertEquals(messageBody, message.getBody());
+
+    }
+
+    private void startDockerImage() {
+
+        genericContainer = new GenericContainer(DOCKER_IMAGE_NAME)
+                .withExposedPorts(SQS_PORT)
+                .withFileSystemBind("/var/run/docker.sock", "/var/run/docker.sock", READ_WRITE)
+                .waitingFor(new LogMessageWaitStrategy().withRegEx(".*Ready\\.\n"));
+
+        genericContainer.start();
+    }
+}

--- a/localstack/ext/java/src/test/resources/logback.xml
+++ b/localstack/ext/java/src/test/resources/logback.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="INFO"/>
+</configuration>


### PR DESCRIPTION
Hi,

i have create a test for: 

* https://github.com/localstack/localstack/issues/308

the portmapping is working again with the latest localstack docker image (was working up to 0.7.4 but stoppped working with 0.7.5)


