### PR TITLE
Fix URL suffix for ES /tags endpoint

### DIFF
--- a/localstack/dashboard/infra.py
+++ b/localstack/dashboard/infra.py
@@ -39,7 +39,8 @@ def run_cached(cmd, cache_duration_secs=None):
         'AWS_DEFAULT_REGION': os.environ.get('AWS_DEFAULT_REGION') or DEFAULT_REGION,
         'PYTHONWARNINGS': 'ignore:Unverified HTTPS request'
     })
-    return run(cmd, cache_duration_secs=cache_duration_secs, env_vars=env_vars)
+    return run(cmd, cache_duration_secs=cache_duration_secs, env_vars=env_vars,
+               stderr=open(os.devnull, 'w'))
 
 
 def run_aws_cmd(service, cmd_params, env=None, cache_duration_secs=None):

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -191,7 +191,7 @@ def delete_domain(domain_name):
     return jsonify(result)
 
 
-@app.route('%s/tags/' % API_PREFIX, methods=['GET', 'POST'])
+@app.route('%s/tags' % API_PREFIX, methods=['GET', 'POST'])
 def add_list_tags():
     if request.method == 'GET' and request.args.get('arn'):
         response = {


### PR DESCRIPTION
Fix URL suffix for Elasticsearch Service `/tags` endpoint. This has been causing test errors with recent versions of `botocore`