### PR TITLE
use url set in S3_BACKEND as endpoint_url for s3 client 

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -327,10 +327,23 @@ def fix_account_id_in_arns(response, colon_delimiter=':', existing=None, replace
 
 
 def get_s3_client():
-    return boto3.resource('s3',
-        endpoint_url=config.TEST_S3_URL,
-        config=boto3.session.Config(s3={'addressing_style': 'path'}),
-        verify=False)
+    if 'S3_BACKEND' in os.environ:
+        endpoint_url = os.environ.get('S3_BACKEND')
+    else:
+        endpoint_url = config.TEST_S3_URL
+
+    if ENV_ACCESS_KEY in os.environ and ENV_SECRET_KEY in os.environ:
+        return boto3.resource('s3',
+            endpoint_url=endpoint_url,
+            config=boto3.session.Config(s3={'addressing_style': 'path'}),
+            aws_access_key_id=os.environ.get(ENV_ACCESS_KEY),
+            aws_secret_access_key=os.environ.get(ENV_SECRET_KEY),
+            verify=False)
+    else :
+        return boto3.resource('s3',
+            endpoint_url=endpoint_url,
+            config=boto3.session.Config(s3={'addressing_style': 'path'}),
+            verify=False)
 
 
 def sqs_queue_url_for_arn(queue_arn):

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -332,19 +332,10 @@ def get_s3_client():
     else:
         endpoint_url = config.TEST_S3_URL
 
-    if ENV_ACCESS_KEY in os.environ and ENV_SECRET_KEY in os.environ:
-        return boto3.resource('s3',
-            endpoint_url=endpoint_url,
-            config=boto3.session.Config(s3={'addressing_style': 'path'}),
-            aws_access_key_id=os.environ.get(ENV_ACCESS_KEY),
-            aws_secret_access_key=os.environ.get(ENV_SECRET_KEY),
-            verify=False)
-    else :
-        return boto3.resource('s3',
-            endpoint_url=endpoint_url,
-            config=boto3.session.Config(s3={'addressing_style': 'path'}),
-            verify=False)
-
+    return boto3.resource('s3',
+        endpoint_url=endpoint_url,
+        config=boto3.session.Config(s3={'addressing_style': 'path'}),
+        verify=False)
 
 def sqs_queue_url_for_arn(queue_arn):
     if '://' in queue_arn:

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -337,6 +337,7 @@ def get_s3_client():
         config=boto3.session.Config(s3={'addressing_style': 'path'}),
         verify=False)
 
+
 def sqs_queue_url_for_arn(queue_arn):
     if '://' in queue_arn:
         return queue_arn


### PR DESCRIPTION
In my scenario i would like to use localstack firehose with S3 somewhere else. 

First problem is that `aws_stack.get_s3_client` doesn't make use of `S3_BACKEND` at all. Second problem: my S3 requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and this change will make use of them if the env variables are set