### PR TITLE
Minor refactoring in CF logic to retrieve resource details

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -74,7 +74,7 @@ def get_entity_id(entity, resource_json=None):
         return entity.physical_resource_id
     # check ID attribute candidates
     types_with_ref_as_id_or_name = (apigw_models.RestAPI, apigw_models.Resource)
-    attr_candidates = ['function_arn', 'Arn', 'id', 'name', 'Id', 'Name']
+    attr_candidates = ['function_arn', 'Arn', 'Ref', 'id', 'Id', 'name', 'Name']
     for attr in attr_candidates:
         if hasattr(entity, attr):
             if attr in ['id', 'name'] and not isinstance(entity, types_with_ref_as_id_or_name):

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -15,6 +15,11 @@ def flask_error_response(msg, code=500, error_type='InternalFailure'):
     return Response(json.dumps(result), status=code, headers=headers)
 
 
+def requests_error_response(msg, code=500, error_type='InternalFailure'):
+    response = flask_error_response(msg, code=code, error_type=error_type)
+    return flask_to_requests_response(response)
+
+
 def requests_response(content, status_code=200, headers={}):
     resp = RequestsResponse()
     content = json.dumps(content) if isinstance(content, dict) else content


### PR DESCRIPTION
Minor refactoring in CF logic:
* make `describe_stack_resource` more resilient to errors
* make `parameters` optional in resource definition, default to plain parameters dict