### PR TITLE
Added @synchronized decorator to provide thread-based locking support for ssl cert creation

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -23,6 +23,7 @@ import six
 import shutil
 import requests
 import dns.resolver
+import functools
 from io import BytesIO
 from contextlib import closing
 from datetime import datetime
@@ -289,6 +290,19 @@ class CaptureOutput(object):
 # ----------------
 # UTILITY METHODS
 # ----------------
+
+def synchronized(lock=None):
+    """
+    Synchronization decorator as described in
+    http://blog.dscpl.com.au/2014/01/the-missing-synchronized-decorator.html.
+    """
+    def _decorator(wrapped):
+        @functools.wraps(wrapped)
+        def _wrapper(*args, **kwargs):
+            with lock:
+                return wrapped(*args, **kwargs)
+        return _wrapper
+    return _decorator
 
 
 def is_string(s, include_unicode=True, exclude_binary=False):
@@ -797,6 +811,7 @@ def cleanup_resources():
     cleanup_threads_and_processes()
 
 
+@synchronized
 def generate_ssl_cert(target_file=None, overwrite=False, random=False, return_content=False, serial_number=None):
     # Note: Do NOT import "OpenSSL" at the root scope
     # (Our test Lambdas are importing this file but don't have the module installed)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -63,6 +63,8 @@ LOG = logging.getLogger(__name__)
 # flag to indicate whether we've received and processed the stop signal
 INFRA_STOPPED = False
 
+SSL_CERT_LOCK = threading.RLock()
+
 
 class CustomEncoder(json.JSONEncoder):
     """ Helper class to convert JSON documents with datetime, decimals, or bytes. """
@@ -811,7 +813,7 @@ def cleanup_resources():
     cleanup_threads_and_processes()
 
 
-@synchronized
+@synchronized(lock=SSL_CERT_LOCK)
 def generate_ssl_cert(target_file=None, overwrite=False, random=False, return_content=False, serial_number=None):
     # Note: Do NOT import "OpenSSL" at the root scope
     # (Our test Lambdas are importing this file but don't have the module installed)

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -1,0 +1,19 @@
+import unittest
+import threading
+from unittest.mock import MagicMock
+from localstack.utils.common import synchronized
+
+
+class SynchronizedTest(unittest.TestCase):
+
+    reallock = threading.RLock()
+    mocklock = MagicMock(wraps=reallock)
+
+    @synchronized(lock=mocklock)
+    def locked(self):
+        pass
+
+    def test_synchronized_uses_with_enter_exit(self):
+        self.locked()
+        self.mocklock.__enter__.assert_called_with()
+        self.mocklock.__exit__.assert_called_with(None, None, None)


### PR DESCRIPTION
Proposed fix for Issue #1811.

1. Adds `@synchronized` decorator to provide thread-based locking support
1. Added `@synchronized` around `common.generate_ssl_cert`

- [x] Add tests for any new features and bug fixes. Ideally, each PR should increase the test coverage.
- [x] Follow the existing code style (e.g., indents). A PEP8 code linting target is included in the Makefile.
- [x] Put a reasonable amount of comments into the code.
- [x] Separate unrelated changes into multiple pull requests.
- [ ] 1 commit per PR: Please squash/rebase multiple commits into one single commit (to keep the history clean).
