### PR TITLE
Bump moto to 1.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ flask_swagger==0.2.12
 jsonpath-rw==1.4.0
 localstack-ext>=0.8.6
 localstack-client==0.4
-moto-ext==1.3.3
+moto-ext==1.3.4
 nose==1.3.7
 psutil==5.4.3
 pyOpenSSL==17.0.0


### PR DESCRIPTION
As it was suggest in the issue https://github.com/localstack/localstack/issues/889 a new version of moto has been recently released.

Changelog:

https://github.com/spulec/moto/blob/master/CHANGELOG.md#134

```
* IAM get account authorization details
* adding account id to ManagedPolicy ARN
* APIGateway usage plans and usage plan keys
* ECR list images
```
