### PR TITLE
Expose correct versionId in S3 event message

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -558,7 +558,7 @@ class ProxyListenerS3(ProxyListener):
             else:
                 parts = parsed.path[1:].split('/', 1)
                 object_path = parts[1] if parts[1][0] == '/' else '/%s' % parts[1]
-            version_id = response.headers.get('x-amz-version-id', None);
+            version_id = response.headers.get('x-amz-version-id', None)
 
             send_notifications(method, bucket_name, object_path, version_id)
 

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -78,7 +78,7 @@ def prefix_with_slash(s):
     return s if s[0] == '/' else '/%s' % s
 
 
-def get_event_message(event_name, bucket_name, file_name='testfile.txt', file_size=1024):
+def get_event_message(event_name, bucket_name, file_name='testfile.txt', version_id=None, file_size=1024):
     # Based on: http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
     return {
         'Records': [{
@@ -111,7 +111,7 @@ def get_event_message(event_name, bucket_name, file_name='testfile.txt', file_si
                     'key': file_name,
                     'size': file_size,
                     'eTag': 'd41d8cd98f00b204e9800998ecf8427e',
-                    'versionId': '096fKKXTRTtl3on89fVO.nfljtsv6qko',
+                    'versionId': version_id,
                     'sequencer': '0055AED6DCD90281E5'
                 }
             }
@@ -126,7 +126,7 @@ def queue_url_for_arn(queue_arn):
         QueueOwnerAWSAccountId=parts[4])['QueueUrl']
 
 
-def send_notifications(method, bucket_name, object_path):
+def send_notifications(method, bucket_name, object_path, version_id):
     for bucket, b_cfg in iteritems(S3_NOTIFICATIONS):
         if bucket == bucket_name:
             action = {'PUT': 'ObjectCreated', 'POST': 'ObjectCreated', 'DELETE': 'ObjectRemoved'}[method]
@@ -143,7 +143,8 @@ def send_notifications(method, bucket_name, object_path):
                 # send notification
                 message = get_event_message(
                     event_name=event_name, bucket_name=bucket_name,
-                    file_name=urlparse.urlparse(object_path[1:]).path
+                    file_name=urlparse.urlparse(object_path[1:]).path,
+                    version_id=version_id
                 )
                 message = json.dumps(message)
                 if b_cfg.get('Queue'):
@@ -557,8 +558,9 @@ class ProxyListenerS3(ProxyListener):
             else:
                 parts = parsed.path[1:].split('/', 1)
                 object_path = parts[1] if parts[1][0] == '/' else '/%s' % parts[1]
+            version_id = response.headers.get('x-amz-version-id', None);
 
-            send_notifications(method, bucket_name, object_path)
+            send_notifications(method, bucket_name, object_path, version_id)
 
         # publish event for creation/deletion of buckets:
         if method in ('PUT', 'DELETE') and ('/' not in path[1:] or len(path[1:].split('/')[1]) <= 0):


### PR DESCRIPTION
This should fix #1250.

To reproduce:

```bash
$ aws --endpoint-url=http://localhost:4572 s3 mb s3://my_bucket
make_bucket: my_bucket
$ aws --endpoint-url=http://localhost:4572 s3api put-bucket-versioning --bucket my_bucket --versioning-configuration Status=Enabled
$ aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name my_queue
{
    "QueueUrl": "http://localhost:4576/queue/my_queue"
}
$ aws --endpoint-url=http://localhost:4576 sqs get-queue-attributes --queue-url "http://localhost:4576/queue/my_queue" --attribute-names QueueArn --query Attributes --output text
arn:aws:sqs:elasticmq:000000000000:my_queue
$ notification_configuration=$(cat << EOF
{
    "QueueConfigurations": [
        {
            "Id": "my_id",
            "QueueArn": "arn:aws:sqs:elasticmq:000000000000:my_queue",
            "Events": [
                "s3:ObjectCreated:*"
            ]
        }
    ]
}
EOF
)
$ aws --endpoint-url=http://localhost:4572 s3api put-bucket-notification-configuration --bucket my_bucket --notification-configuration "$notification_configuration"
$ aws --endpoint-url=http://localhost:4572 s3api put-object --bucket my_bucket --key blargh.txt
{
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
    "VersionId": "0"
}
$ aws --endpoint-url=http://localhost:4576 sqs receive-message --queue-url http://localhost:4576/queue/my_queue | jq .Messages\[0\].Body | jq -r | jq
{
  "Records": [
    {
      "eventVersion": "2.0",
      "eventName": "ObjectCreated:Put",
      "eventTime": "2019-04-11T20:13:45.322357Z",
      "userIdentity": {
        "principalId": "AIDAJDPLRKLG7UEXAMPLE"
      },
      "eventSource": "aws:s3",
      "requestParameters": {
        "sourceIPAddress": "127.0.0.1"
      },
      "s3": {
        "configurationId": "testConfigRule",
        "object": {
          "versionId": "096fKKXTRTtl3on89fVO.nfljtsv6qko",
          "eTag": "d41d8cd98f00b204e9800998ecf8427e",
          "sequencer": "0055AED6DCD90281E5",
          "key": "blargh.txt",
          "size": 1024
        },
        "bucket": {
          "arn": "arn:aws:s3:::my_bucket",
          "name": "my_bucket",
          "ownerIdentity": {
            "principalId": "A3NL1KOZZKExample"
          }
        },
        "s3SchemaVersion": "1.0"
      },
      "responseElements": {
        "x-amz-id-2": "eftixk72aD6Ap51TnqcoF8eFidJG9Z/2",
        "x-amz-request-id": "e7369cc1"
      },
      "awsRegion": "us-east-1"
    }
  ]
}
```

I'm happy to add a test, but currently don't know where this would go best. Help appreciated.