### PR TITLE
v1.13.0 Kinesalite

### DIFF
--- a/localstack/package.json
+++ b/localstack/package.json
@@ -4,7 +4,7 @@
   "description": "Local Cloud Stack and Utilities",
   "version": "0.0.1",
   "dependencies": {
-    "kinesalite": "1.12.1",
+    "kinesalite": "1.13.0",
     "leveldown": "1.6.0"
   }
 }


### PR DESCRIPTION
This upgrades the Kinesalite dependency to version 1.13.0.

This version is significant because of the following resolved issue, which prevented testing of the KCL versions 1.9.x:

https://github.com/mhart/kinesalite/issues/59