### PR TITLE
Fix issue disabled event trigger lambda

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -491,6 +491,9 @@ def forward_to_lambda(records):
             'Records': [record]
         }
         for src in sources:
+            if src.get('State') != 'Enabled':
+                continue
+
             lambda_api.run_lambda(event=event, context={}, func_arn=src['FunctionArn'],
                 asynchronous=not config.SYNCHRONOUS_DYNAMODB_EVENTS)
 


### PR DESCRIPTION
* Fix dynamodb listener
* Add integration test: Disabled event source mapping will not invoke lambda

Issue fixed:
#2541 Disabled lambda event source mapping still triggers lambda
