### PR TITLE
Execute lambda asynchronously for DynamoDB events

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -475,6 +475,8 @@ class LambdaExecutorLocal(LambdaExecutor):
             # TODO: add more event supporting async lambda execution
             if 'Sns' in event['Records'][0]:
                 async = True
+            if 'dynamodb' in event['Records'][0]:
+                async = True
         result, log_output = self.run_lambda_executor(cmd, async=async)
         LOG.debug('Lambda result / log output:\n%s\n> %s' % (result.strip(), log_output.strip().replace('\n', '\n> ')))
         return result, log_output

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -107,6 +107,13 @@ def test_lambda_runtimes():
     result_data = result['Payload'].read()
     assert json.loads(to_str(result_data)) == {'async': 'True'}
 
+    # test DDBEvent
+    result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA, InvocationType='Event',
+                                  Payload=b'{"Records": [{"dynamodb": {"Message": "{}"}}]}')
+    assert result['StatusCode'] == 200
+    result_data = result['Payload'].read()
+    assert json.loads(to_str(result_data)) == {'async': 'True'}
+
     # test KinesisEvent
     result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA,
                                   Payload=b'{"Records": [{"Kinesis": {"Data": "data", "PartitionKey": "partition"}}]}')


### PR DESCRIPTION
Very small change to execute lambda asynchronously when forwarding DynamoDB events. Without it we were seeing timeouts on calls to dynamo db clients.