### PR TITLE
Fix API Gateway Authorizer Implementation

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/LocalstackDocker.java
@@ -26,7 +26,7 @@ public class LocalstackDocker {
     private static final Logger LOG = Logger.getLogger(LocalstackDocker.class.getName());
 
     private static final String PORT_CONFIG_FILENAME = "/opt/code/localstack/" +
-            ".venv/lib/python3.6/site-packages/localstack_client/config.py";
+            ".venv/lib/python3.7/site-packages/localstack_client/config.py";
 
     private static final Pattern READY_TOKEN = Pattern.compile("Ready\\.");
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -54,7 +54,7 @@ def get_authorizer(path):
     api_id = get_api_id_from_path(path)
     authorizer_id = get_authorizer_id_from_path(path)
 
-    authorizer = AUTHORIZERS[authorizer_id]
+    authorizer = AUTHORIZERS.get(authorizer_id)
 
     if authorizer is None:
         return make_error_response('Not found: %s' % authorizer_id, 404)
@@ -95,7 +95,7 @@ def normalize_authorizer(data):
     result = common.clone(data)
 
     # terraform sends this as a string in patch, so convert to int
-    result['authorizerResultTtlInSeconds'] = int(result['authorizerResultTtlInSeconds'] or 300)
+    result['authorizerResultTtlInSeconds'] = int(result.get('authorizerResultTtlInSeconds') or 300)
 
     return result
 
@@ -116,7 +116,7 @@ def add_authorizer(path, data):
 def update_authorizer(path, data):
     api_id = get_api_id_from_path(path)
     authorizer_id = get_authorizer_id_from_path(path)
-    authorizer = AUTHORIZERS[authorizer_id]
+    authorizer = AUTHORIZERS.get(authorizer_id)
 
     if authorizer is None:
         return make_error_response('Not found: %s' % api_id, 404)

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1,5 +1,7 @@
 import re
 import json
+
+from jsonpatch import apply_patch
 from requests.models import Response
 from six.moves.urllib import parse as urlparse
 from localstack.utils import common
@@ -11,6 +13,8 @@ from localstack.utils.aws.aws_responses import requests_response
 PATH_REGEX_MAIN = r'^/restapis/([A-Za-z0-9_\-]+)/[a-z]+(\?.*)?'
 PATH_REGEX_SUB = r'^/restapis/([A-Za-z0-9_\-]+)/[a-z]+/([A-Za-z0-9_\-]+)/.*'
 
+PATH_REGEX_AUTHORIZER = r'^/restapis/[A-Za-z0-9_\-]+/authorizers/(.*)'
+
 # template for SQS inbound data
 APIGATEWAY_SQS_DATA_INBOUND_TEMPLATE = "Action=SendMessage&MessageBody=$util.base64Encode($input.json('$'))"
 
@@ -18,14 +22,20 @@ APIGATEWAY_SQS_DATA_INBOUND_TEMPLATE = "Action=SendMessage&MessageBody=$util.bas
 AUTHORIZERS = {}
 
 
-def make_response(message):
+def make_json_response(message):
     return requests_response(json.dumps(message), headers={'Content-Type': APPLICATION_JSON})
 
 
-def make_error(message, code=400):
+def make_error_response(message, code=400):
     response = Response()
     response.status_code = code
     response._content = json.dumps({'message': message})
+    return response
+
+
+def make_accepted_response():
+    response = Response()
+    response.status_code = 202
     return response
 
 
@@ -36,38 +46,109 @@ def get_api_id_from_path(path):
     return re.match(PATH_REGEX_MAIN, path).group(1)
 
 
-def get_authorizers(path):
-    result = {'item': []}
+def get_authorizer_id_from_path(path):
+    return re.match(PATH_REGEX_AUTHORIZER, path).group(1)
+
+
+def get_authorizer(path):
     api_id = get_api_id_from_path(path)
-    for key, value in AUTHORIZERS.items():
-        auth_api_id = get_api_id_from_path(value['_links']['self']['href'])
-        if auth_api_id == api_id:
-            result['item'].append(value)
+    authorizer_id = get_authorizer_id_from_path(path)
+
+    authorizer = AUTHORIZERS[authorizer_id]
+
+    if authorizer is None:
+        return make_error_response('Not found: %s' % authorizer_id, 404)
+
+    return to_authorizer_response_json(api_id, authorizer)
+
+
+def to_authorizer_response_json(api_id, data):
+    result = common.clone(data)
+
+    self_link = '/restapis/%s/authorizers/%s' % (api_id, data['id'])
+
+    if '_links' not in result:
+        result['_links'] = {}
+
+    result['_links']['self'] = {
+        'href': self_link
+    }
+
+    result['_links']['curies'] = {
+        'href': 'https://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-authorizer-latest.html',
+        'name': 'authorizer',
+        'templated': True
+    }
+
+    result['_links']['authorizer:delete'] = {
+        'href': self_link
+    }
+
+    result['_links']['authorizer:delete'] = {
+        'href': self_link
+    }
+
+    return result
+
+
+def normalize_authorizer(data):
+    result = common.clone(data)
+
+    # terraform sends this as a string in patch, so convert to int
+    result['authorizerResultTtlInSeconds'] = int(result['authorizerResultTtlInSeconds'] or 300)
+
     return result
 
 
 def add_authorizer(path, data):
     api_id = get_api_id_from_path(path)
+    authorizer_id = common.short_uid()
     result = common.clone(data)
-    result['id'] = common.short_uid()
-    if '_links' not in result:
-        result['_links'] = {}
-    result['_links']['self'] = {
-        'href': '/restapis/%s/authorizers/%s' % (api_id, result['id'])
-    }
-    AUTHORIZERS[result['id']] = result
-    return result
+
+    result['id'] = authorizer_id
+    result = normalize_authorizer(result)
+
+    AUTHORIZERS[authorizer_id] = result
+
+    return make_json_response(to_authorizer_response_json(api_id, result))
+
+
+def update_authorizer(path, data):
+    api_id = get_api_id_from_path(path)
+    authorizer_id = get_authorizer_id_from_path(path)
+    authorizer = AUTHORIZERS[authorizer_id]
+
+    if authorizer is None:
+        return make_error_response('Not found: %s' % api_id, 404)
+
+    result = apply_patch(authorizer, data['patchOperations'])
+    result = normalize_authorizer(result)
+
+    AUTHORIZERS[authorizer_id] = result
+
+    return make_json_response(to_authorizer_response_json(api_id, result))
+
+
+def delete_authorizer(path):
+    authorizer_id = get_authorizer_id_from_path(path)
+
+    del AUTHORIZERS[authorizer_id]
+
+    return make_accepted_response()
 
 
 def handle_authorizers(method, path, data, headers):
-    result = {}
+
     if method == 'GET':
-        result = get_authorizers(path)
+        return get_authorizer(path)
     elif method == 'POST':
-        result = add_authorizer(path, data)
-    else:
-        return make_error('Not implemented for API Gateway authorizers: %s' % method, 404)
-    return make_response(result)
+        return add_authorizer(path, data)
+    elif method == 'PATCH':
+        return update_authorizer(path, data)
+    elif method == 'DELETE':
+        return delete_authorizer(path)
+
+    return make_error_response('Not implemented for API Gateway authorizers: %s' % method, 404)
 
 
 def tokenize_path(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,9 @@ flask==1.0.2
 flask-cors==3.0.3
 flask_swagger==0.2.12
 forbiddenfruit==0.1.3
+jsonpatch==1.24
 jsonpath-rw==1.4.0
+jsonpointer==2.0
 localstack-ext[full]>=0.10.51
 localstack-ext>=0.10.51        #basic-lib
 localstack-client>=0.14        #basic-lib

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -4,13 +4,14 @@ import base64
 import re
 import json
 import unittest
+from jsonpatch import apply_patch
 from requests.models import Response
 from xml.dom.minidom import parseString
 from localstack.config import INBOUND_GATEWAY_URL_PATTERN, DEFAULT_REGION
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import to_str, load_file
+from localstack.utils.common import to_str, load_file, clone
 from localstack.utils.common import safe_requests as requests
 from localstack.services.generic_proxy import GenericProxy, ProxyListener
 from localstack.services.awslambda.lambda_api import (
@@ -18,6 +19,8 @@ from localstack.services.awslambda.lambda_api import (
 from localstack.services.apigateway.helpers import (
     get_rest_api_paths, get_resource_for_path, connect_api_gateway_to_sqs)
 from .test_lambda import TEST_LAMBDA_PYTHON, TEST_LAMBDA_LIBS
+
+TEST_API_GATEWAY_ID = 'fugvjdxtri'
 
 
 class TestAPIGatewayIntegrations(unittest.TestCase):
@@ -58,7 +61,31 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
     TEST_LAMBDA_PROXY_BACKEND_WITH_PATH_PARAM = 'test_lambda_apigw_backend_path_param'
     TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD = 'test_ARMlambda_apigw_backend_any_method'
     TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM = 'test_ARMlambda_apigw_backend_any_method_path_param'
-    TEST_LAMBDA_HANDLER_NAME = 'lambda_sqs_handler'
+    TEST_LAMBDA_SQS_HANDLER_NAME = 'lambda_sqs_handler'
+    TEST_LAMBDA_AUTHORIZER_HANDLER_NAME = 'lambda_authorizer_handler'
+
+    TEST_API_GATEWAY_AUTHORIZER = {
+        'restApiId': TEST_API_GATEWAY_ID,
+        'name': 'test',
+        'type': 'TOKEN',
+        'providerARNs': [
+            'arn:aws:cognito-idp:us-east-1:123412341234:userpool/us-east-1_123412341'
+        ],
+        'authType': 'custom',
+        'authorizerUri': 'arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/' +
+                         'arn:aws:lambda:us-east-1:123456789012:function:myApiAuthorizer/invocations',
+        'authorizerCredentials': 'arn:aws:iam::123456789012:role/apigAwsProxyRole',
+        'identitySource': 'method.request.header.Authorization',
+        'identityValidationExpression': '.*',
+        'authorizerResultTtlInSeconds': 300
+    }
+    TEST_API_GATEWAY_AUTHORIZER_OPS = [
+        {
+            'op': 'replace',
+            'path': '/name',
+            'value': 'test1'
+        }
+    ]
 
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
@@ -106,9 +133,9 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
             queue_arn=self.TEST_SQS_QUEUE, path=self.API_PATH_DATA_INBOUND)
 
         # create event source for sqs lambda processor
-        self.create_lambda_function(self.TEST_LAMBDA_HANDLER_NAME)
+        self.create_lambda_function(self.TEST_LAMBDA_SQS_HANDLER_NAME)
         add_event_source(
-            self.TEST_LAMBDA_HANDLER_NAME,
+            self.TEST_LAMBDA_SQS_HANDLER_NAME,
             aws_stack.sqs_queue_arn(self.TEST_SQS_QUEUE),
             True)
 
@@ -276,6 +303,53 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
         self._test_api_gateway_lambda_proxy_integration_any_method(
             self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM,
             self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM)
+
+    def test_api_gateway_authorizer_crud(self):
+
+        apig = aws_stack.connect_to_service('apigateway')
+
+        authorizer = apig.create_authorizer(**self.TEST_API_GATEWAY_AUTHORIZER)
+
+        authorizer_id = authorizer.get('id')
+
+        create_result = apig.get_authorizer(
+            restApiId=TEST_API_GATEWAY_ID,
+            authorizerId=authorizer_id)
+
+        # ignore boto3 stuff
+        del create_result['ResponseMetadata']
+
+        create_expected = clone(self.TEST_API_GATEWAY_AUTHORIZER)
+        del create_expected['restApiId']
+        create_expected['id'] = authorizer_id
+
+        self.assertDictEqual(create_expected, create_result)
+
+        apig.update_authorizer(
+            restApiId=TEST_API_GATEWAY_ID,
+            authorizerId=authorizer_id,
+            patchOperations=self.TEST_API_GATEWAY_AUTHORIZER_OPS)
+
+        update_result = apig.get_authorizer(
+            restApiId=TEST_API_GATEWAY_ID,
+            authorizerId=authorizer_id)
+
+        # ignore boto3 stuff
+        del update_result['ResponseMetadata']
+
+        update_expected = apply_patch(create_expected, self.TEST_API_GATEWAY_AUTHORIZER_OPS)
+
+        self.assertDictEqual(update_expected, update_result)
+
+        apig.delete_authorizer(
+            restApiId=TEST_API_GATEWAY_ID,
+            authorizerId=authorizer_id)
+
+        self.assertRaises(
+            Exception,
+            apig.get_authorizer,
+            TEST_API_GATEWAY_ID,
+            authorizer_id)
 
     def _test_api_gateway_lambda_proxy_integration_any_method(self, fn_name, path):
         self.create_lambda_function(fn_name)


### PR DESCRIPTION
Api Gateway authorizer endpoints didn't work correctly and crashed terraform. Fixed in this PR. Additionally added PUT/DELETE methods.