### PR TITLE
Bump Elasticsearch version to 6.2.0

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -55,7 +55,7 @@ WORKDIR /opt/code/localstack/
 ADD requirements.txt .
 RUN mkdir -p /opt/code/localstack/localstack/infra && \
     wget -O /tmp/localstack.es.zip \
-        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.zip && \
+        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip && \
     wget -O /tmp/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.8.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -69,7 +69,7 @@ APPLICATION_JSON = 'application/json'
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
-ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.0.zip'
+ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip'
 DYNAMODB_JAR_URL = 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip'
 ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.8.jar'
 STS_JAR_URL = 'http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -39,7 +39,7 @@ def get_domain_status(domain_name, deleted=False):
                 'InstanceType': 'm3.medium.elasticsearch',
                 'ZoneAwarenessEnabled': True
             },
-            'ElasticsearchVersion': '5.3',
+            'ElasticsearchVersion': '6.2',
             'Endpoint': None,
             'Processing': True
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ boto==2.46.1
 boto3>=1.4.4
 coverage==4.0.3
 docopt==0.6.2
-elasticsearch==5.3.0
+elasticsearch==6.2.0
 flake8>=3.5.0
 flake8-quotes>=0.11.0
 flask==0.10.1


### PR DESCRIPTION
The [latest AWS-supported Elasticsearch version is 6.2](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/what-is-amazon-elasticsearch-service.html#aes-choosing-version), and the AWS documentation "strongly recommends" using the latest supported version.

This also closes #659.