### PR TITLE
Lambda: add function properties to LambdaContext for invocations

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -110,6 +110,10 @@ class LambdaExecutorContainers(LambdaExecutor):
         environment['AWS_LAMBDA_EVENT_BODY'] = event_body_escaped
         environment['HOSTNAME'] = docker_host
         environment['LOCALSTACK_HOSTNAME'] = docker_host
+        if context:
+            environment['AWS_LAMBDA_FUNCTION_NAME'] = context.function_name
+            environment['AWS_LAMBDA_FUNCTION_VERSION'] = context.function_version
+            environment['AWS_LAMBDA_FUNCTION_INVOKED_ARN'] = context.invoked_function_arn
 
         # custom command to execute in the container
         command = ''

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -181,11 +181,13 @@ class LambdaFunction(Component):
         return self.id
 
     def function(self, qualifier=None):
+        return self.versions.get(self.get_qualifier_version(qualifier)).get('Function')
+
+    def get_qualifier_version(self, qualifier=None):
         if not qualifier:
             qualifier = '$LATEST'
-        version = qualifier if qualifier in self.versions else \
+        return qualifier if qualifier in self.versions else \
             self.aliases.get(qualifier).get('FunctionVersion')
-        return self.versions.get(version).get('Function')
 
     def qualifier_exists(self, qualifier):
         return qualifier in self.aliases or qualifier in self.versions

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -35,7 +35,14 @@ def handler(event, context):
         }
 
     if 'Records' not in event:
-        return event
+        return {
+            'event': event,
+            'context': {
+                'invoked_function_arn': context.invoked_function_arn,
+                'function_version': context.function_version,
+                'function_name': context.function_name
+            }
+        }
 
     raw_event_messages = []
     for record in event['Records']:


### PR DESCRIPTION
This adds some common properties to the LambdaContext, which is passed
to functions during invocations. In particular, the following properties
are added: function_name, function_version, invoked_function_arn.

The above properties are passed to lambda functions running inside docker.

Support for publishing during function creation has also been added,
which was a missing functionality, and was helpful in testing.

Note that this has a slight dependency on https://github.com/lambci/docker-lambda/pull/98, but shouldn't break anything if this was merged first.

Contributed by @quantcast

**Please refer to the contribution guidelines in the README when submitting PRs.**
