### PR TITLE
feat: expose sfn endpoint

### DIFF
--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -21,11 +21,12 @@ def start_stepfunctions(port=None, asynchronous=False, update_listener=None):
     dynamodb_endpoint = aws_stack.get_local_service_url('dynamodb')
     sns_endpoint = aws_stack.get_local_service_url('sns')
     sqs_endpoint = aws_stack.get_local_service_url('sqs')
+    sfn_endpoint = aws_stack.get_local_service_url('stepfunctions')
     cmd = ('cd %s; java -Dcom.amazonaws.sdk.disableCertChecking -Xmx%s -jar StepFunctionsLocal.jar '
            '--lambda-endpoint %s --dynamodb-endpoint %s --sns-endpoint %s '
-           '--sqs-endpoint %s --aws-region %s --aws-account %s') % (
+           '--sqs-endpoint %s --aws-region %s --aws-account %s --step-functions-endpoint %s') % (
         install.INSTALL_DIR_STEPFUNCTIONS, MAX_HEAP_SIZE, lambda_endpoint, dynamodb_endpoint,
-        sns_endpoint, sqs_endpoint, aws_stack.get_region(), TEST_AWS_ACCOUNT_ID)
+        sns_endpoint, sqs_endpoint, aws_stack.get_region(), TEST_AWS_ACCOUNT_ID, sfn_endpoint)
     print('Starting mock StepFunctions (%s port %s)...' % (get_service_protocol(), port))
     start_proxy_for_service('stepfunctions', port, backend_port, update_listener)
     return do_run(cmd, asynchronous)


### PR DESCRIPTION
Currently, when attempting to [execute workflow from task](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-nested-workflows.html), I get this error: {"Type":"TaskFailed","PreviousEventId":6,"TaskFailedEventDetails":{"ResourceType":"states","Resource":"startExecution.sync","Error":"StepFunctions-AWSStepFunctionsException","Cause":"The security token included in the request is invalid. (Service: AWSStepFunctions; Status Code: 400; Error Code: UnrecognizedClientException; Request ID: 1a9d805b-55af-4bf3-8515-4bf49e4f81e3)"}}

This PR exposes the `--step-functions-endpoint` flag that was added to the jar but not documented properly in the AWS docs.