### PR TITLE
Fix #614: S3 Multipart upload notification

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -502,9 +502,7 @@ class ProxyListenerS3(ProxyListener):
             # check if this is an actual put object request, because it could also be
             # a put bucket request with a path like this: /bucket_name/
             bucket_name_in_host or (len(path[1:].split('/')) > 1 and len(path[1:].split('/')[1]) > 0),
-            # don't send notification if url has a query part (some/path/with?query)
-            # (query can be one of 'notification', 'lifecycle', 'tagging', etc)
-            not parsed.query
+            self.is_query_allowable(method, parsed.query)
         ])
 
         # get subscribers and send bucket notifications
@@ -561,6 +559,17 @@ class ProxyListenerS3(ProxyListener):
             # update content-length headers (fix https://github.com/localstack/localstack/issues/541)
             if method == 'DELETE':
                 response.headers['content-length'] = len(response._content)
+
+    @staticmethod
+    def is_query_allowable(method, query):
+        # Generally if there is a query (some/path/with?query) we don't want to send notifications
+        if not query:
+            return True
+        # Except we do want to notify on a multipart upload completion, which does use a query.
+        elif method == 'POST' and query.startswith('uploadId'):
+            return True
+        else:
+            return False
 
 
 # instantiate listener

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -85,6 +85,60 @@ def test_s3_put_object_notification():
     s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
 
 
+def test_s3_multipart_upload_notification():
+
+    s3_client = aws_stack.connect_to_service('s3')
+    sqs_client = aws_stack.connect_to_service('sqs')
+
+    key_by_path = 'key-by-hostname'
+
+    # create test queue
+    queue_url = sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
+    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
+
+    # create test bucket
+    s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+    s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                    NotificationConfiguration={'QueueConfigurations': [
+                                                        {'QueueArn': queue_attributes['Attributes']['QueueArn'],
+                                                         'Events': ['s3:ObjectCreated:*']}]})
+
+    multipart_upload_dict = s3_client.create_multipart_upload(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                              Key=key_by_path)
+    uploadId = multipart_upload_dict['UploadId']
+
+    # Write contents to memory rather than a file.
+    upload_file_object = BytesIO()
+    data = '000000000000000000000000000000'
+    with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
+        filestream.write(data.encode('utf-8'))
+
+    response = s3_client.upload_part(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                     Body=upload_file_object.getvalue(),
+                                     Key=key_by_path,
+                                     PartNumber=1,
+                                     UploadId=uploadId)
+
+    multipart_upload_parts = [{'ETag': response['ETag'], 'PartNumber': 1}]
+
+    s3_client.complete_multipart_upload(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                        Key=key_by_path,
+                                        MultipartUpload={'Parts': multipart_upload_parts},
+                                        UploadId=uploadId)
+
+    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url,
+                                                       AttributeNames=['ApproximateNumberOfMessages'])
+    message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
+    # the ApproximateNumberOfMessages attribute is a string
+    assert message_count == '1'
+
+    # clean up
+    sqs_client.delete_queue(QueueUrl=queue_url)
+    s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                             Delete={'Objects': [{'Key': key_by_path}]})
+    s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+
+
 def test_s3_get_response_default_content_type():
     # When no content type is provided by a PUT request
     # 'binary/octet-stream' should be used

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -176,3 +176,13 @@ class S3ListenerTest (unittest.TestCase):
         self.assertTrue(match(['s3:ObjectDeleted:*'], 'ObjectDeleted', 'Delete'))
         self.assertFalse(match(['s3:ObjectCreated:Post'], 'ObjectCreated', 'Put'))
         self.assertFalse(match(['s3:ObjectCreated:Post'], 'ObjectDeleted', 'Put'))
+
+    def test_is_query_allowable(self):
+        self.assertTrue(s3_listener.ProxyListenerS3.is_query_allowable('POST', 'uploadId'))
+        self.assertTrue(s3_listener.ProxyListenerS3.is_query_allowable('POST', ''))
+        self.assertTrue(s3_listener.ProxyListenerS3.is_query_allowable('PUT', ''))
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('POST', 'differentQueryString'))
+        # abort multipart upload is a delete with the same query string as a complete multipart upload
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('DELETE', 'uploadId'))
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('DELETE', 'differentQueryString'))
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('PUT', 'uploadId'))


### PR DESCRIPTION

Fix: https://github.com/localstack/localstack/issues/614

S3 Multipart Uploads notifications were not triggering Lambdas because we ignored all operations that included a query.

Allow this Multipart Uploads are the only POST operations that starts with `uploadId`, so we can allow this case explicitly to send a notification.

TESTING
Added an integration test for s3 multipart upload and unit tests.

COVERAGE BEFORE
Name                                                                              Stmts   Miss  Cover
localstack/services/s3/s3_listener.py                             319     63    80% 
TOTAL                                                                               6008   1563    74%
Ran 89 tests in 172.724s

COVERAGE AFTER
Name                                                                              Stmts   Miss  Cover 
localstack/services/s3/s3_listener.py                             325     63    81%  
TOTAL                                                                               6015   1581    74%
Ran 91 tests in 164.321s