### PR TITLE
Fix deletion of EC2 NAT Gateways

### DIFF
--- a/localstack/services/ec2/ec2_starter.py
+++ b/localstack/services/ec2/ec2_starter.py
@@ -19,8 +19,16 @@ def patch_ec2():
 
         return revoke_security_group_egress
 
+    def patch_delete_nat_gateway(backend):
+        def delete_nat_gateway(nat_gateway_id):
+            gateway = backend.nat_gateways.get(nat_gateway_id)
+            if gateway:
+                gateway.state = 'deleted'
+        return delete_nat_gateway
+
     for region, backend in ec2_models.ec2_backends.items():
         backend.revoke_security_group_egress = patch_revoke_security_group_egress(backend)
+        backend.delete_nat_gateway = patch_delete_nat_gateway(backend)
 
     # TODO Implement Reserved Instance backend
     # https://github.com/localstack/localstack/issues/2435

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -479,7 +479,6 @@ def fix_metadata_key_underscores(request_headers={}, response=None):
 def fix_creation_date(method, path, response):
     if method != 'GET' or path != '/':
         return
-
     response._content = re.sub(r'([0-9])</CreationDate>', r'\1Z</CreationDate>', to_str(response._content))
 
 
@@ -1130,7 +1129,7 @@ class ProxyListenerS3(PersistingProxyListener):
                 # Pass on the 404 as usual
                 pass
 
-        if response:
+        if response is not None:
             reset_content_length = False
             # append CORS headers and other annotations/patches to response
             append_cors_headers(bucket_name, request_method=method, request_headers=headers, response=response)


### PR DESCRIPTION
Fix deletion of EC2 NAT Gateways - instead of deleting the entry, its state should be set to `deleted`, otherwise Terraform fails. Should fix #2340