### PR TITLE
Update for adding network support for spawning lambda images in local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ You can pass the following environment variables to LocalStack:
   inject `ProvisionedThroughputExceededException` errors into Kinesis API responses.
 * `DYNAMODB_ERROR_PROBABILITY`: Decimal value between 0.0 (default) and 1.0 to randomly
   inject `ProvisionedThroughputExceededException` errors into DynamoDB API responses.
+* `STACK_NETWORK`: Network stack in case needed to join when using docker-compose
+  inject `ProvisionedThroughputExceededException` errors into DynamoDB API responses.
 * `LAMBDA_EXECUTOR`: Method to use for executing Lambda functions. Possible values are:
     - `local`: run Lambda functions in a temporary directory on the local machine
     - `docker`: run each function invocation in a separate Docker container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
+      - STACK_NETWORK=localstack_apitests
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -60,6 +60,8 @@ if not LAMBDA_EXECUTOR:
     except Exception as e:
         pass
 
+STACK_NETWORK = os.environ.get('STACK_NETWORK', '').strip()
+
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -384,7 +384,6 @@ def get_java_handler(zip_file_content, handler, main_file):
 
 
 def set_function_code(code, lambda_name):
-
     def generic_handler(event, context):
         raise Exception(('Unable to find executor for Lambda function "%s". ' +
             'Note that Node.js and .NET Core Lambdas currently require LAMBDA_EXECUTOR=docker') % lambda_name)

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -416,7 +416,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
 
         env_vars_string = ' '.join(['-e {}="${}"'.format(k, k) for (k, v) in env_vars.items()])
 
-        network_to_join_string = ' --network ' + config.STACK_NETWORK if config.STACK_NETWORK != '' else config.STACK_NETWORK
+        network_option = ' --network ' + config.STACK_NETWORK if config.STACK_NETWORK != '' else config.STACK_NETWORK
 
         if config.LAMBDA_REMOTE_DOCKER:
             cmd = ('CONTAINER_ID="$(docker create'
@@ -427,7 +427,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                    ')";'
                    'docker cp "%s/." "$CONTAINER_ID:/var/task";'
                    'docker start -a "$CONTAINER_ID";'
-                   ) % (entrypoint, network_to_join_string, env_vars_string, runtime, command, lambda_cwd)
+                   ) % (entrypoint, network_option, env_vars_string, runtime, command, lambda_cwd)
         else:
             lambda_cwd_on_host = self.get_host_path_for_path_in_docker(lambda_cwd)
             cmd = ('docker run'
@@ -436,7 +436,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                    ' %s'
                    ' --rm'
                    ' "lambci/lambda:%s" %s'
-                   ) % (entrypoint, network_to_join_string, lambda_cwd_on_host, env_vars_string, runtime, command)
+                   ) % (entrypoint, network_option, lambda_cwd_on_host, env_vars_string, runtime, command)
         return cmd
 
     def get_host_path_for_path_in_docker(self, path):


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
Case scenario:
 Given Docker Compose stack, where one of the lambdas spawned needs to communicate to a mongo db image in the same stack. While all other images may be sharing networks, the newly spawned docker image for the lambda is connected to the network.

 Thus the connection and lambda fails.

Fix Provided:
-  Added STACK_NETWORK variable in the configuration variables.
-  Added support for network option being called when STACK_NETWORK is set in docker-compose
-  Added Documentation for the same