### PR TITLE
Update PYTHONPATH for Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN apk del --purge git
 RUN pip uninstall -y awscli boto3 botocore localstack_client idna s3transfer
 RUN rm -rf /tmp/* /root/.cache /opt/yarn-v1.15.2; mkdir -p /tmp/localstack
 RUN ln -s /opt/code/localstack/.venv/bin/aws /usr/bin/aws
-ENV PYTHONPATH=/opt/code/localstack/.venv/lib/python3.7/site-packages
+ENV PYTHONPATH=/opt/code/localstack/.venv/lib/python3.8/site-packages
 
 # add rest of the code
 ADD localstack/ localstack/

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docker-run:        ## Run Docker image locally
 
 docker-mount-run:
 	MOTO_DIR=$$(echo $$(pwd)/.venv/lib/python*/site-packages/moto | awk '{print $$NF}'); echo MOTO_DIR $$MOTO_DIR; \
-		ENTRYPOINT="-v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/plugins.py:/opt/code/localstack/localstack/plugins.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/dashboard:/opt/code/localstack/localstack/dashboard -v `pwd`/tests:/opt/code/localstack/tests -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.6/site-packages/moto/" make docker-run
+		ENTRYPOINT="-v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/plugins.py:/opt/code/localstack/localstack/plugins.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/dashboard:/opt/code/localstack/localstack/dashboard -v `pwd`/tests:/opt/code/localstack/tests -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/" make docker-run
 
 web:               ## Start web application (dashboard)
 	($(VENV_RUN); bin/localstack web)

--- a/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
+++ b/localstack/ext/java/src/main/java/cloud/localstack/Localstack.java
@@ -24,7 +24,7 @@ public class Localstack {
     private static final Logger LOG = Logger.getLogger(Localstack.class.getName());
 
     private static final String PORT_CONFIG_FILENAME = "/opt/code/localstack/" +
-            ".venv/lib/python3.7/site-packages/localstack_client/config.py";
+            ".venv/lib/python3.8/site-packages/localstack_client/config.py";
 
     private static final Pattern READY_TOKEN = Pattern.compile("Ready\\.");
 


### PR DESCRIPTION
Fixes #2066

Similar approach to #1756 but changed everywhere the python path was used along the project.

I think in the long run we should be able to get this value dynamically so it won't break every time python version is updated