### PR TITLE
Install Elasticsearch plugins

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -26,8 +26,8 @@ RUN { \
     && chmod +x /usr/local/bin/docker-java-home
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
-ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.181.13-r0
+ENV JAVA_VERSION 8u191
+ENV JAVA_ALPINE_VERSION 8.191.12-r0
 RUN set -x && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" \
     && [ "$JAVA_HOME" = "$(docker-java-home)" ]
 
@@ -51,6 +51,10 @@ ADD https://raw.githubusercontent.com/carlossg/docker-maven/master/jdk-8/setting
 RUN mkdir -p /opt/code/localstack
 WORKDIR /opt/code/localstack/
 
+# https://github.com/pires/docker-elasticsearch/issues/56
+ENV ES_TMPDIR  /tmp
+# require --batch option that ingest-attachment plugin require additional permissions
+
 # init environment and cache some dependencies
 RUN mkdir -p /opt/code/localstack/localstack/infra && \
     wget -O /tmp/localstack.es.zip \
@@ -59,6 +63,17 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.5.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \
         mv elasticsearch* elasticsearch && rm /tmp/localstack.es.zip) && \
+    (cd localstack/infra/elasticsearch/ && \
+        bin/elasticsearch-plugin install analysis-icu && \
+        bin/elasticsearch-plugin install ingest-attachment --batch && \
+        bin/elasticsearch-plugin install ingest-user-agent && \
+        bin/elasticsearch-plugin install analysis-kuromoji && \
+        bin/elasticsearch-plugin install mapper-murmur3 && \
+        bin/elasticsearch-plugin install mapper-size && \
+        bin/elasticsearch-plugin install analysis-phonetic && \
+        bin/elasticsearch-plugin install analysis-smartcn && \
+        bin/elasticsearch-plugin install analysis-stempel && \
+        bin/elasticsearch-plugin install analysis-ukrainian) && \
     mkdir -p /opt/code/localstack/localstack/infra/dynamodb && \
     wget -O /tmp/localstack.ddb.zip \
         https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -70,6 +70,9 @@ LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
 ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip'
+# https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
+ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'ingest-user-agent', 'analysis-kuromoji',
+ 'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']
 DYNAMODB_JAR_URL = 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip'
 ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar'
 STS_JAR_URL = 'http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -7,7 +7,7 @@ import shutil
 import logging
 import tempfile
 from localstack.constants import (DEFAULT_SERVICE_PORTS, ELASTICMQ_JAR_URL, STS_JAR_URL,
-    ELASTICSEARCH_JAR_URL, DYNAMODB_JAR_URL, LOCALSTACK_MAVEN_VERSION)
+    ELASTICSEARCH_JAR_URL, ELASTICSEARCH_PLUGIN_LIST, DYNAMODB_JAR_URL, LOCALSTACK_MAVEN_VERSION)
 from localstack.utils.common import download, parallelize, run, mkdir, save_file, unzip, rm_rf, chmod_r
 
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -46,6 +46,14 @@ def install_elasticsearch():
             dir_path = '%s/%s' % (INSTALL_DIR_ES, dir_name)
             mkdir(dir_path)
             chmod_r(dir_path, 0o777)
+
+        # install default plugins
+        for plugin in ELASTICSEARCH_PLUGIN_LIST:
+            if is_alpine():
+                # https://github.com/pires/docker-elasticsearch/issues/56
+                os.environ['ES_TMPDIR'] = '/tmp'
+            plugin_binary = os.path.join(INSTALL_DIR_ES, 'bin', 'elasticsearch-plugin')
+            run('%s install %s' % (plugin_binary, plugin))
 
 
 def install_elasticmq():


### PR DESCRIPTION
Fix #1035

install ES plugin by  supports Amazon Elasticsearch Service
https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-plugins.html