### PR TITLE
Expose the port for secretsmanager by default in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV MAVEN_CONFIG=/opt/code/localstack \
     PYTHONUNBUFFERED=1
 
 # expose service & web dashboard ports
-EXPOSE 4567-4583 8080
+EXPOSE 4567-4584 8080
 
 # install supervisor daemon & copy config file
 ADD bin/supervisord.conf /etc/supervisord.conf


### PR DESCRIPTION
This PR exposes the port 4584 which is used by the secretsmanager service.