### PR TITLE
Make LambdaExecutor use lowercase "kinesis" instead of "Kinesis"

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -56,7 +56,7 @@ public class LambdaExecutor {
 				inputObject = deserialisedInput.get();
 			}
 		} else {
-			if (records.stream().anyMatch(record -> record.containsKey("Kinesis"))) {
+			if (records.stream().anyMatch(record -> record.containsKey("kinesis"))) {
 				KinesisEvent kinesisEvent = new KinesisEvent();
 				inputObject = kinesisEvent;
 				kinesisEvent.setRecords(new LinkedList<>());
@@ -64,7 +64,7 @@ public class LambdaExecutor {
 					KinesisEventRecord r = new KinesisEventRecord();
 					kinesisEvent.getRecords().add(r);
 					Record kinesisRecord = new Record();
-					Map<String, Object> kinesis = (Map<String, Object>) get(record, "Kinesis");
+					Map<String, Object> kinesis = (Map<String, Object>) get(record, "kinesis");
 				String dataString = new String(get(kinesis, "Data").toString().getBytes());
 				byte[] decodedData = Base64.getDecoder().decode(dataString);
 				kinesisRecord.setData(ByteBuffer.wrap(decodedData));


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/670

I've got no idea which of "kinesis" or "Kinesis" is more correct, but this makes the `LambdaExecutor` work for Kinesis stream lambdas.