### PR TITLE
Fix port mappings for CloudFormation API

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -16,7 +16,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 from localstack.stepfunctions import models as sfn_models
 from localstack.services.infra import (
-    get_service_protocol, start_proxy_for_service, do_run, setup_logging)
+    get_service_protocol, start_proxy_for_service, do_run, setup_logging, canonicalize_api_names)
 from localstack.utils.cloudformation import template_deployer
 from localstack.services.awslambda.lambda_api import BUCKET_MARKER_LOCAL
 
@@ -417,6 +417,9 @@ def main():
 
     # add memory profiling endpoint
     inject_stats_endpoint()
+
+    # make sure all API names and ports are mapped properly
+    canonicalize_api_names()
 
     # start API
     sys.exit(moto_main())

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -508,12 +508,14 @@ def start_infra_in_docker():
 # -------------
 
 
-def canonicalize_api_names(apis):
+def canonicalize_api_names(apis=None):
     """ Finalize the list of API names by
         (1) resolving and adding dependencies (e.g., "dynamodbstreams" requires "kinesis"),
         (2) resolving and adding composites (e.g., "serverless" describes an ensemble
                 including "iam", "lambda", "dynamodb", "apigateway", "s3", "sns", and "logs"), and
         (3) removing duplicates from the list. """
+    apis = apis or list(config.SERVICE_PORTS.keys())
+
     def contains(apis, api):
         for a in apis:
             if a == api:
@@ -552,8 +554,7 @@ def start_infra(asynchronous=False, apis=None):
         # set up logging
         setup_logging()
 
-        if not apis:
-            apis = list(config.SERVICE_PORTS.keys())
+        apis = apis or list(config.SERVICE_PORTS.keys())
         # prepare APIs
         apis = canonicalize_api_names(apis)
         # set environment


### PR DESCRIPTION
Fix port mappings for CloudFormation API.

This fixes an issue where ports are not mapped correctly if users specify a composite service like `SERVICES=serverless`.