### PR TITLE
Set Java lambda debug port only when needed; fix CORS in proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test-docker:       ## Run automated tests in Docker
 	ENTRYPOINT="--entrypoint=" CMD="make test" make docker-run
 
 test-docker-mount:
-	ENTRYPOINT="--entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/tests:/opt/code/localstack/tests" CMD="make test" make docker-run
+	ENTRYPOINT="--entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/tests:/opt/code/localstack/tests -e TEST_PATH=$(TEST_PATH) -e LAMBDA_JAVA_OPTS=$(LAMBDA_JAVA_OPTS)" CMD="make test" make docker-run
 
 reinstall-p2:      ## Re-initialize the virtualenv with Python 2.x
 	rm -rf $(VENV_DIR)

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -86,5 +86,8 @@ STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctio
 # API endpoint for analytics events
 API_ENDPOINT = os.environ.get('API_ENDPOINT') or 'https://api.localstack.cloud/v1'
 
+# environment variable to indicates that this process is running the Web UI
+LOCALSTACK_WEB_PROCESS = 'LOCALSTACK_WEB_PROCESS'
+
 # Hardcoded AWS account ID used by moto
 MOTO_ACCOUNT_ID = '123456789012'

--- a/localstack/dashboard/api.py
+++ b/localstack/dashboard/api.py
@@ -6,7 +6,7 @@ from localstack import config
 from localstack.utils import common
 from localstack.services import generic_proxy
 from localstack.services import infra as services_infra
-from localstack.constants import VERSION
+from localstack.constants import VERSION, LOCALSTACK_WEB_PROCESS
 from localstack.dashboard import infra
 from localstack.utils.bootstrap import load_plugins, canonicalize_api_names
 from localstack.utils.aws.aws_stack import Environment
@@ -128,6 +128,7 @@ def ensure_webapp_installed():
 
 
 def serve(port):
+    os.environ[LOCALSTACK_WEB_PROCESS] = '1'
     ensure_webapp_installed()
     load_plugins()
     canonicalize_api_names()

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -756,12 +756,12 @@ def cleanup_resources():
     cleanup_threads_and_processes()
 
 
-def generate_ssl_cert(target_file=None, overwrite=False, random=False):
+def generate_ssl_cert(target_file=None, overwrite=False, random=False, return_content=False, serial_number=None):
     # Note: Do NOT import "OpenSSL" at the root scope
     # (Our test Lambdas are importing this file but don't have the module installed)
     from OpenSSL import crypto
 
-    if os.path.exists(target_file):
+    if target_file and not overwrite and os.path.exists(target_file):
         key_file_name = '%s.key' % target_file
         cert_file_name = '%s.crt' % target_file
         return target_file, cert_file_name, key_file_name
@@ -770,8 +770,6 @@ def generate_ssl_cert(target_file=None, overwrite=False, random=False):
             target_file = target_file.replace('.', '.%s.' % short_uid(), 1)
         else:
             target_file = '%s.%s' % (target_file, short_uid())
-    if target_file and not overwrite and os.path.exists(target_file):
-        return
 
     # create a key pair
     k = crypto.PKey()
@@ -786,7 +784,7 @@ def generate_ssl_cert(target_file=None, overwrite=False, random=False):
     subj.O = 'LocalStack Org'  # noqa
     subj.OU = 'Testing'
     subj.CN = 'LocalStack'
-    serial_number = 1001
+    serial_number = serial_number or 1001
     cert.set_serial_number(serial_number)
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
@@ -810,9 +808,8 @@ def generate_ssl_cert(target_file=None, overwrite=False, random=False):
         TMP_FILES.append(target_file)
         TMP_FILES.append(key_file_name)
         TMP_FILES.append(cert_file_name)
-        if random:
+        if not return_content:
             return target_file, cert_file_name, key_file_name
-        return file_content
     return file_content
 
 


### PR DESCRIPTION
* set Java lambda debug port only when needed
* fix CORS in proxy (addresses #1573)
* allow customizing of certificate serial number
* add `LOCALSTACK_WEB_PROCESS` env variable to flag the process running the Web UI