### PR TITLE
Use a range instead of exact pinned versions for some dependencies in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,26 +16,26 @@ awscli>=1.14.18
 boto>=2.49.0
 boto3>=1.9.71                  #basic-lib
 botocore>=1.12.13
-cachetools==3.1.1
+cachetools>=3.1.1,<4.0.0
 coverage==4.5.4
 dnspython==1.16.0              #basic-lib
 docopt>=0.6.2                  #basic-lib
 elasticsearch>=6.0.0,<7.0.0
 flake8>=3.6.0                  #extended-lib
 flake8-quotes>=0.11.0          #extended-lib
-flask==1.0.2
-flask-cors==3.0.3
+flask>=1.0.2
+flask-cors>=3.0.3,<3.1.0
 flask_swagger==0.2.12
 forbiddenfruit==0.1.3
-jsonpatch==1.24
-jsonpath-rw==1.4.0
+jsonpatch>=1.24,<2.0
+jsonpath-rw>=1.4.0,<2.0.0
 localstack-ext[full]>=0.10.51
 localstack-ext>=0.10.51        #basic-lib
 localstack-client>=0.14        #basic-lib
 moto-ext>=1.3.15.5
 nose>=1.3.7
 nose-timer>=0.7.5
-psutil==5.4.8
+psutil>=5.4.8,<6.0.0
 pympler>=0.6
 pyopenssl==17.5.0
 python-coveralls>=2.9.1


### PR DESCRIPTION
Allowing a range provides for more flexibility when integrating localstack into an existing project or package.

There's a bit of a cat-and-mouse game here, where we want to provide some flexibility in the ranges of packages that are allowed, but so many that it introduces subtle incompatibilities due to the increased number of combinations of package versions that are permitted.

----

# References

Closes localstack/localstack#2019.