### PR TITLE
Fix errors deploying Serverless on OSX

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -511,7 +511,7 @@ def _unzip_file_entry(zip_ref, file_entry, target_dir):
     zip_ref.extract(file_entry.filename, path=target_dir)
     out_path = os.path.join(target_dir, file_entry.filename)
     perm = file_entry.external_attr >> 16
-    os.chmod(out_path, perm)
+    os.chmod(out_path, perm or 0o777)
 
 
 def is_jar_archive(content):

--- a/localstack/utils/persistence.py
+++ b/localstack/utils/persistence.py
@@ -39,7 +39,7 @@ def record(api, method, path, data, headers):
     try:
         if isinstance(data, dict):
             data = json.dumps(data)
-        if data:
+        if data or data in [u'', b'']:
             try:
                 data = to_bytes(data)
             except Exception as e:


### PR DESCRIPTION
On OSX, I am having permission errors and related, when trying deploy a simple Serverless function using Python runtime.

Caveats of this PR:
* Tests will be added later, before merging the PR
* Squashing can be done on merge, to keep the blame and reasoning before the merge.