### PR TITLE
Optimize startup and error injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,12 @@ install:
 script:
   - set -e # fail fast
   # run tests using Python 3
-  - DEBUG=1 LAMBDA_EXECUTOR=docker make test
+  - DEBUG=1 LAMBDA_EXECUTOR=docker TEST_ERROR_INJECTION=1 make test
   - LAMBDA_EXECUTOR=local USE_SSL=1 make test
   # run tests using Python 2
   #   Note: we're not using multiple versions in the top-level "python" configuration,
   #   but instead reinstall using 2.x here, as that allows us to use some cached libs etc.
-  - make reinstall-p2
+  - "make reinstall-p2 > /dev/null"
   - make init
   - DEBUG=1 LAMBDA_EXECUTOR=docker make test
   - LAMBDA_EXECUTOR=local USE_SSL=1 make test

--- a/localstack/services/dynamodb/dynamodb_starter.py
+++ b/localstack/services/dynamodb/dynamodb_starter.py
@@ -1,9 +1,10 @@
+import time
 import logging
 import traceback
 from localstack.config import PORT_DYNAMODB, DATA_DIR
 from localstack.constants import DEFAULT_PORT_DYNAMODB_BACKEND
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import mkdir
+from localstack.utils.common import mkdir, is_port_open
 from localstack.services import install
 from localstack.services.infra import get_service_protocol, start_proxy_for_service, do_run
 from localstack.services.install import ROOT_PATH
@@ -14,6 +15,8 @@ LOGGER = logging.getLogger(__name__)
 def check_dynamodb(expect_shutdown=False, print_error=False):
     out = None
     try:
+        # wait for port to be opened
+        wait_for_port_open()
         # check DynamoDB
         out = aws_stack.connect_to_service(service_name='dynamodb').list_tables()
     except Exception as e:
@@ -23,6 +26,13 @@ def check_dynamodb(expect_shutdown=False, print_error=False):
         assert out is None
     else:
         assert isinstance(out['TableNames'], list)
+
+
+def wait_for_port_open():
+    for i in range(0, 8):
+        if is_port_open(DEFAULT_PORT_DYNAMODB_BACKEND):
+            break
+        time.sleep(0.5)
 
 
 def start_dynamodb(port=PORT_DYNAMODB, async=False, update_listener=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ flask_swagger==0.2.12
 jsonpath-rw==1.4.0
 localstack-ext
 localstack-client==0.4
-moto-ext==1.1.24
+moto-ext==1.1.25
 nose==1.3.7
 psutil==5.2.0
 pyOpenSSL==17.0.0


### PR DESCRIPTION
* Avoid error log outputs for DDB startup (see #476)
* Run error injections only in one single test iteration (should reduce build times)
* Bump moto version