### PR TITLE
Allow content-length header to pass-through for HEAD requests

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -519,8 +519,10 @@ class ProxyListenerS3(ProxyListener):
                 if 'text/html' in response.headers.get('Content-Type', ''):
                     response.headers['Content-Type'] = 'application/xml; charset=utf-8'
 
+                response.headers['content-length'] = len(response._content)
+
             # update content-length headers (fix https://github.com/localstack/localstack/issues/541)
-            if isinstance(response._content, (six.string_types, six.binary_type)):
+            if method == 'DELETE':
                 response.headers['content-length'] = len(response._content)
 
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -161,7 +161,7 @@ def test_s3_delete_response_content_length_zero():
 
     # get object and assert headers
     response = requests.delete(url, verify=False)
-    print(response.headers['content-length'])
+
     assert response.headers['content-length'] == '0'
     # clean up
     s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -126,6 +126,48 @@ def test_s3_get_response_content_type_same_as_upload():
     s3_client.delete_bucket(Bucket=bucket_name)
 
 
+def test_s3_head_response_content_length_same_as_upload():
+    bucket_name = 'test-bucket-%s' % short_uid()
+    s3_client = aws_stack.connect_to_service('s3')
+    s3_client.create_bucket(Bucket=bucket_name)
+    body = 'something body'
+    # put object
+    object_key = 'key-by-hostname'
+    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body=body, ContentType='text/html; charset=utf-8')
+    url = s3_client.generate_presigned_url(
+        'head_object', Params={'Bucket': bucket_name, 'Key': object_key}
+    )
+
+    # get object and assert headers
+    response = requests.head(url, verify=False)
+
+    assert response.headers['content-length'] == str(len(body))
+    # clean up
+    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+    s3_client.delete_bucket(Bucket=bucket_name)
+
+
+def test_s3_delete_response_content_length_zero():
+    bucket_name = 'test-bucket-%s' % short_uid()
+    s3_client = aws_stack.connect_to_service('s3')
+    s3_client.create_bucket(Bucket=bucket_name)
+
+    # put object
+    object_key = 'key-by-hostname'
+    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something', ContentType='text/html; charset=utf-8')
+    url = s3_client.generate_presigned_url(
+        'delete_object', Params={'Bucket': bucket_name, 'Key': object_key}
+    )
+
+    # get object and assert headers
+    response = requests.delete(url, verify=False)
+    print(response.headers['content-length'])
+    assert response.headers['content-length'] == '0'
+    # clean up
+    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+    s3_client.delete_bucket(Bucket=bucket_name)
+
+
 def test_s3_get_response_headers():
     bucket_name = 'test-bucket-%s' % short_uid()
     s3_client = aws_stack.connect_to_service('s3')


### PR DESCRIPTION
In response to issue [#541](https://github.com/localstack/localstack/issues/541), content length header was being set 'correctly' for all requests, this masks the content-length header supplied by moto for HEAD requests. Other clients for example spark S3AFileSystem depend on the content-length from the HEAD request to pre-determine the object size. Others affected by this issue [#638](https://github.com/localstack/localstack/issues/638)  ... This pull request illustrates a possible fix that would retain the 'fix' [#541](https://github.com/localstack/localstack/issues/541), though it's possible the aws-sdk mentioned in that issue actually what is at fault, rather than moto / localstack

