### PR TITLE
* Add CFN support for missing resource types

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -61,7 +61,9 @@ MODEL_MAP = {
     'AWS::Logs::LogGroup': service_models.LogsLogGroup,
     'AWS::KinesisFirehose::DeliveryStream': service_models.FirehoseDeliveryStream,
     'AWS::SecretsManager::Secret': service_models.SecretsManagerSecret,
-    'AWS::Elasticsearch::Domain': service_models.ElasticsearchDomain
+    'AWS::Elasticsearch::Domain': service_models.ElasticsearchDomain,
+    'AWS::Events::Rule': service_models.EventsRule,
+    'AWS::S3::BucketPolicy': service_models.S3BucketPolicy
 }
 
 
@@ -158,6 +160,9 @@ def update_physical_resource_id(resource):
             resource.physical_resource_id = resource.params.get('DeliveryStreamName')
 
         elif isinstance(resource, service_models.SecretsManagerSecret):
+            resource.physical_resource_id = resource.params.get('Name')
+
+        elif isinstance(resource, service_models.EventsRule):
             resource.physical_resource_id = resource.params.get('Name')
 
         elif isinstance(resource, service_models.ElasticsearchDomain):

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -8,6 +8,34 @@ class BaseModel(object):
         return cls(**props)
 
 
+class CloudFormationStack(BaseModel):
+    pass
+
+
+class EventsRule(BaseModel):
+    pass
+
+
+class ElasticsearchDomain(BaseModel):
+    pass
+
+
+class FirehoseDeliveryStream(BaseModel):
+    pass
+
+
+class GatewayResponse(BaseModel):
+    pass
+
+
+class LogsLogGroup(BaseModel):
+    pass
+
+
+class S3BucketPolicy(BaseModel):
+    pass
+
+
 class StepFunctionsActivity(BaseModel):
     pass
 
@@ -16,29 +44,9 @@ class SNSSubscription(BaseModel):
     pass
 
 
-class GatewayResponse(BaseModel):
-    pass
-
-
-class CloudFormationStack(BaseModel):
-    pass
-
-
 class SSMParameter(BaseModel):
     pass
 
 
-class LogsLogGroup(BaseModel):
-    pass
-
-
-class FirehoseDeliveryStream(BaseModel):
-    pass
-
-
 class SecretsManagerSecret(BaseModel):
-    pass
-
-
-class ElasticsearchDomain(BaseModel):
     pass

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -212,12 +212,17 @@ RESOURCE_TO_FUNCTION = {
             'function': 'put_bucket_notification_configuration',
             'parameters': s3_bucket_notification_config
         }],
-        'delete': {
+        'delete': [{
+            'function': 'delete_bucket_policy',
+            'parameters': {
+                'Bucket': 'PhysicalResourceId'
+            }
+        }, {
             'function': 'delete_bucket',
             'parameters': {
                 'Bucket': 'PhysicalResourceId'
             }
-        }
+        }]
     },
     'S3::BucketPolicy': {
         'create': {
@@ -403,7 +408,14 @@ RESOURCE_TO_FUNCTION = {
                 'EventBusName': 'EventBusName',
                 'Targets': 'Targets'
             }
-        }]
+        }],
+        'delete': {
+            'function': 'delete_rule',
+            'parameters': {
+                'Name': 'PhysicalResourceId'
+            }
+
+        }
     },
     'IAM::Role': {
         'create': {


### PR DESCRIPTION
  - Events Rule
  - S3 Bucket Policy
* Add integration tests:
  - Events Rule
  - Kinesis Stream
  - S3 Bucket Policy
  - SQS

 Issues fixed:
 #1616 No Moto CloudFormation support for AWS::KinesisFirehose::DeliveryStream / AWS::S3::BucketPolicy
 #2058 Invoking CF stack destroy API call seems to delete the stack but not the resources it has provisioned
