### PR TITLE
Test sns publish message with TargetArn

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -105,11 +105,11 @@ class ProxyListenerSNS(ProxyListener):
 
                 # No need to create a topic to send SMS or single push notifications with SNS
                 # but we can't mock a sending so we only return that it went well
-                if topic_arn:
+                if 'PhoneNumber' not in req_data and 'TargetArn' not in req_data:
                     if topic_arn not in SNS_SUBSCRIPTIONS.keys():
                         return make_error(code=404, code_string='NotFound', message='Topic does not exist')
 
-                    publish_message(topic_arn, req_data)
+                publish_message(topic_arn, req_data)
 
                 # return response here because we do not want the request to be forwarded to SNS backend
                 return make_response(req_action)
@@ -313,6 +313,7 @@ def do_confirm_subscription(topic_arn, token):
 
 
 def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, filter_policy=None):
+    print('do_subscribe: {}'.format(topic_arn))
     # An endpoint may only be subscribed to a topic once. Subsequent
     # subscribe calls do nothing (subscribe is idempotent).
     for existing_topic_subscription in SNS_SUBSCRIPTIONS.get(topic_arn, []):
@@ -340,6 +341,7 @@ def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, fi
             'Status': 'Not Subscribed'
         }
     )
+    print('SUBSCRIPTION_STATUS: {}'.format(SUBSCRIPTION_STATUS))
     # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
     if protocol in ['http', 'https']:
         token = short_uid()

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -313,7 +313,6 @@ def do_confirm_subscription(topic_arn, token):
 
 
 def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, filter_policy=None):
-    print('do_subscribe: {}'.format(topic_arn))
     # An endpoint may only be subscribed to a topic once. Subsequent
     # subscribe calls do nothing (subscribe is idempotent).
     for existing_topic_subscription in SNS_SUBSCRIPTIONS.get(topic_arn, []):
@@ -341,7 +340,6 @@ def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, fi
             'Status': 'Not Subscribed'
         }
     )
-    print('SUBSCRIPTION_STATUS: {}'.format(SUBSCRIPTION_STATUS))
     # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
     if protocol in ['http', 'https']:
         token = short_uid()

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -105,7 +105,7 @@ class ProxyListenerSNS(ProxyListener):
 
                 # No need to create a topic to send SMS or single push notifications with SNS
                 # but we can't mock a sending so we only return that it went well
-                if 'PhoneNumber' not in req_data and 'TargetArn' not in req_data:
+                if topic_arn:
                     if topic_arn not in SNS_SUBSCRIPTIONS.keys():
                         return make_error(code=404, code_string='NotFound', message='Topic does not exist')
 
@@ -149,7 +149,8 @@ class ProxyListenerSNS(ProxyListener):
 
         return True
 
-    def _extract_tags(self, topic_arn, req_data):
+    @staticmethod
+    def _extract_tags(topic_arn, req_data):
         tags = []
         req_tags = {k: v for k, v in req_data.items() if k.startswith('Tags.member.')}
         for i in range(int(len(req_tags.keys()) / 2)):
@@ -158,7 +159,8 @@ class ProxyListenerSNS(ProxyListener):
             tags.append({'Key': key, 'Value': value})
         do_tag_resource(topic_arn, tags)
 
-    def _reset_account_id(self, data):
+    @staticmethod
+    def _reset_account_id(data):
         """ Fix account ID in request payload. All external-facing responses contain our
             predefined account ID (defaults to 000000000000), whereas the backend endpoint
             from moto expects a different hardcoded account ID (123456789012). """

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -1,8 +1,8 @@
 import re
 import os
 import json
-import time
 import shutil
+import time
 import unittest
 import six
 from botocore.exceptions import ClientError
@@ -10,7 +10,7 @@ from io import BytesIO
 from localstack import config
 from localstack.constants import LOCALSTACK_MAVEN_VERSION, LOCALSTACK_ROOT_FOLDER
 from localstack.utils import testutil
-from localstack.utils.testutil import get_lambda_log_stream, get_event_message
+from localstack.utils.testutil import get_lambda_log_events
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
     unzip, new_tmp_dir, short_uid, load_file, to_str, mkdir, download,
@@ -502,17 +502,9 @@ class TestPythonRuntimes(LambdaTestBase):
             Message=message
         )
 
-        logs = aws_stack.connect_to_service('logs')
-
-        log_stream = retry(get_lambda_log_stream, retries=3, sleep=2, function_name=function_name)
-        rs = logs.get_log_events(
-            logGroupName='/aws/lambda/{}'.format(function_name),
-            logStreamName=log_stream
-        )
-
-        message = get_event_message(rs['events'])
-        self.assertEqual(len(message['Records']), 1)
-        notification = message['Records'][0]['Sns']
+        events = get_lambda_log_events(function_name)
+        self.assertEqual(len(events), 1)
+        notification = events[0]['Records'][0]['Sns']
 
         self.assertIn('Subject', notification)
         self.assertEqual(notification['Subject'], subject)


### PR DESCRIPTION
* Refactor get lambda event logs functions
* Add integration tests: publish message with target arn
Issues fixed:
#1876 SNS lambda subscription not triggered when using TargetArn instead of TopicArn on publish
#1933 Specifying targetArn when Publish SNS message seems to no longer work
