### PR TITLE
Fix data parameter which is non-string passed to json parser

### DIFF
--- a/localstack/dashboard/infra.py
+++ b/localstack/dashboard/infra.py
@@ -10,6 +10,7 @@ from localstack.utils.aws.aws_models import (ElasticSearch, S3Notification,
     EventSource, DynamoDB, DynamoDBStream, FirehoseStream, S3Bucket, SqsQueue,
     KinesisShard, KinesisStream, LambdaFunction)
 from localstack.utils.aws import aws_stack
+from localstack.utils.common import to_str
 from localstack.constants import REGION_LOCAL, DEFAULT_REGION
 from six import iteritems
 

--- a/localstack/dashboard/infra.py
+++ b/localstack/dashboard/infra.py
@@ -397,7 +397,7 @@ def get_firehose_streams(filter='.*', pool={}, env=None):
 def read_kinesis_iterator(shard_iterator, max_results=10, env=None):
     data = cmd_kinesis('get-records --shard-iterator %s --limit %s' %
         (shard_iterator, max_results), env, cache_duration_secs=0)
-    data = json.loads(data)
+    data = json.loads(to_str(data))
     result = data
     return result
 

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -140,7 +140,7 @@ def get_cors_response(headers):
 class ProxyListenerApiGateway(ProxyListener):
 
     def forward_request(self, method, path, data, headers):
-        data = data and json.loads(data)
+        data = data and json.loads(to_str(data))
 
         # Paths to match
         regex2 = r'^/restapis/([A-Za-z0-9_\-]+)/([A-Za-z0-9_\-]+)/%s/(.*)$' % PATH_USER_REQUEST

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -7,6 +7,7 @@ from localstack.constants import APPLICATION_JSON, PATH_USER_REQUEST
 from localstack.config import TEST_KINESIS_URL
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
+from localstack.utils.common import to_str
 from localstack.services.awslambda import lambda_api
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.generic_proxy import ProxyListener

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -26,14 +26,14 @@ LOGGER = logging.getLogger(__name__)
 class ProxyListenerDynamoDB(ProxyListener):
 
     def forward_request(self, method, path, data, headers):
-        data = json.loads(data)
+        data = json.loads(to_str(data))
 
         if random.random() < config.DYNAMODB_ERROR_PROBABILITY:
             return error_response_throughput()
         return True
 
     def return_response(self, method, path, data, headers, response):
-        data = json.loads(data)
+        data = json.loads(to_str(data))
 
         # update table definitions
         if data and 'TableName' in data and 'KeySchema' in data:

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -6,6 +6,7 @@ from localstack.utils.common import to_str
 from localstack.utils.analytics import event_publisher
 from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener
+from localstack.utils.common import to_str
 
 # action headers
 ACTION_PREFIX = 'Kinesis_20131202'
@@ -18,7 +19,7 @@ ACTION_DELETE_STREAM = '%s.DeleteStream' % ACTION_PREFIX
 class ProxyListenerKinesis(ProxyListener):
 
     def forward_request(self, method, path, data, headers):
-        data = json.loads(data)
+        data = json.loads(to_str(data))
 
         if random.random() < config.KINESIS_ERROR_PROBABILITY:
             return kinesis_error_response(data)
@@ -26,7 +27,7 @@ class ProxyListenerKinesis(ProxyListener):
 
     def return_response(self, method, path, data, headers, response):
         action = headers.get('X-Amz-Target')
-        data = json.loads(data)
+        data = json.loads(to_str(data))
 
         records = []
         if action in (ACTION_CREATE_STREAM, ACTION_DELETE_STREAM):

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -6,7 +6,6 @@ from localstack.utils.common import to_str
 from localstack.utils.analytics import event_publisher
 from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener
-from localstack.utils.common import to_str
 
 # action headers
 ACTION_PREFIX = 'Kinesis_20131202'


### PR DESCRIPTION
I just added few conversions since data parameter could be b'{}', which json parser does not like (see my issue #463). It works now with python 3.5 on ubuntu. Need more comments? 