### PR TITLE
Fix: Added `groff` package to Dockerfile.base

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -6,7 +6,7 @@ LABEL authors="Waldemar Hummer (waldemar.hummer@gmail.com)"
 # install some common libs
 RUN apk add --no-cache autoconf automake build-base ca-certificates curl g++ gcc git \
         libffi-dev libtool linux-headers make openssl openssl-dev python python-dev \
-        py-pip supervisor tar xz zip && \
+        py-pip supervisor tar xz zip groff && \
     update-ca-certificates
 
 # install Docker (CLI only)


### PR DESCRIPTION
Fix to avoid `aws` command to fail when displaying the help from inside the docker container `localstack/localstack:0.9.0`

```
bash-4.4# aws help

Could not find executable named "groff"
```

**Please refer to the contribution guidelines in the README when submitting PRs.**
