### PR TITLE
Fixing issue with path selection

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -247,7 +247,7 @@ def get_resource_for_path(path, path_map):
             if match[0] == path:
                 return match
             pattern_matched = []
-            if test_path_pattern(path, match[0]):
+            if path_matches_pattern(path, match[0]):
                 pattern_matched.append(match)
             if len(pattern_matched) == 1:
                 return pattern_matched[0]
@@ -255,7 +255,7 @@ def get_resource_for_path(path, path_map):
     return matches[0]
 
 
-def test_path_pattern(path, api_path):
+def path_matches_pattern(path, api_path):
     api_paths = api_path.split('/')
     paths = path.split('/')
     reg_check = re.compile(r'\{(.*)\}')

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -246,23 +246,26 @@ def get_resource_for_path(path, path_map):
         for match in matches:
             if match[0] == path:
                 return match
-            if test_path(path, match[0]):
-                return match
+            pattern_matched = []
+            if test_path_pattern(path, match[0]):
+               pattern_matched.append(match)
+            if len(pattern_matched) == 1:
+                return pattern_matched[0]
         raise Exception('Ambiguous API path %s - matches found: %s' % (path, matches))
     return matches[0]
 
 
-def test_path(path, apiPath):
-    api_paths = apiPath.split('/')
+def test_path_pattern(path, api_path):
+    api_paths = api_path.split('/')
     paths = path.split('/')
-    matched = False
     reg_check = re.compile(r'\{(.*)\}')
+    results = []
     if len(api_paths) != len(paths):
         return False
     for indx, part in enumerate(api_paths):
         if reg_check.match(part) is None and part:
-            matched = part == paths[indx]
-    return matched
+            results.append(part == paths[indx])
+    return len(results) > 0 and all(results)
 
 
 def connect_api_gateway_to_sqs(gateway_name, stage_name, queue_arn, path, region_name=None):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -246,8 +246,23 @@ def get_resource_for_path(path, path_map):
         for match in matches:
             if match[0] == path:
                 return match
+            if test_path(path, match[0]):
+                return match
         raise Exception('Ambiguous API path %s - matches found: %s' % (path, matches))
     return matches[0]
+
+
+def test_path(path, apiPath):
+    api_paths = apiPath.split('/')
+    paths = path.split('/')
+    matched = False
+    reg_check = re.compile(r'\{(.*)\}')
+    if len(api_paths) != len(paths):
+        return False
+    for indx, part in enumerate(api_paths):
+        if reg_check.match(part) is None and part:
+            matched = part == paths[indx]
+    return matched
 
 
 def connect_api_gateway_to_sqs(gateway_name, stage_name, queue_arn, path, region_name=None):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -248,7 +248,7 @@ def get_resource_for_path(path, path_map):
                 return match
             pattern_matched = []
             if test_path_pattern(path, match[0]):
-               pattern_matched.append(match)
+                pattern_matched.append(match)
             if len(pattern_matched) == 1:
                 return pattern_matched[0]
         raise Exception('Ambiguous API path %s - matches found: %s' % (path, matches))

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -246,11 +246,8 @@ def get_resource_for_path(path, path_map):
         for match in matches:
             if match[0] == path:
                 return match
-            pattern_matched = []
             if path_matches_pattern(path, match[0]):
-                pattern_matched.append(match)
-            if len(pattern_matched) == 1:
-                return pattern_matched[0]
+                return match
         raise Exception('Ambiguous API path %s - matches found: %s' % (path, matches))
     return matches[0]
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -61,6 +61,13 @@ class ApiGatewayPathsTest(unittest.TestCase):
         path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
         self.assertEqual(path, '/{param1}/{param2}/baz')
 
+        path_args = {'/foo123/{param1}/baz': {}}
+        result = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
+        self.assertEqual(result, None)
+
+        path_args = {'/foo/{param1}/baz': {}, '/{param1}/bar/baz': {}}
+        self.assertRaises(Exception, apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args))
+
 
 class TestVelocityUtil(unittest.TestCase):
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -41,6 +41,26 @@ class ApiGatewayPathsTest(unittest.TestCase):
         result = apigateway_listener.get_resource_for_path('/foo/bar', {'/{param1}/bar1': {}, '/foo/bar2': {}})
         self.assertEqual(result, None)
 
+        path_args = {'/{param1}/{param2}/foo/{param3}': {}, '/{param}/bar': {}}
+        path, details = apigateway_listener.get_resource_for_path('/foo/bar', path_args)
+        self.assertEqual(path, '/{param}/bar')
+
+        path_args = {'/{param1}/{param2}': {}, '/{param}/bar': {}}
+        path, details = apigateway_listener.get_resource_for_path('/foo/bar', path_args)
+        self.assertEqual(path, '/{param}/bar')
+
+        path_args = {'/{param1}/{param2}': {}, '/{param1}/bar': {}}
+        path, details = apigateway_listener.get_resource_for_path('/foo/baz', path_args)
+        self.assertEqual(path, '/{param1}/{param2}')
+
+        path_args = {'/{param1}/{param2}/baz': {}, '/{param1}/bar/{param2}': {}}
+        path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
+        self.assertEqual(path, '/{param1}/{param2}/baz')
+
+        path_args = {'/{param1}/{param2}/baz': {}, '/{param1}/{param2}/{param2}': {}}
+        path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
+        self.assertEqual(path, '/{param1}/{param2}/baz')
+
 
 class TestVelocityUtil(unittest.TestCase):
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -65,9 +65,6 @@ class ApiGatewayPathsTest(unittest.TestCase):
         result = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
         self.assertEqual(result, None)
 
-        path_args = {'/foo/{param1}/baz': {}, '/{param1}/bar/baz': {}}
-        self.assertRaises(Exception, apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args))
-
 
 class TestVelocityUtil(unittest.TestCase):
 


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**

Found an issue with path selection when the Path starts with a parameter. From the tests added  path_args = {'/{param1}/{param2}/foo/{param3}': {}, '/{param}/bar': {}} is the main culprit.
