### PR TITLE
Fix CreationDate format for S3 ListBuckets

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -916,8 +916,9 @@ def generate_ssl_cert(target_file=None, overwrite=False, random=False, return_co
     cert.gmtime_adj_notAfter(2 * 365 * 24 * 60 * 60)
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(k)
+    alt_names = b'DNS:localhost,DNS:test.localhost.atlassian.io,IP:127.0.0.1'
     cert.add_extensions([
-        crypto.X509Extension(b'subjectAltName', False, b'DNS:localhost,IP:127.0.0.1'),
+        crypto.X509Extension(b'subjectAltName', False, alt_names),
         crypto.X509Extension(b'basicConstraints', True, b'CA:false'),
         crypto.X509Extension(b'keyUsage', True, b'nonRepudiation,digitalSignature,keyEncipherment'),
         crypto.X509Extension(b'extendedKeyUsage', True, b'serverAuth')

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ jsonpath-rw==1.4.0
 localstack-ext[full]>=0.10.51
 localstack-ext>=0.10.51        #basic-lib
 localstack-client>=0.14        #basic-lib
-moto-ext>=1.3.15.3
+moto-ext>=1.3.15.4
 nose>=1.3.7
 nose-timer>=0.7.5
 psutil==5.4.8

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -252,7 +252,7 @@ class S3ListenerTest(unittest.TestCase):
 
         # put object
         object_key = 'key-with-metadata'
-        metadata = {'test_meta_1': 'foo'}
+        metadata = {'test_meta_1': 'foo', '__meta_2': 'bar'}
         self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Metadata=metadata, Body='foo')
         metadata_saved = self.s3_client.head_object(Bucket=bucket_name, Key=object_key)['Metadata']
         self.assertEqual(metadata, metadata_saved)


### PR DESCRIPTION
* Fix CreationDate format for S3 ListBuckets - fixes #1899
* Fix S3 metadata keys starting with an underscore
* Accept self-signed certs in Java tests