### PR TITLE
Add Filter Policy Support To Sns Subscriptions

### DIFF
--- a/localstack/package.json
+++ b/localstack/package.json
@@ -4,7 +4,7 @@
   "description": "Local Cloud Stack and Utilities",
   "version": "0.0.1",
   "dependencies": {
-    "kinesalite": "1.11.6",
+    "kinesalite": "1.12.1",
     "leveldown": "1.6.0"
   }
 }

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -59,43 +59,46 @@ class ProxyListenerSNS(ProxyListener):
                 message = req_data['Message'][0]
                 sqs_client = aws_stack.connect_to_service('sqs')
                 for subscriber in SNS_SUBSCRIPTIONS[topic_arn]:
-                    if subscriber['Protocol'] == 'sqs':
-                        endpoint = subscriber['Endpoint']
-                        if 'sqs_queue_url' in subscriber:
-                            queue_url = subscriber.get('sqs_queue_url')
-                        elif '://' in endpoint:
-                            queue_url = endpoint
-                        else:
-                            queue_name = endpoint.split(':')[5]
-                            queue_url = aws_stack.get_sqs_queue_url(queue_name)
-                            subscriber['sqs_queue_url'] = queue_url
-                        try:
-                            sqs_client.send_message(
-                                QueueUrl=queue_url,
-                                MessageBody=create_sns_message_body(subscriber, req_data)
+                    filter_policy = json.loads(subscriber.get('FilterPolicy', '{}'))
+                    message_attributes = get_message_attributes(req_data)
+                    if check_filter_policy(filter_policy, message_attributes):
+                        if subscriber['Protocol'] == 'sqs':
+                            endpoint = subscriber['Endpoint']
+                            if 'sqs_queue_url' in subscriber:
+                                queue_url = subscriber.get('sqs_queue_url')
+                            elif '://' in endpoint:
+                                queue_url = endpoint
+                            else:
+                                queue_name = endpoint.split(':')[5]
+                                queue_url = aws_stack.get_sqs_queue_url(queue_name)
+                                subscriber['sqs_queue_url'] = queue_url
+                            try:
+                                sqs_client.send_message(
+                                    QueueUrl=queue_url,
+                                    MessageBody=create_sns_message_body(subscriber, req_data)
+                                )
+                            except Exception as exc:
+                                return make_error(message=str(exc), code=400)
+                        elif subscriber['Protocol'] == 'lambda':
+                            lambda_api.process_sns_notification(
+                                subscriber['Endpoint'],
+                                topic_arn, message, subject=req_data.get('Subject', [None])[0]
                             )
-                        except Exception as exc:
-                            return make_error(message=str(exc), code=400)
-                    elif subscriber['Protocol'] == 'lambda':
-                        lambda_api.process_sns_notification(
-                            subscriber['Endpoint'],
-                            topic_arn, message, subject=req_data.get('Subject', [None])[0]
-                        )
-                    elif subscriber['Protocol'] in ['http', 'https']:
-                        try:
-                            message_body = create_sns_message_body(subscriber, req_data)
-                        except Exception as exc:
-                            return make_error(message=str(exc), code=400)
-                        requests.post(
-                            subscriber['Endpoint'],
-                            headers={
-                                'Content-Type': 'text/plain',
-                                'x-amz-sns-message-type': 'Notification'
-                            },
-                            data=message_body
-                        )
-                    else:
-                        LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
+                        elif subscriber['Protocol'] in ['http', 'https']:
+                            try:
+                                message_body = create_sns_message_body(subscriber, req_data)
+                            except Exception as exc:
+                                return make_error(message=str(exc), code=400)
+                            requests.post(
+                                subscriber['Endpoint'],
+                                headers={
+                                    'Content-Type': 'text/plain',
+                                    'x-amz-sns-message-type': 'Notification'
+                                },
+                                data=message_body
+                            )
+                        else:
+                            LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
                 # return response here because we do not want the request to be forwarded to SNS
                 return make_response(req_action)
 
@@ -237,3 +240,58 @@ def get_message_attributes(req_data):
             break
 
     return attributes
+
+
+def evaluate_filter_policy_conditions(conditions, attribute):
+    result = False
+
+    if attribute is None:
+        return False
+
+    if type(conditions) is not list:
+        conditions = [conditions]
+
+    for condition in conditions:
+        if type(condition) is not dict:
+            if attribute['Value'] == condition:
+                result = True
+        elif condition.get('anything-but'):
+            if attribute['Value'] not in condition.get('anything-but'):
+                result = True
+        elif condition.get('prefix'):
+            prefix = condition.get('prefix')
+            if attribute['Value'].startswith(prefix):
+                result = True
+        elif condition.get('numeric'):
+            operator = condition.get('numeric')[0]
+            operand = condition.get('numeric')[1]
+            if operator == '=':
+                if attribute['Value'] == operand:
+                    result = True
+            elif operator == '>':
+                if attribute['Value'] > operand:
+                    result = True
+            elif operator == '<':
+                if attribute['Value'] < operand:
+                    result = True
+            elif operator == '>=':
+                if attribute['Value'] >= operand:
+                    result = True
+            elif operator == '<=':
+                if attribute['Value'] <= operand:
+                    result = True
+
+    return result
+
+
+def check_filter_policy(filter_policy, message_attributes):
+    if not filter_policy:
+        return True
+
+    for criteria in filter_policy:
+        conditions = filter_policy.get(criteria)
+        attribute = message_attributes.get(criteria)
+        if evaluate_filter_policy_conditions(conditions, attribute) is False:
+            return False
+
+    return True

--- a/tests/unit/test_sns_listener.py
+++ b/tests/unit/test_sns_listener.py
@@ -119,3 +119,231 @@ class SNSTests(unittest.TestCase):
         result = json.loads(result_str)
 
         assert (result['Message'] == 'sqs message')
+
+
+def test_filter_policy():
+    test_data = [
+        (
+            'no filter with no attributes',
+            {},
+            {},
+            True
+        ),
+        (
+            'no filter with attributes',
+            {},
+            {'filter': {'Type': 'String', 'Value': 'type1'}},
+            True
+        ),
+        (
+            'exact string filter',
+            {'filter': 'type1'},
+            {'filter': {'Type': 'String', 'Value': 'type1'}},
+            True
+        ),
+        (
+            'exact string filter with no attributes',
+            {'filter': 'type1'},
+            {},
+            False
+        ),
+        (
+            'exact string filter with no match',
+            {'filter': 'type1'},
+            {'filter': {'Type': 'String', 'Value': 'type2'}},
+            False
+        ),
+        (
+            'or string filter with match',
+            {'filter': ['type1', 'type2']},
+            {'filter': {'Type': 'String', 'Value': 'type1'}},
+            True
+        ),
+        (
+            'or string filter with other match',
+            {'filter': ['type1', 'type2']},
+            {'filter': {'Type': 'String', 'Value': 'type2'}},
+            True
+        ),
+        (
+            'or string filter with no attributes',
+            {'filter': ['type1', 'type2']},
+            {},
+            False
+        ),
+        (
+            'or string filter with no match',
+            {'filter': ['type1', 'type2']},
+            {'filter': {'Type': 'String', 'Value': 'type3'}},
+            False
+        ),
+        (
+            'anything-but string filter with match',
+            {'filter': [{'anything-but': 'type1'}]},
+            {'filter': {'Type': 'String', 'Value': 'type1'}},
+            False
+        ),
+        (
+            'anything-but string filter with no match',
+            {'filter': [{'anything-but': 'type1'}]},
+            {'filter': {'Type': 'String', 'Value': 'type2'}},
+            True
+        ),
+        (
+            'prefix string filter with match',
+            {'filter': [{'prefix': 'typ'}]},
+            {'filter': {'Type': 'String', 'Value': 'type1'}},
+            True
+        ),
+        (
+            'prefix string filter with no match',
+            {'filter': [{'prefix': 'test'}]},
+            {'filter': {'Type': 'String', 'Value': 'type2'}},
+            False
+        ),
+        (
+            'numeric = filter with match',
+            {'filter': [{'numeric': ['=', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            True
+        ),
+        (
+            'numeric = filter with no match',
+            {'filter': [{'numeric': ['=', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 301}},
+            False
+        ),
+        (
+            'numeric > filter with match',
+            {'filter': [{'numeric': ['>', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 301}},
+            True
+        ),
+        (
+            'numeric > filter with no match',
+            {'filter': [{'numeric': ['>', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            False
+        ),
+        (
+            'numeric < filter with match',
+            {'filter': [{'numeric': ['<', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 299}},
+            True
+        ),
+        (
+            'numeric < filter with no match',
+            {'filter': [{'numeric': ['<', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            False
+        ),
+        (
+            'numeric >= filter with match',
+            {'filter': [{'numeric': ['>=', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            True
+        ),
+        (
+            'numeric >= filter with no match',
+            {'filter': [{'numeric': ['>=', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 299}},
+            False
+        ),
+        (
+            'numeric <= filter with match',
+            {'filter': [{'numeric': ['<=', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            True
+        ),
+        (
+            'numeric <= filter with no match',
+            {'filter': [{'numeric': ['<=', 300]}]},
+            {'filter': {'Type': 'Number', 'Value': 301}},
+            False
+        ),
+        (
+            'numeric filter with bad data',
+            {'filter': [{'numeric': ['=', 300]}]},
+            {'filter': {'Type': 'String', 'Value': 'test'}},
+            False
+        ),
+        (
+            'logical OR with match',
+            {'filter': ['test1', 'test2', {'prefix': 'typ'}]},
+            {'filter': {'Type': 'String', 'Value': 'test2'}},
+            True
+        ),
+        (
+            'logical OR with match',
+            {'filter': ['test1', 'test2', {'prefix': 'typ'}]},
+            {'filter': {'Type': 'String', 'Value': 'test1'}},
+            True
+        ),
+        (
+            'logical OR no match',
+            {'filter': ['test1', 'test2', {'prefix': 'typ'}]},
+            {'filter': {'Type': 'String', 'Value': 'test3'}},
+            False
+        ),
+        (
+            'logical AND with match',
+            {'filter': [{'numeric': ['=', 300]}], 'other': [{'prefix': 'typ'}]},
+            {'filter': {'Type': 'Number', 'Value': 300}, 'other': {'Type': 'String', 'Value': 'type1'}},
+            True
+        ),
+        (
+            'logical AND missing first attribute',
+            {'filter': [{'numeric': ['=', 300]}], 'other': [{'prefix': 'typ'}]},
+            {'other': {'Type': 'String', 'Value': 'type1'}},
+            False
+        ),
+        (
+            'logical AND missing second attribute',
+            {'filter': [{'numeric': ['=', 300]}], 'other': [{'prefix': 'typ'}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            False
+        ),
+        (
+            'logical AND no match',
+            {'filter': [{'numeric': ['=', 300]}], 'other': [{'prefix': 'typ'}]},
+            {'filter': {'Type': 'Number', 'Value': 299}, 'other': {'Type': 'String', 'Value': 'type1'}},
+            False
+        ),
+        (
+            'multiple numeric filters with first match',
+            {'filter': [{'numeric': ['=', 300]}, {'numeric': ['=', 500]}]},
+            {'filter': {'Type': 'Number', 'Value': 300}},
+            True
+        ),
+        (
+            'multiple numeric filters with second match',
+            {'filter': [{'numeric': ['=', 300]}, {'numeric': ['=', 500]}]},
+            {'filter': {'Type': 'Number', 'Value': 500}},
+            True
+        ),
+        (
+            'multiple prefix filters with first match',
+            {'filter': [{'prefix': 'typ'}, {'prefix': 'tes'}]},
+            {'filter': {'Type': 'String', 'Value': 'type1'}},
+            True
+        ),
+        (
+            'multiple prefix filters with second match',
+            {'filter': [{'prefix': 'typ'}, {'prefix': 'tes'}]},
+            {'filter': {'Type': 'String', 'Value': 'test'}},
+            True
+        ),
+        (
+            'multiple anything-but filters with second match',
+            {'filter': [{'anything-but': 'type1'}, {'anything-but': 'type2'}]},
+            {'filter': {'Type': 'String', 'Value': 'type2'}},
+            True
+        ),
+    ]
+
+    for test in test_data:
+        test_name = test[0]
+        filter_policy = test[1]
+        attributes = test[2]
+        expected = test[3]
+        assert_equal(sns_listener.check_filter_policy(filter_policy, attributes), expected, test_name)

--- a/tests/unit/test_sns_listener.py
+++ b/tests/unit/test_sns_listener.py
@@ -339,6 +339,24 @@ def test_filter_policy():
             {'filter': {'Type': 'String', 'Value': 'type2'}},
             True
         ),
+        (
+            'multiple numeric conditions',
+            {'filter': [{'numeric': ['>', 0, '<=', 150]}]},
+            {'filter': {'Type': 'Number', 'Value': 122}},
+            True
+        ),
+        (
+            'multiple numeric conditions',
+            {'filter': [{'numeric': ['>', 0, '<=', 150]}]},
+            {'filter': {'Type': 'Number', 'Value': 200}},
+            False
+        ),
+        (
+            'multiple numeric conditions',
+            {'filter': [{'numeric': ['>', 0, '<=', 150]}]},
+            {'filter': {'Type': 'Number', 'Value': -1}},
+            False
+        )
     ]
 
     for test in test_data:


### PR DESCRIPTION
See: https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html

This pull request adds support for SNS subscription filters. These filters decide which messages on the topic the subscriber will accept. If a message does not meet the filter conditions then it will not be passed to the subscriber.

Specifically each attribute in the filter policy will be matched against that corresponding attribute in the messages' `MessageAttributes`. If the value of the attribute fails to match at least one of the conditions specified against the attribute in the filter, then it will not be passed to the subscriber.

Currently AWS supports the following:
- Exact matches (whitelisting)
- Anything-But (blacklisting)
- Prefix
- Numeric (=, >, <, >=, <=)
- AND/OR logic
