### PR TITLE
Fix for mis-named logstreams created by lambda invocations.

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -127,7 +127,8 @@ class LambdaExecutor(object):
 
     def _store_logs(self, func_details, log_output, invocation_time):
         log_group_name = '/aws/lambda/%s' % func_details.name()
-        time_str = time.strftime('%Y/%m/%d', time.gmtime(invocation_time))
+        invocation_time_secs = int(invocation_time / 1000)
+        time_str = time.strftime('%Y/%m/%d', time.gmtime(invocation_time_secs))
         log_stream_name = '%s/[$LATEST]%s' % (time_str, short_uid())
         return store_cloudwatch_logs(log_group_name, log_stream_name, log_output, invocation_time)
 


### PR DESCRIPTION
The CloudWatch log stream names created by lambda invocations were incorrect.  
The invocation time is in milliseconds, which wasn't accounted for by the _store_logs method resulting in date prefixes like '52112/01/29'
instead of '2020/02/22'.

So the lambdas thought they ware logging to stream names like:        

"2020/02/21/[$LATEST]549d751bde9d222e4917f4ac838986ed"

but were really logging to names like:

"+52111/12/10/[$LATEST]4b3dcbb1"

There will have to be an additional fix because there's still the issue of the short_uuid vs the long uuid.


