### PR TITLE
Expose AWS SecretsManager service by default in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - "4567-4583:4567-4583"
+      - "4567-4584:4567-4584"
       - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
       - SERVICES=${SERVICES- }


### PR DESCRIPTION
I'm happy that SecretsManager is available in LocalStack. Thanks for release!