### PR TITLE
Support queryStringParameters for Lambda AWS_PROXY apigateway.

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -14,6 +14,11 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.generic_proxy import ProxyListener
 
+try:
+    from urllib.parse import urlparse, parse_qs
+except ImportError:
+    from urlparse import urlparse, parse_qs
+
 # set up logger
 LOGGER = logging.getLogger(__name__)
 
@@ -121,6 +126,21 @@ def extract_path_params(path, extracted_path):
     return path_params
 
 
+def extract_query_string_params(path):
+    parsed_path = urlparse(path)
+    path = parsed_path.path
+    parsed_query_string_params = parse_qs(parsed_path.query)
+
+    query_string_params = {}
+    for query_param_name, query_param_values in parsed_query_string_params.items():
+        if len(query_param_values) <= 1:
+            query_string_params[query_param_name] = query_param_values[0]
+        else:
+            query_string_params[query_param_name] = query_param_values
+
+    return [path, query_string_params]
+
+
 def get_resource_for_path(path, path_map):
     matches = []
     for api_path, details in path_map.items():
@@ -214,12 +234,16 @@ class ProxyListenerApiGateway(ProxyListener):
                     func_arn = uri.split(':lambda:path')[1].split('functions/')[1].split('/invocations')[0]
                     data_str = json.dumps(data) if isinstance(data, dict) else data
 
+                    relative_path, query_string_params = extract_query_string_params(path=relative_path)
+
                     try:
                         path_params = extract_path_params(path=relative_path, extracted_path=extracted_path)
                     except Exception:
                         path_params = {}
+
                     result = lambda_api.process_apigateway_invocation(func_arn, relative_path, data_str,
-                        headers, path_params=path_params, method=method, resource_path=path)
+                        headers, path_params=path_params, query_string_params=query_string_params,
+                        method=method, resource_path=path)
 
                     if isinstance(result, FlaskResponse):
                         return flask_to_requests_response(result)

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -3,6 +3,7 @@ import logging
 import json
 import requests
 import dateutil.parser
+from six.moves.urllib import parse as urlparse
 from requests.models import Response
 from flask import Response as FlaskResponse
 from localstack.constants import APPLICATION_JSON, PATH_USER_REQUEST
@@ -13,11 +14,6 @@ from localstack.utils.common import to_str, to_bytes
 from localstack.services.awslambda import lambda_api
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.generic_proxy import ProxyListener
-
-try:
-    from urllib.parse import urlparse, parse_qs
-except ImportError:
-    from urlparse import urlparse, parse_qs
 
 # set up logger
 LOGGER = logging.getLogger(__name__)
@@ -127,9 +123,9 @@ def extract_path_params(path, extracted_path):
 
 
 def extract_query_string_params(path):
-    parsed_path = urlparse(path)
+    parsed_path = urlparse.urlparse(path)
     path = parsed_path.path
-    parsed_query_string_params = parse_qs(parsed_path.query)
+    parsed_query_string_params = urlparse.parse_qs(parsed_path.query)
 
     query_string_params = {}
     for query_param_name, query_param_values in parsed_query_string_params.items():

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -133,7 +133,7 @@ def extract_query_string_params(path):
 
     query_string_params = {}
     for query_param_name, query_param_values in parsed_query_string_params.items():
-        if len(query_param_values) <= 1:
+        if len(query_param_values) == 1:
             query_string_params[query_param_name] = query_param_values[0]
         else:
             query_string_params[query_param_name] = query_param_values

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -155,7 +155,7 @@ def use_docker():
 
 
 def process_apigateway_invocation(func_arn, path, payload, headers={},
-        resource_path=None, method=None, path_params={}):
+        resource_path=None, method=None, path_params={}, query_string_params={}):
     try:
         resource_path = resource_path or path
         event = {
@@ -166,7 +166,7 @@ def process_apigateway_invocation(func_arn, path, payload, headers={},
             'isBase64Encoded': False,
             'resource': resource_path,
             'httpMethod': method,
-            'queryStringParameters': {},  # TODO
+            'queryStringParameters': query_string_params,
             'stageVariables': {}  # TODO
         }
         return run_lambda(event=event, context={}, func_arn=func_arn)

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -31,6 +31,7 @@ def handler(event, context):
         except Exception:
             body = {}
         body['pathParameters'] = event.get('pathParameters')
+        body['queryStringParameters'] = event.get('queryStringParameters')
         body['httpMethod'] = event.get('httpMethod')
         return {
             'body': body,

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -34,6 +34,7 @@ APIGATEWAY_DATA_INBOUND_TEMPLATE = """{
 API_PATH_DATA_INBOUND = '/data'
 API_PATH_HTTP_BACKEND = '/hello_world'
 API_PATH_LAMBDA_PROXY_BACKEND = '/lambda/{test_param1}'
+
 API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD = '/lambda-any-method/{test_param1}'
 # name of Kinesis stream connected to API Gateway
 TEST_STREAM_KINESIS_API_GW = 'test-stream-api-gw'
@@ -180,6 +181,8 @@ def test_api_gateway_lambda_proxy_integration():
 
     # make test request to gateway and check response
     path = API_PATH_LAMBDA_PROXY_BACKEND.replace('{test_param1}', 'foo1')
+    path = path + '?foo=foo&bar=bar&bar=baz'
+
     url = INBOUND_GATEWAY_URL_PATTERN.format(api_id=result['id'], stage_name=TEST_STAGE_NAME, path=path)
     data = {'return_status_code': 203, 'return_headers': {'foo': 'bar123'}}
     result = requests.post(url, data=json.dumps(data))
@@ -189,6 +192,7 @@ def test_api_gateway_lambda_proxy_integration():
     assert parsed_body.get('return_status_code') == 203
     assert parsed_body.get('return_headers') == {'foo': 'bar123'}
     assert parsed_body.get('pathParameters') == {'test_param1': 'foo1'}
+    assert parsed_body.get('queryStringParameters') == {'foo': 'foo', 'bar': ['bar', 'baz']}
     result = requests.delete(url, data=json.dumps(data))
     assert result.status_code == 404
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -4,6 +4,13 @@ from localstack.services.apigateway import apigateway_listener
 
 class ApiGatewayPathsTest (unittest.TestCase):
 
+    def test_extract_query_params(self):
+        path, query_params = apigateway_listener.extract_query_string_params(
+            '/foo/bar?foo=foo&bar=bar&bar=baz'
+        )
+        self.assertEqual(path, '/foo/bar')
+        self.assertEqual(query_params, {'foo': 'foo', 'bar': ['bar', 'baz']})
+
     def test_extract_path_params(self):
         params = apigateway_listener.extract_path_params('/foo/bar', '/foo/{param1}')
         self.assertEqual(params, {'param1': 'bar'})


### PR DESCRIPTION
queryStringParameters.
---

This is how the apigateway request is translated to an event for lambda AWS_PROXY integration in localstack.

this is my path_part definition `v1.2.0/{locale}/ab-tester/{target}`
.
.
.

```js
2018-09-28T11:31:51.571Z        b8de8ee4-ccde-12c8-68a1-44e666a4b318    Request:  { 
  body: '',
  headers:
   { 
     'content-length': '0',
     'accept-encoding': 'gzip, deflate',
     host: 'localhost:4567',
     accept: '*/*',
     'user-agent': 'Mozilla',
     connection: 'keep-alive',
     'cache-control': 'no-cache',
     'content-type': 'application/x-www-form-urlencoded' 
  },
  resource: '/restapis/A-Z40542153A-Z/dev/_user_request_/v1.2.0/de/ab-tester/learn_language_filter_target?learn_language_alpha3=POR',
  queryStringParameters: {},
  httpMethod: 'POST',
  stageVariables: {},
  path: '/v1.2.0/de/ab-tester/learn_language_filter_target?learn_language_alpha3=POR',
  pathParameters: { 
     locale: 'de',
     target: 'learn_language_filter_target?learn_language_alpha3=POR' 
  },
  isBase64Encoded: false 
}
```

Obviously the **queryStringParams** is not supported yet, and also the resource path will include the part after `?` as part of the the path.

So this is PR to support queryStringParameters.

----

After building the docker image for these changes, this is how the new request looks like

```js
START RequestId: c2289296-c19c-10d9-f875-7a7bd4991c8d Version: $LATEST
2018-10-12T12:21:01.432Z        c2289296-c19c-10d9-f875-7a7bd4991c8d    Request:  { 
  body: '',
  headers:
   { 
     'content-length': '0',
     'accept-encoding': 'gzip, deflate',
     connection: 'keep-alive',
     accept: '*/*',
     'user-agent': 'PostmanRuntime/7.3.0',
     host: 'localhost:4567',
     'cache-control': 'no-cache',
     'postman-token': '60b85d39-b930-4443-977d-02bd5ffc8c72' },
  resource: '/restapis/9A-Z30798483/dev/_user_request_/v1.2.0/de/ab-tester/blabla?foo=foo&bar=bar&bar=baz',
  queryStringParameters: { foo: 'foo', bar: [ 'bar', 'baz' ] },
  httpMethod: 'POST',
  stageVariables: {},
  path: '/v1.2.0/de/ab-tester/blabla',
  pathParameters: { locale: 'de', target: 'blabla' },
  isBase64Encoded: false 
}
```