### PR TITLE
Support stepfunctions in scheduled event rules

### DIFF
--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -69,6 +69,10 @@ def get_scheduled_rule_func(data):
                 sns_client = aws_stack.connect_to_service('sns')
                 sns_client.publish(TopicArn=arn, Message=json.dumps(event))
 
+            elif ':states' in arn:
+                stepfunctions_client = aws_stack.connect_to_service('stepfunctions')
+                stepfunctions_client.start_execution(stateMachineArn=arn, input=json.dumps(event))
+
             else:
                 LOG.info('Unsupported Events rule target ARN "%s"' % arn)
     return func


### PR DESCRIPTION
This PR adds support for scheduled rules that target step functions. This fixes the issue in comment https://github.com/localstack/localstack/issues/2359#issuecomment-622566572 

Note that the new integration test takes just over a minute to run for the same reason as `test_schedule_expression_event_with_http_endpoint` - because it has to add a scheduled execution and the best precision available is running every 1 minute.