### PR TITLE
Make lambdas triggered by SQS run asynchronously

### DIFF
--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -122,7 +122,10 @@ def deserialize_event(event):
     if sqs:
         result = {'data': event['body']}
         return result
-    return event.get('Sns')
+    sns = event.get('Sns')
+    if sns:
+        result = {'data': sns['Message']}
+        return result
 
 
 def forward_events(records):


### PR DESCRIPTION
This PR decouples SQS message processing and lambda execution by running lambdas asynchronously. It also adds a test on SNS-triggered lambdas to see if messages end up in the correct dead letter queue.
It addresses #1967.

@rfunix and @georgeyk contributed with suggestions and pairing.