### PR TITLE
issue 872; fixes query param parsing for s3 notification put

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -448,7 +448,7 @@ class ProxyListenerS3(ProxyListener):
         query = parsed.query
         path = parsed.path
         bucket = path.split('/')[1]
-        query_map = urlparse.parse_qs(query)
+        query_map = urlparse.parse_qs(query, keep_blank_values=True)
         if query == 'notification' or 'notification' in query_map:
             # handle and return response for ?notification request
             response = handle_notification_request(bucket, method, data)


### PR DESCRIPTION
Fix query parameter parsing in s3 put bucket notification configuration api call.

Details on issue can be found here...
https://github.com/localstack/localstack/issues/872

