### PR TITLE
Add initial support for KMS via local-kms

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ LocalStack spins up the following core Cloud APIs on your local machine:
 * **STS** at http://localhost:4592
 * **IAM** at http://localhost:4593
 * **EC2** at http://localhost:4597
+* **KMS** at http://localhost:4599
 
 In addition to the above, the [**Pro version** of LocalStack](https://localstack.cloud/#pricing) supports additional APIs and advanced features, including:
 * **AppSync**

--- a/README.md
+++ b/README.md
@@ -685,11 +685,10 @@ flask                     | BSD License
 flask_swagger             | MIT License
 jsonpath-rw               | Apache License 2.0
 moto                      | Apache License 2.0
-nose                      | GNU LGPL
-pep8                      | Expat license
 requests                  | Apache License 2.0
 subprocess32              | PSF License
 **Node.js/npm modules:**  |
 kinesalite                | MIT License
 **Other tools:**          |
 Elasticsearch             | Apache License 2.0
+local-kms                 | MIT License

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -22,6 +22,7 @@ DEFAULT_PORT_CLOUDFORMATION_BACKEND = 4559
 DEFAULT_PORT_STEPFUNCTIONS_BACKEND = 4558
 DEFAULT_PORT_IAM_BACKEND = 4557
 DEFAULT_PORT_EC2_BACKEND = 4556
+DEFAULT_PORT_KMS_BACKEND = 4555
 
 DEFAULT_PORT_WEB_UI = 8080
 
@@ -85,6 +86,7 @@ ELASTICSEARCH_DELETE_MODULES = ['ingest-geoip']
 ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.2.jar'
 STS_JAR_URL = 'https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip'
+LOCAL_KMS_URL = 'https://github.com/localstack/localstack-artifacts/raw/master/local-kms/build/local-kms.<arch>.bin'
 
 # TODO: Temporarily using a fixed version of DDB in Alpine, as we're hitting a SIGSEGV JVM crash with latest
 DYNAMODB_JAR_URL_ALPINE = 'https://github.com/whummer/dynamodb-local/raw/master/etc/DynamoDBLocal.zip'

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -86,7 +86,7 @@ ELASTICSEARCH_DELETE_MODULES = ['ingest-geoip']
 ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.2.jar'
 STS_JAR_URL = 'https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip'
-LOCAL_KMS_URL = 'https://github.com/localstack/localstack-artifacts/raw/master/local-kms/build/local-kms.<arch>.bin'
+KMS_URL_PATTERN = 'https://github.com/localstack/localstack-artifacts/raw/master/local-kms/build/local-kms.<arch>.bin'
 
 # TODO: Temporarily using a fixed version of DDB in Alpine, as we're hitting a SIGSEGV JVM crash with latest
 DYNAMODB_JAR_URL_ALPINE = 'https://github.com/whummer/dynamodb-local/raw/master/etc/DynamoDBLocal.zip'

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -1,6 +1,7 @@
 import sys
 from localstack.services.es import es_starter
 from localstack.services.s3 import s3_listener, s3_starter
+from localstack.services.kms import kms_starter
 from localstack.services.sns import sns_listener
 from localstack.services.sqs import sqs_listener, sqs_starter
 from localstack.services.iam import iam_listener, iam_starter
@@ -19,15 +20,56 @@ from localstack.services.cloudformation import cloudformation_listener, cloudfor
 
 def register_localstack_plugins():
     try:
-        register_plugin(Plugin('es',
-            start=start_elasticsearch_service))
+        register_plugin(Plugin('apigateway',
+            start=start_apigateway,
+            listener=apigateway_listener.UPDATE_APIGATEWAY))
+        register_plugin(Plugin('cloudformation',
+            start=cloudformation_starter.start_cloudformation,
+            listener=cloudformation_listener.UPDATE_CLOUDFORMATION))
+        register_plugin(Plugin('cloudwatch',
+            start=start_cloudwatch))
+        register_plugin(Plugin('dynamodb',
+            start=dynamodb_starter.start_dynamodb,
+            check=dynamodb_starter.check_dynamodb,
+            listener=dynamodb_listener.UPDATE_DYNAMODB))
+        register_plugin(Plugin('dynamodbstreams',
+            start=start_dynamodbstreams))
+        register_plugin(Plugin('ec2',
+            start=start_ec2))
         register_plugin(Plugin('elasticsearch',
             start=es_starter.start_elasticsearch,
             check=es_starter.check_elasticsearch))
+        register_plugin(Plugin('es',
+            start=start_elasticsearch_service))
+        register_plugin(Plugin('events',
+            start=start_events))
+        register_plugin(Plugin('firehose',
+            start=start_firehose))
+        register_plugin(Plugin('iam',
+            start=iam_starter.start_iam,
+            listener=iam_listener.UPDATE_IAM))
+        register_plugin(Plugin('kinesis',
+            start=kinesis_starter.start_kinesis,
+            check=kinesis_starter.check_kinesis,
+            listener=kinesis_listener.UPDATE_KINESIS))
+        register_plugin(Plugin('kms',
+            start=kms_starter.start_kms))
+        register_plugin(Plugin('lambda',
+            start=start_lambda))
+        register_plugin(Plugin('logs',
+            start=start_cloudwatch_logs))
+        register_plugin(Plugin('redshift',
+            start=start_redshift))
+        register_plugin(Plugin('route53',
+            start=start_route53))
         register_plugin(Plugin('s3',
             start=s3_starter.start_s3,
             check=s3_starter.check_s3,
             listener=s3_listener.UPDATE_S3))
+        register_plugin(Plugin('secretsmanager',
+            start=start_secretsmanager))
+        register_plugin(Plugin('ses',
+            start=start_ses))
         register_plugin(Plugin('sns',
             start=start_sns,
             listener=sns_listener.UPDATE_SNS))
@@ -35,52 +77,13 @@ def register_localstack_plugins():
             start=sqs_starter.start_sqs,
             listener=sqs_listener.UPDATE_SQS,
             check=sqs_starter.check_sqs))
-        register_plugin(Plugin('ses',
-            start=start_ses))
         register_plugin(Plugin('ssm',
             start=start_ssm))
         register_plugin(Plugin('sts',
             start=start_sts))
-        register_plugin(Plugin('iam',
-            start=iam_starter.start_iam,
-            listener=iam_listener.UPDATE_IAM))
-        register_plugin(Plugin('secretsmanager',
-            start=start_secretsmanager))
-        register_plugin(Plugin('apigateway',
-            start=start_apigateway,
-            listener=apigateway_listener.UPDATE_APIGATEWAY))
-        register_plugin(Plugin('dynamodb',
-            start=dynamodb_starter.start_dynamodb,
-            check=dynamodb_starter.check_dynamodb,
-            listener=dynamodb_listener.UPDATE_DYNAMODB))
-        register_plugin(Plugin('dynamodbstreams',
-            start=start_dynamodbstreams))
-        register_plugin(Plugin('firehose',
-            start=start_firehose))
-        register_plugin(Plugin('lambda',
-            start=start_lambda))
-        register_plugin(Plugin('kinesis',
-            start=kinesis_starter.start_kinesis,
-            check=kinesis_starter.check_kinesis,
-            listener=kinesis_listener.UPDATE_KINESIS))
-        register_plugin(Plugin('redshift',
-            start=start_redshift))
-        register_plugin(Plugin('route53',
-            start=start_route53))
-        register_plugin(Plugin('cloudformation',
-            start=cloudformation_starter.start_cloudformation,
-            listener=cloudformation_listener.UPDATE_CLOUDFORMATION))
-        register_plugin(Plugin('cloudwatch',
-            start=start_cloudwatch))
-        register_plugin(Plugin('events',
-            start=start_events))
-        register_plugin(Plugin('logs',
-            start=start_cloudwatch_logs))
         register_plugin(Plugin('stepfunctions',
             start=stepfunctions_starter.start_stepfunctions,
             listener=stepfunctions_listener.UPDATE_STEPFUNCTIONS))
-        register_plugin(Plugin('ec2',
-            start=start_ec2))
     except Exception as e:
         print('Unable to register plugins: %s' % e)
         sys.stdout.flush()

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -53,7 +53,8 @@ def register_localstack_plugins():
             check=kinesis_starter.check_kinesis,
             listener=kinesis_listener.UPDATE_KINESIS))
         register_plugin(Plugin('kms',
-            start=kms_starter.start_kms))
+            start=kms_starter.start_kms,
+            priority=10))
         register_plugin(Plugin('lambda',
             start=start_lambda))
         register_plugin(Plugin('logs',

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -282,7 +282,7 @@ def do_run(cmd, asynchronous, print_output=False, env_vars={}):
         t.start()
         TMP_THREADS.append(t)
         return t
-    return run(cmd)
+    return run(cmd, env_vars=env_vars)
 
 
 def start_proxy_for_service(service_name, port, default_backend_port, update_listener, quiet=False, params={}):

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -11,7 +11,7 @@ from localstack.utils import bootstrap
 from localstack.constants import (DEFAULT_SERVICE_PORTS, ELASTICMQ_JAR_URL, STS_JAR_URL,
     ELASTICSEARCH_JAR_URL, ELASTICSEARCH_PLUGIN_LIST, ELASTICSEARCH_DELETE_MODULES,
     DYNAMODB_JAR_URL, DYNAMODB_JAR_URL_ALPINE, LOCALSTACK_MAVEN_VERSION, STEPFUNCTIONS_ZIP_URL,
-    LOCAL_KMS_URL, LOCALSTACK_INFRA_PROCESS)
+    KMS_URL_PATTERN, LOCALSTACK_INFRA_PROCESS)
 if __name__ == '__main__':
     bootstrap.bootstrap_installation()
 # flake8: noqa: E402
@@ -114,7 +114,8 @@ def install_local_kms():
     if not os.path.exists(binary_path):
         log_install_msg('KMS')
         mkdir(INSTALL_DIR_KMS)
-        download(LOCAL_KMS_URL, binary_path)
+        kms_url = KMS_URL_PATTERN.replace('<arch>', get_arch())
+        download(kms_url, binary_path)
         chmod_r(binary_path, 0o777)
 
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -11,12 +11,13 @@ from localstack.utils import bootstrap
 from localstack.constants import (DEFAULT_SERVICE_PORTS, ELASTICMQ_JAR_URL, STS_JAR_URL,
     ELASTICSEARCH_JAR_URL, ELASTICSEARCH_PLUGIN_LIST, ELASTICSEARCH_DELETE_MODULES,
     DYNAMODB_JAR_URL, DYNAMODB_JAR_URL_ALPINE, LOCALSTACK_MAVEN_VERSION, STEPFUNCTIONS_ZIP_URL,
-    LOCALSTACK_INFRA_PROCESS)
+    LOCAL_KMS_URL, LOCALSTACK_INFRA_PROCESS)
 if __name__ == '__main__':
     bootstrap.bootstrap_installation()
 # flake8: noqa: E402
 from localstack.utils.common import (
-    download, parallelize, run, mkdir, load_file, save_file, unzip, rm_rf, chmod_r, is_alpine, in_docker)
+    download, parallelize, run, mkdir, load_file, save_file, unzip, rm_rf, chmod_r, is_alpine,
+    in_docker, get_arch)
 
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = os.path.realpath(os.path.join(THIS_PATH, '..'))
@@ -27,8 +28,10 @@ INSTALL_DIR_ES = '%s/elasticsearch' % INSTALL_DIR_INFRA
 INSTALL_DIR_DDB = '%s/dynamodb' % INSTALL_DIR_INFRA
 INSTALL_DIR_KCL = '%s/amazon-kinesis-client' % INSTALL_DIR_INFRA
 INSTALL_DIR_STEPFUNCTIONS = '%s/stepfunctions' % INSTALL_DIR_INFRA
+INSTALL_DIR_KMS = '%s/kms' % INSTALL_DIR_INFRA
 INSTALL_DIR_ELASTICMQ = '%s/elasticmq' % INSTALL_DIR_INFRA
 INSTALL_PATH_LOCALSTACK_FAT_JAR = '%s/localstack-utils-fat.jar' % INSTALL_DIR_INFRA
+INSTALL_PATH_KMS_BINARY_PATTERN = os.path.join(INSTALL_DIR_KMS, 'local-kms.<arch>.bin')
 URL_LOCALSTACK_FAT_JAR = ('https://repo1.maven.org/maven2/' +
     'cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar').format(v=LOCALSTACK_MAVEN_VERSION)
 
@@ -104,6 +107,15 @@ def install_kinesalite():
     if not os.path.exists(target_dir):
         log_install_msg('Kinesis')
         run('cd "%s" && npm install' % ROOT_PATH)
+
+
+def install_local_kms():
+    binary_path = INSTALL_PATH_KMS_BINARY_PATTERN.replace('<arch>', get_arch())
+    if not os.path.exists(binary_path):
+        log_install_msg('KMS')
+        mkdir(INSTALL_DIR_KMS)
+        download(LOCAL_KMS_URL, binary_path)
+        chmod_r(binary_path, 0o777)
 
 
 def install_stepfunctions_local():
@@ -185,7 +197,8 @@ def install_component(name):
         'dynamodb': install_dynamodb_local,
         'es': install_elasticsearch,
         'sqs': install_elasticmq,
-        'stepfunctions': install_stepfunctions_local
+        'stepfunctions': install_stepfunctions_local,
+        'kms': install_local_kms
     }
     installer = installers.get(name)
     if installer:

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -1,0 +1,23 @@
+import logging
+from localstack import config
+from localstack.constants import DEFAULT_PORT_KMS_BACKEND, TEST_AWS_ACCOUNT_ID
+from localstack.utils.common import get_arch
+from localstack.services.infra import (
+    get_service_protocol, start_proxy_for_service, do_run)
+from localstack.services.install import INSTALL_PATH_KMS_BINARY_PATTERN
+
+LOG = logging.getLogger(__name__)
+
+
+def start_kms(port=None, backend_port=None, asynchronous=None, update_listener=None):
+    port = port or config.PORT_KMS
+    backend_port = DEFAULT_PORT_KMS_BACKEND
+    kms_binary = INSTALL_PATH_KMS_BINARY_PATTERN.replace('<arch>', get_arch())
+    print('Starting mock KMS (%s port %s)...' % (get_service_protocol(), port))
+    start_proxy_for_service('s3', port, backend_port, update_listener)
+    env_vars = {
+        'PORT': backend_port,
+        'REGION': config.DEFAULT_REGION,
+        'ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
+    }
+    return do_run(kms_binary, asynchronous, env_vars=env_vars)

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -14,9 +14,9 @@ def start_kms(port=None, backend_port=None, asynchronous=None, update_listener=N
     backend_port = DEFAULT_PORT_KMS_BACKEND
     kms_binary = INSTALL_PATH_KMS_BINARY_PATTERN.replace('<arch>', get_arch())
     print('Starting mock KMS (%s port %s)...' % (get_service_protocol(), port))
-    start_proxy_for_service('s3', port, backend_port, update_listener)
+    start_proxy_for_service('kms', port, backend_port, update_listener)
     env_vars = {
-        'PORT': backend_port,
+        'PORT': str(backend_port),
         'REGION': config.DEFAULT_REGION,
         'ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
     }

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -645,6 +645,16 @@ def is_alpine():
         return False
 
 
+def get_arch():
+    if is_mac_os():
+        return 'osx'
+    if is_alpine():
+        return 'alpine'
+    if is_linux():
+        return 'linux'
+    raise Exception('Unable to determine system architecture')
+
+
 def short_uid():
     return str(uuid.uuid4())[0:8]
 

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -4,7 +4,7 @@ from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack
 
 
-class EventsTest(unittest.TestCase):
+class KMSTest(unittest.TestCase):
 
     def test_create_key(self):
         client = aws_stack.connect_to_service('kms')
@@ -24,7 +24,6 @@ class EventsTest(unittest.TestCase):
         self.assertEqual(len(response['Keys']), len(keys_before) + 1)
 
         response = client.describe_key(KeyId=key_id)['KeyMetadata']
-        print(response)
         self.assertEqual(response['KeyId'], key_id)
         self.assertIn(':%s:' % config.DEFAULT_REGION, response['Arn'])
         self.assertIn(':%s:' % TEST_AWS_ACCOUNT_ID, response['Arn'])

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1,0 +1,30 @@
+import unittest
+from localstack import config
+from localstack.constants import TEST_AWS_ACCOUNT_ID
+from localstack.utils.aws import aws_stack
+
+
+class EventsTest(unittest.TestCase):
+
+    def test_create_key(self):
+        client = aws_stack.connect_to_service('kms')
+
+        response = client.list_keys()
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        keys_before = response['Keys']
+
+        response = client.create_key(
+            Policy='policy1',
+            Description='test key 123',
+            KeyUsage='ENCRYPT_DECRYPT')
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        key_id = response['KeyMetadata']['KeyId']
+
+        response = client.list_keys()
+        self.assertEqual(len(response['Keys']), len(keys_before) + 1)
+
+        response = client.describe_key(KeyId=key_id)['KeyMetadata']
+        print(response)
+        self.assertEqual(response['KeyId'], key_id)
+        self.assertIn(':%s:' % config.DEFAULT_REGION, response['Arn'])
+        self.assertIn(':%s:' % TEST_AWS_ACCOUNT_ID, response['Arn'])


### PR DESCRIPTION
Add initial support for KMS - addresses #206 .

This implementation is currently based on the wonderful [`local-kms` library](https://github.com/nsmithuk/local-kms), with pre-built binaries published here: https://github.com/localstack/localstack-artifacts/tree/master/local-kms

Note that moto has recently also added initial [support for KMS](https://github.com/spulec/moto/blob/master/IMPLEMENTATION_COVERAGE.md#kms), so we may want to consider switching to their implementation at some point, depending on API method coverage.