### PR TITLE
Define dependent and composite services in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ services:
   ```    
 
 
-
 ## Configurations
 
 You can pass the following environment variables to LocalStack:
@@ -158,7 +157,9 @@ You can pass the following environment variables to LocalStack:
   [service names of the AWS CLI](http://docs.aws.amazon.com/cli/latest/reference/#available-services)
   (`kinesis`, `lambda`, `sqs`, etc), although LocalStack only supports a subset of them.
   Example value: `kinesis,lambda:4569,sqs:4570` to start Kinesis on the default port,
-  Lambda on port 4569, and SQS on port 4570.
+  Lambda on port 4569, and SQS on port 4570. In addition, the following shorthand values can be
+  specified to run a predefined ensemble of services:
+  - `serverless`: run services often used for Serverless apps (`iam`, `lambda`, `dynamodb`, `apigateway`, `s3`, `sns`)
 * `DEFAULT_REGION`: AWS region to use when talking to the API (defaults to `us-east-1`).
 * `HOSTNAME`: Name of the host to expose the services internally (defaults to `localhost`).
   Use this to customize the framework-internal communication, e.g., if services are
@@ -212,7 +213,7 @@ Additionally, the following *read-only* environment variables are available:
 
 When a container is started for the first time, it will execute files with extensions .sh that are found in /docker-entrypoint-initaws.d. Files will be executed in alphabetical order. You can easily create aws resources on localstack using `awslocal` (or `aws`) cli tool in the initialization scripts.
 
-## A Note About using own SSL Certificate when `USE_SSL` are `True`
+## A note about using custom SSL certificates (for `USE_SSL=1`)
 
 If you need to use your own SSL Certificate and keep it persistent and not use the random automatic generated Certificate, you can place into the localstack temporary directory :
 
@@ -298,9 +299,9 @@ See the example test file `tests/test_integration.py` for more details.
 
 ## Integration with Serverless
 
-You can use the [`localstack-serverless`](https://www.npmjs.com/package/localstack-serverless) plugin to easily run [Serverless](https://serverless.com/framework/) applications on LocalStack.
+You can use the [`serverless-localstack`](https://www.npmjs.com/package/serverless-localstack) plugin to easily run [Serverless](https://serverless.com/framework/) applications on LocalStack.
 For more information, please check out the plugin repository here:
-https://github.com/localstack/localstack-serverlesss
+https://github.com/localstack/serverless-localstack
 
 ## Integration with Java/JUnit
 

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -10,10 +10,10 @@ from moto.apigateway import models as apigw_models
 from moto.cloudformation import parsing, responses
 from boto.cloudformation.stack import Output
 from moto.cloudformation.exceptions import ValidationError, UnformattedGetAttTemplateException
-from localstack.config import PORT_CLOUDFORMATION
+from localstack import config
+from localstack.constants import DEFAULT_PORT_CLOUDFORMATION_BACKEND, DEFAULT_REGION
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
-from localstack.constants import DEFAULT_PORT_CLOUDFORMATION_BACKEND, DEFAULT_REGION
 from localstack.stepfunctions import models as sfn_models
 from localstack.services.infra import (
     get_service_protocol, start_proxy_for_service, do_run, setup_logging)
@@ -26,7 +26,8 @@ LOG = logging.getLogger(__name__)
 CURRENTLY_UPDATING_RESOURCES = {}
 
 
-def start_cloudformation(port=PORT_CLOUDFORMATION, asynchronous=False, update_listener=None):
+def start_cloudformation(port=None, asynchronous=False, update_listener=None):
+    port = port or config.PORT_CLOUDFORMATION
     backend_port = DEFAULT_PORT_CLOUDFORMATION_BACKEND
     cmd = 'python "%s" cloudformation -p %s -H 0.0.0.0' % (__file__, backend_port)
     print('Starting mock CloudFormation (%s port %s)...' % (get_service_protocol(), port))

--- a/localstack/services/dynamodb/dynamodb_starter.py
+++ b/localstack/services/dynamodb/dynamodb_starter.py
@@ -1,6 +1,6 @@
 import logging
 import traceback
-from localstack.config import PORT_DYNAMODB, DATA_DIR
+from localstack import config
 from localstack.constants import DEFAULT_PORT_DYNAMODB_BACKEND
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import mkdir, wait_for_port_open
@@ -30,12 +30,13 @@ def check_dynamodb(expect_shutdown=False, print_error=False):
         assert isinstance(out['TableNames'], list)
 
 
-def start_dynamodb(port=PORT_DYNAMODB, asynchronous=False, update_listener=None):
+def start_dynamodb(port=None, asynchronous=False, update_listener=None):
+    port = port or config.PORT_DYNAMODB
     install.install_dynamodb_local()
     backend_port = DEFAULT_PORT_DYNAMODB_BACKEND
     ddb_data_dir_param = '-inMemory'
-    if DATA_DIR:
-        ddb_data_dir = '%s/dynamodb' % DATA_DIR
+    if config.DATA_DIR:
+        ddb_data_dir = '%s/dynamodb' % config.DATA_DIR
         mkdir(ddb_data_dir)
         ddb_data_dir_param = '-dbPath %s' % ddb_data_dir
     cmd = ('cd %s/infra/dynamodb/; java -Djava.library.path=./DynamoDBLocal_lib ' +

--- a/localstack/services/es/es_starter.py
+++ b/localstack/services/es/es_starter.py
@@ -2,12 +2,12 @@ import os
 import six
 import logging
 import traceback
-from localstack.constants import DEFAULT_PORT_ELASTICSEARCH_BACKEND, LOCALSTACK_ROOT_FOLDER
-from localstack.config import PORT_ELASTICSEARCH, DATA_DIR
-from localstack.services.infra import get_service_protocol, start_proxy_for_service, do_run
-from localstack.utils.common import run, is_root, mkdir, chmod_r
-from localstack.utils.aws import aws_stack
+from localstack import config
 from localstack.services import install
+from localstack.utils.aws import aws_stack
+from localstack.constants import DEFAULT_PORT_ELASTICSEARCH_BACKEND, LOCALSTACK_ROOT_FOLDER
+from localstack.utils.common import run, is_root, mkdir, chmod_r
+from localstack.services.infra import get_service_protocol, start_proxy_for_service, do_run
 from localstack.services.install import ROOT_PATH
 
 LOGGER = logging.getLogger(__name__)
@@ -19,7 +19,8 @@ def delete_all_elasticsearch_data():
     run('rm -rf "%s"' % data_dir)
 
 
-def start_elasticsearch(port=PORT_ELASTICSEARCH, delete_data=True, asynchronous=False, update_listener=None):
+def start_elasticsearch(port=None, delete_data=True, asynchronous=False, update_listener=None):
+    port = port or config.PORT_ELASTICSEARCH
     # delete Elasticsearch data that may be cached locally from a previous test run
     delete_all_elasticsearch_data()
 
@@ -27,8 +28,8 @@ def start_elasticsearch(port=PORT_ELASTICSEARCH, delete_data=True, asynchronous=
     backend_port = DEFAULT_PORT_ELASTICSEARCH_BACKEND
     es_data_dir = '%s/infra/elasticsearch/data' % (ROOT_PATH)
     es_tmp_dir = '%s/infra/elasticsearch/tmp' % (ROOT_PATH)
-    if DATA_DIR:
-        es_data_dir = '%s/elasticsearch' % DATA_DIR
+    if config.DATA_DIR:
+        es_data_dir = '%s/elasticsearch' % config.DATA_DIR
     # Elasticsearch 5.x cannot be bound to 0.0.0.0 in some Docker environments,
     # hence we use the default bind address 127.0.0.0 and put a proxy in front of it
     cmd = (('ES_JAVA_OPTS=\"${ES_JAVA_OPTS:--Xms200m -Xmx500m}\" ES_TMPDIR="%s" ' +

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -6,8 +6,8 @@ import time
 import logging
 import base64
 import traceback
-from flask import Flask, jsonify, request
 from six import iteritems
+from flask import Flask, jsonify, request
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services import generic_proxy
 from localstack.utils.common import short_uid, to_str

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -1,5 +1,5 @@
-import random
 import json
+import random
 from requests.models import Response
 from localstack import config
 from localstack.utils.common import to_str

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -1,6 +1,6 @@
 import logging
 import traceback
-from localstack.config import PORT_KINESIS, DATA_DIR
+from localstack import config
 from localstack.constants import DEFAULT_PORT_KINESIS_BACKEND
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import mkdir
@@ -11,12 +11,13 @@ from localstack.services.install import ROOT_PATH
 LOGGER = logging.getLogger(__name__)
 
 
-def start_kinesis(port=PORT_KINESIS, asynchronous=False, shard_limit=100, update_listener=None):
+def start_kinesis(port=None, asynchronous=False, shard_limit=100, update_listener=None):
+    port = port or config.PORT_KINESIS
     install.install_kinesalite()
     backend_port = DEFAULT_PORT_KINESIS_BACKEND
     kinesis_data_dir_param = ''
-    if DATA_DIR:
-        kinesis_data_dir = '%s/kinesis' % DATA_DIR
+    if config.DATA_DIR:
+        kinesis_data_dir = '%s/kinesis' % config.DATA_DIR
         mkdir(kinesis_data_dir)
         kinesis_data_dir_param = '--path %s' % kinesis_data_dir
     cmd = ('%s/node_modules/kinesalite/cli.js --shardLimit %s --port %s %s' %

--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -1,7 +1,8 @@
 import os
 import logging
+from localstack import config
+from localstack.config import LOCALSTACK_HOSTNAME, TMP_FOLDER
 from localstack.constants import DEFAULT_PORT_SQS_BACKEND
-from localstack.config import PORT_SQS, LOCALSTACK_HOSTNAME, TMP_FOLDER
 from localstack.utils.common import save_file, short_uid, TMP_FILES
 from localstack.services.infra import start_proxy_for_service, get_service_protocol, do_run
 from localstack.services.install import INSTALL_DIR_ELASTICMQ, install_elasticmq
@@ -9,11 +10,12 @@ from localstack.services.install import INSTALL_DIR_ELASTICMQ, install_elasticmq
 LOGGER = logging.getLogger(__name__)
 
 
-def start_sqs(port=PORT_SQS, asynchronous=False, update_listener=None):
+def start_sqs(port=None, asynchronous=False, update_listener=None):
+    port = port or config.PORT_SQS
     install_elasticmq()
     backend_port = DEFAULT_PORT_SQS_BACKEND
     # create config file
-    config = """
+    config_params = """
     include classpath("application.conf")
     node-address {
         protocol = http
@@ -30,7 +32,7 @@ def start_sqs(port=PORT_SQS, asynchronous=False, update_listener=None):
     """ % (LOCALSTACK_HOSTNAME, port, backend_port)
     config_file = os.path.join(TMP_FOLDER, 'sqs.%s.conf' % short_uid())
     TMP_FILES.append(config_file)
-    save_file(config_file, config)
+    save_file(config_file, config_params)
     # start process
     cmd = ('java -Dconfig.file=%s -jar %s/elasticmq-server.jar' % (config_file, INSTALL_DIR_ELASTICMQ))
     print('Starting mock SQS (%s port %s)...' % (get_service_protocol(), port))

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -1,5 +1,5 @@
 import logging
-from localstack.config import PORT_STEPFUNCTIONS
+from localstack import config
 from localstack.services import install
 from localstack.utils.aws import aws_stack
 from localstack.constants import DEFAULT_PORT_STEPFUNCTIONS_BACKEND, TEST_AWS_ACCOUNT_ID, DEFAULT_REGION
@@ -11,7 +11,8 @@ LOG = logging.getLogger(__name__)
 MAX_HEAP_SIZE = '256m'
 
 
-def start_stepfunctions(port=PORT_STEPFUNCTIONS, asynchronous=False, update_listener=None):
+def start_stepfunctions(port=None, asynchronous=False, update_listener=None):
+    port = port or config.PORT_STEPFUNCTIONS
     install.install_stepfunctions_local()
     backend_port = DEFAULT_PORT_STEPFUNCTIONS_BACKEND
     # TODO: local port is currently hard coded in Step Functions Local :/


### PR DESCRIPTION
Fixes #294 - define dependent and composite services in config.

This PR introduces the notion of `API_DEPENDENCIES` and `API_COMPOSITES` in `infra.py`. 

`API_DEPENDENCIES` are used to define which APIs (e.g., `dynamodbstreams`) require which other APIs to be started as well (e.g., `kinesis`). The idea is that the user should not have to define the dependent APIs manually, but the framework should take care of this automatically.

`API_COMPOSITES` allow to define sets of APIs under a shorthand name. For example, `SERVICES=serverless` refers to a set of APIs that are frequently used for Serverless applications. These composites can be combined with other custom APIs the that user specifies.