### PR TITLE
Added JAVA_OPTS env for lambda ide debug purpose. Only as docker in l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ You can pass the following environment variables to LocalStack:
 * `LAMBDA_FALLBACK_URL`: Fallback URL to use when a non-existing Lambda is invoked. Either records invocations in DynamoDB (value `dynamodb://<table_name>`) or forwards invocations as a POST request (value `http(s)://...`).
 * `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header
 * `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Expose-Headers` CORS header
+* `LAMBDA_JAVA_OPTS`: Allow to pass custom options(-Xmx512M) and/or for debugging(-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=) to JVM executed as docker in LAMBDA_EXECUTOR variable. 
+   Pay attention, you shouldn't add a port in address argument, it should empty(address=)                       
 
 
 Additionally, the following *read-only* environment variables are available:

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ You can pass the following environment variables to LocalStack:
 * `LAMBDA_FALLBACK_URL`: Fallback URL to use when a non-existing Lambda is invoked. Either records invocations in DynamoDB (value `dynamodb://<table_name>`) or forwards invocations as a POST request (value `http(s)://...`).
 * `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header
 * `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Expose-Headers` CORS header
-* `LAMBDA_JAVA_OPTS`: Allow to pass custom options(-Xmx512M) and/or for debugging(-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=) to JVM executed as docker in LAMBDA_EXECUTOR variable. 
-   Pay attention, you shouldn't add a port in address argument, it should empty(address=)                       
+* `LAMBDA_JAVA_OPTS`: Allow to pass custom options(-Xmx512M) and/or for debugging(-agentlib:jdwp=transport=dt_socket,server=y,suspend=y) to JVM executed as docker in LAMBDA_EXECUTOR variable. 
+   Pay attention, use __debug_port_ placeholder like port address if you want debug with your IDE (-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,__debug_port_)                
 
 
 Additionally, the following *read-only* environment variables are available:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ You can pass the following environment variables to LocalStack:
 * `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header
 * `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Expose-Headers` CORS header
 * `LAMBDA_JAVA_OPTS`: Allow to pass custom options(-Xmx512M) and/or for debugging(-agentlib:jdwp=transport=dt_socket,server=y,suspend=y) to JVM executed as docker in LAMBDA_EXECUTOR variable. 
-   Pay attention, use __debug_port_ placeholder like port address if you want debug with your IDE (-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,__debug_port_)                
+   Pay attention, use __debug_port_ placeholder like port if you want debug with your IDE.
+   `I.e: (-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=_debug_port_) `               
 
 
 Additionally, the following *read-only* environment variables are available:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -12,6 +12,9 @@ from localstack.constants import DEFAULT_SERVICE_PORTS, LOCALHOST, PATH_USER_REQ
 
 TRUE_VALUES = ('1', 'true')
 
+# java options to Lambda
+
+JAVA_OPTS = os.environ.get('JAVA_OPTS', '').strip()
 
 # randomly inject faults to Kinesis
 KINESIS_ERROR_PROBABILITY = float(os.environ.get('KINESIS_ERROR_PROBABILITY', '').strip() or 0.0)
@@ -100,7 +103,6 @@ if not LAMBDA_EXECUTOR:
     if not has_docker():
         LAMBDA_EXECUTOR = 'local'
 
-
 # Fallback URL to use when a non-existing Lambda is invoked. If this matches
 # `dynamodb://<table_name>`, then the invocation is recorded in the corresponding
 # DynamoDB table. If this matches `http(s)://...`, then the Lambda invocation is
@@ -111,8 +113,11 @@ LAMBDA_FALLBACK_URL = os.environ.get('LAMBDA_FALLBACK_URL', '').strip()
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOSTNAME', 'LAMBDA_FALLBACK_URL',
-    'LAMBDA_EXECUTOR', 'LAMBDA_REMOTE_DOCKER', 'LAMBDA_DOCKER_NETWORK', 'USE_SSL', 'LOCALSTACK_API_KEY', 'DEBUG',
-    'KINESIS_ERROR_PROBABILITY', 'DYNAMODB_ERROR_PROBABILITY', 'PORT_WEB_UI', 'START_WEB', 'DOCKER_BRIDGE_IP']
+                   'LAMBDA_EXECUTOR', 'LAMBDA_REMOTE_DOCKER', 'LAMBDA_DOCKER_NETWORK', 'USE_SSL', 'LOCALSTACK_API_KEY',
+                   'DEBUG',
+                   'KINESIS_ERROR_PROBABILITY', 'DYNAMODB_ERROR_PROBABILITY', 'PORT_WEB_UI', 'START_WEB',
+                   'DOCKER_BRIDGE_IP',
+                   'JAVA_OPTS']
 
 for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
     clean_key = key.upper().replace('-', '_')
@@ -274,4 +279,4 @@ USE_PROFILER = os.environ.get('USE_PROFILER', '').lower() in TRUE_VALUES
 
 # set URL pattern of inbound API gateway
 INBOUND_GATEWAY_URL_PATTERN = ('%s/restapis/{api_id}/{stage_name}/%s{path}' %
-    (TEST_APIGATEWAY_URL, PATH_USER_REQUEST))  # noqa
+                               (TEST_APIGATEWAY_URL, PATH_USER_REQUEST))  # noqa

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -14,7 +14,7 @@ TRUE_VALUES = ('1', 'true')
 
 # java options to Lambda
 
-JAVA_OPTS = os.environ.get('JAVA_OPTS', '').strip()
+LAMBDA_JAVA_OPTS = os.environ.get('LAMBDA_JAVA_OPTS', '').strip()
 
 # randomly inject faults to Kinesis
 KINESIS_ERROR_PROBABILITY = float(os.environ.get('KINESIS_ERROR_PROBABILITY', '').strip() or 0.0)
@@ -117,7 +117,7 @@ CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOST
                    'DEBUG',
                    'KINESIS_ERROR_PROBABILITY', 'DYNAMODB_ERROR_PROBABILITY', 'PORT_WEB_UI', 'START_WEB',
                    'DOCKER_BRIDGE_IP',
-                   'JAVA_OPTS']
+                   'LAMBDA_JAVA_OPTS']
 
 for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
     clean_key = key.upper().replace('-', '_')

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -652,8 +652,8 @@ class Util:
     @staticmethod
     def get_java_opts(port):
         opts = config.LAMBDA_JAVA_OPTS
-        if opts.find('address'):
-            java_opts = opts.replace('address=', ('address=%s' % port))
+        if opts.find('_debug_port_'):
+            java_opts = opts.replace('_debug_port_', ('address=%s' % port))
             return java_opts
 
         return opts

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -582,7 +582,10 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                 ')";'
                 '%s cp "%s/." "$CONTAINER_ID:/var/task"; '
                 '%s start -ai "$CONTAINER_ID";'
-            ) % (entrypoint, debug_docker_java_port, env_vars_string, network_str, runtime, command, docker_cmd, lambda_cwd, docker_cmd)
+            ) % (entrypoint, debug_docker_java_port, env_vars_string, network_str, runtime, command,
+                 docker_cmd,
+                 lambda_cwd,
+                 docker_cmd)
         else:
             lambda_cwd_on_host = self.get_host_path_for_path_in_docker(lambda_cwd)
             cmd = (

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -653,7 +653,7 @@ class Util:
     def get_java_opts(port):
         opts = config.LAMBDA_JAVA_OPTS
         if opts.find('_debug_port_'):
-            java_opts = opts.replace('_debug_port_', ('address=%s' % port))
+            java_opts = opts.replace('_debug_port_', ('%s' % port))
             return java_opts
 
         return opts

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -404,7 +404,7 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_java_options_without_port_specified(self):
         expected = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000'
-        result = self.prepareJavaOpts('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,_debug_port_')
+        result = self.prepareJavaOpts('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=_debug_port_')
         self.assertEqual(expected, result)
 
     def test_java_options_empty_return_empty_value(self):
@@ -419,7 +419,8 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_java_options_with_memory_options_and_agentlib_option(self):
         expected = '-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000'
-        result = self.prepareJavaOpts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,_debug_port_')
+        result = self.prepareJavaOpts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y'
+                                      ',suspend=y,address=_debug_port_')
         self.assertEqual(expected, result)
 
     def prepareJavaOpts(self, java_opts):

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -404,7 +404,7 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_java_options_without_port_specified(self):
         expected = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000'
-        result = self.prepareJavaOpts('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=')
+        result = self.prepareJavaOpts('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,_debug_port_')
         self.assertEqual(expected, result)
 
     def test_java_options_empty_return_empty_value(self):
@@ -419,7 +419,7 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_java_options_with_memory_options_and_agentlib_option(self):
         expected = '-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000'
-        result = self.prepareJavaOpts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=')
+        result = self.prepareJavaOpts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,_debug_port_')
         self.assertEqual(expected, result)
 
     def prepareJavaOpts(self, java_opts):

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -402,6 +402,31 @@ class TestLambdaAPI(unittest.TestCase):
             self.assertTrue('Tags' in result)
             self.assertDictEqual({'hello': 'world'}, result['Tags'])
 
+    def test_java_options_without_port_specified(self):
+        expected = '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000'
+        result = self.prepareJavaOpts('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=')
+        self.assertEqual(expected, result)
+
+    def test_java_options_empty_return_empty_value(self):
+        lambda_executors.config.LAMBDA_JAVA_OPTS = ''
+        result = lambda_executors.Util.get_java_opts(10000)
+        self.assertFalse(result)
+
+    def test_java_options_with_only_memory_options(self):
+        expected = '-Xmx512M'
+        result = self.prepareJavaOpts(expected)
+        self.assertEqual(expected, result)
+
+    def test_java_options_with_memory_options_and_agentlib_option(self):
+        expected = '-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=10000'
+        result = self.prepareJavaOpts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=')
+        self.assertEqual(expected, result)
+
+    def prepareJavaOpts(self, java_opts):
+        lambda_executors.config.LAMBDA_JAVA_OPTS = java_opts
+        result = lambda_executors.Util.get_java_opts(10000)
+        return result
+
     def _create_function(self, function_name, tags={}):
         arn = lambda_api.func_arn(function_name)
         lambda_api.arn_to_lambda[arn] = LambdaFunction(arn)


### PR DESCRIPTION
Added JAVA_OPTS env for lambda ide debug purpose. Only as docker in lambda executor

Add JAVA_OPTS in docker-compose.yml

Sample:
JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y

Port is defined randomly