### PR TITLE
#1221 Add firehose support for tags

### DIFF
--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -37,6 +37,18 @@ def get_delivery_stream_names():
     return names
 
 
+def get_delivery_stream_tags(stream_name, exclusive_start_tag_key=None, limit=50):
+    stream = DELIVERY_STREAMS[stream_name]
+    response = {}
+    start_i = -1
+    if exclusive_start_tag_key is not None:
+        start_i = next(iter([i for i, tag in enumerate(stream['Tags']) if tag['Key'] == exclusive_start_tag_key]))
+
+    response['Tags'] = [tag for i, tag in enumerate(stream['Tags']) if start_i < i < limit]
+    response['HasMore'] = len(response['Tags']) < len(stream['Tags'])
+    return response
+
+
 def put_record(stream_name, record):
     return put_records(stream_name, [record])
 
@@ -122,7 +134,9 @@ def process_records(records, shard_id, fh_d_stream):
 
 
 def create_stream(stream_name, delivery_stream_type='DirectPut', delivery_stream_type_configuration=None,
-                  s3_destination=None, elasticsearch_destination=None):
+                  s3_destination=None, elasticsearch_destination=None, tags=None):
+    if tags is None:
+        tags = {}
     stream = {
         'DeliveryStreamType': delivery_stream_type,
         'KinesisStreamSourceConfiguration': delivery_stream_type_configuration,
@@ -132,7 +146,8 @@ def create_stream(stream_name, delivery_stream_type='DirectPut', delivery_stream
         'DeliveryStreamARN': firehose_stream_arn(stream_name),
         'DeliveryStreamStatus': 'ACTIVE',
         'DeliveryStreamName': stream_name,
-        'Destinations': []
+        'Destinations': [],
+        'Tags': tags
     }
     DELIVERY_STREAMS[stream_name] = stream
     if elasticsearch_destination:
@@ -198,7 +213,8 @@ def post_request():
                                  delivery_stream_type=data.get('DeliveryStreamType'),
                                  delivery_stream_type_configuration=data.get('KinesisStreamSourceConfiguration'),
                                  s3_destination=data.get('S3DestinationConfiguration'),
-                                 elasticsearch_destination=data.get('ElasticsearchDestinationConfiguration'))
+                                 elasticsearch_destination=data.get('ElasticsearchDestinationConfiguration'),
+                                 tags=data.get('Tags'))
     elif action == '%s.DeleteDeliveryStream' % ACTION_HEADER_PREFIX:
         stream_name = data['DeliveryStreamName']
         response = delete_stream(stream_name)
@@ -236,6 +252,9 @@ def post_request():
         update_destination(stream_name=stream_name, destination_id=destination_id,
                            es_update=es_update, version_id=version_id)
         response = {}
+    elif action == '%s.ListTagsForDeliveryStream' % ACTION_HEADER_PREFIX:
+        response = get_delivery_stream_tags(data['DeliveryStreamName'], data.get('ExclusiveStartTagKey'),
+                                            data.get('Limit', 50))
     else:
         response = error_response('Unknown action "%s"' % action, code=400, error_type='InvalidAction')
 

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -135,8 +135,7 @@ def process_records(records, shard_id, fh_d_stream):
 
 def create_stream(stream_name, delivery_stream_type='DirectPut', delivery_stream_type_configuration=None,
                   s3_destination=None, elasticsearch_destination=None, tags=None):
-    if tags is None:
-        tags = {}
+    tags = tags or {}
     stream = {
         'DeliveryStreamType': delivery_stream_type,
         'KinesisStreamSourceConfiguration': delivery_stream_type_configuration,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -25,6 +25,7 @@ TEST_LAMBDA_NAME_QUEUE = 'test_lambda_queue'
 TEST_FIREHOSE_NAME = 'test_firehose'
 TEST_BUCKET_NAME = lambda_integration.TEST_BUCKET_NAME
 TEST_TOPIC_NAME = 'test_topic'
+TEST_TAGS = [{'Key': 'MyTag', 'Value': 'Value'}]
 # constants for forward chain K1->L1->K2->L2
 TEST_CHAIN_STREAM1_NAME = 'test_chain_stream_1'
 TEST_CHAIN_STREAM2_NAME = 'test_chain_stream_2'
@@ -55,10 +56,13 @@ class IntegrationTest(unittest.TestCase):
                 'RoleARN': aws_stack.iam_resource_arn('firehose'),
                 'BucketARN': aws_stack.s3_bucket_arn(TEST_BUCKET_NAME),
                 'Prefix': s3_prefix
-            }
+            },
+            Tags=TEST_TAGS
         )
         self.assertTrue(stream)
         self.assertIn(TEST_FIREHOSE_NAME, firehose.list_delivery_streams()['DeliveryStreamNames'])
+        tags = firehose.list_tags_for_delivery_stream(DeliveryStreamName=TEST_FIREHOSE_NAME)
+        self.assertEquals(TEST_TAGS, tags['Tags'])
         # create target S3 bucket
         s3_resource.create_bucket(Bucket=TEST_BUCKET_NAME)
 

--- a/tests/unit/test_firehose.py
+++ b/tests/unit/test_firehose.py
@@ -1,0 +1,22 @@
+import unittest
+
+from localstack.services.firehose import firehose_api
+
+TEST_STREAM_NAME = "test_stream"
+TEST_TAG_1 = {'Key': 'MyTag', 'Value': 'TestValue'}
+TEST_TAG_2 = {'Key': 'AnotherTag', 'Value': 'AnotherValue'}
+TEST_TAGS = [TEST_TAG_1, TEST_TAG_2]
+
+
+class FirehoseApiTest(unittest.TestCase):
+
+    def setUp(self):
+        firehose_api.create_stream(TEST_STREAM_NAME, tags=TEST_TAGS)
+
+    def test_delivery_stream_tags(self):
+        result = firehose_api.get_delivery_stream_tags(TEST_STREAM_NAME)
+        self.assertEquals(TEST_TAGS, result['Tags'])
+        result = firehose_api.get_delivery_stream_tags(TEST_STREAM_NAME, exclusive_start_tag_key='MyTag')
+        self.assertEquals([TEST_TAG_2], result['Tags'])
+        result = firehose_api.get_delivery_stream_tags(TEST_STREAM_NAME, limit=1)
+        self.assertEquals([TEST_TAG_1], result['Tags'])

--- a/tests/unit/test_firehose.py
+++ b/tests/unit/test_firehose.py
@@ -2,7 +2,7 @@ import unittest
 
 from localstack.services.firehose import firehose_api
 
-TEST_STREAM_NAME = "test_stream"
+TEST_STREAM_NAME = 'test_stream'
 TEST_TAG_1 = {'Key': 'MyTag', 'Value': 'TestValue'}
 TEST_TAG_2 = {'Key': 'AnotherTag', 'Value': 'AnotherValue'}
 TEST_TAGS = [TEST_TAG_1, TEST_TAG_2]
@@ -20,3 +20,4 @@ class FirehoseApiTest(unittest.TestCase):
         self.assertEquals([TEST_TAG_2], result['Tags'])
         result = firehose_api.get_delivery_stream_tags(TEST_STREAM_NAME, limit=1)
         self.assertEquals([TEST_TAG_1], result['Tags'])
+        self.assertEquals(True, result['HasMore'])

--- a/tests/unit/test_firehose.py
+++ b/tests/unit/test_firehose.py
@@ -1,8 +1,9 @@
 import unittest
 
 from localstack.services.firehose import firehose_api
+from localstack.utils.common import short_uid
 
-TEST_STREAM_NAME = 'test_stream'
+TEST_STREAM_NAME = 'firehose_test_' + short_uid()
 TEST_TAG_1 = {'Key': 'MyTag', 'Value': 'TestValue'}
 TEST_TAG_2 = {'Key': 'AnotherTag', 'Value': 'AnotherValue'}
 TEST_TAGS = [TEST_TAG_1, TEST_TAG_2]
@@ -12,6 +13,9 @@ class FirehoseApiTest(unittest.TestCase):
 
     def setUp(self):
         firehose_api.create_stream(TEST_STREAM_NAME, tags=TEST_TAGS)
+
+    def tearDown(self):
+        firehose_api.delete_stream(TEST_STREAM_NAME)
 
     def test_delivery_stream_tags(self):
         result = firehose_api.get_delivery_stream_tags(TEST_STREAM_NAME)


### PR DESCRIPTION
Addresses #1221 with behavior based off of docs [here](https://docs.aws.amazon.com/firehose/latest/APIReference/API_ListTagsForDeliveryStream.html).
