### PR TITLE
WIP: Support IAM Role in Cloudformation without RoleName (#2303)

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -560,7 +560,7 @@ def apply_patches():
 
     @classmethod
     def IAM_Role_create_from_cloudformation_json(cls, resource_name, cloudformation_json, region_name):
-        resource_name = cloudformation_json['Properties']['RoleName']
+        resource_name = cloudformation_json['Properties'].get('RoleName', short_uid())
         return IAM_Role_create_from_cloudformation_json_orig(resource_name, cloudformation_json, region_name)
 
     iam_models.Role.create_from_cloudformation_json = IAM_Role_create_from_cloudformation_json


### PR DESCRIPTION
@duongpv7 I noticed you assigned yourself the issue, so I hope I'm not stepping on your toes. I was trying to fix this before I noticed, but was wondering if you could give me a pointer how I can get this working/what I've done wrong?

With this change, when I create a role without a name (eg. the repro in the issue) I no longer get an error, but when I run `awslocal iam list-roles` afterward I get:

```
{
    "Roles": [
        {
            "Path": "/",
            "RoleName": "dccef",
            "RoleId": "g4hlb2xp8eo2n7t6pjce",
            "Arn": "arn:aws:iam::000000000000:role/dccef",
            "CreateDate": "2020-04-16T13:34:45.673Z",
            "AssumeRolePolicyDocument": {}
        },
        {
            "Path": "/",
            "RoleName": "RoleName",
            "RoleId": "uba7i590qmp0h0xu8fre",
            "Arn": "arn:aws:iam::000000000000:role/RoleName",
            "CreateDate": "2020-04-16T13:34:45.721Z",
            "AssumeRolePolicyDocument": {}
        }
    ]
}
```

2 roles are added instead of one, one has the short uid (correct), the other has 'RoleName'. The test I've added has the same behaviour - it fails because there's this second role being created. I can't figure out how my change could be causing this to happen and I'm not familiar enough with the code to understand how to debug this. Do you have any idea what might be wrong here?

Fixes #2303 