### PR TITLE
DynamoDB StreamArn should be uniform across dynamodb and dynamodbstreams API (# 1540)

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -20,15 +20,16 @@ ACTION_HEADER_PREFIX = 'DynamoDBStreams_20120810'
 SEQUENCE_NUMBER_COUNTER = 1
 
 
-def add_dynamodb_stream(table_name, view_type='NEW_AND_OLD_IMAGES', enabled=True):
+def add_dynamodb_stream(table_name, latest_stream_label, view_type='NEW_AND_OLD_IMAGES', enabled=True):
     if enabled:
         # create kinesis stream as a backend
         stream_name = get_kinesis_stream_name(table_name)
         aws_stack.create_kinesis_stream(stream_name)
         stream = {
-            'StreamArn': aws_stack.dynamodb_stream_arn(table_name=table_name),
+            'StreamArn': aws_stack.dynamodb_stream_arn(table_name=table_name,
+                                                       latest_stream_label=latest_stream_label),
             'TableName': table_name,
-            'StreamLabel': 'TODO',
+            'StreamLabel': latest_stream_label,
             'StreamStatus': 'ENABLED',
             'KeySchema': [],
             'Shards': []

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -13,7 +13,7 @@ from localstack.constants import (
     APPLICATION_X_WWW_FORM_URLENCODED, TEST_AWS_ACCOUNT_ID)
 from localstack.utils.common import (
     run_safe, to_str, is_string, is_string_or_bytes, make_http_request,
-    timestamp, is_port_open, get_service_protocol)
+    is_port_open, get_service_protocol)
 from localstack.utils.aws.aws_models import KinesisStream
 
 # AWS environment variable names
@@ -336,10 +336,10 @@ def dynamodb_table_arn(table_name, account_id=None, region_name=None):
     return _resource_arn(table_name, pattern, account_id=account_id, region_name=region_name)
 
 
-def dynamodb_stream_arn(table_name, account_id=None):
+def dynamodb_stream_arn(table_name, latest_stream_label, account_id=None):
     account_id = get_account_id(account_id)
     return ('arn:aws:dynamodb:%s:%s:table/%s/stream/%s' %
-        (get_local_region(), account_id, table_name, timestamp()))
+        (get_local_region(), account_id, table_name, latest_stream_label))
 
 
 def lambda_function_arn(function_name, account_id=None):


### PR DESCRIPTION
Fixes (#1540)

After creating the dynamodb table with streams, or updating the table and enabling streams, StreamArn should be passed through to make stream definition in dynamodb streams uniform with dynamodb table definitions.

