### PR TITLE
Add support for mounting Lambda code locally

### DIFF
--- a/localstack/dashboard/web/package.json
+++ b/localstack/dashboard/web/package.json
@@ -4,7 +4,7 @@
   "description": "Web app and API to manage AWS resources.",
   "version": "0.0.1",
   "dependencies": {
-    "bootstrap": "4.1.2",
+    "bootstrap": ">=4.3.1",
     "swagger-client": "2.1.32",
     "jquery": "~> 3.0.0",
     "angular-tablesort": "1.1.2",

--- a/localstack/services/dynamodb/dynamodb_starter.py
+++ b/localstack/services/dynamodb/dynamodb_starter.py
@@ -10,6 +10,9 @@ from localstack.services.install import ROOT_PATH
 
 LOGGER = logging.getLogger(__name__)
 
+# max heap size allocated for the Java process
+MAX_HEAP_SIZE = '256m'
+
 
 def check_dynamodb(expect_shutdown=False, print_error=False):
     out = None
@@ -36,7 +39,8 @@ def start_dynamodb(port=PORT_DYNAMODB, asynchronous=False, update_listener=None)
         mkdir(ddb_data_dir)
         ddb_data_dir_param = '-dbPath %s' % ddb_data_dir
     cmd = ('cd %s/infra/dynamodb/; java -Djava.library.path=./DynamoDBLocal_lib ' +
-        '-jar DynamoDBLocal.jar -sharedDb -port %s %s') % (ROOT_PATH, backend_port, ddb_data_dir_param)
+        '-Xmx%s -jar DynamoDBLocal.jar -sharedDb -port %s %s') % (
+        ROOT_PATH, MAX_HEAP_SIZE, backend_port, ddb_data_dir_param)
     print('Starting mock DynamoDB (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('dynamodb', port, backend_port, update_listener)
     return do_run(cmd, asynchronous)

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -7,6 +7,9 @@ from localstack.services.infra import get_service_protocol, start_proxy_for_serv
 
 LOG = logging.getLogger(__name__)
 
+# max heap size allocated for the Java process
+MAX_HEAP_SIZE = '256m'
+
 
 def start_stepfunctions(port=PORT_STEPFUNCTIONS, asynchronous=False, update_listener=None):
     install.install_stepfunctions_local()
@@ -17,10 +20,10 @@ def start_stepfunctions(port=PORT_STEPFUNCTIONS, asynchronous=False, update_list
     dynamodb_endpoint = aws_stack.get_local_service_url('dynamodb')
     sns_endpoint = aws_stack.get_local_service_url('sns')
     sqs_endpoint = aws_stack.get_local_service_url('sqs')
-    cmd = ('cd %s; java -Dcom.amazonaws.sdk.disableCertChecking -jar StepFunctionsLocal.jar '
+    cmd = ('cd %s; java -Dcom.amazonaws.sdk.disableCertChecking -Xmx%s -jar StepFunctionsLocal.jar '
            '--lambda-endpoint %s --dynamodb-endpoint %s --sns-endpoint %s '
            '--sqs-endpoint %s --aws-region %s --aws-account %s') % (
-        install.INSTALL_DIR_STEPFUNCTIONS, lambda_endpoint, dynamodb_endpoint,
+        install.INSTALL_DIR_STEPFUNCTIONS, MAX_HEAP_SIZE, lambda_endpoint, dynamodb_endpoint,
         sns_endpoint, sqs_endpoint, DEFAULT_REGION, TEST_AWS_ACCOUNT_ID)
     print('Starting mock StepFunctions (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('stepfunctions', port, backend_port, update_listener)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ localstack-client==0.7
 moto>=1.3.7
 nose>=1.3.7
 psutil==5.4.8
+pympler>=0.6
 pyopenssl==17.5.0
 python-coveralls>=2.9.1
 pyyaml>=3.13


### PR DESCRIPTION
* Add support for mounting Lambda code locally. The primary goal is to make local Serverless applications deploy faster and with lower memory footprint.
* Add a simple `/_stats` endpoint in CloudFormation API for basic memory profiling
* Adjust max heap size for Java processes