### PR TITLE
set Last-Modified header (s3 proxy)

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -8,6 +8,8 @@ import xmltodict
 import collections
 import botocore.config
 import six
+import datetime
+import dateutil.parser
 from six import iteritems
 from six.moves.urllib import parse as urlparse
 from botocore.client import ClientError
@@ -248,6 +250,31 @@ def append_cors_headers(bucket_name, request_method, request_headers, response):
                             ','.join(expose_headers) if isinstance(expose_headers, list) else expose_headers
                     break
 
+def append_last_modified_headers(response, content=None):
+    '''Add Last-Modified header with current time
+    (if the response content is an XML containing <LastModified>, add that instead)'''
+
+    time_format = '%a, %d %b %Y %H:%M:%S GMT' # TimeFormat
+    try:
+        last_modified_str = re.findall(r'<LastModified>(.*)</LastModified>', content)[0]
+        last_modified_time_format = dateutil.parser.parse(last_modified_str).strftime(time_format)
+        response.headers['Last-Modified'] = last_modified_time_format
+    except TypeError as err:
+        LOGGER.debug('No parsable content: %s' % err)
+    except IndexError as err:
+        LOGGER.debug('Found no <LastModified>(.*)</LastModified> inside response_content: %s' % err)
+    except ValueError as err:
+        LOGGER.error('Failed to parse LastModified: %s' % err)
+    except Exception as err:
+        LOGGER.error('Caught generic exception (parsing LastModified): %s' % err)
+    # if cannot parse any LastModified, just continue
+
+    try:
+        if response.headers.get('Last-Modified', '') == '':
+            response.headers['Last-Modified'] = datetime.datetime.now().strftime(time_format)
+    except Exception as err:
+        LOGGER.error('Caught generic exception (setting LastModified header): %s' % err)
+        
 
 def get_lifecycle(bucket_name):
     response = Response()
@@ -568,6 +595,8 @@ class ProxyListenerS3(ProxyListener):
             # append CORS headers to response
             append_cors_headers(bucket_name, request_method=method, request_headers=headers, response=response)
 
+            append_last_modified_headers(response=response)
+
             response_content_str = None
             try:
                 response_content_str = to_str(response._content)
@@ -581,6 +610,8 @@ class ProxyListenerS3(ProxyListener):
             if response_content_str and response_content_str.startswith('<'):
                 is_bytes = isinstance(response._content, six.binary_type)
 
+                append_last_modified_headers(response=response, content=response_content_str)
+                
                 # un-pretty-print the XML
                 response._content = re.sub(r'([^\?])>\n\s*<', r'\1><', response_content_str, flags=re.MULTILINE)
 


### PR DESCRIPTION
This commit adds a `Last-Modified` header on a S3Proxy response.

If the content has a XML with a `<LastModified>` field, it uses that field. Else, it uses currentDate.

I used this personally to fix an incompatibility with [minio-go](https://github.com/minio/minio-go) library, which requires a `Last-Modified` header ([api-get-object.go:626](https://github.com/minio/minio-go/blob/da91b3bbdca31aef023d51f3ac74cec0e02b23ac/api-get-object.go)), and fails if it is not set. 
As adding a header is an easy-fix and will not break anything, I followed that path.

It works for me, and I though it might be useful for someone else.