### PR TITLE
Fix subprocess.wait() hanging

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -63,9 +63,10 @@ class LambdaExecutor(object):
             result = '{"asynchronous": "%s"}' % asynchronous
             log_output = 'Lambda executed asynchronously'
         else:
-            return_code = process.wait()
-            result = to_str(process.stdout.read())
-            log_output = to_str(process.stderr.read())
+            result, log_output = process.communicate()
+            result = to_str(result)
+            log_output = to_str(log_output)
+            return_code = process.returncode
 
             if return_code != 0:
                 raise Exception('Lambda process returned error status code: %s. Output:\n%s' %


### PR DESCRIPTION
[subprocess.Popen.wait](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait)

> This will deadlock when using stdout=PIPE or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use Popen.communicate() when using pipes to avoid that.

example:
```bash
$ dd if=/dev/zero of=file.txt count=1024 bs=1024
```
```python
import subprocess
process = subprocess.Popen('cat file.txt', shell=True, stdin=subprocess.PIPE, bufsize=-1, stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=None)
process.wait()  # hanging
```