### PR TITLE
Support TemplateURL for CF ValidateTemplate; support Marker for S3 ListObjects; honor DEFAULT_REGION for SNS

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -35,6 +35,7 @@ class ProxyListenerSNS(ProxyListener):
         # check region
         try:
             aws_stack.check_valid_region(headers)
+            aws_stack.set_default_region_in_headers(headers)
         except Exception as e:
             return make_error(message=str(e), code=400)
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -264,6 +264,14 @@ def check_valid_region(headers):
         raise Exception('Invalid region specified in "Authorization" header: "%s"' % region)
 
 
+def set_default_region_in_headers(headers):
+    auth_header = headers.get('Authorization')
+    if not auth_header:
+        return
+    replaced = re.sub(r'(.*Credential=[^/]+/[^/]+/)([^/])+/', r'\1%s/' % get_region(), auth_header)
+    headers['Authorization'] = replaced
+
+
 def fix_account_id_in_arns(response, colon_delimiter=':', existing=None, replace=None):
     """ Fix the account ID in the ARNs returned in the given Flask response or string """
     existing = existing or ['123456789', MOTO_ACCOUNT_ID]


### PR DESCRIPTION
* Support TemplateURL for ValidateTemplate API - fixes #660
* Support Marker argument for S3 list-objects  - fixes #636
* Overwrite default region in SNS request headers - fixes #731