### PR TITLE
Fixes the data schema for the MessageAttributes when being output to Lambda

### DIFF
--- a/tests/unit/test_sqs_listener.py
+++ b/tests/unit/test_sqs_listener.py
@@ -19,12 +19,16 @@ class SQSListenerTest (unittest.TestCase):
 
         expected = {
             'attr_2': {
-                'DataType': 'Custom',
-                'StringValue': 'attr_2_value'
+                'dataType': 'Custom',
+                'stringValue': 'attr_2_value',
+                'stringListValues': [],
+                'binaryListValues': []
             },
             'attr_1': {
-                'DataType': 'String',
-                'StringValue': 'attr_1_value'
+                'dataType': 'String',
+                'stringValue': 'attr_1_value',
+                'stringListValues': [],
+                'binaryListValues': []
             }
         }
 


### PR DESCRIPTION
This PR is a followup to https://github.com/localstack/localstack/pull/1239

### The Issue

In production AWS, Lambda functions initiated by SQS have the schema of the `MessageAttributes` munged from one structure into another structure.  We found this out today while testing out a function in production.   

Unfortunately, I'm unsure if this is as a result of some sort of processing happening on the SQS egress side or on the Lambda ingress side.  Either way, the structure changes and needs more massaging.  I'm also uncertain as to whether this post-processing of the `MessageAttributes` payload will change between languages (e.g. JavaScript vs. Python) or if this will remain consistent.   Because of this uncertainty, I don't know if this is a bug in ElasticMQ or with the Localstack Lambda processing.  

*Note:*
- `stringListValues` and `binaryListValues` aren't implemented right now because I'm not 100% how they work.

Sorry for the trouble and not catching this earlier.  We didn't have a production Lambda set up that was using this functionality. 

