### PR TITLE
Upgrade kinesalite to fix leveldown module not found

### DIFF
--- a/localstack/package.json
+++ b/localstack/package.json
@@ -4,9 +4,9 @@
   "description": "Local Cloud Stack and Utilities",
   "version": "0.0.1",
   "dependencies": {
-    "kinesalite": "1.15.0"
+    "kinesalite": "3.1.0"
   },
   "optionalDependencies": {
-    "leveldown": "^4.0.1"
+    "leveldown": "^5.2.1"
   }
 }


### PR DESCRIPTION
When the persistence is enabled, the Kinesis mock service crash with the follow stacktrace 
```
Starting mock Kinesis (http port 4568)...
internal/modules/cjs/loader.js:797
throw err;
^

Error: Cannot find module 'leveldown'
Require stack:
- /opt/code/localstack/localstack/node_modules/kinesalite/db/index.js
- /opt/code/localstack/localstack/node_modules/kinesalite/index.js
- /opt/code/localstack/localstack/node_modules/kinesalite/cli.js
at Function.Module._resolveFilename (internal/modules/cjs/loader.js:794:15)
at Function.Module._load (internal/modules/cjs/loader.js:687:27)
at Module.require (internal/modules/cjs/loader.js:849:19)
at require (internal/modules/cjs/helpers.js:74:18)
at Object.create (/opt/code/localstack/localstack/node_modules/kinesalite/db/index.js:31:35)
at kinesalite (/opt/code/localstack/localstack/node_modules/kinesalite/index.js:24:26)
at Object.<anonymous> (/opt/code/localstack/localstack/node_modules/kinesalite/cli.js:29:35)
at Module._compile (internal/modules/cjs/loader.js:956:30)
at Object.Module._extensions..js (internal/modules/cjs/loader.js:973:10)
at Module.load (internal/modules/cjs/loader.js:812:32) {
code: 'MODULE_NOT_FOUND',
requireStack: [
'/opt/code/localstack/localstack/node_modules/kinesalite/db/index.js',
'/opt/code/localstack/localstack/node_modules/kinesalite/index.js',
'/opt/code/localstack/localstack/node_modules/kinesalite/cli.js'
]
}
```

Potentially caused by an incompatibility with the most recent version of NPM and the leveldown module mhart/kinesalite#27 .

Upgrade to the v3.1.0 mhart/kinesalite@2afcafc3ec9132bb942e3e0322a15049d71d0ef7 solves the issue.

Resolves #1003 #918 #1689 #771
