### PR TITLE
Implement EC2 support through Moto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ADD bin/supervisord.conf /etc/supervisord.conf
 ADD bin/docker-entrypoint.sh /usr/local/bin/
 
 # expose service & web dashboard ports
-EXPOSE 4567-4593 8080
+EXPOSE 4567-4597 8080
 
 # define command at startup
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ any longer.
 * **CloudWatch Logs** at http://localhost:4586
 * **STS** at http://localhost:4592
 * **IAM** at http://localhost:4593
-
+* **EC2** at http://localhost:4597
 
 Additionally, *LocalStack* provides a powerful set of tools to interact with the cloud services, including
 a fully featured KCL Kinesis client with Python binding, simple setup/teardown integration for nosetests, as

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - "4567-4593:4567-4593"
+      - "4567-4593:4567-4597"
       - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
       - SERVICES=${SERVICES- }

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -2,7 +2,7 @@ import os
 import localstack_client.config
 
 # LocalStack version
-VERSION = '0.9.4'
+VERSION = '0.9.5'
 
 # default AWS region
 if 'DEFAULT_REGION' not in os.environ:

--- a/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
@@ -203,6 +203,11 @@ public class Localstack {
         return ensureInstallationAndGetEndpoint(ServiceName.STEPFUNCTIONS);
     }
 
+    public static String getEndpointEC2() {
+        return ensureInstallationAndGetEndpoint(ServiceName.EC2);
+    }
+
+
     /* UTILITY METHODS */
 
     /**

--- a/localstack/ext/java/src/main/java/cloud/localstack/ServiceName.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/ServiceName.java
@@ -20,4 +20,6 @@ public class ServiceName {
     public static final String SSM = "ssm";
     public static final String SECRETSMANAGER = "secretsmanager";
     public static final String STEPFUNCTIONS = "stepfunctions";
+    public static final String EC2 = "ec2";
+
 }

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -175,6 +175,10 @@ public class LocalstackDocker {
     public String getEndpointSecretsmanager() {
         return endpointForService(ServiceName.SECRETSMANAGER);
     }
+    
+    public String getEndpointEC2() {
+        return endpointForService(ServiceName.EC2);
+    }
 
     public String getEndpointStepFunctions() { return endpointForService(ServiceName.STEPFUNCTIONS); }
 

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -7,7 +7,7 @@ from localstack.services.iam import iam_listener
 from localstack.services.infra import (register_plugin, Plugin,
     start_sns, start_ses, start_apigateway, start_elasticsearch_service, start_lambda,
     start_redshift, start_firehose, start_cloudwatch, start_dynamodbstreams, start_route53,
-    start_ssm, start_sts, start_secretsmanager, start_iam, start_cloudwatch_logs)
+    start_ssm, start_sts, start_secretsmanager, start_iam, start_cloudwatch_logs, start_ec2)
 from localstack.services.kinesis import kinesis_listener, kinesis_starter
 from localstack.services.dynamodb import dynamodb_listener, dynamodb_starter
 from localstack.services.apigateway import apigateway_listener
@@ -76,6 +76,8 @@ def register_localstack_plugins():
         register_plugin(Plugin('stepfunctions',
             start=stepfunctions_starter.start_stepfunctions,
             listener=stepfunctions_listener.UPDATE_STEPFUNCTIONS))
+        register_plugin(Plugin('ec2',
+            start=start_ec2))
     except Exception as e:
         print('Unable to register plugins: %s' % e)
         sys.stdout.flush()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -263,8 +263,9 @@ def start_secretsmanager(port=None, asynchronous=False):
 
 
 def start_ec2(port=None, asynchronous=False):
-    port = port or config.PORT_EC2 
+    port = port or config.PORT_EC2
     return start_moto_server('ec2', port, name='EC2', asynchronous=asynchronous)
+
 
 # ---------------
 # HELPER METHODS

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -262,6 +262,10 @@ def start_secretsmanager(port=None, asynchronous=False):
     return start_moto_server('secretsmanager', port, name='Secrets Manager', asynchronous=asynchronous)
 
 
+def start_ec2(port=None, asynchronous=False):
+    port = port or config.PORT_EC2 
+    return start_moto_server('ec2', port, name='EC2', asynchronous=asynchronous)
+
 # ---------------
 # HELPER METHODS
 # ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ flask-cors==3.0.3
 flask_swagger==0.2.12
 jsonpath-rw==1.4.0
 localstack-ext>=0.8.6
-localstack-client==0.8
+localstack-client==0.9
 moto-ext>=1.3.7.1
 nose>=1.3.7
 psutil==5.4.8


### PR DESCRIPTION
This adds basic EC2 support using the prexisting Moto implementation. 

It needs an update to the client to pass through the proper port, although I've already bumped the requirements.txt version and submitted a PR - see [here](https://github.com/localstack/localstack-python-client/pull/15).

Open to any input! :)

Closes #691 