### PR TITLE
fixes regression with underscores in S3 upload metadata #1975

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -828,7 +828,7 @@ class ProxyListenerS3(ProxyListener):
                 return set_object_lock(bucket, data)
 
         if modified_data is not None or headers_changed:
-            return Request(data=modified_data, headers=headers, method=method)
+            return Request(data=modified_data or data, headers=headers, method=method)
         return True
 
     def get_201_reponse(self, key, bucket_name):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -252,7 +252,7 @@ class S3ListenerTest(unittest.TestCase):
         # put object
         object_key = 'key-with-metadata'
         metadata = {'test_meta_1': 'foo'}
-        self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Metadata=metadata)
+        self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Metadata=metadata, Body='foo')
         metadata_saved = self.s3_client.head_object(Bucket=bucket_name, Key=object_key)['Metadata']
         self.assertEqual(metadata, metadata_saved)
 


### PR DESCRIPTION
If `headers_changed` is `True`, `modified_data` is not necessarily set.  This adds a Body to the `put_object` request to capture this issue.