### PR TITLE
Support resources with HTTP method 'ANY' in API Gateway

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -451,6 +451,10 @@ def create_api_gateway_integrations(api_id, resource_id, method, integrations=[]
             )
 
 
+def apigateway_invocations_arn(lambda_uri):
+    return 'arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations' % (DEFAULT_REGION, lambda_uri)
+
+
 def get_elasticsearch_endpoint(domain=None, region_name=None):
     env = get_environment(region_name=region_name)
     if env.region == REGION_LOCAL:

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -26,8 +26,12 @@ def handler(event, context):
 
     if 'httpMethod' in event:
         # looks like this is a call from an AWS_PROXY API Gateway
-        body = json.loads(event['body'])
+        try:
+            body = json.loads(event['body'])
+        except Exception:
+            body = {}
         body['pathParameters'] = event.get('pathParameters')
+        body['httpMethod'] = event.get('httpMethod')
         return {
             'body': body,
             'statusCode': body.get('return_status_code', 200),


### PR DESCRIPTION
This allows the API Gateway integration to properly dispatch HTTP requests to resources setup with HTTP method `ANY`.

Hopefully, this should fix #667 ... and maybe #449 as well.