### PR TITLE
Fix upstream regression in CloudFormation deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ RUN ES_BASE_DIR=localstack/infra/elasticsearch; \
 ADD tests/ tests/
 RUN LAMBDA_EXECUTOR=local make test
 # clean up temporary files created during test execution
-RUN rm -rf /tmp/localstack/elasticsearch /tmp/localstack.* tests/
+RUN rm -rf /tmp/localstack/elasticsearch /tmp/localstack.* tests/ /root/.npm/*cache

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -811,6 +811,7 @@ def apply_patches():
         FuncThread(run_loop).start()
 
     def initialize_resources(self):
+        self.resource_map.load()
         self.resource_map.create()
         self.output_map.create()
         run_dependencies_deployment_loop(self, 'CREATE')

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -144,7 +144,7 @@ def apply_patches():
             self._set_action('KEY', 'DELETE', query)
             self._authenticate_and_authorize_s3_action()
             key = self.backend.get_key(bucket_name, key_name)
-            key.tags = s3_models.FakeTagging()
+            key.tags = {}
             return 204, {}, ''
         result = s3_key_response_delete_orig(bucket_name, query, key_name, *args, **kwargs)
         return result


### PR DESCRIPTION
Fix regression in CloudFormation deployment, caused by recent change in upstream `moto`.