### PR TITLE
Use elasticmq 0.15.5 to handle invalid string attribute value

### DIFF
--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -73,7 +73,7 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
     curl -L -o /tmp/localstack.es.zip \
         https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip && \
     curl -L -o /tmp/elasticmq-server.jar \
-        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.4.jar && \
+        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.5.jar && \
     (cd localstack/infra/ && unzip -q /tmp/localstack.es.zip && \
         mv elasticsearch* elasticsearch && rm /tmp/localstack.es.zip) && \
     (cd localstack/infra/elasticsearch/ && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -86,7 +86,7 @@ ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'analysis-kuro
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']
 # Default ES modules to exclude (save apprx 66MB in the final image)
 ELASTICSEARCH_DELETE_MODULES = ['ingest-geoip']
-ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.4.jar'
+ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.5.jar'
 STS_JAR_URL = 'https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip'
 KMS_URL_PATTERN = 'https://s3-eu-west-2.amazonaws.com/local-kms/localstack/v3/local-kms.<arch>.bin'

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -126,6 +126,23 @@ class SQSTest(unittest.TestCase):
         # clean up
         self.client.delete_queue(QueueUrl=queue_url)
 
+    def test_send_message_with_invalid_string_attributes(self):
+        queue_name = 'queue-%s' % short_uid()
+
+        queue_url = self.client.create_queue(QueueName=queue_name)['QueueUrl']
+
+        payload = {}
+        # String Attributes must not contain non-printable characters
+        # See: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html
+        attrs = {'attr1':
+        {'StringValue': 'invalid characters, %s, %s, %s' % (chr(8), chr(11), chr(12)), 'DataType': 'String'}}
+        with self.assertRaises(Exception):
+            self.client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(payload),
+                                     MessageAttributes=attrs)
+
+        # clean up
+        self.client.delete_queue(QueueUrl=queue_url)
+
     def test_dead_letter_queue_config(self):
         queue_name = 'queue-%s' % short_uid()
         dlq_name = 'queue-%s' % short_uid()


### PR DESCRIPTION
See: https://github.com/softwaremill/elasticmq/pull/341

This PR makes it more compatible with string attributes.

Until now, string attribute has not been validated.
Now it will verify that string attribute does not contain invalid characters .