### PR TITLE
Do not modify docker.sock permissions by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,5 @@ RUN mkdir -p /.npm && \
     ln -s `pwd` /tmp/localstack_install_dir
 
 # run tests (to verify the build before pushing the image)
-USER localstack
 ADD tests/ tests/
 RUN make test

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -4,22 +4,9 @@ logfile=/tmp/supervisord.log
 
 [program:infra]
 command=make infra
-user=localstack
 autostart=true
 autorestart=true
 stdout_logfile=/tmp/localstack_infra.log
-stderr_logfile=/dev/fd/2
-stderr_logfile_maxbytes=0
-
-[program:fix_docker_sock]
-command=bash -c 'test ! -e /var/run/docker.sock || chmod 777 /var/run/docker.sock'
-user=root
-autostart=true
-autorestart=false
-exitcodes=0
-startsecs=0
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
 

--- a/localstack/dashboard/api.py
+++ b/localstack/dashboard/api.py
@@ -1,5 +1,7 @@
 import os
 import json
+import logging
+import click
 from flask import Flask, render_template, jsonify, send_from_directory, request
 from flask_swagger import swagger
 from localstack.constants import VERSION
@@ -98,4 +100,11 @@ def ensure_webapp_installed():
 
 def serve(port):
     ensure_webapp_installed()
+
+    def noecho(*args, **kwargs):
+        pass
+
+    click.echo = noecho
+    logging.getLogger('werkzeug').setLevel(logging.ERROR)
+    app.config['ENV'] = 'development'
     app.run(port=int(port), debug=True, threaded=True, host='0.0.0.0')

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -54,6 +54,9 @@ LOG = logging.getLogger(os.path.basename(__file__))
 # map of service plugins, mapping from service name to plugin details
 SERVICE_PLUGINS = {}
 
+# whether or not to manually fix permissions on /var/run/docker.sock (currently disabled)
+DO_CHMOD_DOCKER_SOCK = False
+
 # plugin scopes
 PLUGIN_SCOPE_SERVICES = 'services'
 PLUGIN_SCOPE_COMMANDS = 'commands'
@@ -508,12 +511,13 @@ def start_infra_in_docker():
     t.start()
     time.sleep(2)
 
-    # fix permissions on /var/run/docker.sock
-    for i in range(0, 100):
-        if docker_container_running(container_name):
-            break
-        time.sleep(2)
-    run('docker exec -u root "%s" chmod 777 /var/run/docker.sock' % container_name)
+    if DO_CHMOD_DOCKER_SOCK:
+        # fix permissions on /var/run/docker.sock
+        for i in range(0, 100):
+            if docker_container_running(container_name):
+                break
+            time.sleep(2)
+        run('docker exec -u root "%s" chmod 777 /var/run/docker.sock' % container_name)
 
     t.process.wait()
     sys.exit(t.process.returncode)


### PR DESCRIPTION
Do not modify docker.sock permissions by default, as this can have dangerous side-effects.

This PR reverts to the previous behavior where the LocalStack main process runs as `root` (by default) and hence should have access to `/var/run/docker.sock`.

Note that `root` is the default, but not enforced in `supervisord.conf` - users can overwrite the user by passing the `--user=..` to docker run when starting the container. 