### PR TITLE
Support requestContext object in aws_proxy integration type for apigateway.

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -152,6 +152,7 @@ class ProxyListenerApiGateway(ProxyListener):
         if re.match(regex2, path):
             search_match = re.search(regex2, path)
             api_id = search_match.group(1)
+            stage = search_match.group(2)
             relative_path = '/%s' % search_match.group(3)
             try:
                 integration = aws_stack.get_apigateway_integration(api_id, method, path=relative_path)
@@ -201,9 +202,26 @@ class ProxyListenerApiGateway(ProxyListener):
             elif integration['type'] == 'AWS_PROXY':
                 if uri.startswith('arn:aws:apigateway:') and ':lambda:path' in uri:
                     func_arn = uri.split(':lambda:path')[1].split('functions/')[1].split('/invocations')[0]
+                    account_id = uri.split(':lambda:path')[1].split(':function:')[0].split(':')[-1]
                     data_str = json.dumps(data) if isinstance(data, dict) else data
 
                     relative_path, query_string_params = extract_query_string_params(path=relative_path)
+
+                    source_ip = headers['X-Forwarded-For'].split(',')[-2]
+
+                    # Sample request context:
+                    # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html#api-gateway-create-api-as-simple-proxy-for-lambda-test
+                    request_context = {
+                        'path': relative_path,
+                        'accountId': account_id,
+                        'resourceId': resource.get('id'),
+                        'stage': stage,
+                        'identity': {
+                            'accountId': account_id,
+                            'sourceIp': source_ip,
+                            'userAgent': headers['User-Agent'],
+                        }
+                    }
 
                     try:
                         path_params = extract_path_params(path=relative_path, extracted_path=extracted_path)
@@ -212,7 +230,7 @@ class ProxyListenerApiGateway(ProxyListener):
 
                     result = lambda_api.process_apigateway_invocation(func_arn, relative_path, data_str,
                         headers, path_params=path_params, query_string_params=query_string_params,
-                        method=method, resource_path=path)
+                        method=method, resource_path=path, request_context=request_context)
 
                     if isinstance(result, FlaskResponse):
                         return flask_to_requests_response(result)

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1,0 +1,30 @@
+import re
+from localstack.utils.aws import aws_stack
+
+
+def get_rest_api_paths(rest_api_id):
+    apigateway = aws_stack.connect_to_service(service_name='apigateway')
+    resources = apigateway.get_resources(restApiId=rest_api_id, limit=100)
+    resource_map = {}
+    for resource in resources['items']:
+        path = aws_stack.get_apigateway_path_for_resource(rest_api_id, resource['id'])
+        resource_map[path] = resource
+    return resource_map
+
+
+def get_resource_for_path(path, path_map):
+    matches = []
+    for api_path, details in path_map.items():
+        api_path_regex = re.sub(r'\{[^\+]+\+\}', r'[^\?#]+', api_path)
+        api_path_regex = re.sub(r'\{[^\}]+\}', r'[^/]+', api_path_regex)
+        if re.match(r'^%s$' % api_path_regex, path):
+            matches.append((api_path, details))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        # check if we have an exact match
+        for match in matches:
+            if match[0] == path:
+                return match
+        raise Exception('Ambiguous API path %s - matches found: %s' % (path, matches))
+    return matches[0]

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -156,7 +156,8 @@ def use_docker():
 
 
 def process_apigateway_invocation(func_arn, path, payload, headers={},
-        resource_path=None, method=None, path_params={}, query_string_params={}):
+        resource_path=None, method=None, path_params={},
+        query_string_params={}, request_context={}):
     try:
         resource_path = resource_path or path
         event = {
@@ -168,6 +169,7 @@ def process_apigateway_invocation(func_arn, path, payload, headers={},
             'resource': resource_path,
             'httpMethod': method,
             'queryStringParameters': query_string_params,
+            'requestContext': request_context,
             'stageVariables': {}  # TODO
         }
         return run_lambda(event=event, context={}, func_arn=func_arn)

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -155,6 +155,19 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
                     except socket.timeout:
                         break
 
+    def build_x_forwarded_for(self, headers):
+        x_forwarded_for = headers.get('X-Forwarded-For')
+
+        client_address = self.client_address[0]
+        server_address = ':'.join(map(str, self.server.server_address))
+
+        if x_forwarded_for:
+            x_forwarded_for_list = (x_forwarded_for, client_address, server_address)
+        else:
+            x_forwarded_for_list = (client_address, server_address)
+
+        return ', '.join(x_forwarded_for_list)
+
     def forward(self, method):
         path = self.path
         if '://' in path:
@@ -171,6 +184,8 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
             forward_headers['host'] = urlparse(target_url).netloc
         if 'localhost.atlassian.io' in forward_headers.get('Host'):
             forward_headers['host'] = 'localhost'
+
+        forward_headers['X-Forwarded-For'] = self.build_x_forwarded_for(forward_headers)
 
         try:
             response = None

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -31,6 +31,7 @@ def handler(event, context):
         except Exception:
             body = {}
         body['pathParameters'] = event.get('pathParameters')
+        body['requestContext'] = event.get('requestContext')
         body['queryStringParameters'] = event.get('queryStringParameters')
         body['httpMethod'] = event.get('httpMethod')
         return {

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1,5 +1,6 @@
 import re
 import json
+import unittest
 from requests.models import Response
 from localstack.constants import DEFAULT_REGION, TEST_AWS_ACCOUNT_ID
 from localstack.config import INBOUND_GATEWAY_URL_PATTERN
@@ -12,231 +13,289 @@ from localstack.services.awslambda.lambda_api import (LAMBDA_RUNTIME_PYTHON27)
 from localstack.services.apigateway.helpers import get_rest_api_paths, get_resource_for_path
 from .test_lambda import TEST_LAMBDA_PYTHON, TEST_LAMBDA_LIBS
 
-# template used to transform incoming requests at the API Gateway (stream name to be filled in later)
-APIGATEWAY_DATA_INBOUND_TEMPLATE = """{
-    "StreamName": "%s",
-    "Records": [
-        #set( $numRecords = $input.path('$.records').size() )
-        #if($numRecords > 0)
-        #set( $maxIndex = $numRecords - 1 )
-        #foreach( $idx in [0..$maxIndex] )
-        #set( $elem = $input.path("$.records[${idx}]") )
-        #set( $elemJsonB64 = $util.base64Encode($elem.data) )
-        {
-            "Data": "$elemJsonB64",
-            "PartitionKey": #if( $elem.partitionKey != '')"$elem.partitionKey"
-                            #else"$elemJsonB64.length()"#end
-        }#if($foreach.hasNext),#end
-        #end
-        #end
-    ]
-}"""
-# endpoint paths
-API_PATH_DATA_INBOUND = '/data'
-API_PATH_HTTP_BACKEND = '/hello_world'
-API_PATH_LAMBDA_PROXY_BACKEND = '/lambda/{test_param1}'
 
-API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD = '/lambda-any-method/{test_param1}'
-# name of Kinesis stream connected to API Gateway
-TEST_STREAM_KINESIS_API_GW = 'test-stream-api-gw'
-TEST_STAGE_NAME = 'testing'
-TEST_LAMBDA_PROXY_BACKEND = 'test_lambda_apigw_backend'
-TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD = 'test_lambda_apigw_backend_any_method'
+class TestAPIGatewayIntegrations(unittest.TestCase):
+    # template used to transform incoming requests at the API Gateway (stream name to be filled in later)
+    APIGATEWAY_DATA_INBOUND_TEMPLATE = """{
+        "StreamName": "%s",
+        "Records": [
+            #set( $numRecords = $input.path('$.records').size() )
+            #if($numRecords > 0)
+            #set( $maxIndex = $numRecords - 1 )
+            #foreach( $idx in [0..$maxIndex] )
+            #set( $elem = $input.path("$.records[${idx}]") )
+            #set( $elemJsonB64 = $util.base64Encode($elem.data) )
+            {
+                "Data": "$elemJsonB64",
+                "PartitionKey": #if( $elem.partitionKey != '')"$elem.partitionKey"
+                                #else"$elemJsonB64.length()"#end
+            }#if($foreach.hasNext),#end
+            #end
+            #end
+        ]
+    }"""
 
+    # endpoint paths
+    API_PATH_DATA_INBOUND = '/data'
+    API_PATH_HTTP_BACKEND = '/hello_world'
+    API_PATH_LAMBDA_PROXY_BACKEND = '/lambda/{test_param1}'
 
-def connect_api_gateway_to_kinesis(gateway_name, kinesis_stream):
-    resources = {}
-    template = APIGATEWAY_DATA_INBOUND_TEMPLATE % (kinesis_stream)
-    resource_path = API_PATH_DATA_INBOUND.replace('/', '')
-    resources[resource_path] = [{
-        'httpMethod': 'POST',
-        'authorizationType': 'NONE',
-        'integrations': [{
-            'type': 'AWS',
-            'uri': 'arn:aws:apigateway:%s:kinesis:action/PutRecords' % DEFAULT_REGION,
-            'requestTemplates': {
-                'application/json': template
-            }
-        }]
-    }]
-    return aws_stack.create_api_gateway(name=gateway_name, resources=resources,
-        stage_name=TEST_STAGE_NAME)
+    API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD = '/lambda-any-method/{test_param1}'
 
+    # name of Kinesis stream connected to API Gateway
+    TEST_STREAM_KINESIS_API_GW = 'test-stream-api-gw'
+    TEST_STAGE_NAME = 'testing'
+    TEST_LAMBDA_PROXY_BACKEND = 'test_lambda_apigw_backend'
+    TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD = 'test_lambda_apigw_backend_any_method'
 
-def connect_api_gateway_to_http(gateway_name, target_url, methods=[], path=None):
-    if not methods:
-        methods = ['GET', 'POST']
-    if not path:
-        path = '/'
-    resources = {}
-    resource_path = path.replace('/', '')
-    resources[resource_path] = []
-    for method in methods:
-        resources[resource_path].append({
-            'httpMethod': method,
-            'integrations': [{
-                'type': 'HTTP',
-                'uri': target_url
-            }]
-        })
-    return aws_stack.create_api_gateway(name=gateway_name, resources=resources,
-        stage_name=TEST_STAGE_NAME)
+    def test_api_gateway_kinesis_integration(self):
+        # create target Kinesis stream
+        aws_stack.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
 
+        # create API Gateway and connect it to the target stream
+        result = self.connect_api_gateway_to_kinesis('test_gateway1', self.TEST_STREAM_KINESIS_API_GW)
 
-def connect_api_gateway_to_http_with_lambda_proxy(gateway_name, target_uri, methods=[], path=None):
-    if not methods:
-        methods = ['GET', 'POST']
-    if not path:
-        path = '/'
-    resources = {}
-    resource_path = path.lstrip('/')
-    resources[resource_path] = []
-    for method in methods:
-        resources[resource_path].append({
-            'httpMethod': method,
-            'integrations': [{
-                'type': 'AWS_PROXY',
-                'uri': target_uri
-            }]
-        })
-    return aws_stack.create_api_gateway(name=gateway_name, resources=resources,
-        stage_name=TEST_STAGE_NAME)
+        # generate test data
+        test_data = {'records': [
+            {'data': '{"foo": "bar1"}'},
+            {'data': '{"foo": "bar2"}'},
+            {'data': '{"foo": "bar3"}'}
+        ]}
 
+        url = INBOUND_GATEWAY_URL_PATTERN.format(
+            api_id=result['id'],
+            stage_name=self.TEST_STAGE_NAME,
+            path=self.API_PATH_DATA_INBOUND
+        )
+        result = requests.post(url, data=json.dumps(test_data))
+        result = json.loads(to_str(result.content))
 
-def test_api_gateway_kinesis_integration():
-    # create target Kinesis stream
-    aws_stack.create_kinesis_stream(TEST_STREAM_KINESIS_API_GW)
+        self.assertEqual(result['FailedRecordCount'], 0)
+        self.assertEqual(len(result['Records']), len(test_data['records']))
 
-    # create API Gateway and connect it to the target stream
-    result = connect_api_gateway_to_kinesis('test_gateway1', TEST_STREAM_KINESIS_API_GW)
+    def test_api_gateway_http_integration(self):
+        test_port = 12123
+        backend_url = 'http://localhost:%s%s' % (test_port, self.API_PATH_HTTP_BACKEND)
 
-    # generate test data
-    test_data = {'records': [
-        {'data': '{"foo": "bar1"}'},
-        {'data': '{"foo": "bar2"}'},
-        {'data': '{"foo": "bar3"}'}
-    ]}
+        # create target HTTP backend
+        class TestListener(ProxyListener):
 
-    url = INBOUND_GATEWAY_URL_PATTERN.format(api_id=result['id'],
-        stage_name=TEST_STAGE_NAME, path=API_PATH_DATA_INBOUND)
-    result = requests.post(url, data=json.dumps(test_data))
-    result = json.loads(to_str(result.content))
-    assert result['FailedRecordCount'] == 0
-    assert len(result['Records']) == len(test_data['records'])
+            def forward_request(self, **kwargs):
+                response = Response()
+                response.status_code = 200
+                response._content = kwargs.get('data') or '{}'
+                return response
 
+        proxy = GenericProxy(test_port, update_listener=TestListener())
+        proxy.start()
 
-def test_api_gateway_http_integration():
-    test_port = 12123
-    backend_url = 'http://localhost:%s%s' % (test_port, API_PATH_HTTP_BACKEND)
+        # create API Gateway and connect it to the HTTP backend
+        result = self.connect_api_gateway_to_http(
+            'test_gateway2',
+            backend_url,
+            path=self.API_PATH_HTTP_BACKEND
+        )
 
-    # create target HTTP backend
-    class TestListener(ProxyListener):
+        url = INBOUND_GATEWAY_URL_PATTERN.format(
+            api_id=result['id'],
+            stage_name=self.TEST_STAGE_NAME,
+            path=self.API_PATH_HTTP_BACKEND
+        )
 
-        def forward_request(self, **kwargs):
-            response = Response()
-            response.status_code = 200
-            response._content = kwargs.get('data') or '{}'
-            return response
+        # make sure CORS headers are present
+        origin = 'localhost'
+        result = requests.options(url, headers={'origin': origin})
+        self.assertEqual(result.status_code, 200)
+        self.assertTrue(re.match(result.headers['Access-Control-Allow-Origin'].replace('*', '.*'), origin))
+        self.assertIn('POST', result.headers['Access-Control-Allow-Methods'])
 
-    proxy = GenericProxy(test_port, update_listener=TestListener())
-    proxy.start()
+        # make test request to gateway
+        result = requests.get(url)
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(to_str(result.content), '{}')
 
-    # create API Gateway and connect it to the HTTP backend
-    result = connect_api_gateway_to_http('test_gateway2', backend_url, path=API_PATH_HTTP_BACKEND)
+        data = {'data': 123}
+        result = requests.post(url, data=json.dumps(data))
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(json.loads(to_str(result.content)), data)
 
-    url = INBOUND_GATEWAY_URL_PATTERN.format(api_id=result['id'],
-        stage_name=TEST_STAGE_NAME, path=API_PATH_HTTP_BACKEND)
+        # clean up
+        proxy.stop()
 
-    # make sure CORS headers are present
-    origin = 'localhost'
-    result = requests.options(url, headers={'origin': origin})
-    assert result.status_code == 200
-    assert re.match(result.headers['Access-Control-Allow-Origin'].replace('*', '.*'), origin)
-    assert 'POST' in result.headers['Access-Control-Allow-Methods']
+    def test_api_gateway_lambda_proxy_integration(self):
+        # create lambda function
+        zip_file = testutil.create_lambda_archive(
+            load_file(TEST_LAMBDA_PYTHON),
+            get_content=True,
+            libs=TEST_LAMBDA_LIBS,
+            runtime=LAMBDA_RUNTIME_PYTHON27
+        )
+        testutil.create_lambda_function(
+            func_name=self.TEST_LAMBDA_PROXY_BACKEND,
+            zip_file=zip_file,
+            runtime=LAMBDA_RUNTIME_PYTHON27
+        )
 
-    # make test request to gateway
-    result = requests.get(url)
-    assert result.status_code == 200
-    assert to_str(result.content) == '{}'
-    data = {'data': 123}
-    result = requests.post(url, data=json.dumps(data))
-    assert result.status_code == 200
-    assert json.loads(to_str(result.content)) == data
+        # create API Gateway and connect it to the Lambda proxy backend
+        lambda_uri = aws_stack.lambda_function_arn(self.TEST_LAMBDA_PROXY_BACKEND)
+        invocation_uri = 'arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations'
+        target_uri = invocation_uri % (DEFAULT_REGION, lambda_uri)
 
-    # clean up
-    proxy.stop()
+        result = self.connect_api_gateway_to_http_with_lambda_proxy(
+            'test_gateway2',
+            target_uri,
+            path=self.API_PATH_LAMBDA_PROXY_BACKEND
+        )
 
+        api_id = result['id']
+        path_map = get_rest_api_paths(api_id)
+        _, resource = get_resource_for_path('/lambda/foo1', path_map)
 
-def test_api_gateway_lambda_proxy_integration():
-    # create lambda function
-    zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_PYTHON), get_content=True,
-        libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
-    testutil.create_lambda_function(func_name=TEST_LAMBDA_PROXY_BACKEND,
-        zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27)
+        # make test request to gateway and check response
+        path = self.API_PATH_LAMBDA_PROXY_BACKEND.replace('{test_param1}', 'foo1')
+        path = path + '?foo=foo&bar=bar&bar=baz'
 
-    # create API Gateway and connect it to the Lambda proxy backend
-    lambda_uri = aws_stack.lambda_function_arn(TEST_LAMBDA_PROXY_BACKEND)
-    target_uri = 'arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations' % (DEFAULT_REGION, lambda_uri)
-    result = connect_api_gateway_to_http_with_lambda_proxy('test_gateway2', target_uri,
-        path=API_PATH_LAMBDA_PROXY_BACKEND)
+        url = INBOUND_GATEWAY_URL_PATTERN.format(
+            api_id=api_id,
+            stage_name=self.TEST_STAGE_NAME,
+            path=path
+        )
 
-    api_id = result['id']
-    path_map = get_rest_api_paths(api_id)
-    _, resource = get_resource_for_path('/lambda/foo1', path_map)
+        data = {'return_status_code': 203, 'return_headers': {'foo': 'bar123'}}
+        result = requests.post(
+            url,
+            data=json.dumps(data),
+            headers={'User-Agent': 'python-requests/testing'}
+        )
 
-    # make test request to gateway and check response
-    path = API_PATH_LAMBDA_PROXY_BACKEND.replace('{test_param1}', 'foo1')
-    path = path + '?foo=foo&bar=bar&bar=baz'
+        self.assertEqual(result.status_code, 203)
+        self.assertEqual(result.headers.get('foo'), 'bar123')
 
-    url = INBOUND_GATEWAY_URL_PATTERN.format(api_id=api_id, stage_name=TEST_STAGE_NAME, path=path)
-    data = {'return_status_code': 203, 'return_headers': {'foo': 'bar123'}}
-    result = requests.post(url, data=json.dumps(data), headers={'User-Agent': 'python-requests/testing'})
-    assert result.status_code == 203
-    assert result.headers.get('foo') == 'bar123'
-    parsed_body = json.loads(to_str(result.content))
-    assert parsed_body.get('return_status_code') == 203
-    assert parsed_body.get('return_headers') == {'foo': 'bar123'}
-    assert parsed_body.get('pathParameters') == {'test_param1': 'foo1'}
-    assert parsed_body.get('queryStringParameters') == {'foo': 'foo', 'bar': ['bar', 'baz']}
-
-    request_context = parsed_body.get('requestContext')
-    source_ip = request_context['identity'].pop('sourceIp')
-
-    assert re.match(re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'), source_ip)
-
-    assert request_context['path'] == '/lambda/foo1'
-    assert request_context['accountId'] == TEST_AWS_ACCOUNT_ID
-    assert request_context['resourceId'] == resource.get('id')
-    assert request_context['stage'] == TEST_STAGE_NAME
-    assert request_context['identity']['userAgent'] == 'python-requests/testing'
-
-    result = requests.delete(url, data=json.dumps(data))
-    assert result.status_code == 404
-
-
-def test_api_gateway_lambda_proxy_integration_any_method():
-    # create lambda function
-    zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_PYTHON), get_content=True,
-        libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
-    testutil.create_lambda_function(func_name=TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD,
-        zip_file=zip_file, runtime=LAMBDA_RUNTIME_PYTHON27)
-
-    # create API Gateway and connect it to the Lambda proxy backend
-    lambda_uri = aws_stack.lambda_function_arn(TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD)
-    target_uri = aws_stack.apigateway_invocations_arn(lambda_uri)
-
-    result = connect_api_gateway_to_http_with_lambda_proxy('test_gateway3', target_uri,
-        methods=['ANY'],
-        path=API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD)
-
-    # make test request to gateway and check response
-    path = API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD.replace('{test_param1}', 'foo1')
-    url = INBOUND_GATEWAY_URL_PATTERN.format(api_id=result['id'], stage_name=TEST_STAGE_NAME, path=path)
-    data = {}
-
-    for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'):
-        body = json.dumps(data) if method in ('POST', 'PUT', 'PATCH') else None
-        result = getattr(requests, method.lower())(url, data=body)
-        assert result.status_code == 200
         parsed_body = json.loads(to_str(result.content))
-        assert parsed_body.get('httpMethod') == method
+        self.assertEqual(parsed_body.get('return_status_code'), 203)
+        self.assertDictEqual(parsed_body.get('return_headers'), {'foo': 'bar123'})
+        self.assertDictEqual(parsed_body.get('pathParameters'), {'test_param1': 'foo1'})
+        self.assertDictEqual(parsed_body.get('queryStringParameters'), {'foo': 'foo', 'bar': ['bar', 'baz']})
+
+        request_context = parsed_body.get('requestContext')
+        source_ip = request_context['identity'].pop('sourceIp')
+
+        self.assertTrue(re.match(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$', source_ip))
+
+        self.assertEqual(request_context['path'], '/lambda/foo1')
+        self.assertEqual(request_context['accountId'], TEST_AWS_ACCOUNT_ID)
+        self.assertEqual(request_context['resourceId'], resource.get('id'))
+        self.assertEqual(request_context['stage'], self.TEST_STAGE_NAME)
+        self.assertEqual(request_context['identity']['userAgent'], 'python-requests/testing')
+
+        result = requests.delete(url, data=json.dumps(data))
+        self.assertEqual(result.status_code, 404)
+
+    def test_api_gateway_lambda_proxy_integration_any_method(self):
+        # create lambda function
+        zip_file = testutil.create_lambda_archive(
+            load_file(TEST_LAMBDA_PYTHON),
+            get_content=True,
+            libs=TEST_LAMBDA_LIBS,
+            runtime=LAMBDA_RUNTIME_PYTHON27
+        )
+        testutil.create_lambda_function(
+            func_name=self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD,
+            zip_file=zip_file,
+            runtime=LAMBDA_RUNTIME_PYTHON27
+        )
+
+        # create API Gateway and connect it to the Lambda proxy backend
+        lambda_uri = aws_stack.lambda_function_arn(self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD)
+        target_uri = aws_stack.apigateway_invocations_arn(lambda_uri)
+
+        result = self.connect_api_gateway_to_http_with_lambda_proxy(
+            'test_gateway3',
+            target_uri,
+            methods=['ANY'],
+            path=self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD
+        )
+
+        # make test request to gateway and check response
+        path = self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD.replace('{test_param1}', 'foo1')
+        url = INBOUND_GATEWAY_URL_PATTERN.format(
+            api_id=result['id'],
+            stage_name=self.TEST_STAGE_NAME,
+            path=path
+        )
+        data = {}
+
+        for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'):
+            body = json.dumps(data) if method in ('POST', 'PUT', 'PATCH') else None
+            result = getattr(requests, method.lower())(url, data=body)
+            self.assertEqual(result.status_code, 200)
+            parsed_body = json.loads(to_str(result.content))
+            self.assertEqual(parsed_body.get('httpMethod'), method)
+
+    # =====================================================================
+    # Helper methods
+    # =====================================================================
+    def connect_api_gateway_to_kinesis(self, gateway_name, kinesis_stream):
+        resources = {}
+        template = self.APIGATEWAY_DATA_INBOUND_TEMPLATE % (kinesis_stream)
+        resource_path = self.API_PATH_DATA_INBOUND.replace('/', '')
+        resources[resource_path] = [{
+            'httpMethod': 'POST',
+            'authorizationType': 'NONE',
+            'integrations': [{
+                'type': 'AWS',
+                'uri': 'arn:aws:apigateway:%s:kinesis:action/PutRecords' % DEFAULT_REGION,
+                'requestTemplates': {
+                    'application/json': template
+                }
+            }]
+        }]
+        return aws_stack.create_api_gateway(
+            name=gateway_name,
+            resources=resources,
+            stage_name=self.TEST_STAGE_NAME
+        )
+
+    def connect_api_gateway_to_http(self, gateway_name, target_url, methods=[], path=None):
+        if not methods:
+            methods = ['GET', 'POST']
+        if not path:
+            path = '/'
+        resources = {}
+        resource_path = path.replace('/', '')
+        resources[resource_path] = []
+        for method in methods:
+            resources[resource_path].append({
+                'httpMethod': method,
+                'integrations': [{
+                    'type': 'HTTP',
+                    'uri': target_url
+                }]
+            })
+        return aws_stack.create_api_gateway(
+            name=gateway_name,
+            resources=resources,
+            stage_name=self.TEST_STAGE_NAME
+        )
+
+    def connect_api_gateway_to_http_with_lambda_proxy(self, gateway_name, target_uri, methods=[], path=None):
+        if not methods:
+            methods = ['GET', 'POST']
+        if not path:
+            path = '/'
+        resources = {}
+        resource_path = path.lstrip('/')
+        resources[resource_path] = []
+        for method in methods:
+            resources[resource_path].append({
+                'httpMethod': method,
+                'integrations': [{
+                    'type': 'AWS_PROXY',
+                    'uri': target_uri
+                }]
+            })
+        return aws_stack.create_api_gateway(
+            name=gateway_name,
+            resources=resources,
+            stage_name=self.TEST_STAGE_NAME
+        )


### PR DESCRIPTION
requestContext
---
According to aws docs https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html

the event that is passed to the lambda when aws_proxy integration type is used, should contain `requestContext` object that contains some information about the request.

In my case I use this object to get the the `sourceIp` of the request where my lambda behaviour depends on that `sourceIp`:

```js
const remoteIp = requestContext.identity.sourceIp;
```
So this PR is a solution to support the missing object in general, and in particular to support some of the information that my lambda behaviour depends on it such as the `sourceIP`

closes #996 