### PR TITLE
Fix Docker port mapping for JUnit test runner

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
@@ -75,7 +75,8 @@ public class Localstack {
                     dockerConfiguration.isPullNewImage(),
                     dockerConfiguration.isRandomizePorts(),
                     dockerConfiguration.getImageTag(),
-                    dockerConfiguration.getEnvironmentVariables()
+                    dockerConfiguration.getEnvironmentVariables(),
+                    dockerConfiguration.getPortMappings()
             );
             loadServiceToPortMap();
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/TestUtils.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/TestUtils.java
@@ -61,8 +61,13 @@ public class TestUtils {
     }
 
     public static AmazonSQS getClientSQS() {
+        return getClientSQS(null);
+    }
+
+    public static AmazonSQS getClientSQS(String endpoint) {
+        endpoint = endpoint == null ? Localstack.INSTANCE.getEndpointSQS() : endpoint;
         return AmazonSQSClientBuilder.standard().
-                withEndpointConfiguration(getEndpointConfigurationSQS()).
+                withEndpointConfiguration(getEndpointConfiguration(endpoint)).
                 withCredentials(getCredentialsProvider()).build();
     }
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
@@ -10,7 +10,8 @@ import java.util.Map;
 /**
  * Bean to specify the docker configuration.
  *
- * @author Patrick Allain.
+ * @author Patrick Allain
+ * @author Waldemar Hummer
  */
 @Data
 @Builder
@@ -29,5 +30,8 @@ public class LocalstackDockerConfiguration {
 
     @Builder.Default
     private final Map<String, String> environmentVariables = Collections.emptyMap();
+
+    @Builder.Default
+    private final Map<Integer, Integer> portMappings = Collections.emptyMap();
 
 }

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 import java.lang.annotation.Inherited;
 
 /**
- * An annotation to provide parameters to the LocalstackDockerTestRunner
+ * An annotation to provide parameters to the main (Docker-based) LocalstackTestRunner
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/command/PortCommand.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/command/PortCommand.java
@@ -22,7 +22,6 @@ public class PortCommand extends Command {
         this.containerId = containerId;
     }
 
-
     public List<PortMapping> execute() {
         String output = dockerExe.execute(Arrays.asList("port", containerId));
 
@@ -30,7 +29,6 @@ public class PortCommand extends Command {
                 .map(matchToPortMapping)
                 .collect(Collectors.toList());
     }
-
 
     private Function<MatchResult, PortMapping> matchToPortMapping = m -> new PortMapping(m.group(IP_GROUP), m.group(EXTERNAL_PORT_GROUP), m.group(INTERNAL_PORT_GROUP));
 

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/ContainerTest.java
@@ -21,7 +21,8 @@ public class ContainerTest {
 
         HashMap<String, String> environmentVariables = new HashMap<>();
         environmentVariables.put(MY_PROPERTY, MY_VALUE);
-        Container localStackContainer = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, pullNewImage, true, null, environmentVariables);
+        Container localStackContainer = Container.createLocalstackContainer(
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, environmentVariables, null);
 
         try {
             localStackContainer.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -49,7 +50,8 @@ public class ContainerTest {
 
     @Test
     public void createLocalstackContainerWithRandomPorts() throws Exception {
-        Container container = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, pullNewImage, true, null, new HashMap<>());
+        Container container = Container.createLocalstackContainer(
+            EXTERNAL_HOST_NAME, pullNewImage, true, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);
@@ -67,7 +69,8 @@ public class ContainerTest {
 
     @Test
     public void createLocalstackContainerWithStaticPorts() throws Exception {
-        Container container = Container.createLocalstackContainer(EXTERNAL_HOST_NAME, pullNewImage, false, null, new HashMap<>());
+        Container container = Container.createLocalstackContainer(
+            EXTERNAL_HOST_NAME, pullNewImage, false, null, null, null);
 
         try {
             container.waitForAllPorts(EXTERNAL_HOST_NAME);

--- a/localstack/ext/java/src/test/java/cloud/localstack/docker/PortBindingTest.java
+++ b/localstack/ext/java/src/test/java/cloud/localstack/docker/PortBindingTest.java
@@ -1,0 +1,29 @@
+package cloud.localstack.docker;
+
+import cloud.localstack.Localstack;
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.TestUtils;
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.runner.RunWith;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+
+@RunWith(LocalstackTestRunner.class)
+@ExtendWith(LocalstackDockerExtension.class)
+@LocalstackDockerProperties(randomizePorts = false, services = { "sqs:12345" })
+public class PortBindingTest {
+
+    @Test
+    public void testAccessPredefinedPort() {
+        String endpoint = Localstack.INSTANCE.endpointForPort(12345);
+        AmazonSQS amazonSQS = TestUtils.getClientSQS(endpoint);
+        String url = amazonSQS.createQueue("test-queue").getQueueUrl();
+        Assert.assertTrue(url.contains("://localhost:12345/queue/test-queue"));
+    }
+
+}


### PR DESCRIPTION
Fix Docker port mapping for JUnit test runner - fixes #1198 .

This PR ensures that the Docker ports are correctly exposed when using the `services` configuration in `LocalstackDockerProperties` (e.g., port `12345` in the example below):
```
@RunWith(LocalstackTestRunner.class)
@ExtendWith(LocalstackDockerExtension.class)
@LocalstackDockerProperties(randomizePorts = false, services = { "sqs:12345" })
public class PortBindingTest {
...
```