### PR TITLE
Refactor CloudFormation implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   - make docker-push-master
 
 after_success:
-  - make coveralls
+  - make coveralls || true
 
 notifications:
   email: false

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -1,10 +1,9 @@
 from localstack.services.infra import (register_plugin, Plugin,
-    start_s3, start_sns, start_ses, start_apigateway,
-    start_elasticsearch_service, start_lambda, start_redshift, start_firehose,
-    start_cloudwatch, start_cloudformation, start_dynamodbstreams, start_route53,
+    start_s3, start_sns, start_ses, start_apigateway, start_elasticsearch_service, start_lambda,
+    start_redshift, start_firehose, start_cloudwatch, start_dynamodbstreams, start_route53,
     start_ssm, start_sts, start_secretsmanager)
 from localstack.services.apigateway import apigateway_listener
-from localstack.services.cloudformation import cloudformation_listener
+from localstack.services.cloudformation import cloudformation_listener, cloudformation_starter
 from localstack.services.dynamodb import dynamodb_listener, dynamodb_starter
 from localstack.services.kinesis import kinesis_listener, kinesis_starter
 from localstack.services.sns import sns_listener
@@ -62,7 +61,7 @@ def register_localstack_plugins():
         register_plugin(Plugin('route53',
             start=start_route53))
         register_plugin(Plugin('cloudformation',
-            start=start_cloudformation,
+            start=cloudformation_starter.start_cloudformation,
             listener=cloudformation_listener.UPDATE_CLOUDFORMATION))
         register_plugin(Plugin('cloudwatch',
             start=start_cloudwatch))

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -1,0 +1,100 @@
+import sys
+import logging
+from moto.s3 import models as s3_models
+from moto.server import main as moto_main
+from moto.dynamodb import models as dynamodb_models
+from moto.cloudformation import parsing
+from boto.cloudformation.stack import Output
+from localstack.config import PORT_CLOUDFORMATION
+from localstack.constants import DEFAULT_PORT_CLOUDFORMATION_BACKEND
+from localstack.services.infra import get_service_protocol, start_proxy_for_service, do_run
+from localstack.utils.aws import aws_stack
+from localstack.utils.cloudformation import template_deployer
+
+LOG = logging.getLogger(__name__)
+
+
+def start_cloudformation(port=PORT_CLOUDFORMATION, asynchronous=False, update_listener=None):
+    backend_port = DEFAULT_PORT_CLOUDFORMATION_BACKEND
+    cmd = 'python "%s" cloudformation -p %s -H 0.0.0.0' % (__file__, backend_port)
+    print('Starting mock CloudFormation (%s port %s)...' % (get_service_protocol(), port))
+    start_proxy_for_service('dynamodb', port, backend_port, update_listener)
+    env_vars = {'PYTHONPATH': ':'.join(sys.path)}
+    return do_run(cmd, asynchronous, env_vars=env_vars)
+
+
+def apply_patches():
+    """ Apply patches to make LocalStack seamlessly interact with the moto backend.
+        TODO: Eventually, these patches should be contributed to the upstream repo! """
+
+    # Patch S3Backend.get_key method in moto to use S3 API from LocalStack
+
+    def get_key(self, bucket_name, key_name, version_id=None):
+        s3_client = aws_stack.connect_to_service('s3')
+        value = s3_client.get_object(Bucket=bucket_name, Key=key_name)['Body'].read()
+        return s3_models.FakeKey(name=key_name, value=value)
+
+    s3_models.S3Backend.get_key = get_key
+
+    # Patch parse_and_create_resource method in moto to deploy resources in LocalStack
+
+    def parse_and_create_resource(logical_id, resource_json, resources_map, region_name):
+        # parse and get final resource JSON
+        resource_tuple = parsing.parse_resource(logical_id, resource_json, resources_map)
+        if not resource_tuple:
+            return None
+        _, resource_json, _ = resource_tuple
+
+        # create resource definition and store CloudFormation metadata in moto
+        resource = parse_and_create_resource_orig(logical_id, resource_json, resources_map, region_name)
+
+        # deploy resource in LocalStack
+        stack_name = resources_map.get('AWS::StackName')
+        resource_wrapped = {logical_id: resource_json}
+        if template_deployer.should_be_deployed(logical_id, resource_wrapped, stack_name):
+            LOG.debug('Deploying CloudFormation resource: %s' % resource_json)
+            template_deployer.deploy_resource(logical_id, resource_wrapped, stack_name=stack_name)
+        return resource
+
+    parse_and_create_resource_orig = parsing.parse_and_create_resource
+    parsing.parse_and_create_resource = parse_and_create_resource
+
+    # Patch CloudFormation parse_output(..) method to fix a bug in moto
+
+    def parse_output(output_logical_id, output_json, resources_map):
+        try:
+            return parse_output_orig(output_logical_id, output_json, resources_map)
+        except KeyError:
+            output = Output()
+            output.key = output_logical_id
+            output.value = None
+            output.description = output_json.get('Description')
+            return output
+
+    parse_output_orig = parsing.parse_output
+    parsing.parse_output = parse_output
+
+    # Patch DynamoDB get_cfn_attribute(..) method to fix a bug in moto
+
+    def get_cfn_attribute(self, attribute_name):
+        try:
+            return get_cfn_attribute_orig(self, attribute_name)
+        except Exception:
+            if attribute_name == 'Arn':
+                return aws_stack.dynamodb_table_arn(table_name=self.name)
+            raise
+
+    get_cfn_attribute_orig = dynamodb_models.Table.get_cfn_attribute
+    dynamodb_models.Table.get_cfn_attribute = get_cfn_attribute
+
+
+def main():
+    # patch moto implementation
+    apply_patches()
+
+    # start API
+    sys.exit(moto_main())
+
+
+if __name__ == '__main__':
+    main()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -11,13 +11,13 @@ import six
 import warnings
 import pkgutil
 from localstack import constants, config
-from localstack.constants import (ENV_DEV, DEFAULT_REGION, LOCALSTACK_VENV_FOLDER,
-    DEFAULT_PORT_S3_BACKEND, DEFAULT_PORT_APIGATEWAY_BACKEND,
-    DEFAULT_PORT_SNS_BACKEND, DEFAULT_PORT_CLOUDFORMATION_BACKEND)
+from localstack.constants import (
+    ENV_DEV, DEFAULT_REGION, LOCALSTACK_VENV_FOLDER, DEFAULT_PORT_S3_BACKEND,
+    DEFAULT_PORT_APIGATEWAY_BACKEND, DEFAULT_PORT_SNS_BACKEND)
 from localstack.config import (USE_SSL, PORT_ROUTE53, PORT_S3,
     PORT_FIREHOSE, PORT_LAMBDA, PORT_SNS, PORT_REDSHIFT, PORT_CLOUDWATCH,
-    PORT_DYNAMODBSTREAMS, PORT_SES, PORT_ES, PORT_CLOUDFORMATION, PORT_APIGATEWAY,
-    PORT_SSM, PORT_SECRETSMANAGER, PORT_STS)
+    PORT_DYNAMODBSTREAMS, PORT_SES, PORT_ES, PORT_APIGATEWAY, PORT_SSM,
+    PORT_SECRETSMANAGER, PORT_STS)
 from localstack.utils import common, persistence
 from localstack.utils.common import (run, TMP_THREADS, in_ci, run_cmd_safe,
     TIMESTAMP_FORMAT, FuncThread, ShellCommandThread, mkdir)
@@ -33,8 +33,6 @@ from localstack.services.generic_proxy import GenericProxy
 SIGNAL_HANDLERS_SETUP = False
 # maps plugin scope ("services", "commands") to flags which indicate whether plugins have been loaded
 PLUGINS_LOADED = {}
-# flag to indicate whether we've received and processed the stop signal
-INFRA_STOPPED = False
 
 # default backend host address
 DEFAULT_BACKEND_HOST = '127.0.0.1'
@@ -153,9 +151,9 @@ def start_sns(port=PORT_SNS, asynchronous=False, update_listener=None):
         backend_port=DEFAULT_PORT_SNS_BACKEND, update_listener=update_listener)
 
 
-def start_cloudformation(port=PORT_CLOUDFORMATION, asynchronous=False, update_listener=None):
-    return start_moto_server('cloudformation', port, name='CloudFormation', asynchronous=asynchronous,
-        backend_port=DEFAULT_PORT_CLOUDFORMATION_BACKEND, update_listener=update_listener)
+# def start_cloudformation(port=PORT_CLOUDFORMATION, asynchronous=False, update_listener=None):
+#     return start_moto_server('cloudformation', port, name='CloudFormation', asynchronous=asynchronous,
+#         backend_port=DEFAULT_PORT_CLOUDFORMATION_BACKEND, update_listener=update_listener)
 
 
 def start_cloudwatch(port=PORT_CLOUDWATCH, asynchronous=False):
@@ -216,6 +214,7 @@ def setup_logging():
     logging.getLogger('urllib3').setLevel(logging.WARNING)
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('botocore').setLevel(logging.ERROR)
+    logging.getLogger('s3transfer').setLevel(logging.INFO)
     logging.getLogger('elasticsearch').setLevel(logging.ERROR)
 
 
@@ -246,13 +245,13 @@ def is_debug():
     return os.environ.get('DEBUG', '').strip() not in ['', '0', 'false']
 
 
-def do_run(cmd, asynchronous, print_output=False):
+def do_run(cmd, asynchronous, print_output=False, env_vars={}):
     sys.stdout.flush()
     if asynchronous:
         if is_debug():
             print_output = True
         outfile = subprocess.PIPE if print_output else None
-        t = ShellCommandThread(cmd, outfile=outfile)
+        t = ShellCommandThread(cmd, outfile=outfile, env_vars=env_vars)
         t.start()
         TMP_THREADS.append(t)
         return t
@@ -302,9 +301,9 @@ def start_local_api(name, port, method, asynchronous=False):
 
 
 def stop_infra():
-    global INFRA_STOPPED
-    if INFRA_STOPPED:
+    if common.INFRA_STOPPED:
         return
+    common.INFRA_STOPPED = True
 
     event_publisher.fire_event(event_publisher.EVENT_STOP_INFRA)
 
@@ -315,7 +314,6 @@ def stop_infra():
     time.sleep(2)
     # TODO: optimize this (takes too long currently)
     # check_infra(retries=2, expect_shutdown=True)
-    INFRA_STOPPED = True
 
 
 def check_aws_credentials():

--- a/tests/integration/templates/template1.yaml
+++ b/tests/integration/templates/template1.yaml
@@ -16,4 +16,3 @@ Resources:
       Name: cf-test-stream-1
   SQSQueueNoNameProperty:
     Type: AWS::SQS::Queue
-

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -117,8 +117,8 @@ class CloudFormationTest(unittest.TestCase):
             self.fail('Should raise ValidationError')
         except (ClientError, ResponseParserError) as err:
             if isinstance(err, ClientError):
-                assert err.response['ResponseMetadata']['HTTPStatusCode'] == 400
-                assert err.response['Error']['Message'] == 'Template Validation Error'
+                self.assertEquals(err.response['ResponseMetadata']['HTTPStatusCode'], 400)
+                self.assertEquals(err.response['Error']['Message'], 'Template Validation Error')
 
     def test_list_stack_resources_returns_queue_urls(self):
         cloudformation = aws_stack.connect_to_resource('cloudformation')
@@ -137,8 +137,9 @@ class CloudFormationTest(unittest.TestCase):
 
         stack_queues = [r for r in list_stack_summaries if r['ResourceType'] == 'AWS::SQS::Queue']
         for resource in stack_queues:
-            assert resource['PhysicalResourceId'] in queue_urls
+            url = aws_stack.get_sqs_queue_url(resource['PhysicalResourceId'])
+            self.assertIn(url, queue_urls)
 
         stack_topics = [r for r in list_stack_summaries if r['ResourceType'] == 'AWS::SNS::Topic']
         for resource in stack_topics:
-            assert resource['PhysicalResourceId'] in topic_arns
+            self.assertIn(resource['PhysicalResourceId'], topic_arns)


### PR DESCRIPTION
This PR refactors the CloudFormation (CF) implementation.

The main change is to rebase the API onto the latest version of `moto`'s CF implementation. We currently use `moto` as the backend for CRUD functionality of CF stacks, as well as keeping track of CF events. However, in `moto` the CF implementation is tightly coupled to the other AWS service stubs (e.g., in-memory creation of CF resources like S3 buckets, Lambda functions, etc), which is not suitable for our purposes.

Therefore, in this PR we introduce a loose coupling between moto's CF's and our own APIs, by patching some methods in `moto` and forwarding CF requests to our `template_deployer.py` implementation.

This PR also contains some cleanup and removal of old/deprecated/unneeded code.