### PR TITLE
Fix setting of empty SQS queue attribute values

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -436,6 +436,7 @@ def run(cmd, print_error=True, asynchronous=False, stdin=False,
     env_dict = os.environ.copy() if inherit_env else {}
     if env_vars:
         env_dict.update(env_vars)
+    env_dict = dict([(k, to_str(str(v))) for k, v in env_dict.items()])
 
     if tty:
         asynchronous = True


### PR DESCRIPTION
* Fix setting of empty SQS queue attribute values - fixes #2046
* Modify payload to forward only supported queue attributes to SQS backend
* Ensure environment variable values are strings - should fix #1891