### PR TITLE
Check for None before iterating.

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -253,7 +253,9 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
             parsed_result = common.json_safe(parsed_result)
             parsed_result = {} if parsed_result is None else parsed_result
             response.status_code = int(parsed_result.get('statusCode', 200))
-            response.headers.update(parsed_result.get('headers', {}))
+            parsed_headers = parsed_result.get('headers', {})
+            if parsed_headers is not None:
+                response.headers.update(parsed_headers)
             try:
                 if isinstance(parsed_result['body'], dict):
                     response._content = json.dumps(parsed_result['body'])


### PR DESCRIPTION
Fixes: #2055
Check for None before iterating the parsed headers.