### PR TITLE
chore: bump elasticmq to v0.14.2

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -26,16 +26,16 @@ RUN { \
     && chmod +x /usr/local/bin/docker-java-home
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
-ENV JAVA_VERSION 8u131
-ENV JAVA_ALPINE_VERSION 8.131.11-r2
+ENV JAVA_VERSION 8u171
+ENV JAVA_ALPINE_VERSION 8.171.11-r0
 RUN set -x && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" \
     && [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
 # Install Maven - taken from official repo:
 # https://github.com/carlossg/docker-maven/blob/master/jdk-8/Dockerfile)
-ARG MAVEN_VERSION=3.5.2
+ARG MAVEN_VERSION=3.5.4
 ARG USER_HOME_DIR="/root"
-ARG SHA=707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff
+ARG SHA=ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-$MAVEN_VERSION-bin.tar.gz \

--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -57,7 +57,7 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
     wget -O /tmp/localstack.es.zip \
         https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip && \
     wget -O /tmp/elasticmq-server.jar \
-        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.10.jar && \
+        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \
         mv elasticsearch* elasticsearch && rm /tmp/localstack.es.zip) && \
     mkdir -p /opt/code/localstack/localstack/infra/dynamodb && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -71,7 +71,7 @@ LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 # installation constants
 ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip'
 DYNAMODB_JAR_URL = 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip'
-ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.13.10.jar'
+ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar'
 STS_JAR_URL = 'http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 
 # API endpoint for analytics events

--- a/localstack/package.json
+++ b/localstack/package.json
@@ -4,7 +4,7 @@
   "description": "Local Cloud Stack and Utilities",
   "version": "0.0.1",
   "dependencies": {
-    "kinesalite": "1.13.0",
-    "leveldown": "1.6.0"
+    "kinesalite": "1.14.0",
+    "leveldown": "3.0.1"
   }
 }

--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -21,13 +21,9 @@ class ProxyListenerSQS(ProxyListener):
         if method == 'POST' and path == '/':
             req_data = urlparse.parse_qs(to_str(data))
             if 'QueueName' in req_data:
-                if '.' in req_data['QueueName'][0]:
-                    # ElasticMQ currently does not support "." in the queue name, e.g., for *.fifo queues
-                    # TODO: remove this once *.fifo queues are supported in ElasticMQ
-                    req_data['QueueName'][0] = req_data['QueueName'][0].replace('.', '_')
-                    modified_data = urlencode(req_data, doseq=True)
-                    request = Request(data=modified_data, headers=headers, method=method)
-                    return request
+                encoded_data = urlencode(req_data, doseq=True)
+                request = Request(data=encoded_data, headers=headers, method=method)
+                return request
 
         return True
 

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -27,7 +27,7 @@ def test_sqs_queue_names():
     sqs_client = aws_stack.connect_to_service('sqs')
     queue_name = '%s.fifo' % short_uid()
     # make sure we can create *.fifo queues
-    queue_url = sqs_client.create_queue(QueueName=queue_name)['QueueUrl']
+    queue_url = sqs_client.create_queue(QueueName=queue_name, Attributes={'FifoQueue': 'true'})['QueueUrl']
     sqs_client.delete_queue(QueueUrl=queue_url)
 
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -20,7 +20,7 @@ class SQSTest(unittest.TestCase):
     def test_create_fifo_queue(self):
         fifo_queue = 'my-queue.fifo'
         sqs_client = aws_stack.connect_to_service('sqs')
-        queue_info = sqs_client.create_queue(QueueName=fifo_queue)
+        queue_info = sqs_client.create_queue(QueueName=fifo_queue, Attributes={'FifoQueue': 'true'})
         queue_url = queue_info['QueueUrl']
 
         # it should preserve .fifo in the queue name

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -16,3 +16,12 @@ class SQSTest(unittest.TestCase):
 
         # Apparently, if there are no tags, then `Tags` should NOT appear in the response.
         assert 'Tags' not in res
+
+    def test_create_fifo_queue(self):
+        fifo_queue = 'my-queue.fifo'
+        sqs_client = aws_stack.connect_to_service('sqs')
+        queue_info = sqs_client.create_queue(QueueName=fifo_queue)
+        queue_url = queue_info['QueueUrl']
+
+        # it should preserve .fifo in the queue name
+        assert fifo_queue in queue_url


### PR DESCRIPTION
I opened this morning an issue about upgrading elasticmq dependency: https://github.com/localstack/localstack/issues/879

It seems that after the merge of adamw/elasticmq#143 FIFO queues should be available so I tried to bump to a more recent version. Not sure I missed something but I tried to create one FIFO queue and it still seems to not work

*Step to reproduce*

```
$ docker build -t localstack:custom .
$ docker run -d -e SERVICES=sqs -p 4576:4576 localstack:custom
$ aws --endpoint-url=http://localhost:4576 sqs list-queues
# empty output without queues
```

I created then the following terraform configuration:

References:
https://github.com/localstack/localstack/issues/718
https://www.terraform.io/docs/providers/aws/r/sqs_queue.html

```tf
provider "aws" {
  region                      = "us-east-1"
  access_key                  = "anaccesskey"
  secret_key                  = "asecretkey"
  skip_credentials_validation = true
  skip_metadata_api_check     = true
  s3_force_path_style         = true

  endpoints {
    sqs      = "http://localhost:4576"
  }
}

resource "aws_sqs_queue" "terraform_queue" {
  name                        = "terraform-example-queue.fifo"
  fifo_queue                  = true
  content_based_deduplication = true
}
```
I saved this file in `tf/main.tf`

```
$ cd tf
$ terraform init -input=false
$ terraform plan -input=false
$ terraform apply -input=false -auto-approve

aws_sqs_queue.terraform_queue: Refreshing state... (ID: http://localhost:4576/queue/terraform-example-queue_fifo)
aws_sqs_queue.terraform_queue: Destroying... (ID: http://localhost:4576/queue/terraform-example-queue_fifo)
aws_sqs_queue.terraform_queue: Destruction complete after 0s
aws_sqs_queue.terraform_queue: Creating...
  arn:                               "" => "<computed>"
  content_based_deduplication:       "" => "true"
  delay_seconds:                     "" => "0"
  fifo_queue:                        "" => "true"
  kms_data_key_reuse_period_seconds: "" => "<computed>"
  max_message_size:                  "" => "262144"
  message_retention_seconds:         "" => "345600"
  name:                              "" => "terraform-example-queue.fifo"
  policy:                            "" => "<computed>"
  receive_wait_time_seconds:         "" => "0"
  visibility_timeout_seconds:        "" => "30"

Error: Error applying plan:

1 error(s) occurred:

* aws_sqs_queue.terraform_queue: 1 error(s) occurred:

* aws_sqs_queue.terraform_queue: [ERR] Error updating SQS attributes: InvalidAttributeName: InvalidAttributeName; see the SQS docs.
	status code: 400, request id: 00000000-0000-0000-0000-000000000000

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

Would I need any further step?