### PR TITLE
Upgrade to ElasticSearch 6.7

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -65,7 +65,7 @@ RUN pip install supervisor
 # init environment and cache some dependencies
 RUN mkdir -p /opt/code/localstack/localstack/infra && \
     wget -O /tmp/localstack.es.zip \
-        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.5.0.zip && \
+        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip && \
     wget -O /tmp/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.5.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \
@@ -73,7 +73,6 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
     (cd localstack/infra/elasticsearch/ && \
         bin/elasticsearch-plugin install analysis-icu && \
         bin/elasticsearch-plugin install ingest-attachment --batch && \
-        bin/elasticsearch-plugin install ingest-user-agent && \
         bin/elasticsearch-plugin install analysis-kuromoji && \
         bin/elasticsearch-plugin install mapper-murmur3 && \
         bin/elasticsearch-plugin install mapper-size && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -74,9 +74,9 @@ APPLICATION_JSON = 'application/json'
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
-ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.5.0.zip'
+ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip'
 # See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
-ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'ingest-user-agent', 'analysis-kuromoji',
+ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'analysis-kuromoji',
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']
 DYNAMODB_JAR_URL = 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip'
 ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar'

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -136,7 +136,7 @@ def get_domain_status(domain_name, deleted=False):
                 'InstanceType': 'm3.medium.elasticsearch',
                 'ZoneAwarenessEnabled': False
             },
-            'ElasticsearchVersion': '6.5',
+            'ElasticsearchVersion': '6.7',
             'Endpoint': aws_stack.get_elasticsearch_endpoint(),
             'Processing': False,
             'EBSOptions': {


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2019/06/amazon-elasticsearch-service-announces-support-for-elasticsearch-67/?nc1=h_ls

 ingest-user-agent is already built-in ES
https://www.elastic.co/guide/en/elasticsearch/plugins/6.7/ingest-user-agent.html