### PR TITLE
Set PYTHONUNBUFFERED=1 to improve printing from Lambda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ RUN mkdir -p /.npm && \
 
 # expose default environment (required for aws-cli to work)
 ENV MAVEN_CONFIG=/opt/code/localstack \
-    USER=localstack
+    USER=localstack \
+    PYTHONUNBUFFERED=1
 
 # expose service & web dashboard ports
 EXPOSE 4567-4583 8080


### PR DESCRIPTION
I had a lambda function being invoked by an SNS topic. I was getting very confused about why my lambda's printing to stdout was appearing in batches of 5 at once. Turns out this was nothing to do with localstack's sns+lambda doing some strange batching, but just Python's output buffering.

This sets the env-var to disable buffering in Docker, and I have verified this fixes my problem. Should I actually set this somewhere else so it works for non-Docker users? Though that might have surprising knock-on effects when it is not isolated with a container (ie, the env-var will affect other, non-localstack code).