### PR TITLE
Update docker compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ localstack start --docker
 (Note that on MacOS you may have to run `TMPDIR=/private$TMPDIR localstack start --docker` if
 `$TMPDIR` contains a symbolic link that cannot be mounted by Docker.)
 
-Or using docker-compose (you need to clone the repository first, currently supports docker-compose version 2):
+Or using docker-compose (you need to clone the repository first, currently requires docker-compose version 2.1+):
 
 ```
 docker-compose up
@@ -128,6 +128,7 @@ docker-compose up
 Use on existing docker-compose project. Add in existing services. The project can be found in docker hub, no need to download or clone source:
 
 ```
+version: '2.1'
 services:
 ...
   localstack:


### PR DESCRIPTION
Update to make clear that the docker-compose file requires version 2.1 or greater.
This is related to #1177

