### PR TITLE
Parameterize-able CORS Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ You can pass the following environment variables to LocalStack:
 * `DOCKER_FLAGS`: Allows to pass custom flags (e.g., volume mounts) to "docker run" when running LocalStack in Docker.
 * `START_WEB`: Flag to control whether the Web API should be started in Docker (values: `0`/`1`; default: `1`).
 * `LAMBDA_FALLBACK_URL`: Fallback URL to use when a non-existing Lambda is invoked. Either records invocations in DynamoDB (value `dynamodb://<table_name>`) or forwards invocations as a POST request (value `http(s)://...`).
+* `EXTRA_CORS_ALLOWED_HEADERS`: Allow localstack services to accept additional custom headers
+* `EXTRA_CORS_EXPOSE_HEADERS`: Allow localstack services to expose additional custom headers
 
 
 Additionally, the following *read-only* environment variables are available:

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -24,9 +24,19 @@ QUIET = False
 SERVER_CERT_PEM_FILE = '%s/server.test.pem' % (TMP_FOLDER)
 
 # CORS settings
+extra_cors_allowed_headers = os.environ.get('EXTRA_CORS_ALLOWED_HEADERS')
 CORS_ALLOWED_HEADERS = ('authorization', 'content-type', 'content-md5', 'cache-control',
-    'x-amz-content-sha256', 'x-amz-date', 'x-amz-security-token', 'x-amz-user-agent')
+    'x-amz-content-sha256', 'x-amz-date', 'x-amz-security-token', 'x-amz-user-agent',
+    'x-amz-acl', 'x-amz-version-id')
+if extra_cors_allowed_headers:
+    CORS_ALLOWED_HEADERS = CORS_ALLOWED_HEADERS + tuple(extra_cors_allowed_headers.split(','))
+
 CORS_ALLOWED_METHODS = ('HEAD', 'GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'PATCH')
+
+extra_cors_expose_headers = os.environ.get('EXTRA_CORS_EXPOSE_HEADERS')
+CORS_EXPOSE_HEADERS = ('x-amz-version-id',)
+if extra_cors_expose_headers:
+    CORS_EXPOSE_HEADERS = CORS_EXPOSE_HEADERS + tuple(extra_cors_expose_headers.split(','))
 
 # set up logger
 LOGGER = logging.getLogger(__name__)
@@ -261,6 +271,8 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
                 self.send_header('Access-Control-Allow-Methods', ','.join(CORS_ALLOWED_METHODS))
             if 'Access-Control-Allow-Headers' not in response.headers:
                 self.send_header('Access-Control-Allow-Headers', ','.join(CORS_ALLOWED_HEADERS))
+            if 'Access-Control-Expose-Headers' not in response.headers:
+                self.send_header('Access-Control-Expose-Headers', ','.join(CORS_EXPOSE_HEADERS))
 
             self.end_headers()
             if response.content and len(response.content):


### PR DESCRIPTION
While developing a browser application using the AWS S3 Javascript SDK, I ran into some (quite obtuse) issues related to CORS headers.

the S3 SDK expects that certain headers will be both allowed in PUT requests (and the like) and that certain headers will be available in the output. If those headers are not present, the SDK will behave inconsistently (and silently).

Specifically, the SDK expects that `x-amz-acl` and `x-amz-version-id` to be in `Access-Control-Allow-Headers`. It additionally assumes that `x-amz-version-id` will be in the response headers.

Further, S3 `Metadata` is sent via headers, and therefore expects a header looking like `x-amz-meta-*` to be present. However, I couldn't figure out how to GLOB, so instead I elected to add an env var facilitating parameterization of the CORS header space.

Anyway, this PR should unblock consumers using the AWS S3 SDK for Javascript in the Browser Context.