### PR TITLE
Implement LambdaContext.get_remaining_time_in_millis.

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -79,14 +79,18 @@ class LambdaContext(object):
     def __init__(self, func_details, qualifier=None):
         self.function_name = func_details.name()
         self.function_version = func_details.get_qualifier_version(qualifier)
-
         self.invoked_function_arn = func_details.arn()
+
+        self.timeout = func_details.timeout
+        self.started_at = time.time() * 1000
+
         if qualifier:
             self.invoked_function_arn += ':' + qualifier
 
     def get_remaining_time_in_millis(self):
-        # TODO implement!
-        return 1000 * 60
+        right_now = time.time() * 1000
+        elapsed = right_now - self.started_at
+        return self.timeout - elapsed
 
 
 def cleanup():

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -111,7 +111,8 @@ def create_zip_file(file_path, get_content=False):
 
 
 def create_lambda_function(func_name, zip_file, event_source_arn=None, handler=LAMBDA_DEFAULT_HANDLER,
-        starting_position=LAMBDA_DEFAULT_STARTING_POSITION, runtime=LAMBDA_DEFAULT_RUNTIME,
+                           starting_position=LAMBDA_DEFAULT_STARTING_POSITION, runtime=LAMBDA_DEFAULT_RUNTIME,
+                           timeout=LAMBDA_DEFAULT_TIMEOUT,
         envvars={}):
     """Utility method to create a new function via the Lambda API"""
 
@@ -125,7 +126,7 @@ def create_lambda_function(func_name, zip_file, event_source_arn=None, handler=L
         Code={
             'ZipFile': zip_file
         },
-        Timeout=LAMBDA_DEFAULT_TIMEOUT,
+        Timeout=timeout,
         Environment=dict(Variables=envvars)
     )
     # create event source mapping

--- a/tests/integration/lambdas/lambda_context.py
+++ b/tests/integration/lambdas/lambda_context.py
@@ -1,0 +1,16 @@
+import os
+import time
+
+def handler(event, context):
+    """ Simple Lambda function that returns values related to the context initially time remaining """
+    try:
+        body = json.loads(event['body'])
+    except Exception:
+        body = event
+
+    seconds_to_sleep = (int(body["seconds_to_sleep"]) or 0)
+
+    time.sleep(seconds_to_sleep)
+
+    return { 'TimeRemainingInMillis': context.get_remaining_time_in_millis(),
+             'SecondsISlept': seconds_to_sleep }


### PR DESCRIPTION
Added the functionality to keep track fo how long a lambda has been running. get_remaining_time_in_millis() now will return how much longer the lambda can run before it will be killed.

Tests: To test this we implemented test_lambda_remaining_time() that runs two lambdas. The first lambda sleeps for 5 seconds and then we check to make sure it has passed it's timeout. The other returns instantly and a check is done to make sure that there is still time left in its 5 second timeout.



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-84) by [Unito](https://www.unito.io/learn-more)
