### PR TITLE
Add support for FORCE_NONINTERACTIVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ You can pass the following environment variables to LocalStack:
 * `<SERVICE>_BACKEND`: Custom endpoint URL to use for a specific service, where `<SERVICE>` is the uppercase
   service name (currently works for: `APIGATEWAY`, `CLOUDFORMATION`, `DYNAMODB`, `ELASTICSEARCH`,
   `KINESIS`, `S3`, `SNS`, `SQS`). This allows to easily integrate third-party services into LocalStack.
+* `FORCE_NONINTERACTIVE`: when running with Docker, disables the `--interactive` and `--tty` flags. Useful when running headless.
 
 Additionally, the following *read-only* environment variables are available:
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -369,6 +369,7 @@ def start_infra_in_docker():
     cmd = os.environ.get('CMD', '')
     image_name = os.environ.get('IMAGE_NAME', constants.DOCKER_IMAGE_NAME)
     service_ports = config.SERVICE_PORTS
+    force_noninteractive = os.environ.get('FORCE_NONINTERACTIVE', '')
 
     # construct port mappings
     ports_list = sorted(service_ports.values())
@@ -409,7 +410,7 @@ def start_infra_in_docker():
         data_dir_mount = '-v "%s:%s" ' % (data_dir, container_data_dir)
         env_str += '-e DATA_DIR="%s" ' % container_data_dir
 
-    interactive = '-it ' if not in_ci() else ''
+    interactive = '' if force_noninteractive or in_ci() else '-it '
 
     # append space if parameter is set
     entrypoint = '%s ' % entrypoint if entrypoint else entrypoint


### PR DESCRIPTION
I've added support for an env var of the name `FORCE_NONITERACTIVE`.
It disables the `-it` flags when running with Docker (i.e. `localstack start --docker`).

This solves an issue I've encountered when trying to make localstack run in the background (via [hote.dev)](https://github.com/typicode/hotel).

I'm aware that mimicking CI environment via the `CI`/`TRAVIS` var is possible and will achieve the same effect, but I didn't want to abuse this. 
