### PR TITLE
set Last-Modified header

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/local/bin/python3"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,5 @@ RUN mkdir -p /.npm && \
 
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
+ENV TEST_PATH ./tests/unit
 RUN make test


### PR DESCRIPTION
This commit adds a `Last-Modified` header on a S3Proxy response.

If the content has a XML with a `<LastModified>` field, it uses that field. Else, it uses currentDate.

I used this personally to fix an incompatibility with [minio-go](https://github.com/minio/minio-go) library, which requires a `Last-Modified` header ([api-get-object.go:626](https://github.com/minio/minio-go/blob/da91b3bbdca31aef023d51f3ac74cec0e02b23ac/api-get-object.go)), and fails if it is not set. 
As adding a header is an easy-fix and will not break anything, I followed that path.

It works for me, and I though it might be useful for someone else.