### PR TITLE
PoC for feedback: Handling expires for presigned S3 uploads

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -50,6 +50,13 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 
 class ProxyListener(object):
 
+    @staticmethod
+    def default_handle_expect_100(http_handler):
+        return BaseHTTPRequestHandler.handle_expect_100(http_handler)
+
+    def handle_expect_100(self, http_handler):
+        return ProxyListener.default_handle_expect_100(http_handler)
+
     def forward_request(self, method, path, data, headers):
         """ This interceptor method is called by the proxy when receiving a new request
             (*before* forwarding the request to the backend service). It receives details
@@ -106,6 +113,12 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
         except Exception as e:
             if 'cannot read from timed out object' not in str(e):
                 LOG.warning('Unknown error: %s' % e)
+
+    def handle_expect_100(self):
+        if self.proxy.update_listener:
+            return self.proxy.update_listener.handle_expect_100(self)
+
+        return super().handle_expect_100()
 
     def parse_request(self):
         result = BaseHTTPRequestHandler.parse_request(self)
@@ -309,27 +322,7 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
                     response = updated_response
 
             # copy headers and return response
-            self.send_response(response.status_code)
-
-            content_length_sent = False
-            for header_key, header_value in iteritems(response.headers):
-                # filter out certain headers that we don't want to transmit
-                if header_key.lower() not in ('transfer-encoding', 'date', 'server'):
-                    self.send_header(header_key, header_value)
-                    content_length_sent = content_length_sent or header_key.lower() == 'content-length'
-
-            if not content_length_sent:
-                self.send_header('Content-Length', '%s' % len(response.content) if response.content else 0)
-
-            if isinstance(response, LambdaResponse):
-                self.send_multi_value_headers(response.multi_value_headers)
-
-            # allow pre-flight CORS headers by default
-            self._send_cors_headers(response)
-
-            self.end_headers()
-            if response.content and len(response.content):
-                self.wfile.write(to_bytes(response.content))
+            self.write_response(response)
         except Exception as e:
             trace = str(traceback.format_exc())
             conn_errors = ('ConnectionRefusedError', 'NewConnectionError',
@@ -355,6 +348,29 @@ class GenericProxyHandler(BaseHTTPRequestHandler):
                 self.wfile.flush()
             except Exception as e:
                 LOG.warning('Unable to flush write file: %s' % e)
+
+    def write_response(self, response):
+        self.send_response(response.status_code)
+
+        content_length_sent = False
+        for header_key, header_value in iteritems(response.headers):
+            # filter out certain headers that we don't want to transmit
+            if header_key.lower() not in ('transfer-encoding', 'date', 'server'):
+                self.send_header(header_key, header_value)
+                content_length_sent = content_length_sent or header_key.lower() == 'content-length'
+
+        if not content_length_sent:
+            self.send_header('Content-Length', '%s' % len(response.content) if response.content else 0)
+
+        if isinstance(response, LambdaResponse):
+            self.send_multi_value_headers(response.multi_value_headers)
+
+        # allow pre-flight CORS headers by default
+        self._send_cors_headers(response)
+
+        self.end_headers()
+        if response.content and len(response.content):
+            self.wfile.write(to_bytes(response.content))
 
     def _send_cors_headers(self, response=None):
         # Note: Use "response is not None" here instead of "not response"!

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -304,7 +304,7 @@ class S3ListenerTest(unittest.TestCase):
         # waiting for the url to expire
         time.sleep(3)
         resp = requests.get(url, verify=False)
-        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.status_code, 403)
 
         url = self.s3_client.generate_presigned_url(
             'get_object', Params={'Bucket': bucket_name, 'Key': object_key}, ExpiresIn=120


### PR DESCRIPTION
This PR extends the approach in https://github.com/localstack/localstack/pull/2333 to also work for HTTP methods other than GET. More importantly it extends it to support requests that include a file upload including an `Expect: 100-continue` request header.

This is challenging because by default Python's HTTP handler sends an `HTTP/1.1 100 Continue` **at the request parse stage** ([Python Doc](https://docs.python.org/3.2/library/http.server.html#http.server.BaseHTTPRequestHandler.handle_expect_100), [Python Source](https://github.com/python/cpython/blob/3.8/Lib/http/server.py#L364)) which is before the S3 listener gets involved and can check the expires. This means that regardless what we eventually respond (eg. a token expired error), curl hides it because it's already received a 100 continue:

```
$ curl --upload-file test.txt http://localhost:4566/testbucket/test.txt\?AWSAccessKeyId\=AKIAIG7AH67ANH3GAWPQ\&Signature\=lnrEdiaMrRoZXjnj%2FPueQu8Fa5c%3D\&Expires\=1591024990
$ echo $?
0
```

The solution to this is to override the `handle_expected_100` function in `GenericProxyHandler` and use it to allow the listener (eg S3 listener) to get involved at that stage. It does that by calling `handle_expect_100` on `ProxyListener` which has the same contract in terms of its response but also receives the `http_handler` - giving it access to all of the request details.

A listener such as S3 listener can then override that function, and implement its own handling. In this case it uses the same logic as `forward_request` to determine if the request is expired, and writes the same token_expired_error if it has. If it hasn't expired then it just defers to the default implementation (as do all other listeners that haven't overridden the function).

### Examples

**Link has expired**

```
$ curl --upload-file test.txt http://localhost:4572/testbucket/test.txt\?AWSAccessKeyId\=AKIAIG7AH67ANH3GAWPQ\&Signature\=lnrEdiaMrRoZXjnj%2FPueQu8Fa5c%3D\&Expires\=1591024990
<?xml version="1.0" encoding="utf-8"?>
<Error><Code>ExpiredToken</Code><Message>The provided token has expired.</Message><Resource>/testbucket/test.txt?AWSAccessKeyId=AKIAIG7AH67ANH3GAWPQ&amp;Signature=lnrEdiaMrRoZXjnj%2FPueQu8Fa5c%3D&amp;Expires=1591024990</Resource><RequestId></RequestId></Error>%
```

**Link has not expired**

```
$ curl --upload-file test.txt http://localhost:4572/testbucket/test.txt\?AWSAccessKeyId\=AKIAIG7AH67ANH3GAWPQ\&Signature\=lnrEdiaMrRoZXjnj%2FPueQu8Fa5c%3D\&Expires\=9991591024990
$ echo $?
0
```

I appreciate that this is fiddling with some pretty low-level details of HTTP handling in localstack, so I figured it was worth opening an early draft PR to get a sanity check on the approach before going too far with it. Feedback appreicated! :) 

As an aside I've also changed the expired status code to 403, which is what I always see from AWS on these calls. Let me know if that should be changed back, I did need to update a test.

TODO:

- [ ] Probably worth thinking about whether we can expose a different API for the listener side. Currently it's implementing the same `handle_expect_100` API as Python's BaseHttpRequestHandler and writing to the handler itself which is probably lower level than is necessary. It could probably just return a response/None and get handled by the `GenericProxyHandler`
- [ ] Handle the edge port, which will need to implement `handle_expect_100` and pass it to the correct listener
- [ ] Test how the post equivalent works. If it has the same expects header then the S3 listener will need to handle a multipart form too, otherwise this might be sufficient as-is. If there's a lot of extra work then it might make sense to do in a separate PR but definitely worth testing here.
- [ ] Tests!

Fixes https://github.com/localstack/localstack/issues/2493