### PR TITLE
Prefixing each CloudWatch event written to disk with a millisecond-precision timestamp so that clients can more easily assert about the order in which events were published.

### DIFF
--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import time
 import uuid
 
 from requests.models import Response
@@ -61,8 +62,10 @@ class ProxyListenerEvents(ProxyListener):
             TMP_FILES.append(EVENTS_TMP_DIR)
 
     def _dump_events_to_files(self, events_with_added_uuid):
+        current_time_millis = int(round(time.time() * 1000))
         for event in events_with_added_uuid:
-            save_file(os.path.join(EVENTS_TMP_DIR, event['uuid']), json.dumps(event['event']))
+            save_file(os.path.join(EVENTS_TMP_DIR, '%s_%s' % (current_time_millis, event['uuid'])),
+                      json.dumps(event['event']))
 
     def _fix_date_format(self, response):
         """ Normalize date to format '2019-06-13T18:10:09.1234Z' """


### PR DESCRIPTION
A [previous PR](https://github.com/localstack/localstack/pull/1830) wrote CloudWatch events to disk so that clients could verify their expected events had been published. This worked great in our tests until it came to reasoning about the order in which events had been published.

This change prepends the current time in milliseconds to the name of the event file (it's currently just the event id).

We considered instead relying on the modification timestamp of the file to determine the order events had been published in, but we encountered certain OSs and filesystems that are unable to report these timestamps with sub-second precision.

Another option would have been to rely on a timestamp included in the event payload itself, but some of our events do not contain timestamps.
