### PR TITLE
LocalstackDockerTestRunner: Avoid NPE on failure

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -73,15 +73,15 @@ public class LocalstackDocker {
             LOG.info("Waiting for localstack container to be ready...");
             localStackContainer.waitForLogToken(READY_TOKEN);
         } catch (Exception t) {
-            if (this.localStackContainer != null) {
-                this.stop();
-            }
+            this.stop();
             throw new LocalstackDockerException("Could not start the localstack docker container.", t);
         }
     }
 
     public void stop() {
-        localStackContainer.stop();
+        if (this.localStackContainer != null) {
+            localStackContainer.stop();
+        }
         locked = false;
     }
 


### PR DESCRIPTION
When an exception is thrown in this block before `this.localStackContainer` is initialized, then `stop()` is not invoked. However, in https://github.com/localstack/localstack/blob/a35b8d18286e4db8e8ac41931d7d61befc3a9ae8/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDockerTestRunner.java#L45, `stop()` is called unconditionally and produces a `NullPointerException`.
