### PR TITLE
Lambda responses match the corresponding AWS responses

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -478,7 +478,7 @@ def set_function_code(code, lambda_name):
             return zip_file_content
         code_sha_256 = base64.standard_b64encode(hashlib.sha256(zip_file_content).digest())
         lambda_details.get_version('$LATEST')['CodeSize'] = len(zip_file_content)
-        lambda_details.get_version('$LATEST')['CodeSha256'] = code_sha_256.decode("utf-8")
+        lambda_details.get_version('$LATEST')['CodeSha256'] = code_sha_256.decode('utf-8')
         tmp_dir = '%s/zipfile.%s' % (config.TMP_FOLDER, short_uid())
         mkdir(tmp_dir)
         tmp_file = '%s/%s' % (tmp_dir, LAMBDA_ZIP_FILE_NAME)

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -34,8 +34,7 @@ from localstack.services.awslambda.lambda_executors import (
     LAMBDA_RUNTIME_CUSTOM_RUNTIME)
 from localstack.utils.common import (to_str, load_file, save_file, TMP_FILES, ensure_readable,
     mkdir, unzip, is_zip_file, run, short_uid, is_jar_archive, timestamp, TIMESTAMP_FORMAT_MILLIS,
-    md5, new_tmp_file, parse_chunked_data, is_number, now_utc, safe_requests, generate_random_revision_id,
-    isoformat_milliseconds)
+    md5, new_tmp_file, parse_chunked_data, is_number, now_utc, safe_requests, isoformat_milliseconds)
 from localstack.utils.aws import aws_stack, aws_responses
 from localstack.utils.analytics import event_publisher
 from localstack.utils.cloudwatch.cloudwatch_util import cloudwatched
@@ -281,7 +280,7 @@ def publish_new_function_version(arn):
         'CodeSize': versions.get('$LATEST').get('CodeSize'),
         'CodeSha256': versions.get('$LATEST').get('CodeSha256'),
         'Function': versions.get('$LATEST').get('Function'),
-        'RevisionId': generate_random_revision_id()
+        'RevisionId': str(uuid.uuid4())
     }
     return get_function_version(arn, str(last_version + 1))
 
@@ -297,7 +296,7 @@ def do_update_alias(arn, alias, version, description=None):
         'FunctionVersion': version,
         'Name': alias,
         'Description': description or '',
-        'RevisionId': generate_random_revision_id()
+        'RevisionId': str(uuid.uuid4())
     }
     arn_to_lambda.get(arn).aliases[alias] = new_alias
     return new_alias
@@ -639,7 +638,7 @@ def create_function():
             return error_response('Function already exist: %s' %
                 lambda_name, 409, error_type='ResourceConflictException')
         arn_to_lambda[arn] = func_details = LambdaFunction(arn)
-        func_details.versions = {'$LATEST': {'RevisionId': generate_random_revision_id()}}
+        func_details.versions = {'$LATEST': {'RevisionId': str(uuid.uuid4())}}
         func_details.last_modified = isoformat_milliseconds(datetime.utcnow()) + '+0000'
         func_details.description = data.get('Description', '')
         func_details.handler = data['Handler']

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -478,7 +478,7 @@ def set_function_code(code, lambda_name):
             return zip_file_content
         code_sha_256 = base64.standard_b64encode(hashlib.sha256(zip_file_content).digest())
         lambda_details.get_version('$LATEST')['CodeSize'] = len(zip_file_content)
-        lambda_details.get_version('$LATEST')['CodeSha256'] = code_sha_256
+        lambda_details.get_version('$LATEST')['CodeSha256'] = code_sha_256.decode("utf-8")
         tmp_dir = '%s/zipfile.%s' % (config.TMP_FOLDER, short_uid())
         mkdir(tmp_dir)
         tmp_file = '%s/%s' % (tmp_dir, LAMBDA_ZIP_FILE_NAME)

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -34,7 +34,8 @@ from localstack.services.awslambda.lambda_executors import (
     LAMBDA_RUNTIME_CUSTOM_RUNTIME)
 from localstack.utils.common import (to_str, load_file, save_file, TMP_FILES, ensure_readable,
     mkdir, unzip, is_zip_file, run, short_uid, is_jar_archive, timestamp, TIMESTAMP_FORMAT_MILLIS,
-    md5, new_tmp_file, parse_chunked_data, is_number, now_utc, safe_requests, generate_random_revision_id)
+    md5, new_tmp_file, parse_chunked_data, is_number, now_utc, safe_requests, generate_random_revision_id,
+    isoformat_milliseconds)
 from localstack.utils.aws import aws_stack, aws_responses
 from localstack.utils.analytics import event_publisher
 from localstack.utils.cloudwatch.cloudwatch_util import cloudwatched
@@ -637,7 +638,7 @@ def create_function():
                 lambda_name, 409, error_type='ResourceConflictException')
         arn_to_lambda[arn] = func_details = LambdaFunction(arn)
         func_details.versions = {'$LATEST': {}}
-        func_details.last_modified = datetime.utcnow().isoformat(timespec='milliseconds') + '+0000'
+        func_details.last_modified = isoformat_milliseconds(datetime.utcnow()) + '+0000'
         func_details.revision_id = generate_random_revision_id()
         func_details.description = data.get('Description', '')
         func_details.handler = data['Handler']

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -476,8 +476,9 @@ def set_function_code(code, lambda_name):
         zip_file_content = get_zip_bytes(code)
         if isinstance(zip_file_content, Response):
             return zip_file_content
+        code_sha_256 = base64.standard_b64encode(hashlib.sha256(zip_file_content).digest())
         lambda_details.get_version('$LATEST')['CodeSize'] = len(zip_file_content)
-        lambda_details.get_version('$LATEST')['CodeSha256'] = base64.standard_b64encode(hashlib.sha256(zip_file_content).digest())
+        lambda_details.get_version('$LATEST')['CodeSha256'] = code_sha_256
         tmp_dir = '%s/zipfile.%s' % (config.TMP_FOLDER, short_uid())
         mkdir(tmp_dir)
         tmp_file = '%s/%s' % (tmp_dir, LAMBDA_ZIP_FILE_NAME)
@@ -568,7 +569,7 @@ def format_func_details(func_details, version=None, always_add_version=False):
         'Description': func_details.description,
         'MemorySize': func_details.memory_size,
         'LastModified': func_details.last_modified,
-        'TracingConfig': {"Mode": "PassThrough"},
+        'TracingConfig': {'Mode': 'PassThrough'},
         'RevisionId': func_details.revision_id
     }
     if func_details.envvars:
@@ -636,7 +637,7 @@ def create_function():
                 lambda_name, 409, error_type='ResourceConflictException')
         arn_to_lambda[arn] = func_details = LambdaFunction(arn)
         func_details.versions = {'$LATEST': {}}
-        func_details.last_modified = datetime.utcnow().isoformat(timespec="milliseconds") + "+0000"
+        func_details.last_modified = datetime.utcnow().isoformat(timespec='milliseconds') + '+0000'
         func_details.revision_id = generate_random_revision_id()
         func_details.description = data.get('Description', '')
         func_details.handler = data['Handler']

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -745,6 +745,9 @@ def update_function_code(function):
     """
     data = json.loads(to_str(request.data))
     result = set_function_code(data, function)
+    arn = func_arn(function)
+    func_details = arn_to_lambda.get(arn)
+    result.update(format_func_details(func_details))
     if isinstance(result, Response):
         return result
     return jsonify(result or {})

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -172,7 +172,7 @@ class LambdaFunction(Component):
         self.timeout = None
         self.last_modified = None
         self.revision_id = None
-        self.description = None
+        self.description = ''
         self.role = None
         self.memory_size = None
 

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -171,7 +171,6 @@ class LambdaFunction(Component):
         self.cwd = None
         self.timeout = None
         self.last_modified = None
-        self.revision_id = None
         self.description = ''
         self.role = None
         self.memory_size = None

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -173,8 +173,8 @@ class LambdaFunction(Component):
         self.last_modified = None
         self.revision_id = None
         self.description = None
-        self.code_size = None
-        self.code_sha_256 = None
+        self.role = None
+        self.memory_size = None
 
     def get_version(self, version):
         return self.versions.get(version)

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -170,6 +170,11 @@ class LambdaFunction(Component):
         self.handler = None
         self.cwd = None
         self.timeout = None
+        self.last_modified = None
+        self.revision_id = None
+        self.description = None
+        self.code_size = None
+        self.code_sha_256 = None
 
     def get_version(self, version):
         return self.versions.get(version)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -994,15 +994,6 @@ def parallelize(func, list, size=None):
     return result
 
 
-def generate_random_revision_id():
-    revision_id_part_sizes = (4, 2, 2, 2, 6)
-    revision_id_parts = (
-        binascii.hexlify(os.urandom(revision_id_part_size)).decode('utf-8')
-        for revision_id_part_size in revision_id_part_sizes
-    )
-    return '-'.join(revision_id_parts)
-
-
 def isoformat_milliseconds(t):
     try:
         return t.isoformat(timespec='milliseconds')

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1001,3 +1001,10 @@ def generate_random_revision_id():
         for revision_id_part_size in revision_id_part_sizes
     )
     return '-'.join(revision_id_parts)
+
+
+def isoformat_milliseconds(t):
+    try:
+        return t.isoformat(timespec='milliseconds')
+    except TypeError:
+        return t.isoformat()[:-3]

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -997,6 +997,7 @@ def parallelize(func, list, size=None):
 def generate_random_revision_id():
     revision_id_part_sizes = (4, 2, 2, 2, 6)
     revision_id_parts = (
-        binascii.hexlify(os.urandom(revision_id_part_size)).decode("utf-8") for revision_id_part_size in revision_id_part_sizes
+        binascii.hexlify(os.urandom(revision_id_part_size)).decode('utf-8')
+        for revision_id_part_size in revision_id_part_sizes
     )
-    return "-".join(revision_id_parts)
+    return '-'.join(revision_id_parts)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -992,3 +992,11 @@ def parallelize(func, list, size=None):
     pool.close()
     pool.join()
     return result
+
+
+def generate_random_revision_id():
+    revision_id_part_sizes = (4, 2, 2, 2, 6)
+    revision_id_parts = (
+        binascii.hexlify(os.urandom(revision_id_part_size)).decode("utf-8") for revision_id_part_size in revision_id_part_sizes
+    )
+    return "-".join(revision_id_parts)

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -400,7 +400,7 @@ class TestLambdaAPI(unittest.TestCase):
         arn = lambda_api.func_arn(function_name)
         lambda_api.arn_to_lambda[arn] = LambdaFunction(arn)
         lambda_api.arn_to_lambda[arn].versions = {
-            '$LATEST': {'CodeSize': self.CODE_SIZE, 'CodeSha256': self.CODE_SHA_256, "RevisionId": self.REVISION_ID}
+            '$LATEST': {'CodeSize': self.CODE_SIZE, 'CodeSha256': self.CODE_SHA_256, 'RevisionId': self.REVISION_ID}
         }
         lambda_api.arn_to_lambda[arn].handler = self.HANDLER
         lambda_api.arn_to_lambda[arn].runtime = self.RUNTIME

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -107,6 +107,8 @@ class TestLambdaAPI(unittest.TestCase):
 
             result = json.loads(lambda_api.publish_version(self.FUNCTION_NAME).get_data())
             result2 = json.loads(lambda_api.publish_version(self.FUNCTION_NAME).get_data())
+            result.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
+            result2.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
 
             expected_result = dict()
             expected_result['CodeSize'] = self.CODE_SIZE
@@ -121,7 +123,6 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result['Role'] = self.ROLE
             expected_result['LastModified'] = self.LAST_MODIFIED
             expected_result['TracingConfig'] = self.TRACING_CONFIG
-            expected_result['RevisionId'] = self.REVISION_ID
             expected_result['Version'] = '1'
             expected_result2 = dict(expected_result)
             expected_result2['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':2'
@@ -143,6 +144,7 @@ class TestLambdaAPI(unittest.TestCase):
             lambda_api.publish_version(self.FUNCTION_NAME)
 
             result = json.loads(lambda_api.list_versions(self.FUNCTION_NAME).get_data())
+            result.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
 
             latest_version = dict()
             latest_version['CodeSize'] = self.CODE_SIZE
@@ -157,7 +159,6 @@ class TestLambdaAPI(unittest.TestCase):
             latest_version['Role'] = self.ROLE
             latest_version['LastModified'] = self.LAST_MODIFIED
             latest_version['TracingConfig'] = self.TRACING_CONFIG
-            latest_version['RevisionId'] = self.REVISION_ID
             latest_version['Version'] = '$LATEST'
             version1 = dict(latest_version)
             version1['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':1'
@@ -255,6 +256,7 @@ class TestLambdaAPI(unittest.TestCase):
         response = self.client.get('{0}/functions/{1}/aliases/{2}'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME,
                                                                           self.ALIAS_NAME))
         result = json.loads(response.get_data())
+        result.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
 
         expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
                            'FunctionVersion': '1', 'Description': '',
@@ -288,6 +290,8 @@ class TestLambdaAPI(unittest.TestCase):
 
         response = self.client.get('{0}/functions/{1}/aliases'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME))
         result = json.loads(response.get_data())
+        for alias in result['Aliases']:
+            alias.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
         expected_result = {'Aliases': [
             {
                 'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -144,7 +144,9 @@ class TestLambdaAPI(unittest.TestCase):
             lambda_api.publish_version(self.FUNCTION_NAME)
 
             result = json.loads(lambda_api.list_versions(self.FUNCTION_NAME).get_data())
-            result.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
+            for version in result['Versions']:
+                # we need to remove this, since this is random, so we cannot know its value
+                version.pop('RevisionId', None)
 
             latest_version = dict()
             latest_version['CodeSize'] = self.CODE_SIZE

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -184,6 +184,7 @@ class TestLambdaAPI(unittest.TestCase):
                          data=json.dumps({'Name': self.ALIAS_NAME, 'FunctionVersion': '1',
                              'Description': ''}))
         result = json.loads(response.get_data())
+        result.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
 
         expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
                            'FunctionVersion': '1', 'Description': '', 'Name': self.ALIAS_NAME}
@@ -222,6 +223,7 @@ class TestLambdaAPI(unittest.TestCase):
                                                                           self.ALIAS_NAME),
                                    data=json.dumps({'FunctionVersion': '$LATEST', 'Description': 'Test-Description'}))
         result = json.loads(response.get_data())
+        result.pop('RevisionId', None)  # we need to remove this, since this is random, so we cannot know its value
 
         expected_result = {'AliasArn': lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME,
                            'FunctionVersion': '$LATEST', 'Description': 'Test-Description',
@@ -398,7 +400,7 @@ class TestLambdaAPI(unittest.TestCase):
         arn = lambda_api.func_arn(function_name)
         lambda_api.arn_to_lambda[arn] = LambdaFunction(arn)
         lambda_api.arn_to_lambda[arn].versions = {
-            '$LATEST': {'CodeSize': self.CODE_SIZE, 'CodeSha256': self.CODE_SHA_256}
+            '$LATEST': {'CodeSize': self.CODE_SIZE, 'CodeSha256': self.CODE_SHA_256, "RevisionId": self.REVISION_ID}
         }
         lambda_api.arn_to_lambda[arn].handler = self.HANDLER
         lambda_api.arn_to_lambda[arn].runtime = self.RUNTIME
@@ -406,6 +408,5 @@ class TestLambdaAPI(unittest.TestCase):
         lambda_api.arn_to_lambda[arn].tags = tags
         lambda_api.arn_to_lambda[arn].envvars = {}
         lambda_api.arn_to_lambda[arn].last_modified = self.LAST_MODIFIED
-        lambda_api.arn_to_lambda[arn].revision_id = self.REVISION_ID
         lambda_api.arn_to_lambda[arn].role = self.ROLE
         lambda_api.arn_to_lambda[arn].memory_size = self.MEMORY_SIZE

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -6,6 +6,12 @@ from localstack.utils.aws.aws_models import LambdaFunction
 
 class TestLambdaAPI(unittest.TestCase):
     CODE_SIZE = 50
+    CODE_SHA_256 = '/u60ZpAA9bzZPVwb8d4390i5oqP1YAObUwV03CZvsWA='
+    MEMORY_SIZE = 128
+    ROLE = 'arn:aws:iam::123456:role/role-name'
+    LAST_MODIFIED = '2019-05-25T17:00:48.260+0000'
+    TRACING_CONFIG = {'Mode': 'PassThrough'}
+    REVISION_ID = 'e54dbcf8-e3ef-44ab-9af7-8dbef510608a'
     HANDLER = 'index.handler'
     RUNTIME = 'node.js4.3'
     TIMEOUT = 60  # Default value, hardcoded
@@ -104,17 +110,22 @@ class TestLambdaAPI(unittest.TestCase):
 
             expected_result = dict()
             expected_result['CodeSize'] = self.CODE_SIZE
+            expected_result['CodeSha256'] = self.CODE_SHA_256
             expected_result['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':1'
             expected_result['FunctionName'] = str(self.FUNCTION_NAME)
             expected_result['Handler'] = str(self.HANDLER)
             expected_result['Runtime'] = str(self.RUNTIME)
             expected_result['Timeout'] = self.TIMEOUT
+            expected_result['Description'] = ''
+            expected_result['MemorySize'] = self.MEMORY_SIZE
+            expected_result['Role'] = self.ROLE
+            expected_result['LastModified'] = self.LAST_MODIFIED
+            expected_result['TracingConfig'] = self.TRACING_CONFIG
+            expected_result['RevisionId'] = self.REVISION_ID
             expected_result['Version'] = '1'
-            expected_result['Environment'] = {'Variables': {}}
             expected_result2 = dict(expected_result)
             expected_result2['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':2'
             expected_result2['Version'] = '2'
-            expected_result2['Environment'] = {'Variables': {}}
             self.assertDictEqual(expected_result, result)
             self.assertDictEqual(expected_result2, result2)
 
@@ -135,21 +146,25 @@ class TestLambdaAPI(unittest.TestCase):
 
             latest_version = dict()
             latest_version['CodeSize'] = self.CODE_SIZE
+            latest_version['CodeSha256'] = self.CODE_SHA_256
             latest_version['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':$LATEST'
             latest_version['FunctionName'] = str(self.FUNCTION_NAME)
             latest_version['Handler'] = str(self.HANDLER)
             latest_version['Runtime'] = str(self.RUNTIME)
             latest_version['Timeout'] = self.TIMEOUT
+            latest_version['Description'] = ''
+            latest_version['MemorySize'] = self.MEMORY_SIZE
+            latest_version['Role'] = self.ROLE
+            latest_version['LastModified'] = self.LAST_MODIFIED
+            latest_version['TracingConfig'] = self.TRACING_CONFIG
+            latest_version['RevisionId'] = self.REVISION_ID
             latest_version['Version'] = '$LATEST'
-            latest_version['Environment'] = {'Variables': {}}
             version1 = dict(latest_version)
             version1['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':1'
             version1['Version'] = '1'
-            version1['Environment'] = {'Variables': {}}
             version2 = dict(latest_version)
             version2['FunctionArn'] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ':2'
             version2['Version'] = '2'
-            version2['Environment'] = {'Variables': {}}
             expected_result = {'Versions': sorted([latest_version, version1, version2],
                                                   key=lambda k: str(k.get('Version')))}
             self.assertDictEqual(expected_result, result)
@@ -382,9 +397,15 @@ class TestLambdaAPI(unittest.TestCase):
     def _create_function(self, function_name, tags={}):
         arn = lambda_api.func_arn(function_name)
         lambda_api.arn_to_lambda[arn] = LambdaFunction(arn)
-        lambda_api.arn_to_lambda[arn].versions = {'$LATEST': {'CodeSize': self.CODE_SIZE}}
+        lambda_api.arn_to_lambda[arn].versions = {
+            '$LATEST': {'CodeSize': self.CODE_SIZE, 'CodeSha256': self.CODE_SHA_256}
+        }
         lambda_api.arn_to_lambda[arn].handler = self.HANDLER
         lambda_api.arn_to_lambda[arn].runtime = self.RUNTIME
         lambda_api.arn_to_lambda[arn].timeout = self.TIMEOUT
         lambda_api.arn_to_lambda[arn].tags = tags
         lambda_api.arn_to_lambda[arn].envvars = {}
+        lambda_api.arn_to_lambda[arn].last_modified = self.LAST_MODIFIED
+        lambda_api.arn_to_lambda[arn].revision_id = self.REVISION_ID
+        lambda_api.arn_to_lambda[arn].role = self.ROLE
+        lambda_api.arn_to_lambda[arn].memory_size = self.MEMORY_SIZE


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
The responses returned from `list_versions`, `create_function`, `create_alias`, `update_alias` and `update_function_code` did not match the corresponding responses returned by AWS. This has been fixed in this PR.