### PR TITLE
Make target 'docker-build-base' failing

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -26,10 +26,11 @@ RUN { \
     && chmod +x /usr/local/bin/docker-java-home
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
-ENV JAVA_VERSION 8u191
-ENV JAVA_ALPINE_VERSION 8.191.12-r0
+ENV JAVA_VERSION 8u201b09
+ENV JAVA_ALPINE_VERSION 8.201.08-r0
 RUN set -x && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" \
     && [ "$JAVA_HOME" = "$(docker-java-home)" ]
+RUN apk add --no-cache nss
 
 # Install Maven - taken from official repo:
 # https://github.com/carlossg/docker-maven/blob/master/jdk-8/Dockerfile)


### PR DESCRIPTION
Make target 'docker-build-base' is failing due to java version conflicts, with the following error:

```
Step 12/33 : RUN set -x && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION"     && [ "$JAVA_HOME" = "$(docker-java-home)" ]
 ---> Running in 27d520e1a379
+ apk add --no-cache 'openjdk8=8.191.12-r0'
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.9/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  openjdk8-8.201.08-r0:
    breaks: world[openjdk8=8.191.12-r0]
The command '/bin/sh -c set -x && apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION"     && [ "$JAVA_HOME" = "$(docker-java-home)" ]' returned a non-zero code: 1
make: *** [Makefile:49: docker-build-base] Error 1
```

- Updates Java Alpine version
- Add extra step to manually install package 'nss' due to a bug in the current version of Alpine Linux described here: https://bugs.alpinelinux.org/issues/10126

