### PR TITLE
Deploy stack with DynamoDB table: Ref returning table name

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -172,6 +172,9 @@ def update_physical_resource_id(resource):
         elif isinstance(resource, service_models.ElasticsearchDomain):
             resource.physical_resource_id = resource.params.get('DomainName')
 
+        elif isinstance(resource, dynamodb_models.Table):
+            resource.physical_resource_id = resource.name
+
         elif isinstance(resource, dynamodb2_models.Table):
             resource.physical_resource_id = resource.name
 

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1162,7 +1162,7 @@ class CloudFormationTest(unittest.TestCase):
         topics = [tp for tp in rs['Topics'] if tp['TopicArn'] == topic_arn]
         self.assertEqual(len(topics), 0)
 
-    def test_deploy_stack_with_dynamodb_resource(self):
+    def test_deploy_stack_with_dynamodb_table(self):
         stack_name = 'stack-%s' % short_uid()
         change_set_name = 'change-set-%s' % short_uid()
         env = 'Staging'
@@ -1211,6 +1211,9 @@ class CloudFormationTest(unittest.TestCase):
         self.assertIn('Arn', outputs)
         self.assertEqual(outputs['Arn'], 'arn:aws:dynamodb:{}:{}:table/{}'.format(
             aws_stack.get_region(), TEST_AWS_ACCOUNT_ID, ddb_table_name))
+
+        self.assertIn('Name', outputs)
+        self.assertEqual(outputs['Name'], ddb_table_name)
 
         ddb_client = aws_stack.connect_to_service('dynamodb')
         rs = ddb_client.list_tables()


### PR DESCRIPTION
* Update integration test

Issue fixed:
#2573 Cloudformation: using Ref on a DynamoDB Table is returning the ARN instead of the table name
