### PR TITLE
Add support to get s3 bucket name from hostname

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,7 +1,11 @@
+import os
 import json
+import requests
 from localstack.utils.aws import aws_stack
 
 TEST_BUCKET_NAME_WITH_POLICY = 'test_bucket_policy_1'
+TEST_BUCKET_WITH_NOTIFICATION = 'test_bucket_notification_1'
+TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION = 'test_queue_for_bucket_notification_1'
 
 
 def test_bucket_policy():
@@ -33,3 +37,46 @@ def test_bucket_policy():
     # retrieve and check policy config
     saved_policy = s3_client.get_bucket_policy(Bucket=TEST_BUCKET_NAME_WITH_POLICY)['Policy']
     assert json.loads(saved_policy) == policy
+
+
+def test_s3_put_object_notification():
+
+    s3_client = aws_stack.connect_to_service('s3')
+    sqs_client = aws_stack.connect_to_service('sqs')
+
+    key_by_path = 'key-by-hostname'
+    key_by_host = 'key-by-host'
+
+    # create test queue
+    queue_url = sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
+    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
+
+    # create test bucket
+    s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+    s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                    NotificationConfiguration={'QueueConfigurations': [
+                                                        {'QueueArn': queue_attributes['Attributes']['QueueArn'],
+                                                         'Events': ['s3:ObjectCreated:*']}]})
+
+    # put an object where the bucket_name is in the path
+    s3_client.put_object(Bucket=TEST_BUCKET_WITH_NOTIFICATION, Key=key_by_path, Body='something')
+
+    # put an object where the bucket_name is in the host
+    # it doesn't care about the authorization header as long as it's present
+    headers = {'Host': '{}.s3.amazonaws.com'.format(TEST_BUCKET_WITH_NOTIFICATION), 'authorization': 'some_token'}
+    url = '{}/{}'.format(os.getenv('TEST_S3_URL'), key_by_host)
+    # verify=False must be set as this test fails on travis because of an SSL error non-existent locally
+    response = requests.put(url, data='something else', headers=headers, verify=False)
+    assert response.ok
+
+    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url,
+                                                       AttributeNames=['ApproximateNumberOfMessages'])
+    message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
+    # the ApproximateNumberOfMessages attribute is a string
+    assert message_count == '2'
+
+    # clean up
+    sqs_client.delete_queue(QueueUrl=queue_url)
+    s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                             Delete={'Objects': [{'Key': key_by_path}, {'Key': key_by_host}]})
+    s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,5 +1,6 @@
 import unittest
 from localstack.services.s3 import s3_listener, multipart_content
+from requests.models import CaseInsensitiveDict
 
 
 class S3ListenerTest (unittest.TestCase):
@@ -100,3 +101,69 @@ class S3ListenerTest (unittest.TestCase):
         self.assertIsNot(expanded3, data3, 'Should have changed content of string data with filename to interpolate')
         self.assertIn(b'uploads/20170826T181315.679087009Z/upload/pixel.txt', expanded3,
             'Should see the interpolated filename')
+
+    def test_get_bucket_name(self):
+        bucket_name = 'test-bucket'
+        s3_key = '/some-folder/some-key.txt'
+
+        hosts = ['s3-ap-northeast-1.amazonaws.com',
+                 's3-ap-northeast-2.amazonaws.com',
+                 's3-ap-south-1.amazonaws.com',
+                 's3-ap-southeast-1.amazonaws.com',
+                 's3-ap-southeast-2.amazonaws.com',
+                 's3-ca-central-1.amazonaws.com',
+                 's3-eu-central-1.amazonaws.com',
+                 's3-eu-west-1.amazonaws.com',
+                 's3-eu-west-2.amazonaws.com',
+                 's3-eu-west-3.amazonaws.com',
+                 's3-external-1.amazonaws.com',
+                 's3-sa-east-1.amazonaws.com',
+                 's3-us-east-2.amazonaws.com',
+                 's3-us-west-1.amazonaws.com',
+                 's3-us-west-2.amazonaws.com',
+                 's3.amazonaws.com',
+                 's3.ap-northeast-1.amazonaws.com',
+                 's3.ap-northeast-2.amazonaws.com',
+                 's3.ap-south-1.amazonaws.com',
+                 's3.ap-southeast-1.amazonaws.com',
+                 's3.ap-southeast-2.amazonaws.com',
+                 's3.ca-central-1.amazonaws.com',
+                 's3.cn-north-1.amazonaws.com.cn',
+                 's3.cn-northwest-1.amazonaws.com.cn',
+                 's3.dualstack.ap-northeast-1.amazonaws.com',
+                 's3.dualstack.ap-northeast-2.amazonaws.com',
+                 's3.dualstack.ap-south-1.amazonaws.com',
+                 's3.dualstack.ap-southeast-1.amazonaws.com',
+                 's3.dualstack.ap-southeast-2.amazonaws.com',
+                 's3.dualstack.ca-central-1.amazonaws.com',
+                 's3.dualstack.eu-central-1.amazonaws.com',
+                 's3.dualstack.eu-west-1.amazonaws.com',
+                 's3.dualstack.eu-west-2.amazonaws.com',
+                 's3.dualstack.eu-west-3.amazonaws.com',
+                 's3.dualstack.sa-east-1.amazonaws.com',
+                 's3.dualstack.us-east-1.amazonaws.com',
+                 's3.dualstack.us-east-2.amazonaws.com',
+                 's3.dualstack.us-west-1.amazonaws.com',
+                 's3.dualstack.us-west-2.amazonaws.com',
+                 's3.eu-central-1.amazonaws.com',
+                 's3.eu-west-1.amazonaws.com',
+                 's3.eu-west-2.amazonaws.com',
+                 's3.eu-west-3.amazonaws.com',
+                 's3.sa-east-1.amazonaws.com',
+                 's3.us-east-1.amazonaws.com',
+                 's3.us-east-2.amazonaws.com',
+                 's3.us-west-1.amazonaws.com',
+                 's3.us-west-2.amazonaws.com']
+
+        # test all available hosts with the bucket_name in the path
+        bucket_path = '/{}/{}'.format(bucket_name, s3_key)
+        for host in hosts:
+            headers = CaseInsensitiveDict({'Host': hosts[0]})
+            returned_bucket_name = s3_listener.get_bucket_name(bucket_path, headers)
+            self.assertEqual(returned_bucket_name, bucket_name, 'Should match when bucket_name is in path')
+
+        # test all available hosts with the bucket_name in the host and the path is only the s3_key
+        for host in hosts:
+            headers = CaseInsensitiveDict({'Host': '{}.{}'.format(bucket_name, host)})
+            returned_bucket_name = s3_listener.get_bucket_name(s3_key, headers)
+            self.assertEqual(returned_bucket_name, bucket_name, 'Should match when bucket_name is in the host')


### PR DESCRIPTION
Fixes #558 

Since the JavaScript AWS SDK uses another approach for putting objects than that of boto(3), this adds support for getting the bucket name from the host instead of only allowing it to be part of the `path`.

In addition, this also then uses the entire `path` as the object `key` [as per the documenation](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html#RESTObjectPUT-requests).

---

I couldn't get the entire test suite to run properly locally or inside docker due to the below error though, any suggestions here?

```
======================================================================
ERROR: tests.integration.test_integration.test_kinesis_lambda_sns_ddb_streams
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/localstack/.venv/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/opt/code/localstack/tests/integration/test_integration.py", line 94, in test_kinesis_lambda_sns_ddb_streams
    wait_until_started=True, ddb_lease_table_suffix=ddb_lease_table_suffix)
  File "/opt/code/localstack/localstack/utils/kinesis/kinesis_connector.py", line 435, in listen_to_kinesis
    raise Exception('Timeout when waiting for KCL initialization.')
Exception: Timeout when waiting for KCL initialization.
```