### PR TITLE
Fix deploy dynamodb table resource issues

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -172,6 +172,9 @@ def update_physical_resource_id(resource):
         elif isinstance(resource, service_models.ElasticsearchDomain):
             resource.physical_resource_id = resource.params.get('DomainName')
 
+        elif isinstance(resource, dynamodb2_models.Table):
+            resource.physical_resource_id = resource.name
+
         else:
             LOG.warning('Unable to determine physical_resource_id for resource %s' % type(resource))
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -822,8 +822,7 @@ def create_kinesis_stream(stream_name, shards=1, env=None, delete=False):
     if delete:
         run_safe(lambda: stream.destroy(), print_error=False)
     stream.create()
-    # Disable this wait_for to reduce create_table operation time
-    # stream.wait_for()
+    # Note: Returning the stream without awaiting its creation (via wait_for()) to avoid API call timeouts/retries.
     return stream
 
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -822,7 +822,8 @@ def create_kinesis_stream(stream_name, shards=1, env=None, delete=False):
     if delete:
         run_safe(lambda: stream.destroy(), print_error=False)
     stream.create()
-    stream.wait_for()
+    # Disable this wait_for to reduce create_table operation time
+    # stream.wait_for()
     return stream
 
 

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -16,7 +16,7 @@ def sqs_error_to_dead_letter_queue(queue_arn, event, error):
     try:
         policy = json.loads(attrs.get('RedrivePolicy') or '{}')
     except JSONDecodeError:
-        LOG.warning('Parsing RedrivePolicy failed, Queue: {}'.format(queue_arn))
+        LOG.warning('Parsing RedrivePolicy {} failed, Queue: {}'.format(attrs.get('RedrivePolicy'), queue_arn))
         return
 
     target_arn = policy.get('deadLetterTargetArn')

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -1,6 +1,8 @@
 import json
 import uuid
 import logging
+
+from json import JSONDecodeError
 from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
@@ -11,7 +13,12 @@ def sqs_error_to_dead_letter_queue(queue_arn, event, error):
     queue_url = aws_stack.get_sqs_queue_url(queue_arn)
     attrs = client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['RedrivePolicy'])
     attrs = attrs.get('Attributes', {})
-    policy = json.loads(attrs.get('RedrivePolicy') or '{}')
+    try:
+        policy = json.loads(attrs.get('RedrivePolicy') or '{}')
+    except JSONDecodeError:
+        LOG.warning('Parsing RedrivePolicy failed, Queue: {}'.format(queue_arn))
+        return
+
     target_arn = policy.get('deadLetterTargetArn')
     if not target_arn:
         return

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -412,6 +412,12 @@ RESOURCE_TO_FUNCTION = {
                     'WriteCapacityUnits': 5
                 }
             }
+        },
+        'delete': {
+            'function': 'delete_table',
+            'parameters': {
+                'TableName': 'PhysicalResourceId'
+            }
         }
     },
     'Events::Rule': {

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2,6 +2,8 @@ import os
 import json
 import time
 import unittest
+
+from localstack.config import DEFAULT_REGION
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import load_file, retry, short_uid, to_str
@@ -503,6 +505,106 @@ Outputs:
       Name: !Sub '${AWS::StackName}-MyTopicName'
 """
 
+TEST_DEPLOY_BODY_3 = """
+AWSTemplateFormatVersion: '2010-09-09'
+Description: DynamoDB resource stack creation using Amplify CLI
+Parameters:
+  partitionKeyName:
+    Type: String
+    Default: startTime
+  partitionKeyType:
+    Type: String
+    Default: String
+  env:
+    Type: String
+    Default: Staging
+  sortKeyName:
+    Type: String
+    Default: name
+  sortKeyType:
+    Type: String
+    Default: String
+  tableName:
+    Type: String
+    Default: ddb1
+Conditions:
+  ShouldNotCreateEnvResources:
+    Fn::Equals:
+    - Ref: env
+    - NONE
+Resources:
+  DynamoDBTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName:
+        Fn::If:
+          - ShouldNotCreateEnvResources
+          - Ref: tableName
+          - Fn::Join:
+              - ''
+              - - Ref: tableName
+                - "-"
+                - Ref: env
+      AttributeDefinitions:
+      - AttributeName: name
+        AttributeType: S
+      - AttributeName: startTime
+        AttributeType: S
+      - AttributeName: externalUserID
+        AttributeType: S
+      KeySchema:
+      - AttributeName: name
+        KeyType: HASH
+      - AttributeName: startTime
+        KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+      StreamSpecification:
+        StreamViewType: NEW_IMAGE
+      GlobalSecondaryIndexes:
+      - IndexName: byUser
+        KeySchema:
+        - AttributeName: externalUserID
+          KeyType: HASH
+        - AttributeName: startTime
+          KeyType: RANGE
+        Projection:
+          ProjectionType: ALL
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+Outputs:
+  Name:
+    Value:
+      Ref: DynamoDBTable
+  Arn:
+    Value:
+      Fn::GetAtt:
+      - DynamoDBTable
+      - Arn
+  StreamArn:
+    Value:
+      Fn::GetAtt:
+      - DynamoDBTable
+      - StreamArn
+  PartitionKeyName:
+    Value:
+      Ref: partitionKeyName
+  PartitionKeyType:
+    Value:
+      Ref: partitionKeyType
+  SortKeyName:
+    Value:
+      Ref: sortKeyName
+  SortKeyType:
+    Value:
+      Ref: sortKeyType
+  Region:
+    Value:
+      Ref: AWS::Region
+"""
+
 TEST_TEMPLATE_19 = """
 Conditions:
   IsPRD:
@@ -916,10 +1018,11 @@ class CloudFormationTest(unittest.TestCase):
         )
 
     def test_deploy_stack_with_iam_role(self):
-        cloudformation = aws_stack.connect_to_service('cloudformation')
         stack_name = 'stack-%s' % short_uid()
         change_set_name = 'change-set-%s' % short_uid()
         role_name = 'role-%s' % short_uid()
+
+        cloudformation = aws_stack.connect_to_service('cloudformation')
 
         try:
             cloudformation.describe_stacks(
@@ -1059,6 +1162,71 @@ class CloudFormationTest(unittest.TestCase):
         rs = sns_client.list_topics()
         topics = [tp for tp in rs['Topics'] if tp['TopicArn'] == topic_arn]
         self.assertEqual(len(topics), 0)
+
+    def test_deploy_stack_with_dynamodb_resource(self):
+        stack_name = 'stack-%s' % short_uid()
+        change_set_name = 'change-set-%s' % short_uid()
+        env = 'Staging'
+        ddb_table_name_prefix = 'ddb-table-%s' % short_uid()
+        ddb_table_name = '{}-{}'.format(ddb_table_name_prefix, env)
+
+        cloudformation = aws_stack.connect_to_service('cloudformation')
+
+        rs = cloudformation.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name,
+            TemplateBody=TEST_DEPLOY_BODY_3,
+            Parameters=[
+                {
+                    'ParameterKey': 'tableName',
+                    'ParameterValue': ddb_table_name_prefix
+                },
+                {
+                    'ParameterKey': 'env',
+                    'ParameterValue': env
+                }
+            ]
+        )
+        self.assertEqual(rs['ResponseMetadata']['HTTPStatusCode'], 200)
+        change_set_id = rs['Id']
+
+        rs = cloudformation.execute_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name
+        )
+        self.assertEqual(rs['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        rs = cloudformation.describe_stacks(
+            StackName=stack_name
+        )
+        self.assertEqual(rs['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        stacks = [stack for stack in rs['Stacks'] if stack['StackName'] == stack_name]
+        self.assertEqual(len(stacks), 1)
+        self.assertEqual(stacks[0]['ChangeSetId'], change_set_id)
+
+        outputs = {
+            output['OutputKey']: output['OutputValue']
+            for output in stacks[0]['Outputs']
+        }
+        self.assertIn('Arn', outputs)
+        self.assertEqual(outputs['Arn'], 'arn:aws:dynamodb:{}:{}:table/{}'.format(
+            DEFAULT_REGION, TEST_AWS_ACCOUNT_ID, ddb_table_name))
+
+        ddb_client = aws_stack.connect_to_service('dynamodb')
+        rs = ddb_client.list_tables()
+        self.assertIn(ddb_table_name, rs['TableNames'])
+
+        # clean up
+        cloudformation.delete_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name
+        )
+        cloudformation.delete_stack(
+            StackName=stack_name
+        )
+        rs = ddb_client.list_tables()
+        self.assertNotIn(ddb_table_name, rs['TableNames'])
 
     def test_cfn_handle_s3_bucket_resources(self):
         stack_name = 'stack-%s' % short_uid()

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -3,7 +3,6 @@ import json
 import time
 import unittest
 
-from localstack.config import DEFAULT_REGION
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import load_file, retry, short_uid, to_str
@@ -1211,7 +1210,7 @@ class CloudFormationTest(unittest.TestCase):
         }
         self.assertIn('Arn', outputs)
         self.assertEqual(outputs['Arn'], 'arn:aws:dynamodb:{}:{}:table/{}'.format(
-            DEFAULT_REGION, TEST_AWS_ACCOUNT_ID, ddb_table_name))
+            aws_stack.get_region(), TEST_AWS_ACCOUNT_ID, ddb_table_name))
 
         ddb_client = aws_stack.connect_to_service('dynamodb')
         rs = ddb_client.list_tables()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -150,6 +150,10 @@ class IntegrationTest(unittest.TestCase):
     # TODO fix duplication with test_lambda_streams_batch_and_transactions(..)!
     # @profiled()
     def test_kinesis_lambda_sns_ddb_sqs_streams(self):
+        def create_kinesis_stream(name, delete=False):
+            stream = aws_stack.create_kinesis_stream(name, delete=delete)
+            stream.wait_for()
+
         ddb_lease_table_suffix = '-kclapp'
         table_name = TEST_TABLE_NAME + 'klsdss' + ddb_lease_table_suffix
         stream_name = TEST_STREAM_NAME
@@ -163,8 +167,9 @@ class IntegrationTest(unittest.TestCase):
         LOGGER.info('Creating test streams...')
         run_safe(lambda: dynamodb_service.delete_table(
             TableName=stream_name + ddb_lease_table_suffix), print_error=False)
-        aws_stack.create_kinesis_stream(stream_name, delete=True)
-        aws_stack.create_kinesis_stream(TEST_LAMBDA_SOURCE_STREAM_NAME)
+
+        create_kinesis_stream(stream_name, delete=True)
+        create_kinesis_stream(TEST_LAMBDA_SOURCE_STREAM_NAME)
 
         events = []
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -286,7 +286,7 @@ class IntegrationTest(unittest.TestCase):
             sqs.send_message(QueueUrl=sqs_queue_info['QueueUrl'], MessageBody=str(i))
 
         LOGGER.info('Waiting some time before finishing test.')
-        time.sleep(5)
+        time.sleep(2)
 
         num_events_lambda = num_events_ddb + num_events_sns + num_events_sqs
         num_events = num_events_lambda + num_events_kinesis

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -281,7 +281,7 @@ class IntegrationTest(unittest.TestCase):
             sqs.send_message(QueueUrl=sqs_queue_info['QueueUrl'], MessageBody=str(i))
 
         LOGGER.info('Waiting some time before finishing test.')
-        time.sleep(2)
+        time.sleep(5)
 
         num_events_lambda = num_events_ddb + num_events_sns + num_events_sqs
         num_events = num_events_lambda + num_events_kinesis


### PR DESCRIPTION
* Disable wait_for block (related to dynamodb stream) when creating dynamodb table
* Add action delete for dynamodb table resource type
* Add integration test

Issues fixed:
#2607 Cloudformation does not work (tested with DynamoDBstack-amplify.txt template)
#2336 cloudformation deploy regression in latest version
