### PR TITLE
Fix URL encoding when reading key name for S3 Range fix

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -360,6 +360,7 @@ def fix_range_content_type(bucket_name, path, headers, response):
         return
 
     s3_client = aws_stack.connect_to_service('s3')
+    path = urlparse.unquote(path)
     key_name = get_key_name(path, headers)
     result = s3_client.head_object(Bucket=bucket_name, Key=key_name)
     content_type = result['ContentType']


### PR DESCRIPTION
Should fix https://github.com/localstack/serverless-localstack/issues/64