### PR TITLE
Fix CloudFormation template downloads from S3 URLs

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -651,7 +651,7 @@ def fix_account_id_in_arns(params):
     def fix_ids(o, **kwargs):
         if isinstance(o, dict):
             for k, v in o.items():
-                if common.is_string(v):
+                if common.is_string(v, exclude_binary=True):
                     o[k] = aws_stack.fix_account_id_in_arns(v)
         return o
     result = common.recurse_object(params, fix_ids)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -289,7 +289,9 @@ class CaptureOutput(object):
 # ----------------
 
 
-def is_string(s, include_unicode=True):
+def is_string(s, include_unicode=True, exclude_binary=False):
+    if isinstance(s, six.binary_type) and exclude_binary:
+        return False
     if isinstance(s, str):
         return True
     if include_unicode and isinstance(s, six.text_type):

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -441,16 +441,16 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_java_options_with_only_memory_options(self):
         expected = '-Xmx512M'
-        result = self.prepareJavaOpts(expected)
+        result = self.prepare_java_opts(expected)
         self.assertEqual(expected, result)
 
     def test_java_options_with_memory_options_and_agentlib_option(self):
         expected = '.*transport=dt_socket,server=y,suspend=y,address=[0-9]+'
-        result = self.prepareJavaOpts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y'
+        result = self.prepare_java_opts('-Xmx512M -agentlib:jdwp=transport=dt_socket,server=y'
                                       ',suspend=y,address=_debug_port_')
         self.assertTrue(re.match(expected, result))
 
-    def prepareJavaOpts(self, java_opts):
+    def prepare_java_opts(self, java_opts):
         lambda_executors.config.LAMBDA_JAVA_OPTS = java_opts
         result = lambda_executors.Util.get_java_opts()
         return result


### PR DESCRIPTION
Fix cloudformation template downloads from S3 URLs - direct downloads have been failing with 403 if no proper ACLs are provided.