### PR TITLE
fix(bug): fix SQS->Lambda when setup with api gateway

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -80,8 +80,8 @@ class ProxyListenerApiGateway(ProxyListener):
                     new_request = aws_stack.render_velocity_template(template, data) + '&QueueName=%s' % queue
                     headers = aws_stack.mock_aws_request_headers(service='sqs', region_name=region_name)
 
-                    url = urljoin(TEST_SQS_URL, '%s/%s?%s' % (account_id, queue, new_request))
-                    result = common.make_http_request(url, method='GET', headers=headers)
+                    url = urljoin(TEST_SQS_URL, '%s/%s' % (account_id, queue))
+                    result = common.make_http_request(url, method='POST', headers=headers, data=new_request)
                     return result
 
                 else:


### PR DESCRIPTION
This is an attempt to help fix this issue https://github.com/localstack/localstack/issues/1596 raised by @vballa whenever an SQS -> Lambda is triggered by previously it was erroring in the md5 hashing the response. This would only ever happen if an event source with a lambda was setup for the GW -> SQS -> lambda. 

The reason for this was that there was no "data" body for GET requests meaning that data in https://github.com/localstack/localstack/blob/e65705a6ebf93ed7fbb05b690ebeb2c9c4aa88ae/localstack/services/sqs/sqs_listener.py#L52 was None and therefore throwing an exception when trying to hash.

We could have fixed it by remapping the query params in the [forward_request](
https://github.com/localstack/localstack/blob/e65705a6ebf93ed7fbb05b690ebeb2c9c4aa88ae/localstack/services/sqs/sqs_listener.py#L69-L76) to data and passing that, however it felt more natural that this should correctly be a POST request as its creating a resource even though AWS docs support GET with query params.

To validate that the change was covered, we needed to expand on the existing test by creating an event source and lamdbda for the SQS event, so that it correctly triggered the sqs flows from the API gateway setup, because without the event source when this line was called

https://github.com/localstack/localstack/blob/e65705a6ebf93ed7fbb05b690ebeb2c9c4aa88ae/localstack/services/sqs/sqs_listener.py#L236

and hit the below function it wasn't triggered any lambda and therefore just returning

https://github.com/localstack/localstack/blob/e65705a6ebf93ed7fbb05b690ebeb2c9c4aa88ae/localstack/services/awslambda/lambda_api.py#L246-L253

I kept the original test as it also provides value in itself as well

Any feedback appreciated and thanks for maintaining this project