### PR TITLE
Update to Elasticsearch API to support addition of tags during testing and access policy

### DIFF
--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -23,6 +23,144 @@ def error_response(error_type, code=400, message='Unknown error.'):
     return response, code
 
 
+def get_domain_config(domain_name):
+    return {
+        'DomainConfig': {
+            'AccessPolicies': {
+                'Options': '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::%s:root"},"Action":"es:*","Resource":"arn:aws:es:%s:%s:domain/%s/*"}]}' % (TEST_AWS_ACCOUNT_ID, DEFAULT_REGION, TEST_AWS_ACCOUNT_ID, domain_name),  # noqa: E501
+                'Status': {
+                    'CreationDate': 1499817484.04,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1500308955.652,
+                    'UpdateVersion': 17
+                }
+            },
+            'AdvancedOptions': {
+                'Options': {
+                    'indices.fielddata.cache.size': '',
+                    'rest.action.multi.allow_explicit_index': 'true'
+                },
+                'Status': {
+                    'CreationDate': 1499817484.04,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1499818054.108,
+                    'UpdateVersion': 5
+                }
+            },
+            'EBSOptions': {
+                'Options': {
+                    'EBSEnabled': True,
+                    'EncryptionEnabled': False,
+                    'Iops': 0,
+                    'VolumeSize': 10,
+                    'VolumeType': 'gp2'
+                },
+                'Status': {
+                    'CreationDate': 1499817484.04,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1499818054.108,
+                    'UpdateVersion': 5
+                }
+            },
+            'ElasticsearchClusterConfig': {
+                'Options': {
+                    'DedicatedMasterCount': 1,
+                    'DedicatedMasterEnabled': True,
+                    'DedicatedMasterType': 'm4.large.elasticsearch',
+                    'InstanceCount': 1,
+                    'InstanceType': 'm4.large.elasticsearch',
+                    'ZoneAwarenessEnabled': False
+                },
+                'Status': {
+                    'CreationDate': 1499817484.04,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1499966854.612,
+                    'UpdateVersion': 13
+                }
+            },
+            'ElasticsearchVersion': {
+                'Options': '5.3',
+                'Status': {
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'CreationDate': 1436913638.995,
+                    'UpdateVersion': 6,
+                    'UpdateDate': 1436914324.278
+                }
+            },
+            'EncryptionAtRestOptions': {
+                'Options': {
+                    'Enabled': False,
+                    'KmsKeyId': ''
+                },
+                'Status': {
+                    'CreationDate': 1509490412.757,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1509490953.717,
+                    'UpdateVersion': 6
+                }
+            },
+            'LogPublishingOptions': {
+                'Status': {
+                    'CreationDate': 1502774634.546,
+                    'PendingDeletion': False,
+                    'State': 'Processing',
+                    'UpdateDate': 1502779590.448,
+                    'UpdateVersion': 60
+                },
+                'Options': {
+                    'INDEX_SLOW_LOGS': {
+                        'CloudWatchLogsLogGroupArn': 'arn:aws:logs:%s:%s:log-group:sample-domain' % (DEFAULT_REGION, TEST_AWS_ACCOUNT_ID),  # noqa: E501
+                        'Enabled': False
+                    },
+                    'SEARCH_SLOW_LOGS': {
+                        'CloudWatchLogsLogGroupArn': 'arn:aws:logs:%s:%s:log-group:sample-domain' % (DEFAULT_REGION, TEST_AWS_ACCOUNT_ID),  # noqa: E501
+                        'Enabled': False,
+                    }
+                }
+            },
+            'SnapshotOptions': {
+                'Options': {
+                    'AutomatedSnapshotStartHour': 6
+                },
+                'Status': {
+                    'CreationDate': 1499817484.04,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1499818054.108,
+                    'UpdateVersion': 5
+                }
+            },
+            'VPCOptions': {
+                'Options': {
+                    'AvailabilityZones': [
+                        'us-east-1b'
+                    ],
+                    'SecurityGroupIds': [
+                        'sg-12345678'
+                    ],
+                    'SubnetIds': [
+                        'subnet-12345678'
+                    ],
+                    'VPCId': 'vpc-12345678'
+                },
+                'Status': {
+                    'CreationDate': 1499817484.04,
+                    'PendingDeletion': False,
+                    'State': 'Active',
+                    'UpdateDate': 1499818054.108,
+                    'UpdateVersion': 5
+                }
+            }
+        }
+    }
+
+
 def get_domain_status(domain_name, deleted=False):
     return {
         'DomainStatus': {
@@ -34,14 +172,20 @@ def get_domain_status(domain_name, deleted=False):
             'ElasticsearchClusterConfig': {
                 'DedicatedMasterCount': 1,
                 'DedicatedMasterEnabled': True,
-                'DedicatedMasterType': 'm3.medium.elasticsearch',
+                'DedicatedMasterType': 'm4.large.elasticsearch',
                 'InstanceCount': 1,
-                'InstanceType': 'm3.medium.elasticsearch',
-                'ZoneAwarenessEnabled': True
+                'InstanceType': 'm4.large.elasticsearch',
+                'ZoneAwarenessEnabled': False
             },
             'ElasticsearchVersion': '6.2',
-            'Endpoint': None,
-            'Processing': True
+            'Endpoint': 'http://localhost:4571',
+            'Processing': False,
+            'EBSOptions': {
+                'EBSEnabled': True,
+                'VolumeType': 'gp2',
+                'VolumeSize': 10,
+                'Iops': 0
+            },
         }
     }
 
@@ -73,6 +217,12 @@ def describe_domain(domain_name):
     return jsonify(result)
 
 
+@app.route('%s/es/domain/<domain_name>/config' % API_PREFIX, methods=['GET', 'POST'])
+def domain_config(domain_name):
+    config = get_domain_config(domain_name)
+    return jsonify(config)
+
+
 @app.route('%s/es/domain/<domain_name>' % API_PREFIX, methods=['DELETE'])
 def delete_domain(domain_name):
     if domain_name not in ES_DOMAINS:
@@ -80,6 +230,26 @@ def delete_domain(domain_name):
     result = get_domain_status(domain_name, deleted=True)
     ES_DOMAINS.pop(domain_name)
     return jsonify(result)
+
+
+@app.route('%s/tags/' % API_PREFIX, methods=['GET', 'POST'])
+def add_list_tags():
+    if request.method == 'POST' and request.args.get('arn'):
+        response = {
+            'TagList': [
+                {
+                    'Key': 'Example1',
+                    'Value': 'Value'
+                },
+                {
+                    'Key': 'Example2',
+                    'Value': 'Value'
+                }
+            ]
+        }
+        return jsonify(response)
+
+    return jsonify({})
 
 
 def serve(port, quiet=True):

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -5,6 +5,7 @@ from flask import Flask, jsonify, request, make_response
 from localstack.services import generic_proxy
 from localstack.constants import TEST_AWS_ACCOUNT_ID, DEFAULT_REGION
 from localstack.utils.common import to_str
+from localstack.utils.aws import aws_stack
 
 APP_NAME = 'es_api'
 API_PREFIX = '/2015-01-01'
@@ -136,7 +137,7 @@ def get_domain_status(domain_name, deleted=False):
                 'ZoneAwarenessEnabled': False
             },
             'ElasticsearchVersion': '6.2',
-            'Endpoint': 'http://localhost:4571',
+            'Endpoint': aws_stack.get_elasticsearch_endpoint(),
             'Processing': False,
             'EBSOptions': {
                 'EBSEnabled': True,
@@ -192,7 +193,7 @@ def delete_domain(domain_name):
 
 @app.route('%s/tags/' % API_PREFIX, methods=['GET', 'POST'])
 def add_list_tags():
-    if request.method == 'POST' and request.args.get('arn'):
+    if request.method == 'GET' and request.args.get('arn'):
         response = {
             'TagList': [
                 {

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -1,4 +1,6 @@
 import json
+import time
+from random import randint
 from flask import Flask, jsonify, request, make_response
 from localstack.services import generic_proxy
 from localstack.constants import TEST_AWS_ACCOUNT_ID, DEFAULT_REGION
@@ -23,31 +25,29 @@ def error_response(error_type, code=400, message='Unknown error.'):
     return response, code
 
 
+def get_domain_config_status():
+    return {
+        'CreationDate': '%.2f' % time.time(),
+        'PendingDeletion': False,
+        'State': 'Active',
+        'UpdateDate': '%.2f' % time.time(),
+        'UpdateVersion': randint(1, 100)
+    }
+
+
 def get_domain_config(domain_name):
     return {
         'DomainConfig': {
             'AccessPolicies': {
                 'Options': '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::%s:root"},"Action":"es:*","Resource":"arn:aws:es:%s:%s:domain/%s/*"}]}' % (TEST_AWS_ACCOUNT_ID, DEFAULT_REGION, TEST_AWS_ACCOUNT_ID, domain_name),  # noqa: E501
-                'Status': {
-                    'CreationDate': 1499817484.04,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1500308955.652,
-                    'UpdateVersion': 17
-                }
+                'Status': get_domain_config_status()
             },
             'AdvancedOptions': {
                 'Options': {
                     'indices.fielddata.cache.size': '',
                     'rest.action.multi.allow_explicit_index': 'true'
                 },
-                'Status': {
-                    'CreationDate': 1499817484.04,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1499818054.108,
-                    'UpdateVersion': 5
-                }
+                'Status': get_domain_config_status()
             },
             'EBSOptions': {
                 'Options': {
@@ -57,62 +57,32 @@ def get_domain_config(domain_name):
                     'VolumeSize': 10,
                     'VolumeType': 'gp2'
                 },
-                'Status': {
-                    'CreationDate': 1499817484.04,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1499818054.108,
-                    'UpdateVersion': 5
-                }
+                'Status': get_domain_config_status()
             },
             'ElasticsearchClusterConfig': {
                 'Options': {
                     'DedicatedMasterCount': 1,
                     'DedicatedMasterEnabled': True,
-                    'DedicatedMasterType': 'm4.large.elasticsearch',
+                    'DedicatedMasterType': 'm3.medium.elasticsearch',
                     'InstanceCount': 1,
-                    'InstanceType': 'm4.large.elasticsearch',
+                    'InstanceType': 'm3.medium.elasticsearch',
                     'ZoneAwarenessEnabled': False
                 },
-                'Status': {
-                    'CreationDate': 1499817484.04,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1499966854.612,
-                    'UpdateVersion': 13
-                }
+                'Status': get_domain_config_status()
             },
             'ElasticsearchVersion': {
                 'Options': '5.3',
-                'Status': {
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'CreationDate': 1436913638.995,
-                    'UpdateVersion': 6,
-                    'UpdateDate': 1436914324.278
-                }
+                'Status': get_domain_config_status()
             },
             'EncryptionAtRestOptions': {
                 'Options': {
                     'Enabled': False,
                     'KmsKeyId': ''
                 },
-                'Status': {
-                    'CreationDate': 1509490412.757,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1509490953.717,
-                    'UpdateVersion': 6
-                }
+                'Status': get_domain_config_status()
             },
             'LogPublishingOptions': {
-                'Status': {
-                    'CreationDate': 1502774634.546,
-                    'PendingDeletion': False,
-                    'State': 'Processing',
-                    'UpdateDate': 1502779590.448,
-                    'UpdateVersion': 60
-                },
+                'Status': get_domain_config_status(),
                 'Options': {
                     'INDEX_SLOW_LOGS': {
                         'CloudWatchLogsLogGroupArn': 'arn:aws:logs:%s:%s:log-group:sample-domain' % (DEFAULT_REGION, TEST_AWS_ACCOUNT_ID),  # noqa: E501
@@ -126,15 +96,9 @@ def get_domain_config(domain_name):
             },
             'SnapshotOptions': {
                 'Options': {
-                    'AutomatedSnapshotStartHour': 6
+                    'AutomatedSnapshotStartHour': randint(0, 23)
                 },
-                'Status': {
-                    'CreationDate': 1499817484.04,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1499818054.108,
-                    'UpdateVersion': 5
-                }
+                'Status': get_domain_config_status()
             },
             'VPCOptions': {
                 'Options': {
@@ -149,13 +113,7 @@ def get_domain_config(domain_name):
                     ],
                     'VPCId': 'vpc-12345678'
                 },
-                'Status': {
-                    'CreationDate': 1499817484.04,
-                    'PendingDeletion': False,
-                    'State': 'Active',
-                    'UpdateDate': 1499818054.108,
-                    'UpdateVersion': 5
-                }
+                'Status': get_domain_config_status()
             }
         }
     }
@@ -172,9 +130,9 @@ def get_domain_status(domain_name, deleted=False):
             'ElasticsearchClusterConfig': {
                 'DedicatedMasterCount': 1,
                 'DedicatedMasterEnabled': True,
-                'DedicatedMasterType': 'm4.large.elasticsearch',
+                'DedicatedMasterType': 'm3.medium.elasticsearch',
                 'InstanceCount': 1,
-                'InstanceType': 'm4.large.elasticsearch',
+                'InstanceType': 'm3.medium.elasticsearch',
                 'ZoneAwarenessEnabled': False
             },
             'ElasticsearchVersion': '6.2',

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -69,7 +69,7 @@ def test_domain_creation():
     assert_true(status['DomainStatus']['Created'])
     assert_false(status['DomainStatus']['Processing'])
     assert_false(status['DomainStatus']['Deleted'])
-    assert_equal(status['DomainStatus']['Endpoint'], TEST_ENDPOINT_URL)
+    assert_equal(status['DomainStatus']['Endpoint'], aws_stack.get_elasticsearch_endpoint())
     assert_true(status['DomainStatus']['EBSOptions']['EBSEnabled'])
 
     # make sure we can fake adding tags to a domain

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -13,6 +13,7 @@ COMMON_HEADERS = {
     'Accept-encoding': 'identity'
 }
 TEST_DOMAIN_NAME = 'test_es_domain_1'
+TEST_ENDPOINT_URL = 'http://localhost:4571'
 
 
 def setUp():
@@ -66,7 +67,14 @@ def test_domain_creation():
     status = es_client.describe_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
     assert_equal(status['DomainStatus']['DomainName'], TEST_DOMAIN_NAME)
     assert_true(status['DomainStatus']['Created'])
+    assert_false(status['DomainStatus']['Processing'])
     assert_false(status['DomainStatus']['Deleted'])
+    assert_equal(status['DomainStatus']['Endpoint'], TEST_ENDPOINT_URL)
+    assert_true(status['DomainStatus']['EBSOptions']['EBSEnabled'])
+
+    # make sure we can fake adding tags to a domain
+    response = es_client.add_tags(ARN='string', TagList=[{'Key': 'SOME_TAG', 'Value': 'SOME_VALUE'}])
+    assert_equal(200, response['ResponseMetadata']['HTTPStatusCode'])
 
     # make sure domain deletion works
     es_client.delete_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)


### PR DESCRIPTION
These updates came from testing with Terraform.  Terraform would fail to create the Elasticsearch domain because it never saw it as completed.  Making these changes allowed creating an Elasticsearch domain and applying an access policy to that domain for testing.