### PR TITLE
 Cloudformation ListStackResources returns QueueUrl for PhysicalResourceId

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -33,7 +33,7 @@ RESOURCE_TO_FUNCTION = {
             'boto_client': 'resource',
             'function': 'create_queue',
             'parameters': {
-                'QueueName': 'QueueName'
+                'QueueName': PLACEHOLDER_RESOURCE_NAME
             }
         }
     },
@@ -291,7 +291,7 @@ def retrieve_resource_details(resource_id, resource_status, resources, stack_nam
             queues = aws_stack.connect_to_service('sqs').list_queues()
             result = list(filter(lambda item:
                 # TODO possibly find a better way to compare resource_id with queue URLs
-                item.endswith('/%s' % resource_id), queues['QueueUrls']))
+                item.endswith('/%s' % resource_id), queues.get('QueueUrls', [])))
             return result
         if resource_type == 'AWS::S3::Bucket':
             return aws_stack.connect_to_service('s3').get_bucket_location(Bucket=resource_id)

--- a/tests/integration/templates/template1.yaml
+++ b/tests/integration/templates/template1.yaml
@@ -14,3 +14,6 @@ Resources:
     Type: AWS::Kinesis::Stream
     Properties:
       Name: cf-test-stream-1
+  SQSQueueNoNameProperty:
+    Type: AWS::SQS::Queue
+

--- a/tests/integration/templates/template2.yaml
+++ b/tests/integration/templates/template2.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Simple CloudFormation Test Template
+Resources:
+  SQSQueue1:
+    Type: AWS::SQS::Queue
+  SQSQueue2:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: cf-test-queue-2

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -8,8 +8,10 @@ from botocore.parsers import ResponseParserError
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_TEMPLATE_1 = os.path.join(THIS_FOLDER, 'templates', 'template1.yaml')
+TEST_TEMPLATE_2 = os.path.join(THIS_FOLDER, 'templates', 'template2.yaml')
 
 TEST_STACK_NAME = 'test-cf-stack-1'
+TEST_STACK_NAME_2 = 'test-cf-stack-2'
 
 
 def bucket_exists(name):
@@ -28,6 +30,12 @@ def queue_exists(name):
             return True
 
 
+def queue_url_exists(queue_url):
+    sqs_client = aws_stack.connect_to_service('sqs')
+    queues = sqs_client.list_queues()
+    return queue_url in queues['QueueUrls']
+
+
 def stream_exists(name):
     kinesis_client = aws_stack.connect_to_service('kinesis')
     streams = kinesis_client.list_streams()
@@ -36,10 +44,30 @@ def stream_exists(name):
 
 def get_stack_details(stack_name):
     cloudformation = aws_stack.connect_to_service('cloudformation')
-    stacks = cloudformation.describe_stacks(StackName=TEST_STACK_NAME)
+    stacks = cloudformation.describe_stacks(StackName=stack_name)
     for stack in stacks['Stacks']:
         if stack['StackName'] == stack_name:
             return stack
+
+
+def describe_stack_resource(stack_name, resource_logical_id):
+    cloudformation = aws_stack.connect_to_service('cloudformation')
+    response = cloudformation.describe_stack_resources(StackName=stack_name)
+    for resource in response['StackResources']:
+        if resource['LogicalResourceId'] == resource_logical_id:
+            return resource
+
+
+def list_stack_resources(stack_name):
+    cloudformation = aws_stack.connect_to_service('cloudformation')
+    response = cloudformation.list_stack_resources(StackName=stack_name)
+    return response['StackResourceSummaries']
+
+
+def get_queue_urls():
+    sqs = aws_stack.connect_to_service('sqs')
+    response = sqs.list_queues()
+    return response['QueueUrls']
 
 
 class CloudFormationTest(unittest.TestCase):
@@ -64,6 +92,9 @@ class CloudFormationTest(unittest.TestCase):
         assert queue_exists('cf-test-queue-1')
         # assert that stream has been created
         assert stream_exists('cf-test-stream-1')
+        # assert that queue has been created
+        resource = describe_stack_resource(TEST_STACK_NAME, 'SQSQueueNoNameProperty')
+        assert queue_exists(resource['PhysicalResourceId'])
 
     def test_validate_template(self):
         cloudformation = aws_stack.connect_to_service('cloudformation')
@@ -82,3 +113,20 @@ class CloudFormationTest(unittest.TestCase):
             if isinstance(err, ClientError):
                 assert err.response['ResponseMetadata']['HTTPStatusCode'] == 400
                 assert err.response['Error']['Message'] == 'Template Validation Error'
+
+    def test_list_stack_resources_returns_queue_urls(self):
+        cloudformation = aws_stack.connect_to_resource('cloudformation')
+        template = template_deployer.template_to_json(load_file(TEST_TEMPLATE_2))
+        cloudformation.create_stack(StackName=TEST_STACK_NAME_2, TemplateBody=template)
+
+        def check_stack():
+            stack = get_stack_details(TEST_STACK_NAME_2)
+            assert stack['StackStatus'] == 'CREATE_COMPLETE'
+
+        retry(check_stack, retries=3, sleep=2)
+
+        list_stack_summaries = list_stack_resources(TEST_STACK_NAME_2)
+        queue_urls = get_queue_urls()
+
+        for resource in list_stack_summaries:
+            assert resource['PhysicalResourceId'] in queue_urls


### PR DESCRIPTION
In Cloudformation the PhysicalResourceId of a SQS resource is the QueueUrl. Implemented this for ListQueueResources.

This should also be the case for DescribeStackResources/DescribeStackResource but it's very tightly connected to the template_deployer functionality.

With this pull request, Spring Cloud AWS Messaging works with localstack :D