### PR TITLE
fix link for contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ the [**Contributor License Agreement**](doc/contributor_license_agreement).
 ## Contributors
 
 This project exists thanks to all the people who contribute.
-<a href="graphs/contributors"><img src="https://opencollective.com/localstack/contributors.svg?width=890" /></a>
+<a href="../../graphs/contributors"><img src="https://opencollective.com/localstack/contributors.svg?width=890" /></a>
 
 
 ## Backers

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ the [**Contributor License Agreement**](doc/contributor_license_agreement).
 ## Contributors
 
 This project exists thanks to all the people who contribute.
-<a href="../../graphs/contributors"><img src="https://opencollective.com/localstack/contributors.svg?width=890" /></a>
+<a href="https://github.com/localstack/localstack/graphs/contributors"><img src="https://opencollective.com/localstack/contributors.svg?width=890" /></a>
 
 
 ## Backers


### PR DESCRIPTION
This fixes the contributors link on the README.md and should close https://github.com/localstack/localstack/issues/748

**Please refer to the contribution guidelines in the README when submitting PRs.**
I agree to https://github.com/localstack/localstack/tree/master/doc/contributor_license_agreement


