### PR TITLE
Update sns forward_request for HTTP/S to handle RawMessageDelivery

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -56,7 +56,6 @@ class ProxyListenerSNS(ProxyListener):
 
             elif req_action == 'Publish':
                 message = req_data['Message'][0]
-                subject = (req_data.get('Subject', ['']))[0]
                 sqs_client = aws_stack.connect_to_service('sqs')
                 for subscriber in SNS_SUBSCRIPTIONS[topic_arn]:
                     if subscriber['Protocol'] == 'sqs':
@@ -79,12 +78,7 @@ class ProxyListenerSNS(ProxyListener):
                                 'Content-Type': 'text/plain',
                                 'x-amz-sns-message-type': 'Notification'
                             },
-                            data=json.dumps({
-                                'Type': 'Notification',
-                                'Subject': subject,
-                                'Message': message,
-                            })
-                        )
+                            data=create_sns_message_body(subscriber, req_data))
                     else:
                         LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
                 # return response here because we do not want the request to be forwarded to SNS


### PR DESCRIPTION
It seems that RawMessageDelivery has only been respected for sns->sqs.

Though the docs for [Raw Message Delivery](http://docs.aws.amazon.com/sns/latest/dg/large-payload-raw-message.html) state:

> Amazon SNS you can now enable raw message delivery for messages delivered to either Amazon SQS endpoints or HTTP/S endpoints.

Please let me know if anything else needs to be added.
