### PR TITLE
Respect the lambda event source mapping state that is passed in

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -964,9 +964,7 @@ def update_event_source_mapping(mapping_uuid):
     if not mapping_uuid:
         return jsonify({})
     function_name = data.get('FunctionName') or ''
-    enabled = data.get('Enabled')
-    if enabled is None:
-        enabled = True
+    enabled = data.get('Enabled', True)
     batch_size = data.get('BatchSize') or 100
     mapping = update_event_source(mapping_uuid, function_name, enabled, batch_size)
     return jsonify(mapping)

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -420,7 +420,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             # Check if the container is already running
             # Note: filtering by *exact* name using regex filter '^...$' seems unstable on some
             # systems. Therefore, we use a combination of filter and grep to get the results.
-            cmd = ('docker ps -a --filter name=\'%s\' '
+            cmd = ("docker ps -a --filter name='%s' "
                    '--format "{{ .Status }} - {{ .Names }}" '
                    '| grep -w "%s" | cat') % (container_name, container_name)
             LOG.debug('Getting status for container "%s": %s' % (container_name, cmd))

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -51,7 +51,7 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_create_event_source_mapping(self):
         self.client.post('{0}/event-source-mappings/'.format(lambda_api.PATH_ROOT),
-                            data=json.dumps({'FunctionName': 'test-lambda-function', 'EventSourceArn': 'fake-arn'}))
+            data=json.dumps({'FunctionName': 'test-lambda-function', 'EventSourceArn': 'fake-arn'}))
 
         listResponse = self.client.get('{0}/event-source-mappings/'.format(lambda_api.PATH_ROOT))
         listResult = json.loads(listResponse.get_data())
@@ -63,28 +63,34 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_create_disabled_event_source_mapping(self):
         createResponse = self.client.post('{0}/event-source-mappings/'.format(lambda_api.PATH_ROOT),
-                            data=json.dumps({'FunctionName': 'test-lambda-function', 'EventSourceArn': 'fake-arn', 'Enabled': 'false'}))
+                            data=json.dumps({'FunctionName': 'test-lambda-function',
+                                             'EventSourceArn': 'fake-arn',
+                                             'Enabled': 'false'}))
         createResult = json.loads(createResponse.get_data())
 
         self.assertEqual('Disabled', createResult['State'])
 
-        getResponse = self.client.get('{0}/event-source-mappings/{1}'.format(lambda_api.PATH_ROOT, createResult.get('UUID')))
-        getResult = json.loads(createResponse.get_data())
+        getResponse = self.client.get('{0}/event-source-mappings/{1}'.format(lambda_api.PATH_ROOT,
+                        createResult.get('UUID')))
+        getResult = json.loads(getResponse.get_data())
 
         self.assertEqual('Disabled', getResult['State'])
 
     def test_update_event_source_mapping(self):
         createResponse = self.client.post('{0}/event-source-mappings/'.format(lambda_api.PATH_ROOT),
-                            data=json.dumps({'FunctionName': 'test-lambda-function', 'EventSourceArn': 'fake-arn', 'Enabled': 'true'}))
+                            data=json.dumps({'FunctionName': 'test-lambda-function',
+                                             'EventSourceArn': 'fake-arn',
+                                             'Enabled': 'true'}))
         createResult = json.loads(createResponse.get_data())
 
-        putResponse = self.client.put('{0}/event-source-mappings/{1}'.format(lambda_api.PATH_ROOT, createResult.get('UUID')),
-                            data=json.dumps({'Enabled': 'false'}))
+        putResponse = self.client.put('{0}/event-source-mappings/{1}'.format(lambda_api.PATH_ROOT,
+                        createResult.get('UUID')), data=json.dumps({'Enabled': 'false'}))
         putResult = json.loads(putResponse.get_data())
 
         self.assertEqual('Disabled', putResult['State'])
 
-        getResponse = self.client.get('{0}/event-source-mappings/{1}'.format(lambda_api.PATH_ROOT, createResult.get('UUID')))
+        getResponse = self.client.get('{0}/event-source-mappings/{1}'.format(lambda_api.PATH_ROOT,
+                        createResult.get('UUID')))
         getResult = json.loads(getResponse.get_data())
 
         self.assertEqual('Disabled', getResult['State'])

--- a/tests/unit/test_sns_listener.py
+++ b/tests/unit/test_sns_listener.py
@@ -170,7 +170,7 @@ def test_filter_policy():
         (
             'exact string filter on an array',
             {'filter': 'soccer'},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'soccer\', \'rugby\', \'hockey\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['soccer', 'rugby', 'hockey']"}},
             True
         ),
         (
@@ -200,7 +200,7 @@ def test_filter_policy():
         (
             'or string filter match with an array',
             {'filter': ['soccer', 'basketball']},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'soccer\', \'rugby\', \'hockey\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['soccer', 'rugby', 'hockey']"}},
             True
         ),
         (
@@ -218,7 +218,7 @@ def test_filter_policy():
         (
             'or string filter no match with an array',
             {'filter': ['volleyball', 'basketball']},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'soccer\', \'rugby\', \'hockey\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['soccer', 'rugby', 'hockey']"}},
             False
         ),
         (
@@ -242,7 +242,7 @@ def test_filter_policy():
         (
             'prefix string filter match with an array',
             {'filter': [{'prefix': 'soc'}]},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'soccer\', \'rugby\', \'hockey\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['soccer', 'rugby', 'hockey']"}},
             True
         ),
         (
@@ -332,7 +332,7 @@ def test_filter_policy():
         (
             'logical OR with match on an array',
             {'filter': ['test1', 'test2', {'prefix': 'typ'}]},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'test1\', \'other\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['test1', 'other']"}},
             True
         ),
         (
@@ -344,7 +344,7 @@ def test_filter_policy():
         (
             'logical OR no match on an array',
             {'filter': ['test1', 'test2', {'prefix': 'typ'}]},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'anything\', \'something\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['anything', 'something']"}},
             False
         ),
         (
@@ -422,7 +422,7 @@ def test_filter_policy():
         (
             'multiple conditions on an array',
             {'filter': ['test1', 'test2', {'prefix': 'som'}]},
-            {'filter': {'Type': 'String.Array', 'Value': '[\'anything\', \'something\']'}},
+            {'filter': {'Type': 'String.Array', 'Value': "['anything', 'something']"}},
             True
         )
     ]


### PR DESCRIPTION
Fix Lambda event source mappings to respect the state (enabled/disabled). Default to enabled if no state is present.

This requires updated to `add_event_source_mapping` and `update_event_source_mapping`.

Added tests for these functions.
