### PR TITLE
Refactor #614: S3 Multipart upload notification testing

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -572,8 +572,6 @@ class ProxyListenerS3(ProxyListener):
         # Except we do want to notify on a multipart upload completion, which does use a query.
         elif method == 'POST' and query.startswith('uploadId'):
             return True
-        else:
-            return False
 
 
 # instantiate listener

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -500,17 +500,13 @@ class ProxyListenerS3(ProxyListener):
 
         bucket_name_in_host = headers['host'].startswith(bucket_name)
 
-        # TODO Not sure if this is the best way to determine the multipart upload or not
-        multipart_upload_complete = method is 'POST' and 'uploadId' in parsed.query
-        should_send_notifications = multipart_upload_complete or all([
+        should_send_notifications = all([
             method in ('PUT', 'POST', 'DELETE'),
             '/' in path[1:] or bucket_name_in_host,
             # check if this is an actual put object request, because it could also be
             # a put bucket request with a path like this: /bucket_name/
             bucket_name_in_host or (len(path[1:].split('/')) > 1 and len(path[1:].split('/')[1]) > 0),
-            # don't send notification if url has a query part (some/path/with?query)
-            # (query can be one of 'notification', 'lifecycle', 'tagging', etc)
-            not parsed.query
+            self.is_query_allowable(method, parsed.query)
         ])
 
         # get subscribers and send bucket notifications
@@ -567,6 +563,17 @@ class ProxyListenerS3(ProxyListener):
             # update content-length headers (fix https://github.com/localstack/localstack/issues/541)
             if method == 'DELETE':
                 response.headers['content-length'] = len(response._content)
+
+    @staticmethod
+    def is_query_allowable(method, query):
+        # Generally if there is a query (some/path/with?query) we don't want to send notifications
+        if not query:
+            return True
+        # Except we do want to notify on a multipart upload completion, which does use a query.
+        elif method == 'POST' and query.startswith('uploadId'):
+            return True
+        else:
+            return False
 
 
 # instantiate listener

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,7 +1,8 @@
 import gzip
-import os
 import json
+import os
 import requests
+import unittest
 import uuid
 from io import BytesIO
 from localstack.utils.aws import aws_stack
@@ -12,346 +13,332 @@ TEST_BUCKET_WITH_NOTIFICATION = 'test_bucket_notification_1'
 TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION = 'test_queue_for_bucket_notification_1'
 
 
-def test_bucket_policy():
+class S3ListenerTest (unittest.TestCase):
 
-    s3_resource = aws_stack.connect_to_resource('s3')
-    s3_client = aws_stack.connect_to_service('s3')
+    def setUp(self):
+        self.s3_client = aws_stack.connect_to_service('s3')
+        self.sqs_client = aws_stack.connect_to_service('sqs')
 
-    # create test bucket
-    s3_resource.create_bucket(Bucket=TEST_BUCKET_NAME_WITH_POLICY)
+    def test_bucket_policy(self):
+        # create test bucket
+        self.s3_client.create_bucket(Bucket=TEST_BUCKET_NAME_WITH_POLICY)
 
-    # put bucket policy
-    policy = {
-        'Version': '2012-10-17',
-        'Statement': {
-            'Action': ['s3:GetObject'],
-            'Effect': 'Allow',
-            'Resource': 'arn:aws:s3:::bucketName/*',
-            'Principal': {
-                'AWS': ['*']
+        # put bucket policy
+        policy = {
+            'Version': '2012-10-17',
+            'Statement': {
+                'Action': ['s3:GetObject'],
+                'Effect': 'Allow',
+                'Resource': 'arn:aws:s3:::bucketName/*',
+                'Principal': {
+                    'AWS': ['*']
+                }
             }
         }
-    }
-    response = s3_client.put_bucket_policy(
-        Bucket=TEST_BUCKET_NAME_WITH_POLICY,
-        Policy=json.dumps(policy)
-    )
-    assert response['ResponseMetadata']['HTTPStatusCode'] == 204
+        response = self.s3_client.put_bucket_policy(
+            Bucket=TEST_BUCKET_NAME_WITH_POLICY,
+            Policy=json.dumps(policy)
+        )
+        assert response['ResponseMetadata']['HTTPStatusCode'] == 204
 
-    # retrieve and check policy config
-    saved_policy = s3_client.get_bucket_policy(Bucket=TEST_BUCKET_NAME_WITH_POLICY)['Policy']
-    assert json.loads(saved_policy) == policy
+        # retrieve and check policy config
+        saved_policy = self.s3_client.get_bucket_policy(Bucket=TEST_BUCKET_NAME_WITH_POLICY)['Policy']
+        assert json.loads(saved_policy) == policy
 
+    def test_s3_put_object_notification(self):
+        key_by_path = 'key-by-hostname'
+        key_by_host = 'key-by-host'
 
-def test_s3_put_object_notification():
+        # create test queue
+        queue_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
+        queue_attributes = self.sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
 
-    s3_client = aws_stack.connect_to_service('s3')
-    sqs_client = aws_stack.connect_to_service('sqs')
+        # create test bucket
+        self.s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+        self.s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                        NotificationConfiguration={'QueueConfigurations': [
+                                                            {'QueueArn': queue_attributes['Attributes']['QueueArn'],
+                                                             'Events': ['s3:ObjectCreated:*']}]})
 
-    key_by_path = 'key-by-hostname'
-    key_by_host = 'key-by-host'
+        # put an object where the bucket_name is in the path
+        self.s3_client.put_object(Bucket=TEST_BUCKET_WITH_NOTIFICATION, Key=key_by_path, Body='something')
 
-    # create test queue
-    queue_url = sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
-    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
+        # put an object where the bucket_name is in the host
+        # it doesn't care about the authorization header as long as it's present
+        headers = {'Host': '{}.s3.amazonaws.com'.format(TEST_BUCKET_WITH_NOTIFICATION), 'authorization': 'some_token'}
+        url = '{}/{}'.format(os.getenv('TEST_S3_URL'), key_by_host)
+        # verify=False must be set as this test fails on travis because of an SSL error non-existent locally
+        response = requests.put(url, data='something else', headers=headers, verify=False)
+        assert response.ok
 
-    # create test bucket
-    s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
-    s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                                                    NotificationConfiguration={'QueueConfigurations': [
-                                                        {'QueueArn': queue_attributes['Attributes']['QueueArn'],
-                                                         'Events': ['s3:ObjectCreated:*']}]})
+        queue_attributes = self.sqs_client.get_queue_attributes(QueueUrl=queue_url,
+                                                           AttributeNames=['ApproximateNumberOfMessages'])
+        message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
+        # the ApproximateNumberOfMessages attribute is a string
+        assert message_count == '2'
 
-    # put an object where the bucket_name is in the path
-    s3_client.put_object(Bucket=TEST_BUCKET_WITH_NOTIFICATION, Key=key_by_path, Body='something')
+        # clean up
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
+        self.s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                 Delete={'Objects': [{'Key': key_by_path}, {'Key': key_by_host}]})
+        self.s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
 
-    # put an object where the bucket_name is in the host
-    # it doesn't care about the authorization header as long as it's present
-    headers = {'Host': '{}.s3.amazonaws.com'.format(TEST_BUCKET_WITH_NOTIFICATION), 'authorization': 'some_token'}
-    url = '{}/{}'.format(os.getenv('TEST_S3_URL'), key_by_host)
-    # verify=False must be set as this test fails on travis because of an SSL error non-existent locally
-    response = requests.put(url, data='something else', headers=headers, verify=False)
-    assert response.ok
+    def generate_large_file(self, size):
+        # https://stackoverflow.com/questions/8816059/create-file-of-particular-size-in-python
+        filename = 'large_file_%s' % uuid.uuid4()
+        f = open(filename, 'wb')
+        f.seek(size - 1)
+        f.write(b'\0')
+        f.close()
+        return open(filename, 'r')
 
-    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url,
-                                                       AttributeNames=['ApproximateNumberOfMessages'])
-    message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
-    # the ApproximateNumberOfMessages attribute is a string
-    assert message_count == '2'
+    def test_s3_upload_fileobj_with_large_file_notification(self):
+        # create test queue
+        queue_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
+        queue_attributes = self.sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
 
-    # clean up
-    sqs_client.delete_queue(QueueUrl=queue_url)
-    s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                             Delete={'Objects': [{'Key': key_by_path}, {'Key': key_by_host}]})
-    s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+        # create test bucket
+        self.s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+        self.s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                        NotificationConfiguration={'QueueConfigurations': [
+                                                            {'QueueArn': queue_attributes['Attributes']['QueueArn'],
+                                                             'Events': ['s3:ObjectCreated:*']}]})
 
+        # has to be larger than 64MB to be broken up into a multipart upload
+        large_file = self.generate_large_file(75000000)
+        try:
+            self.s3_client.upload_file(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                       Key=large_file.name,
+                                       Filename=large_file.name)
+            queue_attributes = self.sqs_client.get_queue_attributes(QueueUrl=queue_url,
+                                                            AttributeNames=['ApproximateNumberOfMessages'])
+            message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
+            # the ApproximateNumberOfMessages attribute is a string
+            assert message_count == '1'
 
-def generate_large_file(size):
-    # https://stackoverflow.com/questions/8816059/create-file-of-particular-size-in-python
-    filename = 'large_file_%s' % uuid.uuid4()
-    f = open(filename, 'wb')
-    f.seek(size - 1)
-    f.write(b'\0')
-    f.close()
-    return open(filename, 'r')
+            # ensure that the first message's eventName is ObjectCreated:CompleteMultipartUpload
+            messages = self.sqs_client.receive_message(QueueUrl=queue_url, AttributeNames=['All'])
+            message = json.loads(messages['Messages'][0]['Body'])
+            assert message['Records'][0]['eventName'] == 'ObjectCreated:CompleteMultipartUpload'
 
+            # clean up
+            self.sqs_client.delete_queue(QueueUrl=queue_url)
+            self.s3_client.delete_object(Bucket=TEST_BUCKET_WITH_NOTIFICATION, Key=large_file.name)
+            self.s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+        finally:
+            # clean up large file
+            large_file.close()
+            os.remove(large_file.name)
 
-def test_s3_upload_fileobj_with_large_file_notification():
+    def test_s3_multipart_upload_with_small_single_part(self):
+        # In a multipart upload "Each part must be at least 5 MB in size, except the last part."
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
 
-    s3_client = aws_stack.connect_to_service('s3')
-    sqs_client = aws_stack.connect_to_service('sqs')
+        key_by_path = 'key-by-hostname'
 
-    # create test queue
-    queue_url = sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
-    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
+        # create test queue
+        queue_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
+        queue_attributes = self.sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
 
-    # create test bucket
-    s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
-    s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                                                    NotificationConfiguration={'QueueConfigurations': [
-                                                        {'QueueArn': queue_attributes['Attributes']['QueueArn'],
-                                                         'Events': ['s3:ObjectCreated:*']}]})
+        # create test bucket
+        self.s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+        self.s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                        NotificationConfiguration={'QueueConfigurations': [
+                                                            {'QueueArn': queue_attributes['Attributes']['QueueArn'],
+                                                             'Events': ['s3:ObjectCreated:*']}]})
 
-    # has to be larger than 64MB to be broken up into a multipart upload
-    large_file = generate_large_file(75000000)
-    try:
-        s3_client.upload_file(Bucket=TEST_BUCKET_WITH_NOTIFICATION, Key=large_file.name, Filename=large_file.name)
-        queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url,
-                                                        AttributeNames=['ApproximateNumberOfMessages'])
+        multipart_upload_dict = self.s3_client.create_multipart_upload(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                                                  Key=key_by_path)
+        uploadId = multipart_upload_dict['UploadId']
+
+        # Write contents to memory rather than a file.
+        upload_file_object = BytesIO()
+        data = '000000000000000000000000000000'
+        with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
+            filestream.write(data.encode('utf-8'))
+
+        response = self.s3_client.upload_part(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                         Body=upload_file_object.getvalue(),
+                                         Key=key_by_path,
+                                         PartNumber=1,
+                                         UploadId=uploadId)
+
+        multipart_upload_parts = [{'ETag': response['ETag'], 'PartNumber': 1}]
+
+        self.s3_client.complete_multipart_upload(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                            Key=key_by_path,
+                                            MultipartUpload={'Parts': multipart_upload_parts},
+                                            UploadId=uploadId)
+
+        queue_attributes = self.sqs_client.get_queue_attributes(QueueUrl=queue_url,
+                                                           AttributeNames=['ApproximateNumberOfMessages'])
         message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
         # the ApproximateNumberOfMessages attribute is a string
         assert message_count == '1'
 
-        # ensure that the first message's eventName is ObjectCreated:CompleteMultipartUpload
-        messages = sqs_client.receive_message(QueueUrl=queue_url, AttributeNames=['All'])
-        message = json.loads(messages['Messages'][0]['Body'])
-        assert message['Records'][0]['eventName'] == 'ObjectCreated:CompleteMultipartUpload'
-
         # clean up
-        sqs_client.delete_queue(QueueUrl=queue_url)
-        s3_client.delete_object(Bucket=TEST_BUCKET_WITH_NOTIFICATION, Key=large_file.name)
-        s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
-    finally:
-        # clean up large file
-        large_file.close()
-        os.remove(large_file.name)
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
+        self.s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
+                                 Delete={'Objects': [{'Key': key_by_path}]})
+        self.s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
 
+    def test_s3_get_response_default_content_type(self):
+        # When no content type is provided by a PUT request
+        # 'binary/octet-stream' should be used
+        # src: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
 
-def test_s3_multipart_upload_with_small_single_part():
-    # In a multipart upload "Each part must be at least 5 MB in size, except the last part."
-    # https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
-    s3_client = aws_stack.connect_to_service('s3')
-    sqs_client = aws_stack.connect_to_service('sqs')
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
 
-    key_by_path = 'key-by-hostname'
+        # put object
+        object_key = 'key-by-hostname'
+        self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something')
+        url = self.s3_client.generate_presigned_url(
+            'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
+        )
 
-    # create test queue
-    queue_url = sqs_client.create_queue(QueueName=TEST_QUEUE_FOR_BUCKET_WITH_NOTIFICATION)['QueueUrl']
-    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['QueueArn'])
+        # get object and assert headers
+        response = requests.get(url, verify=False)
+        assert response.headers['content-type'] == 'binary/octet-stream'
+        # clean up
+        self.s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+        self.s3_client.delete_bucket(Bucket=bucket_name)
 
-    # create test bucket
-    s3_client.create_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
-    s3_client.put_bucket_notification_configuration(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                                                    NotificationConfiguration={'QueueConfigurations': [
-                                                        {'QueueArn': queue_attributes['Attributes']['QueueArn'],
-                                                         'Events': ['s3:ObjectCreated:*']}]})
+    def test_s3_get_response_content_type_same_as_upload(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
 
-    multipart_upload_dict = s3_client.create_multipart_upload(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                                                              Key=key_by_path)
-    uploadId = multipart_upload_dict['UploadId']
+        # put object
+        object_key = 'key-by-hostname'
+        self.s3_client.put_object(Bucket=bucket_name,
+                                  Key=object_key,
+                                  Body='something',
+                                  ContentType='text/html; charset=utf-8')
+        url = self.s3_client.generate_presigned_url(
+            'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
+        )
 
-    # Write contents to memory rather than a file.
-    upload_file_object = BytesIO()
-    data = '000000000000000000000000000000'
-    with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
-        filestream.write(data.encode('utf-8'))
+        # get object and assert headers
+        response = requests.get(url, verify=False)
+        assert response.headers['content-type'] == 'text/html; charset=utf-8'
+        # clean up
+        self.s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+        self.s3_client.delete_bucket(Bucket=bucket_name)
 
-    response = s3_client.upload_part(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                                     Body=upload_file_object.getvalue(),
-                                     Key=key_by_path,
-                                     PartNumber=1,
-                                     UploadId=uploadId)
+    def test_s3_head_response_content_length_same_as_upload(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        body = 'something body'
+        # put object
+        object_key = 'key-by-hostname'
+        self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Body=body, ContentType='text/html; charset=utf-8')
+        url = self.s3_client.generate_presigned_url(
+            'head_object', Params={'Bucket': bucket_name, 'Key': object_key}
+        )
 
-    multipart_upload_parts = [{'ETag': response['ETag'], 'PartNumber': 1}]
+        # get object and assert headers
+        response = requests.head(url, verify=False)
 
-    s3_client.complete_multipart_upload(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                                        Key=key_by_path,
-                                        MultipartUpload={'Parts': multipart_upload_parts},
-                                        UploadId=uploadId)
+        assert response.headers['content-length'] == str(len(body))
+        # clean up
+        self.s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+        self.s3_client.delete_bucket(Bucket=bucket_name)
 
-    queue_attributes = sqs_client.get_queue_attributes(QueueUrl=queue_url,
-                                                       AttributeNames=['ApproximateNumberOfMessages'])
-    message_count = queue_attributes['Attributes']['ApproximateNumberOfMessages']
-    # the ApproximateNumberOfMessages attribute is a string
-    assert message_count == '1'
+    def test_s3_delete_response_content_length_zero(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
 
-    # clean up
-    sqs_client.delete_queue(QueueUrl=queue_url)
-    s3_client.delete_objects(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
-                             Delete={'Objects': [{'Key': key_by_path}]})
-    s3_client.delete_bucket(Bucket=TEST_BUCKET_WITH_NOTIFICATION)
+        # put object
+        object_key = 'key-by-hostname'
+        self.s3_client.put_object(Bucket=bucket_name,
+                                  Key=object_key,
+                                  Body='something',
+                                  ContentType='text/html; charset=utf-8')
+        url = self.s3_client.generate_presigned_url(
+            'delete_object', Params={'Bucket': bucket_name, 'Key': object_key}
+        )
 
+        # get object and assert headers
+        response = requests.delete(url, verify=False)
 
-def test_s3_get_response_default_content_type():
-    # When no content type is provided by a PUT request
-    # 'binary/octet-stream' should be used
-    # src: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
-    bucket_name = 'test-bucket-%s' % short_uid()
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
+        assert response.headers['content-length'] == '0'
+        # clean up
+        self.s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+        self.s3_client.delete_bucket(Bucket=bucket_name)
 
-    # put object
-    object_key = 'key-by-hostname'
-    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something')
-    url = s3_client.generate_presigned_url(
-        'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
-    )
+    def test_s3_get_response_headers(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
 
-    # get object and assert headers
-    response = requests.get(url, verify=False)
-    assert response.headers['content-type'] == 'binary/octet-stream'
-    # clean up
-    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
-    s3_client.delete_bucket(Bucket=bucket_name)
+        # put object and CORS configuration
+        object_key = 'key-by-hostname'
+        self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something')
+        url = self.s3_client.generate_presigned_url(
+            'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
+        )
+        self.s3_client.put_bucket_cors(Bucket=bucket_name,
+            CORSConfiguration={
+                'CORSRules': [{
+                    'AllowedMethods': ['GET', 'PUT', 'POST'],
+                    'AllowedOrigins': ['*'],
+                    'ExposeHeaders': [
+                        'Date', 'x-amz-delete-marker', 'x-amz-version-id'
+                    ]
+                }]
+            },
+        )
 
+        # get object and assert headers
+        url = self.s3_client.generate_presigned_url(
+            'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
+        )
+        response = requests.get(url, verify=False)
+        assert response.headers['Date']
+        assert response.headers['x-amz-delete-marker']
+        assert response.headers['x-amz-version-id']
+        assert not response.headers.get('x-amz-id-2')
+        assert not response.headers.get('x-amz-request-id')
+        # clean up
+        self.s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
+        self.s3_client.delete_bucket(Bucket=bucket_name)
 
-def test_s3_get_response_content_type_same_as_upload():
-    bucket_name = 'test-bucket-%s' % short_uid()
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
+    def test_s3_invalid_content_md5(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
 
-    # put object
-    object_key = 'key-by-hostname'
-    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something', ContentType='text/html; charset=utf-8')
-    url = s3_client.generate_presigned_url(
-        'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
-    )
+        # put object with invalid content MD5
+        for hash in ['__invalid__', '000']:
+            raised = False
+            try:
+                self.s3_client.put_object(Bucket=bucket_name, Key='test-key',
+                    Body='something', ContentMD5=hash)
+            except Exception:
+                raised = True
+            if not raised:
+                raise Exception('Invalid MD5 hash "%s" should have raised an error' % hash)
 
-    # get object and assert headers
-    response = requests.get(url, verify=False)
-    assert response.headers['content-type'] == 'text/html; charset=utf-8'
-    # clean up
-    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
-    s3_client.delete_bucket(Bucket=bucket_name)
+    def test_s3_upload_download_gzip(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
 
+        self.s3_client.create_bucket(Bucket=bucket_name)
 
-def test_s3_head_response_content_length_same_as_upload():
-    bucket_name = 'test-bucket-%s' % short_uid()
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
-    body = 'something body'
-    # put object
-    object_key = 'key-by-hostname'
-    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body=body, ContentType='text/html; charset=utf-8')
-    url = s3_client.generate_presigned_url(
-        'head_object', Params={'Bucket': bucket_name, 'Key': object_key}
-    )
+        data = '000000000000000000000000000000'
 
-    # get object and assert headers
-    response = requests.head(url, verify=False)
+        # Write contents to memory rather than a file.
+        upload_file_object = BytesIO()
+        with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
+            filestream.write(data.encode('utf-8'))
 
-    assert response.headers['content-length'] == str(len(body))
-    # clean up
-    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
-    s3_client.delete_bucket(Bucket=bucket_name)
+        # Upload gzip
+        self.s3_client.put_object(Bucket=bucket_name,
+                                  Key='test.gz',
+                                  ContentEncoding='gzip',
+                                  Body=upload_file_object.getvalue())
 
+        # Download gzip
+        downloaded_object = self.s3_client.get_object(Bucket=bucket_name, Key='test.gz')
+        download_file_object = BytesIO(downloaded_object['Body'].read())
+        with gzip.GzipFile(fileobj=download_file_object, mode='rb') as filestream:
+            downloaded_data = filestream.read().decode('utf-8')
 
-def test_s3_delete_response_content_length_zero():
-    bucket_name = 'test-bucket-%s' % short_uid()
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
-
-    # put object
-    object_key = 'key-by-hostname'
-    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something', ContentType='text/html; charset=utf-8')
-    url = s3_client.generate_presigned_url(
-        'delete_object', Params={'Bucket': bucket_name, 'Key': object_key}
-    )
-
-    # get object and assert headers
-    response = requests.delete(url, verify=False)
-
-    assert response.headers['content-length'] == '0'
-    # clean up
-    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
-    s3_client.delete_bucket(Bucket=bucket_name)
-
-
-def test_s3_get_response_headers():
-    bucket_name = 'test-bucket-%s' % short_uid()
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
-
-    # put object and CORS configuration
-    object_key = 'key-by-hostname'
-    s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something')
-    url = s3_client.generate_presigned_url(
-        'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
-    )
-    s3_client.put_bucket_cors(Bucket=bucket_name,
-        CORSConfiguration={
-            'CORSRules': [{
-                'AllowedMethods': ['GET', 'PUT', 'POST'],
-                'AllowedOrigins': ['*'],
-                'ExposeHeaders': [
-                    'Date', 'x-amz-delete-marker', 'x-amz-version-id'
-                ]
-            }]
-        },
-    )
-
-    # get object and assert headers
-    url = s3_client.generate_presigned_url(
-        'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
-    )
-    response = requests.get(url, verify=False)
-    assert response.headers['Date']
-    assert response.headers['x-amz-delete-marker']
-    assert response.headers['x-amz-version-id']
-    assert not response.headers.get('x-amz-id-2')
-    assert not response.headers.get('x-amz-request-id')
-    # clean up
-    s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
-    s3_client.delete_bucket(Bucket=bucket_name)
-
-
-def test_s3_invalid_content_md5():
-    bucket_name = 'test-bucket-%s' % short_uid()
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
-
-    # put object with invalid content MD5
-    for hash in ['__invalid__', '000']:
-        raised = False
-        try:
-            s3_client.put_object(Bucket=bucket_name, Key='test-key',
-                Body='something', ContentMD5=hash)
-        except Exception:
-            raised = True
-        if not raised:
-            raise Exception('Invalid MD5 hash "%s" should have raised an error' % hash)
-
-
-def test_s3_upload_download_gzip():
-    bucket_name = 'test-bucket-%s' % short_uid()
-
-    s3_client = aws_stack.connect_to_service('s3')
-    s3_client.create_bucket(Bucket=bucket_name)
-
-    data = '000000000000000000000000000000'
-
-    # Write contents to memory rather than a file.
-    upload_file_object = BytesIO()
-    with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
-        filestream.write(data.encode('utf-8'))
-
-    # Upload gzip
-    s3_client.put_object(Bucket=bucket_name, Key='test.gz', ContentEncoding='gzip', Body=upload_file_object.getvalue())
-
-    # Download gzip
-    downloaded_object = s3_client.get_object(Bucket=bucket_name, Key='test.gz')
-    download_file_object = BytesIO(downloaded_object['Body'].read())
-    with gzip.GzipFile(fileobj=download_file_object, mode='rb') as filestream:
-        downloaded_data = filestream.read().decode('utf-8')
-
-    assert downloaded_data == data, '{} != {}'.format(downloaded_data, data)
+        assert downloaded_data == data, '{} != {}'.format(downloaded_data, data)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -137,8 +137,9 @@ def test_s3_upload_fileobj_with_large_file_notification():
         os.remove(large_file.name)
 
 
-def test_s3_multipart_upload_notification():
-
+def test_s3_multipart_upload_with_small_single_part():
+    # In a multipart upload "Each part must be at least 5 MB in size, except the last part."
+    # https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
     s3_client = aws_stack.connect_to_service('s3')
     sqs_client = aws_stack.connect_to_service('sqs')
 
@@ -165,8 +166,6 @@ def test_s3_multipart_upload_notification():
     with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
         filestream.write(data.encode('utf-8'))
 
-    # In a multipart upload "Each part must be at least 5 MB in size, except the last part."
-    # https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
     response = s3_client.upload_part(Bucket=TEST_BUCKET_WITH_NOTIFICATION,
                                      Body=upload_file_object.getvalue(),
                                      Key=key_by_path,

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -176,3 +176,13 @@ class S3ListenerTest (unittest.TestCase):
         self.assertTrue(match(['s3:ObjectDeleted:*'], 'ObjectDeleted', 'Delete'))
         self.assertFalse(match(['s3:ObjectCreated:Post'], 'ObjectCreated', 'Put'))
         self.assertFalse(match(['s3:ObjectCreated:Post'], 'ObjectDeleted', 'Put'))
+
+    def test_is_query_allowable(self):
+        self.assertTrue(s3_listener.ProxyListenerS3.is_query_allowable('POST', 'uploadId'))
+        self.assertTrue(s3_listener.ProxyListenerS3.is_query_allowable('POST', ''))
+        self.assertTrue(s3_listener.ProxyListenerS3.is_query_allowable('PUT', ''))
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('POST', 'differentQueryString'))
+        # abort multipart upload is a delete with the same query string as a complete multipart upload
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('DELETE', 'uploadId'))
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('DELETE', 'differentQueryString'))
+        self.assertFalse(s3_listener.ProxyListenerS3.is_query_allowable('PUT', 'uploadId'))


### PR DESCRIPTION
Refactor issue https://github.com/localstack/localstack/issues/614

Refactor to add a static helper method for readability and testability.

This helper method makes it explicit how we notify on Multipart Uploads; the only POST operations that starts with `uploadId`

Added an integration test for s3 multipart upload and unit tests.

    Name                                                            Stmts   Miss  Cover   Missing
    ---------------------------------------------------------------------------------------------
    localstack/services/s3/s3_listener.py                             319     63    80%   61, 64-66, 147-148, 154-155, 161-167, 170, 175-185, 200-203, 229, 231, 240-250, 255-260, 275-280, 429, 437, 459, 462-463, 466-469, 472, 482, 491-493, 514
    ---------------------------------------------------------------------------------------------
    TOTAL                                                            6008   1563    74%
    ----------------------------------------------------------------------
    Ran 89 tests in 172.724s

    Name                                                            Stmts   Miss  Cover   Missing
    ---------------------------------------------------------------------------------------------
    localstack/services/s3/s3_listener.py                             325     63    81%   61, 64-66, 147-148, 154-155, 161-167, 170, 175-185, 200-203, 229, 231, 240-250, 255-260, 275-280, 429, 437, 459, 462-463, 466-469, 472, 482, 491-493, 512
    ---------------------------------------------------------------------------------------------
    TOTAL                                                            6015   1581    74%
    ----------------------------------------------------------------------
    Ran 91 tests in 164.321s