### PR TITLE
Replace region in dynamodb LatestStreamArn

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -94,9 +94,9 @@ class ProxyListenerDynamoDB(ProxyListener):
             TABLE_DEFINITIONS[data['TableName']] = data
 
         if response._content:
-            # fix the table ARN (DynamoDBLocal hardcodes "ddblocal" as the region)
-            content_replaced = re.sub(r'"TableArn"\s*:\s*"arn:aws:dynamodb:ddblocal:([^"]+)"',
-                r'"TableArn": "arn:aws:dynamodb:%s:\1"' % aws_stack.get_local_region(), to_str(response._content))
+            # fix the table and latest stream ARNs (DynamoDBLocal hardcodes "ddblocal" as the region)
+            content_replaced = re.sub(r'("TableArn"|"LatestStreamArn")\s*:\s*"arn:aws:dynamodb:ddblocal:([^"]+)"',
+                r'\1: "arn:aws:dynamodb:%s:\2"' % aws_stack.get_local_region(), to_str(response._content))
             if content_replaced != response._content:
                 response._content = content_replaced
                 fix_headers_for_updated_response(response)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -9,6 +9,7 @@ from localstack.utils.common import json_safe
 TEST_DDB_TABLE_NAME = 'test-ddb-table-1'
 TEST_DDB_TABLE_NAME_2 = 'test-ddb-table-2'
 TEST_DDB_TABLE_NAME_3 = 'test-ddb-table-3'
+TEST_DDB_TABLE_NAME_4 = 'test-ddb-table-4'
 PARTITION_KEY = 'id'
 
 
@@ -132,3 +133,14 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         }))
         assert response.status_code == 200
         assert json.loads(response._content)['Tags'] == []  # Empty list returned
+
+    def test_region_replacement(self):
+        dynamodb = aws_stack.connect_to_resource('dynamodb')
+        testutil.create_dynamodb_table(TEST_DDB_TABLE_NAME_4, partition_key=PARTITION_KEY, stream_view_type='NEW_AND_OLD_IMAGES')
+
+        table = dynamodb.Table(TEST_DDB_TABLE_NAME_4)
+
+        expected_arn_prefix = 'arn:aws:dynamodb:' + aws_stack.get_local_region()
+
+        assert table.table_arn.startswith(expected_arn_prefix)
+        assert table.latest_stream_arn.startswith(expected_arn_prefix)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -136,7 +136,11 @@ class DynamoDBIntegrationTest (unittest.TestCase):
 
     def test_region_replacement(self):
         dynamodb = aws_stack.connect_to_resource('dynamodb')
-        testutil.create_dynamodb_table(TEST_DDB_TABLE_NAME_4, partition_key=PARTITION_KEY, stream_view_type='NEW_AND_OLD_IMAGES')
+        testutil.create_dynamodb_table(
+            TEST_DDB_TABLE_NAME_4,
+            partition_key=PARTITION_KEY,
+            stream_view_type='NEW_AND_OLD_IMAGES'
+        )
 
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_4)
 


### PR DESCRIPTION
Found out that the `LatestStreamArn` was returning the stream name with the `ddblocal` region. This PR extends the region replacement to also apply to that field.