### PR TITLE
Add START_WEB config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ You can pass the following environment variables to LocalStack:
   `KINESIS`, `S3`, `SNS`, `SQS`). This allows to easily integrate third-party services into LocalStack.
 * `FORCE_NONINTERACTIVE`: when running with Docker, disables the `--interactive` and `--tty` flags. Useful when running headless.
 * `DOCKER_FLAGS`: Allows to pass custom flags (e.g., volume mounts) to "docker run" when running LocalStack in Docker.
+* `START_WEB`: Flag to control whether the Web API should be started in Docker (values: `0`/`1`; default: `1`).
 
 Additionally, the following *read-only* environment variables are available:
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -5,17 +5,22 @@ shopt -s nullglob
 
 supervisord -c /etc/supervisord.conf &
 
-until grep -q "^Ready.$" /tmp/localstack_infra.log >/dev/null 2>&1 ; do
-  echo "Waiting for all LocalStack services to be ready"
-  sleep 7
-done
+function run_startup_scripts {
+  until grep -q "^Ready.$" /tmp/localstack_infra.log >/dev/null 2>&1 ; do
+    echo "Waiting for all LocalStack services to be ready"
+    sleep 7
+  done
 
-for f in /docker-entrypoint-initaws.d/*; do
-  case "$f" in
-    *.sh)     echo "$0: running $f"; . "$f" ;;
-    *)        echo "$0: ignoring $f" ;;
-  esac
-  echo
-done
+  for f in /docker-entrypoint-initaws.d/*; do
+    case "$f" in
+      *.sh)     echo "$0: running $f"; . "$f" ;;
+      *)        echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
+}
 
+run_startup_scripts &
+
+touch /tmp/localstack_infra.log
 tail -f /tmp/localstack_infra.log

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -12,9 +12,11 @@ stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 
 [program:dashboard]
-command=make web
+command=bash -c 'if [ "$START_WEB" = "0" ]; then exit 0; fi; make web'
 autostart=true
-autorestart=true
+autorestart=false
+exitcodes=0
+startsecs=0
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -73,7 +73,7 @@ if not LAMBDA_EXECUTOR:
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOSTNAME',
     'LAMBDA_EXECUTOR', 'LAMBDA_REMOTE_DOCKER', 'LAMBDA_DOCKER_NETWORK', 'USE_SSL', 'LICENSE_KEY', 'DEBUG',
-    'KINESIS_ERROR_PROBABILITY', 'DYNAMODB_ERROR_PROBABILITY', 'PORT_WEB_UI']
+    'KINESIS_ERROR_PROBABILITY', 'DYNAMODB_ERROR_PROBABILITY', 'PORT_WEB_UI', 'START_WEB']
 for key, value in iteritems(DEFAULT_SERVICE_PORTS):
     backend_override_var = '%s_BACKEND' % key.upper().replace('-', '_')
     if os.environ.get(backend_override_var):


### PR DESCRIPTION
Add `START_WEB` config parameter, which allows to control whether the Web API should be started in Docker