### PR TITLE
Bump Elasticsearch version to 6.4.0

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -58,7 +58,7 @@ ENV ES_TMPDIR  /tmp
 # init environment and cache some dependencies
 RUN mkdir -p /opt/code/localstack/localstack/infra && \
     wget -O /tmp/localstack.es.zip \
-        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip && \
+        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.4.0.zip && \
     wget -O /tmp/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.5.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -70,7 +70,7 @@ APPLICATION_JSON = 'application/json'
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
-ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip'
+ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.4.0.zip'
 # https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
 ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'ingest-user-agent', 'analysis-kuromoji',
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -136,7 +136,7 @@ def get_domain_status(domain_name, deleted=False):
                 'InstanceType': 'm3.medium.elasticsearch',
                 'ZoneAwarenessEnabled': False
             },
-            'ElasticsearchVersion': '6.2',
+            'ElasticsearchVersion': '6.4',
             'Endpoint': aws_stack.get_elasticsearch_endpoint(),
             'Processing': False,
             'EBSOptions': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ boto3>=1.9.71
 botocore>=1.12.13
 coverage>=4.0.3
 docopt>=0.6.2
-elasticsearch==6.2.0
+elasticsearch==6.4.0
 flake8>=3.6.0
 flake8-quotes>=0.11.0
 flask==0.12.4


### PR DESCRIPTION
The [latest AWS-supported Elasticsearch version is 6.4](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/what-is-amazon-elasticsearch-service.html#aes-choosing-version), and the AWS documentation "strongly recommends" using the latest supported version.

This PR is a clone of #694.