### PR TITLE
Fix encoding of non-ASCII results from API Gateway

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -9,7 +9,7 @@ from localstack.constants import APPLICATION_JSON, PATH_USER_REQUEST
 from localstack.config import TEST_KINESIS_URL, TEST_SQS_URL
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import to_str
+from localstack.utils.common import to_str, to_bytes
 from localstack.utils.analytics import event_publisher
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.awslambda import lambda_api
@@ -230,9 +230,10 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
                 if isinstance(parsed_result['body'], dict):
                     response._content = json.dumps(parsed_result['body'])
                 else:
-                    response._content = parsed_result['body']
+                    response._content = to_bytes(parsed_result['body'])
             except Exception:
                 response._content = '{}'
+            response.headers['Content-Length'] = len(response._content)
             return response
         else:
             msg = 'API Gateway action uri "%s" not yet implemented' % uri

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -43,10 +43,13 @@ def handler(event, context):
         body['requestContext'] = event.get('requestContext')
         body['queryStringParameters'] = event.get('queryStringParameters')
         body['httpMethod'] = event.get('httpMethod')
+        status_code = body.get('return_status_code', 200)
+        headers = body.get('return_headers', {})
+        body = body.get('return_raw_body') or body
         return {
             'body': body,
-            'statusCode': body.get('return_status_code', 200),
-            'headers': body.get('return_headers', {})
+            'statusCode': status_code,
+            'headers': headers
         }
 
     if 'Records' not in event:

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import base64
 import re
 import json
@@ -215,10 +217,7 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
         target_uri = invocation_uri % (DEFAULT_REGION, lambda_uri)
 
         result = self.connect_api_gateway_to_http_with_lambda_proxy(
-            'test_gateway2',
-            target_uri,
-            path=path
-        )
+            'test_gateway2', target_uri, path=path)
 
         api_id = result['id']
         path_map = get_rest_api_paths(api_id)
@@ -229,17 +228,11 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
         path = path + '?foo=foo&bar=bar&bar=baz'
 
         url = INBOUND_GATEWAY_URL_PATTERN.format(
-            api_id=api_id,
-            stage_name=self.TEST_STAGE_NAME,
-            path=path
-        )
+            api_id=api_id, stage_name=self.TEST_STAGE_NAME, path=path)
 
         data = {'return_status_code': 203, 'return_headers': {'foo': 'bar123'}}
-        result = requests.post(
-            url,
-            data=json.dumps(data),
-            headers={'User-Agent': 'python-requests/testing'}
-        )
+        result = requests.post(url, data=json.dumps(data),
+            headers={'User-Agent': 'python-requests/testing'})
 
         self.assertEqual(result.status_code, 203)
         self.assertEqual(result.headers.get('foo'), 'bar123')
@@ -263,6 +256,11 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
         result = requests.delete(url, data=json.dumps(data))
         self.assertEqual(result.status_code, 404)
 
+        # send message with non-ASCII chars
+        body_msg = '🙀 - 参よ'
+        result = requests.post(url, data=json.dumps({'return_raw_body': body_msg}))
+        self.assertEqual(to_str(result.content), body_msg)
+
     def test_api_gateway_lambda_proxy_integration_any_method(self):
         self._test_api_gateway_lambda_proxy_integration_any_method(
             self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD,
@@ -281,19 +279,12 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
         target_uri = aws_stack.apigateway_invocations_arn(lambda_uri)
 
         result = self.connect_api_gateway_to_http_with_lambda_proxy(
-            'test_gateway3',
-            target_uri,
-            methods=['ANY'],
-            path=path
-        )
+            'test_gateway3', target_uri, methods=['ANY'], path=path)
 
         # make test request to gateway and check response
         path = path.replace('{test_param1}', 'foo1')
         url = INBOUND_GATEWAY_URL_PATTERN.format(
-            api_id=result['id'],
-            stage_name=self.TEST_STAGE_NAME,
-            path=path
-        )
+            api_id=result['id'], stage_name=self.TEST_STAGE_NAME, path=path)
         data = {}
 
         for method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'):
@@ -379,7 +370,6 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
             libs=TEST_LAMBDA_LIBS,
             runtime=LAMBDA_RUNTIME_PYTHON27
         )
-
         testutil.create_lambda_function(
             func_name=fn_name,
             zip_file=zip_file,


### PR DESCRIPTION
Fix encoding of non-ASCII results from API Gateway