### PR TITLE
Add S3 website ErrorDocument emulation

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -667,7 +667,8 @@ class ProxyListenerS3(ProxyListener):
             return response
 
         # emulate ErrorDocument functionality if a website is configured
-        if method == 'GET' and response.status_code == 404:
+
+        if method == 'GET' and response.status_code == 404 and parsed.query != 'website':
             s3_client = aws_stack.connect_to_service('s3')
 
             try:
@@ -675,7 +676,7 @@ class ProxyListenerS3(ProxyListener):
                 s3_client.head_bucket(Bucket=bucket_name)
                 website_config = s3_client.get_bucket_website(Bucket=bucket_name)
 
-                if website_config['ErrorDocument'] and website_config['ErrorDocument']['Key']:
+                if 'ErrorDocument' in website_config and 'Key' in website_config['ErrorDocument']:
                     error_object = s3_client.get_object(Bucket=bucket_name, Key=website_config['ErrorDocument']['Key'])
                     response.status_code = 200
                     response._content = error_object['Body'].read()

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -666,6 +666,24 @@ class ProxyListenerS3(ProxyListener):
             response.status_code = 204
             return response
 
+        # emulate ErrorDocument functionality if a website is configured
+        if method == 'GET' and response.status_code == 404:
+            s3_client = aws_stack.connect_to_service('s3')
+
+            try:
+                # Verify the bucket exists in the first place--if not, we want normal processing of the 404
+                s3_client.head_bucket(Bucket=bucket_name)
+                website_config = s3_client.get_bucket_website(Bucket=bucket_name)
+
+                if website_config['ErrorDocument'] and website_config['ErrorDocument']['Key']:
+                    error_object = s3_client.get_object(Bucket=bucket_name, Key=website_config['ErrorDocument']['Key'])
+                    response.status_code = 200
+                    response._content = error_object['Body'].read()
+                    response.headers['content-length'] = len(response._content)
+            except ClientError:
+                # Pass on the 404 as usual
+                pass
+
         if response:
             reset_content_length = False
 

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -675,9 +675,10 @@ class ProxyListenerS3(ProxyListener):
                 # Verify the bucket exists in the first place--if not, we want normal processing of the 404
                 s3_client.head_bucket(Bucket=bucket_name)
                 website_config = s3_client.get_bucket_website(Bucket=bucket_name)
+                error_doc_key = website_config.get('ErrorDocument', {}).get('Key')
 
-                if 'ErrorDocument' in website_config and 'Key' in website_config['ErrorDocument']:
-                    error_object = s3_client.get_object(Bucket=bucket_name, Key=website_config['ErrorDocument']['Key'])
+                if error_doc_key:
+                    error_object = s3_client.get_object(Bucket=bucket_name, Key=error_doc_key)
                     response.status_code = 200
                     response._content = error_object['Body'].read()
                     response.headers['content-length'] = len(response._content)


### PR DESCRIPTION
See #1734 for what this PR partially addresses (it handles the ErrorDocument functionality but not IndexDocument).

This adds emulation of S3's ErrorDocument website configuration. It should not change the behavior of a LocalStack S3 bucket that has no website configuration.