### PR TITLE
Use same subject for lambda notications as other protocols

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -74,7 +74,7 @@ class ProxyListenerSNS(ProxyListener):
                     elif subscriber['Protocol'] == 'lambda':
                         lambda_api.process_sns_notification(
                             subscriber['Endpoint'],
-                            topic_arn, message, subject=req_data.get('Subject')
+                            topic_arn, message, subject=req_data.get('Subject', [None])[0]
                         )
                     elif subscriber['Protocol'] in ['http', 'https']:
                         requests.post(


### PR DESCRIPTION
     Without this fix, the subject was being sent to lambda functions as
     an array containing a single string i.e. [ "Subject" ], instead of just the string,
     which is the behavior for other subscription protocols, and is how
     it behaves in AWS
