### PR TITLE
Use LAMBDA_REMOVE_CONTAINERS with docker reuse

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -302,7 +302,8 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
     def startup(self):
         self.cleanup()
         # start a process to remove idle containers
-        self.start_idle_container_destroyer_interval()
+        if config.LAMBDA_REMOVE_CONTAINERS:
+            self.start_idle_container_destroyer_interval()
 
     def cleanup(self, arn=None):
         if arn:


### PR DESCRIPTION
This pull request is related to an issue I opened a few days ago: https://github.com/localstack/localstack/issues/2018

I chose to use the already existing environment variable LAMBDA_REMOVE_CONTAINERS to prevent containers from being deleted after 10 minutes. At the moment this variable is not taken in consideration when the docker-reuse executor is used.

Let me know your thoughts

Cheers