### PR TITLE
Upgrade ElasticSearch 6.5

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -65,7 +65,7 @@ RUN pip install supervisor
 # init environment and cache some dependencies
 RUN mkdir -p /opt/code/localstack/localstack/infra && \
     wget -O /tmp/localstack.es.zip \
-        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip && \
+        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.5.0.zip && \
     wget -O /tmp/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.5.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -74,7 +74,7 @@ APPLICATION_JSON = 'application/json'
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
-ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.0.zip'
+ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.5.0.zip'
 # See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
 ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'ingest-user-agent', 'analysis-kuromoji',
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -136,7 +136,7 @@ def get_domain_status(domain_name, deleted=False):
                 'InstanceType': 'm3.medium.elasticsearch',
                 'ZoneAwarenessEnabled': False
             },
-            'ElasticsearchVersion': '6.2',
+            'ElasticsearchVersion': '6.5',
             'Endpoint': aws_stack.get_elasticsearch_endpoint(),
             'Processing': False,
             'EBSOptions': {

--- a/localstack/services/es/es_starter.py
+++ b/localstack/services/es/es_starter.py
@@ -46,6 +46,8 @@ def start_elasticsearch(port=None, delete_data=True, asynchronous=False, update_
     chmod_r('%s/infra/elasticsearch' % ROOT_PATH, 0o777)
     mkdir(es_data_dir)
     chmod_r(es_data_dir, 0o777)
+    mkdir(es_tmp_dir)
+    chmod_r(es_tmp_dir, 0o777)
     # start proxy and ES process
     start_proxy_for_service('elasticsearch', port, backend_port,
         update_listener, quiet=True, params={'protocol_version': 'HTTP/1.0'})

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -54,7 +54,8 @@ def install_elasticsearch():
                 # https://github.com/pires/docker-elasticsearch/issues/56
                 os.environ['ES_TMPDIR'] = '/tmp'
             plugin_binary = os.path.join(INSTALL_DIR_ES, 'bin', 'elasticsearch-plugin')
-            run('%s install %s' % (plugin_binary, plugin))
+            print('install elasticsearch-plugin %s' % (plugin))
+            run('%s install -b  %s' % (plugin_binary, plugin))
 
     # patch JVM options file - replace hardcoded heap size settings
     jvm_options_file = os.path.join(INSTALL_DIR_ES, 'config', 'jvm.options')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ boto3>=1.9.71
 botocore>=1.12.13
 coverage>=4.0.3
 docopt>=0.6.2
-elasticsearch==6.3.1
+elasticsearch>=6.0.0,<7.0.0
 flake8>=3.6.0
 flake8-quotes>=0.11.0
 flask==1.0.2


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-elasticsearch-service-announces-support-for-elasticsearch-6-5/?nc1=h_ls
