### PR TITLE
Fix incorrect statement id in Lambda add-permission API

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -924,7 +924,7 @@ def update_function_configuration(function):
 def add_permission(function):
     data = json.loads(to_str(request.data))
     iam_client = aws_stack.connect_to_service('iam')
-    sid = short_uid()
+    sid = data.get('StatementId')
     policy = {
         'Version': IAM_POLICY_VERSION,
         'Id': 'LambdaFuncAccess-%s' % sid,
@@ -964,7 +964,8 @@ def remove_permission(function, statement):
 def get_policy(function):
     policy = get_lambda_policy(function)
     if not policy:
-        return jsonify({}), 404
+        return error_response('The resource you requested does not exist.',
+            404, error_type='ResourceNotFoundException')
     return jsonify({'Policy': json.dumps(policy), 'RevisionId': 'test1234'})
 
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -113,14 +113,16 @@ class TestLambdaBaseFeatures(unittest.TestCase):
 
         # create lambda permission
         action = 'lambda:InvokeFunction'
+        sid = 's3'
         resp = lambda_client.add_permission(FunctionName=TEST_LAMBDA_NAME_PY, Action=action,
-            StatementId='s3', Principal='s3.amazonaws.com', SourceArn=aws_stack.s3_bucket_arn('test-bucket'))
+            StatementId=sid, Principal='s3.amazonaws.com', SourceArn=aws_stack.s3_bucket_arn('test-bucket'))
         self.assertIn('Statement', resp)
         # fetch lambda policy
         policy = lambda_client.get_policy(FunctionName=TEST_LAMBDA_NAME_PY)['Policy']
         self.assertIsInstance(policy, six.string_types)
         policy = json.loads(to_str(policy))
         self.assertEqual(policy['Statement'][0]['Action'], action)
+        self.assertEqual(policy['Statement'][0]['Sid'], sid)
         self.assertEqual(policy['Statement'][0]['Resource'], lambda_api.func_arn(TEST_LAMBDA_NAME_PY))
         # fetch IAM policy
         policies = iam_client.list_policies(Scope='Local', MaxItems=500)['Policies']


### PR DESCRIPTION
Fixed random statement id in order to use the provided by the requests #1788.

Updated tests and responses when the policies don't exists anymore.
