### PR TITLE
Fix not_found check on lambda execution

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -942,8 +942,9 @@ def invoke_function(function):
     not_found = None
     if arn not in arn_to_lambda:
         not_found = not_found_error(arn)
-    if qualifier and not arn_to_lambda.get(arn).qualifier_exists(qualifier):
+    elif qualifier and not arn_to_lambda.get(arn).qualifier_exists(qualifier):
         not_found = not_found_error('{0}:{1}'.format(arn, qualifier))
+
     if not_found:
         forward_result = forward_to_fallback_url(func_arn, data)
         if forward_result is not None:


### PR DESCRIPTION
Fixes #1581 — only check that the qualifier exists for the lambda function if the lambda function exists in the first place.

I couldn't find any tests around this to add to — any advice on how to test this would be very welcome!