### PR TITLE
Increase docker pull timeout

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/Container.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/Container.java
@@ -46,9 +46,9 @@ public class Container {
      */
     public static Container createLocalstackContainer(String externalHostName, boolean pullNewImage,
                                                       boolean randomizePorts, Map<String, String> environmentVariables) {
-        LOG.info("Pulling latest image...");
 
         if(pullNewImage) {
+            LOG.info("Pulling latest image...");
             new PullCommand(LOCALSTACK_NAME).execute();
         }
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/DockerExe.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/DockerExe.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class DockerExe {
 
-    private static final int WAIT_TIMEOUT_MINUTES = 3;
+    private static final int DEFAULT_WAIT_TIME_MINUTES = 1;
 
     private static final List<String> POSSIBLE_EXE_LOCATIONS = Arrays.asList(
             System.getenv("DOCKER_LOCATION"),
@@ -48,6 +48,10 @@ public class DockerExe {
 
 
     public String execute(List<String> args) {
+        return execute(args, DEFAULT_WAIT_TIME_MINUTES);
+    }
+
+    public String execute(List<String> args, int waitTimeoutMinutes) {
         try {
             List<String> command = new ArrayList<>();
             command.add(exeLocation);
@@ -61,8 +65,8 @@ public class DockerExe {
             ExecutorService exec = newSingleThreadExecutor();
             Future<String> outputFuture = exec.submit(() -> handleOutput(process));
 
-            String output = outputFuture.get(WAIT_TIMEOUT_MINUTES, TimeUnit.MINUTES);
-            process.waitFor(WAIT_TIMEOUT_MINUTES, TimeUnit.MINUTES);
+            String output = outputFuture.get(waitTimeoutMinutes, TimeUnit.MINUTES);
+            process.waitFor(waitTimeoutMinutes, TimeUnit.MINUTES);
             exec.shutdown();
 
             return output;

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/command/PullCommand.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/command/PullCommand.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 public class PullCommand extends Command {
 
+    private static final int PULL_COMMAND_TIMEOUT_MINUTES = 10;
     private static final String LATEST_TAG = "latest";
 
     private final String imageName;
@@ -15,6 +16,6 @@ public class PullCommand extends Command {
 
     public void execute() {
         String image = String.format("%s:%s", imageName, LATEST_TAG);
-        dockerExe.execute(Arrays.asList("pull", image));
+        dockerExe.execute(Arrays.asList("pull", image), PULL_COMMAND_TIMEOUT_MINUTES);
     }
 }


### PR DESCRIPTION
We were getting intermittent test failures with the DockerTestRunner because the timeout for the Pull command was too short.  Pull command now has 10 minutes to complete.  Default for the rest of the commands is 1 minute.
