### PR TITLE
Add basic EventBridge (CloudWatch Events) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ any longer.
 * **SecretsManager** at http://localhost:4584
 * **StepFunctions** at http://localhost:4585
 * **CloudWatch Logs** at http://localhost:4586
+* **EventBridge (CloudWatch Events)** at http://localhost:4587
 * **STS** at http://localhost:4592
 * **IAM** at http://localhost:4593
 * **EC2** at http://localhost:4597

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -5,7 +5,7 @@ from localstack.services.sns import sns_listener
 from localstack.services.sqs import sqs_listener, sqs_starter
 from localstack.services.iam import iam_listener
 from localstack.services.infra import (register_plugin, Plugin,
-    start_sns, start_ses, start_apigateway, start_elasticsearch_service, start_lambda,
+    start_sns, start_ses, start_apigateway, start_elasticsearch_service, start_events, start_lambda,
     start_redshift, start_firehose, start_cloudwatch, start_dynamodbstreams, start_route53,
     start_ssm, start_sts, start_secretsmanager, start_iam, start_cloudwatch_logs, start_ec2)
 from localstack.services.kinesis import kinesis_listener, kinesis_starter
@@ -71,6 +71,8 @@ def register_localstack_plugins():
             listener=cloudformation_listener.UPDATE_CLOUDFORMATION))
         register_plugin(Plugin('cloudwatch',
             start=start_cloudwatch))
+        register_plugin(Plugin('events',
+            start=start_events))
         register_plugin(Plugin('logs',
             start=start_cloudwatch_logs))
         register_plugin(Plugin('stepfunctions',

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -206,6 +206,11 @@ def start_cloudwatch_logs(port=None, asynchronous=False):
     return start_moto_server('logs', port, name='CloudWatch Logs', asynchronous=asynchronous)
 
 
+def start_events(port=None, asynchronous=False):
+    port = port or config.PORT_EVENTS
+    return start_moto_server('events', port, name='CloudWatch Events', asynchronous=asynchronous)
+
+
 def start_sts(port=None, asynchronous=False):
     port = port or config.PORT_STS
     return start_moto_server('sts', port, name='STS', asynchronous=asynchronous)

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import json
+import unittest
+from datetime import datetime
+
+from localstack.utils.aws import aws_stack
+
+TEST_RULE_NAME = 'TestRule'
+TEST_EVENT_SOURCE = 'integration_tests'
+TEST_DETAIL_TYPE = 'TEST_EVENT'
+
+TEST_EVENT_PATTERN = {
+    'Source': TEST_EVENT_SOURCE,
+    'DetailType': TEST_DETAIL_TYPE,
+    'Detail': 'something'
+}
+
+
+class EventsTest(unittest.TestCase):
+
+    def setUp(self):
+        self.events_client = aws_stack.connect_to_service('events')
+
+    def test_put_rule(self):
+        self.events_client.put_rule(Name='test_rule', EventPattern=json.dumps(TEST_EVENT_PATTERN))
+        rules = self.events_client.list_rules(NamePrefix='test_rule')['Rules']
+
+        self.assertEqual(1, len(rules))
+        self.assertEqual(TEST_EVENT_PATTERN, json.loads(rules[0]['EventPattern']))
+
+    def test_put_events(self):
+        self.events_client.put_events(Entries=[{
+            'Time': datetime(2019, 7, 29),
+            'DetailType': TEST_DETAIL_TYPE,
+            'Detail': 'some detail'
+        }])


### PR DESCRIPTION
This adds a moto server for CloudWatch Events / EventBridge.

Relates to issue #103 but does not add a full implementation with event triggering. The benefit of merging this PR is that you can invoke CloudWatch Events APIs like `put_rule` and `put_events` against a local target. A separate PR would be required to add full event bus support with scheduled events, triggers and targets.