### PR TITLE
Add Filter Policy Support To Sns Subscriptions

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -59,33 +59,36 @@ class ProxyListenerSNS(ProxyListener):
                 message = req_data['Message'][0]
                 sqs_client = aws_stack.connect_to_service('sqs')
                 for subscriber in SNS_SUBSCRIPTIONS[topic_arn]:
-                    if subscriber['Protocol'] == 'sqs':
-                        endpoint = subscriber['Endpoint']
-                        if 'sqs_queue_url' in subscriber:
-                            queue_url = subscriber.get('sqs_queue_url')
-                        elif '://' in endpoint:
-                            queue_url = endpoint
+                    filter_policy = json.loads(subscriber.get('FilterPolicy', '{}'))
+                    message_attributes = get_message_attributes(req_data)
+                    if check_filter_policy(filter_policy, message_attributes):
+                        if subscriber['Protocol'] == 'sqs':
+                            endpoint = subscriber['Endpoint']
+                            if 'sqs_queue_url' in subscriber:
+                                queue_url = subscriber.get('sqs_queue_url')
+                            elif '://' in endpoint:
+                                queue_url = endpoint
+                            else:
+                                queue_name = endpoint.split(':')[5]
+                                queue_url = aws_stack.get_sqs_queue_url(queue_name)
+                                subscriber['sqs_queue_url'] = queue_url
+                            sqs_client.send_message(QueueUrl=queue_url,
+                                MessageBody=create_sns_message_body(subscriber, req_data))
+                        elif subscriber['Protocol'] == 'lambda':
+                            lambda_api.process_sns_notification(
+                                subscriber['Endpoint'],
+                                topic_arn, message, subject=req_data.get('Subject', [None])[0]
+                            )
+                        elif subscriber['Protocol'] in ['http', 'https']:
+                            requests.post(
+                                subscriber['Endpoint'],
+                                headers={
+                                    'Content-Type': 'text/plain',
+                                    'x-amz-sns-message-type': 'Notification'
+                                },
+                                data=create_sns_message_body(subscriber, req_data))
                         else:
-                            queue_name = endpoint.split(':')[5]
-                            queue_url = aws_stack.get_sqs_queue_url(queue_name)
-                            subscriber['sqs_queue_url'] = queue_url
-                        sqs_client.send_message(QueueUrl=queue_url,
-                            MessageBody=create_sns_message_body(subscriber, req_data))
-                    elif subscriber['Protocol'] == 'lambda':
-                        lambda_api.process_sns_notification(
-                            subscriber['Endpoint'],
-                            topic_arn, message, subject=req_data.get('Subject', [None])[0]
-                        )
-                    elif subscriber['Protocol'] in ['http', 'https']:
-                        requests.post(
-                            subscriber['Endpoint'],
-                            headers={
-                                'Content-Type': 'text/plain',
-                                'x-amz-sns-message-type': 'Notification'
-                            },
-                            data=create_sns_message_body(subscriber, req_data))
-                    else:
-                        LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
+                            LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
                 # return response here because we do not want the request to be forwarded to SNS
                 return make_response(req_action)
 
@@ -219,3 +222,58 @@ def get_message_attributes(req_data):
             break
 
     return attributes
+
+
+def evaluate_filter_policy_conditions(conditions, attribute):
+    result = False
+
+    if attribute is None:
+        return False
+
+    if type(conditions) is not list:
+        conditions = [ conditions ];
+
+    for condition in conditions:
+        if type(condition) is not dict:
+            if attribute['Value'] == condition:
+                result = True
+        elif condition.get('anything-but'):
+            if attribute['Value'] not in condition.get('anything-but'):
+                result = True
+        elif condition.get('prefix'):
+            prefix = condition.get('prefix')
+            if attribute['Value'].startswith(prefix):
+                result = True
+        elif condition.get('numeric'):
+            operator = condition.get('numeric')[0]
+            operand = condition.get('numeric')[1]
+            if operator == '=':
+                if attribute['Value'] == operand:
+                    result = True
+            elif operator == '>':
+                if attribute['Value'] > operand:
+                    result = True
+            elif operator == '<':
+                if attribute['Value'] < operand:
+                    result = True
+            elif operator == '>=':
+                if attribute['Value'] >= operand:
+                    result = True
+            elif operator == '<=':
+                if attribute['Value'] <= operand:
+                    result = True
+
+    return result
+
+
+def check_filter_policy(filter_policy, message_attributes):
+    if not filter_policy:
+        return True
+
+    for criteria in filter_policy:
+        conditions = filter_policy.get(criteria)
+        attribute = message_attributes.get(criteria)
+        if evaluate_filter_policy_conditions(conditions, attribute) is False:
+            return False
+
+    return True


### PR DESCRIPTION
See: https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html

This commit adds filter policy support for SNS subscriptions. Filter
policies are set on the subscription and help filter the messages that
that subscription is interested in. If a message does not contain the
appropriate message attributes to pass the filter check, then the
message is not relayed to the subscriber. If the message does pass the
filter check then the message is passed to the subscriber.

**Please refer to the contribution guidelines in the README when submitting PRs.**
