### PR TITLE
fix pyaml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ nose==1.3.7
 psutil==5.4.3
 pyopenssl==17.5.0
 python-coveralls==2.7.0
-pyyaml==4.2b4
+pyyaml>=3.13
 requests==2.20.0
 requests-aws4auth==0.9
 six==1.10.0


### PR DESCRIPTION
When you `pip install localstack` it wont work, due to version conflict of the module `PyYAML` so this fixes #1052 