### PR TITLE
Allow using 'LOCALSTACK_' prefix in Docker environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ services:
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
-  ```    
+```
 
+To facilitate interoperability, configuration variables can be prefixed with `LOCALSTACK_` in docker. For instance, setting `LOCALSTACK_SERVICES=s3` is equivalent to `SERVICES=s3`.
 
 ## Configurations
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -3,6 +3,9 @@
 set -eo pipefail
 shopt -s nullglob
 
+# Strip `LOCALSTACK_` prefix in environment variables name.
+source <(env | sed -ne 's/^LOCALSTACK_\([^=]\+\)=.*/export \1=${LOCALSTACK_\1}/p')
+
 supervisord -c /etc/supervisord.conf &
 
 function run_startup_scripts {

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -74,13 +74,17 @@ if not LAMBDA_EXECUTOR:
 CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOSTNAME',
     'LAMBDA_EXECUTOR', 'LAMBDA_REMOTE_DOCKER', 'LAMBDA_DOCKER_NETWORK', 'USE_SSL', 'LICENSE_KEY', 'DEBUG',
     'KINESIS_ERROR_PROBABILITY', 'DYNAMODB_ERROR_PROBABILITY', 'PORT_WEB_UI', 'START_WEB']
+
+
 for key, value in iteritems(DEFAULT_SERVICE_PORTS):
-    backend_override_var = '%s_BACKEND' % key.upper().replace('-', '_')
-    if os.environ.get(backend_override_var):
-        CONFIG_ENV_VARS.append(backend_override_var)
-    port_external_override_var = '%s_PORT_EXTERNAL' % key.upper().replace('-', '_')
-    if os.environ.get(port_external_override_var):
-        CONFIG_ENV_VARS.append(port_external_override_var)
+    clean_key = key.upper().replace('-', '_')
+    CONFIG_ENV_VARS += [
+        clean_key + '_BACKEND',
+        clean_key + '_PORT_EXTERNAL',
+    ]
+
+
+CONFIG_ENV_VARS += ['LOCALSTACK_' + v for v in CONFIG_ENV_VARS]
 
 
 def in_docker():


### PR DESCRIPTION
Closes #1102 

cc @whummer 

As mentioned in the issue, this only goes for Docker. I don't think it's worth doing it in localstack itself.

Maybe one very minor point of attention though: `LOCALSTACK_HOSTNAME` environment variable does already exist in localstack as a read-only environment variable. It'll be overridden by the localstack process itself, so I don't think it will cause any problem, apart from some confusion maybe.

Thanks.