### PR TITLE
updates to support Windows 10 using linux subsystem

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/LocalstackTestRunner.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LocalstackTestRunner.java
@@ -13,6 +13,13 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
@@ -27,16 +34,20 @@ import java.util.logging.Logger;
 public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 	private static final Logger LOG = Logger.getLogger(LocalstackTestRunner.class.getName());
 
+	private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("windows");
+
 	private static final AtomicReference<Process> INFRA_STARTED = new AtomicReference<Process>();
 
 	private static final String INFRA_READY_MARKER = "Ready.";
-	private static final String TMP_INSTALL_DIR = System.getProperty("java.io.tmpdir") +
-			File.separator + "localstack_install_dir";
+	private static final String LOCAL_INSTALL_DIR = "localstack_install_dir";
 	private static final String ADDITIONAL_PATH = "/usr/local/bin/";
 	private static final String LOCALSTACK_REPO_URL = "https://github.com/localstack/localstack";
+	private static final String INSTALLATION_FINISHED_MARKER = "installation_finished_marker";
 
 	public static final String ENV_CONFIG_USE_SSL = "USE_SSL";
 	private static final String ENV_LOCALSTACK_PROCESS_GROUP = "ENV_LOCALSTACK_PROCESS_GROUP";
+
+	private static String tmpInstallDir = null;
 
 	public LocalstackTestRunner(Class<?> klass) throws InitializationError {
 		super(klass);
@@ -130,28 +141,62 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 
 	/* UTILITY METHODS */
 
+	/**
+	 * for paths that will be passed into bash/linux we need to convert windows file paths to linux file paths
+	 * (assuming the linux subsystem for windows is being used)
+	 */
+	private static String getTmpInstallDir() {
+		if (null == tmpInstallDir) {
+			String tempDir = getRawTmpInstallDir();
+			tempDir = tempDir.replaceAll("^((c:)|(C:))", "/mnt/c");
+			tmpInstallDir = tempDir.replaceAll("\\\\", "/");
+		}
+		return tmpInstallDir;
+	}
+
+	/**
+	 * only add a trailing path separator if one doesn't already exist
+	 */
+	private static String getRawTmpInstallDir() {
+		String tempDir = System.getProperty("java.io.tmpdir");
+		if (!tempDir.endsWith(File.separator)) {
+			tempDir += File.separator;
+		}
+		return tempDir + LOCAL_INSTALL_DIR;
+	}
+
 	private static void ensureInstallation() {
-		File dir = new File(TMP_INSTALL_DIR);
+		File dir = new File(getRawTmpInstallDir());
+
 		File constantsFile = new File(dir, "localstack/constants.py");
-		String logMsg = "Installing LocalStack to temporary directory (this may take a while): " + TMP_INSTALL_DIR;
+		String logMsg = "Installing LocalStack to temporary directory (this may take a while): " + getTmpInstallDir();
 		boolean messagePrinted = false;
+
 		if(!constantsFile.exists()) {
 			LOG.info(logMsg);
 			messagePrinted = true;
 			deleteDirectory(dir);
-			exec("git clone " + LOCALSTACK_REPO_URL + " " + TMP_INSTALL_DIR);
+			LOG.info("cloning...");
+			exec("git clone " + LOCALSTACK_REPO_URL + " " + getTmpInstallDir());
 		}
-		File installationDoneMarker = new File(dir, "localstack/infra/installation.finished.marker");
-		if(!installationDoneMarker.exists()) {
+
+		File installationDoneMarker = new File(getRawTmpInstallDir() + "/localstack/infra/" + INSTALLATION_FINISHED_MARKER);
+		LOG.info("checking installation...");
+		if (!installationDoneMarker.getAbsoluteFile().exists()) {
 			if(!messagePrinted) {
 				LOG.info(logMsg);
 			}
-			exec("cd \"" + TMP_INSTALL_DIR + "\"; make install");
+			LOG.info("installing...");
+			exec("cd '" + getTmpInstallDir() + "'; make install");
 			/* create marker file */
-			try {
-				installationDoneMarker.createNewFile();
-			} catch (IOException e) {
-				throw new RuntimeException(e);
+			if (IS_WINDOWS) {
+				exec(false, "cd '" + getTmpInstallDir() + "/localstack/infra'; cat > " + INSTALLATION_FINISHED_MARKER);
+			} else {
+				try {
+					installationDoneMarker.createNewFile();
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
 			}
 		}
 	}
@@ -192,11 +237,18 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 	}
 
 	private static String getEndpoint(String service) {
+		LOG.info(String.format("fetching endpoint for '%s'...", service));
+		String result = IS_WINDOWS ? getEndpointOnWindows(service) : getEndpointOnLinux(service);
+		LOG.info(String.format("'%s' located at %s", service, result));
+		return result;
+	}
+
+	private static String getEndpointOnLinux(String service) {
 		String useSSL = useSSL() ? "USE_SSL=1" : "";
-		String cmd = "cd '" + TMP_INSTALL_DIR + "'; "
+		String cmd = "cd '" + getTmpInstallDir() + "'; "
 				+ ". .venv/bin/activate; "
 				+ useSSL + " python -c 'import localstack_client.config; "
-					+ "print(localstack_client.config.get_service_endpoint(\"" + service + "\"))'";
+				+ "print(localstack_client.config.get_service_endpoint(\"" + service + "\"))'";
 		Process p = exec(cmd);
 		try {
 			return IOUtils.toString(p.getInputStream()).trim();
@@ -205,11 +257,19 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 		}
 	}
 
+	private static String getEndpointOnWindows(String service) {
+		return ServiceName.getServiceUrl(service);
+	}
+
 	private static Process exec(String ... cmd) {
 		return exec(true, cmd);
 	}
 
 	private static Process exec(boolean wait, String ... cmd) {
+		return IS_WINDOWS ? execWindows(wait, cmd) : execLinux(wait, cmd);
+	}
+
+	private static Process execLinux(boolean wait, String ... cmd) {
 		try {
 			if (cmd.length == 1 && !new File(cmd[0]).exists()) {
 				cmd = new String[]{"bash", "-c", cmd[0]};
@@ -241,6 +301,67 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 		}
 	}
 
+	/**
+	 * for Windows there are a several key differnces:
+	 *   1.  the command passed in to bash needs to be surrounded by quotes
+	 *   2.  windows automatically appends the system path onto the linux path when invoking bash
+	 *   3.  windows file paths need to be converted to work in linux (i.e. change '\' to '/' and 'c:' to '/mnt/c')
+	 *   4.  Process.waitFor() never returns when the java process invokes bash and thus waitFor(timeout) is being used
+	 */
+	private static Process execWindows(boolean wait, String ... cmd) {
+		try {
+			int timeout = 15;
+			if (cmd.length == 1 && !new File(cmd[0]).exists()) {
+				String commandArg = "\"" + cmd[0] + "; exit\"";
+				timeout = getProcessTimeout(commandArg);
+				LOG.info(String.format("executing (timeout = %ds) : bash -c %s", timeout, commandArg));
+				cmd = new String[]{"bash", "-c", commandArg};
+			}
+			ProcessBuilder builder = new ProcessBuilder(cmd);
+			builder.environment().put(ENV_LOCALSTACK_PROCESS_GROUP, ENV_LOCALSTACK_PROCESS_GROUP);
+
+			final Process p = builder.start();
+
+			if (wait) {
+				if (!p.waitFor(timeout, TimeUnit.SECONDS)) {
+					LOG.info("process timeout, assume completed successfully...");
+					Runtime.getRuntime().addShutdownHook(new Thread() {
+						public void run() {
+							killProcess(p);
+						}
+					});
+				}
+			} else {
+				/* make sure we destroy the process on JVM shutdown */
+				Runtime.getRuntime().addShutdownHook(new Thread() {
+					public void run() {
+						killProcess(p);
+					}
+				});
+			}
+			return p;
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 *  these numbers are based on empirical observations with some padding added in
+	 */
+	private static int getProcessTimeout(String cmd) {
+		int result = 15;
+
+		if (cmd.contains("make ") && cmd.contains(" infra")) {
+			result = 120;
+		} else if (cmd.contains("make install")) {
+			result = 300;
+		} else if (cmd.contains("git clone ")) {
+			result = 10;
+		}
+
+		return result;
+	}
+
 	private void setupInfrastructure() {
 		synchronized (INFRA_STARTED) {
 			// make sure everything is installed locally
@@ -248,14 +369,16 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 			// make sure we avoid any errors related to locally generated SSL certificates
 			TestUtils.disableSslCertChecking();
 
-			if(INFRA_STARTED.get() != null) return;
-			String[] cmd = new String[]{"make", "-C", TMP_INSTALL_DIR, "infra"};
+			// check to see if the server process is already running or created
+			if (INFRA_STARTED.get() != null || isAlive()) return;
+
 			Process proc;
 			try {
-				proc = exec(false, cmd);
+				LOG.info("starting...");
+				proc = exec(false, "make -C '" + getTmpInstallDir() + "' infra");
 				BufferedReader r1 = new BufferedReader(new InputStreamReader(proc.getInputStream()));
 				String line;
-				LOG.info(TMP_INSTALL_DIR);
+				LOG.info(getTmpInstallDir());
 				LOG.info("Waiting for infrastructure to be spun up");
 				boolean ready = false;
 				String output = "";
@@ -270,10 +393,37 @@ public class LocalstackTestRunner extends BlockJUnit4ClassRunner {
 					throw new RuntimeException("Unable to start local infrastructure. Debug output: " + output);
 				}
 				INFRA_STARTED.set(proc);
+				LOG.info("started...");
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
 		}
+	}
+
+	/**
+	 *  determine if the services are already running;  if so, this may or may not be ok - issue a warning and continue
+	 */
+	private static boolean isAlive() {
+		boolean result = false;
+
+		try {
+			URL url = new URL(ServiceName.getServiceUrl(ServiceName.S3));
+
+			HttpURLConnection.setFollowRedirects(false);
+			HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+			connection.setRequestMethod("HEAD");
+
+			int responseCode = connection.getResponseCode();
+			result = responseCode == HttpURLConnection.HTTP_OK;
+
+			if (result) {
+				LOG.warning("Services already running.  Please stop the running instance if it is interfering with your tests.");
+			}
+		} catch (IOException e) {
+			// this is ok
+		}
+
+		return result;
 	}
 
 	public static void teardownInfrastructure() {

--- a/localstack/ext/java/src/main/java/cloud/localstack/ServiceName.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/ServiceName.java
@@ -1,5 +1,8 @@
 package cloud.localstack;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ServiceName {
     public static final String API_GATEWAY = "apigateway";
     public static final String KINESIS = "kinesis";
@@ -18,4 +21,30 @@ public class ServiceName {
     public static final String CLOUDFORMATION = "cloudformation";
     public static final String CLOUDWATCH = "cloudwatch";
     public static final String SSM = "ssm";
+
+    private static Map<String, String> serviceMap = new HashMap<>();
+    public static String getServiceUrl(String service) {
+        return serviceMap.get(service);
+    }
+
+    static {
+        serviceMap.put(API_GATEWAY, "http://localhost:4567");
+        serviceMap.put(KINESIS, "http://localhost:4568");
+        serviceMap.put(DYNAMO, "http://localhost:4569");
+        serviceMap.put(DYNAMO_STREAMS, "http://localhost:4570");
+        serviceMap.put(ELASTICSEARCH, "http://localhost:4571");
+        serviceMap.put(S3, "http://localhost:4572");
+        serviceMap.put(FIREHOSE, "http://localhost:4573");
+        serviceMap.put(LAMBDA, "http://localhost:4574");
+        serviceMap.put(SNS, "http://localhost:4575");
+        serviceMap.put(SQS, "http://localhost:4576");
+        serviceMap.put(REDSHIFT, "http://localhost:4577");
+        serviceMap.put(ELASTICSEARCH_SERVICE, "http://localhost:4578");
+        serviceMap.put(SES, "http://localhost:4579");
+        serviceMap.put(ROUTE53, "http://localhost:4580");
+        serviceMap.put(CLOUDFORMATION, "http://localhost:4581");
+        serviceMap.put(CLOUDWATCH, "http://localhost:4582");
+        serviceMap.put(SSM, "http://localhost:4583");
+    }
+
 }


### PR DESCRIPTION
The following issues are corrected:


* windows paths are injected into the bash scripts (fixed by converting to linux paths)
* commands passed into bash on windows must be enclosed in quotes
* Process.waitFor() not working as expected on Windows (with embedded Linux)
* reading the output streams from bash running in the java process problematic, leading to the following adjustments:
  * process.waitFor() changed to process.waitFor(timeout) with suitable timeouts selected based on empirical data
  * workarounds for all the stream reads put in place

Also added additional helpful logging/output which will assist Windows users in troubleshooting.

Tested on Windows 10 using the Linux Subsystem for Windows.  All of the localstack tests pass except for the SQS messaging tests.



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-305) by [Unito](https://www.unito.io/learn-more)
