### PR TITLE
Add support for @Nested Junit5 tests

### DIFF
--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/Junit5NestedTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/Junit5NestedTest.java
@@ -1,0 +1,22 @@
+package cloud.localstack.docker;
+
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import org.junit.Assert;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(LocalstackDockerExtension.class)
+@LocalstackDockerProperties(randomizePorts = true, services = "sqs")
+public class Junit5NestedTest {
+
+    @Nested
+    class NestedClass {
+
+        @Test
+        public void ShouldNotStartNewContainerInNestedTest() {
+            // This should not trigger an error by calling the beforeAll twice
+            Assert.assertTrue(true);
+        }
+    }
+}


### PR DESCRIPTION
By registering the Extension in the context, we can avoid multiple image creation and this way avoid Exception thrown.
See #1330 for more context.