### PR TITLE
Fix: Lambda code mount fails with path with spaces

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -560,7 +560,7 @@ def set_function_code(code, lambda_name, lambda_cwd=None):
             # running Lambdas locally (not in Docker), or (3) we're using remote Docker.
             # -> We do *not* want to raise an error if we're using local mount in non-remote Docker
             if not is_local_mount or not use_docker() or config.LAMBDA_REMOTE_DOCKER:
-                file_list = run('cd %s; du -d 3 .' % lambda_cwd)
+                file_list = run('cd "%s"; du -d 3 .' % lambda_cwd)
                 config_debug = ('Config for local mount, docker, remote: "%s", "%s", "%s"' %
                     (is_local_mount, use_docker(), config.LAMBDA_REMOTE_DOCKER))
                 LOG.debug('Lambda archive content:\n%s' % file_list)


### PR DESCRIPTION
I noticed that lambda deployment fails if the file path to the code has any spaces in it (When deploying without mounting flag enabled). I've found the error and added the fix.

It was missing quotes around the file path. I didn't think tests for this was necessary.