### PR TITLE
Lazily start up Elasticsearch instance on ES domain creation

### DIFF
--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -6,7 +6,6 @@ from localstack.utils.bootstrap import ENV_SCRIPT_STARTING_DOCKER
 def register_localstack_plugins():
     # register default plugins
     try:
-        from localstack.services.es import es_starter
         from localstack.services.s3 import s3_listener, s3_starter
         from localstack.services.kms import kms_starter
         from localstack.services.sns import sns_listener
@@ -39,9 +38,6 @@ def register_localstack_plugins():
             start=start_dynamodbstreams))
         register_plugin(Plugin('ec2',
             start=start_ec2))
-        register_plugin(Plugin('elasticsearch',
-            start=es_starter.start_elasticsearch,
-            check=es_starter.check_elasticsearch))
         register_plugin(Plugin('es',
             start=start_elasticsearch_service))
         register_plugin(Plugin('events',

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -1,11 +1,11 @@
 import json
 import time
+import unittest
+from nose.tools import assert_in, assert_equal
 from botocore.exceptions import ClientError
-from nose.tools import assert_raises, assert_equal, assert_true, assert_false
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import safe_requests as requests
 
-ES_URL = aws_stack.get_local_service_url('elasticsearch')
 TEST_INDEX = 'megacorp'
 TEST_DOC_ID = 1
 COMMON_HEADERS = {
@@ -16,96 +16,101 @@ TEST_DOMAIN_NAME = 'test_es_domain_1'
 TEST_ENDPOINT_URL = 'http://localhost:4571'
 
 
-def setUp():
-    document = {
-        'first_name': 'Jane',
-        'last_name': 'Smith',
-        'age': 32,
-        'about': 'I like to collect rock albums',
-        'interests': ['music']
-    }
-    resp = add_document(TEST_DOC_ID, document)
-    assert_equal(201, resp.status_code,
-        msg='Request failed({}): {}'.format(resp.status_code, resp.text))
+class ElasticsearchTest(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        cls.es_url = aws_stack.get_local_service_url('elasticsearch')
+        # create ES domain
+        cls._create_domain()
+        document = {
+            'first_name': 'Jane',
+            'last_name': 'Smith',
+            'age': 32,
+            'about': 'I like to collect rock albums',
+            'interests': ['music']
+        }
+        resp = cls._add_document(TEST_DOC_ID, document)
+        assert_equal(resp.status_code, 201,
+            msg='Request failed({}): {}'.format(resp.status_code, resp.text))
 
-def tearDown():
-    delete_document(TEST_DOC_ID)
+    @classmethod
+    def tearDownClass(cls):
+        cls._delete_document(TEST_DOC_ID)
 
+    def test_domain_creation(self):
+        es_client = aws_stack.connect_to_service('es')
 
-def add_document(id, document):
-    article_path = '{}/{}/employee/{}?pretty'.format(ES_URL, TEST_INDEX, id)
-    resp = requests.put(
-        article_path,
-        data=json.dumps(document),
-        headers=COMMON_HEADERS)
-    # Pause to allow the document to be indexed
-    time.sleep(1)
-    return resp
+        # make sure we cannot re-create same domain name
+        self.assertRaises(ClientError, es_client.create_elasticsearch_domain, DomainName=TEST_DOMAIN_NAME)
 
+        # get domain status
+        status = es_client.describe_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
+        self.assertEqual(status['DomainStatus']['DomainName'], TEST_DOMAIN_NAME)
+        self.assertTrue(status['DomainStatus']['Created'])
+        self.assertFalse(status['DomainStatus']['Processing'])
+        self.assertFalse(status['DomainStatus']['Deleted'])
+        self.assertEqual(status['DomainStatus']['Endpoint'], aws_stack.get_elasticsearch_endpoint())
+        self.assertTrue(status['DomainStatus']['EBSOptions']['EBSEnabled'])
 
-def delete_document(id):
-    article_path = '{}/{}/employee/{}?pretty'.format(ES_URL, TEST_INDEX, id)
-    resp = requests.delete(article_path, headers=COMMON_HEADERS)
-    # Pause to allow the document to be indexed
-    time.sleep(1)
-    return resp
+        # make sure we can fake adding tags to a domain
+        response = es_client.add_tags(ARN='string', TagList=[{'Key': 'SOME_TAG', 'Value': 'SOME_VALUE'}])
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
 
+        # make sure domain deletion works
+        es_client.delete_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
+        self.assertNotIn(TEST_DOMAIN_NAME,
+            [d['DomainName'] for d in es_client.list_domain_names()['DomainNames']])
 
-def test_domain_creation():
-    es_client = aws_stack.connect_to_service('es')
+    def test_elasticsearch_get_document(self):
+        article_path = '{}/{}/employee/{}?pretty'.format(
+            self.es_url, TEST_INDEX, TEST_DOC_ID)
+        resp = requests.get(article_path, headers=COMMON_HEADERS)
 
-    # create ES domain
-    es_client.create_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
-    assert_true(TEST_DOMAIN_NAME in
-        [d['DomainName'] for d in es_client.list_domain_names()['DomainNames']])
+        self.assertIn('I like to collect rock albums', resp.text,
+            msg='Document not found({}): {}'.format(resp.status_code, resp.text))
 
-    # make sure we cannot re-create same domain name
-    assert_raises(ClientError, es_client.create_elasticsearch_domain, DomainName=TEST_DOMAIN_NAME)
+    def test_elasticsearch_search(self):
+        search_path = '{}/{}/employee/_search?pretty'.format(self.es_url, TEST_INDEX)
 
-    # get domain status
-    status = es_client.describe_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
-    assert_equal(status['DomainStatus']['DomainName'], TEST_DOMAIN_NAME)
-    assert_true(status['DomainStatus']['Created'])
-    assert_false(status['DomainStatus']['Processing'])
-    assert_false(status['DomainStatus']['Deleted'])
-    assert_equal(status['DomainStatus']['Endpoint'], aws_stack.get_elasticsearch_endpoint())
-    assert_true(status['DomainStatus']['EBSOptions']['EBSEnabled'])
-
-    # make sure we can fake adding tags to a domain
-    response = es_client.add_tags(ARN='string', TagList=[{'Key': 'SOME_TAG', 'Value': 'SOME_VALUE'}])
-    assert_equal(200, response['ResponseMetadata']['HTTPStatusCode'])
-
-    # make sure domain deletion works
-    es_client.delete_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
-    assert_false(TEST_DOMAIN_NAME in
-        [d['DomainName'] for d in es_client.list_domain_names()['DomainNames']])
-
-
-def test_elasticsearch_get_document():
-    article_path = '{}/{}/employee/{}?pretty'.format(
-        ES_URL, TEST_INDEX, TEST_DOC_ID)
-    resp = requests.get(article_path, headers=COMMON_HEADERS)
-
-    assert_true('I like to collect rock albums' in resp.text,
-        msg='Document not found({}): {}'.format(resp.status_code, resp.text))
-
-
-def test_elasticsearch_search():
-    search_path = '{}/{}/employee/_search?pretty'.format(ES_URL, TEST_INDEX)
-
-    search = {
-        'query': {
-            'match': {
-                'last_name': 'Smith'
+        search = {
+            'query': {
+                'match': {
+                    'last_name': 'Smith'
+                }
             }
         }
-    }
 
-    resp = requests.get(
-        search_path,
-        data=json.dumps(search),
-        headers=COMMON_HEADERS)
+        resp = requests.get(
+            search_path,
+            data=json.dumps(search),
+            headers=COMMON_HEADERS)
 
-    assert_true('I like to collect rock albums' in resp.text,
-        msg='Search failed({}): {}'.format(resp.status_code, resp.text))
+        self.assertIn('I like to collect rock albums', resp.text,
+            msg='Search failed({}): {}'.format(resp.status_code, resp.text))
+
+    @classmethod
+    def _add_document(self, id, document):
+        article_path = '{}/{}/employee/{}?pretty'.format(self.es_url, TEST_INDEX, id)
+        resp = requests.put(
+            article_path,
+            data=json.dumps(document),
+            headers=COMMON_HEADERS)
+        # Pause to allow the document to be indexed
+        time.sleep(1)
+        return resp
+
+    @classmethod
+    def _delete_document(self, id):
+        article_path = '{}/{}/employee/{}?pretty'.format(self.es_url, TEST_INDEX, id)
+        resp = requests.delete(article_path, headers=COMMON_HEADERS)
+        # Pause to allow the document to be indexed
+        time.sleep(1)
+        return resp
+
+    @classmethod
+    def _create_domain(cls):
+        es_client = aws_stack.connect_to_service('es')
+        es_client.create_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)
+        assert_in(TEST_DOMAIN_NAME,
+            [d['DomainName'] for d in es_client.list_domain_names()['DomainNames']])

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -27,7 +27,7 @@ class PutRequest(Request):
         return 'PUT'
 
 
-class S3ListenerTest (unittest.TestCase):
+class S3ListenerTest(unittest.TestCase):
 
     def setUp(self):
         self.s3_client = aws_stack.connect_to_service('s3')


### PR DESCRIPTION
Lazily start up Elasticsearch instance on ES domain creation. This helps to significantly speed up startup time and reduce memory consumption for the default configuration.