### PR TITLE
Fixed IAM requests sent with wrong account ID to moto

### DIFF
--- a/localstack/services/iam/iam_listener.py
+++ b/localstack/services/iam/iam_listener.py
@@ -32,8 +32,8 @@ class ProxyListenerIAM(ProxyListener):
         self._replace(response, pattern, replacement)
 
     def _fix_account_id(self, response):
-        pattern = r'<Arn>\s*arn:aws:iam::([0-9]+):([^<]+)</Arn>'
-        replacement = r'<Arn>arn:aws:iam::%s:\2</Arn>' % TEST_AWS_ACCOUNT_ID
+        pattern = r'<([^>]*)Arn>\s*arn:aws:iam::([0-9]+):([^<]+)</\1Arn>'
+        replacement = r'<\1Arn>arn:aws:iam::%s:\3</\1Arn>' % TEST_AWS_ACCOUNT_ID
         self._replace(response, pattern, replacement)
 
     def _reset_account_id(self, data):

--- a/localstack/services/iam/iam_listener.py
+++ b/localstack/services/iam/iam_listener.py
@@ -1,10 +1,19 @@
 import re
-from localstack.constants import TEST_AWS_ACCOUNT_ID
+from requests.models import Request
+from localstack.constants import TEST_AWS_ACCOUNT_ID, MOTO_ACCOUNT_ID
+from localstack.utils.aws import aws_stack
 from localstack.utils.common import to_str
 from localstack.services.generic_proxy import ProxyListener
 
 
 class ProxyListenerIAM(ProxyListener):
+
+    def forward_request(self, method, path, data, headers):
+        if method == 'POST' and path == '/':
+            data = self._reset_account_id(data)
+            return Request(data=data, headers=headers, method=method)
+
+        return True
 
     def return_response(self, method, path, data, headers, response):
 
@@ -26,6 +35,13 @@ class ProxyListenerIAM(ProxyListener):
         pattern = r'<Arn>\s*arn:aws:iam::([0-9]+):([^<]+)</Arn>'
         replacement = r'<Arn>arn:aws:iam::%s:\2</Arn>' % TEST_AWS_ACCOUNT_ID
         self._replace(response, pattern, replacement)
+
+    def _reset_account_id(self, data):
+        """ Fix account ID in request payload. All external-facing responses contain our
+            predefined account ID (defaults to 000000000000), whereas the backend endpoint
+            from moto expects a different hardcoded account ID (123456789012). """
+        return aws_stack.fix_account_id_in_arns(
+            data, colon_delimiter='%3A', existing=TEST_AWS_ACCOUNT_ID, replace=MOTO_ACCOUNT_ID)
 
     def _replace(self, response, pattern, replacement):
         content = to_str(response.content)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -255,7 +255,7 @@ def fix_account_id_in_arns(response, colon_delimiter=':', existing=None, replace
 
     replace = r'arn{col}aws{col}\1{col}\2{col}{acc}{col}'.format(col=colon_delimiter, acc=replace)
     for acc_id in existing:
-        regex = r'arn{col}aws{col}([^:%]+){col}([^:%]+){col}{acc}{col}'.format(col=colon_delimiter, acc=acc_id)
+        regex = r'arn{col}aws{col}([^:%]+){col}([^:%]*){col}{acc}{col}'.format(col=colon_delimiter, acc=acc_id)
         content = re.sub(regex, replace, content)
 
     if not is_str_obj:

--- a/tests/integration/test_iam_credentials.py
+++ b/tests/integration/test_iam_credentials.py
@@ -3,6 +3,7 @@ import logging
 import json
 import unittest
 
+from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack
 from localstack.utils.kinesis import kinesis_connector
 
@@ -45,4 +46,8 @@ class TestIAMIntegrations(unittest.TestCase):
         response = iam_client.create_policy(PolicyName='test-policy',
                                             PolicyDocument=json.dumps(test_policy_document))
         test_policy_arn = response['Policy']['Arn']
+        assert TEST_AWS_ACCOUNT_ID in test_policy_arn
         iam_client.attach_user_policy(UserName=test_user_name, PolicyArn=test_policy_arn)
+        attached_user_policies = iam_client.list_attached_user_policies(UserName=test_user_name)
+        assert len(attached_user_policies['AttachedPolicies']) == 1
+        assert attached_user_policies['AttachedPolicies'][0]['PolicyArn'] == test_policy_arn

--- a/tests/integration/test_iam_credentials.py
+++ b/tests/integration/test_iam_credentials.py
@@ -1,23 +1,48 @@
 import os
 import logging
+import json
+import unittest
+
+from localstack.utils.aws import aws_stack
 from localstack.utils.kinesis import kinesis_connector
 
 
-def run_kcl_with_iam_assume_role():
-    env_vars = {}
-    if os.environ.get('AWS_ASSUME_ROLE_ARN'):
-        env_vars['AWS_ASSUME_ROLE_ARN'] = os.environ.get('AWS_ASSUME_ROLE_ARN')
-        env_vars['AWS_ASSUME_ROLE_SESSION_NAME'] = os.environ.get('AWS_ASSUME_ROLE_SESSION_NAME')
-        env_vars['ENV'] = os.environ.get('ENV') or 'main'
+class TestIAMIntegrations(unittest.TestCase):
 
-        def process_records(records):
-            print(records)
+    def test_run_kcl_with_iam_assume_role(self):
+        env_vars = {}
+        if os.environ.get('AWS_ASSUME_ROLE_ARN'):
+            env_vars['AWS_ASSUME_ROLE_ARN'] = os.environ.get('AWS_ASSUME_ROLE_ARN')
+            env_vars['AWS_ASSUME_ROLE_SESSION_NAME'] = os.environ.get('AWS_ASSUME_ROLE_SESSION_NAME')
+            env_vars['ENV'] = os.environ.get('ENV') or 'main'
 
-        # start Kinesis client
-        stream_name = 'test-foobar'
-        kinesis_connector.listen_to_kinesis(
-            stream_name=stream_name,
-            listener_func=process_records,
-            env_vars=env_vars,
-            kcl_log_level=logging.INFO,
-            wait_until_started=True)
+            def process_records(records):
+                print(records)
+
+            # start Kinesis client
+            stream_name = 'test-foobar'
+            kinesis_connector.listen_to_kinesis(
+                stream_name=stream_name,
+                listener_func=process_records,
+                env_vars=env_vars,
+                kcl_log_level=logging.INFO,
+                wait_until_started=True)
+
+    def test_attach_iam_role_to_new_iam_user(self):
+        test_policy_document = {
+            'Version': '2012-10-17',
+            'Statement': {
+                'Effect': 'Allow',
+                'Action': 's3:ListBucket',
+                'Resource': 'arn:aws:s3:::example_bucket'
+            }
+        }
+        test_user_name = 'test-user'
+
+        iam_client = aws_stack.connect_to_service('iam')
+
+        iam_client.create_user(UserName=test_user_name)
+        response = iam_client.create_policy(PolicyName='test-policy',
+                                            PolicyDocument=json.dumps(test_policy_document))
+        test_policy_arn = response['Policy']['Arn']
+        iam_client.attach_user_policy(UserName=test_user_name, PolicyArn=test_policy_arn)

--- a/tests/integration/test_iam_credentials.py
+++ b/tests/integration/test_iam_credentials.py
@@ -46,8 +46,8 @@ class TestIAMIntegrations(unittest.TestCase):
         response = iam_client.create_policy(PolicyName='test-policy',
                                             PolicyDocument=json.dumps(test_policy_document))
         test_policy_arn = response['Policy']['Arn']
-        assert TEST_AWS_ACCOUNT_ID in test_policy_arn
+        self.assertIn(TEST_AWS_ACCOUNT_ID, test_policy_arn)
         iam_client.attach_user_policy(UserName=test_user_name, PolicyArn=test_policy_arn)
         attached_user_policies = iam_client.list_attached_user_policies(UserName=test_user_name)
-        assert len(attached_user_policies['AttachedPolicies']) == 1
-        assert attached_user_policies['AttachedPolicies'][0]['PolicyArn'] == test_policy_arn
+        self.assertEqual(len(attached_user_policies['AttachedPolicies']), 1)
+        self.assertEqual(attached_user_policies['AttachedPolicies'][0]['PolicyArn'], test_policy_arn)


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
Localstack overwrites the account ID in ARNs in IAM responses from moto, but did not reset it when sending requests to it.
I added a test case to demonstrate the bug that this PR addresses.
