### PR TITLE
Set S3 ACL default value in case comes empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ localstack/infra/
 *.sw*
 ~*
 *~
+/.idea

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -24,7 +24,7 @@ RESOURCE_TO_FUNCTION = {
             'function': 'create_bucket',
             'parameters': {
                 'Bucket': ['BucketName', PLACEHOLDER_RESOURCE_NAME],
-                'ACL': lambda params: convert_acl_cf_to_s3(params['AccessControl'])
+                'ACL': lambda params: convert_acl_cf_to_s3(params['AccessControl'] if hasattr(params, 'AccessControl') else 'PublicRead')
             }
         }
     },

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -24,7 +24,7 @@ RESOURCE_TO_FUNCTION = {
             'function': 'create_bucket',
             'parameters': {
                 'Bucket': ['BucketName', PLACEHOLDER_RESOURCE_NAME],
-                'ACL': lambda params: convert_acl_cf_to_s3(params['AccessControl'] if hasattr(params, 'AccessControl') else 'PublicRead')
+                'ACL': lambda params: convert_acl_cf_to_s3(params.get('AccessControl', 'PublicRead'))
             }
         }
     },


### PR DESCRIPTION
Hi,

When you try to use Serverless Framework with Localstack is impossible to deploy because the Cloudformation generated by Serverless doesn't come with AccessControl property so the deployment breaks, I debug into the issue and we only need to make a quick fix and set a default value for this ACL to continue with the deployment.

This also fixes the issue #475  that I reported before.

NOTE: I also add a gitignore entry because I use PyCharm as IDE and there always create an .idea directory.