### PR TITLE
Add cfn support for IAM role resource type

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -536,6 +536,23 @@ def apply_patches():
     IAM_Role_get_cfn_attribute_orig = iam_models.Role.get_cfn_attribute
     iam_models.Role.get_cfn_attribute = IAM_Role_get_cfn_attribute
 
+    # Patch IAM Role model
+    # https://github.com/localstack/localstack/issues/925
+    @property
+    def IAM_Role_physical_resource_id(self):
+        return self.name
+
+    iam_models.Role.physical_resource_id = IAM_Role_physical_resource_id
+
+    IAM_Role_create_from_cloudformation_json_orig = iam_models.Role.create_from_cloudformation_json
+
+    @classmethod
+    def IAM_Role_create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
+        resource_name = cloudformation_json['Properties']['RoleName']
+        return IAM_Role_create_from_cloudformation_json_orig(resource_name, cloudformation_json, region_name)
+
+    iam_models.Role.create_from_cloudformation_json = IAM_Role_create_from_cloudformation_json
+
     # Patch SNS Topic get_cfn_attribute(..) method in moto
     def SNS_Topic_get_cfn_attribute(self, attribute_name):
         result = SNS_Topic_get_cfn_attribute_orig(self, attribute_name)

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -365,7 +365,13 @@ RESOURCE_TO_FUNCTION = {
                         select_parameters('Path', 'RoleName', 'AssumeRolePolicyDocument',
                             'Description', 'MaxSessionDuration', 'PermissionsBoundary', 'Tags'),
                         'AssumeRolePolicyDocument'),
-                    {'RoleName': PLACEHOLDER_RESOURCE_NAME})
+                    {'RoleName': 'RoleName'})
+        },
+        'delete': {
+            'function': 'delete_role',
+            'parameters': {
+                'RoleName': 'PhysicalResourceId'
+            }
         }
     },
     'ApiGateway::RestApi': {

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -246,7 +246,7 @@ Resources:
               - 'sts:AssumeRole'
             Resource:
               - !Sub >-
-                arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/aws-dev-hello:*
+                arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/aws-dev-log:*
 """
 
 TEST_CHANGE_SET_BODY = """

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -203,6 +203,7 @@ Resources:
     MyRole:
       Type: AWS::IAM::Role
       Properties:
+        RoleName: %s
         AssumeRolePolicyDocument:
           Statement:
             - Effect: Allow
@@ -757,10 +758,11 @@ class CloudFormationTest(unittest.TestCase):
     def test_cfn_handle_firehose(self):
         stack_name = 'stack-%s' % short_uid()
         firehose_name = 'firehose-%s' % short_uid()
+        role_name = 'firehose-role-%s' % short_uid()
 
         cloudformation = aws_stack.connect_to_service('cloudformation')
         params = [{'ParameterKey': 'DeliveryStreamName', 'ParameterValue': firehose_name}]
-        cloudformation.create_stack(StackName=stack_name, TemplateBody=TEST_TEMPLATE_12, Parameters=params)
+        cloudformation.create_stack(StackName=stack_name, TemplateBody=TEST_TEMPLATE_12 % role_name, Parameters=params)
 
         _await_stack_completion(stack_name)
 

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -363,7 +363,7 @@ def _deploy_stack(stack_name, template_body):
     return _await_stack_completion(stack_name)
 
 
-def _await_stack_status(self, stack_name, expected_status, retries=3, sleep=2):
+def _await_stack_status(stack_name, expected_status, retries=3, sleep=2):
     def check_stack():
         stack = get_stack_details(stack_name)
         assert stack['StackStatus'] == expected_status
@@ -372,7 +372,7 @@ def _await_stack_status(self, stack_name, expected_status, retries=3, sleep=2):
 
 
 def _await_stack_completion(stack_name, retries=3, sleep=2):
-    return _await_stack_status(stack_name, 'CREATE_COMPLETE', retries, sleep)
+    return _await_stack_status(stack_name, 'CREATE_COMPLETE', retries=retries, sleep=sleep)
 
 
 class CloudFormationTest(unittest.TestCase):

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -99,6 +99,7 @@ TEST_TEMPLATE_7 = {
         'LambdaExecutionRole': {
             'Type': 'AWS::IAM::Role',
             'Properties': {
+                'RoleName': '',
                 'AssumeRolePolicyDocument': {
                     'Version': '2012-10-17',
                     'Statement': [
@@ -512,6 +513,8 @@ class CloudFormationTest(unittest.TestCase):
         lambdas_before = len(rs['Functions'])
 
         stack_name = 'stack-%s' % short_uid()
+        lambda_role_name = 'lambda-role-%s' % short_uid()
+        TEST_TEMPLATE_7['Resources']['LambdaExecutionRole']['Properties']['RoleName'] = lambda_role_name
         rs = cloudformation.create_stack(StackName=stack_name, TemplateBody=json.dumps(TEST_TEMPLATE_7))
 
         self.assertEqual(rs['ResponseMetadata']['HTTPStatusCode'], 200)


### PR DESCRIPTION
* Patch moto IAM model
* Add integration test
Fixed:
#925 Serverless CloudFormation templates using AWS::Partition fail
