### PR TITLE
Added support for dead queue to SNS service.

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -223,25 +223,22 @@ def process_apigateway_invocation(func_arn, path, payload, headers={},
 
 
 def process_sns_notification(func_arn, topic_arn, subscriptionArn, message, message_attributes, subject='',):
-    try:
-        event = {
-            'Records': [{
-                'EventSource': 'localstack:sns',
-                'EventVersion': '1.0',
-                'EventSubscriptionArn': subscriptionArn,
-                'Sns': {
-                    'Type': 'Notification',
-                    'TopicArn': topic_arn,
-                    'Subject': subject,
-                    'Message': message,
-                    'Timestamp': timestamp(format=TIMESTAMP_FORMAT_MILLIS),
-                    'MessageAttributes': message_attributes
-                }
-            }]
-        }
-        return run_lambda(event=event, context={}, func_arn=func_arn, asynchronous=True)
-    except Exception as e:
-        LOG.warning('Unable to run Lambda function on SNS message: %s %s' % (e, traceback.format_exc()))
+    event = {
+        'Records': [{
+            'EventSource': 'localstack:sns',
+            'EventVersion': '1.0',
+            'EventSubscriptionArn': subscriptionArn,
+            'Sns': {
+                'Type': 'Notification',
+                'TopicArn': topic_arn,
+                'Subject': subject,
+                'Message': message,
+                'Timestamp': timestamp(format=TIMESTAMP_FORMAT_MILLIS),
+                'MessageAttributes': message_attributes
+            }
+        }]
+    }
+    return run_lambda(event=event, context={}, func_arn=func_arn, asynchronous=True)
 
 
 def process_kinesis_records(records, stream_name):

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -1,19 +1,24 @@
 import ast
 import json
-import uuid
 import logging
-import six
+import traceback
+import uuid
+
 import requests
+import six
 import xmltodict
+from flask import Response as FlaskResponse
 from requests.models import Response, Request
 from six.moves.urllib import parse as urlparse
+
 from localstack.config import external_service_url
 from localstack.constants import TEST_AWS_ACCOUNT_ID, MOTO_ACCOUNT_ID
-from localstack.utils.aws import aws_stack
-from localstack.utils.common import short_uid, to_str, timestamp, TIMESTAMP_FORMAT_MILLIS
-from localstack.utils.analytics import event_publisher
 from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener
+from localstack.utils.analytics import event_publisher
+from localstack.utils.aws import aws_stack
+from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
+from localstack.utils.common import short_uid, to_str, timestamp, TIMESTAMP_FORMAT_MILLIS
 
 # mappings for SNS topic subscriptions
 SNS_SUBSCRIPTIONS = {}
@@ -185,52 +190,70 @@ def publish_message(topic_arn, req_data, subscription_arn=None):
         message_attributes = get_message_attributes(req_data)
         if not check_filter_policy(filter_policy, message_attributes):
             continue
+
         if subscriber['Protocol'] == 'sqs':
-            endpoint = subscriber['Endpoint']
-            if 'sqs_queue_url' in subscriber:
-                queue_url = subscriber.get('sqs_queue_url')
-            elif '://' in endpoint:
-                queue_url = endpoint
-            else:
-                queue_name = endpoint.split(':')[5]
-                queue_url = aws_stack.get_sqs_queue_url(queue_name)
-                subscriber['sqs_queue_url'] = queue_url
             try:
+                endpoint = subscriber['Endpoint']
+                if 'sqs_queue_url' in subscriber:
+                    queue_url = subscriber.get('sqs_queue_url')
+                elif '://' in endpoint:
+                    queue_url = endpoint
+                else:
+                    queue_name = endpoint.split(':')[5]
+                    queue_url = aws_stack.get_sqs_queue_url(queue_name)
+                    subscriber['sqs_queue_url'] = queue_url
+
                 sqs_client.send_message(
                     QueueUrl=queue_url,
                     MessageBody=create_sns_message_body(subscriber, req_data),
                     MessageAttributes=create_sqs_message_attributes(subscriber, message_attributes)
                 )
             except Exception as exc:
+                sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
                 return make_error(message=str(exc), code=400)
+
         elif subscriber['Protocol'] == 'lambda':
-            lambda_api.process_sns_notification(
-                subscriber['Endpoint'],
-                topic_arn,
-                subscriber['SubscriptionArn'],
-                message,
-                message_attributes,
-                subject=req_data.get('Subject', [None])[0]
-            )
+            try:
+                response = lambda_api.process_sns_notification(
+                        subscriber['Endpoint'],
+                        topic_arn,
+                        subscriber['SubscriptionArn'],
+                        message,
+                        message_attributes,
+                        subject=req_data.get('Subject', [None])[0]
+                    )
+                if isinstance(response, FlaskResponse):
+                    response.raise_for_status()
+            except Exception as exc:
+                LOGGER.warning('Unable to run Lambda function on SNS message: %s %s' % (exc, traceback.format_exc()))
+                sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
+                return make_error(message=str(exc), code=400)
+
         elif subscriber['Protocol'] in ['http', 'https']:
             msg_type = (req_data.get('Type') or ['Notification'])[0]
             try:
                 message_body = create_sns_message_body(subscriber, req_data)
             except Exception as exc:
                 return make_error(message=str(exc), code=400)
-            requests.post(
-                subscriber['Endpoint'],
-                headers={
-                    'Content-Type': 'text/plain',
-                    # AWS headers according to
-                    # https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html#http-header
-                    'x-amz-sns-message-type': msg_type,
-                    'x-amz-sns-topic-arn': subscriber['TopicArn'],
-                    'x-amz-sns-subscription-arn': subscriber['SubscriptionArn'],
-                    'User-Agent': 'Amazon Simple Notification Service Agent'
-                },
-                data=message_body,
-                verify=False)
+            try:
+                response = requests.post(
+                    subscriber['Endpoint'],
+                    headers={
+                        'Content-Type': 'text/plain',
+                        # AWS headers according to
+                        # https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html#http-header
+                        'x-amz-sns-message-type': msg_type,
+                        'x-amz-sns-topic-arn': subscriber['TopicArn'],
+                        'x-amz-sns-subscription-arn': subscriber['SubscriptionArn'],
+                        'User-Agent': 'Amazon Simple Notification Service Agent'
+                    },
+                    data=message_body,
+                    verify=False
+                )
+                response.raise_for_status()
+            except Exception as exc:
+                sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
+                return make_error(message=str(exc), code=400)
         else:
             LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2,21 +2,23 @@
 
 import json
 import unittest
+
 from botocore.exceptions import ClientError
+
+from localstack.services.generic_proxy import ProxyListener
+from localstack.services.infra import start_proxy
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
     to_str, get_free_tcp_port, retry, wait_for_port_open, get_service_protocol, short_uid, load_file
 )
-from localstack.services.infra import start_proxy
-from localstack.services.generic_proxy import ProxyListener
-
 from .lambdas import lambda_integration
 from .test_lambda import TEST_LAMBDA_PYTHON, LAMBDA_RUNTIME_PYTHON36, TEST_LAMBDA_LIBS
 
 TEST_TOPIC_NAME = 'TestTopic_snsTest'
 TEST_QUEUE_NAME = 'TestQueue_snsTest'
 TEST_QUEUE_NAME_2 = 'TestQueue_snsTest2'
+TEST_QUEUE_DLQ_NAME = 'TestQueue_DLQ_snsTest'
 
 
 class SNSTest(unittest.TestCase):
@@ -27,9 +29,12 @@ class SNSTest(unittest.TestCase):
         self.topic_arn = self.sns_client.create_topic(Name=TEST_TOPIC_NAME)['TopicArn']
         self.queue_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME)['QueueUrl']
         self.queue_url_2 = self.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME_2)['QueueUrl']
+        self.dlq_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_DLQ_NAME)['QueueUrl']
 
     def tearDown(self):
         self.sqs_client.delete_queue(QueueUrl=self.queue_url)
+        self.sqs_client.delete_queue(QueueUrl=self.queue_url_2)
+        self.sqs_client.delete_queue(QueueUrl=self.dlq_url)
         self.sns_client.delete_topic(TopicArn=self.topic_arn)
 
     def test_publish_unicode_chars(self):
@@ -213,3 +218,105 @@ class SNSTest(unittest.TestCase):
             self.assertIn('ErrorCode', msg_attrs)
             self.assertIn('ErrorMessage', msg_attrs)
         retry(receive_dlq, retries=8, sleep=2)
+
+
+    def unsubscripe_all_from_sns(self):
+        for subscription_arn in self.sns_client.list_subscriptions()['Subscriptions']:
+            self.sns_client.unsubscribe(SubscriptionArn=subscription_arn['SubscriptionArn'])
+
+    def test_redrive_policy_http_subscription(self):
+        self.unsubscripe_all_from_sns()
+
+        # create HTTP endpoint and connect it to SNS topic
+        class MyUpdateListener(ProxyListener):
+            def forward_request(self, method, path, data, headers):
+                records.append((json.loads(to_str(data)), headers))
+                return 200
+
+        records = []
+        local_port = get_free_tcp_port()
+        proxy = start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
+        wait_for_port_open(local_port)
+        http_endpoint = '%s://localhost:%s' % (get_service_protocol(), local_port)
+        subscription_arn = self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol='http', Endpoint=http_endpoint)['SubscriptionArn']
+        self.sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName='RedrivePolicy',
+            AttributeValue=json.dumps({"deadLetterTargetArn": aws_stack.sqs_queue_arn(TEST_QUEUE_DLQ_NAME)})
+        )
+        proxy.stop()
+
+        self.sns_client.publish(TopicArn=self.topic_arn, Message=json.dumps({"message": "test_redrive_policy"}))
+
+        def receive_dlq():
+            result = self.sqs_client.receive_message(QueueUrl=self.dlq_url, MessageAttributeNames=['All'])
+            self.assertGreater(len(result['Messages']), 0)
+            self.assertEqual(
+                json.loads(json.loads(result['Messages'][0]['Body'])['Message'][0])['message'],
+                'test_redrive_policy'
+            )
+        retry(receive_dlq, retries=10, sleep=2)
+
+    def test_redrive_policy_lambda_subscription(self):
+        self.unsubscripe_all_from_sns()
+
+        lambda_name = 'test-%s' % short_uid()
+        lambda_arn = aws_stack.lambda_function_arn(lambda_name)
+
+        zip_file = testutil.create_lambda_archive(
+            load_file(TEST_LAMBDA_PYTHON),
+            get_content=True,
+            libs=TEST_LAMBDA_LIBS,
+            runtime=LAMBDA_RUNTIME_PYTHON36,
+        )
+        testutil.create_lambda_function(
+            func_name=lambda_name,
+            zip_file=zip_file,
+            runtime=LAMBDA_RUNTIME_PYTHON36
+        )
+        subscription_arn = self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol='lambda', Endpoint=lambda_arn)['SubscriptionArn']
+        self.sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName='RedrivePolicy',
+            AttributeValue=json.dumps({"deadLetterTargetArn": aws_stack.sqs_queue_arn(TEST_QUEUE_DLQ_NAME)})
+        )
+        testutil.delete_lambda_function(lambda_name)
+
+        self.sns_client.publish(TopicArn=self.topic_arn, Message=json.dumps({"message": "test_redrive_policy"}))
+
+        def receive_dlq():
+            result = self.sqs_client.receive_message(QueueUrl=self.dlq_url, MessageAttributeNames=['All'])
+            self.assertGreater(len(result['Messages']), 0)
+            self.assertEqual(
+                json.loads(json.loads(result['Messages'][0]['Body'])['Message'][0])['message'],
+                'test_redrive_policy'
+            )
+
+        retry(receive_dlq, retries=10, sleep=2)
+
+    def test_redrive_policy_queue_subscription(self):
+        self.unsubscripe_all_from_sns()
+
+        temp_queue_name = "TestQueue_tmp_snsTest"
+        tmp_queue_url = self.sqs_client.create_queue(QueueName=temp_queue_name)['QueueUrl']
+        tmp_queue_arn = aws_stack.sqs_queue_arn(temp_queue_name)
+
+        subscription_arn = self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol='sqs', Endpoint=tmp_queue_arn)['SubscriptionArn']
+        self.sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName='RedrivePolicy',
+            AttributeValue=json.dumps({"deadLetterTargetArn": aws_stack.sqs_queue_arn(TEST_QUEUE_DLQ_NAME)})
+        )
+        self.sqs_client.delete_queue(QueueUrl=tmp_queue_url)
+
+        self.sns_client.publish(TopicArn=self.topic_arn, Message=json.dumps({"message": "test_redrive_policy"}))
+
+        def receive_dlq():
+            result = self.sqs_client.receive_message(QueueUrl=self.dlq_url, MessageAttributeNames=['All'])
+            self.assertGreater(len(result['Messages']), 0)
+            self.assertEqual(
+                json.loads(json.loads(result['Messages'][0]['Body'])['Message'][0])['message'],
+                'test_redrive_policy'
+            )
+
+        retry(receive_dlq, retries=10, sleep=2)


### PR DESCRIPTION
Created function to check if redrive policy exists for the SNS and send message.
Changed exception handle in process_sns_notification function (it is only used in one situation today).
Changed exception handle in SQS send message (inside SNS publish message function).
Added exception handle for HTTP type subscriber in publish message function.
Created tests for the 3 types of subscribers.