### PR TITLE
Upgrade elasticmq server's version in Dockerfile.base 0.14.5 -> 0.15.2

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -73,7 +73,7 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
     curl -L -o /tmp/localstack.es.zip \
         https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip && \
     curl -L -o /tmp/elasticmq-server.jar \
-        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.14.5.jar && \
+        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.2.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \
         mv elasticsearch* elasticsearch && rm /tmp/localstack.es.zip) && \
     (cd localstack/infra/elasticsearch/ && \


### PR DESCRIPTION
ref: https://github.com/localstack/localstack/issues/1619
ref: https://github.com/localstack/localstack/pull/1652

#1652 fixed the bug and upgrade the version of elasticmq in python code.
But in docker, the old version is used.
