### PR TITLE
Read expires in S3 multipart POST by decoding policy

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -80,6 +80,10 @@ ALLOWED_HEADER_OVERRIDES = {
     'response-content-encoding': 'Content-Encoding',
 }
 
+# From botocore's auth.py:
+# https://github.com/boto/botocore/blob/30206ab9e9081c80fa68e8b2cb56296b09be6337/botocore/auth.py#L47
+POLICY_EXPIRATION_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
+
 
 def event_type_matches(events, action, api_method):
     """ check whether any of the event types in `events` matches the
@@ -988,6 +992,18 @@ class ProxyListenerS3(PersistingProxyListener):
         if method == 'GET' and 'Expires' in query_map:
             if is_url_already_expired(query_map.get('Expires')[0]):
                 return token_expired_error(path, headers.get('x-amz-request-id'), 400)
+
+        # If multipart POST with policy in the params, return error if the policy has expired
+        if method == 'POST':
+            policy_key, policy_value = multipart_content.find_multipart_key_value(data, headers, 'policy')
+            if policy_key and policy_value:
+                policy = json.loads(base64.b64decode(policy_value).decode('utf-8'))
+                expiration_string = policy.get('expiration', None)  # Example: 2020-06-05T13:37:12Z
+                if expiration_string:
+                    expiration_datetime = datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT)
+                    expiration_timestamp = expiration_datetime.timestamp()
+                    if is_url_already_expired(expiration_timestamp):
+                        return token_expired_error(path, headers.get('x-amz-request-id'), 400)
 
         if query == 'cors' or 'cors' in query_map:
             if method == 'GET':

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -475,6 +475,31 @@ class S3ListenerTest(unittest.TestCase):
         # clean up
         self._delete_bucket(bucket_name, [object_key])
 
+    def test_s3_presigned_post_expires(self):
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+
+        # presign a post with a short expiry time
+        object_key = 'test-presigned-post-key'
+        presigned_request = self.s3_client.generate_presigned_post(
+            Bucket=bucket_name,
+            Key=object_key,
+            ExpiresIn=2
+        )
+
+        # sleep so it expires
+        time.sleep(3)
+
+        # attempt to use the presigned request
+        files = {'file': 'file content'}
+        response = requests.post(presigned_request['url'], data=presigned_request['fields'], files=files, verify=False)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertTrue('ExpiredToken' in response.text)
+
+        # clean up
+        self._delete_bucket(bucket_name)
+
     def test_s3_delete_response_content_length_zero(self):
         bucket_name = 'test-bucket-%s' % short_uid()
         self.s3_client.create_bucket(Bucket=bucket_name)


### PR DESCRIPTION
This adds support for handling expiration in presigned POST URLs. The `policy` is base-64 encoded and may include an `expiration` date field. If it does then we compare it to the current time and return a token expired error if it has expired, in the same way as the existing handling of expires in URL params.

Relevant AWS documentation on constructing a policy: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html 