### PR TITLE
Squash and reduce size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,12 @@ RUN mkdir -p /.npm && \
     chown -R localstack:localstack . /tmp/localstack && \
     ln -s `pwd` /tmp/localstack_install_dir
 
+# clean up and prepare for squashing the image
+RUN pip uninstall -y awscli boto3 botocore localstack_client idna s3transfer
+RUN rm -rf /tmp/* /root/.cache /opt/yarn-v1.15.2
+RUN ln -s /opt/code/localstack/.venv/bin/aws /usr/bin/aws
+ENV PYTHONPATH=/opt/code/localstack/.venv/lib/python3.6/site-packages
+
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
 RUN make test

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,9 @@ infra:             ## Manually start the local infrastructure for testing
 
 docker-build:      ## Build Docker image
 	docker build -t $(IMAGE_NAME) .
-	# remove topmost layer ("make test") from image
-	LAST_BUT_ONE_LAYER=`docker history -q $(IMAGE_NAME) | head -n 3 | tail -n 1`; \
-		docker tag $$LAST_BUT_ONE_LAYER $(IMAGE_NAME); \
-		docker tag $$LAST_BUT_ONE_LAYER $(IMAGE_NAME):$(IMAGE_TAG)
+	# squash entire image
+	which docker-squash || $(PIP_CMD) install docker-squash; \
+		docker-squash -t $(IMAGE_NAME) $(IMAGE_NAME)
 
 docker-build-base:
 	docker build --squash -t $(IMAGE_NAME_BASE) -f bin/Dockerfile.base .


### PR DESCRIPTION
Squash and reduce size of Docker image. Reduces the size of the uncompressed image from approximately 1.29GB to 702MB.