### PR TITLE
Add persistence for Elasticsearch Service API calls

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -891,7 +891,7 @@ class ProxyListenerS3(ProxyListener):
         bucket_name = get_bucket_name(path, headers)
 
         # persist this API call to disk
-        persistence.record('s3', method, path, data, headers, response)
+        persistence.record('s3', method, path, data, headers, response=response)
 
         # No path-name based bucket name? Try host-based
         hostname_parts = headers['host'].split('.')

--- a/localstack/utils/persistence.py
+++ b/localstack/utils/persistence.py
@@ -28,16 +28,21 @@ LOG = logging.getLogger(__name__)
 
 def should_record(api, method, path, data, headers, response=None):
     """ Decide whether or not a given API call should be recorded (persisted to disk) """
-    if api == 's3':
+    if api in ['es', 's3']:
         return method in ['PUT', 'POST', 'DELETE']
     return False
 
 
-def record(api, method, path, data, headers, response=None):
+def record(api, method=None, path=None, data=None, headers=None, response=None, request=None):
     """ Record a given API call to a persistent file on disk """
     file_path = get_file_path(api)
     if CURRENTLY_REPLAYING or not file_path:
         return
+    if request:
+        method = method or request.method
+        path = path or request.path
+        headers = headers or request.headers
+        data = data or request.data
     should_be_recorded = should_record(api, method, path, data, headers, response=response)
     if not should_be_recorded:
         return


### PR DESCRIPTION
Add persistence for Elasticsearch Service API calls - supports re-creation of ES domains across LocalStack restarts.