### PR TITLE
Use POJO Type for RequestHandler input

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -6,12 +6,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
@@ -19,11 +22,13 @@ import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent.KinesisEventRecord;
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent.Record;
 import com.amazonaws.util.StringInputStream;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
+import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
 
 /**
  * Simple implementation of a Java Lambda function executor.
@@ -31,6 +36,8 @@ import org.joda.time.DateTime;
  * @author Waldemar Hummer
  */
 public class LambdaExecutor {
+
+	private static Object inputObject;
 
 	@SuppressWarnings("unchecked")
 	public static void main(String[] args) throws Exception {
@@ -42,14 +49,15 @@ public class LambdaExecutor {
 
 		String fileContent = readFile(args[1]);
 		ObjectMapper reader = new ObjectMapper();
-		@SuppressWarnings("deprecation")
-		Map<String,Object> map = reader.reader(Map.class).readValue(fileContent);
+		Map<String,Object> map = reader.readerFor(Map.class).readValue(fileContent);
 
 		List<Map<String,Object>> records = (List<Map<String, Object>>) get(map, "Records");
-		@SuppressWarnings("rawtypes")
-		Object inputObject = map;
+		inputObject = map;
 
-		if (records != null) {
+		Object handler = getHandler(args[0]);
+		if (records == null) {
+			setInputObject(reader, fileContent, handler);
+		} else {
 			if (records.stream().filter(record -> record.containsKey("Kinesis")).count() > 0) {
 				KinesisEvent kinesisEvent = new KinesisEvent();
 				inputObject = kinesisEvent;
@@ -85,10 +93,15 @@ public class LambdaExecutor {
 			//TODO: Support other events (S3, SQS...)
 		}
 
-		Object handler = getHandler(args[0]);
 		Context ctx = new LambdaContext();
 		if (handler instanceof RequestHandler) {
 			Object result = ((RequestHandler) handler).handleRequest(inputObject, ctx);
+			// try turning the output into json
+			try {
+				result = new ObjectMapper().writeValueAsString(result);
+			} catch (JsonProcessingException jsonException) {
+				// continue with results as it is
+			}
 			// The contract with lambci is to print the result to stdout, whereas logs go to stderr
 			System.out.println(result);
 		} else if (handler instanceof RequestStreamHandler) {
@@ -96,6 +109,22 @@ public class LambdaExecutor {
 			((RequestStreamHandler) handler).handleRequest(
 				new StringInputStream(fileContent), os, ctx);
 			System.out.println(os);
+		}
+	}
+
+	private static void setInputObject(ObjectMapper mapper, String objectString, Object handler) {
+		try {
+			Optional<Type> handlerInterface = Arrays.stream(handler.getClass().getGenericInterfaces())
+					.filter(genericInterface ->
+						((ParameterizedTypeImpl) genericInterface).getRawType().equals(RequestHandler.class))
+					.findFirst();
+			if (handlerInterface.isPresent()) {
+				Class handlerInputType = Class.forName(((ParameterizedTypeImpl) handlerInterface.get())
+						.getActualTypeArguments()[0].getTypeName());
+				inputObject = mapper.readerFor(handlerInputType).readValue(objectString);
+			}
+		} catch (Exception genericException) {
+			// do nothing
 		}
 	}
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -37,8 +37,6 @@ import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl;
  */
 public class LambdaExecutor {
 
-	private static Object inputObject;
-
 	@SuppressWarnings("unchecked")
 	public static void main(String[] args) throws Exception {
 		if(args.length < 2) {
@@ -52,11 +50,14 @@ public class LambdaExecutor {
 		Map<String,Object> map = reader.readerFor(Map.class).readValue(fileContent);
 
 		List<Map<String,Object>> records = (List<Map<String, Object>>) get(map, "Records");
-		inputObject = map;
+		Object inputObject = map;
 
 		Object handler = getHandler(args[0]);
 		if (records == null) {
-			setInputObject(reader, fileContent, handler);
+			Optional<Object> deserialisedInput = getInputObject(reader, fileContent, handler);
+			if (deserialisedInput.isPresent()) {
+				inputObject = deserialisedInput.get();
+			}
 		} else {
 			if (records.stream().filter(record -> record.containsKey("Kinesis")).count() > 0) {
 				KinesisEvent kinesisEvent = new KinesisEvent();
@@ -112,7 +113,8 @@ public class LambdaExecutor {
 		}
 	}
 
-	private static void setInputObject(ObjectMapper mapper, String objectString, Object handler) {
+	private static Optional<Object> getInputObject(ObjectMapper mapper, String objectString, Object handler) {
+		Optional<Object> inputObject = Optional.empty();
 		try {
 			Optional<Type> handlerInterface = Arrays.stream(handler.getClass().getGenericInterfaces())
 					.filter(genericInterface ->
@@ -121,11 +123,12 @@ public class LambdaExecutor {
 			if (handlerInterface.isPresent()) {
 				Class handlerInputType = Class.forName(((ParameterizedTypeImpl) handlerInterface.get())
 						.getActualTypeArguments()[0].getTypeName());
-				inputObject = mapper.readerFor(handlerInputType).readValue(objectString);
+				inputObject = Optional.of(mapper.readerFor(handlerInputType).readValue(objectString));
 			}
 		} catch (Exception genericException) {
 			// do nothing
 		}
+		return inputObject;
 	}
 
 	private static Object getHandler(String handlerName) throws NoSuchMethodException, IllegalAccessException,

--- a/localstack/ext/java/src/test/java/cloud/localstack/sample/SerializedInputLambdaHandler.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/sample/SerializedInputLambdaHandler.java
@@ -1,0 +1,52 @@
+package cloud.localstack.sample;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+/**
+ * Test Lambda handler class
+ */
+public class SerializedInputLambdaHandler implements RequestHandler<SerializedInputLambdaHandler.S3Input, Object> {
+
+    @Override
+    public Object handleRequest(S3Input input, Context context) {
+        System.err.println(input);
+        input.setValidated(true);
+        return input;
+    }
+
+    public static class S3Input {
+
+        public S3Input() {}
+
+        private String bucket;
+
+        private String key;
+
+        private boolean validated = false;
+
+        public String getBucket() {
+            return bucket;
+        }
+
+        public void setBucket(String bucket) {
+            this.bucket = bucket;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public void setValidated(boolean validated) {
+            this.validated = validated;
+        }
+
+        public boolean isValidated() {
+            return validated;
+        }
+    }
+}

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -23,6 +23,7 @@ TEST_LAMBDA_NAME_PY3 = 'test_lambda_py3'
 TEST_LAMBDA_NAME_JS = 'test_lambda_js'
 TEST_LAMBDA_NAME_JAVA = 'test_lambda_java'
 TEST_LAMBDA_NAME_JAVA_STREAM = 'test_lambda_java_stream'
+TEST_LAMBDA_NAME_JAVA_SERIALIZABLE = 'test_lambda_java_serializable'
 TEST_LAMBDA_NAME_ENV = 'test_lambda_env'
 
 TEST_LAMBDA_JAR_URL = ('https://repo.maven.apache.org/maven2/cloud/localstack/' +
@@ -121,6 +122,15 @@ def test_lambda_runtimes():
     assert result['StatusCode'] == 200
     result_data = result['Payload'].read()
     assert to_str(result_data).strip() == '{}'
+
+    # deploy and invoke lambda - Java with serializable input object
+    testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_JAVA_SERIALIZABLE, zip_file=zip_file,
+        runtime=LAMBDA_RUNTIME_JAVA8, handler='cloud.localstack.sample.SerializedInputLambdaHandler')
+    result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA_SERIALIZABLE,
+                                  Payload=b'{"bucket": "test_bucket", "key": "test_key"}')
+    assert result['StatusCode'] == 200
+    result_data = result['Payload'].read()
+    assert json.loads(to_str(result_data)) == {'validated': True, 'bucket': 'test_bucket', 'key': 'test_key'}
 
     if use_docker():
         # deploy and invoke lambda - Node.js


### PR DESCRIPTION
According to amazon documentation, RequestHandler can use POJOs as input: http://docs.aws.amazon.com/lambda/latest/dg/java-programming-model-req-resp.html

Executor will learn the type and try to deserialise the payload, then serialise the response if possible.
It will continue as normal if unable to serialise/deserialise.

One thing I did not do was to bump `localstack-utils` version, but since the build process requires some additional work I hope I can leave it up to @whummer ;)
