### PR TITLE
Support secretsmanager via LocalstackDockerExtension

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/Container.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/Container.java
@@ -21,7 +21,7 @@ public class Container {
     private static final Logger LOG = Logger.getLogger(Container.class.getName());
 
     private static final String LOCALSTACK_NAME = "localstack/localstack";
-    private static final String LOCALSTACK_PORTS = "4567-4583";
+    private static final String LOCALSTACK_PORTS = "4567-4584";
 
     private static final int MAX_PORT_CONNECTION_ATTEMPTS = 10;
 

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/BasicDockerFunctionalityTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/BasicDockerFunctionalityTest.java
@@ -22,6 +22,9 @@ import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.model.CreateSecretRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
@@ -48,6 +51,22 @@ public class BasicDockerFunctionalityTest {
 
     static {
         TestUtils.setEnv("AWS_CBOR_DISABLE", "1");
+    }
+
+    @org.junit.Test
+    @org.junit.jupiter.api.Test
+    public void testSecretsManager() throws Exception {
+        AWSSecretsManager secretsManager = DockerTestUtils.getClientSecretsManager();
+
+        CreateSecretRequest createSecretRequest = new CreateSecretRequest();
+        createSecretRequest.setName("my-secret-name");
+        createSecretRequest.setSecretString("this is a secret thing");
+        secretsManager.createSecret(createSecretRequest);
+
+        GetSecretValueRequest getSecretValueRequest = new GetSecretValueRequest().withSecretId("my-secret-name");
+        String result = secretsManager.getSecretValue(getSecretValueRequest).getSecretString();
+        Assertions.assertThat(result).isEqualTo("this is a secret thing");
+
     }
 
     @org.junit.Test

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
@@ -57,6 +57,7 @@ public class ContainerTest {
             assertNotEquals(4567, container.getExternalPortFor(4567));
             assertNotEquals(4575, container.getExternalPortFor(4575));
             assertNotEquals(4583, container.getExternalPortFor(4583));
+            assertNotEquals(4584, container.getExternalPortFor(4584));
         }
         finally {
             container.stop();
@@ -74,6 +75,7 @@ public class ContainerTest {
             assertEquals(4567, container.getExternalPortFor(4567));
             assertEquals(4575, container.getExternalPortFor(4575));
             assertEquals(4583, container.getExternalPortFor(4583));
+            assertEquals(4584, container.getExternalPortFor(4584));
         }
         finally {
             container.stop();


### PR DESCRIPTION
The LOCALSTACK_PORTS constant in Container.java didn't include the secretsmanager port (4584).  I added it plus a basic test to verify the plumbing.

This is to address #1350.
