### PR TITLE
adding double quotes to make copying and pasting of pip install easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ localstack start --host
 LocalStack will attempt to automatically fetch the missing dependencies when you first start it up in "host" mode; alternatively, you can use the `full` profile to install all dependencies at `pip` installation time:
 
 ```
-pip install localstack[full]
+pip install "localstack[full]"
 ```
 
 ## Configurations


### PR DESCRIPTION
The pip install command mentioned in the README for localstack[full] will not work if simply copied and pasted on Linux and other systems.  Added quotes to the command to make this easier to copy and paste.