### PR TITLE
Updated local-kms binary repository

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -87,7 +87,7 @@ ELASTICSEARCH_DELETE_MODULES = ['ingest-geoip']
 ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.2.jar'
 STS_JAR_URL = 'https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip'
-KMS_URL_PATTERN = 'https://github.com/localstack/localstack-artifacts/raw/master/local-kms/build/local-kms.<arch>.bin'
+KMS_URL_PATTERN = 'https://s3-eu-west-2.amazonaws.com/local-kms/localstack/v3/local-kms.<arch>.bin'
 
 # TODO: Temporarily using a fixed version of DDB in Alpine, as we're hitting a SIGSEGV JVM crash with latest
 DYNAMODB_JAR_URL_ALPINE = 'https://github.com/whummer/dynamodb-local/raw/master/etc/DynamoDBLocal.zip'

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -17,7 +17,7 @@ def start_kms(port=None, backend_port=None, asynchronous=None, update_listener=N
     start_proxy_for_service('kms', port, backend_port, update_listener)
     env_vars = {
         'PORT': str(backend_port),
-        'REGION': config.DEFAULT_REGION,
-        'ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
+        'KMS_REGION': config.DEFAULT_REGION,
+        'KMS_ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
     }
     return do_run(kms_binary, asynchronous, env_vars=env_vars)


### PR DESCRIPTION
Following on from @whummer's PR: https://github.com/localstack/localstack/pull/1839

Pulls in the binaries from the official local-kms repo. The URL will always return the latest stable tag of v3. Ensures new features (e.g. https://github.com/nsmithuk/local-kms/issues/12) are incorporated into localstack. Locking it to MAJOR version 3 ensures no backward breaking changes will be introduced.

Localstack has been given its own subfolder to allow for its naming convention: `local-kms.<arch>.bin`.

At present there are 3 pre-compiled versions:
* `local-kms.osx.bin`
* `local-kms.linux.bin`
* `local-kms.alpine.bin`

local-kms now also prefers some of its environment variables to be prefixed with `KMS_`.
