### PR TITLE
#2131 Missing Message Subject at LambdaExecutor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ reinstall-p3:      ## Re-initialize the virtualenv with Python 3.x
 	PIP_CMD=pip3 VENV_OPTS="-p '`which python3`'" make install
 
 lint:              ## Run code linter to check code style
-	($(VENV_RUN); flake8 --inline-quotes=single --show-source --max-line-length=120 --ignore=E128,W504 --exclude=node_modules,$(VENV_DIR)*,dist .)
+	($(VENV_RUN); flake8 --inline-quotes=single --show-source --max-line-length=120 --ignore=E128,W504 --exclude=node_modules,$(VENV_DIR)*,dist,fixes .)
 
 clean:             ## Clean up (npm dependencies, downloaded infrastructure code, compiled Java classes)
 	rm -rf localstack/dashboard/web/node_modules/

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -123,7 +123,6 @@ class ClientError(Exception):
 
 
 class LambdaContext(object):
-
     def __init__(self, func_details, qualifier=None):
         self.function_name = func_details.name()
         self.function_version = func_details.get_qualifier_version(qualifier)
@@ -226,13 +225,13 @@ def process_apigateway_invocation(func_arn, path, payload, headers={},
         LOG.warning('Unable to run Lambda function on API Gateway message: %s %s' % (e, traceback.format_exc()))
 
 
-def process_sns_notification(func_arn, topic_arn, subscriptionArn, message, message_attributes, subject='',):
+def process_sns_notification(func_arn, topic_arn, subscription_arn, message, message_attributes, subject='',):
     try:
         event = {
             'Records': [{
                 'EventSource': 'localstack:sns',
                 'EventVersion': '1.0',
-                'EventSubscriptionArn': subscriptionArn,
+                'EventSubscriptionArn': subscription_arn,
                 'Sns': {
                     'Type': 'Notification',
                     'TopicArn': topic_arn,
@@ -513,7 +512,6 @@ def get_java_handler(zip_file_content, main_file, func_details=None):
 
 
 def set_archive_code(code, lambda_name, zip_file_content=None):
-
     # get metadata
     lambda_arn = func_arn(lambda_name)
     lambda_details = arn_to_lambda[lambda_arn]
@@ -550,7 +548,6 @@ def set_archive_code(code, lambda_name, zip_file_content=None):
 
 
 def set_function_code(code, lambda_name, lambda_cwd=None):
-
     def generic_handler(event, context):
         raise ClientError(('Unable to find executor for Lambda function "%s". Note that ' +
             'Node.js, Golang, and .Net Core Lambdas currently require LAMBDA_EXECUTOR=docker') % lambda_name)
@@ -600,7 +597,6 @@ def set_function_code(code, lambda_name, lambda_cwd=None):
 
     # Obtain handler details for any non-Java Lambda function
     if not is_java:
-
         handler_file = get_handler_file_from_name(handler_name, runtime=runtime)
         handler_function = get_handler_function_from_name(handler_name, runtime=runtime)
 
@@ -633,7 +629,6 @@ def set_function_code(code, lambda_name, lambda_cwd=None):
                 raise ClientError('Unable to get handler function from lambda code.', e)
 
     add_function_mapping(lambda_name, lambda_handler, lambda_cwd)
-
     return {'FunctionName': lambda_name}
 
 
@@ -677,7 +672,7 @@ def format_func_details(func_details, version=None, always_add_version=False):
             'Variables': func_details.envvars
         }
     if (always_add_version or version != '$LATEST') and len(result['FunctionArn'].split(':')) <= 7:
-        result['FunctionArn'] += ':%s' % (version)
+        result['FunctionArn'] += ':%s' % version
     return result
 
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -441,10 +441,10 @@ RESOURCE_TO_FUNCTION = {
     }
 }
 
-
 # ----------------
 # UTILITY METHODS
 # ----------------
+
 
 def convert_acl_cf_to_s3(acl):
     """ Convert a CloudFormation ACL string (e.g., 'PublicRead') to an S3 ACL string (e.g., 'public-read') """

--- a/tests/integration/lambdas/lambda_echo.py
+++ b/tests/integration/lambdas/lambda_echo.py
@@ -1,7 +1,7 @@
 import json
 
 
-def lambda_handler(event, context):
+def handler(event, context):
     # Just print the event was passed to lambda
     print(json.dumps(event))
     return 0

--- a/tests/integration/lambdas/lambda_echo.py
+++ b/tests/integration/lambdas/lambda_echo.py
@@ -3,5 +3,5 @@ import json
 
 def lambda_handler(event, context):
     # Just print the event was passed to lambda
-    print('{}'.format(json.dumps(event)))
+    print(json.dumps(event))
     return 0

--- a/tests/integration/lambdas/lambda_function.py
+++ b/tests/integration/lambdas/lambda_function.py
@@ -1,0 +1,7 @@
+import json
+
+
+def lambda_handler(event, context):
+    # Just print the event was passed to lambda
+    print('{}'.format(json.dumps(event)))
+    return 0

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -34,6 +34,7 @@ TEST_LAMBDA_JAVA = os.path.join(LOCALSTACK_ROOT_FOLDER, 'localstack', 'infra', '
 TEST_LAMBDA_JAVA_WITH_LIB = os.path.join(THIS_FOLDER, 'lambdas', 'java', 'lambda-function-with-lib-0.0.1.jar')
 TEST_LAMBDA_ENV = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_environment.py')
 
+
 TEST_LAMBDA_NAME_PY = 'test_lambda_py'
 TEST_LAMBDA_NAME_PY3 = 'test_lambda_py3'
 TEST_LAMBDA_NAME_JS = 'test_lambda_js'
@@ -45,16 +46,32 @@ TEST_LAMBDA_NAME_JAVA_STREAM = 'test_lambda_java_stream'
 TEST_LAMBDA_NAME_JAVA_SERIALIZABLE = 'test_lambda_java_serializable'
 TEST_LAMBDA_NAME_ENV = 'test_lambda_env'
 
+TEST_LAMBDA_S3_KEY = os.path.join(THIS_FOLDER, 'lambdas')
+TEST_LAMBDA_FUNCTION_NAME = 'test-lambda-function'
+TEST_SNS_TOPIC_NAME = 'sns-topic-1'
+
 MAVEN_BASE_URL = 'https://repo.maven.apache.org/maven2'
-TEST_LAMBDA_JAR_URL = ('{url}/cloud/localstack/{name}/{version}/{name}-{version}-tests.jar').format(
+
+TEST_LAMBDA_JAR_URL = '{url}/cloud/localstack/{name}/{version}/{name}-{version}-tests.jar'.format(
     version=LOCALSTACK_MAVEN_VERSION, url=MAVEN_BASE_URL, name='localstack-utils')
 
-TEST_LAMBDA_LIBS = ['localstack', 'localstack_client', 'requests',
-    'psutil', 'urllib3', 'chardet', 'certifi', 'idna', 'pip', 'dns']
+TEST_LAMBDA_LIBS = [
+    'localstack', 'localstack_client', 'requests', 'psutil', 'urllib3', 'chardet', 'certifi', 'idna', 'pip', 'dns'
+]
+
+
+def _run_forward_to_fallback_url(url, num_requests=3):
+    lambda_client = aws_stack.connect_to_service('lambda')
+    config.LAMBDA_FALLBACK_URL = url
+    try:
+        for i in range(num_requests):
+            lambda_client.invoke(FunctionName='non-existing-lambda-%s' % i,
+                Payload=b'{}', InvocationType='RequestResponse')
+    finally:
+        config.LAMBDA_FALLBACK_URL = ''
 
 
 class LambdaTestBase(unittest.TestCase):
-
     def check_lambda_logs(self, func_name, expected_lines=[]):
         logs_client = aws_stack.connect_to_service('logs')
         log_group_name = '/aws/lambda/%s' % func_name
@@ -72,7 +89,6 @@ class LambdaTestBase(unittest.TestCase):
 
 
 class TestLambdaBaseFeatures(unittest.TestCase):
-
     def test_forward_to_fallback_url_dynamodb(self):
         db_table = 'lambda-records'
         ddb_client = aws_stack.connect_to_service('dynamodb')
@@ -81,7 +97,7 @@ class TestLambdaBaseFeatures(unittest.TestCase):
             return len((run_safe(ddb_client.scan, TableName=db_table) or {'Items': []})['Items'])
 
         items_before = num_items()
-        self._run_forward_to_fallback_url('dynamodb://%s' % db_table)
+        _run_forward_to_fallback_url('dynamodb://%s' % db_table)
         items_after = num_items()
         self.assertEqual(items_after, items_before + 3)
 
@@ -96,20 +112,10 @@ class TestLambdaBaseFeatures(unittest.TestCase):
         proxy = start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
 
         items_before = len(records)
-        self._run_forward_to_fallback_url('%s://localhost:%s' % (get_service_protocol(), local_port))
+        _run_forward_to_fallback_url('%s://localhost:%s' % (get_service_protocol(), local_port))
         items_after = len(records)
         self.assertEqual(items_after, items_before + 3)
         proxy.stop()
-
-    def _run_forward_to_fallback_url(self, url, num_requests=3):
-        lambda_client = aws_stack.connect_to_service('lambda')
-        config.LAMBDA_FALLBACK_URL = url
-        try:
-            for i in range(num_requests):
-                lambda_client.invoke(FunctionName='non-existing-lambda-%s' % i,
-                    Payload=b'{}', InvocationType='RequestResponse')
-        finally:
-            config.LAMBDA_FALLBACK_URL = ''
 
     def test_dead_letter_queue(self):
         sqs_client = aws_stack.connect_to_service('sqs')
@@ -176,6 +182,8 @@ class TestPythonRuntimes(LambdaTestBase):
     def setUpClass(cls):
         cls.lambda_client = aws_stack.connect_to_service('lambda')
         cls.s3_client = aws_stack.connect_to_service('s3')
+        cls.sns_client = aws_stack.connect_to_service('sns')
+
         Util.create_function(TEST_LAMBDA_PYTHON, TEST_LAMBDA_NAME_PY,
             runtime=LAMBDA_RUNTIME_PYTHON27, libs=TEST_LAMBDA_LIBS)
 
@@ -373,6 +381,65 @@ class TestPythonRuntimes(LambdaTestBase):
         result_data = json.loads(result['Payload'].read())
         self.assertEqual(result['StatusCode'], 200)
         self.assertEqual(result_data['event'], json.loads('{}'))
+
+    def test_lambda_subscribe_sns_topic(self):
+        function_name = '{}-{}'.format(TEST_LAMBDA_FUNCTION_NAME, short_uid())
+        lambda_function = self.lambda_client.create_function(
+            FunctionName=function_name,
+            Runtime=LAMBDA_RUNTIME_PYTHON36,
+            Code={
+                'S3Bucket': '__local__',
+                'S3Key': TEST_LAMBDA_S3_KEY
+            },
+            Handler='lambda_function.lambda_handler',
+            Role='whatever'
+        )
+
+        topic = self.sns_client.create_topic(
+            Name=TEST_SNS_TOPIC_NAME
+        )
+        topic_arn = topic['TopicArn']
+
+        self.sns_client.subscribe(
+            TopicArn=topic_arn,
+            Protocol='lambda',
+            Endpoint=lambda_function['FunctionArn'],
+        )
+
+        subject = '[Subject] Test subject'
+        message = 'Hello world.'
+        self.sns_client.publish(
+            TopicArn=topic_arn,
+            Subject=subject,
+            Message=message
+        )
+
+        logs = aws_stack.connect_to_service('logs')
+
+        # wait for lambda executing
+        def check_log_steams():
+            rs = logs.describe_log_streams(
+                logGroupName='/aws/lambda/{}'.format(function_name)
+            )
+
+            self.assertEqual(len(rs['logStreams']), 1)
+            return rs['logStreams'][0]['logStreamName']
+
+        log_stream = retry(check_log_steams, retries=3, sleep=2)
+
+        rs = logs.get_log_events(
+            logGroupName='/aws/lambda/{}'.format(function_name),
+            logStreamName=log_stream
+        )
+
+        self.assertEqual(len(rs['events']), 1)
+        message = json.loads(rs['events'][0]['message'])
+
+        self.assertEqual(len(message['Records']), 1)
+        notification = message['Records'][0]['Sns']
+
+        self.assertIn('Subject', notification)
+        self.assertEqual(notification['Subject'], subject)
 
 
 class TestNodeJSRuntimes(LambdaTestBase):

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -394,7 +394,6 @@ class TestPythonRuntimes(LambdaTestBase):
         testutil.create_lambda_function(
             zip_file=zip_file,
             func_name=function_name,
-            handler='lambda_echo.lambda_handler',
             runtime=LAMBDA_RUNTIME_PYTHON36
         )
 

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -604,7 +604,7 @@ class TestLambdaAPI(unittest.TestCase):
     @mock.patch('localstack.services.awslambda.lambda_executors.store_cloudwatch_logs')
     def test_executor_store_logs_can_handle_milliseconds(self, mock_store_cloudwatch_logs):
         mock_details = mock.Mock()
-        executor = lambda_executors.LambdaExecutor()
+        executor = lambda_executors
         t_sec = time.time()  # plain old epoch secs
         t_ms = time.time() * 1000  # epoch ms as a long-int like AWS
 

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -604,12 +604,11 @@ class TestLambdaAPI(unittest.TestCase):
     @mock.patch('localstack.services.awslambda.lambda_executors.store_cloudwatch_logs')
     def test_executor_store_logs_can_handle_milliseconds(self, mock_store_cloudwatch_logs):
         mock_details = mock.Mock()
-        executor = lambda_executors
         t_sec = time.time()  # plain old epoch secs
         t_ms = time.time() * 1000  # epoch ms as a long-int like AWS
 
         # pass t_ms millisecs to _store_logs
-        executor._store_logs(mock_details, 'mock log output', t_ms)
+        lambda_executors._store_logs(mock_details, 'mock log output', t_ms)
 
         # expect the computed log-stream-name to having a prefix matching the date derived from t_sec
         today = datetime.datetime.utcfromtimestamp(t_sec).strftime('%Y/%m/%d')


### PR DESCRIPTION
* Fix lint error template_deployer.py
* Fix log steam name (That was an issue with get-log-events API)
* Add lambda integration test
 - Create topic
 - Create a lambda function that subscribe that topic
 - Push an message with subject
 - Get event message from cloudwatch logs to confirm subject exists in message event