### PR TITLE
Fix dynamodbstreams api uuid generation incompatibility with python 3.6

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -5,6 +5,7 @@ from flask import Flask, jsonify, request, make_response
 from localstack.services import generic_proxy
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import to_str
+import six
 
 APP_NAME = 'ddb_streams_api'
 
@@ -133,8 +134,11 @@ def stream_name_from_stream_arn(stream_arn):
 
 
 def random_id(stream_arn, kinesis_shard_id):
-    namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn.encode('utf-8')).digest()[:16])
-    return uuid.uuid5(namespace, kinesis_shard_id.encode('utf-8')).hex
+    if six.PY2:
+        stream_arn = stream_arn.encode('utf-8')
+        kinesis_shard_id = kinesis_shard_id('utf-8')
+    namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn).digest()[:16])
+    return uuid.uuid5(namespace, kinesis_shard_id).hex
 
 
 def shard_id(stream_arn, kinesis_shard_id):

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -4,8 +4,7 @@ import hashlib
 from flask import Flask, jsonify, request, make_response
 from localstack.services import generic_proxy
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import to_str
-import six
+from localstack.utils.common import to_str, to_bytes
 
 APP_NAME = 'ddb_streams_api'
 
@@ -134,10 +133,8 @@ def stream_name_from_stream_arn(stream_arn):
 
 
 def random_id(stream_arn, kinesis_shard_id):
-    if six.PY2:
-        kinesis_shard_id = kinesis_shard_id.encode('utf-8')
     namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn.encode('utf-8')).digest()[:16])
-    return uuid.uuid5(namespace, kinesis_shard_id).hex
+    return uuid.uuid5(namespace, to_bytes(kinesis_shard_id)).hex
 
 
 def shard_id(stream_arn, kinesis_shard_id):

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -135,9 +135,8 @@ def stream_name_from_stream_arn(stream_arn):
 
 def random_id(stream_arn, kinesis_shard_id):
     if six.PY2:
-        stream_arn = stream_arn.encode('utf-8')
-        kinesis_shard_id = kinesis_shard_id('utf-8')
-    namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn).digest()[:16])
+        kinesis_shard_id = kinesis_shard_id.encode('utf-8')
+    namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn.encode('utf-8')).digest()[:16])
     return uuid.uuid5(namespace, kinesis_shard_id).hex
 
 


### PR DESCRIPTION
#### This change set aims to fix the uuid generation error by removing `.decode('utf-8')` in python3.6.

python3.6 will return `TypeError: encoding without a string argument` when running ```uuid.uuid5(namespace=namespace, name=namestring.encode('utf-8'))``` , which seems to be only supported by python2, thus causing error on DynamoDB streams api.

Since LocalStack latest docker image runs on python3.6, I think this issue will cause shard_id generation failure in `dynamodbstreams_api.py`.

More reference regarding to this issue:
`https://bugs.python.org/issue34145` 
