### PR TITLE
Added MessageAttributes and others on SNS publish payload

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -192,9 +192,9 @@ def process_sns_notification(func_arn, topic_arn, subscriptionArn, message, mess
     try:
         event = {
             'Records': [{
-                "EventSource": "localstack:sns",
-                "EventVersion": "1.0",
-                "EventSubscriptionArn": subscriptionArn,
+                'EventSource': 'localstack:sns',
+                'EventVersion': '1.0',
+                'EventSubscriptionArn': subscriptionArn,
                 'Sns': {
                     'Type': 'Notification',
                     'TopicArn': topic_arn,

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -188,16 +188,20 @@ def process_apigateway_invocation(func_arn, path, payload, headers={},
         LOG.warning('Unable to run Lambda function on API Gateway message: %s %s' % (e, traceback.format_exc()))
 
 
-def process_sns_notification(func_arn, topic_arn, message, subject=''):
+def process_sns_notification(func_arn, topic_arn, subscriptionArn, message, message_attributes, subject='',):
     try:
         event = {
             'Records': [{
+                "EventSource": "localstack:sns",
+                "EventVersion": "1.0",
+                "EventSubscriptionArn": subscriptionArn,
                 'Sns': {
                     'Type': 'Notification',
                     'TopicArn': topic_arn,
                     'Subject': subject,
                     'Message': message,
-                    'Timestamp': timestamp(format=TIMESTAMP_FORMAT_MILLIS)
+                    'Timestamp': timestamp(format=TIMESTAMP_FORMAT_MILLIS),
+                    'MessageAttributes': message_attributes
                 }
             }]
         }

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -150,7 +150,11 @@ def publish_message(topic_arn, req_data):
         elif subscriber['Protocol'] == 'lambda':
             lambda_api.process_sns_notification(
                 subscriber['Endpoint'],
-                topic_arn, message, subject=req_data.get('Subject', [None])[0]
+                topic_arn,
+                subscriber['SubscriptionArn'],
+                message,
+                message_attributes,
+                subject=req_data.get('Subject', [None])[0]
             )
         elif subscriber['Protocol'] in ['http', 'https']:
             try:


### PR DESCRIPTION
Currently, when a Lambda function is invoked by a SNS topic, some attributes aren't forwarded. This PR includes the following attributes inside the object in the `Records` array:

- EventSource with a fixed value of `localstack:sns`
- EventVersion with a fixed value of `1.0`
- EventSubscriptionArn with the arn of the subscriptoin between the topic and function,
- MessageAttributes containing an object with the message attributes published in the original event

**Note for the `EventSource` attribute**: originally, this attribute have a fixed value of `aws:sns`. In my opinion, change this value gives an opportunity to the services that are using localstack to know in which environment they are being executed, but I would like to know what you think about.

