### PR TITLE
Add message polling mechanism for Lambda-SQS integration

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -37,7 +37,7 @@ from localstack.services.awslambda.lambda_executors import (
     LAMBDA_RUNTIME_PROVIDED)
 from localstack.utils.common import (to_str, load_file, save_file, TMP_FILES, ensure_readable,
     mkdir, unzip, is_zip_file, zip_contains_jar_entries, run, short_uid, timestamp,
-    TIMESTAMP_FORMAT_MILLIS, md5, parse_chunked_data, now_utc, safe_requests,
+    TIMESTAMP_FORMAT_MILLIS, parse_chunked_data, now_utc, safe_requests, FuncThread,
     isoformat_milliseconds)
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws.aws_models import LambdaFunction
@@ -97,6 +97,10 @@ JSON_START_CHAR_MAP = {
 POSSIBLE_JSON_TYPES = (str, bytes)
 JSON_START_TYPES = tuple(set(JSON_START_CHAR_MAP.keys()) - set(POSSIBLE_JSON_TYPES))
 JSON_START_CHARS = tuple(set(functools.reduce(lambda x, y: x + y, JSON_START_CHAR_MAP.values())))
+
+# SQS listener thread settings
+SQS_LISTENER_THREAD = None
+SQS_POLL_INTERVAL_SEC = 1
 
 # lambda executor instance
 LAMBDA_EXECUTOR = lambda_executors.AVAILABLE_EXECUTORS.get(config.LAMBDA_EXECUTOR, lambda_executors.DEFAULT_EXECUTOR)
@@ -277,7 +281,76 @@ def process_kinesis_records(records, stream_name):
         LOG.warning('Unable to run Lambda function on Kinesis records: %s %s' % (e, traceback.format_exc()))
 
 
-def process_sqs_message(message_body, message_attributes, queue_name, region_name=None):
+def start_lambda_sqs_listener():
+    global SQS_LISTENER_THREAD
+    if SQS_LISTENER_THREAD:
+        return
+
+    def send_event_to_lambda(queue_arn, queue_url, lambda_arn, messages, region):
+        records = []
+        for msg in messages:
+            records.append({
+                'body': msg['Body'],
+                'receiptHandle': msg['ReceiptHandle'],
+                'md5OfBody': msg['MD5OfBody'],
+                'eventSourceARN': queue_arn,
+                'eventSource': lambda_executors.EVENT_SOURCE_SQS,
+                'awsRegion': region,
+                'messageId': msg['MessageId'],
+                'attributes': msg.get('Attributes', {}),
+                'messageAttributes': msg.get('MessageAttributes', {}),
+                'md5OfMessageAttributes': msg.get('MD5OfMessageAttributes'),
+                'sqs': True,
+            })
+        event = {'Records': records}
+
+        def delete_messages(result, func_arn, event, error=None, **kwargs):
+            if error:
+                # Do not delete messages from the queue in case of processing errors;
+                # We'll pick them up and retry next time they become available on the queue.
+                return
+            sqs_client = aws_stack.connect_to_service('sqs')
+            entries = [{'Id': r['receiptHandle'], 'ReceiptHandle': r['receiptHandle']} for r in records]
+            sqs_client.delete_message_batch(QueueUrl=queue_url, Entries=entries)
+
+        run_lambda(event=event, context={}, func_arn=lambda_arn, asynchronous=True, callback=delete_messages)
+
+    def listener_loop(*args):
+        while True:
+            try:
+                sources = get_event_sources(source_arn=r'.*:sqs:.*')
+                if not sources:
+                    global SQS_LISTENER_THREAD
+                    # Temporarily disable polling if no event sources are configured
+                    # anymore. The loop will get restarted next time a message
+                    # arrives and if an event source is configured.
+                    SQS_LISTENER_THREAD = None
+                    return
+
+                sqs_client = aws_stack.connect_to_service('sqs')
+                for source in sources:
+                    try:
+                        queue_arn = source['EventSourceArn']
+                        lambda_arn = source['FunctionArn']
+                        region_name = queue_arn.split(':')[3]
+                        queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
+                        result = sqs_client.receive_message(QueueUrl=queue_url)
+                        messages = result.get('Messages')
+                        if not messages:
+                            return
+                        send_event_to_lambda(queue_arn, queue_url, lambda_arn, messages, region=region_name)
+                    except Exception as e:
+                        LOG.debug('Unable to poll SQS messages for queue %s: %s' % (queue_arn, e))
+                time.sleep(SQS_POLL_INTERVAL_SEC)
+            except Exception:
+                pass
+
+    LOG.debug('Starting SQS message polling thread for Lambda API')
+    SQS_LISTENER_THREAD = FuncThread(listener_loop)
+    SQS_LISTENER_THREAD.start()
+
+
+def process_sqs_message(queue_name, message_body, message_attributes, region_name=None):
     # feed message into the first listening lambda (message should only get processed once)
     try:
         region_name = region_name or aws_stack.get_region()
@@ -288,27 +361,8 @@ def process_sqs_message(message_body, message_attributes, queue_name, region_nam
         source = next(iter(sources), None)
         if not source:
             return False
-        if source:
-            arn = source['FunctionArn']
-            event = {'Records': [{
-                'body': message_body,
-                'receiptHandle': short_uid(),
-                'md5OfBody': md5(message_body),
-                'eventSourceARN': queue_arn,
-                'eventSource': 'aws:sqs',
-                'awsRegion': region_name,
-                'messageId': str(uuid.uuid4()),
-                'attributes': {
-                    'ApproximateFirstReceiveTimestamp': '{}000'.format(int(time.time())),
-                    'SenderId': TEST_AWS_ACCOUNT_ID,
-                    'ApproximateReceiveCount': '1',
-                    'SentTimestamp': '{}000'.format(int(time.time()))
-                },
-                'messageAttributes': message_attributes,
-                'sqs': True,
-            }]}
-            run_lambda(event=event, context={}, func_arn=arn, asynchronous=True)
-            return True
+        start_lambda_sqs_listener()
+        return True
     except Exception as e:
         LOG.warning('Unable to run Lambda function on SQS messages: %s %s' % (e, traceback.format_exc()))
 
@@ -317,25 +371,26 @@ def get_event_sources(func_name=None, source_arn=None):
     result = []
     for m in event_source_mappings:
         if not func_name or (m['FunctionArn'] in [func_name, func_arn(func_name)]):
-            if _arn_match(mapped=m['EventSourceArn'], occurred=source_arn):
+            if _arn_match(mapped=m['EventSourceArn'], searched=source_arn):
                 result.append(m)
     return result
 
 
-def _arn_match(mapped, occurred):
-    if not occurred or mapped == occurred:
+def _arn_match(mapped, searched):
+    if not searched or mapped == searched:
         return True
     # Some types of ARNs can end with a path separated by slashes, for
-    # example the ARN of a DynamoDB stream is tableARN/stream/ID.  It's
+    # example the ARN of a DynamoDB stream is tableARN/stream/ID. It's
     # a little counterintuitive that a more specific mapped ARN can
     # match a less specific ARN on the event, but some integration tests
     # rely on it for things like subscribing to a stream and matching an
     # event labeled with the table ARN.
-    elif mapped.startswith(occurred):
-        suffix = mapped[len(occurred):]
+    if re.match(searched, mapped):
+        return True
+    if mapped.startswith(searched):
+        suffix = mapped[len(searched):]
         return suffix[0] == '/'
-    else:
-        return False
+    return False
 
 
 def get_function_version(arn, version):
@@ -374,7 +429,8 @@ def do_update_alias(arn, alias, version, description=None):
 
 
 @cloudwatched('lambda')
-def run_lambda(event, context, func_arn, version=None, suppress_output=False, asynchronous=False):
+def run_lambda(event, context, func_arn, version=None, suppress_output=False,
+        asynchronous=False, callback=None):
     if suppress_output:
         stdout_ = sys.stdout
         stderr_ = sys.stderr
@@ -388,8 +444,8 @@ def run_lambda(event, context, func_arn, version=None, suppress_output=False, as
             return not_found_error(msg='The resource specified in the request does not exist.')
         if not context:
             context = LambdaContext(func_details, version)
-        result = LAMBDA_EXECUTOR.execute(func_arn, func_details,
-            event, context=context, version=version, asynchronous=asynchronous)
+        result = LAMBDA_EXECUTOR.execute(func_arn, func_details, event, context=context,
+            version=version, asynchronous=asynchronous, callback=callback)
     except Exception as e:
         return error_response('Error executing Lambda function %s: %s %s' % (func_arn, e, traceback.format_exc()))
     finally:

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -385,7 +385,7 @@ def _arn_match(mapped, searched):
     # match a less specific ARN on the event, but some integration tests
     # rely on it for things like subscribing to a stream and matching an
     # event labeled with the table ARN.
-    if re.match(searched, mapped):
+    if re.match(r'^%s$' % searched, mapped):
         return True
     if mapped.startswith(searched):
         suffix = mapped[len(searched):]

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -102,23 +102,26 @@ class LambdaExecutor(object):
             # start the execution
             raised_error = None
             result = None
+            dlq_sent = None
             try:
                 result = self._execute(func_arn, func_details, event, context, version)
             except Exception as e:
                 raised_error = e
+                print('!!!Lambda error', e, asynchronous, get_from_event(event, 'eventSource'))
                 if asynchronous:
                     if get_from_event(event, 'eventSource') == EVENT_SOURCE_SQS:
                         sqs_queue_arn = get_from_event(event, 'eventSourceARN')
                         if sqs_queue_arn:
                             # event source is SQS, send event back to dead letter queue
-                            sqs_error_to_dead_letter_queue(sqs_queue_arn, event, e)
+                            dlq_sent = sqs_error_to_dead_letter_queue(sqs_queue_arn, event, e)
+                        print('!!!!!sqs_queue_arn', sqs_queue_arn, dlq_sent)
                     else:
                         # event source is not SQS, send back to lambda dead letter queue
                         lambda_error_to_dead_letter_queue(func_details, event, e)
                 raise e
             finally:
                 self.function_invoke_times[func_arn] = invocation_time
-                callback and callback(result, func_arn, event, error=raised_error)
+                callback and callback(result, func_arn, event, error=raised_error, dlq_sent=dlq_sent)
             # return final result
             return result
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -107,14 +107,12 @@ class LambdaExecutor(object):
                 result = self._execute(func_arn, func_details, event, context, version)
             except Exception as e:
                 raised_error = e
-                print('!!!Lambda error', e, asynchronous, get_from_event(event, 'eventSource'))
                 if asynchronous:
                     if get_from_event(event, 'eventSource') == EVENT_SOURCE_SQS:
                         sqs_queue_arn = get_from_event(event, 'eventSourceARN')
                         if sqs_queue_arn:
                             # event source is SQS, send event back to dead letter queue
                             dlq_sent = sqs_error_to_dead_letter_queue(sqs_queue_arn, event, e)
-                        print('!!!!!sqs_queue_arn', sqs_queue_arn, dlq_sent)
                     else:
                         # event source is not SQS, send back to lambda dead letter queue
                         lambda_error_to_dead_letter_queue(func_details, event, e)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -152,15 +152,6 @@ def get_event_message(event_name, bucket_name, file_name='testfile.txt', version
     }
 
 
-def queue_url_for_arn(queue_arn):
-    if '://' in queue_arn:
-        return queue_arn
-    sqs_client = aws_stack.connect_to_service('sqs')
-    parts = queue_arn.split(':')
-    return sqs_client.get_queue_url(QueueName=parts[5],
-        QueueOwnerAWSAccountId=parts[4])['QueueUrl']
-
-
 def send_notifications(method, bucket_name, object_path, version_id):
     bucket_name = normalize_bucket_name(bucket_name)
     for bucket, notifs in S3_NOTIFICATIONS.items():
@@ -207,7 +198,7 @@ def send_notification_for_subscriber(notif, bucket_name, object_path, version_id
     if notif.get('Queue'):
         sqs_client = aws_stack.connect_to_service('sqs')
         try:
-            queue_url = queue_url_for_arn(notif['Queue'])
+            queue_url = aws_stack.sqs_queue_url_for_arn(notif['Queue'])
             sqs_client.send_message(QueueUrl=queue_url, MessageBody=message)
         except Exception as e:
             LOGGER.warning('Unable to send notification for S3 bucket "%s" to SQS queue "%s": %s' %

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -433,7 +433,7 @@ def lambda_function_or_layer_arn(type, entity_name, version=None, account_id=Non
     pattern = re.sub(r'\([^\|]+\|.+\)', type, pattern)
     result = pattern.replace('.*', '%s') % (region_name, account_id, entity_name)
     if version:
-        result = '%s:%s' (result, version)
+        result = '%s:%s' % (result, version)
     return result
 
 

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -43,3 +43,4 @@ def _send_to_dead_letter_queue(source_type, source_arn, dlq_arn, event, error):
         sns_client.publish(TopicArn=dlq_arn, Message=message, MessageAttributes=message_attrs)
     else:
         LOG.warning('Unsupported dead letter queue type: %s' % dlq_arn)
+    return dlq_arn

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -152,10 +152,8 @@ class TestAPIGatewayIntegrations(unittest.TestCase):
         result = parsed_json['SendMessageResponse']['SendMessageResult']
 
         body_md5 = result['MD5OfMessageBody']
-        attr_md5 = result['MD5OfMessageAttributes']
 
         self.assertEqual(body_md5, 'b639f52308afd65866c86f274c59033f')
-        self.assertEqual(attr_md5, 'd41d8cd98f00b204e9800998ecf8427e')
 
     def test_api_gateway_sqs_integration(self):
         # create target SQS stream

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -35,8 +35,8 @@ class SQSTest(unittest.TestCase):
         cls.client = aws_stack.connect_to_service('sqs')
 
     def test_list_queue_tags(self):
-        # Since this API call is not implemented in ElasticMQ, we're mocking it
-        # and letting it return an empty response
+        # Since this API call is not implemented in ElasticMQ, we're
+        # mocking it and letting it return an empty response
         queue_info = self.client.create_queue(QueueName=TEST_QUEUE_NAME)
         queue_url = queue_info['QueueUrl']
         result = self.client.list_queue_tags(QueueUrl=queue_url)
@@ -200,7 +200,7 @@ class SQSTest(unittest.TestCase):
         queue_name = 'queue-%s' % short_uid()
 
         attributes = {
-            'MessageRetentionPeriod': '604800',  # This one is unsupported by ElasticMq and should be saved in memory
+            'MessageRetentionPeriod': '604800',  # Unsupported by ElasticMq, should be saved in memory
             'ReceiveMessageWaitTimeSeconds': '10',
             'VisibilityTimeout': '30'
         }


### PR DESCRIPTION
Add message polling mechanism for Lambda-SQS integration.

This is a follow-up PR for the change in #2139 . Prior to this change, we used to intercept incoming SQS messages, check if they are linked to a Lambda function (via an event source mapping), and in that case call the Lambda directly with the event message, *without* forwarding the message to the actual SQS queue. This approach is fundamentally flawed, because Lambdas need to have access to the actual message `receiptHandle` in order to manipulate messages in the queue.

With this PR, we now implement an approach that is more in line with what's happening in real AWS. We're forwarding all SQS messages to the queues in all cases, and use a polling thread in the Lambda API to poll SQS queues for new messages. We're using a short-polling approach (`receive_message` with zero wait time), as we want to monitor several queues in parallel, in regular intervals (currently configured to poll every second).

Should fix #2039. 