### PR TITLE
Fix API Gateway to Lambda when payload is received as bytes

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -213,7 +213,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
     elif integration['type'] == 'AWS_PROXY':
         if uri.startswith('arn:aws:apigateway:') and ':lambda:path' in uri:
             func_arn = uri.split(':lambda:path')[1].split('functions/')[1].split('/invocations')[0]
-            data_str = json.dumps(data) if isinstance(data, (dict, list)) else data
+            data_str = json.dumps(data) if isinstance(data, (dict, list)) else to_str(data)
             account_id = uri.split(':lambda:path')[1].split(':function:')[0].split(':')[-1]
 
             source_ip = headers['X-Forwarded-For'].split(',')[-2]


### PR DESCRIPTION
For some reason the payload going through the listener is of binary type. I've tried to write a test reproducing the issue, but it seems the test setup isn't exactly the same as when not in the test environment.

Fixes this :
When sending this request :
```
POST http://localhost:4567/restapis/{{api_id}}/test/_user_request_/resolve
Content-Type: application/json

{
    "firstName": "Charles",
    "lastName": "Darwin"
}
```

It returns this error :
```
File "/opt/code/localstack/localstack/services/awslambda/lambda_api.py", line 459, in run_lambda
   result = LAMBDA_EXECUTOR.execute(func_arn, func_details, event, context=context,
 File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 132, in execute
   return do_execute()
 File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 119, in do_execute
   raise e
 File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 107, in do_execute
   result = self._execute(func_arn, func_details, event, context, version)
 File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 669, in _execute
   process.run()
 File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
   self._target(*self._args, **self._kwargs)
 File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 664, in do_execute
   result = lambda_function(event, context)
 File "/opt/code/localstack/localstack/services/awslambda/lambda_api.py", line 586, in execute
   result = lambda_executors.EXECUTOR_LOCAL.execute_java_lambda(
 File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 686, in execute_java_lambda
   save_file(event_file, json.dumps(event))
 File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
   return _default_encoder.encode(obj)
 File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
   chunks = self.iterencode(o, _one_shot=True)
 File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
   return _iterencode(o, 0)
 File "/usr/lib/python3.8/json/encoder.py", line 179, in default
   raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```