### PR TITLE
Resolve issues with building in Java 9 (and above) environments #1028

### DIFF
--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -71,7 +71,14 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.20</version>
+            <version>1.18.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- required to build on java 9+ -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/localstack/ext/java/src/main/java/org/ow2/proactive/process_tree_killer/ProcessTree.java
+++ b/localstack/ext/java/src/main/java/org/ow2/proactive/process_tree_killer/ProcessTree.java
@@ -424,11 +424,12 @@ public abstract class ProcessTree
     }
 
     static abstract class Unix extends Local {
+
         @Override
         public OSProcess get(Process proc) {
             try {
-                return get((Integer) UnixReflection.PID_FIELD.get(proc));
-            } catch (IllegalAccessException e) { // impossible
+                return get((Integer) UnixReflection.pid(proc));
+            } catch (IllegalAccessError e) { // impossible
                 IllegalAccessError x = new IllegalAccessError();
                 x.initCause(e);
                 throw x;
@@ -533,58 +534,90 @@ public abstract class ProcessTree
     private static final class UnixReflection {
         /**
          * Field to access the PID of the process.
+         * Required for Java 8 and older JVMs.
          */
-        private static final Field PID_FIELD;
+        private static final Field JAVA8_PID_FIELD;
+
+        /**
+         * Field to access the PID of the process.
+         * Required for Java 9 and above until this is replaced by multi-release JAR.
+         */
+        private static final Method JAVA9_PID_METHOD;
 
         /**
          * Method to destroy a process, given pid.
          *
          * Looking at the JavaSE source code, this is using SIGTERM (15)
          */
-        private static final Method DESTROY_PROCESS;
+        private static final Method JAVA8_DESTROY_PROCESS;
+        private static final Method JAVA_9_PROCESSHANDLE_OF;
+        private static final Method JAVA_9_PROCESSHANDLE_DESTROY;
 
         static {
             try {
-                Class<?> clazz = Class.forName("java.lang.UNIXProcess");
-                PID_FIELD = clazz.getDeclaredField("pid");
-                PID_FIELD.setAccessible(true);
-
-                if (isPreJava8()) {
-                    DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess", int.class);
+                if (isPostJava8()) {
+                    Class<?> clazz = Process.class;
+                    JAVA9_PID_METHOD = clazz.getMethod("pid");
+                    JAVA8_PID_FIELD = null;
+                    Class<?> processHandleClazz = Class.forName("java.lang.ProcessHandle");
+                    JAVA_9_PROCESSHANDLE_OF = processHandleClazz.getMethod("of", long.class);
+                    JAVA_9_PROCESSHANDLE_DESTROY = processHandleClazz.getMethod("destroy");
+                    JAVA8_DESTROY_PROCESS = null;
                 } else {
-                    DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess", int.class, boolean.class);
+                    Class<?> clazz = Class.forName("java.lang.UNIXProcess");
+                    JAVA8_PID_FIELD = clazz.getDeclaredField("pid");
+                    JAVA8_PID_FIELD.setAccessible(true);
+                    JAVA9_PID_METHOD = null;
+
+                    JAVA8_DESTROY_PROCESS = clazz.getDeclaredMethod("destroyProcess", int.class, boolean.class);
+                    JAVA8_DESTROY_PROCESS.setAccessible(true);
+                    JAVA_9_PROCESSHANDLE_OF = null;
+                    JAVA_9_PROCESSHANDLE_DESTROY = null;
                 }
-                DESTROY_PROCESS.setAccessible(true);
-            } catch (ClassNotFoundException e) {
-                LinkageError x = new LinkageError();
-                x.initCause(e);
-                throw x;
-            } catch (NoSuchFieldException e) {
-                LinkageError x = new LinkageError();
-                x.initCause(e);
-                throw x;
-            } catch (NoSuchMethodException e) {
-                LinkageError x = new LinkageError();
-                x.initCause(e);
+            } catch (ClassNotFoundException | NoSuchFieldException | NoSuchMethodException e) {
+                LinkageError x = new LinkageError("Cannot initialize reflection for Unix Processes", e);
                 throw x;
             }
         }
 
-        public static void destroy(int pid) throws IllegalAccessException, InvocationTargetException {
-            if (isPreJava8()) {
-                DESTROY_PROCESS.invoke(null, pid);
+        public static void destroy(int pid) throws IllegalAccessException,
+                InvocationTargetException {
+            if (JAVA8_DESTROY_PROCESS != null) {
+                JAVA8_DESTROY_PROCESS.invoke(null, pid, false);
             } else {
-                DESTROY_PROCESS.invoke(null, pid, false);
+                final Optional handle = (Optional)JAVA_9_PROCESSHANDLE_OF.invoke(null, pid);
+                if (handle.isPresent()) {
+                    JAVA_9_PROCESSHANDLE_DESTROY.invoke(handle.get());
+                }
             }
         }
 
-        private static boolean isPreJava8() {
-            int javaVersionAsAnInteger = Integer.parseInt(System.getProperty("java.version")
-                                                                .replaceAll("\\.", "")
-                                                                .replaceAll("_", "")
-                                                                .substring(0, 2));
-            return javaVersionAsAnInteger < 18;
+        public static int pid(Process proc) {
+            try {
+                if (JAVA8_PID_FIELD != null) {
+                    return JAVA8_PID_FIELD.getInt(proc);
+                } else {
+                    long pid = (long) JAVA9_PID_METHOD.invoke(proc);
+                    if (pid > Integer.MAX_VALUE) {
+                        throw new IllegalAccessError("PID is out of bounds: " + pid);
+                    }
+                    return (int) pid;
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) { // impossible
+                IllegalAccessError x = new IllegalAccessError();
+                x.initCause(e);
+                throw x;
+            }
         }
+
+        private static String getJavaVersionFromSystemProperty(){
+            return System.getProperty("java.version");
+        }
+
+        private static boolean isPostJava8(){
+            return !getJavaVersionFromSystemProperty().startsWith("1.");
+        }
+
     }
 
     static class Linux extends ProcfsUnix {
@@ -1121,12 +1154,12 @@ public abstract class ProcessTree
      * instead you'd do it with the sysctl
      * <http://search.cpan.org/src/DURIST/Proc-ProcessTable-0.42/os/darwin.c>
      * <http://developer.apple.com/documentation/Darwin/Reference/ManPages/man3/sysctl.3.html>
-     * 
+     *
      * There's CLI but that doesn't seem to offer the access to per-process info
      * <http://developer.apple.com/documentation/Darwin/Reference/ManPages/man8/sysctl.8.html>
-     * 
-     * 
-     * 
+     *
+     *
+     *
      * On HP-UX, pstat_getcommandline get you command line, but I'm not seeing any environment
      * variables.
      */


### PR DESCRIPTION
Fix test failures while running in JDK 9 and above due to failure to destroy process from removal of UNIXProcess class in java 9.
