### PR TITLE
clear tmp supervisord logs at container startup

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -11,6 +11,9 @@ source <(
   sed -ne 's/^LOCALSTACK_\([^=]\+\)=.*/export \1=${LOCALSTACK_\1}/p'
 )
 
+cat /dev/null > /tmp/localstack_infra.log
+cat /dev/null > /tmp/localstack_infra.err
+
 supervisord -c /etc/supervisord.conf &
 
 function run_startup_scripts {
@@ -30,6 +33,4 @@ function run_startup_scripts {
 
 run_startup_scripts &
 
-touch /tmp/localstack_infra.log
-touch /tmp/localstack_infra.err
 tail -qF /tmp/localstack_infra.log /tmp/localstack_infra.err


### PR DESCRIPTION
the supervisord logfiles are touched but not cleared on container
runtime which causes the scripts under `/docker-entrypoint-initaws.d/`
to run prematurely. This will most likely fix #1494 , #1457 , and #1412.

I'm not sure how much this impacts people on backward compatibility i.e. people using the supervisord logs directly instead of the containers logs.