### PR TITLE
allow overriding aws account id with TEST_AWS_ACCOUNT_ID env var

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -37,8 +37,9 @@ DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
 BIND_HOST = '0.0.0.0'
 
 # AWS user account ID used for tests
-TEST_AWS_ACCOUNT_ID = '000000000000'
-os.environ['TEST_AWS_ACCOUNT_ID'] = TEST_AWS_ACCOUNT_ID
+if 'TEST_AWS_ACCOUNT_ID' not in os.environ:
+    os.environ['TEST_AWS_ACCOUNT_ID'] = '000000000000'
+TEST_AWS_ACCOUNT_ID = os.environ['TEST_AWS_ACCOUNT_ID']
 
 # root code folder
 LOCALSTACK_ROOT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**

I ran into issue #1416, which seems to result from interactions between Localstack and Moto where Localstack hardcodes AWS account ID 000000000000 into SQS queue ARNs, but Moto expects ARNs containing AWS account ID 123456789012.

This PR allows users of Localstack to workaround #1416 by supplying `TEST_AWS_ACCOUNT_ID=123456789012` as an environment variable to Localstack. It's not a true fix, but hopefully an acceptable stop-gap.