### PR TITLE
Update elasticmq 0.15.1

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -83,7 +83,7 @@ ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'analysis-kuro
 # Default ES modules to exclude (save apprx 66MB in the final image)
 ELASTICSEARCH_DELETE_MODULES = ['ingest-geoip']
 DYNAMODB_JAR_URL = 'https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip'
-ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.2.jar'
+ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.1.jar'
 STS_JAR_URL = 'https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip'
 

--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -33,6 +33,15 @@ def start_sqs(port=None, asynchronous=False, update_listener=None):
         sqs-limits = strict
     }
     """ % (LOCALSTACK_HOSTNAME, port, backend_port)
+    # NOTE: elasticmq 0.14.15 ~ accepts region and accountId configuration changes
+    #       default accountId is set 000000000 in elasticmq 0.14.15 ~ 0.15.1
+    # TODO: when accountId returns to 000000000000, remove this assignment
+    config_params += """
+    aws {
+        region = "elasticmq"
+        accountId = "000000000000"
+    }
+    """
     config_file = os.path.join(TMP_FOLDER, 'sqs.%s.conf' % short_uid())
     TMP_FILES.append(config_file)
     save_file(config_file, config_params)


### PR DESCRIPTION
ref: https://github.com/localstack/localstack/pull/1652
see: https://github.com/softwaremill/elasticmq/pull/298

As you can see, 
https://travis-ci.org/localstack/localstack/builds/598668449#L1315
`EventSourceArn` is set `arn:aws:sqs:us-east-1:000000000:test_lambda_queue`

But actually it requires `arn:aws:sqs:us-east-1:000000000000:test_lambda_queue`
https://travis-ci.org/localstack/localstack/builds/598668449#L1558

In this change, overrides accountId because elasticmq 0.14.15 ~ behaves as accountId: 000000000.

