### PR TITLE
Added invoke support for json types that are not maps or lists

### DIFF
--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -163,6 +163,16 @@ class TestLambdaAPI(unittest.TestCase):
             self.assertEquals({'Content-Type': 'application/json'}, response[2])
 
     @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_string_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '"thing"'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'"thing"\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
     def test_invoke_integer_json_response(self, mock_run_lambda):
         with self.app.test_request_context() as context:
             self._request_response(context)

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import unittest
+import mock
 from localstack.utils.common import save_file, new_tmp_dir, mkdir
 from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.utils.aws.aws_models import LambdaFunction
@@ -88,6 +89,118 @@ class TestLambdaAPI(unittest.TestCase):
             result = lambda_api.delete_event_source_mapping(self.TEST_UUID)
             self.assertEqual(json.loads(result.get_data()).get('UUID'), self.TEST_UUID)
             self.assertEqual(0, len(lambda_api.event_source_mappings))
+
+    def test_invoke_RETURNS_415_WHEN_not_json_input(self):
+        with self.app.test_request_context() as context:
+            context.request._cached_data = '~notjsonrequest~'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual('415 UNSUPPORTED MEDIA TYPE', response.status)
+
+    def _request_response(self, context):
+        context.request._cached_data = '{}'
+        context.request.args = {'Qualifier': '$LATEST'}
+        context.request.environ['HTTP_X_AMZ_INVOCATION_TYPE'] = 'RequestResponse'
+        self._create_function(self.FUNCTION_NAME)
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_plain_text_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '~notjsonresponse~'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual('~notjsonresponse~', response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'text/plain'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_empty_plain_text_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = ''
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual('', response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'text/plain'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_empty_map_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '{}'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'{}\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEquals({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_populated_map_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '{"bool":true,"int":1}'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'{"bool":true,"int":1}\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEquals({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_empty_list_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '[]'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'[]\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEquals({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_populated_list_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '[true,1,"thing"]'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'[true,1,"thing"]\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEquals({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_integer_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '1234'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'1234\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_float_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = '1.3'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'1.3\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_boolean_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = 'true'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'true\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'application/json'}, response[2])
+
+    @mock.patch('localstack.services.awslambda.lambda_api.run_lambda')
+    def test_invoke_null_json_response(self, mock_run_lambda):
+        with self.app.test_request_context() as context:
+            self._request_response(context)
+            mock_run_lambda.return_value = 'null'
+            response = lambda_api.invoke_function(self.FUNCTION_NAME)
+            self.assertEqual(b'null\n', response[0].response[0])
+            self.assertEqual(200, response[1])
+            self.assertEqual({'Content-Type': 'application/json'}, response[2])
 
     def test_create_event_source_mapping(self):
         self.client.post('{0}/event-source-mappings/'.format(lambda_api.PATH_ROOT),


### PR DESCRIPTION
Addresses https://github.com/localstack/localstack/issues/1883

Rather than trying to pre-determine whether or not a given string is json-encoded based on the first character, simply give it a try, and assume that raised errors imply it was not.

- [x] Add tests for any new features and bug fixes. Ideally, each PR should increase the test coverage.
- [x] Follow the existing code style (e.g., indents). A PEP8 code linting target is included in the Makefile.
- [x] Put a reasonable amount of comments into the code.
- [x] Separate unrelated changes into multiple pull requests.
- [ ] 1 commit per PR: Please squash/rebase multiple commits into one single commit (to keep the history clean).