### PR TITLE
Adding content-length header in success_action_status response

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -816,6 +816,8 @@ class ProxyListenerS3(ProxyListener):
             if response.status_code == 200 and status_code == '201' and key:
                 response.status_code = 201
                 response._content = self.get_201_reponse(key, bucket_name)
+                response.headers['Content-Length']=len(response._content)
+                response.headers['Content-Type'] = 'application/xml; charset=utf-8'
                 return response
 
         parsed = urlparse.urlparse(path)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -816,7 +816,7 @@ class ProxyListenerS3(ProxyListener):
             if response.status_code == 200 and status_code == '201' and key:
                 response.status_code = 201
                 response._content = self.get_201_reponse(key, bucket_name)
-                response.headers['Content-Length']=len(response._content)
+                response.headers['Content-Length'] = str(len(response._content))
                 response.headers['Content-Type'] = 'application/xml; charset=utf-8'
                 return response
 


### PR DESCRIPTION
The objective of this PR is to add content-length header to success_action_status response because it sends an empty response if that header has no value.

This is related to https://github.com/localstack/localstack/pull/1849