### PR TITLE
Remove unnecessary escaping of single-quotes, resolves #1281.

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -165,12 +165,11 @@ class LambdaExecutorContainers(LambdaExecutor):
             LOG.warning('Empty event body specified for invocation of Lambda "%s"' % func_arn)
             event = {}
         event_body = json.dumps(event)
-        event_body_escaped = event_body.replace("'", "\\'")
 
         docker_host = config.DOCKER_HOST_FROM_CONTAINER
 
         # amend the environment variables for execution
-        environment['AWS_LAMBDA_EVENT_BODY'] = event_body_escaped
+        environment['AWS_LAMBDA_EVENT_BODY'] = event_body
         environment['HOSTNAME'] = docker_host
         environment['LOCALSTACK_HOSTNAME'] = docker_host
         if context:


### PR DESCRIPTION
This removes an issue where a string.replace call unnecessarily escapes characters before a call to shlex (which does it properly). This causes some issues with golang runtimes.