### PR TITLE
support overriding kinesalite defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ You can pass the following environment variables to LocalStack:
 * `USE_SSL`: Whether to use `https://...` URLs with SSL encryption (defaults to `false`).
 * `KINESIS_ERROR_PROBABILITY`: Decimal value between 0.0 (default) and 1.0 to randomly
   inject `ProvisionedThroughputExceededException` errors into Kinesis API responses.
+* `KINESIS_SHARD_LIMIT`: Integer value (defaults to `100`) or `Infinity` (to disable), in which to kinesalite will start throwing exceptions to mimick the [default shard limit](https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html).
+* `KINESIS_LATENCY`: Integer value (defaults to `500`) or `0` (to disable), in which to kinesalite will delay returning a response in order to mimick latency from a live AWS call.
 * `DYNAMODB_ERROR_PROBABILITY`: Decimal value between 0.0 (default) and 1.0 to randomly
   inject `ProvisionedThroughputExceededException` errors into DynamoDB API responses.
 * `LAMBDA_EXECUTOR`: Method to use for executing Lambda functions. Possible values are:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -12,6 +12,11 @@ from localstack.constants import DEFAULT_SERVICE_PORTS, LOCALHOST, PATH_USER_REQ
 
 TRUE_VALUES = ('1', 'true')
 
+# limit in which to kinesalite will start throwing exceptions
+KINESIS_SHARD_LIMIT = os.environ.get('KINESIS_SHARD_LIMIT', '').strip() or '100'
+
+# delay in kinesalite response when making changes to streams
+KINESIS_LATENCY = os.environ.get('KINESIS_LATENCY', '').strip() or '500'
 
 # randomly inject faults to Kinesis
 KINESIS_ERROR_PROBABILITY = float(os.environ.get('KINESIS_ERROR_PROBABILITY', '').strip() or 0.0)

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -11,17 +11,23 @@ from localstack.services.install import ROOT_PATH
 LOGGER = logging.getLogger(__name__)
 
 
-def start_kinesis(port=None, asynchronous=False, shard_limit=100, update_listener=None):
+def start_kinesis(port=None, asynchronous=False, update_listener=None):
     port = port or config.PORT_KINESIS
     install.install_kinesalite()
     backend_port = DEFAULT_PORT_KINESIS_BACKEND
+    latency = config.KINESIS_LATENCY
     kinesis_data_dir_param = ''
     if config.DATA_DIR:
         kinesis_data_dir = '%s/kinesis' % config.DATA_DIR
         mkdir(kinesis_data_dir)
         kinesis_data_dir_param = '--path %s' % kinesis_data_dir
-    cmd = ('%s/node_modules/kinesalite/cli.js --shardLimit %s --port %s %s' %
-        (ROOT_PATH, shard_limit, backend_port, kinesis_data_dir_param))
+    cmd = (
+        '%s/node_modules/kinesalite/cli.js --shardLimit %s --port %s'
+        ' --createStreamMs %s --deleteStreamMs %s --updateStreamMs %s %s'
+    ) % (
+        ROOT_PATH, config.KINESIS_SHARD_LIMIT, backend_port,
+        latency, latency, latency, kinesis_data_dir_param
+    )
     print('Starting mock Kinesis (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('kinesis', port, backend_port, update_listener)
     return do_run(cmd, asynchronous)


### PR DESCRIPTION
Ability to set two new environment variables (both of which default to values prior to this PR):

KINESIS_SHARD_LIMIT
KINESIS_LATENCY

Can fix #1524 by setting (should this be the default setting?)

KINESIS_SHARD_LIMIT=Infinity

When using localstack in a test environment in which many streams are created/destroyed over time, the latency introduced by kinesalite defaults, arbitrarily increase execution time and the tests eventually hang after repeated use due to #1524.

Possibly related issues (briefly reviewed some of the dialog in each):

#1091
#894
#918
#230
#789
#753
#514

For those having issues with the references tickets, see if running my docker build solves your issues: `parisholley/localstack:latest`

I haven't dug into, but I think the way the GeneralProxy is handling exceptions from the kinesalite endpoint is broken (and causing hangs/timeouts).