### PR TITLE
Allow sns publish to a target-arn

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -76,9 +76,9 @@ class ProxyListenerSNS(ProxyListener):
             elif req_action == 'DeleteTopic':
                 do_delete_topic(topic_arn)
             elif req_action == 'Publish':
-                # No need to create a topic to send SMS with SNS
+                # No need to create a topic to send SMS or single push notifications with SNS
                 # but we can't mock a sending so we only return that it went well
-                if 'PhoneNumber' not in req_data:
+                if 'PhoneNumber' not in req_data and 'TargetArn' not in req_data:
                     if topic_arn not in SNS_SUBSCRIPTIONS.keys():
                         return make_error(code=404, code_string='NotFound', message='Topic does not exist')
                     publish_message(topic_arn, req_data)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -84,6 +84,13 @@ class SNSTest(unittest.TestCase):
         self.assertTrue('MessageId' in response)
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
 
+    def test_publish_target(self):
+        response = self.sns_client.publish(
+            TargetArn='arn:aws:sns:us-east-1:000000000000:endpoint/APNS/abcdef/0f7d5971-aa8b-4bd5-b585-0826e9f93a66', 
+            Message='This is a push notification')
+        self.assertTrue('MessageId' in response)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
     def test_tags(self):
         self.sns_client.tag_resource(
             ResourceArn=self.topic_arn,

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -86,7 +86,7 @@ class SNSTest(unittest.TestCase):
 
     def test_publish_target(self):
         response = self.sns_client.publish(
-            TargetArn='arn:aws:sns:us-east-1:000000000000:endpoint/APNS/abcdef/0f7d5971-aa8b-4bd5-b585-0826e9f93a66', 
+            TargetArn='arn:aws:sns:us-east-1:000000000000:endpoint/APNS/abcdef/0f7d5971-aa8b-4bd5-b585-0826e9f93a66',
             Message='This is a push notification')
         self.assertTrue('MessageId' in response)
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)


### PR DESCRIPTION
Currently calls like 

```
awslocal sns publish \
  --target-arn "arn:aws:sns:us-east-1:000000000000:endpoint/APNS/abc/0f7d5971-aa8b-4bd5-b585-0826e9f93a66" \
  --message "Hello world"
```

do not work, and give the error "Topic not found". The SNS docs state that only one of topic, target or phone number is required. This change means they'd be silently handled in the same way as SMS messages currently are, as per #1369  