### PR TITLE
Mark LocalstackExtension deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ public class MyCloudAppTest {
 Or with JUnit 5 :
 
 ```
-@ExtendWith(LocalstackExtension.class)
+@ExtendWith(LocalstackDockerExtension.class)
 @LocalstackDockerProperties(...)
 public class MyCloudAppTest {
    ...

--- a/localstack/ext/java/src/main/java/cloud/localstack/deprecated/LocalstackExtension.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/deprecated/LocalstackExtension.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *
  * @author Patrick Allain
  */
+@Deprecated
 public class LocalstackExtension implements BeforeTestExecutionCallback {
 
     @Override

--- a/localstack/ext/java/src/main/java/cloud/localstack/deprecated/TestUtils.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/deprecated/TestUtils.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 
 import static cloud.localstack.TestUtils.getCredentialsProvider;
 
+@Deprecated
 @SuppressWarnings("all")
 public class TestUtils {
 


### PR DESCRIPTION
LocalstackExtension was previously deprecated but was lacking the proper annotation.

This also fixes the documentation for JUnit 5 in the README to use LocalstackDockerExtension instead of the deprecated LocalstackExtension.

Resolves: #1928