### PR TITLE
Fix sns listener to handle parameters in path request

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -48,9 +48,15 @@ class ProxyListenerSNS(PersistingProxyListener):
         except Exception as e:
             return make_error(message=str(e), code=400)
 
-        if method == 'POST' and path == '/':
+        if method == 'POST':
             # parse payload and extract fields
             req_data = urlparse.parse_qs(to_str(data), keep_blank_values=True)
+
+            # parse data from query path
+            if not req_data:
+                parsed_path = urlparse.urlparse(path)
+                req_data = urlparse.parse_qs(parsed_path.query, keep_blank_values=True)
+
             req_action = req_data['Action'][0]
             topic_arn = req_data.get('TargetArn') or req_data.get('TopicArn') or req_data.get('ResourceArn')
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -567,8 +567,9 @@ def mock_aws_request_headers(service='dynamodb', region_name=None):
     ctype = APPLICATION_AMZ_JSON_1_0
     if service == 'kinesis':
         ctype = APPLICATION_AMZ_JSON_1_1
-    elif service == 'sqs':
+    elif service in ['sns', 'sqs']:
         ctype = APPLICATION_X_WWW_FORM_URLENCODED
+
     access_key = get_boto3_credentials().access_key
     region_name = region_name or get_region()
     headers = {

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -627,10 +627,7 @@ class SNSTest(unittest.TestCase):
 
         r = requests.post(
             url='{}/?{}'.format(base_url, path),
-            headers={
-                'Authorization': 'AWS4-HMAC-SHA256 Credential=test-id/20200609/us-east-1/sns/aws4_request, '
-                                 'SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=fer'
-            }
+            headers=aws_stack.mock_aws_request_headers('sns')
         )
         self.assertEqual(r.status_code, 200)
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2,9 +2,12 @@
 
 import json
 import os
+import requests
 import time
 import unittest
 from botocore.exceptions import ClientError
+from localstack import config
+
 from localstack.config import external_service_url
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -494,9 +497,9 @@ class SNSTest(unittest.TestCase):
 
     def test_create_topic_test_arn(self):
         response = self.sns_client.create_topic(Name=TEST_TOPIC_NAME)
-        topicArnParams = response['TopicArn'].split(':')
-        self.assertEqual(topicArnParams[4], TEST_AWS_ACCOUNT_ID)
-        self.assertEqual(topicArnParams[5], TEST_TOPIC_NAME)
+        topic_arn_params = response['TopicArn'].split(':')
+        self.assertEqual(topic_arn_params[4], TEST_AWS_ACCOUNT_ID)
+        self.assertEqual(topic_arn_params[5], TEST_TOPIC_NAME)
 
     def test_publish_message_by_target_arn(self):
         self.unsubscribe_all_from_sns()
@@ -606,6 +609,42 @@ class SNSTest(unittest.TestCase):
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
+
+    def test_publish_by_path_parameters(self):
+        topic_name = 'topic-{}'.format(short_uid())
+        queue_name = 'queue-{}'.format(short_uid())
+
+        message = 'test message {}'.format(short_uid())
+        topic_arn = self.sns_client.create_topic(Name=topic_name)['TopicArn']
+
+        base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SNS)
+        path = 'Action=Publish&Version=2010-03-31&TopicArn={}&Message={}'.format(topic_arn, message)
+
+        queue_url = self.sqs_client.create_queue(QueueName=queue_name)['QueueUrl']
+        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+
+        self.sns_client.subscribe(TopicArn=topic_arn, Protocol='sqs', Endpoint=queue_arn)
+
+        r = requests.post(
+            url='{}/?{}'.format(base_url, path),
+            headers={
+                'Authorization': 'AWS4-HMAC-SHA256 Credential=test-id/20200609/us-east-1/sns/aws4_request, '
+                                 'SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=fer'
+            }
+        )
+        self.assertEqual(r.status_code, 200)
+
+        def get_notification(q_url):
+            resp = self.sqs_client.receive_message(QueueUrl=q_url)
+            return json.loads(resp['Messages'][0]['Body'])
+
+        notification = retry(get_notification, retries=3, sleep=2, q_url=queue_url)
+        self.assertEqual(notification['TopicArn'], topic_arn)
+        self.assertEqual(notification['Message'], message)
+
+        # clean up
+        self.sns_client.delete_topic(TopicArn=topic_arn)
+        self.sqs_client.delete_queue(QueueUrl=queue_url)
 
     def _create_queue(self):
         queue_name = 'queue-%s' % short_uid()


### PR DESCRIPTION
* Add integration test: publish to topic using pure http request

Issue fixed:
#2438 SNS publish does not work with aws-sdk-java 2.11.8
