### PR TITLE
Fix port range for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - "4567-4593:4567-4597"
+      - "4567-4597:4567-4597"
       - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
       - SERVICES=${SERVICES- }


### PR DESCRIPTION
Currently there isn't a one to one mapping in the ports.  Therefore it is causing the `docker-compose up` command to generate the error in the screenshot below: 

![Screen Shot 2019-06-11 at 2 31 02 PM](https://user-images.githubusercontent.com/5545603/59308331-aa5f6c80-8c55-11e9-8b54-7f0bc93aedaa.png)

The PR here increases the ports to match the ranges and prevent this error.  If it needs to be decreased instead, I can go ahead and do that as well