### PR TITLE
sqs: add ability to define the external port

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ You can pass the following environment variables to LocalStack:
   started in different containers using docker-compose.
 * `HOSTNAME_EXTERNAL`: Name of the host to expose the services externally (defaults to `localhost`).
   This host is used, e.g., when returning queue URLs from the SQS service to the client.
+* `<SERVICE>_PORT_EXTERNAL`: Number of the port to expose a specific service externally (defaults to service ports above)
+  `SQS_PORT_EXTERNAL`, for example, is used when returning queue URLs from the SQS service to the client.
 * `USE_SSL`: Whether to use `https://...` URLs with SSL encryption (defaults to `false`).
 * `KINESIS_ERROR_PROBABILITY`: Decimal value between 0.0 (default) and 1.0 to randomly
   inject `ProvisionedThroughputExceededException` errors into Kinesis API responses.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -21,6 +21,9 @@ HOSTNAME = os.environ.get('HOSTNAME', '').strip() or LOCALHOST
 # expose services on a specific host externally
 HOSTNAME_EXTERNAL = os.environ.get('HOSTNAME_EXTERNAL', '').strip() or LOCALHOST
 
+# expose SQS on a specific port externally
+SQS_PORT_EXTERNAL = int(os.environ.get('SQS_PORT_EXTERNAL') or 0)
+
 # name of the host under which the LocalStack services are available
 LOCALSTACK_HOSTNAME = os.environ.get('LOCALSTACK_HOSTNAME', '').strip() or HOSTNAME
 
@@ -74,6 +77,9 @@ for key, value in iteritems(DEFAULT_SERVICE_PORTS):
     backend_override_var = '%s_BACKEND' % key.upper().replace('-', '_')
     if os.environ.get(backend_override_var):
         CONFIG_ENV_VARS.append(backend_override_var)
+    port_external_override_var = '%s_PORT_EXTERNAL' % key.upper().replace('-', '_')
+    if os.environ.get(port_external_override_var):
+        CONFIG_ENV_VARS.append(port_external_override_var)
 
 
 def in_docker():

--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -5,7 +5,7 @@ from six.moves.urllib import parse as urlparse
 from six.moves.urllib.parse import urlencode
 from requests.models import Request, Response
 from localstack import config
-from localstack.config import HOSTNAME_EXTERNAL
+from localstack.config import HOSTNAME_EXTERNAL, SQS_PORT_EXTERNAL
 from localstack.utils.common import to_str, md5
 from localstack.utils.analytics import event_publisher
 from localstack.services.awslambda import lambda_api
@@ -91,7 +91,7 @@ class ProxyListenerSQS(ProxyListener):
                     # return https://... if we're supposed to use SSL
                     content_str = re.sub(r'<QueueUrl>\s*http://', r'<QueueUrl>https://', content_str)
                 # expose external hostname:port
-                external_port = get_external_port(headers, request_handler)
+                external_port = SQS_PORT_EXTERNAL or get_external_port(headers, request_handler)
                 content_str = re.sub(r'<QueueUrl>\s*([a-z]+)://[^<]*:([0-9]+)/([^<]*)\s*</QueueUrl>',
                     r'<QueueUrl>\1://%s:%s/\3</QueueUrl>' % (HOSTNAME_EXTERNAL, external_port), content_str)
                 new_response._content = content_str


### PR DESCRIPTION
First, thanks for your amazing work on `localstack`!

Please treat this as a start of a conversation rather than a full-featured PR. I'm not certain that this is the right direction and would love your feedback.

## Motivation

The issue I'm having is that I'm running `localstack` behind a proxy, which is running on a specific host (which is covered by `HOSTNAME_EXTERNAL`, but is also on a different port from that of the proxy. So, when SQS returns the queue URL it returns the `HOSTNAME_EXTERNAL` that I set, but returns the local port and not the port that the client requests the proxy with.

`[proxy:80]` -> `[localstack:4576]` -> `[elasticmq:4561]`

What I've done at the moment, is I've set my SQS port to `:80` (which is what my proxy wants). This works, but in my opinion is more of a workaround because any other service needs to return a URL pointing back to itself, I will not be able to also put it on `:80` as it will be taken by SQS.

## Proposed solution

So, the solution I'm proposing is to define a `<SERVICE>_PORT_EXTERNAL` and use that along with `HOSTNAME_EXTERNAL`. Alternatively (and if there are no plans to use `HOSTNAME_EXTERNAL` as a single external hostname for all services) we can change it to something like `<SERVICE>_EXTERNAL_URI`, which would be a `host:port` combination specific to a service.