### PR TITLE
Refactor CF deployment for Lambda, DynamoDB & API GW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ test:              ## Run automated tests
 		($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py' .)
 
 test-java:         ## Run tests for Java/JUnit compatibility
-	cd localstack/ext/java; mvn -q test && USE_SSL=1 mvn -q test
+	cd localstack/ext/java; USE_SSL=1 mvn -q test
 
 prepare-java-tests-if-changed:
 	@(! (git log -n 1 --no-merges --raw | grep localstack/ext/java/)) || (\

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Simply add the following dependency to your `pom.xml` file:
 <dependency>
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
-    <version>0.1.16</version>
+    <version>0.1.18</version>
 </dependency>
 ```
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -31,7 +31,7 @@ DEFAULT_PORT_WEB_UI = 8080
 LOCALHOST = 'localhost'
 
 # version of the Maven dependency with Java utility code
-LOCALSTACK_MAVEN_VERSION = '0.1.17'
+LOCALSTACK_MAVEN_VERSION = '0.1.18'
 
 # map of default service APIs and ports to be spun up (fetch map from localstack_client)
 DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()

--- a/localstack/ext/java/pom.xml
+++ b/localstack/ext/java/pom.xml
@@ -5,7 +5,7 @@
     <groupId>cloud.localstack</groupId>
     <artifactId>localstack-utils</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.17</version>
+    <version>0.1.18</version>
     <name>localstack-utils</name>
 
     <description>Java utilities for the LocalStack platform.</description>

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -5,6 +5,7 @@ from moto.iam import models as iam_models
 from moto.core import BaseModel
 from moto.server import main as moto_main
 from moto.dynamodb import models as dynamodb_models
+from moto.awslambda import models as lambda_models
 from moto.apigateway import models as apigw_models
 from moto.cloudformation import parsing, responses
 from boto.cloudformation.stack import Output
@@ -55,11 +56,16 @@ def apply_patches():
         result = clean_json_orig(resource_json, resources_map)
         if isinstance(result, BaseModel):
             if isinstance(resource_json, dict) and 'Ref' in resource_json:
-                if hasattr(result, 'id'):
-                    return result.id
-                if hasattr(result, 'name'):
-                    # TODO: Check if this is the desired behavior. Better return ARN instead of ID?
-                    return result.name
+                types_with_ref_as_id_or_name = (apigw_models.RestAPI, )
+                attr_candidates = ['function_arn', 'id', 'name']
+                for attr in attr_candidates:
+                    if hasattr(result, attr):
+                        if attr in ['id', 'name'] and not isinstance(result, types_with_ref_as_id_or_name):
+                            LOG.warning('Unable to find ARN, using "%s" instead: %s - %s',
+                                        attr, resource_json, result)
+                        return getattr(result, attr)
+                LOG.warning('Unable to resolve "Ref" attribute for: %s - %s - %s',
+                            resource_json, result, type(result))
         return result
 
     clean_json_orig = parsing.clean_json
@@ -71,7 +77,7 @@ def apply_patches():
         stack_name = resources_map.get('AWS::StackName')
         resource_hash_key = (stack_name, logical_id)
 
-        # If the current stack is being updated, avoid
+        # If the current stack is being updated, avoid infinite recursion
         updating = CURRENTLY_UPDATING_RESOURCES.get(resource_hash_key)
         LOG.debug('Currently updating stack resource %s/%s: %s' % (stack_name, logical_id, updating))
         if updating:
@@ -83,87 +89,126 @@ def apply_patches():
             return None
         _, resource_json, _ = resource_tuple
 
-        # create resource definition and store CloudFormation metadata in moto
-        resource = parse_and_create_resource_orig(logical_id, resource_json, resources_map, region_name)
+        # check if this resource already exists in the resource map
+        resource = resources_map._parsed_resources.get(logical_id)
 
         # check whether this resource needs to be deployed
         resource_wrapped = {logical_id: resource_json}
-        should_be_deployed = template_deployer.should_be_deployed(logical_id, resource_wrapped, stack_name)
-        if not should_be_deployed:
-            LOG.debug('Resource %s need not be deployed: %s' % (logical_id, resource_json))
-            return resource
+        should_be_created = template_deployer.should_be_deployed(logical_id, resource_wrapped, stack_name)
+        if not should_be_created:
+            # This resource is either not deployable or already exists. Check if it can be updated
+            if not template_deployer.is_updateable(logical_id, resource_wrapped, stack_name):
+                LOG.debug('Resource %s need not be deployed: %s' % (logical_id, resource_json))
+                if resource:
+                    return resource
 
-        # deploy resource in LocalStack
+        if not resource:
+            # create resource definition and store CloudFormation metadata in moto
+            resource = parse_and_create_resource_orig(logical_id, resource_json, resources_map, region_name)
+
+        # Apply some fixes/patches to the resource names, then deploy resource in LocalStack
+        update_resource_name(resource, resource_json)
         LOG.debug('Deploying CloudFormation resource: %s' % resource_json)
 
         try:
             CURRENTLY_UPDATING_RESOURCES[resource_hash_key] = True
-            result = template_deployer.deploy_resource(logical_id, resource_wrapped, stack_name=stack_name)
+            deploy_func = template_deployer.deploy_resource if should_be_created else template_deployer.update_resource
+            result = deploy_func(logical_id, resource_wrapped, stack_name=stack_name)
         finally:
             CURRENTLY_UPDATING_RESOURCES[resource_hash_key] = False
+
+        if not should_be_created:
+            # skip the parts below for update requests
+            return resource
+
         props = resource_json.get('Properties') or {}
 
-        # update id in created resource
-        def find_id(result):
+        def find_id(resource):
+            """ Find ID of the given resource. """
             for id_attr in ('Id', 'id', 'ResourceId', 'RestApiId', 'DeploymentId'):
-                if id_attr in result:
-                    return result[id_attr]
+                if id_attr in resource:
+                    return resource[id_attr]
 
-        def update_id(resource, new_id):
-            # Update the ID of the given resource.
-            # NOTE: this is a bit of a hack, which is required because
-            # of the order of events when CloudFormation resources are created.
-            # When we process a request to create a CF resource that's part of a
-            # stack, say, an API Gateway Resource, then we (1) create the object
-            # in memory in moto, which generates a random ID for the resource, and
-            # (2) create the actual resource in the backend service using
-            # template_deployer.deploy_resource(..) (see above).
-            # The resource created in (2) now has a different ID than the resource
-            # created in (1), which leads to downstream problems. Hence, we need
-            # the logic below to reconcile the ids, i.e., apply IDs from (2) to (1).
-
-            backend = apigw_models.apigateway_backends[region_name]
-            if isinstance(resource, apigw_models.RestAPI):
-                backend.apis.pop(resource.id, None)
-                backend.apis[new_id] = resource
-                # We also need to fetch the resources to replace the root resource
-                # that moto automatically adds to newly created RestAPI objects
-                client = aws_stack.connect_to_service('apigateway')
-                resources = client.get_resources(restApiId=new_id, limit=500)['items']
-                # make sure no resources have been added in addition to the root /
-                assert len(resource.resources) == 1
-                resource.resources = {}
-                for res in resources:
-                    res_path_part = res.get('pathPart') or res.get('path')
-                    child = resource.add_child(res_path_part, res.get('parentId'))
-                    resource.resources.pop(child.id)
-                    child.id = res['id']
-                    resource.resources[child.id] = child
-                resource.id = new_id
-            elif isinstance(resource, apigw_models.Resource):
-                api_id = props['RestApiId']
-                backend.apis[api_id].resources.pop(resource.id, None)
-                backend.apis[api_id].resources[new_id] = resource
-                resource.id = new_id
-            elif isinstance(resource, apigw_models.Deployment):
-                api_id = props['RestApiId']
-                backend.apis[api_id].deployments.pop(resource['id'], None)
-                backend.apis[api_id].deployments[new_id] = resource
-                resource['id'] = new_id
-            else:
-                LOG.warning('Unexpected resource type when updating ID: %s' % type(resource))
-
+        # update resource IDs to avoid mismatch between CF moto and LocalStack backend resources
         if hasattr(resource, 'id') or (isinstance(resource, dict) and resource.get('id')):
             existing_id = resource.id if hasattr(resource, 'id') else resource['id']
             new_res_id = find_id(result)
             LOG.debug('Updating resource id: %s - %s, %s - %s' % (existing_id, new_res_id, resource, resource_json))
             if new_res_id:
                 LOG.info('Updating resource ID from %s to %s' % (existing_id, new_res_id))
-                update_id(resource, new_res_id)
+                update_resource_id(resource, new_res_id, props, region_name)
             else:
                 LOG.warning('Unable to extract id for resource %s: %s' % (logical_id, result))
 
+        # update physical_resource_id field
+        update_physical_resource_id(resource)
+
         return resource
+
+    def update_resource_name(resource, resource_json):
+        """ Some resources require minor fixes in their CF resource definition
+            before we can pass them on to deployment. """
+        props = resource_json['Properties'] = resource_json.get('Properties') or {}
+        if isinstance(resource, sfn_models.StateMachine) and not props.get('StateMachineName'):
+            props['StateMachineName'] = resource.name
+
+    def update_resource_id(resource, new_id, props, region_name):
+        """ Update and fix the ID(s) of the given resource. """
+
+        # NOTE: this is a bit of a hack, which is required because
+        # of the order of events when CloudFormation resources are created.
+        # When we process a request to create a CF resource that's part of a
+        # stack, say, an API Gateway Resource, then we (1) create the object
+        # in memory in moto, which generates a random ID for the resource, and
+        # (2) create the actual resource in the backend service using
+        # template_deployer.deploy_resource(..) (see above).
+        # The resource created in (2) now has a different ID than the resource
+        # created in (1), which leads to downstream problems. Hence, we need
+        # the logic below to reconcile the ids, i.e., apply IDs from (2) to (1).
+
+        backend = apigw_models.apigateway_backends[region_name]
+        if isinstance(resource, apigw_models.RestAPI):
+            backend.apis.pop(resource.id, None)
+            backend.apis[new_id] = resource
+            # We also need to fetch the resources to replace the root resource
+            # that moto automatically adds to newly created RestAPI objects
+            client = aws_stack.connect_to_service('apigateway')
+            resources = client.get_resources(restApiId=new_id, limit=500)['items']
+            # make sure no resources have been added in addition to the root /
+            assert len(resource.resources) == 1
+            resource.resources = {}
+            for res in resources:
+                res_path_part = res.get('pathPart') or res.get('path')
+                child = resource.add_child(res_path_part, res.get('parentId'))
+                resource.resources.pop(child.id)
+                child.id = res['id']
+                child.api_id = new_id
+                resource.resources[child.id] = child
+            resource.id = new_id
+        elif isinstance(resource, apigw_models.Resource):
+            api_id = props['RestApiId']
+            backend.apis[api_id].resources.pop(resource.id, None)
+            backend.apis[api_id].resources[new_id] = resource
+            resource.id = new_id
+        elif isinstance(resource, apigw_models.Deployment):
+            api_id = props['RestApiId']
+            backend.apis[api_id].deployments.pop(resource['id'], None)
+            backend.apis[api_id].deployments[new_id] = resource
+            resource['id'] = new_id
+        else:
+            LOG.warning('Unexpected resource type when updating ID: %s' % type(resource))
+
+    def update_physical_resource_id(resource):
+        phys_res_id = getattr(resource, 'physical_resource_id') if hasattr(resource, 'physical_resource_id') else None
+        if not phys_res_id:
+            if isinstance(resource, lambda_models.LambdaFunction):
+                func_arn = aws_stack.lambda_function_arn(resource.function_name)
+                resource.function_arn = resource.physical_resource_id = func_arn
+            elif isinstance(resource, sfn_models.StateMachine):
+                sm_arn = aws_stack.state_machine_arn(resource.name)
+                resource.physical_resource_id = sm_arn
+            else:
+                LOG.warning('Unable to determine physical_resource_id for resource %s' % type(resource))
 
     parse_and_create_resource_orig = parsing.parse_and_create_resource
     parsing.parse_and_create_resource = parse_and_create_resource
@@ -196,6 +241,36 @@ def apply_patches():
     DynamoDB_Table_get_cfn_attribute_orig = dynamodb_models.Table.get_cfn_attribute
     dynamodb_models.Table.get_cfn_attribute = DynamoDB_Table_get_cfn_attribute
 
+    # Patch Lambda get_cfn_attribute(..) method in moto
+
+    def Lambda_Function_get_cfn_attribute(self, attribute_name):
+        try:
+            if attribute_name == 'Arn':
+                return self.function_arn
+            return Lambda_Function_get_cfn_attribute_orig(self, attribute_name)
+        except Exception:
+            if attribute_name in ('Name', 'FunctionName'):
+                return self.function_name
+            raise
+
+    Lambda_Function_get_cfn_attribute_orig = lambda_models.LambdaFunction.get_cfn_attribute
+    lambda_models.LambdaFunction.get_cfn_attribute = Lambda_Function_get_cfn_attribute
+
+    # Patch DynamoDB get_cfn_attribute(..) method in moto
+
+    def DynamoDB_Table_get_cfn_attribute(self, attribute_name):
+        try:
+            if attribute_name == 'StreamArn':
+                streams = aws_stack.connect_to_service('dynamodbstreams').list_streams(TableName=self.name)['Streams']
+                return streams[0]['StreamArn'] if streams else None
+            return DynamoDB_Table_get_cfn_attribute_orig(self, attribute_name)
+        except Exception as e:
+            LOG.warning('Unable to get attribute "%s" from resource %s: %s' % (attribute_name, type(self), e))
+            raise
+
+    DynamoDB_Table_get_cfn_attribute_orig = dynamodb_models.Table.get_cfn_attribute
+    dynamodb_models.Table.get_cfn_attribute = DynamoDB_Table_get_cfn_attribute
+
     # Patch IAM get_cfn_attribute(..) method in moto
 
     def IAM_Role_get_cfn_attribute(self, attribute_name):
@@ -208,6 +283,16 @@ def apply_patches():
 
     IAM_Role_get_cfn_attribute_orig = iam_models.Role.get_cfn_attribute
     iam_models.Role.get_cfn_attribute = IAM_Role_get_cfn_attribute
+
+    # Patch LambdaFunction create_from_cloudformation_json(..) method in moto
+
+    @classmethod
+    def Lambda_create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        resource_name = cloudformation_json.get('Properties', {}).get('FunctionName') or resource_name
+        return Lambda_create_from_cloudformation_json_orig(resource_name, cloudformation_json, region_name)
+
+    Lambda_create_from_cloudformation_json_orig = lambda_models.LambdaFunction.create_from_cloudformation_json
+    lambda_models.LambdaFunction.create_from_cloudformation_json = Lambda_create_from_cloudformation_json
 
     # add CloudWatch types
 

--- a/localstack/stepfunctions/models.py
+++ b/localstack/stepfunctions/models.py
@@ -18,7 +18,7 @@ class StateMachine(BaseModel):
     @classmethod
     def create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
         props = cloudformation_json['Properties']
-        name = props.get('RoleArn') or resource_name
+        name = props.get('StateMachineName') or resource_name
         definition = props.get('DefinitionString')
         role_arn = props.get('RoleArn')
         return StateMachine(name, definition=definition, role_arn=role_arn)

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -63,11 +63,11 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result['Runtime'] = str(self.RUNTIME)
             expected_result['Timeout'] = self.TIMEOUT
             expected_result['Version'] = '1'
-            expected_result['Environment'] = {}
+            expected_result['Environment'] = {'Variables': {}}
             expected_result2 = dict(expected_result)
             expected_result2['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':2'
             expected_result2['Version'] = '2'
-            expected_result2['Environment'] = {}
+            expected_result2['Environment'] = {'Variables': {}}
             self.assertDictEqual(expected_result, result)
             self.assertDictEqual(expected_result2, result2)
 
@@ -94,15 +94,15 @@ class TestLambdaAPI(unittest.TestCase):
             latest_version['Runtime'] = str(self.RUNTIME)
             latest_version['Timeout'] = self.TIMEOUT
             latest_version['Version'] = '$LATEST'
-            latest_version['Environment'] = {}
+            latest_version['Environment'] = {'Variables': {}}
             version1 = dict(latest_version)
             version1['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':1'
             version1['Version'] = '1'
-            version1['Environment'] = {}
+            version1['Environment'] = {'Variables': {}}
             version2 = dict(latest_version)
             version2['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':2'
             version2['Version'] = '2'
-            version2['Environment'] = {}
+            version2['Environment'] = {'Variables': {}}
             expected_result = {'Versions': sorted([latest_version, version1, version2],
                                                   key=lambda k: str(k.get('Version')))}
             self.assertDictEqual(expected_result, result)


### PR DESCRIPTION
* Fix mapping of environment variables in Lambda functions
* Ensure that the CloudFormation `Ref` attribute returns the appropriate value (ARN instead of resource name)
* Support updates in CF template deployment (e.g., update environment variables of a Lambda)
* Correctly set `physical_resource_id` in the `moto` resource objects that represent the CF stack