### PR TITLE
Fix for incorrect response handling in dynamodb listener

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -152,7 +152,9 @@ class ProxyListenerDynamoDB(ProxyListener):
                     return keys
                 record['dynamodb']['Keys'] = keys
                 record['dynamodb']['NewImage'] = data['Item']
-                record['dynamodb']['SizeBytes'] = len(json.dumps(data['Item']))                
+                record['dynamodb']['SizeBytes'] = len(json.dumps(data['Item']))
+                if existing_item:
+                    record['dynamodb']['OldImage'] = existing_item
         elif action == '%s.GetItem' % ACTION_PREFIX:
             if response.status_code == 200:
                 content = json.loads(to_str(response.content))

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -118,14 +118,15 @@ class ProxyListenerDynamoDB(ProxyListener):
         records = [record]
 
         if action == '%s.UpdateItem' % ACTION_PREFIX:
-            updated_item = find_existing_item(data)
-            if not updated_item:
-                return
-            record['eventName'] = 'MODIFY'
-            record['dynamodb']['Keys'] = data['Key']
-            record['dynamodb']['OldImage'] = self._thread_local('existing_item')
-            record['dynamodb']['NewImage'] = updated_item
-            record['dynamodb']['SizeBytes'] = len(json.dumps(updated_item))
+            if response.status_code == 200:
+                updated_item = find_existing_item(data)
+                if not updated_item:
+                    return
+                record['eventName'] = 'MODIFY'
+                record['dynamodb']['Keys'] = data['Key']
+                record['dynamodb']['OldImage'] = self._thread_local('existing_item')
+                record['dynamodb']['NewImage'] = updated_item
+                record['dynamodb']['SizeBytes'] = len(json.dumps(updated_item))
         elif action == '%s.BatchWriteItem' % ACTION_PREFIX:
             records = []
             for table_name, requests in data['RequestItems'].items():
@@ -142,15 +143,16 @@ class ProxyListenerDynamoDB(ProxyListener):
                         new_record['eventSourceARN'] = aws_stack.dynamodb_table_arn(table_name)
                         records.append(new_record)
         elif action == '%s.PutItem' % ACTION_PREFIX:
-            existing_item = self._thread_local('existing_item')
-            ProxyListenerDynamoDB.thread_local.existing_item = None
-            record['eventName'] = 'INSERT' if not existing_item else 'MODIFY'
-            keys = dynamodb_extract_keys(item=data['Item'], table_name=data['TableName'])
-            if isinstance(keys, Response):
-                return keys
-            record['dynamodb']['Keys'] = keys
-            record['dynamodb']['NewImage'] = data['Item']
-            record['dynamodb']['SizeBytes'] = len(json.dumps(data['Item']))
+            if response.status_code == 200:
+                existing_item = self._thread_local('existing_item')
+                ProxyListenerDynamoDB.thread_local.existing_item = None
+                record['eventName'] = 'INSERT' if not existing_item else 'MODIFY'
+                keys = dynamodb_extract_keys(item=data['Item'], table_name=data['TableName'])
+                if isinstance(keys, Response):
+                    return keys
+                record['dynamodb']['Keys'] = keys
+                record['dynamodb']['NewImage'] = data['Item']
+                record['dynamodb']['SizeBytes'] = len(json.dumps(data['Item']))                
         elif action == '%s.GetItem' % ACTION_PREFIX:
             if response.status_code == 200:
                 content = json.loads(to_str(response.content))
@@ -164,10 +166,11 @@ class ProxyListenerDynamoDB(ProxyListener):
                     response._content = json.dumps(content)
                     fix_headers_for_updated_response(response)
         elif action == '%s.DeleteItem' % ACTION_PREFIX:
-            old_item = self._thread_local('existing_item')
-            record['eventName'] = 'REMOVE'
-            record['dynamodb']['Keys'] = data['Key']
-            record['dynamodb']['OldImage'] = old_item
+            if response.status_code == 200:
+                old_item = self._thread_local('existing_item')
+                record['eventName'] = 'REMOVE'
+                record['dynamodb']['Keys'] = data['Key']
+                record['dynamodb']['OldImage'] = old_item
         elif action == '%s.CreateTable' % ACTION_PREFIX:
             if 'StreamSpecification' in data:
                 create_dynamodb_stream(data)


### PR DESCRIPTION
In case of a failing data modification in dynamodb (other response codes than 200) the dynamodbstream was still getting the data.
This PR fixes this issue for UpdateItem, DeleteItem  and PutItem.

Further, if PutItem is a MODIFY, the OldImage should be provided in the dynamodb stream. This is fixed as well.

