### PR TITLE
Fix API gateway AWS_PROXY when sending a JSON list as payload

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -230,7 +230,7 @@ class ProxyListenerApiGateway(ProxyListener):
             elif integration['type'] == 'AWS_PROXY':
                 if uri.startswith('arn:aws:apigateway:') and ':lambda:path' in uri:
                     func_arn = uri.split(':lambda:path')[1].split('functions/')[1].split('/invocations')[0]
-                    data_str = json.dumps(data) if isinstance(data, dict) else data
+                    data_str = json.dumps(data) if isinstance(data, dict) or isinstance(data, list) else data
 
                     relative_path, query_string_params = extract_query_string_params(path=relative_path)
 


### PR DESCRIPTION
This fixes an error when sending a JSON encoded list via an AWS_PROXY to a lambda function.
When using the `aws-lambda-go/lambda` Go package the error looks like:
```
{
  "errorMessage": "json: cannot unmarshal array into Go struct field APIGatewayProxyRequest.body of type string",
  "errorType": "UnmarshalTypeError"
}
Traceback (most recent call last):
    File "/opt/code/localstack/localstack/services/awslambda/lambda_api.py", line 301, in run_lambda event, context=context, version=version, asynchronous=asynchronous)
    File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 136, in execute result, log_output = self.run_lambda_executor(cmd, environment, asynchronous)
    File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 69, in run_lambda_executor (return_code, log_output))
Exception: Lambda process returned error status code: 1. Output:
2018/11/27 14:01:16 [console]

```

If the payload is send to lambda function it should be encoded as a JSON string.
I don't know if the other `isinstance(...., dict)` checks in the function should be extended too, and check for lists.

