### PR TITLE
Add support for static refs in CF Fn::Sub strings

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -242,6 +242,7 @@ def apply_patches():
             try:
                 resource = parse_and_create_resource_orig(logical_id,
                     resource_json_arns_fixed, resources_map, region_name)
+                resource.logical_id = logical_id
             except Exception as e:
                 if should_be_created:
                     raise

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -238,6 +238,9 @@ class VelocityInput:
     def json(self, path):
         return json.dumps(self.path(path))
 
+    def __repr__(self):
+        return '$input'
+
 
 class VelocityUtil:
     """Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration velocity templates.
@@ -260,6 +263,10 @@ class VelocityUtil:
 
 def render_velocity_template(template, context, variables={}, as_json=False):
     import airspeed
+
+    # run a few fixes to properly prepare the template
+    template = re.sub(r'(^|\n)#\s+set(.*)', r'\1#set\2', template, re.MULTILINE)
+
     t = airspeed.Template(template)
     var_map = {
         'input': VelocityInput(context),

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -21,6 +21,9 @@ LOG = logging.getLogger(__name__)
 # list of resource types that can be updated
 UPDATEABLE_RESOURCES = ['Lambda::Function', 'ApiGateway::Method']
 
+# list of static attribute references to be replaced in {'Fn::Sub': '...'} strings
+STATIC_REFS = ['AWS::Region', 'AWS::Partition', 'AWS::StackName']
+
 # create safe yaml loader that parses date strings as string, not date objects
 NoDatesSafeLoader = yaml.SafeLoader
 NoDatesSafeLoader.yaml_implicit_resolvers = {
@@ -707,8 +710,12 @@ def resolve_refs_recursively(stack_name, value, resources):
                 raise Exception('Cannot resolve CF fn::Join %s due to null values: %s' % (value, join_values))
             return value[keys_list[0]][0].join(join_values)
         if keys_list and keys_list[0].lower() == 'fn::sub':
-            result = value[keys_list[0]][0]
-            for key, val in value[keys_list[0]][1].items():
+            item_to_sub = value[keys_list[0]]
+            if not isinstance(item_to_sub, list):
+                attr_refs = dict([(r, {'Ref': r}) for r in STATIC_REFS])
+                item_to_sub = [item_to_sub, attr_refs]
+            result = item_to_sub[0]
+            for key, val in item_to_sub[1].items():
                 val = resolve_refs_recursively(stack_name, val, resources)
                 result = result.replace('${%s}' % key, val)
             return result


### PR DESCRIPTION
* Add support for static refs in CF `Fn::Sub` strings. Allows to define interpolated strings like `{'Fn::Sub': 'test region ${AWS::Region}'}`
* Minor fix for velocity templates