### PR TITLE
S3 Fix: Set message subject when publishing to SNS

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -145,7 +145,7 @@ def send_notifications(method, bucket_name, object_path):
                 if config.get('Topic'):
                     sns_client = aws_stack.connect_to_service('sns')
                     try:
-                        sns_client.publish(TopicArn=config['Topic'], Message=message)
+                        sns_client.publish(TopicArn=config['Topic'], Message=message, Subject='Amazon S3 Notification')
                     except Exception as e:
                         LOGGER.warning('Unable to send notification for S3 bucket "%s" to SNS topic "%s".' %
                             (bucket_name, config['Topic']))


### PR DESCRIPTION
To be consistent with behavior in AWS, set SNS message subject to
'Amazon S3 Notification' when publishing to SNS in response to actions in S3.

Messages going to Lambda or SQS are unaffected.

Created a test for this in integrations/test_notifications.py
