### PR TITLE
Use old ruby image

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -698,7 +698,7 @@ class Util:
         docker_image = config.LAMBDA_CONTAINER_REGISTRY
         # TODO: remove prefix once execution issues are fixed with dotnetcore/python lambdas
         # See https://github.com/lambci/docker-lambda/pull/218
-        lambdas_to_add_prefix = ['dotnetcore', 'python2.7', 'python3.6', 'python3.7']
+        lambdas_to_add_prefix = ['dotnetcore', 'python2.7', 'python3.6', 'python3.7', 'ruby2.5']
         if docker_image == 'lambci/lambda' and any(img in docker_tag for img in lambdas_to_add_prefix):
             docker_tag = '20191117-%s' % docker_tag
         return '"%s:%s"' % (docker_image, docker_tag)


### PR DESCRIPTION
The new one consistently fails with this message:

```
Aws::Lambda::Errors::InternalFailure:
       Error executing Lambda function arn:aws:lambda:us-east-1:000000000000:function:*******: Lambda process returned error status code: 1. Result: . Output:
       2020/02/06 13:46:40 listen tcp 127.0.0.1:9001: bind: address already in use Traceback (most recent call last):
         File "/opt/code/localstack/localstack/services/awslambda/lambda_api.py", line 380, in run_lambda
           event, context=context, version=version, asynchronous=asynchronous)
         File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 116, in execute
           return do_execute()
         File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 101, in do_execute
           raise e
         File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 90, in do_execute
           result, log_output = self._execute(func_arn, func_details, event, context, version)
         File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 235, in _execute
           result, log_output = self.run_lambda_executor(cmd, stdin, environment)
         File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 153, in run_lambda_executor
           (return_code, result, log_output))
       Exception: Lambda process returned error status code: 1. Result: . Output:
       2020/02/06 13:46:40 listen tcp 127.0.0.1:9001: bind: address already in use
```

I haven't tested that this actually works, it's just a theory. The new
images were published 13 hours ago, so more languages could actually
have broken.