### PR TITLE
Adjust urllib3 pool size to allow more parallel HTTP requests

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -206,7 +206,7 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
         forward_headers = CaseInsensitiveDict(self.headers)
 
         # force close connection
-        if forward_headers.get('Connection', '').lower() != 'keep-alive':
+        if forward_headers.get('Connection') not in ['keep-alive', None]:
             self.close_connection = 1
 
         def is_full_url(url):


### PR DESCRIPTION
* Adjust urllib3 pool size to allow more parallel HTTP requests - fixes #1980
* Avoid auto-closing connections if no `Connection` header is closed - fixes connection issues with the Go AWS SDK.