### PR TITLE
Fix the key case so that it matches the event

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/LambdaExecutor.java
@@ -68,7 +68,7 @@ public class LambdaExecutor {
 				inputObject = deserialisedInput.get();
 			}
 		} else {
-			if (records.stream().anyMatch(record -> record.containsKey("Kinesis"))) {
+			if (records.stream().anyMatch(record -> record.containsKey("kinesis"))) {
 				KinesisEvent kinesisEvent = new KinesisEvent();
 				inputObject = kinesisEvent;
 				kinesisEvent.setRecords(new LinkedList<>());
@@ -76,11 +76,11 @@ public class LambdaExecutor {
 					KinesisEventRecord r = new KinesisEventRecord();
 					kinesisEvent.getRecords().add(r);
 					Record kinesisRecord = new Record();
-					Map<String, Object> kinesis = (Map<String, Object>) get(record, "Kinesis");
-				String dataString = new String(get(kinesis, "Data").toString().getBytes());
+					Map<String, Object> kinesis = (Map<String, Object>) get(record, "kinesis");
+				String dataString = new String(get(kinesis, "data").toString().getBytes());
 				byte[] decodedData = Base64.getDecoder().decode(dataString);
 				kinesisRecord.setData(ByteBuffer.wrap(decodedData));
-					kinesisRecord.setPartitionKey((String) get(kinesis, "PartitionKey"));
+					kinesisRecord.setPartitionKey((String) get(kinesis, "partitionKey"));
 					kinesisRecord.setApproximateArrivalTimestamp(new Date());
 					r.setKinesis(kinesisRecord);
 				}

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -480,12 +480,12 @@ class TestJavaRuntimes(LambdaTestBase):
 
     def test_kinesis_event(self):
         result = self.lambda_client.invoke(
-            FunctionName=TEST_LAMBDA_NAME_JAVA,
+            FunctionName=TEST_LAMBDA_NAME_JAVA, InvocationType='Event',
             Payload=b'{"Records": [{"Kinesis": {"Data": "data", "PartitionKey": "partition"}}]}')
         result_data = result['Payload'].read()
 
-        self.assertEqual(result['StatusCode'], 200)
-        self.assertIn('KinesisEvent', to_str(result_data))
+        self.assertEqual(result['StatusCode'], 202)
+        self.assertEqual(to_str(result_data).strip(), '')
 
     def test_stream_handler(self):
         result = self.lambda_client.invoke(


### PR DESCRIPTION
While testing lambda triggered by kinesis events I found LambdaExecutor trying to call lambda class with HashMap instead of KinesisEvent.

I tracked down the cause to be the mismatch in the key case in LambdaExecutor v.s. the event body (see below)
https://github.com/localstack/localstack/blob/master/localstack/services/awslambda/lambda_api.py#L221
https://github.com/localstack/localstack/blob/master/localstack/services/kinesis/kinesis_listener.py#L41

This PR makes LambdaExecutor look for keys that match the case in the event.

See https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html for the event data structure.