### PR TITLE
fix #1469 - must wrap stream_arn, not kinesis_shard_id

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -133,8 +133,8 @@ def stream_name_from_stream_arn(stream_arn):
 
 
 def random_id(stream_arn, kinesis_shard_id):
-    namespace = uuid.UUID(bytes=hashlib.sha1(stream_arn.encode('utf-8')).digest()[:16])
-    return uuid.uuid5(namespace, to_bytes(kinesis_shard_id)).hex
+    namespace = uuid.UUID(bytes=hashlib.sha1(to_bytes(stream_arn)).digest()[:16])
+    return uuid.uuid5(namespace, kinesis_shard_id).hex
 
 
 def shard_id(stream_arn, kinesis_shard_id):


### PR DESCRIPTION
while trying to test my docker image for #1526 i ran into the issue supposedly fixed by #1469, but the same exception "encoding without a string argument" was happening. these tweaks made it work for me...