### PR TITLE
Change aws cloud id to comply with \d{12}

### DIFF
--- a/localstack/services/cloudformation/cloudformation_listener.py
+++ b/localstack/services/cloudformation/cloudformation_listener.py
@@ -19,7 +19,7 @@ from localstack.services.generic_proxy import ProxyListener
 XMLNS_CLOUDFORMATION = 'http://cloudformation.amazonaws.com/doc/2010-05-15/'
 LOG = logging.getLogger(__name__)
 
-MOTO_CLOUDFORMATION_ACCOUNT_ID = '123456789'
+MOTO_CLOUDFORMATION_ACCOUNT_ID = '123456789012'
 
 
 def error_response(message, code=400, error_type='ValidationError'):


### PR DESCRIPTION
When creating lambda function using cloudformation create-stack (`aws cloudformation create-stack --stack-name stack-name --endpoint-url http://localhost:4566 --template-body file://template.yaml`), I'm getting error:
```
Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:iam::(\\d{12}):role/?[a-zA-Z_0-9+=,.@\\-_/]+"
``` 
and in the logs there is (debug enabled):
```
ERROR:localstack.services.cloudformation.cloudformation_starter: Unable to parse and create resource "SampleLambda": An error occurred (ValidationException) when calling the None operation: 1 validation error detected: Value 'arn:aws:iam::123456789:role/a-role' at 'role' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:iam::(\d{12}):role/?[a-zA-Z_0-9+=,.@\-_/]+ Traceback (most recent call last):
```

The suspicious part is that I'm not specifying "123456789" anywhere -  (`template.yaml`, simplified):
```
...
Resources:
  SampleLambda:
    Type: AWS::Serverless::Function
    Properties:
      FunctionName: "function-name"
      Handler: index.handler
      Runtime: python3.8
      InlineCode: |
        def handler(event, context):
          print("Hey!")
      Role: "arn:aws:iam::000000000000:role/a-role"    # this causes the problem, works fine when omitted, but then new role is created which I don't want in this case
```
I searched the codebase for "123456789" to find out if it doesn't come from localstack and I've found this in `cloudformation_listener.py`. I don't fully understand the logic behind [this replacement](https://github.com/localstack/localstack/blob/c501046c611aba0d891b2cfea1752c35bc285f49/localstack/services/cloudformation/cloudformation_listener.py#L175) but i think that this is the root cause of the issue.

The role with given arn exists: output from `aws iam --endpoint-url=http://localhost:4566 list-roles`:
```
{
    "Roles": [
        {
            "Path": "/",
            "RoleName": "a-role",
            "RoleId": "ky8b9qs20hq7cyofd9de",
            "Arn": "arn:aws:iam::000000000000:role/a-role",
            ....
}
```

I'm using latest (0.11.1) docker version (`docker-compose.yml`):
```
...
  localstack-s3-lambda:
    image: localstack/localstack:0.11.1
    environment:
      - SERVICES=s3:4572,lambda:4574,cloudformation:4581,stepfunctions:4585,iam:4593
      - DEFAULT_REGION=us-east-1
      - DEBUG=1
      - LAMBDA_EXECUTOR=docker
      - LAMBDA_DOCKER_NETWORK=host
    ports:
      - "4566:4566"
    volumes:
      -  "/var/run/docker.sock:/var/run/docker.sock"
```