### PR TITLE
#1293 fix PORT_CONFIG_FILENAME path to the python3.6 location

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -26,7 +26,7 @@ public class LocalstackDocker {
     private static final Logger LOG = Logger.getLogger(LocalstackDocker.class.getName());
 
     private static final String PORT_CONFIG_FILENAME = "/opt/code/localstack/" +
-            ".venv/lib/python2.7/site-packages/localstack_client/config.py";
+            ".venv/lib/python3.6/site-packages/localstack_client/config.py";
 
     private static final Pattern READY_TOKEN = Pattern.compile("Ready\\.");
 


### PR DESCRIPTION
This is to make the path correct after the python3 change in https://github.com/localstack/localstack/commit/0886a249ab8bbfea47b68597045a061ef5c55ece
