### PR TITLE
Fix blocked out/err output under docker/docker-compose

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -26,4 +26,5 @@ function run_startup_scripts {
 run_startup_scripts &
 
 touch /tmp/localstack_infra.log
-tail -f /tmp/localstack_infra.log
+touch /tmp/localstack_infra.err
+tail -qF /tmp/localstack_infra.log /tmp/localstack_infra.err

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -7,8 +7,7 @@ command=make infra
 autostart=true
 autorestart=true
 stdout_logfile=/tmp/localstack_infra.log
-stderr_logfile=/dev/fd/2
-stderr_logfile_maxbytes=0
+stderr_logfile=/tmp/localstack_infra.err
 
 [program:dashboard]
 command=bash -c 'if [ "$START_WEB" = "0" ]; then exit 0; fi; make web'


### PR DESCRIPTION
Ok, so this is kind of crazy. See [this docker-compose issue](https://github.com/docker/compose/issues/6018).

Unfortunately, we're logging a lot through our go1.x lambdas, which will eventually fill up the /dev/fd/2 descriptor. This causes a HARD hang on localstack that just ... confounded us for 96 developer hours. We inspected the threads once the program blocked, and saw that it was blocking one either print or writes to stderr. That was a new one for me. If we write to a file instead then tail both the out and the err streams, this issue goes away completely for us.

If you'd like to handle the output in a different way please let me know and I'll see what other solutions there could be.