### PR TITLE
Additional fix for #1160 when running Java lambdas locally

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -689,7 +689,7 @@ class LambdaExecutorLocal(LambdaExecutor):
         save_file(event_file, json.dumps(event))
         TMP_FILES.append(event_file)
         class_name = handler.split('::')[0]
-        classpath = '%s:%s:%s' % (LAMBDA_EXECUTOR_JAR, main_file, Util.get_java_classpath(main_file))
+        classpath = '%s:%s:%s' % (main_file, Util.get_java_classpath(main_file), LAMBDA_EXECUTOR_JAR)
         cmd = 'java %s -cp %s %s %s %s' % (opts, classpath, LAMBDA_EXECUTOR_CLASS, class_name, event_file)
         LOG.warning(cmd)
         result = self.run_lambda_executor(cmd, func_details=func_details)


### PR DESCRIPTION
#1160 describes problems caused by AWS SDK classes from the localstack-utils-fat.jar overriding classes defined in the actual Lambda jar/zip itself. This causes numerous incompatibility problems.

I was able to isolate and repro this problem with a minimal example ( https://github.com/krrg/localstack-java-classpath-debug )

@whummer implemented a partial fix for this that moved the `localstack-utils-fat.jar` later on the classpath, but this fix only applied to lambdas being run using the `docker` executor.

This PR takes a similar approach, but this time for lambdas being executed locally. Using the minimal example above, I verified that the classpath is now correctly ordered for local lambdas and that my example is able to be invoked without error.