### PR TITLE
Enhance docker test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ public class MyCloudAppTest {
 }
 ```
 
+Additionally, there is a version of the *LocalStack* Test Runner which runs in a docker container 
+instead of installing *LocalStack* on the current machine.  The only dependency is to have docker 
+installed locally. The test runner will automatically pull the image and start the container for the
+duration of the test.  The container can be configured by using the @LocalstackDockerProperties annotation.
+
+```
+@RunWith(LocalstackDockerTestRunner.class)
+@LocalstackDockerProperties(randomizePorts = true)
+public class MyDockerCloudAppTest {
+
+  @Test
+  public void testKinesis() {
+    AmazonKinesis kinesis = DockerTestUtils.getClientKinesis();
+
+    ListStreamsResult streams = kinesis.listStreams();
+    ...
+```
+
 The *LocalStack* JUnit test runner is published as an artifact in Maven Central.
 Simply add the following dependency to your `pom.xml` file:
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/DefaultEnvironmentVariableProvider.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/DefaultEnvironmentVariableProvider.java
@@ -1,0 +1,13 @@
+package cloud.localstack.docker.annotation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultEnvironmentVariableProvider implements IEnvironmentVariableProvider {
+
+    @Override
+    public Map<String, String> getEnvironmentVariables() {
+        return new HashMap<>();
+    }
+
+}

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/IEnvironmentVariableProvider.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/IEnvironmentVariableProvider.java
@@ -1,0 +1,8 @@
+package cloud.localstack.docker.annotation;
+
+import java.util.Map;
+
+public interface IEnvironmentVariableProvider {
+
+    Map<String, String> getEnvironmentVariables();
+}

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalHostNameResolver.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalHostNameResolver.java
@@ -1,0 +1,12 @@
+package cloud.localstack.docker.annotation;
+
+/**
+ * A default host name resolver
+ */
+public class LocalHostNameResolver implements IHostNameResolver {
+
+    @Override
+    public String getHostName() {
+        return "localhost";
+    }
+}

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -12,6 +12,27 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 public @interface LocalstackDockerProperties {
 
-    Class<? extends IHostNameResolver> hostNameResolver();
+    /**
+     * Used for determining the host name of the machine running the docker containers
+     * so that the containers can be addressed.
+     */
+    Class<? extends IHostNameResolver> hostNameResolver() default LocalHostNameResolver.class;
+
+    /**
+     * Used for injecting environment variables into the container.  Implement a class that provides a map of the environment
+     * variables and they will be injected into the container on start-up
+     */
+    Class<? extends IEnvironmentVariableProvider> environmentVariableProvider() default DefaultEnvironmentVariableProvider.class;
+
+    /**
+     * Determines if a new image is pulled from the docker repo before the tests are run.
+     */
+    boolean pullNewImage() default true;
+
+    /**
+     * Determines if the container should expose the default local stack ports (4567-4583) or if it should expose randomized ports
+     *  in order to prevent conflicts with other localstack containers running on the same machine
+     */
+    boolean randomizePorts() default false;
 }
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/command/RunCommand.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/command/RunCommand.java
@@ -22,8 +22,9 @@ public class RunCommand extends Command {
         return dockerExe.execute(args);
     }
 
-    public RunCommand withExposedPorts(String portsToExpose) {
-        addOptions("-p", ":" + portsToExpose);
+    public RunCommand withExposedPorts(String portsToExpose, boolean randomize) {
+        String portsOption = String.format("%s:%s", randomize ? "" : portsToExpose, portsToExpose );
+        addOptions("-p", portsOption);
         return this;
     }
 

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/BasicDockerFunctionalityTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/BasicDockerFunctionalityTest.java
@@ -45,11 +45,10 @@ import com.amazonaws.util.IOUtils;
 
 import cloud.localstack.DockerTestUtils;
 import cloud.localstack.TestUtils;
-import cloud.localstack.docker.annotation.EC2HostNameResolver;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 
 @RunWith(LocalstackDockerTestRunner.class)
-@LocalstackDockerProperties(hostNameResolver = EC2HostNameResolver.class)
+@LocalstackDockerProperties(randomizePorts = true)
 public class BasicDockerFunctionalityTest {
 
     static {

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class ContainerTest {
 
@@ -19,7 +20,7 @@ public class ContainerTest {
 
         HashMap<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(MY_PROPERTY, MY_VALUE);
-        Container localStackContainer = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, environmentVariables);
+        Container localStackContainer = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, true, true, environmentVariables);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -43,6 +44,40 @@ public class ContainerTest {
         args.add("-c");
         args.add(String.format("echo $%s", valueToEcho));
         return args;
+    }
+
+
+    @Test
+    public void createLocalstackContainerWithRandomPorts() throws Exception {
+        Container container = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, true, true, new HashMap<>());
+
+        try {
+            container.waitForAllPorts(EXTERNAL_HOST_NAME);
+
+            assertNotEquals(4567, container.getExternalPortFor(4567));
+            assertNotEquals(4575, container.getExternalPortFor(4575));
+            assertNotEquals(4583, container.getExternalPortFor(4583));
+        }
+        finally {
+            container.stop();
+        }
+    }
+
+
+    @Test
+    public void createLocalstackContainerWithStaticPorts() throws Exception {
+        Container container = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, true, false, new HashMap<>());
+
+        try {
+            container.waitForAllPorts(EXTERNAL_HOST_NAME);
+
+            assertEquals(4567, container.getExternalPortFor(4567));
+            assertEquals(4575, container.getExternalPortFor(4575));
+            assertEquals(4583, container.getExternalPortFor(4583));
+        }
+        finally {
+            container.stop();
+        }
     }
 
 }


### PR DESCRIPTION
I've added the ability to better configure the container through the LocalstackDockerProperties annotation.  The annotation will allow you to:

- Skip the pull new image step before tests
- Choose if the ports are randomized or not (this now defaults to not-random)
- Inject Environment Variables by implementing an IEnvironmentVariableProvider
- Allow for custom behaviour when resolving the host name of the containers by implementing an IHostNameResolver
