### PR TITLE
Mock missing local DynamoDB apis to avoid Terraform exceptions

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -138,12 +138,14 @@ class ProxyListenerDynamoDB(ProxyListener):
                 create_dynamodb_stream(data)
             return
         elif action == '%s.UpdateTimeToLive' % ACTION_PREFIX:
+            # TODO: TTL status is maintained/mocked but no real expiry is happening for items
             ProxyListenerDynamoDB.table_ttl_map[data['TableName']] = {
                 'AttributeName': data['TimeToLiveSpecification']['AttributeName'],
                 'Status': data['TimeToLiveSpecification']['Enabled']
             }
             response.status_code = 200
             response._content = json.dumps({'TimeToLiveSpecification': data['TimeToLiveSpecification']})
+            fix_headers_for_updated_response(response)
             return
         elif action == '%s.DescribeTimeToLive' % ACTION_PREFIX:
             response.status_code = 200
@@ -160,14 +162,17 @@ class ProxyListenerDynamoDB(ProxyListener):
                 })
             else:  # TTL for dynamodb table not set
                 response._content = json.dumps({'TimeToLiveDescription': {'TimeToLiveStatus': 'DISABLED'}})
+            fix_headers_for_updated_response(response)
             return
         elif action == '%s.TagResource' % ACTION_PREFIX or action == '%s.UntagResource' % ACTION_PREFIX:
             response.status_code = 200
-            response._content = {}
+            response._content = ''  # TODO: this api is mocked for now and always returns success.
+            fix_headers_for_updated_response(response)
             return
         elif action == '%s.ListTagsOfResource' % ACTION_PREFIX:
             response.status_code = 200
-            response._content = {}
+            response._content = json.dumps({'Tags': []})  # TODO: mocked and returns an empty list of tags for now.
+            fix_headers_for_updated_response(response)
             return
         else:
             # nothing to do

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -27,7 +27,9 @@ LOGGER = logging.getLogger(__name__)
 class ProxyListenerDynamoDB(ProxyListener):
 
     thread_local = threading.local()
-    table_ttl_map = {}
+
+    def __init__(self):
+        self._table_ttl_map = {}
 
     def forward_request(self, method, path, data, headers):
         data = json.loads(to_str(data))
@@ -40,6 +42,36 @@ class ProxyListenerDynamoDB(ProxyListener):
             # find an existing item and store it in a thread-local, so we can access it in return_response,
             # in order to determine whether an item already existed (MODIFY) or not (INSERT)
             ProxyListenerDynamoDB.thread_local.existing_item = find_existing_item(data)
+        elif action == '%s.DescribeTimeToLive' % ACTION_PREFIX:
+            response = Response()
+            response.status_code = 200
+            if data['TableName'] in self._table_ttl_map:
+                if self._table_ttl_map[data['TableName']]['Status']:
+                    ttl_status = 'ENABLED'
+                else:
+                    ttl_status = 'DISABLED'
+                response._content = json.dumps({
+                    'TimeToLiveDescription': {
+                        'AttributeName': self._table_ttl_map[data['TableName']]['AttributeName'],
+                        'TimeToLiveStatus': ttl_status
+                    }
+                })
+            else:  # TTL for dynamodb table not set
+                response._content = json.dumps({'TimeToLiveDescription': {'TimeToLiveStatus': 'DISABLED'}})
+            fix_headers_for_updated_response(response)
+            return response
+        elif action == '%s.TagResource' % ACTION_PREFIX or action == '%s.UntagResource' % ACTION_PREFIX:
+            response = Response()
+            response.status_code = 200
+            response._content = ''  # returns an empty body on success.
+            fix_headers_for_updated_response(response)
+            return response
+        elif action == '%s.ListTagsOfResource' % ACTION_PREFIX:
+            response = Response()
+            response.status_code = 200
+            response._content = json.dumps({'Tags': []})  # TODO: mocked and returns an empty list of tags for now.
+            fix_headers_for_updated_response(response)
+            return response
 
         return True
 
@@ -139,39 +171,12 @@ class ProxyListenerDynamoDB(ProxyListener):
             return
         elif action == '%s.UpdateTimeToLive' % ACTION_PREFIX:
             # TODO: TTL status is maintained/mocked but no real expiry is happening for items
-            ProxyListenerDynamoDB.table_ttl_map[data['TableName']] = {
+            self._table_ttl_map[data['TableName']] = {
                 'AttributeName': data['TimeToLiveSpecification']['AttributeName'],
                 'Status': data['TimeToLiveSpecification']['Enabled']
             }
             response.status_code = 200
             response._content = json.dumps({'TimeToLiveSpecification': data['TimeToLiveSpecification']})
-            fix_headers_for_updated_response(response)
-            return
-        elif action == '%s.DescribeTimeToLive' % ACTION_PREFIX:
-            response.status_code = 200
-            if data['TableName'] in ProxyListenerDynamoDB.table_ttl_map:
-                if ProxyListenerDynamoDB.table_ttl_map[data['TableName']]['Status']:
-                    ttl_status = 'ENABLED'
-                else:
-                    ttl_status = 'DISABLED'
-                response._content = json.dumps({
-                    'TimeToLiveDescription': {
-                        'AttributeName': ProxyListenerDynamoDB.table_ttl_map[data['TableName']]['AttributeName'],
-                        'TimeToLiveStatus': ttl_status
-                    }
-                })
-            else:  # TTL for dynamodb table not set
-                response._content = json.dumps({'TimeToLiveDescription': {'TimeToLiveStatus': 'DISABLED'}})
-            fix_headers_for_updated_response(response)
-            return
-        elif action == '%s.TagResource' % ACTION_PREFIX or action == '%s.UntagResource' % ACTION_PREFIX:
-            response.status_code = 200
-            response._content = ''  # TODO: this api is mocked for now and always returns success.
-            fix_headers_for_updated_response(response)
-            return
-        elif action == '%s.ListTagsOfResource' % ACTION_PREFIX:
-            response.status_code = 200
-            response._content = json.dumps({'Tags': []})  # TODO: mocked and returns an empty list of tags for now.
             fix_headers_for_updated_response(response)
             return
         else:

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -136,6 +136,23 @@ class ProxyListenerDynamoDB(ProxyListener):
             if 'StreamSpecification' in data:
                 create_dynamodb_stream(data)
             return
+        elif action == '%s.UpdateTimeToLive' % ACTION_PREFIX:
+            response.status_code = 200
+            # Accepts the recquest but ignores TLL as not supported in local DynamoDB
+            response._content = json.dumps({'TimeToLiveSpecification': data['TimeToLiveSpecification']})
+            return
+        elif action == '%s.DescribeTimeToLive' % ACTION_PREFIX:
+            response.status_code = 200
+            response._content = json.dumps({'TimeToLiveDescription': {'TimeToLiveStatus': 'DISABLED'}})
+            return
+        elif action == '%s.TagResource' % ACTION_PREFIX or action == '%s.UntagResource' % ACTION_PREFIX:
+            response.status_code = 200
+            response._content = {}
+            return
+        elif action == '%s.ListTagsOfResource' % ACTION_PREFIX:
+            response.status_code = 200
+            response._content = {}
+            return
         else:
             # nothing to do
             return

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -116,7 +116,7 @@ class DynamoDBIntegrationTest (unittest.TestCase):
             'Tags': [{'tagkey1': 'tagvalue1'}, {'tagkey2': 'tagvalue2'}, {'tagkey3': 'tagvalue3'}]
         }))
         assert response.status_code == 200
-        assert response._content == ''  # Empty string if tagging succeeded (mocked for now)
+        assert not response._content  # Empty string if tagging succeeded (mocked for now)
 
     def test_untag_resource(self):
         response = testutil.send_dynamodb_request('', action='UntagResource', request_body=json.dumps({
@@ -124,7 +124,7 @@ class DynamoDBIntegrationTest (unittest.TestCase):
             'TagKeys': ['tagkey1', 'tagkey2']  # Keys to untag
         }))
         assert response.status_code == 200
-        assert response._content == ''  # Empty string if untagging succeeded (mocked for now)
+        assert not response._content  # Empty string if untagging succeeded (mocked for now)
 
     def test_list_tags_of_resource(self):
         response = testutil.send_dynamodb_request('', action='ListTagsOfResource', request_body=json.dumps({

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import json
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import json_safe
 
 TEST_DDB_TABLE_NAME = 'test-ddb-table-1'
 TEST_DDB_TABLE_NAME_2 = 'test-ddb-table-2'
+TEST_DDB_TABLE_NAME_3 = 'test-ddb-table-3'
 PARTITION_KEY = 'id'
 
 
@@ -53,3 +55,80 @@ class DynamoDBIntegrationTest (unittest.TestCase):
 
         # Clean up
         dynamodb_client.delete_table(TableName=TEST_DDB_TABLE_NAME_2)
+
+    def test_time_to_live(self):
+        dynamodb = aws_stack.connect_to_resource('dynamodb')
+        dynamodb_client = aws_stack.connect_to_service('dynamodb')
+
+        testutil.create_dynamodb_table(TEST_DDB_TABLE_NAME_3, partition_key=PARTITION_KEY)
+        table = dynamodb.Table(TEST_DDB_TABLE_NAME_3)
+
+        # Insert some items to the table
+        items = {
+            'id1': {PARTITION_KEY: 'id1', 'data': 'IT IS'},
+            'id2': {PARTITION_KEY: 'id2', 'data': 'TIME'},
+            'id3': {PARTITION_KEY: 'id3', 'data': 'TO LIVE!'}
+        }
+        for k, item in items.items():
+            table.put_item(Item=item)
+
+        # Describe TTL when still unset.
+        response = testutil.send_describe_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveDescription']['TimeToLiveStatus'] == 'DISABLED'
+
+        # Enable TTL for given table
+        response = testutil.send_update_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3, True)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveSpecification']['Enabled'] is True
+
+        # Describe TTL status after being enabled.
+        response = testutil.send_describe_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveDescription']['TimeToLiveStatus'] == 'ENABLED'
+
+        # Disable TTL for given table
+        response = testutil.send_update_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3, False)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveSpecification']['Enabled'] is False
+
+        # Describe TTL status after being disabled.
+        response = testutil.send_describe_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveDescription']['TimeToLiveStatus'] == 'DISABLED'
+
+        # Enable TTL for given table again
+        response = testutil.send_update_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3, True)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveSpecification']['Enabled'] is True
+
+        # Describe TTL status after being enabled again.
+        response = testutil.send_describe_dynamodb_ttl_request(TEST_DDB_TABLE_NAME_3)
+        assert response.status_code == 200
+        assert json.loads(response._content)['TimeToLiveDescription']['TimeToLiveStatus'] == 'ENABLED'
+
+        # Clean up table
+        dynamodb_client.delete_table(TableName=TEST_DDB_TABLE_NAME_3)
+
+    def test_tag_resource(self):
+        response = testutil.send_dynamodb_request('', action='TagResource', request_body=json.dumps({
+            'ResourceArn': testutil.get_sample_arn('dynamodb', 'table'),
+            'Tags': [{'tagkey1': 'tagvalue1'}, {'tagkey2': 'tagvalue2'}, {'tagkey3': 'tagvalue3'}]
+        }))
+        assert response.status_code == 200
+        assert response._content == ''  # Empty string if tagging succeeded (mocked for now)
+
+    def test_untag_resource(self):
+        response = testutil.send_dynamodb_request('', action='UntagResource', request_body=json.dumps({
+            'ResourceArn': testutil.get_sample_arn('dynamodb', 'table'),
+            'TagKeys': ['tagkey1', 'tagkey2']  # Keys to untag
+        }))
+        assert response.status_code == 200
+        assert response._content == ''  # Empty string if untagging succeeded (mocked for now)
+
+    def test_list_tags_of_resource(self):
+        response = testutil.send_dynamodb_request('', action='ListTagsOfResource', request_body=json.dumps({
+            'ResourceArn': testutil.get_sample_arn('dynamodb', 'table')
+        }))
+        assert response.status_code == 200
+        assert json.loads(response._content)['Tags'] == []  # Empty list returned


### PR DESCRIPTION
- Mocks UpdateTimeToLive, DescribeTimeToLive, TagResource, UntagResource & ListTagsOfResource apis as they are not implemented in DynamoDB.
- Default response for DescribeTimeToLive is DISABLED.
- Fixes [this](https://github.com/terraform-providers/terraform-provider-aws/issues/1059) issue when integrating Terraform with localstack endpoints

Tested on terraform with dynamodb endpoint redirected to localstack dynamodb endpoint where the dynamodb tables in terraform files have ttl & tags attributes.
