### PR TITLE
fix describe-stream crash for python3.6.8 (#1604)

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 import hashlib
+import six
 from flask import Flask, jsonify, request, make_response
 from localstack.services import generic_proxy
 from localstack.utils.aws import aws_stack
@@ -140,7 +141,9 @@ def stream_name_from_stream_arn(stream_arn):
 
 def random_id(stream_arn, kinesis_shard_id):
     namespace = uuid.UUID(bytes=hashlib.sha1(to_bytes(stream_arn)).digest()[:16])
-    return uuid.uuid5(namespace, to_bytes(kinesis_shard_id)).hex
+    if six.PY2:
+        kinesis_shard_id = to_bytes(kinesis_shard_id, 'utf-8')
+    return uuid.uuid5(namespace, kinesis_shard_id).hex
 
 
 def shard_id(stream_arn, kinesis_shard_id):


### PR DESCRIPTION
Fixes #1604 

localstack docker image is using python 3.6.8, latest fix for describe stream fixed the crash for python 2.7 and broke it for the docker image, the cause is #1605. This PR will roll it back because the docker image is reference.
