### PR TITLE
pass multivalue headers and multivalue query string parameters to lam…

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -38,6 +38,7 @@ from localstack.services.awslambda.lambda_executors import (
     LAMBDA_RUNTIME_RUBY,
     LAMBDA_RUNTIME_RUBY25,
     LAMBDA_RUNTIME_PROVIDED)
+from localstack.services.awslambda.multivalue_transformer import multi_value_dict_for_list
 from localstack.utils.common import (to_str, load_file, save_file, TMP_FILES, ensure_readable,
     mkdir, unzip, is_zip_file, zip_contains_jar_entries, run, short_uid,
     timestamp_millis, parse_chunked_data, now_utc, safe_requests, FuncThread,
@@ -247,12 +248,14 @@ def process_apigateway_invocation(func_arn, path, payload, headers={},
         event = {
             'path': path,
             'headers': dict(headers),
+            'multiValueHeaders': multi_value_dict_for_list(headers),
             'pathParameters': dict(path_params),
             'body': payload,
             'isBase64Encoded': False,
             'resource': resource_path,
             'httpMethod': method,
             'queryStringParameters': query_string_params,
+            'multiValueQueryStringParameters': multi_value_dict_for_list(query_string_params),
             'requestContext': request_context,
             'stageVariables': {}  # TODO
         }

--- a/localstack/services/awslambda/multivalue_transformer.py
+++ b/localstack/services/awslambda/multivalue_transformer.py
@@ -1,0 +1,9 @@
+from collections import defaultdict
+
+
+def multi_value_dict_for_list(elements):
+    temp_mv_dict = defaultdict(list)
+    for key in elements:
+        temp_mv_dict[key].append(elements[key])
+
+    return dict((k, tuple(v)) for k, v in temp_mv_dict.items())


### PR DESCRIPTION
…bda from api gateway aws_proxy integration request
This PR addresses two of the inconsistencies mentioned in #2210 .

If someone can give me a hint how to create a new test / extend an existing test, I will do my best to add some. Sorry if the changes look awkward - it's my first python contact ever :-).
I tested that I can now integrate Java lambdas as AWS_PROXY integration which use the AWS models in com.amazonaws.serverless:aws-serverless-java-container (e.g. AwsProxyRequest) where multi value headers and query string parameters are mandatory.
Therefore I was looking at the Java lambda in integration tests but it is not used for tests in combination with api gateway.

