### PR TITLE
API Gateway should support wildcard path segments, e.g. {proxy+}

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -113,7 +113,10 @@ def extract_path_params(path, extracted_path):
     for param in path_params_list:
         path_param_name = param[1][1:-1].encode('utf-8')
         path_param_position = param[0]
-        path_params[path_param_name] = tokenized_path[path_param_position]
+        if path_param_name.endswith(b'+'):
+            path_params[path_param_name] = '/'.join(tokenized_path[path_param_position:])
+        else:
+            path_params[path_param_name] = tokenized_path[path_param_position]
     path_params = common.json_safe(path_params)
     return path_params
 
@@ -121,7 +124,8 @@ def extract_path_params(path, extracted_path):
 def get_resource_for_path(path, path_map):
     matches = []
     for api_path, details in path_map.items():
-        api_path_regex = re.sub(r'\{[^\}]+\}', '[^/]+', api_path)
+        api_path_regex = re.sub(r'\{[^\+]+\+\}', '[^\?#]+', api_path)
+        api_path_regex = re.sub(r'\{[^\}]+\}', '[^/]+', api_path_regex)
         if re.match(r'^%s$' % api_path_regex, path):
             matches.append((api_path, details))
     if not matches:

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -14,12 +14,18 @@ class ApiGatewayPathsTest (unittest.TestCase):
         params = apigateway_listener.extract_path_params('/foo/bar', '/foo/bar')
         self.assertEqual(params, {})
 
+        params = apigateway_listener.extract_path_params('/foo/bar/baz', '/foo/{proxy+}')
+        self.assertEqual(params, {'proxy+': 'bar/baz'})
+
     def test_path_matches(self):
         path, details = apigateway_listener.get_resource_for_path('/foo/bar', {'/foo/{param1}': {}})
         self.assertEqual(path, '/foo/{param1}')
 
         path, details = apigateway_listener.get_resource_for_path('/foo/bar', {'/foo/bar': {}, '/foo/{param1}': {}})
         self.assertEqual(path, '/foo/bar')
+
+        path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', {'/foo/bar': {}, '/foo/{proxy+}': {}})
+        self.assertEqual(path, '/foo/{proxy+}')
 
         result = apigateway_listener.get_resource_for_path('/foo/bar', {'/foo/bar1': {}, '/foo/bar2': {}})
         self.assertEqual(result, None)


### PR DESCRIPTION
API Gateway has path variables like `{param}` but also wildcard path variables like `{proxy+}`: https://aws.amazon.com/blogs/aws/api-gateway-update-new-features-simplify-api-development/

This PR adds support for wildcard path variables.