### PR TITLE
Fix path matching to ignore query strings

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -142,6 +142,8 @@ def get_resource_for_path(path, path_map):
     for api_path, details in path_map.items():
         api_path_regex = re.sub(r'\{[^\+]+\+\}', '[^\?#]+', api_path)
         api_path_regex = re.sub(r'\{[^\}]+\}', '[^/]+', api_path_regex)
+        # We aren't interested in matching against anything with query strings.
+        path = re.sub(r'\?.*', '', path)
         if re.match(r'^%s$' % api_path_regex, path):
             matches.append((api_path, details))
     if not matches:

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -140,8 +140,8 @@ def extract_query_string_params(path):
 def get_resource_for_path(path, path_map):
     matches = []
     for api_path, details in path_map.items():
-        api_path_regex = re.sub(r'\{[^\+]+\+\}', '[^\?#]+', api_path)
-        api_path_regex = re.sub(r'\{[^\}]+\}', '[^/]+', api_path_regex)
+        api_path_regex = re.sub(r'\{[^\+]+\+\}', r'[^\?#]+', api_path)
+        api_path_regex = re.sub(r'\{[^\}]+\}', r'[^/]+', api_path_regex)
         # We aren't interested in matching against anything with query strings.
         path = re.sub(r'\?.*', '', path)
         if re.match(r'^%s$' % api_path_regex, path):


### PR DESCRIPTION
Related to #960, while that PR meant that the `queryStringParameters` are passed to the lambda if it's called, a bug in the get_resource_for_path function meant it was never actually possible to invoke a lambda via a URL if you added a query string, as the regexp was excluding `?` characters and not allowing for them on the end.