### PR TITLE
firehose put-record-batch response format

### DIFF
--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -247,9 +247,12 @@ def post_request():
         stream_name = data['DeliveryStreamName']
         records = data['Records']
         put_records(stream_name, records)
+        request_responses = []
+        for i in records:
+            request_responses.append({'RecordId': str(uuid.uuid4())})
         response = {
             'FailedPutCount': 0,
-            'RequestResponses': []
+            'RequestResponses': request_responses
         }
     elif action == '%s.UpdateDestination' % ACTION_HEADER_PREFIX:
         stream_name = data['DeliveryStreamName']


### PR DESCRIPTION
Fixed firehose put-record-batch to return 'RequestResponses' as list of maps with 'RecordId' as a uuid4 similar to put-record

I couldn't find how to test this properly from your other test files, if you have any pointers to add a test for this let me know.