### PR TITLE
changed `async` references to `asynchronous` to support Python 3.7

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -58,7 +58,7 @@ class LambdaExecutor(object):
         process = run(cmd, asynchronous=True, stderr=subprocess.PIPE, outfile=subprocess.PIPE, env_vars=env_vars)
         if asynchronous:
             result = '{"asynchronous": "%s"}' % asynchronous
-            log_output = 'Lambda executed asynchronoushronously'
+            log_output = 'Lambda executed asynchronously'
         else:
             return_code = process.wait()
             result = to_str(process.stdout.read())

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -45,7 +45,7 @@ class LambdaExecutor(object):
     def __init__(self):
         pass
 
-    def execute(self, func_arn, func_details, event, context=None, version=None, async=False):
+    def execute(self, func_arn, func_details, event, context=None, version=None, asynchronous=False):
         raise Exception('Not implemented.')
 
     def startup(self):
@@ -54,11 +54,11 @@ class LambdaExecutor(object):
     def cleanup(self, arn=None):
         pass
 
-    def run_lambda_executor(self, cmd, env_vars={}, async=False):
-        process = run(cmd, async=True, stderr=subprocess.PIPE, outfile=subprocess.PIPE, env_vars=env_vars)
-        if async:
-            result = '{"async": "%s"}' % async
-            log_output = 'Lambda executed asynchronously'
+    def run_lambda_executor(self, cmd, env_vars={}, asynchronous=False):
+        process = run(cmd, asynchronous=True, stderr=subprocess.PIPE, outfile=subprocess.PIPE, env_vars=env_vars)
+        if asynchronous:
+            result = '{"asynchronous": "%s"}' % asynchronous
+            log_output = 'Lambda executed asynchronoushronously'
         else:
             return_code = process.wait()
             result = to_str(process.stdout.read())
@@ -86,7 +86,7 @@ class LambdaExecutorContainers(LambdaExecutor):
     def prepare_execution(self, func_arn, env_vars, runtime, command, handler, lambda_cwd):
         raise Exception('Not implemented')
 
-    def execute(self, func_arn, func_details, event, context=None, version=None, async=False):
+    def execute(self, func_arn, func_details, event, context=None, version=None, asynchronous=False):
 
         lambda_cwd = func_details.cwd
         runtime = func_details.runtime
@@ -129,7 +129,7 @@ class LambdaExecutorContainers(LambdaExecutor):
 
         # lambci writes the Lambda result to stdout and logs to stderr, fetch it from there!
         LOG.debug('Running lambda cmd: %s' % cmd)
-        result, log_output = self.run_lambda_executor(cmd, environment, async)
+        result, log_output = self.run_lambda_executor(cmd, environment, asynchronous)
         LOG.debug('Lambda result / log output:\n%s\n>%s' % (result.strip(), log_output.strip().replace('\n', '\n> ')))
         return result, log_output
 
@@ -259,7 +259,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             ) % (runtime)
 
             LOG.debug(cmd)
-            run_result = run(cmd, async=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
+            run_result = run(cmd, asynchronous=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
 
             entry_point = run_result.strip('[]\n\r ')
 
@@ -285,7 +285,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
                 ) % (container_name)
 
                 LOG.debug(cmd)
-                run(cmd, async=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
+                run(cmd, asynchronous=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
 
                 status = self.get_docker_container_status(func_arn)
 
@@ -296,7 +296,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
                 ) % (container_name)
 
                 LOG.debug(cmd)
-                run(cmd, async=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
+                run(cmd, asynchronous=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
 
     def get_all_container_names(self):
         """
@@ -307,7 +307,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             LOG.debug('Getting all lambda containers names.')
             cmd = 'docker ps -a --filter="name=localstack_lambda_*" --format "{{.Names}}"'
             LOG.debug(cmd)
-            cmd_result = run(cmd, async=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE).strip()
+            cmd_result = run(cmd, asynchronous=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE).strip()
 
             if len(cmd_result) > 0:
                 container_names = cmd_result.split('\n')
@@ -328,7 +328,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             for container_name in container_names:
                 cmd = 'docker rm -f %s' % container_name
                 LOG.debug(cmd)
-                run(cmd, async=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
+                run(cmd, asynchronous=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
 
     def get_docker_container_status(self, func_arn):
         """
@@ -352,7 +352,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             ) % (container_name)
 
             LOG.debug(cmd)
-            cmd_result = run(cmd, async=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
+            cmd_result = run(cmd, asynchronous=False, stderr=subprocess.PIPE, outfile=subprocess.PIPE)
 
             # If the container doesn't exist. Create and start it.
             container_status = cmd_result.strip()
@@ -440,7 +440,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
 
 class LambdaExecutorLocal(LambdaExecutor):
 
-    def execute(self, func_arn, func_details, event, context=None, version=None, async=False):
+    def execute(self, func_arn, func_details, event, context=None, version=None, asynchronous=False):
         lambda_cwd = func_details.cwd
         environment = func_details.envvars.copy()
 
@@ -472,15 +472,15 @@ class LambdaExecutorLocal(LambdaExecutor):
         class_name = handler.split('::')[0]
         classpath = '%s:%s' % (LAMBDA_EXECUTOR_JAR, main_file)
         cmd = 'java -cp %s %s %s %s' % (classpath, LAMBDA_EXECUTOR_CLASS, class_name, event_file)
-        async = False
-        # flip async flag depending on origin
+        asynchronous = False
+        # flip asynchronous flag depending on origin
         if 'Records' in event:
-            # TODO: add more event supporting async lambda execution
+            # TODO: add more event supporting asynchronous lambda execution
             if 'Sns' in event['Records'][0]:
-                async = True
+                asynchronous = True
             if 'dynamodb' in event['Records'][0]:
-                async = True
-        result, log_output = self.run_lambda_executor(cmd, async=async)
+                asynchronous = True
+        result, log_output = self.run_lambda_executor(cmd, asynchronous=asynchronous)
         LOG.debug('Lambda result / log output:\n%s\n> %s' % (result.strip(), log_output.strip().replace('\n', '\n> ')))
         return result, log_output
 

--- a/localstack/services/dynamodb/dynamodb_starter.py
+++ b/localstack/services/dynamodb/dynamodb_starter.py
@@ -27,7 +27,7 @@ def check_dynamodb(expect_shutdown=False, print_error=False):
         assert isinstance(out['TableNames'], list)
 
 
-def start_dynamodb(port=PORT_DYNAMODB, async=False, update_listener=None):
+def start_dynamodb(port=PORT_DYNAMODB, asynchronous=False, update_listener=None):
     install.install_dynamodb_local()
     backend_port = DEFAULT_PORT_DYNAMODB_BACKEND
     ddb_data_dir_param = '-inMemory'
@@ -39,4 +39,4 @@ def start_dynamodb(port=PORT_DYNAMODB, async=False, update_listener=None):
         '-jar DynamoDBLocal.jar -sharedDb -port %s %s') % (ROOT_PATH, backend_port, ddb_data_dir_param)
     print('Starting mock DynamoDB (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('dynamodb', port, backend_port, update_listener)
-    return do_run(cmd, async)
+    return do_run(cmd, asynchronous)

--- a/localstack/services/es/es_starter.py
+++ b/localstack/services/es/es_starter.py
@@ -19,7 +19,7 @@ def delete_all_elasticsearch_data():
     run('rm -rf "%s"' % data_dir)
 
 
-def start_elasticsearch(port=PORT_ELASTICSEARCH, delete_data=True, async=False, update_listener=None):
+def start_elasticsearch(port=PORT_ELASTICSEARCH, delete_data=True, asynchronous=False, update_listener=None):
     # delete Elasticsearch data that may be cached locally from a previous test run
     delete_all_elasticsearch_data()
 
@@ -47,7 +47,7 @@ def start_elasticsearch(port=PORT_ELASTICSEARCH, delete_data=True, async=False, 
         update_listener, quiet=True, params={'protocol_version': 'HTTP/1.0'})
     if is_root():
         cmd = "su -c '%s' localstack" % cmd
-    thread = do_run(cmd, async)
+    thread = do_run(cmd, asynchronous)
     return thread
 
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -66,9 +66,9 @@ class Plugin(object):
         self.listener = listener
         self.check_function = check
 
-    def start(self, async):
+    def start(self, asynchronous):
         kwargs = {
-            'async': async
+            'asynchronous': asynchronous
         }
         if self.listener:
             kwargs['update_listener'] = self.listener
@@ -137,60 +137,60 @@ def load_plugins(scope=None):
 # -----------------
 
 
-def start_apigateway(port=PORT_APIGATEWAY, async=False, update_listener=None):
-    return start_moto_server('apigateway', port, name='API Gateway', async=async,
+def start_apigateway(port=PORT_APIGATEWAY, asynchronous=False, update_listener=None):
+    return start_moto_server('apigateway', port, name='API Gateway', asynchronous=asynchronous,
         backend_port=DEFAULT_PORT_APIGATEWAY_BACKEND, update_listener=update_listener)
 
 
-def start_s3(port=PORT_S3, async=False, update_listener=None):
-    return start_moto_server('s3', port, name='S3', async=async,
+def start_s3(port=PORT_S3, asynchronous=False, update_listener=None):
+    return start_moto_server('s3', port, name='S3', asynchronous=asynchronous,
         backend_port=DEFAULT_PORT_S3_BACKEND, update_listener=update_listener)
 
 
-def start_sns(port=PORT_SNS, async=False, update_listener=None):
-    return start_moto_server('sns', port, name='SNS', async=async,
+def start_sns(port=PORT_SNS, asynchronous=False, update_listener=None):
+    return start_moto_server('sns', port, name='SNS', asynchronous=asynchronous,
         backend_port=DEFAULT_PORT_SNS_BACKEND, update_listener=update_listener)
 
 
-def start_cloudformation(port=PORT_CLOUDFORMATION, async=False, update_listener=None):
-    return start_moto_server('cloudformation', port, name='CloudFormation', async=async,
+def start_cloudformation(port=PORT_CLOUDFORMATION, asynchronous=False, update_listener=None):
+    return start_moto_server('cloudformation', port, name='CloudFormation', asynchronous=asynchronous,
         backend_port=DEFAULT_PORT_CLOUDFORMATION_BACKEND, update_listener=update_listener)
 
 
-def start_cloudwatch(port=PORT_CLOUDWATCH, async=False):
-    return start_moto_server('cloudwatch', port, name='CloudWatch', async=async)
+def start_cloudwatch(port=PORT_CLOUDWATCH, asynchronous=False):
+    return start_moto_server('cloudwatch', port, name='CloudWatch', asynchronous=asynchronous)
 
 
-def start_redshift(port=PORT_REDSHIFT, async=False):
-    return start_moto_server('redshift', port, name='Redshift', async=async)
+def start_redshift(port=PORT_REDSHIFT, asynchronous=False):
+    return start_moto_server('redshift', port, name='Redshift', asynchronous=asynchronous)
 
 
-def start_route53(port=PORT_ROUTE53, async=False):
-    return start_moto_server('route53', port, name='Route53', async=async)
+def start_route53(port=PORT_ROUTE53, asynchronous=False):
+    return start_moto_server('route53', port, name='Route53', asynchronous=asynchronous)
 
 
-def start_ses(port=PORT_SES, async=False):
-    return start_moto_server('ses', port, name='SES', async=async)
+def start_ses(port=PORT_SES, asynchronous=False):
+    return start_moto_server('ses', port, name='SES', asynchronous=asynchronous)
 
 
-def start_elasticsearch_service(port=PORT_ES, async=False):
-    return start_local_api('ES', port, method=es_api.serve, async=async)
+def start_elasticsearch_service(port=PORT_ES, asynchronous=False):
+    return start_local_api('ES', port, method=es_api.serve, asynchronous=asynchronous)
 
 
-def start_firehose(port=PORT_FIREHOSE, async=False):
-    return start_local_api('Firehose', port, method=firehose_api.serve, async=async)
+def start_firehose(port=PORT_FIREHOSE, asynchronous=False):
+    return start_local_api('Firehose', port, method=firehose_api.serve, asynchronous=asynchronous)
 
 
-def start_dynamodbstreams(port=PORT_DYNAMODBSTREAMS, async=False):
-    return start_local_api('DynamoDB Streams', port, method=dynamodbstreams_api.serve, async=async)
+def start_dynamodbstreams(port=PORT_DYNAMODBSTREAMS, asynchronous=False):
+    return start_local_api('DynamoDB Streams', port, method=dynamodbstreams_api.serve, asynchronous=asynchronous)
 
 
-def start_lambda(port=PORT_LAMBDA, async=False):
-    return start_local_api('Lambda', port, method=lambda_api.serve, async=async)
+def start_lambda(port=PORT_LAMBDA, asynchronous=False):
+    return start_local_api('Lambda', port, method=lambda_api.serve, asynchronous=asynchronous)
 
 
-def start_ssm(port=PORT_SSM, async=False):
-    return start_moto_server('ssm', port, name='SSM', async=async)
+def start_ssm(port=PORT_SSM, asynchronous=False):
+    return start_moto_server('ssm', port, name='SSM', asynchronous=asynchronous)
 
 
 # ---------------
@@ -237,9 +237,9 @@ def is_debug():
     return os.environ.get('DEBUG', '').strip() not in ['', '0', 'false']
 
 
-def do_run(cmd, async, print_output=False):
+def do_run(cmd, asynchronous, print_output=False):
     sys.stdout.flush()
-    if async:
+    if asynchronous:
         if is_debug():
             print_output = True
         outfile = subprocess.PIPE if print_output else None
@@ -266,7 +266,7 @@ def start_proxy(port, backend_url, update_listener, quiet=False, params={}):
     return proxy_thread
 
 
-def start_moto_server(key, port, name=None, backend_port=None, async=False, update_listener=None):
+def start_moto_server(key, port, name=None, backend_port=None, asynchronous=False, update_listener=None):
     moto_server_cmd = '%s/bin/moto_server' % LOCALSTACK_VENV_FOLDER
     if not os.path.exists(moto_server_cmd):
         moto_server_cmd = run('which moto_server').strip()
@@ -278,12 +278,12 @@ def start_moto_server(key, port, name=None, backend_port=None, async=False, upda
         start_proxy_for_service(key, port, backend_port, update_listener)
     elif USE_SSL:
         cmd += ' --ssl'
-    return do_run(cmd, async)
+    return do_run(cmd, asynchronous)
 
 
-def start_local_api(name, port, method, async=False):
+def start_local_api(name, port, method, asynchronous=False):
     print('Starting mock %s service (%s port %s)...' % (name, get_service_protocol(), port))
-    if async:
+    if asynchronous:
         thread = FuncThread(method, port, quiet=True)
         thread.start()
         TMP_THREADS.append(thread)
@@ -442,7 +442,7 @@ def start_infra_in_docker():
 # -------------
 
 
-def start_infra(async=False, apis=None):
+def start_infra(asynchronous=False, apis=None):
     try:
         # load plugins
         load_plugins()
@@ -474,7 +474,7 @@ def start_infra(async=False, apis=None):
         # loop through plugins and start each service
         for name, plugin in SERVICE_PLUGINS.items():
             if name in apis:
-                t1 = plugin.start(async=True)
+                t1 = plugin.start(asynchronous=True)
                 thread = thread or t1
 
         time.sleep(sleep_time)
@@ -484,7 +484,7 @@ def start_infra(async=False, apis=None):
         restore_persisted_data(apis=apis)
         print('Ready.')
         sys.stdout.flush()
-        if not async and thread:
+        if not asynchronous and thread:
             # this is a bit of an ugly hack, but we need to make sure that we
             # stay in the execution context of the main thread, otherwise our
             # signal handlers don't work
@@ -498,5 +498,5 @@ def start_infra(async=False, apis=None):
         sys.stdout.flush()
         raise e
     finally:
-        if not async:
+        if not asynchronous:
             stop_infra()

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -11,7 +11,7 @@ from localstack.services.install import ROOT_PATH
 LOGGER = logging.getLogger(__name__)
 
 
-def start_kinesis(port=PORT_KINESIS, async=False, shard_limit=100, update_listener=None):
+def start_kinesis(port=PORT_KINESIS, asynchronous=False, shard_limit=100, update_listener=None):
     install.install_kinesalite()
     backend_port = DEFAULT_PORT_KINESIS_BACKEND
     kinesis_data_dir_param = ''
@@ -23,7 +23,7 @@ def start_kinesis(port=PORT_KINESIS, async=False, shard_limit=100, update_listen
         (ROOT_PATH, shard_limit, backend_port, kinesis_data_dir_param))
     print('Starting mock Kinesis (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('kinesis', port, backend_port, update_listener)
-    return do_run(cmd, async)
+    return do_run(cmd, asynchronous)
 
 
 def check_kinesis(expect_shutdown=False, print_error=False):

--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -9,7 +9,7 @@ from localstack.services.install import INSTALL_DIR_ELASTICMQ, install_elasticmq
 LOGGER = logging.getLogger(__name__)
 
 
-def start_sqs(port=PORT_SQS, async=False, update_listener=None):
+def start_sqs(port=PORT_SQS, asynchronous=False, update_listener=None):
     install_elasticmq()
     backend_port = DEFAULT_PORT_SQS_BACKEND
     # create config file
@@ -35,4 +35,4 @@ def start_sqs(port=PORT_SQS, async=False, update_listener=None):
     cmd = ('java -Dconfig.file=%s -jar %s/elasticmq-server.jar' % (config_file, INSTALL_DIR_ELASTICMQ))
     print('Starting mock SQS (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('sqs', port, backend_port, update_listener)
-    return do_run(cmd, async)
+    return do_run(cmd, asynchronous)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -109,7 +109,7 @@ class ShellCommandThread (FuncThread):
             return line.strip() + '\r\n'
 
         try:
-            self.process = run(self.cmd, async=True, stdin=self.stdin, outfile=self.outfile,
+            self.process = run(self.cmd, asynchronous=True, stdin=self.stdin, outfile=self.outfile,
                 env_vars=self.env_vars, inherit_cwd=self.inherit_cwd)
             if self.outfile:
                 if self.outfile == subprocess.PIPE:
@@ -611,7 +611,7 @@ def run_cmd_safe(**kwargs):
     return run_safe(run, print_error=False, **kwargs)
 
 
-def run(cmd, cache_duration_secs=0, print_error=True, async=False, stdin=False,
+def run(cmd, cache_duration_secs=0, print_error=True, asynchronous=False, stdin=False,
         stderr=subprocess.STDOUT, outfile=None, env_vars=None, inherit_cwd=False):
     # don't use subprocess module as it is not thread-safe
     # http://stackoverflow.com/questions/21194380/is-subprocess-popen-not-thread-safe
@@ -628,7 +628,7 @@ def run(cmd, cache_duration_secs=0, print_error=True, async=False, stdin=False,
     def do_run(cmd):
         try:
             cwd = os.getcwd() if inherit_cwd else None
-            if not async:
+            if not asynchronous:
                 if stdin:
                     return subprocess.check_output(cmd, shell=True,
                         stderr=stderr, stdin=subprocess.PIPE, env=env_dict, cwd=cwd)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -10,7 +10,7 @@ def setup_package():
         # disable SSL verification for local tests
         safe_requests.verify_ssl = False
         # start infrastructure services
-        infra.start_infra(async=True)
+        infra.start_infra(asynchronous=True)
     except Exception as e:
         # make sure to tear down the infrastructure
         infra.stop_infra()

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -109,14 +109,14 @@ def test_lambda_runtimes():
                                   Payload=b'{"Records": [{"Sns": {"Message": "{}"}}]}')
     assert result['StatusCode'] == 200
     result_data = result['Payload'].read()
-    assert json.loads(to_str(result_data)) == {'async': 'True'}
+    assert json.loads(to_str(result_data)) == {'asynchronous': 'True'}
 
     # test DDBEvent
     result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA, InvocationType='Event',
                                   Payload=b'{"Records": [{"dynamodb": {"Message": "{}"}}]}')
     assert result['StatusCode'] == 200
     result_data = result['Payload'].read()
-    assert json.loads(to_str(result_data)) == {'async': 'True'}
+    assert json.loads(to_str(result_data)) == {'asynchronous': 'True'}
 
     # test KinesisEvent
     result = lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA,


### PR DESCRIPTION
`async` is a reserved keyword in Python 3.7 and currently breaks localstack, replaced all references with `asynchronous`. Tests passing.

See:
- https://docs.python.org/3/whatsnew/3.7.html 
- https://docs.python.org/3/reference/compound_stmts.html#async