### PR TITLE
AWS S3 sets the content-type to `binary/octet-stream` for GET Requests

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -479,6 +479,8 @@ class ProxyListenerS3(ProxyListener):
             if isinstance(response._content, (six.string_types, six.binary_type)):
                 response.headers['content-length'] = len(response._content)
 
+            response.headers['content-type'] = 'binary/octet-stream'
+
 
 # instantiate listener
 UPDATE_S3 = ProxyListenerS3()

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -80,3 +80,19 @@ def test_s3_put_object_notification():
     s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
                              Delete={'Objects': [{'Key': key_by_path}, {'Key': key_by_host}]})
     s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+
+
+def test_s3_get_response_content_type():
+    bucket_name = 'test-bucket'
+    s3_client = aws_stack.connect_to_service('s3')
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    key_by_path = 'key-by-hostname'
+
+    s3_client.put_object(Bucket=bucket_name, Key=key_by_path, Body='something')
+    url = s3_client.generate_presigned_url(
+        'get_object', ExpiresIn=0, Params={'Bucket': bucket_name, 'Key': key_by_path}
+    )
+
+    response = requests.get(url)
+    assert response.headers['content-type'] == 'binary/octet-stream'


### PR DESCRIPTION
This allows a browser to download it as a file, rather then try to
render it in the browser.

fixes https://github.com/localstack/localstack/issues/564 
^^ issue contains reproduction steps and more detail