### PR TITLE
Fix corner-case with `LOCALSTACK_` prefix strip.

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -4,7 +4,12 @@ set -eo pipefail
 shopt -s nullglob
 
 # Strip `LOCALSTACK_` prefix in environment variables name (except LOCALSTACK_HOSTNAME)
-source <(env | grep -v -e '^LOCALSTACK_HOSTNAME' | sed -ne 's/^LOCALSTACK_\([^=]\+\)=.*/export \1=${LOCALSTACK_\1}/p')
+source <(
+  env |
+  grep -v -e '^LOCALSTACK_HOSTNAME' |
+  grep -v -e '^LOCALSTACK_[[:digit:]]' | # See issue #1387
+  sed -ne 's/^LOCALSTACK_\([^=]\+\)=.*/export \1=${LOCALSTACK_\1}/p'
+)
 
 supervisord -c /etc/supervisord.conf &
 


### PR DESCRIPTION
PR #1181 introduced the ability to prefix localstack's environment
variables with `LOCALSTACK_` in the Docker image. However, it also
introduced a crash when a variable called `LOCALSTACK_` immediately
followed by a digit was present in the environment. The entrypoint
would try to re-export a variable starting with a digit which would
obviously fail.

The fix consist in skipping problematic variables in the entrypoint.
Such variable don't make sense for localstack anyways.

Fixes #1387

