### PR TITLE
ADDED an env variable to the docker compose file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+LOCALSTACK_DOCKER_NAME=localstack

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-LOCALSTACK_DOCKER_NAME=localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '2.1'
+version: '3.0'
 
 services:
   localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME}"
     image: localstack/localstack
     ports:
       - "4567-4597:4567-4597"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.0'
+version: '2.1'
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack
     ports:
       - "4567-4597:4567-4597"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack}"
     image: localstack/localstack
     ports:
       - "4567-4597:4567-4597"


### PR DESCRIPTION
Addresses #1113

Basically allow for the container to have a name when it is launched.  Is it defined as an environment variable.  The `.env` file is there as according to the documentation here: https://docs.docker.com/compose/environment-variables/

Variables listed in the `.env` file can be read in when the user runs `docker-compose up`

The last change made is that there is a newer spec for compose files which is shown here: 
https://docs.docker.com/compose/compose-file/#variable-substitution

So I went ahead and updated the specs for the docker-compose file to a later version

Signed-off-by: Zuhayr Elahi <elahi.zuhayr@gmail.com>
