### PR TITLE
Fix handling of Lambda results

### DIFF
--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -9,7 +9,7 @@ from localstack.services.infra import (register_plugin, Plugin,
 from localstack.services.kinesis import kinesis_listener, kinesis_starter
 from localstack.services.dynamodb import dynamodb_listener, dynamodb_starter
 from localstack.services.apigateway import apigateway_listener
-from localstack.services.stepfunctions import stepfunctions_starter
+from localstack.services.stepfunctions import stepfunctions_starter, stepfunctions_listener
 from localstack.services.cloudformation import cloudformation_listener, cloudformation_starter
 
 
@@ -69,7 +69,8 @@ def register_localstack_plugins():
         register_plugin(Plugin('cloudwatch',
             start=start_cloudwatch))
         register_plugin(Plugin('stepfunctions',
-            start=stepfunctions_starter.start_stepfunctions))
+            start=stepfunctions_starter.start_stepfunctions,
+            listener=stepfunctions_listener.UPDATE_STEPFUNCTIONS))
     except Exception as e:
         print('Unable to register plugins: %s' % e)
         raise e

--- a/localstack/services/stepfunctions/stepfunctions_listener.py
+++ b/localstack/services/stepfunctions/stepfunctions_listener.py
@@ -6,9 +6,14 @@ LOG = logging.getLogger(__name__)
 
 class ProxyListenerStepFunctions(ProxyListener):
 
-    def forward_request(self, method, path, data, headers):
-        LOG.debug('StepFunctions request:', method, path, data)
+    # TODO: listener methods currently disabled
+
+    def forward_request_DISABLED(self, method, path, data, headers):
+        LOG.debug('StepFunctions request: %s %s %s', method, path, data)
         return True
+
+    def return_response_DISABLED(self, method, path, data, headers, response):
+        LOG.debug('StepFunctions response: %s %s %s %s', method, path, response.status_code, response.content)
 
 
 # instantiate listener

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ docopt>=0.6.2
 elasticsearch==6.2.0
 flake8>=3.6.0
 flake8-quotes>=0.11.0
-flask==0.12.4
+flask==1.0.2
 flask-cors==3.0.3
 flask_swagger==0.2.12
 jsonpath-rw==1.4.0


### PR DESCRIPTION
Fix handling of Lambda invocation results.

* Update `flask` to latest version (fixes an issue with chunked transfer encoding in Lambda API)
* Fix Step Functions integration test (previously were hanging as soon as more than one state was defined in the state machine)
* Return `X-Amz-Function-Error` header in Lambda API