### PR TITLE
Implemented correct behavior for CORSConfiguration.CorsRules.ExposeHe…

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -241,21 +241,11 @@ def append_cors_headers(bucket_name, request_method, request_headers, response):
             for allowed in allowed_origins:
                 if origin in allowed or re.match(allowed.replace('*', '.*'), origin):
                     response.headers['Access-Control-Allow-Origin'] = origin
+                    if 'ExposeHeader' in rule:
+                        expose_headers = rule['ExposeHeader']
+                        response.headers['Access-Control-Expose-Headers'] = \
+                            ','.join(expose_headers) if isinstance(expose_headers, list) else expose_headers
                     break
-        # add additional headers
-        exposed_headers = rule.get('ExposeHeader', [])
-        for header in exposed_headers:
-            if header.lower() == 'date':
-                response.headers[header] = timestamp(format='%a, %d %b %Y %H:%M:%S +0000')
-            elif header.lower() == 'etag':
-                response.headers[header] = md5(response._content)
-            elif header.lower() in ('server', 'x-amz-id-2', 'x-amz-request-id'):
-                response.headers[header] = short_uid()
-            elif header.lower() == 'x-amz-delete-marker':
-                response.headers[header] = 'false'
-            elif header.lower() == 'x-amz-version-id':
-                # TODO: check whether bucket versioning is enabled and return proper version id
-                response.headers[header] = 'null'
 
 
 def get_lifecycle(bucket_name):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -281,16 +281,13 @@ class S3ListenerTest (unittest.TestCase):
         # put object and CORS configuration
         object_key = 'key-by-hostname'
         self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Body='something')
-        url = self.s3_client.generate_presigned_url(
-            'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
-        )
         self.s3_client.put_bucket_cors(Bucket=bucket_name,
             CORSConfiguration={
                 'CORSRules': [{
                     'AllowedMethods': ['GET', 'PUT', 'POST'],
                     'AllowedOrigins': ['*'],
                     'ExposeHeaders': [
-                        'Date', 'x-amz-delete-marker', 'x-amz-version-id'
+                        'ETag', 'x-amz-version-id'
                     ]
                 }]
             },
@@ -301,11 +298,7 @@ class S3ListenerTest (unittest.TestCase):
             'get_object', Params={'Bucket': bucket_name, 'Key': object_key}
         )
         response = requests.get(url, verify=False)
-        self.assertTrue(response.headers['Date'])
-        self.assertTrue(response.headers['x-amz-delete-marker'])
-        self.assertTrue(response.headers['x-amz-version-id'])
-        self.assertFalse(response.headers.get('x-amz-id-2'))
-        self.assertFalse(response.headers.get('x-amz-request-id'))
+        self.assertEquals(response.headers['Access-Control-Expose-Headers'], 'ETag,x-amz-version-id')
         # clean up
         self.s3_client.delete_objects(Bucket=bucket_name, Delete={'Objects': [{'Key': object_key}]})
         self.s3_client.delete_bucket(Bucket=bucket_name)


### PR DESCRIPTION
…aders

The current implementation of `ExposeHeaders` returns dummy values for arbitrary headers, but it is not how it is supposed to work. This should instead add header named `Access-Control-Expose-Headers`. It specifies response headers, which can be read by the JS code. See [this SO answer](https://stackoverflow.com/a/25673446/1377864) for more details.

I've tested it in our frontend application, which does file uploads directly to S3 (the use case from #520) and it seems to work correctly now. However I didn't manage to run tests locally, getting [bunch of errors](https://gist.github.com/devoto13/f1514c68ea52cc9afe6df268e92cac46), when I run `make test`. Any ideas?

Fixes https://github.com/localstack/localstack/issues/520