### PR TITLE
added 'True' as valid option for RawMessageDelivery subscription attr…

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -404,7 +404,7 @@ def create_sns_message_body(subscriber, req_data):
         # fix non-ascii unicode characters under Python 2
         message = message.encode('raw-unicode-escape')
 
-    if subscriber.get('RawMessageDelivery') in ('true', 'True', True):
+    if is_raw_message_delivery(subscriber):
         return message
 
     if req_data.get('MessageStructure') == ['json']:
@@ -434,7 +434,7 @@ def create_sns_message_body(subscriber, req_data):
 
 
 def create_sqs_message_attributes(subscriber, attributes):
-    if subscriber.get('RawMessageDelivery') not in ('true', True):
+    if not is_raw_message_delivery(subscriber):
         return {}
 
     message_attributes = {}
@@ -566,3 +566,7 @@ def check_filter_policy(filter_policy, message_attributes):
             return False
 
     return True
+
+
+def is_raw_message_delivery(susbcriber):
+    return susbcriber.get('RawMessageDelivery') in ('true', True, 'True')

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -477,3 +477,20 @@ class SNSTests(unittest.TestCase):
             attributes = test[2]
             expected = test[3]
             self.assertEqual(sns_listener.check_filter_policy(filter_policy, attributes), expected, test_name)
+
+    def test_is_raw_message_delivery(self):
+        valid_true_values = ['true', 'True', True]
+
+        for true_value in valid_true_values:
+            self.subscriber['RawMessageDelivery'] = true_value
+            self.assertTrue(sns_listener.is_raw_message_delivery(self.subscriber))
+
+    def test_is_not_raw_message_delivery(self):
+        invalid_values = ['false', 'False', False, 'somevalue', '']
+
+        for invalid_values in invalid_values:
+            self.subscriber['RawMessageDelivery'] = invalid_values
+            self.assertFalse(sns_listener.is_raw_message_delivery(self.subscriber))
+
+        del self.subscriber['RawMessageDelivery']
+        self.assertFalse(sns_listener.is_raw_message_delivery(self.subscriber))


### PR DESCRIPTION
…ibute for SNS - SQS integration

This fixes an issue where the Message Attributes were not being delivered from SNS to SQS when the RawMessageDelivery attribute is set like this in the cloudformation template:

```
  QueueTopicSubscription:
    Type: AWS::SNS::Subscription
    Properties:
      Endpoint: !GetAtt SomeEndpoint.Arn
      Protocol: sqs
      RawMessageDelivery: True
      TopicArn: !Ref SomeTopic.Arn
```

Moved the check to a function to centralize this logic.
