### PR TITLE
Added support for identifying the docker network when running lambda …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ localstack/infra/
 *.sw*
 ~*
 *~
+.vscode
+.idea
+tmp

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,39 @@ web:               ## Start web application (dashboard)
 
 test:              ## Run automated tests
 	make lint && \
-		($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py' .)
+	($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py,lambda_python3_nwtest.py' .)
+
+test-lambdanet:    ## Test running lambdas in specific docker networks
+	# setup docker infrastructure needed by tests
+	# basically run simple http servers in separate bridge networks
+	-docker network create -d bridge test_localstack_lambdanet_default
+	-docker network create -d bridge test_localstack_lambdanet_custom
+	-docker run -d -P --network=test_localstack_lambdanet_default \
+			  --name=test_localstack_lambdanet_default_id  \
+	          --net-alias=networkidentifier --rm \
+			  -v $$(pwd)/tests/integration/nwfiles/default:/www fnichol/uhttpd
+	-docker run -d -P --network=test_localstack_lambdanet_custom \
+			  --name=test_localstack_lambdanet_custom_id  \
+	          --net-alias=networkidentifier --rm \
+			  -v $$(pwd)/tests/integration/nwfiles/custom:/www fnichol/uhttpd
+	# run the tests -- note the lambda network settings
+	($(VENV_RUN); \
+	DEBUG=$(DEBUG) \
+	PYTHONPATH=`pwd` \
+	LAMBDA_EXECUTOR=docker \
+	LAMBDA_DEFAULT_DOCKER_NETWORK=test_localstack_lambdanet_default \
+	LAMBDA_SUBNET_AS_DOCKERNET=1 \
+	nosetests --with-coverage --logging-level=WARNING --nocapture \
+	          --no-skip --exe --cover-erase --cover-tests --cover-inclusive \
+			  --cover-package=localstack --with-xunit \
+			  --exclude='$(VENV_DIR).*' \
+			  --ignore-files='lambda_python3.py,lambda_python3_nwtest.py' .)
+	#cleanup our docker infrastructure
+	docker kill test_localstack_lambdanet_default_id
+	docker kill test_localstack_lambdanet_custom_id
+	docker network rm test_localstack_lambdanet_default
+	docker network rm test_localstack_lambdanet_custom
+	
 
 test-java:         ## Run tests for Java/JUnit compatibility
 	cd localstack/ext/java; mvn -q test && USE_SSL=1 mvn -q test

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ You can pass the following environment variables to LocalStack:
     - when set to `true`: your lambda functions definitions will be passed to the container by
       copying the zip file (potentially slower). It allows for remote execution, where the host
       and the client are not on the same machine
+* `LAMBDA_DEFAULT_DOCKER_NETWORK`:
+    - When set, and running lambda functions in a docker container 
+      (LAMBDA_EXECUTOR=docker) the docker container running the lambda function
+      will be attached to the docker network identified by LAMBDA_DEFAULT_DOCKER_NETWORK
+* `LAMBDA_SUBNET_AS_DOCKERNET`:
+    - When set to 1, and lambda functions are run in a docker container
+      (LAMBDA_EXECUTOR=docker) if a lambda function is created with a vpc config,
+      the subnet identified in the vpc config will be used as the identifier of the docker network for the lambda function's docker container 
 * `DATA_DIR`: Local directory for saving persistent data (currently only supported for these services:
   Kinesis, DynamoDB, Elasticsearch). Set it to `/tmp/localstack/data` to enable persistence
   (`/tmp/localstack` is mounted into the Docker container), leave blank to disable

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -59,6 +59,9 @@ if not LAMBDA_EXECUTOR:
     except Exception as e:
         pass
 
+LAMBDA_DEFAULT_DOCKER_NETWORK = os.environ.get('LAMBDA_DEFAULT_DOCKER_NETWORK', '').strip()
+LAMBDA_SUBNET_AS_DOCKERNET = os.environ.get('LAMBDA_SUBNET_AS_DOCKERNET', False)    
+
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -208,6 +208,7 @@ def setup_logging():
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('botocore').setLevel(logging.ERROR)
     logging.getLogger('elasticsearch').setLevel(logging.ERROR)
+    logging.getLogger('localstack.services.awslambda.lambda_api').setLevel(log_level)
 
 
 def get_service_protocol():

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -167,6 +167,7 @@ class LambdaFunction(Component):
         self.runtime = None
         self.handler = None
         self.cwd = None
+        self.vpc_config = None
 
     def get_version(self, version):
         return self.versions.get(version)

--- a/tests/integration/lambdas/lambda_python3_nwtest.py
+++ b/tests/integration/lambdas/lambda_python3_nwtest.py
@@ -1,0 +1,13 @@
+# simple test function that identifies the network it is running on
+# note: this requires a web server on the local docker network which will
+# with the alias "networkidentifier" that respond to the endpoingt /network.txt
+#
+# The makefile will set this up before running this test
+
+import requests
+
+
+def handler(event, context):
+    r = requests.get('http://networkidentifier/network.txt')
+    event['network'] = r.text
+    return event

--- a/tests/integration/nwfiles/custom/network.txt
+++ b/tests/integration/nwfiles/custom/network.txt
@@ -1,0 +1,1 @@
+custom network

--- a/tests/integration/nwfiles/default/network.txt
+++ b/tests/integration/nwfiles/default/network.txt
@@ -1,0 +1,1 @@
+default network


### PR DESCRIPTION
…functions in docker containers

The docker network used when running lambda functions in a container may be specified with the LAMBDA_DEFAULT_DOCKER_NETWORK and LAMBDA_SUBNET_AS_DOCKERNET environment variables along with the subnet specified in the lambda's vpc config

**Please refer to the contribution guidelines in the README when submitting PRs.**
