### PR TITLE
Add optional useSingleDockerContainer annotation attribute

### DIFF
--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerAnnotationProcessor.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
  *
  * @author Alan Bevier
  * @author Patrick Allain
+ * @author Omar Khammassi
  */
 public class LocalstackDockerAnnotationProcessor {
 
@@ -34,6 +35,7 @@ public class LocalstackDockerAnnotationProcessor {
             .pullNewImage(properties.pullNewImage())
             .randomizePorts(properties.randomizePorts())
             .imageTag(StringUtils.isEmpty(properties.imageTag()) ? null : properties.imageTag())
+            .useSingleDockerContainer(properties.useSingleDockerContainer())
             .build();
     }
 

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerConfiguration.java
@@ -2,7 +2,6 @@ package cloud.localstack.docker.annotation;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
 
 import java.util.Collections;
 import java.util.Map;
@@ -12,6 +11,7 @@ import java.util.Map;
  *
  * @author Patrick Allain
  * @author Waldemar Hummer
+ * @author Omar Khammassi
  */
 @Data
 @Builder
@@ -33,5 +33,8 @@ public class LocalstackDockerConfiguration {
 
     @Builder.Default
     private final Map<Integer, Integer> portMappings = Collections.emptyMap();
+
+    @Builder.Default
+    private final boolean useSingleDockerContainer = false;
 
 }

--- a/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/docker/annotation/LocalstackDockerProperties.java
@@ -47,4 +47,9 @@ public @interface LocalstackDockerProperties {
      * Use a specific image tag for docker container
      */
     String imageTag() default "";
+
+    /**
+     * Determines if the singleton container should be used by all test classes
+     */
+    boolean useSingleDockerContainer() default false;
 }


### PR DESCRIPTION
This PR is about adding an optional flag to use a singleton docker container instead of start/stop Localstack container for each test class

I agree to the contributor license agreement