### PR TITLE
Add correct handling of S3 multipart form upload via edge port (#2464)

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -111,6 +111,16 @@ def get_api_from_headers(headers, path=None):
     return result[0], result_before[1] or result[1], path, host
 
 
+def is_s3_form_data(data_bytes):
+    if(to_bytes('key=') in data_bytes):
+        return True
+
+    if(to_bytes('Content-Disposition: form-data') in data_bytes and to_bytes('name="key"') in data_bytes):
+        return True
+
+    return False
+
+
 def get_port_from_custom_rules(method, path, data, headers):
     """ Determine backend port based on custom rules. """
 
@@ -128,8 +138,8 @@ def get_port_from_custom_rules(method, path, data, headers):
         if method == 'PUT':
             # assume that this is an S3 PUT bucket request with URL path `/<bucket>`
             return config.PORT_S3
-        if method == 'POST' and to_bytes('key=') in data_bytes:
-            # assume that this is an S3 POST request with form parameters in the body
+        if method == 'POST' and is_s3_form_data(data_bytes):
+            # assume that this is an S3 POST request with form parameters or multipart form in the body
             return config.PORT_S3
 
     if path == '/' and to_bytes('QueueName=') in data_bytes:

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -1,0 +1,59 @@
+import unittest
+from localstack.services.edge import is_s3_form_data
+
+
+class EdgeServiceTest(unittest.TestCase):
+
+    def test_data_contains_key_equal_is_true(self):
+        data_bytes = b'AWSAccessKeyId=someId&policy=somePolicy&key=someKey&signature=someSig'
+        self.assertEqual(is_s3_form_data(data_bytes), True)
+
+    def test_s3_form_data_is_true(self):
+        data_bytes = b"""--28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="Content-Type"
+
+        text/plain
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="key"
+
+        log.txt
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="AWSAccessKeyId"
+
+        AKIAIG7AH67ANH3GAWPQ
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="policy"
+
+        somePolicy
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="signature"
+
+        hTahNRfuCxL5HEKdhXxJPwvC6IQ=
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="file"; filename="file"
+
+        Hello World!
+        --28f72589b2be0c9de84386b52c615990--
+        """
+        self.assertEqual(is_s3_form_data(data_bytes), True)
+
+    def test_other_query_params_is_false(self):
+        data_bytes = b'AWSAccessKeyId=someId&policy=somePolicy&param=value&signature=someSig'
+        self.assertEqual(is_s3_form_data(data_bytes), False)
+
+    def test_other_form_data_is_false(self):
+        data_bytes = b"""--28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="AWSAccessKeyId"
+
+        AKIAIG7AH67ANH3GAWPQ
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="policy"
+
+        somePolicy
+        --28f72589b2be0c9de84386b52c615990
+        Content-Disposition: form-data; name="signature"
+
+        hTahNRfuCxL5HEKdhXxJPwvC6IQ=
+        --28f72589b2be0c9de84386b52c615990--
+        """
+        self.assertEqual(is_s3_form_data(data_bytes), False)


### PR DESCRIPTION
Tweak the existing handling of POST form data to also treat multipart forms with a 'key' field as S3

I've kept the same logic for multipart forms as the existing logic used for normal form params - if it's a multipart form with a `key` field it's treated as S3.

Added unit tests with example form/multipart form data, and an integration test using presigned post URLs against the edge port.

Hopefully this is the last of the S3 weirdness around the edge port! :) 

Fixes #2464 