### PR TITLE
fix: prevent infra from stopping if multiserver is used

### DIFF
--- a/localstack/utils/server/multiserver.py
+++ b/localstack/utils/server/multiserver.py
@@ -67,7 +67,7 @@ def start_server(port):
 
 def start_api_server(api, port, server_port=None):
     server_port = server_port or MULTI_SERVER_PORT
-    start_server_process(server_port)
+    thread = start_server_process(server_port)
     url = 'http://localhost:%s%s' % (server_port, API_PATH_SERVERS)
     payload = {
         'api': api,
@@ -77,6 +77,7 @@ def start_api_server(api, port, server_port=None):
     if result.status_code >= 400:
         raise Exception('Unable to start API in multi server (%s): %s' %
                         (result.status_code, result.content))
+    return thread
 
 
 def start_server_process(port):


### PR DESCRIPTION
If you start localstack with only one (moto)service (e.g. `events) it will start it and stop it immediately.
I've found that the newly introduced multiserver causes this issue, cause it's thread is not returned [here](https://github.com/localstack/localstack/blob/4fe68f064b2f3d6dff2a102ba2de4793502ccf1b/localstack/services/infra.py#L385) in the main thread (and therefore the main thread is stopped [here](https://github.com/localstack/localstack/blob/4fe68f064b2f3d6dff2a102ba2de4793502ccf1b/localstack/services/infra.py#L395), as expected).