### PR TITLE
Extend test for SQS delete message

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -495,6 +495,10 @@ def set_archive_code(code, lambda_name, zip_file_content=None):
     lambda_details = arn_to_lambda[lambda_arn]
     is_local_mount = code.get('S3Bucket') == BUCKET_MARKER_LOCAL
 
+    if is_local_mount and config.LAMBDA_REMOTE_DOCKER:
+        msg = 'Please note that Lambda mounts (bucket name "%s") cannot be used with LAMBDA_REMOTE_DOCKER=1'
+        raise Exception(msg % BUCKET_MARKER_LOCAL)
+
     # Stop/remove any containers that this arn uses.
     LAMBDA_EXECUTOR.cleanup(lambda_arn)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -52,8 +52,9 @@ class SQSTest(unittest.TestCase):
 
         # publish/receive message
         self.client.send_message(QueueUrl=queue_url, MessageBody='msg123')
-        messages = self.client.receive_message(QueueUrl=queue_url)['Messages']
-        self.assertEquals(len(messages), 1)
+        for i in range(2):
+            messages = self.client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)['Messages']
+            self.assertEquals(len(messages), 1)
 
         # delete/receive message
         self.client.delete_message(QueueUrl=queue_url, ReceiptHandle=messages[0]['ReceiptHandle'])


### PR DESCRIPTION
* Extend test for SQS delete message - addresses #468
* Raise error for local Lambda mount in combination with `LAMBDA_REMOTE_DOCKER`