### PR TITLE
Fix missing root element in S3 Get_Lifecycle

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -246,7 +246,7 @@ def get_lifecycle(bucket_name):
     if not lifecycle:
         # TODO: check if bucket exists, otherwise return 404-like error
         lifecycle = {
-            'LifecycleConfiguration': []
+            'LifecycleConfiguration': { }
         }
     body = xmltodict.unparse(lifecycle)
     response._content = body

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -246,7 +246,7 @@ def get_lifecycle(bucket_name):
     if not lifecycle:
         # TODO: check if bucket exists, otherwise return 404-like error
         lifecycle = {
-            'LifecycleConfiguration': { }
+            'LifecycleConfiguration': {}
         }
     body = xmltodict.unparse(lifecycle)
     response._content = body

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -105,7 +105,7 @@ class S3ListenerTest (unittest.TestCase):
     def test_get_bucket_lifecycle(self):
         bucket_name = 'test-bucket'
         returned_empty_lifecycle = s3_listener.get_lifecycle(bucket_name)
-        self.assertRegexpMatches(returned_empty_lifecycle._content,r'LifecycleConfiguration')
+        self.assertRegexpMatches(returned_empty_lifecycle._content, r'LifecycleConfiguration')
 
     def test_get_bucket_name(self):
         bucket_name = 'test-bucket'

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -102,6 +102,11 @@ class S3ListenerTest (unittest.TestCase):
         self.assertIn(b'uploads/20170826T181315.679087009Z/upload/pixel.txt', expanded3,
             'Should see the interpolated filename')
 
+    def test_get_bucket_lifecycle(self):
+        bucket_name = 'test-bucket'
+        returned_empty_lifecycle = s3_listener.get_lifecycle(bucket_name)
+        self.assertRegexpMatches(returned_empty_lifecycle._content,r'LifecycleConfiguration')
+
     def test_get_bucket_name(self):
         bucket_name = 'test-bucket'
         s3_key = '/some-folder/some-key.txt'


### PR DESCRIPTION
When the AWS SDK requests the S3 bucket lifecycle it expects to have at least the root element LifecycleConfiguration and the current code does not return the expected result.

**Please refer to the contribution guidelines in the README when submitting PRs.**
