### PR TITLE
Removes the last runtime dependency of JUnit on common code

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.1.12</version>
+    <version>0.1.13</version>
 </dependency>
 ```
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -30,7 +30,7 @@ DEFAULT_PORT_WEB_UI = 8080
 LOCALHOST = 'localhost'
 
 # version of the Maven dependency with Java utility code
-LOCALSTACK_MAVEN_VERSION = '0.1.12'
+LOCALSTACK_MAVEN_VERSION = '0.1.13'
 
 # map of default service APIs and ports to be spun up (fetch map from localstack_client)
 DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()

--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -5,7 +5,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.12</version>
+    <version>0.1.13</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -60,10 +60,6 @@ public class LocalstackDocker {
 
 
     public void startup() {
-        // make sure the local infrastructure is not running, to avoid port conflicts
-        LocalstackTestRunner.teardownInfrastructure();
-
-        // now create the container
         if (locked) {
             throw new IllegalStateException("A docker instance is starting or already started.");
         }
@@ -79,7 +75,6 @@ public class LocalstackDocker {
             locked = false;
             throw new LocalstackDockerException("Could not start the localstack docker container.", t);
         }
-
     }
 
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDockerTestRunner.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDockerTestRunner.java
@@ -57,6 +57,8 @@ public class LocalstackDockerTestRunner extends BlockJUnit4ClassRunner {
 
     @Override
     public void run(RunNotifier notifier) {
+        LocalstackTestRunner.teardownInfrastructure();
+
         localstackDocker.setExternalHostName(externalHostName);
         localstackDocker.setPullNewImage(pullNewImage);
         localstackDocker.setRandomizePorts(randomizePorts);

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
@@ -17,7 +17,6 @@ public class ContainerTest {
     @Test
     public void createLocalstackContainer() throws Exception {
 
-
         HashMap<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(MY_PROPERTY, MY_VALUE);
         Container localStackContainer = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, true, true, environmentVariables);
@@ -35,7 +34,6 @@ public class ContainerTest {
         finally {
             localStackContainer.stop();
         }
-
     }
 
     private ArrayList<String> buildEchoStatement(String valueToEcho) {


### PR DESCRIPTION
Hello, again. I need this change for removing the runtime dependency of JUnit on the application. I already coded basic auto-configuration factories for the Spring Boot and it runs alright with this change. If you want you can checkout more here:

https://github.com/fabianoo/spring-localstack

I would need this change and a new version. Is it possible?

Best wishes,
Fabiano