### PR TITLE
TEST: Show that master is no longer building with noop change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Climate](https://codeclimate.com/github/atlassian/localstack/badges/gpa.svg)](https://codeclimate.com/github/atlassian/localstack)
 [![Twitter](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/_localstack)
 
-# LocalStack - A fully functional local AWS cloud stack
+# LocalStack - A fully functional local AWS cloud stack 
 
 ![LocalStack](https://github.com/localstack/localstack/raw/master/localstack/dashboard/web/img/localstack.png)
 


### PR DESCRIPTION
I believe that the currently pushed `localstack/java-maven-node-python:latest ` does not build `localstack/localstack`.

This is a test to see if this is the case.

I'll put up an issue if this PR does in fact fail CI.

Short fix: Rerun `make docker-build-base` and push the image.
I rebuild and pushed as `adamryman/localstack-base:latest` and tested it [here](https://travis-ci.org/adamryman/localstack/jobs/313833753).

I also recommend adding daily cron on master with [Travis-CI Cron Jobs](https://docs.travis-ci.com/user/cron-jobs/).