### PR TITLE
fix sqs CORS preflight response

### DIFF
--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -32,6 +32,11 @@ class ProxyListenerSQS(ProxyListener):
         return True
 
     def return_response(self, method, path, data, headers, response, request_handler):
+        if method == 'OPTIONS' and path == '/':
+            # Allow CORS preflight requests to succeed.
+            new_response = Response()
+            new_response.status_code = 200
+            return new_response
 
         if method == 'POST' and path == '/':
             req_data = urlparse.parse_qs(to_str(data))


### PR DESCRIPTION
I'm using the aws js sdk locally in the browser. After hooking up lambda executions successfully, I was surprised to see sqs requests being denied by CORS. This turned out to be because localstack was 404ing on OPTIONS to the root url.

This change fixes that by returning a 200 instead. After the change I was able to send messages as expected.