### PR TITLE
Update Elasticsearch to 7.1 [WIP]

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -70,12 +70,12 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
     mkdir -p /opt/code/localstack/localstack/infra/dynamodb && \
       curl -L -o /tmp/localstack.ddb.zip ${DYNAMODB_ZIP_URL} && \
       (cd localstack/infra/dynamodb && unzip -q /tmp/localstack.ddb.zip && rm /tmp/localstack.ddb.zip) && \
-    curl -L -o /tmp/localstack.es.zip \
-        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip && \
+    curl -L -o /tmp/localstack.es.tar.gz \
+        https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0-linux-x86_64.tar.gz && \
     curl -L -o /tmp/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.2.jar && \
-    (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \
-        mv elasticsearch* elasticsearch && rm /tmp/localstack.es.zip) && \
+    (cd localstack/infra/ && tar -xf /tmp/localstack.es.tar.gz && \
+        mv elasticsearch* elasticsearch && rm /tmp/localstack.es.tar.gz) && \
     (cd localstack/infra/elasticsearch/ && \
         bin/elasticsearch-plugin install analysis-icu && \
         bin/elasticsearch-plugin install ingest-attachment --batch && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -80,7 +80,7 @@ FALSE_STRINGS = ('0', 'false', 'False')
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
-ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip'
+ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0.zip'
 # See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
 ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'analysis-kuromoji',
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -80,7 +80,7 @@ FALSE_STRINGS = ('0', 'false', 'False')
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID
 
 # installation constants
-ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0.zip'
+ELASTICSEARCH_JAR_URL = 'https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0-linux-x86_64.tar.gz'
 # See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
 ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'analysis-kuromoji',
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -144,7 +144,7 @@ def get_domain_status(domain_name, deleted=False):
                 'InstanceType': 'm3.medium.elasticsearch',
                 'ZoneAwarenessEnabled': False
             },
-            'ElasticsearchVersion': '6.7',
+            'ElasticsearchVersion': '7.1',
             'Endpoint': aws_stack.get_elasticsearch_endpoint(domain_name),
             'Processing': False,
             'EBSOptions': {

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     bootstrap.bootstrap_installation()
 # flake8: noqa: E402
 from localstack.utils.common import (
-    download, parallelize, run, mkdir, load_file, save_file, unzip, rm_rf, chmod_r, is_alpine,
+    download, parallelize, run, mkdir, load_file, save_file, unzip, ungzip, rm_rf, chmod_r, is_alpine,
     in_docker, get_arch)
 
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
@@ -52,7 +52,7 @@ def install_elasticsearch():
         log_install_msg('Elasticsearch')
         mkdir(INSTALL_DIR_INFRA)
         # download and extract archive
-        tmp_archive = os.path.join(tempfile.gettempdir(), 'localstack.es.zip')
+        tmp_archive = os.path.join(tempfile.gettempdir(), 'localstack.es.tar.gz')
         download_and_extract_with_retry(ELASTICSEARCH_JAR_URL, tmp_archive, INSTALL_DIR_INFRA)
         elasticsearch_dir = glob.glob(os.path.join(INSTALL_DIR_INFRA, 'elasticsearch*'))
         if not elasticsearch_dir:
@@ -234,7 +234,14 @@ def download_and_extract_with_retry(archive_url, tmp_archive, target_dir):
     def download_and_extract():
         if not os.path.exists(tmp_archive):
             download(archive_url, tmp_archive)
-        unzip(tmp_archive, target_dir)
+
+        _, ext = os.path.splitext(tmp_archive)
+        if ext == '.zip':
+            unzip(tmp_archive, target_dir)
+        elif ext == '.gz' or ext == '.bz2':
+            ungzip(tmp_archive, target_dir)
+        else:
+            raise Exception('Unsupported archive format: %s' % ext)
 
     try:
         download_and_extract()

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -820,6 +820,21 @@ def unzip(path, target_dir, overwrite=True):
         zip_ref.close()
 
 
+def ungzip(path, target_dir):
+    if is_alpine():
+        pass
+    try:
+        tar_ref = tarfile.TarFile(path, 'r')
+    except Exception as e:
+        LOG.warning('Unable to open tarball file: %s: %s' % (path, e))
+        raise e
+
+    try:
+        tar_ref.extractall(target_dir)
+    finally:
+        tar_ref.close()
+
+
 def _unzip_file_entry(zip_ref, file_entry, target_dir):
     """
     Extracts a Zipfile entry and preserves permissions

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cachetools==3.1.1
 coverage==4.5.4
 dnspython==1.16.0              #basic-lib
 docopt>=0.6.2                  #basic-lib
-elasticsearch>=6.0.0,<7.0.0
+elasticsearch>=7.0.0,<8.0.0
 flake8>=3.6.0                  #extended-lib
 flake8-quotes>=0.11.0          #extended-lib
 flask==1.0.2


### PR DESCRIPTION
Updates Elasticsearch to 7.1.
This is the latest supported version by AWS