### PR TITLE
Add test for CW logs multi-byte message; allow trailing slashes in Elasticsearch API; add CloudWatch tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test:              ## Run automated tests
 		($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests --with-timer --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py' $(TEST_PATH))
 
 test-java:         ## Run tests for Java/JUnit compatibility
-	cd localstack/ext/java; USE_SSL=1 SERVICES=serverless,kinesis,sns,sqs mvn $(MVN_ARGS) -q test
+	cd localstack/ext/java; USE_SSL=1 SERVICES=serverless,kinesis,sns,sqs,cloudwatch mvn $(MVN_ARGS) -q test
 
 prepare-java-tests-if-changed:
 	@(! (git log -n 1 --no-merges --raw | grep localstack/ext/java/)) || (\

--- a/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
@@ -160,6 +160,10 @@ public class Localstack {
         return endpointForService(ServiceName.REDSHIFT);
     }
 
+    public String getEndpointCloudWatch() {
+        return endpointForService(ServiceName.CLOUDWATCH);
+    }
+
     public String getEndpointSES() {
         return endpointForService(ServiceName.SES);
     }
@@ -170,10 +174,6 @@ public class Localstack {
 
     public String getEndpointCloudFormation() {
         return endpointForService(ServiceName.CLOUDFORMATION);
-    }
-
-    public String getEndpointCloudWatch() {
-        return endpointForService(ServiceName.CLOUDWATCH);
     }
 
     public String getEndpointSSM() {

--- a/localstack/ext/java/src/main/java/cloud/localstack/TestUtils.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/TestUtils.java
@@ -6,6 +6,8 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.client.builder.ExecutorFactory;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams;
@@ -162,6 +164,12 @@ public class TestUtils {
                 withCredentials(getCredentialsProvider()).build();
     }
 
+    public static AmazonCloudWatch getClientCloudWatch() {
+        return AmazonCloudWatchClientBuilder.standard().
+                withEndpointConfiguration(getEndpointConfigurationCloudWatch()).
+                withCredentials(getCredentialsProvider()).build();
+    }
+
     protected static AwsClientBuilder.EndpointConfiguration getEndpointConfigurationLambda() {
         return getEndpointConfiguration(Localstack.INSTANCE.getEndpointLambda());
     }
@@ -188,6 +196,10 @@ public class TestUtils {
 
     protected static AwsClientBuilder.EndpointConfiguration getEndpointConfigurationSNS() {
         return getEndpointConfiguration(Localstack.INSTANCE.getEndpointSNS());
+    }
+
+    protected static AwsClientBuilder.EndpointConfiguration getEndpointConfigurationCloudWatch() {
+        return getEndpointConfiguration(Localstack.INSTANCE.getEndpointCloudWatch());
     }
 
     protected static AwsClientBuilder.EndpointConfiguration getEndpointConfigurationSecretsManager() {

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -14,6 +14,7 @@ API_PREFIX = '/2015-01-01'
 ES_DOMAINS = {}
 
 app = Flask(APP_NAME)
+app.url_map.strict_slashes = False
 
 
 def error_response(error_type, code=400, message='Unknown error.'):

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -32,4 +32,4 @@ class CloudWatchTest(unittest.TestCase):
             },
         ]
         response = client.put_metric_data(Namespace='string', MetricData=data)
-        print(response)
+        self.assertEquals(response['ResponseMetadata']['HTTPStatusCode'], 200)

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -1,0 +1,35 @@
+import unittest
+from localstack.utils.aws import aws_stack
+
+
+class CloudWatchTest(unittest.TestCase):
+
+    def test_put_metric_data(self):
+        client = aws_stack.connect_to_service('cloudwatch')
+
+        data = [
+            {
+                'MetricName': 'm1',
+                'Dimensions': [{
+                    'Name': 'foo',
+                    'Value': 'bar'
+                }],
+                'Value': 123.45,
+                'StatisticValues': {
+                    'SampleCount': 123.0,
+                    'Sum': 123.0,
+                    'Minimum': 123.0,
+                    'Maximum': 123.0
+                },
+                'Values': [
+                    123.0,
+                ],
+                'Counts': [
+                    123.0,
+                ],
+                'Unit': 'Seconds',
+                'StorageResolution': 123
+            },
+        ]
+        response = client.put_metric_data(Namespace='string', MetricData=data)
+        print(response)

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from localstack.utils.aws import aws_stack
+from localstack.utils.common import short_uid
+
+
+class CloudWatchLogsTest(unittest.TestCase):
+
+    def test_put_events_multibyte_msg(self):
+        client = aws_stack.connect_to_service('logs')
+
+        group = 'g-%s' % short_uid()
+        stream = 's-%s' % short_uid()
+        response = client.create_log_group(logGroupName=group)
+        self.assertEquals(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        response = client.create_log_stream(logGroupName=group, logStreamName=stream)
+        self.assertEquals(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        # send message with non-ASCII (multi-byte) chars
+        body_msg = '🙀 - 参よ'
+        events = [{
+            'timestamp': 1234567,
+            'message': body_msg
+        }]
+        response = client.put_log_events(logGroupName=group, logStreamName=stream, logEvents=events)
+        self.assertEquals(response['ResponseMetadata']['HTTPStatusCode'], 200)


### PR DESCRIPTION
* Add test for CW logs multi-byte message - addresses #1828 
* Allow trailing slashes in Elasticsearch API requests - fixes #1139
* Add basic tests for CloudWatch - addresses #1123