### PR TITLE
fix supervisor warning when running in docker

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -1,6 +1,7 @@
 [supervisord]
 nodaemon=true
 logfile=/tmp/supervisord.log
+user=root
 
 [program:infra]
 command=make infra


### PR DESCRIPTION
When you start localstack from the official docker container you will get a warning from supervisor:

    CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.

this PR fixes this warning

**Please refer to the contribution guidelines in the README when submitting PRs.**
