### PR TITLE
Extracting the container logic from the JUnit runner

### DIFF
--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -72,6 +72,11 @@
             <version>1.1.0</version>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.16.12</version>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-events</artifactId>
             <version>1.3.0</version>

--- a/localstack/ext/java/src/main/java/cloud/localstack/DockerTestUtils.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/DockerTestUtils.java
@@ -34,25 +34,25 @@ public class DockerTestUtils {
 
     public static AmazonSQS getClientSQS() {
         return AmazonSQSClientBuilder.standard().
-                withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointSQS)).
+                withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointSQS)).
                 withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonSNS getClientSNS() {
         return AmazonSNSClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointSNS))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointSNS))
                 .withCredentials(getCredentialsProvider()).build();
     }
 
     public static AWSLambda getClientLambda() {
         return AWSLambdaClientBuilder.standard().
-                withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointLambda)).
+                withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointLambda)).
                 withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonS3 getClientS3() {
         AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointS3))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointS3))
                 .withCredentials(getCredentialsProvider());
         builder.setPathStyleAccessEnabled(true);
         return builder.build();
@@ -60,37 +60,37 @@ public class DockerTestUtils {
 
     public static AmazonKinesis getClientKinesis() {
         return AmazonKinesisClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointKinesis))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointKinesis))
                 .withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonDynamoDB getClientDynamoDb() {
         return AmazonDynamoDBClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointDynamoDB))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointDynamoDB))
                 .withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonCloudWatch getClientCloudWatch() {
         return AmazonCloudWatchClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointCloudWatch))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointCloudWatch))
                 .withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonKinesisFirehose getClientFirehose() {
         return AmazonKinesisFirehoseClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointFirehose))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointFirehose))
                 .withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonDynamoDBStreams getClientDynamoDbStreams() {
         return AmazonDynamoDBStreamsClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointDynamoDBStreams))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointDynamoDBStreams))
                 .withCredentials(getCredentialsProvider()).build();
     }
 
     public static AmazonCloudFormation getClientCloudFormation() {
         return AmazonCloudFormationClientBuilder.standard()
-                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner::getEndpointCloudFormation))
+                .withEndpointConfiguration(createEndpointConfiguration(LocalstackDockerTestRunner.getLocalstackDocker()::getEndpointCloudFormation))
                 .withCredentials(getCredentialsProvider()).build();
     }
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -1,0 +1,198 @@
+package cloud.localstack.docker;
+
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.ServiceName;
+import cloud.localstack.docker.command.RegexStream;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Localstack Docker instance
+ *
+ * @author fabianoo
+ */
+public class LocalstackDocker {
+
+    private static final Logger LOG = Logger.getLogger(LocalstackDocker.class.getName());
+
+    private static final String PORT_CONFIG_FILENAME = "/opt/code/localstack/.venv/lib/python2.7/site-packages/localstack_client/config.py";
+
+    private static final Pattern READY_TOKEN = Pattern.compile("Ready\\.");
+
+    //Regular expression used to parse localstack config to determine default ports for services
+    private static final Pattern DEFAULT_PORT_PATTERN = Pattern.compile("'(\\w+)'\\Q: '{proto}://{host}:\\E(\\d+)'");
+    private static final int SERVICE_NAME_GROUP = 1;
+    private static final int PORT_GROUP = 2;
+
+    private Container localStackContainer;
+
+    /**
+     * This is a mapping from service name to internal ports.  In order to use them, the
+     * internal port must be resolved to an external docker port via Container.getExternalPortFor()
+     */
+    private static Map<String, Integer> serviceToPortMap;
+
+    private static boolean started = false;
+
+    @Setter()
+    private String externalHostName = "localhost";
+    @Setter
+    private boolean pullNewImage = true;
+    @Setter
+    private boolean randomizePorts = false;
+    @Setter
+    private Map<String, String> environmentVariables = new HashMap<>();
+
+    @Getter
+    private static LocalstackDocker localstackDocker = new LocalstackDocker();
+
+    private LocalstackDocker() {}
+
+
+    public void startup() {
+        // make sure the local infrastructure is not running, to avoid port conflicts
+        LocalstackTestRunner.teardownInfrastructure();
+
+        // now create the container
+        if (started) {
+            throw new IllegalStateException("A docker instance is already started.");
+        }
+        started = true;
+        localStackContainer = Container.createLocalstackContainer(externalHostName, pullNewImage, randomizePorts, environmentVariables);
+        loadServiceToPortMap();
+
+        LOG.info("Waiting for localstack container to be ready...");
+        localStackContainer.waitForLogToken(READY_TOKEN);
+    }
+
+
+    public void stop() {
+        started = false;
+        localStackContainer.stop();
+    }
+
+
+    private void loadServiceToPortMap() {
+        String localStackPortConfig = localStackContainer.executeCommand(Arrays.asList("cat", PORT_CONFIG_FILENAME));
+
+        Map<String, Integer> ports = new RegexStream(DEFAULT_PORT_PATTERN.matcher(localStackPortConfig)).stream()
+            .collect(Collectors.toMap(match -> match.group(SERVICE_NAME_GROUP),
+                match -> Integer.parseInt(match.group(PORT_GROUP))));
+
+        serviceToPortMap = Collections.unmodifiableMap(ports);
+    }
+
+
+    public String getEndpointS3() {
+        String s3Endpoint = endpointForService(ServiceName.S3);
+        /*
+         * Use the domain name wildcard *.localhost.atlassian.io which maps to 127.0.0.1
+         * We need to do this because S3 SDKs attempt to access a domain <bucket-name>.<service-host-name>
+         * which by default would result in <bucket-name>.localhost, but that name cannot be resolved
+         * (unless hardcoded in /etc/hosts)
+         */
+        s3Endpoint = s3Endpoint.replace("localhost", "test.localhost.atlassian.io");
+        return s3Endpoint;
+    }
+
+
+    public String getEndpointKinesis() {
+        return endpointForService(ServiceName.KINESIS);
+    }
+
+    public String getEndpointLambda() {
+        return endpointForService(ServiceName.LAMBDA);
+    }
+
+    public String getEndpointDynamoDB() {
+        return endpointForService(ServiceName.DYNAMO);
+    }
+
+    public String getEndpointDynamoDBStreams() {
+        return endpointForService(ServiceName.DYNAMO_STREAMS);
+    }
+
+    public String getEndpointAPIGateway() {
+        return endpointForService(ServiceName.API_GATEWAY);
+    }
+
+    public String getEndpointElasticsearch() {
+        return endpointForService(ServiceName.ELASTICSEARCH);
+    }
+
+    public String getEndpointElasticsearchService() {
+        return endpointForService(ServiceName.ELASTICSEARCH_SERVICE);
+    }
+
+    public String getEndpointFirehose() {
+        return endpointForService(ServiceName.FIREHOSE);
+    }
+
+    public String getEndpointSNS() {
+        return endpointForService(ServiceName.SNS);
+    }
+
+    public String getEndpointSQS() {
+        return endpointForService(ServiceName.SQS);
+    }
+
+    public String getEndpointRedshift() {
+        return endpointForService(ServiceName.REDSHIFT);
+    }
+
+    public String getEndpointSES() {
+        return endpointForService(ServiceName.SES);
+    }
+
+    public String getEndpointRoute53() {
+        return endpointForService(ServiceName.ROUTE53);
+    }
+
+    public String getEndpointCloudFormation() {
+        return endpointForService(ServiceName.CLOUDFORMATION);
+    }
+
+    public String getEndpointCloudWatch() {
+        return endpointForService(ServiceName.CLOUDWATCH);
+    }
+
+    public String getEndpointSSM() {
+        return endpointForService(ServiceName.SSM);
+    }
+
+
+    public String endpointForService(String serviceName) {
+        if (serviceToPortMap == null) {
+            throw new IllegalStateException("Service to port mapping has not been determined yet.");
+        }
+
+        if (!serviceToPortMap.containsKey(serviceName)) {
+            throw new IllegalArgumentException("Unknown port mapping for service");
+        }
+
+        int internalPort = serviceToPortMap.get(serviceName);
+        return endpointForPort(internalPort);
+    }
+
+
+    public String endpointForPort(int port) {
+        if (localStackContainer != null) {
+            int externalPort = localStackContainer.getExternalPortFor(port);
+            return String.format("http://%s:%s", externalHostName, externalPort);
+        }
+
+        throw new RuntimeException("Container not started");
+    }
+
+    public Container getLocalStackContainer() {
+        return localStackContainer;
+    }
+}

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/BasicDockerFunctionalityTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/BasicDockerFunctionalityTest.java
@@ -158,7 +158,7 @@ public class BasicDockerFunctionalityTest {
 
     private SQSConnection createSQSConnection() throws Exception {
         SQSConnectionFactory connectionFactory = SQSConnectionFactory.builder().withEndpoint(
-                LocalstackDockerTestRunner.getEndpointSQS()).withAWSCredentialsProvider(
+            LocalstackDockerTestRunner.getLocalstackDocker().getEndpointSQS()).withAWSCredentialsProvider(
                 new AWSStaticCredentialsProvider(TestUtils.TEST_CREDENTIALS)).build();
         return  connectionFactory.createConnection();
     }

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/DockerOnlySQSFunctionalityTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/DockerOnlySQSFunctionalityTest.java
@@ -106,7 +106,7 @@ public class DockerOnlySQSFunctionalityTest {
 
     private SQSConnection createSQSConnection() throws Exception {
         SQSConnectionFactory connectionFactory = SQSConnectionFactory.builder().withEndpoint(
-                LocalstackDockerTestRunner.getEndpointSQS()).withAWSCredentialsProvider(
+            LocalstackDockerTestRunner.getLocalstackDocker().getEndpointSQS()).withAWSCredentialsProvider(
                 new AWSStaticCredentialsProvider(TestUtils.TEST_CREDENTIALS)).build();
         return  connectionFactory.createConnection();
     }

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/LocalstackDockerTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/LocalstackDockerTest.java
@@ -1,0 +1,56 @@
+package cloud.localstack.docker;
+
+import cloud.localstack.DockerTestUtils;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class LocalstackDockerTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void startup() {
+        LocalstackDocker localstackDocker = LocalstackDocker.getLocalstackDocker();
+        localstackDocker.setRandomizePorts(true);
+        localstackDocker.startup();
+
+        AmazonSQS amazonSQS = DockerTestUtils.getClientSQS();
+        String queueUrl = amazonSQS.createQueue("test-queue").getQueueUrl();
+
+        SendMessageResult sendMessageResult = amazonSQS.sendMessage(queueUrl, "test-message");
+        assertNotNull(sendMessageResult);
+
+        String messageId = sendMessageResult.getMessageId();
+        assertNotNull(messageId);
+
+        thrown.expect(IllegalStateException.class);
+
+        localstackDocker.startup();
+        localstackDocker.stop();
+    }
+
+    @Test
+    public void stop() {
+        LocalstackDocker localstackDocker = LocalstackDocker.getLocalstackDocker();
+        localstackDocker.setRandomizePorts(true);
+        localstackDocker.startup();
+        localstackDocker.stop();
+
+        AmazonSQS amazonSQS = DockerTestUtils.getClientSQS();
+        thrown.expect(SdkClientException.class);
+        amazonSQS.createQueue("test-queue").getQueueUrl();
+    }
+
+    @After
+    public void tearDown() {
+        LocalstackDocker.getLocalstackDocker().stop();
+    }
+}


### PR DESCRIPTION
The idea of this little refactoring is to extract the Container initialization from the JUnit Runner, so we can manage programmatically a docker container. This way we can use the Java lib not only for tests, but to develop and to test integrated with Spring, for instances.