### PR TITLE
Allow a init.d like dir to be used to execute scripts upon startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ localstack/infra/
 /.idea
 **/obj/**
 **/bin/**
+!bin/docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,12 @@ EXPOSE 4567-4584 8080
 # install supervisor daemon & copy config file
 ADD bin/supervisord.conf /etc/supervisord.conf
 
+RUN pip install awscli awscli-local --upgrade --user
+
+ADD bin/docker-entrypoint.sh /usr/local/bin/
+
 # define command at startup
-ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ Additionally, the following *read-only* environment variables are available:
   The variable `LOCALSTACK_HOSTNAME` is available for both, local Lambda execution
   (`LAMBDA_EXECUTOR=local`) and execution inside separate Docker containers (`LAMBDA_EXECUTOR=docker`).
 
+### Initializing a fresh instance
+
+When a container is started for the first time, it will execute files with extensions .sh that are found in /docker-entrypoint-initaws.d. Files will be executed in alphabetical order. You can easily create aws resources on localstack using `awslocal` (or `aws`) cli tool in the initialization scripts.
+
 ## A Note About using own SSL Certificate when `USE_SSL` are `True`
 
 If you need to use your own SSL Certificate and keep it persistent and not use the random automatic generated Certificate, you can place into the localstack temporary directory :

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eo pipefail
+shopt -s nullglob
+
+supervisord -c /etc/supervisord.conf &
+
+until grep -q "^Ready.$" /tmp/localstack_infra.log >/dev/null 2>&1 ; do
+  echo "waiting for localstack"
+  sleep 2
+done
+
+for f in /docker-entrypoint-initaws.d/*; do
+  case "$f" in
+    *.sh)     echo "$0: running $f"; . "$f" ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done
+
+tail -f /tmp/localstack_infra.log

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -6,8 +6,7 @@ logfile=/tmp/supervisord.log
 command=make infra
 autostart=true
 autorestart=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
+stdout_logfile=/tmp/localstack_infra.log
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 


### PR DESCRIPTION
Primarily this can be used to create resources on localstack which is why the aws cli is also installed so the script running inside container can use it.

It solves problems like https://github.com/localstack/localstack/issues/1014

**Please refer to the contribution guidelines in the README when submitting PRs.**