### PR TITLE
Auto-remove docker contain after java unit test

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/command/RunCommand.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/command/RunCommand.java
@@ -16,6 +16,7 @@ public class RunCommand extends Command {
         List<String> args = new ArrayList<>();
         args.add("run");
         args.add("-d");
+        args.add("--rm");
         args.addAll(options);
         args.add(imageName);
 


### PR DESCRIPTION
This is to address the issue https://github.com/localstack/localstack/issues/815 
right now the junit triggered docker containers will stay around and pile up since they are not removed automatically. 

I think it's ok to ALWAYS use the --rm option since the junit containers are meant to be temporary anyways. 

Thoughts? 