### PR TITLE
awscli requires `PyYAML<=5.1,>=3.10`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ psutil==5.4.8
 pympler>=0.6
 pyopenssl==17.5.0
 python-coveralls>=2.9.1
-pyyaml>=3.13
+pyyaml>=3.13,<=5.1
 requests>=2.20.0
 requests-aws4auth==0.9
 six>=1.12.0


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**

Having some issue running with `make reinstall-p3 init prepare-java-tests-if-changed`
```
...
Installing setuptools, pip, wheel...
done.
ERROR: awscli 1.16.206 has requirement PyYAML<=5.1,>=3.10; python_version != "2.6", but you'll have pyyaml 5.1.1 which is incompatible.
...
```

After version constraint update, it works fine.