### PR TITLE
Create stripped-down light version of Docker image, with lazy loading of ES libs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ node_modules/
 .vscode
 
 **/obj/**
-**/bin/**
 **/lib/**
 
 !bin/docker-entrypoint.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
   - LAMBDA_EXECUTOR=docker-reuse TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
   # build Docker image
   - make docker-build
+  - make docker-build-light
   # extract .coverage details from created image
   - make docker-cp-coverage
   - sed -i 's:/opt/code/localstack:/home/travis/build/localstack/localstack:g' .coverage

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 IMAGE_NAME ?= localstack/localstack
 IMAGE_NAME_BASE ?= localstack/java-maven-node-python
+IMAGE_NAME_LIGHT ?= localstack/localstack-light
 IMAGE_TAG ?= $(shell cat localstack/constants.py | grep '^VERSION =' | sed "s/VERSION = ['\"]\(.*\)['\"].*/\1/")
 VENV_DIR ?= .venv
 PIP_CMD ?= pip
@@ -76,8 +77,8 @@ docker-push-master:## Push Docker image to registry IF we are currently on the m
 		((! (git diff HEAD~1 localstack/constants.py | grep '^+VERSION =') && \
 			echo "Only pushing tag 'latest' as version has not changed.") || \
 			(docker tag $(IMAGE_NAME):latest $(IMAGE_NAME):$(IMAGE_TAG) && \
-				docker push $(IMAGE_NAME):$(IMAGE_TAG))) && \
-		docker push $(IMAGE_NAME):latest \
+				docker push $(IMAGE_NAME):$(IMAGE_TAG) && docker push $(IMAGE_NAME_LIGHT):$(IMAGE_TAG))) && \
+		docker push $(IMAGE_NAME):latest && docker push $(IMAGE_NAME_LIGHT):latest \
 	)
 
 docker-run:        ## Run Docker image locally
@@ -86,6 +87,13 @@ docker-run:        ## Run Docker image locally
 docker-mount-run:
 	MOTO_DIR=$$(echo $$(pwd)/.venv/lib/python*/site-packages/moto | awk '{print $$NF}'); echo MOTO_DIR $$MOTO_DIR; \
 		ENTRYPOINT="-v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/plugins.py:/opt/code/localstack/localstack/plugins.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/localstack/dashboard:/opt/code/localstack/localstack/dashboard -v `pwd`/tests:/opt/code/localstack/tests -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/" make docker-run
+
+docker-build-light:
+	@img_name=$(IMAGE_NAME_LIGHT); \
+		docker build --squash -t $$img_name -f bin/Dockerfile.light .; \
+		IMAGE_NAME=$$img_name make docker-squash; \
+		docker tag $$img_name $$img_name:$(IMAGE_TAG); \
+		docker tag $$img_name:$(IMAGE_TAG) $$img_name:latest
 
 docker-cp-coverage:
 	@echo 'Extracting .coverage file from Docker image'; \

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ docker-mount-run:
 
 docker-build-light:
 	@img_name=$(IMAGE_NAME_LIGHT); \
-		docker build --squash -t $$img_name -f bin/Dockerfile.light .; \
+		docker build -t $$img_name -f bin/Dockerfile.light .; \
 		IMAGE_NAME=$$img_name make docker-squash; \
 		docker tag $$img_name $$img_name:$(IMAGE_TAG); \
 		docker tag $$img_name:$(IMAGE_TAG) $$img_name:latest

--- a/bin/Dockerfile.light
+++ b/bin/Dockerfile.light
@@ -1,0 +1,8 @@
+FROM localstack/localstack
+
+RUN rm -rf localstack/infra/elasticsearch \
+  localstack/dashboard/web
+
+RUN touch localstack/infra/.light-version
+
+ENV START_WEB=0

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -34,6 +34,7 @@ INSTALL_PATH_LOCALSTACK_FAT_JAR = '%s/localstack-utils-fat.jar' % INSTALL_DIR_IN
 INSTALL_PATH_KMS_BINARY_PATTERN = os.path.join(INSTALL_DIR_KMS, 'local-kms.<arch>.bin')
 URL_LOCALSTACK_FAT_JAR = ('https://repo1.maven.org/maven2/' +
     'cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar').format(v=LOCALSTACK_MAVEN_VERSION)
+MARKER_FILE_LIGHT_VERSION = '%s/.light-version' % INSTALL_DIR_INFRA
 
 # Target version for javac, to ensure compatibility with earlier JREs
 JAVAC_TARGET_VERSION = '1.8'
@@ -55,7 +56,7 @@ def get_elasticsearch_install_version(version=None):
 
 def get_elasticsearch_install_dir(version=None):
     version = get_elasticsearch_install_version(version)
-    if version == ELASTICSEARCH_DEFAULT_VERSION:
+    if version == ELASTICSEARCH_DEFAULT_VERSION and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
         # install the default version into a subfolder of the code base
         install_dir = os.path.join(INSTALL_DIR_INFRA, 'elasticsearch')
     else:
@@ -74,7 +75,7 @@ def install_elasticsearch(version=None):
         install_dir_parent = os.path.dirname(install_dir)
         mkdir(install_dir_parent)
         # download and extract archive
-        tmp_archive = os.path.join(tempfile.gettempdir(), 'localstack.%s' % os.path.basename(es_url))
+        tmp_archive = os.path.join(config.TMP_FOLDER, 'localstack.%s' % os.path.basename(es_url))
         download_and_extract_with_retry(es_url, tmp_archive, install_dir_parent)
         elasticsearch_dir = glob.glob(os.path.join(install_dir_parent, 'elasticsearch*'))
         if not elasticsearch_dir:
@@ -220,7 +221,6 @@ def install_component(name):
     installers = {
         'kinesis': install_kinesalite,
         'dynamodb': install_dynamodb_local,
-        'es': install_elasticsearch,
         'sqs': install_elasticmq,
         'stepfunctions': install_stepfunctions_local,
         'kms': install_local_kms


### PR DESCRIPTION
Create a stripped-down "light" version of the Docker image, with lazy loading of Elasticsearch libs, and with the (deprecated) dashboard Web UI sources removed.

The name of the light image is currently `localstack/localstack-light`. This change cuts down the image size (compared to the default `localstack/localstack`) by more than 20%.

In the future, we may want to make this the default behavior, to reduce image size and download volume overall.