### PR TITLE
Instead of trying to set the default content-type on GET, set it on PUT

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -348,6 +348,11 @@ class ProxyListenerS3(ProxyListener):
             if expanded_data is not original_data:
                 modified_data = expanded_data
 
+        # If no content-type is provided, 'binary/octet-stream' should be used
+        # src: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
+        if method == 'PUT' and not headers.get('content-type'):
+            headers['content-type'] = 'binary/octet-stream'
+
         # persist this API call to disk
         persistence.record('s3', method, path, data, headers)
 
@@ -486,10 +491,6 @@ class ProxyListenerS3(ProxyListener):
         if response:
             # append CORS headers to response
             append_cors_headers(bucket_name, request_method=method, request_headers=headers, response=response)
-
-            if response._content:
-                # default content type; possibly overwritten with "text/xml" for API calls further below
-                response.headers['Content-Type'] = 'binary/octet-stream'
 
             response_content_str = None
             try:


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
, if there is a PUT without a content-type, 'binary/octet-stream' will be used
as the default.

This changes the previous attempt at fixing this default, which was just setting
the content-type for GET's, which would override the content type of the
uploaded file, rather then respect the original uploaded content-type, like it
should have.

Fixes https://github.com/localstack/localstack/issues/581

This functionally Reverts https://github.com/localstack/localstack/pull/565 , which incorrectly fixed #564 . 

Thanks for the help identifying this @viniciuskneves !
