### PR TITLE
Lambda Event Body over STDIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+dist: xenial
 
 language: python
 
@@ -6,13 +6,14 @@ services:
   - docker
 
 python:
-  - "3.6"
+  - "3.7"
 
 branches:
   only:
     - master
 
 before_install:
+  - "sudo apt-get update -q"
   - "sudo apt-get purge openjdk-6*"
   - "sudo apt-get purge openjdk-7*"
   - "sudo apt-get purge oracle-java7-*"
@@ -23,11 +24,11 @@ before_install:
 addons:
   apt:
     packages:
-    - oracle-java8-installer
+    - openjdk-8-jre-headless
 
 env:
   global:
-    - JAVA_HOME=/usr/lib/jvm/java-8-oracle
+    - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 install:
   - set -e
@@ -50,7 +51,7 @@ script:
   #   but instead reinstall using 2.x here, as that allows us to re-use some cached libs etc.
   - "make reinstall-p2 > /dev/null"
   - make init
-  - LAMBDA_EXECUTOR=docker-reuse USE_SSL=1 make test
+  - DEBUG=1 LAMBDA_EXECUTOR=docker-reuse USE_SSL=1 make test
   # build Docker image
   - make docker-build
   # run Java tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ addons:
 env:
   global:
     - JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - BOTO_CONFIG=/dev/null
 
 install:
   - set -e

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -26,7 +26,7 @@ public class LocalstackDocker {
     private static final Logger LOG = Logger.getLogger(LocalstackDocker.class.getName());
 
     private static final String PORT_CONFIG_FILENAME = "/opt/code/localstack/" +
-            ".venv/lib/python3.6/site-packages/localstack_client/config.py";
+            ".venv/lib/python3.7/site-packages/localstack_client/config.py";
 
     private static final Pattern READY_TOKEN = Pattern.compile("Ready\\.");
 
@@ -171,11 +171,11 @@ public class LocalstackDocker {
     public String getEndpointSSM() {
         return endpointForService(ServiceName.SSM);
     }
-    
+
     public String getEndpointSecretsmanager() {
         return endpointForService(ServiceName.SECRETSMANAGER);
     }
-    
+
     public String getEndpointEC2() {
         return endpointForService(ServiceName.EC2);
     }

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -568,7 +568,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                 ' "lambci/lambda:%s" %s'
                 ')";'
                 '%s cp "%s/." "$CONTAINER_ID:/var/task"; '
-                '%s start -a "$CONTAINER_ID";'
+                '%s start -ai "$CONTAINER_ID";'
             ) % (entrypoint, env_vars_string, network_str, runtime, command, docker_cmd, lambda_cwd, docker_cmd)
         else:
             lambda_cwd_on_host = self.get_host_path_for_path_in_docker(lambda_cwd)

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -189,7 +189,7 @@ class LambdaExecutorContainers(LambdaExecutor):
             LOG.warning('Empty event body specified for invocation of Lambda "%s"' % func_arn)
             event = {}
         event_body = json.dumps(event)
-        stdin = self.prepare_event(environment, event)
+        stdin = self.prepare_event(environment, event_body)
 
         docker_host = config.DOCKER_HOST_FROM_CONTAINER
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -273,13 +273,14 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             copy_command = '%s cp "%s" "%s:/var/task";' % (docker_cmd, event_file, container_info.name)
 
         if copy_command is not None:
+            LOG.debug('Running lambda copy cmd: %s' % copy_command)
             self.run_lambda_executor(copy_command)
 
         cmd = (
             '%s exec -i'
             ' %s'  # env variables
             ' %s'  # container name
-            ' %s'  # run cmd
+            ' %s "$(</dev/stdin)"'  # run cmd
         ) % (docker_cmd, exec_env_vars, container_info.name, command)
         LOG.debug('Command for docker-reuse Lambda executor: %s' % cmd)
 

--- a/localstack/utils/server/multiserver.py
+++ b/localstack/utils/server/multiserver.py
@@ -94,7 +94,7 @@ def start_server_process(port):
     thread.start()
     TMP_THREADS.append(thread)
     config['thread'] = thread
-    wait_for_port_open(port, retries=10, sleep_time=1)
+    wait_for_port_open(port, retries=20, sleep_time=1)
     return thread
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ airspeed==0.5.10
 amazon_kclpy-ext==1.5.1
 # amazon-kclpy==1.5.1
 awscli>=1.14.18
-google-compute-engine>=2.8.13,<3.0.0
 boto>=2.49.0
 boto3>=1.9.71                  #basic-lib
 botocore>=1.12.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ airspeed==0.5.10
 amazon_kclpy-ext==1.5.1
 # amazon-kclpy==1.5.1
 awscli>=1.14.18
+google-compute-engine>=2.8.13,<3.0.0
 boto>=2.49.0
 boto3>=1.9.71                  #basic-lib
 botocore>=1.12.13


### PR DESCRIPTION
Command line arguments are limited in size, but the event body for lambda should be able to accommodate up to 6Mb of data.  Event bodies can be sent to [lambci/docker-lambda](https://github.com/lambci/docker-lambda) as either an environment variable, a command line argument, or as STDIN.  

Fixes #1055 and #1081 