### PR TITLE
Changing to restrict prefix to only dotnet and python images

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -686,7 +686,8 @@ class Util:
         docker_image = config.LAMBDA_CONTAINER_REGISTRY
         # TODO: remove prefix once execution issues are fixed with dotnetcore/python lambdas
         # See https://github.com/lambci/docker-lambda/pull/218
-        if docker_image == 'lambci/lambda':
+        lambdas_to_add_prefix = ['dotnetcore', 'python']
+        if docker_image == 'lambci/lambda' and any(img in docker_tag for img in lambdas_to_add_prefix):
             docker_tag = '20191117-%s' % docker_tag
         return '"%s:%s"' % (docker_image, docker_tag)
 


### PR DESCRIPTION
This PR is to improve the changes made on https://github.com/localstack/localstack/pull/1771 that has changed the lambda executors to add the prefix `20191117-` to the image. 

As it says that this change is necessary to dotnetcore/python lambdas images, I added a check to add the prefix only to these images.