### PR TITLE
Lambda enhancements -- Docker configuration, including networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ localstack/infra/
 /.idea
 **/obj/**
 **/bin/**
+.vscode
+.idea
+tmp
+/.pydevproject

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ services:
 python:
   - "3.6"
 
-branches:
-  only:
-    - master
-
 before_install:
   - "sudo apt-get purge openjdk-6*"
   - "sudo apt-get purge openjdk-7*"
@@ -37,7 +33,8 @@ install:
 script:
   - set -e # fail fast
   # run tests using Python 3
-  - DEBUG=1 LAMBDA_EXECUTOR=docker TEST_ERROR_INJECTION=1 make test
+  - DEBUG=1 LAMBDA_EXECUTOR=docker make test
+  - DEBUG=1 LAMBDA_EXECUTOR=docker make test-lambdanet
   - LAMBDA_EXECUTOR=local USE_SSL=1 make test
   # run tests using Python 2
   #   Note: we're not using multiple versions in the top-level "python" configuration,
@@ -45,10 +42,16 @@ script:
   - "make reinstall-p2 > /dev/null"
   - make init
   - DEBUG=1 LAMBDA_EXECUTOR=docker-reuse USE_SSL=1 make test
-  # build Docker image
-  - make docker-build
+  - DEBUG=1 LAMBDA_EXECUTOR=docker-reuse make test-lambdanet
+  - DEBUG=1 LAMBDA_EXECUTOR=docker make test
+  - DEBUG=1 LAMBDA_EXECUTOR=docker make test-lambdanet
+  - LAMBDA_EXECUTOR=local USE_SSL=1 make test
   # run Java tests
   - make test-java-if-changed
+
+  # build Docker image
+  - make docker-build
+
   # push Docker image (if on master branch)
   - make docker-push-master
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ You can pass the following environment variables to LocalStack:
     - `false`: your Lambda function definitions will be passed to the container by mounting a
       volume (potentially faster). This requires to have the Docker client and the Docker
       host on the same machine.
+* `LAMBDA_DEFAULT_DOCKER_NETWORK`:
+    - When set, and running lambda functions in a docker container 
+      (LAMBDA_EXECUTOR=docker or docker-reuse) the docker container running the lambda function
+      will be attached to the docker network identified by LAMBDA_DEFAULT_DOCKER_NETWORK
+* `LAMBDA_SUBNET_AS_DOCKERNET`:
+    - When set to 1, and lambda functions are run in a docker container
+      (LAMBDA_EXECUTOR=docker or docker-reuse) if a lambda function is created with a vpc config,
+      the subnet identified in the vpc config will be used as the identifier of the docker network for the lambda function's docker container 
+* `LAMBDA_DOCKER_OPTIONS`:
+    - Specifies custom options to be passed to the docker engine as part of the docker run or docker create command.  
+
+        For example, to log lambda function output to a syslog server listening on the local host at port 5601, you can set LAMBDA_DOCKER_OPTIONS to:
+
+          --log-driver=syslog --log-opt=tag=lambda.$LAMBDA_FUNCTION_NAME --log-opt=syslog-address=tcp://127.0.0.1:5601
+
+
 * `DATA_DIR`: Local directory for saving persistent data (currently only supported for these services:
   Kinesis, DynamoDB, Elasticsearch, S3). Set it to `/tmp/localstack/data` to enable persistence
   (`/tmp/localstack` is mounted into the Docker container), leave blank to disable
@@ -180,7 +196,11 @@ Additionally, the following *read-only* environment variables are available:
   (e.g., to store an item to DynamoDB or S3 from Lambda).
   The variable `LOCALSTACK_HOSTNAME` is available for both, local Lambda execution
   (`LAMBDA_EXECUTOR=local`) and execution inside separate Docker containers (`LAMBDA_EXECUTOR=docker`).
+* `LAMBDA_FUNCTION_ARN` is  arn of the function executed
+* `LAMBDA_FUNCTION_NAME` is the name of the function being created/executed
 
+These variables can be referenced from within a lambda function, or in the value of the `LAMBDA_DOCKER_OPTIONS` or `LAMBDA_DEFAULT_DOCKER_NETWORK` variables specified above.
+ 
 ## Accessing the infrastructure via CLI or code
 
 You can point your `aws` CLI to use the local infrastructure, for example:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -60,6 +60,10 @@ if not LAMBDA_EXECUTOR:
     except Exception as e:
         pass
 
+LAMBDA_DEFAULT_DOCKER_NETWORK = os.environ.get('LAMBDA_DEFAULT_DOCKER_NETWORK', '').strip()
+LAMBDA_SUBNET_AS_DOCKERNET = os.environ.get('LAMBDA_SUBNET_AS_DOCKERNET', False)    
+LAMBDA_DOCKER_OPTIONS = ' ' + os.environ.get('LAMBDA_DOCKER_OPTIONS', '')
+
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -474,6 +474,7 @@ def format_func_details(func_details, version=None, always_add_version=False):
         'Handler': func_details.handler,
         'Runtime': func_details.runtime,
         'Timeout': func_details.timeout,
+        'VpcConfig': func_details.vpc_config,
         'Environment': func_details.envvars,
         # 'Description': ''
         # 'MemorySize': 192,
@@ -507,12 +508,15 @@ def create_function():
         if arn in arn_to_lambda:
             return error_response('Function already exist: %s' %
                 lambda_name, 409, error_type='ResourceConflictException')
+
         arn_to_lambda[arn] = func_details = LambdaFunction(arn)
         func_details.versions = {'$LATEST': {'CodeSize': 50}}
         func_details.handler = data['Handler']
         func_details.runtime = data['Runtime']
         func_details.envvars = data.get('Environment', {}).get('Variables', {})
         func_details.timeout = data.get('Timeout')
+        func_details.vpc_config = data.get('VpcConfig', {'SubnetIds': [], 'SecurityGroupIds': []})
+
         result = set_function_code(data['Code'], lambda_name)
         if isinstance(result, Response):
             del arn_to_lambda[arn]
@@ -648,6 +652,7 @@ def get_function_configuration(function):
         operationId: 'getFunctionConfiguration'
         parameters:
     """
+
     arn = func_arn(function)
     lambda_details = arn_to_lambda.get(arn)
     if not lambda_details:
@@ -680,6 +685,9 @@ def update_function_configuration(function):
         lambda_details.envvars = data.get('Environment', {}).get('Variables', {})
     if data.get('Timeout'):
         lambda_details.timeout = data['Timeout']
+    if data.get('VpcConfig'):
+        lambda_details.vpc_config = data['VpcConfig']
+
     result = {}
     return jsonify(result)
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -208,6 +208,7 @@ def setup_logging():
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('botocore').setLevel(logging.ERROR)
     logging.getLogger('elasticsearch').setLevel(logging.ERROR)
+    logging.getLogger('localstack.services.awslambda.lambda_api').setLevel(log_level)
 
 
 def get_service_protocol():

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -169,6 +169,7 @@ class LambdaFunction(Component):
         self.handler = None
         self.cwd = None
         self.timeout = None
+        self.vpc_config = None
 
     def get_version(self, version):
         return self.versions.get(version)

--- a/tests/integration/lambdas/lambda_python3_nwtest.py
+++ b/tests/integration/lambdas/lambda_python3_nwtest.py
@@ -1,0 +1,13 @@
+# simple test function that identifies the network it is running on
+# note: this requires a web server on the local docker network which will
+# with the alias "networkidentifier" that respond to the endpoingt /network.txt
+#
+# The makefile will set this up before running this test
+
+import requests
+
+
+def handler(event, context):
+    r = requests.get('http://networkidentifier/network.txt')
+    event['network'] = r.text
+    return event

--- a/tests/integration/nwfiles/custom/network.txt
+++ b/tests/integration/nwfiles/custom/network.txt
@@ -1,0 +1,1 @@
+custom network

--- a/tests/integration/nwfiles/default/network.txt
+++ b/tests/integration/nwfiles/default/network.txt
@@ -1,0 +1,1 @@
+default network

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -9,10 +9,12 @@ from localstack.utils.common import short_uid, load_file, to_str, mkdir, downloa
 from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.services.awslambda.lambda_api import (LAMBDA_RUNTIME_NODEJS, LAMBDA_RUNTIME_DOTNETCORE2,
     LAMBDA_RUNTIME_PYTHON27, LAMBDA_RUNTIME_PYTHON36, LAMBDA_RUNTIME_JAVA8, use_docker)
+from localstack import config
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_LAMBDA_PYTHON = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_integration.py')
 TEST_LAMBDA_PYTHON3 = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_python3.py')
+TEST_LAMBDA_PYTHON3_DOCKER_NETWORKING = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_python3_nwtest.py')
 TEST_LAMBDA_NODEJS = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_integration.js')
 TEST_LAMBDA_DOTNETCORE2 = os.path.join(THIS_FOLDER, 'lambdas', 'dotnetcore2', 'dotnetcore2.zip')
 TEST_LAMBDA_JAVA = os.path.join(LOCALSTACK_ROOT_FOLDER, 'localstack', 'infra', 'localstack-utils-tests.jar')
@@ -20,6 +22,7 @@ TEST_LAMBDA_ENV = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_environment.py')
 
 TEST_LAMBDA_NAME_PY = 'test_lambda_py'
 TEST_LAMBDA_NAME_PY3 = 'test_lambda_py3'
+TEST_LAMBDA_NAME_PY3_DN = 'test_lambda_py3_dn'
 TEST_LAMBDA_NAME_JS = 'test_lambda_js'
 TEST_LAMBDA_NAME_DOTNETCORE2 = 'test_lambda_dotnetcore2'
 TEST_LAMBDA_NAME_JAVA = 'test_lambda_java'
@@ -63,6 +66,61 @@ def test_upload_lambda_from_s3():
     result = lambda_client.invoke(FunctionName=lambda_name, Payload=data_before)
     data_after = result['Payload'].read()
     assert json.loads(to_str(data_before)) == json.loads(to_str(data_after))
+
+
+def test_lambda_docker_networking():
+    """Test ability to run lambas in specific docker networks"""
+
+    if use_docker() and (config.LAMBDA_DEFAULT_DOCKER_NETWORK or config.LAMBDA_SUBNET_AS_DOCKERNET):
+        lambda_client = aws_stack.connect_to_service('lambda')
+        # deploy and invoke lambda - Python 3.6
+        zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_PYTHON3_DOCKER_NETWORKING),
+                                                  get_content=True,
+                                                  libs=TEST_LAMBDA_LIBS,
+                                                  runtime=LAMBDA_RUNTIME_PYTHON36)
+
+        # make sure we can connect to the default network if configured
+        if config.LAMBDA_DEFAULT_DOCKER_NETWORK:
+            testutil.create_lambda_function(func_name=TEST_LAMBDA_NAME_PY3_DN,
+                                            zip_file=zip_file,
+                                            runtime=LAMBDA_RUNTIME_PYTHON36)
+            result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_PY3_DN,
+                                          Payload=b'{}')
+            assert result['StatusCode'] == 200
+            result_text = result['Payload'].read()
+            result_data = json.loads(result_text)
+            assert result_data['network'].strip() == 'default network'
+            lambda_client.delete_function(FunctionName=TEST_LAMBDA_NAME_PY3_DN)
+
+        # make sure we can connect to a specific network if configured
+        if config.LAMBDA_SUBNET_AS_DOCKERNET:
+            lambda_client.create_function(
+                FunctionName=TEST_LAMBDA_NAME_PY3_DN,
+                Code={
+                    'ZipFile': zip_file
+                },
+                VpcConfig={
+                    'SubnetIds': [
+                        'test_localstack_lambdanet_custom',
+                    ],
+                    'SecurityGroupIds': [
+                        'securitygroupsareignored',
+                    ]
+                },
+                Role='somerolewhichisignored',
+                Runtime=LAMBDA_RUNTIME_PYTHON36,
+                Handler='handler.handler'
+            )
+
+            result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_PY3_DN,
+                                          Payload=b'{}')
+
+            assert result['StatusCode'] == 200
+            result_text = result['Payload'].read()
+            result_data = json.loads(result_text)
+            assert result_data['network'].strip() == 'custom network'
+
+            lambda_client.delete_function(FunctionName=TEST_LAMBDA_NAME_PY3_DN)
 
 
 def test_lambda_runtimes():

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -62,6 +62,7 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result['Handler'] = str(self.HANDLER)
             expected_result['Runtime'] = str(self.RUNTIME)
             expected_result['Timeout'] = self.TIMEOUT
+            expected_result['VpcConfig'] = None
             expected_result['Version'] = '1'
             expected_result['Environment'] = {}
             expected_result2 = dict(expected_result)
@@ -94,6 +95,7 @@ class TestLambdaAPI(unittest.TestCase):
             latest_version['Runtime'] = str(self.RUNTIME)
             latest_version['Timeout'] = self.TIMEOUT
             latest_version['Version'] = '$LATEST'
+            latest_version['VpcConfig'] = None
             latest_version['Environment'] = {}
             version1 = dict(latest_version)
             version1['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':1'


### PR DESCRIPTION
   - Added support for identifying the docker network when running lambda functions in docker containers

    The docker network used when running lambda functions in a container may be specified with the LAMBDA_DEFAULT_DOCKER_NETWORK and LAMBDA_SUBNET_AS_DOCKERNET environment variables along with the subnet specified in the lambda's vpc config

   - Added environment variables specifying the function arn and function name
     for use in docker command options -- useful when combined with LAMBDA_DOCKER_OPTIONS
   - fixed issue where environment variables were not returned in get_function_configuration
   - Added support for custom docker actions when running lambda functions in docker containers
   custom options to be passed to docker can be specified via the LAMBDA_DOCKER_OPTIONS
   environment variables

   - Added test configurations for lambda docker network config
   - Added lambda networking test to travis build

While this pull request is active, I am maintaining a docker image with these changes in the docker registry by the name of gadgetjunkie/localstack.  Feel free to use it as you see fit.