### PR TITLE
add support for lambda PutFunctionConcurrency

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -509,6 +509,9 @@ def get_function(function):
                     'Location': '%s/code' % request.url
                 }
             }
+            lambda_details = arn_to_lambda.get(func['FunctionArn'])
+            if lambda_details.concurrency is not None:
+                result['Concurrency'] = lambda_details.concurrency
             return jsonify(result)
     result = {
         'ResponseMetadata': {
@@ -791,6 +794,20 @@ def list_aliases(function):
         return error_response('Function not found: %s' % arn, 404, error_type='ResourceNotFoundException')
     return jsonify({'Aliases': sorted(arn_to_lambda.get(arn).aliases.values(),
                                       key=lambda x: x['Name'])})
+
+
+@app.route('/<version>/functions/<function>/concurrency', methods=['PUT'])
+def put_concurrency(version, function):
+    # the version for put_concurrency != PATH_ROOT, at the time of this
+    # writing it's: /2017-10-31 for this endpoint
+    # https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionConcurrency.html
+    arn = func_arn(function)
+    data = json.loads(request.data)
+    lambda_details = arn_to_lambda.get(arn)
+    if not lambda_details:
+        return error_response('Function not found: %s' % arn, 404, error_type='ResourceNotFoundException')
+    lambda_details.concurrency = data
+    return jsonify(data)
 
 
 def serve(port, quiet=True):

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -164,6 +164,7 @@ class LambdaFunction(Component):
         self.versions = {}
         self.aliases = {}
         self.envvars = {}
+        self.concurrency = None
         self.runtime = None
         self.handler = None
         self.cwd = None

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -207,6 +207,35 @@ class TestLambdaAPI(unittest.TestCase):
         name = executor.get_container_name('arn:aws:lambda:us-east-1:00000000:function:my_function_name')
         self.assertEqual(name, 'localstack_lambda_arn_aws_lambda_us-east-1_00000000_function_my_function_name')
 
+    def test_put_concurrency(self):
+        with self.app.test_request_context():
+            self._create_function(self.FUNCTION_NAME)
+            # note: PutFunctionConcurrency is mounted at: /2017-10-31
+            # NOT lambda_api.PATH_ROOT
+            # https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionConcurrency.html
+            concurrency_data = {'ReservedConcurrentExecutions': 10}
+            response = self.client.put('/2017-10-31/functions/{0}/concurrency'.format(self.FUNCTION_NAME),
+                                       data=json.dumps(concurrency_data))
+
+            result = json.loads(response.get_data())
+            self.assertDictEqual(concurrency_data, result)
+
+    def test_concurrency_get_function(self):
+        with self.app.test_request_context():
+            self._create_function(self.FUNCTION_NAME)
+            # note: PutFunctionConcurrency is mounted at: /2017-10-31
+            # NOT lambda_api.PATH_ROOT
+            # https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionConcurrency.html
+            concurrency_data = {'ReservedConcurrentExecutions': 10}
+            self.client.put('/2017-10-31/functions/{0}/concurrency'.format(self.FUNCTION_NAME),
+                            data=json.dumps(concurrency_data))
+
+            response = self.client.get('{0}/functions/{1}'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
+
+            result = json.loads(response.get_data())
+            self.assertTrue('Concurrency' in result)
+            self.assertDictEqual(concurrency_data, result['Concurrency'])
+
     def _create_function(self, function_name):
         arn = lambda_api.func_arn(function_name)
         lambda_api.arn_to_lambda[arn] = LambdaFunction(arn)


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionConcurrency.html

Additionally alters GetFunction to return the `Concurrency` key.

See Concurrency response example here:

https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html

Using tools like CloudFormation or Terraform the user can set the concurrency limit. For the purposes of localstack this doesn't have to do anything as it's for local testing only. I don't think the expectation would be there that this actually supports the requested level of concurrency.

But the ability to run CloudFormation or Terraform allows teams to mock that implementation and go from there with their testing.

