### PR TITLE
Fix CloudFormation deployment for EventPattern attribute in Events::Rule

### DIFF
--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1,4 +1,5 @@
 from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
+from localstack.utils.aws import aws_stack
 
 
 class BaseModel(object):
@@ -24,7 +25,11 @@ class CloudFormationStack(BaseModel):
 
 
 class EventsRule(BaseModel):
-    pass
+
+    def get_cfn_attribute(self, attribute_name):
+        if attribute_name == 'Arn':
+            return self.params.get('Arn') or aws_stack.events_rule_arn(self.params.get('Name'))
+        return super(EventsRule, self).get_cfn_attribute(attribute_name)
 
 
 class ElasticsearchDomain(BaseModel):

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -19,6 +19,9 @@ from localstack.utils.aws.aws_responses import response_regex_replace
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
 from localstack.utils.common import timestamp_millis, short_uid, to_str
 
+# set up logger
+LOG = logging.getLogger(__name__)
+
 # mappings for SNS topic subscriptions
 SNS_SUBSCRIPTIONS = {}
 
@@ -27,9 +30,6 @@ SUBSCRIPTION_STATUS = {}
 
 # mappings for SNS tags
 SNS_TAGS = {}
-
-# set up logger
-LOGGER = logging.getLogger(__name__)
 
 
 class ProxyListenerSNS(ProxyListener):
@@ -214,13 +214,24 @@ class ProxyListenerSNS(ProxyListener):
 UPDATE_SNS = ProxyListenerSNS()
 
 
+def unsubscribe_sqs_queue(queue_url):
+    """ Called upon deletion of an SQS queue, to remove the queue from subscriptions """
+    for topic_arn, subscriptions in SNS_SUBSCRIPTIONS.items():
+        subscriptions = SNS_SUBSCRIPTIONS.get(topic_arn, [])
+        for subscriber in list(subscriptions):
+            sub_url = subscriber.get('sqs_queue_url') or subscriber['Endpoint']
+            if queue_url == sub_url:
+                subscriptions.remove(subscriber)
+
+
 def publish_message(topic_arn, req_data, subscription_arn=None):
     message = req_data['Message'][0]
     sqs_client = aws_stack.connect_to_service('sqs')
 
-    LOGGER.debug('Publishing message to TopicArn: %s | Message:  %s' % (topic_arn, message))
+    LOG.debug('Publishing message to TopicArn: %s | Message:  %s' % (topic_arn, message))
 
-    for subscriber in SNS_SUBSCRIPTIONS.get(topic_arn, []):
+    subscriptions = SNS_SUBSCRIPTIONS.get(topic_arn, [])
+    for subscriber in list(subscriptions):
         if subscription_arn not in [None, subscriber['SubscriptionArn']]:
             continue
         filter_policy = json.loads(subscriber.get('FilterPolicy') or '{}')
@@ -229,6 +240,7 @@ def publish_message(topic_arn, req_data, subscription_arn=None):
             continue
 
         if subscriber['Protocol'] == 'sqs':
+            queue_url = None
             try:
                 endpoint = subscriber['Endpoint']
                 if 'sqs_queue_url' in subscriber:
@@ -246,8 +258,11 @@ def publish_message(topic_arn, req_data, subscription_arn=None):
                     MessageAttributes=create_sqs_message_attributes(subscriber, message_attributes)
                 )
             except Exception as exc:
-                sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
-                return make_error(message=str(exc), code=400)
+                if 'NonExistentQueue' in str(exc):
+                    LOG.info('Removing non-existent queue "%s" subscribed to topic "%s"' % (queue_url, topic_arn))
+                    subscriptions.remove(subscriber)
+                else:
+                    sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
 
         elif subscriber['Protocol'] == 'lambda':
             try:
@@ -262,16 +277,15 @@ def publish_message(topic_arn, req_data, subscription_arn=None):
                 if isinstance(response, FlaskResponse):
                     response.raise_for_status()
             except Exception as exc:
-                LOGGER.warning('Unable to run Lambda function on SNS message: %s %s' % (exc, traceback.format_exc()))
+                LOG.warning('Unable to run Lambda function on SNS message: %s %s' % (exc, traceback.format_exc()))
                 sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
-                return make_error(message=str(exc), code=400)
 
         elif subscriber['Protocol'] in ['http', 'https']:
             msg_type = (req_data.get('Type') or ['Notification'])[0]
             try:
                 message_body = create_sns_message_body(subscriber, req_data)
-            except Exception as exc:
-                return make_error(message=str(exc), code=400)
+            except Exception:
+                continue
             try:
                 response = requests.post(
                     subscriber['Endpoint'],
@@ -290,9 +304,8 @@ def publish_message(topic_arn, req_data, subscription_arn=None):
                 response.raise_for_status()
             except Exception as exc:
                 sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
-                return make_error(message=str(exc), code=400)
         else:
-            LOGGER.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
+            LOG.warning('Unexpected protocol "%s" for SNS subscription' % subscriber['Protocol'])
 
 
 def do_create_topic(topic_arn):

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -258,11 +258,10 @@ def publish_message(topic_arn, req_data, subscription_arn=None):
                     MessageAttributes=create_sqs_message_attributes(subscriber, message_attributes)
                 )
             except Exception as exc:
+                sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
                 if 'NonExistentQueue' in str(exc):
                     LOG.info('Removing non-existent queue "%s" subscribed to topic "%s"' % (queue_url, topic_arn))
                     subscriptions.remove(subscriber)
-                else:
-                    sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
 
         elif subscriber['Protocol'] == 'lambda':
             try:

--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -9,6 +9,7 @@ from requests.models import Request
 from localstack import config
 from localstack.config import HOSTNAME_EXTERNAL, SQS_PORT_EXTERNAL
 from localstack.utils.aws import aws_stack
+from localstack.services.sns import sns_listener
 from localstack.utils.common import to_str, clone
 from localstack.utils.analytics import event_publisher
 from localstack.services.awslambda import lambda_api
@@ -209,7 +210,9 @@ class ProxyListenerSQS(ProxyListener):
                     return _get_attributes_forward_request(method, path, headers, req_data, forward_attrs)
 
             elif action == 'DeleteQueue':
-                QUEUE_ATTRIBUTES.pop(_queue_url(path, req_data, headers), None)
+                queue_url = _queue_url(path, req_data, headers)
+                QUEUE_ATTRIBUTES.pop(queue_url, None)
+                sns_listener.unsubscribe_sqs_queue(queue_url)
 
             elif action == 'ListDeadLetterSourceQueues':
                 queue_url = _queue_url(path, req_data, headers)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -426,6 +426,11 @@ def log_group_arn(group_name, account_id=None, region_name=None):
     return _resource_arn(group_name, pattern, account_id=account_id, region_name=region_name)
 
 
+def events_rule_arn(rule_name, account_id=None, region_name=None):
+    pattern = 'arn:aws:events:%s:%s:rule/%s'
+    return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
+
+
 def lambda_function_arn(function_name, account_id=None, region_name=None):
     return lambda_function_or_layer_arn('function', function_name, account_id=account_id, region_name=region_name)
 

--- a/tests/integration/serverless/serverless.yml
+++ b/tests/integration/serverless/serverless.yml
@@ -11,7 +11,16 @@ provider:
 functions:
   test:
     handler: "handler.test"
-    events: []
+    events:
+      - cloudwatchEvent:
+          name: sls-test-cf-event
+          event:
+            source: aws.cloudformation
+            detail-type: AWS API Call from CloudFormation
+            detail:
+              eventName:
+                - CreateStack
+                - UpdateStack
 
 plugins:
   - "serverless-localstack"

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -1,4 +1,5 @@
 import os
+import json
 import unittest
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import run
@@ -6,7 +7,8 @@ from localstack.utils.common import run
 
 class TestServerless(unittest.TestCase):
 
-    def test_deploy_template(self):
+    @classmethod
+    def setUpClass(cls):
         base_dir = os.path.join(os.path.dirname(__file__), 'serverless')
 
         if not os.path.exists(os.path.join(base_dir, 'node_modules')):
@@ -15,3 +17,13 @@ class TestServerless(unittest.TestCase):
 
         # deploy serverless app
         run('cd %s; npm run serverless -- --region=%s' % (base_dir, aws_stack.get_region()))
+
+    def test_event_rules_deployed(self):
+        events = aws_stack.connect_to_service('events')
+        rules = events.list_rules()['Rules']
+        rule = ([r for r in rules if r['Name'] == 'sls-test-cf-event'] or [None])[0]
+        self.assertTrue(rule)
+        self.assertIn('Arn', rule)
+        pattern = json.loads(rule['EventPattern'])
+        self.assertEqual(pattern['source'], ['aws.cloudformation'])
+        self.assertIn('detail-type', pattern)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -21,7 +21,6 @@ from .test_lambda import TEST_LAMBDA_PYTHON, LAMBDA_RUNTIME_PYTHON36, TEST_LAMBD
 
 TEST_TOPIC_NAME = 'TestTopic_snsTest'
 TEST_QUEUE_NAME = 'TestQueue_snsTest'
-TEST_QUEUE_NAME_2 = 'TestQueue_snsTest2'
 TEST_QUEUE_DLQ_NAME = 'TestQueue_DLQ_snsTest'
 TEST_TOPIC_NAME_2 = 'topic-test-2'
 
@@ -37,29 +36,30 @@ class SNSTest(unittest.TestCase):
         cls.sns_client = aws_stack.connect_to_service('sns')
         cls.topic_arn = cls.sns_client.create_topic(Name=TEST_TOPIC_NAME)['TopicArn']
         cls.queue_url = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME)['QueueUrl']
-        cls.queue_url_2 = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME_2)['QueueUrl']
         cls.dlq_url = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_DLQ_NAME)['QueueUrl']
 
     @classmethod
     def tearDownClass(cls):
         cls.sqs_client.delete_queue(QueueUrl=cls.queue_url)
-        cls.sqs_client.delete_queue(QueueUrl=cls.queue_url_2)
         cls.sqs_client.delete_queue(QueueUrl=cls.dlq_url)
         cls.sns_client.delete_topic(TopicArn=cls.topic_arn)
 
     def test_publish_unicode_chars(self):
-        # connect the SNS topic to the SQS queue
-        queue_arn = aws_stack.sqs_queue_arn(TEST_QUEUE_NAME)
+        # connect an SNS topic to a new SQS queue
+        _, queue_arn, queue_url = self._create_queue()
         self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol='sqs', Endpoint=queue_arn)
 
         # publish message to SNS, receive it from SQS, assert that messages are equal
         message = u'ö§a1"_!?,. £$-'
         self.sns_client.publish(TopicArn=self.topic_arn, Message=message)
-        msgs = self.sqs_client.receive_message(QueueUrl=self.queue_url)
+        msgs = self.sqs_client.receive_message(QueueUrl=queue_url)
         msg_received = msgs['Messages'][0]
         msg_received = json.loads(to_str(msg_received['Body']))
         msg_received = msg_received['Message']
         self.assertEqual(message, msg_received)
+
+        # clean up
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
 
     def test_subscribe_http_endpoint(self):
         # create HTTP endpoint and connect it to SNS topic
@@ -124,7 +124,8 @@ class SNSTest(unittest.TestCase):
 
     def test_filter_policy(self):
         # connect SNS topic to an SQS queue
-        queue_arn = aws_stack.sqs_queue_arn(TEST_QUEUE_NAME_2)
+        queue_name, queue_arn, queue_url = self._create_queue()
+
         filter_policy = {'attr1': [{'numeric': ['>', 0, '<=', 100]}]}
         self.sns_client.subscribe(
             TopicArn=self.topic_arn,
@@ -136,25 +137,28 @@ class SNSTest(unittest.TestCase):
         )
 
         # get number of messages
-        num_msgs_0 = len(self.sqs_client.receive_message(QueueUrl=self.queue_url_2).get('Messages', []))
+        num_msgs_0 = len(self.sqs_client.receive_message(QueueUrl=queue_url).get('Messages', []))
 
         # publish message that satisfies the filter policy, assert that message is received
         message = u'This is a test message'
         self.sns_client.publish(TopicArn=self.topic_arn, Message=message,
             MessageAttributes={'attr1': {'DataType': 'Number', 'StringValue': '99'}})
-        num_msgs_1 = len(self.sqs_client.receive_message(QueueUrl=self.queue_url_2, VisibilityTimeout=0)['Messages'])
+        num_msgs_1 = len(self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)['Messages'])
         self.assertEqual(num_msgs_1, num_msgs_0 + 1)
 
         # publish message that does not satisfy the filter policy, assert that message is not received
         message = u'This is a test message'
         self.sns_client.publish(TopicArn=self.topic_arn, Message=message,
             MessageAttributes={'attr1': {'DataType': 'Number', 'StringValue': '111'}})
-        num_msgs_2 = len(self.sqs_client.receive_message(QueueUrl=self.queue_url_2, VisibilityTimeout=0)['Messages'])
+        num_msgs_2 = len(self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)['Messages'])
         self.assertEqual(num_msgs_2, num_msgs_1)
+
+        # clean up
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
 
     def test_exists_filter_policy(self):
         # connect SNS topic to an SQS queue
-        queue_arn = aws_stack.sqs_queue_arn(TEST_QUEUE_NAME_2)
+        queue_name, queue_arn, queue_url = self._create_queue()
         filter_policy = {'store': [{'exists': True}]}
 
         def do_subscribe(self, filter_policy, queue_arn):
@@ -169,21 +173,21 @@ class SNSTest(unittest.TestCase):
         do_subscribe(self, filter_policy, queue_arn)
 
         # get number of messages
-        num_msgs_0 = len(self.sqs_client.receive_message(QueueUrl=self.queue_url_2).get('Messages', []))
+        num_msgs_0 = len(self.sqs_client.receive_message(QueueUrl=queue_url).get('Messages', []))
 
         # publish message that satisfies the filter policy, assert that message is received
         message = u'This is a test message'
         self.sns_client.publish(TopicArn=self.topic_arn, Message=message,
                                 MessageAttributes={'store': {'DataType': 'Number', 'StringValue': '99'},
                                                    'def': {'DataType': 'Number', 'StringValue': '99'}})
-        num_msgs_1 = len(self.sqs_client.receive_message(QueueUrl=self.queue_url_2, VisibilityTimeout=0)['Messages'])
+        num_msgs_1 = len(self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)['Messages'])
         self.assertEqual(num_msgs_1, num_msgs_0 + 1)
 
         # publish message that does not satisfy the filter policy, assert that message is not received
         message = u'This is a test message'
         self.sns_client.publish(TopicArn=self.topic_arn, Message=message,
                                 MessageAttributes={'attr1': {'DataType': 'Number', 'StringValue': '111'}})
-        num_msgs_2 = len(self.sqs_client.receive_message(QueueUrl=self.queue_url_2, VisibilityTimeout=0)['Messages'])
+        num_msgs_2 = len(self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)['Messages'])
         self.assertEqual(num_msgs_2, num_msgs_1)
 
         # test with exist operator set to false.
@@ -210,8 +214,12 @@ class SNSTest(unittest.TestCase):
                                                          VisibilityTimeout=0).get('Messages', []))
         self.assertEqual(num_msgs_2, num_msgs_1)
 
+        # clean up
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
+
     def test_data_type_sns_message(self):
-        queue_arn = aws_stack.sqs_queue_arn(TEST_QUEUE_NAME_2)
+        queue_name, queue_arn, queue_url = self._create_queue()
+
         filter_policy = {'attr1': [{'numeric': ['>', 0, '<=', 100]}]}
         self.sns_client.subscribe(
             TopicArn=self.topic_arn,
@@ -226,8 +234,11 @@ class SNSTest(unittest.TestCase):
         message = u'This is a test message'
         self.sns_client.publish(TopicArn=self.topic_arn, Message=message,
                                 MessageAttributes={'attr1': {'DataType': 'Number', 'StringValue': '99.12'}})
-        messages = self.sqs_client.receive_message(QueueUrl=self.queue_url_2, VisibilityTimeout=0)['Messages']
+        messages = self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)['Messages']
         self.assertEqual(json.loads(messages[0]['Body'])['MessageAttributes']['attr1']['Value'], '99.12')
+
+        # clean up
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
 
     def test_unknown_topic_publish(self):
         fake_arn = 'arn:aws:sns:us-east-1:123456789012:i_dont_exist'
@@ -529,3 +540,9 @@ class SNSTest(unittest.TestCase):
         self.sns_client.delete_topic(TopicArn=topic_arn)
         lambda_client = aws_stack.connect_to_service('lambda')
         lambda_client.delete_function(FunctionName=func_name)
+
+    def _create_queue(self):
+        queue_name = 'queue-%s' % short_uid()
+        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_url = self.sqs_client.create_queue(QueueName=queue_name)['QueueUrl']
+        return queue_name, queue_arn, queue_url

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -30,19 +30,22 @@ TEST_LAMBDA_ECHO_FILE = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_echo.py')
 
 
 class SNSTest(unittest.TestCase):
-    def setUp(self):
-        self.sqs_client = aws_stack.connect_to_service('sqs')
-        self.sns_client = aws_stack.connect_to_service('sns')
-        self.topic_arn = self.sns_client.create_topic(Name=TEST_TOPIC_NAME)['TopicArn']
-        self.queue_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME)['QueueUrl']
-        self.queue_url_2 = self.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME_2)['QueueUrl']
-        self.dlq_url = self.sqs_client.create_queue(QueueName=TEST_QUEUE_DLQ_NAME)['QueueUrl']
 
-    def tearDown(self):
-        self.sqs_client.delete_queue(QueueUrl=self.queue_url)
-        self.sqs_client.delete_queue(QueueUrl=self.queue_url_2)
-        self.sqs_client.delete_queue(QueueUrl=self.dlq_url)
-        self.sns_client.delete_topic(TopicArn=self.topic_arn)
+    @classmethod
+    def setUpClass(cls):
+        cls.sqs_client = aws_stack.connect_to_service('sqs')
+        cls.sns_client = aws_stack.connect_to_service('sns')
+        cls.topic_arn = cls.sns_client.create_topic(Name=TEST_TOPIC_NAME)['TopicArn']
+        cls.queue_url = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME)['QueueUrl']
+        cls.queue_url_2 = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME_2)['QueueUrl']
+        cls.dlq_url = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_DLQ_NAME)['QueueUrl']
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.sqs_client.delete_queue(QueueUrl=cls.queue_url)
+        cls.sqs_client.delete_queue(QueueUrl=cls.queue_url_2)
+        cls.sqs_client.delete_queue(QueueUrl=cls.dlq_url)
+        cls.sns_client.delete_topic(TopicArn=cls.topic_arn)
 
     def test_publish_unicode_chars(self):
         # connect the SNS topic to the SQS queue


### PR DESCRIPTION
* Fix CloudFormation deployment for EventPattern attribute in Events::Rule - addresses #2241 
* Refactor SNS integration tests to create resources locally instead of globally
* Add CF support to update instances of IAM::Role