### PR TITLE
Replace ${filename} variable in presigned post responses

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1110,12 +1110,12 @@ class ProxyListenerS3(PersistingProxyListener):
                 response.headers['Location'] = expand_redirect_url(redirect_url, key, bucket_name)
                 LOGGER.debug('S3 POST {} to {}'.format(response.status_code, response.headers['Location']))
 
+            expanded_data = multipart_content.expand_multipart_filename(data, headers)
             key, status_code = multipart_content.find_multipart_key_value(
-                data, headers, 'success_action_status'
+                expanded_data, headers, 'success_action_status'
             )
 
-            if response.status_code == 200 and status_code == '201' and key:
-                response.status_code = 201
+            if response.status_code == 201 and key:
                 response._content = self.get_201_response(key, bucket_name)
                 response.headers['Content-Length'] = str(len(response._content))
                 response.headers['Content-Type'] = 'application/xml; charset=utf-8'


### PR DESCRIPTION
This PR fixes an issue for s3 where the response content for a presigned post (with `success_action_status` = 201) was incorrect when the "${filename}" variable was used in the key.  The "${filename}" variable should be replaced with the name of the provided file.

### Example
Given a POST to the presigned post url with the following parameters:

Bucket: my-bucket
Key: my-key-${filename}
Filename: file.txt
Success Action Status: 201

#### Before
```
<PostResponse>
    <Location>http://localhost/my-key-%24%7Bfilename%7D</Location>
    <Bucket>my-bucket</Bucket>
    <Key>my-key-${filename}</Key>
    <ETag>d41d8cd98f00b204e9800998ecf8427f</ETag>
</PostResponse>
```

#### After
```
<PostResponse>
    <Location>http://localhost/my-key-file.txt</Location>
    <Bucket>my-bucket</Bucket>
     <Key>my-key-file.txt</Key>
     <ETag>d41d8cd98f00b204e9800998ecf8427f</ETag>
</PostResponse>
```