### PR TITLE
Fix bad idle container time check

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -475,7 +475,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
         :return: None
         """
         LOG.info('Checking if there are idle containers.')
-        current_time = time.time()
+        current_time = int(time.time() * 1000)
         for func_arn, last_run_time in self.function_invoke_times.items():
             duration = current_time - last_run_time
 


### PR DESCRIPTION
It looks like duration on line 400 was always negative as the times in the invocation time dictionary is the invocation time * 1000. This makes that comparison symmetric.