### PR TITLE
Add --rm to docker create command to delete container on exit

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -578,6 +578,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                 ' %s'
                 ' %s'
                 ' %s'  # network
+                ' --rm'
                 ' "lambci/lambda:%s" %s'
                 ')";'
                 '%s cp "%s/." "$CONTAINER_ID:/var/task"; '


### PR DESCRIPTION
Fixes #1583 — Add missing `--rm` flag to `docker create` for `LAMBDA_REMOTE_DOCKER=true`