### PR TITLE
fix lambda_api.get_function to return correct error

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -513,12 +513,8 @@ def get_function(function):
             if lambda_details.concurrency is not None:
                 result['Concurrency'] = lambda_details.concurrency
             return jsonify(result)
-    result = {
-        'ResponseMetadata': {
-            'HTTPStatusCode': 404
-        }
-    }
-    return make_response((jsonify(result), 404, {}))
+    return error_response(
+        'Function not found: %s' % func_arn(function), 404, error_type='ResourceNotFoundException')
 
 
 @app.route('%s/functions/' % PATH_ROOT, methods=['GET'])

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -27,6 +27,14 @@ class TestLambdaAPI(unittest.TestCase):
         self.app.testing = True
         self.client = self.app.test_client()
 
+    def test_get_non_existent_function_returns_error(self):
+        with self.app.test_request_context():
+            result = json.loads(lambda_api.get_function('non_existent_function_name').get_data())
+            self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
+            self.assertEqual(
+                self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn('non_existent_function_name'),
+                result['message'])
+
     def test_get_event_source_mapping(self):
         with self.app.test_request_context():
             lambda_api.event_source_mappings.append({'UUID': self.TEST_UUID})


### PR DESCRIPTION
The `get_function` API should return the same response as the Lambda API when the function is not found, but this does not seem to be the case right now, which means it's broken with some tools that depend on proper responses when the lambda is not found:

Currently localstack returns:
```
curl http://localhost:4574/2015-03-31/functions/test -v
< HTTP/1.0 404 NOT FOUND
< Content-Type: application/json
< Content-Length: 57
< Access-Control-Allow-Origin: *
< Server: Werkzeug/0.14.1 Python/2.7.13
< Date: Tue, 03 Apr 2018 15:49:12 GMT
<
{
  "ResponseMetadata": {
    "HTTPStatusCode": 404
  }
}
```
However the correct API response is: 
```
Content-Type:       application/json
x-amazon-ErrorType: ResourceNotFoundException
{
    "Message":"Function not found: arn:aws:lambda:us-west-2:364942603424:function:nonsense",
    "Type":"User"
}
```
The existing handling looks out-of-date, since it was never updated to use the `error_response` functionality. 

