### PR TITLE
add support for lambda GetEventSourceMapping

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -692,6 +692,23 @@ def list_event_source_mappings():
     return jsonify(response)
 
 
+@app.route('%s/event-source-mappings/<mapping_uuid>' % PATH_ROOT, methods=['GET'])
+def get_event_source_mapping(mapping_uuid):
+    """ Get an existing event source mapping
+        ---
+        operationId: 'getEventSourceMapping'
+        parameters:
+            - name: 'request'
+              in: body
+    """
+    mappings = event_source_mappings
+    mappings = [m for m in mappings if mapping_uuid == m.get('UUID')]
+
+    if len(mappings) == 0:
+        return error_response('The resource you requested does not exist.', 404, error_type='ResourceNotFoundException')
+    return jsonify(mappings[0])
+
+
 @app.route('%s/event-source-mappings/' % PATH_ROOT, methods=['POST'])
 def create_event_source_mapping():
     """ Create new event source mapping

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -27,6 +27,12 @@ class TestLambdaAPI(unittest.TestCase):
         self.app.testing = True
         self.client = self.app.test_client()
 
+    def test_get_event_source_mapping(self):
+        with self.app.test_request_context():
+            lambda_api.event_source_mappings.append({'UUID': self.TEST_UUID})
+            result = lambda_api.get_event_source_mapping(self.TEST_UUID)
+            self.assertEqual(json.loads(result.get_data()).get('UUID'), self.TEST_UUID)
+
     def test_delete_event_source_mapping(self):
         with self.app.test_request_context():
             lambda_api.event_source_mappings.append({'UUID': self.TEST_UUID})


### PR DESCRIPTION
See #648

Supports:

https://docs.aws.amazon.com/lambda/latest/dg/API_GetEventSourceMapping.html

```
aws lambda get-event-source-mapping --uuid cef34cb4-39d9-497d-8a6e-3a7438d77826 --endpoint http://localhost:4574
```

[Terraform](https://www.terraform.io) makes this call to do it's thing.