### PR TITLE
Fix bug where lambda was sent JSON strings

### DIFF
--- a/localstack/services/events/events_starter.py
+++ b/localstack/services/events/events_starter.py
@@ -33,7 +33,7 @@ def send_event_to_sqs(event, arn):
 
 
 def send_event_to_lambda(event, arn):
-    run_lambda(event=json.dumps(event), context={}, func_arn=arn, asynchronous=True)
+    run_lambda(event=event, context={}, func_arn=arn, asynchronous=True)
 
 
 def send_event_to_firehose(event, arn):

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -236,7 +236,7 @@ class EventsTest(unittest.TestCase):
         # Get lambda's log events
         events = get_lambda_log_events(function_name)
         self.assertEqual(len(events), 1)
-        actual_event = json.loads(events[0])
+        actual_event = events[0]
         self.assertIsValidEvent(actual_event)
         self.assertDictEqual(json.loads(actual_event['detail']), json.loads(TEST_EVENT_PATTERN['Detail']))
 


### PR DESCRIPTION
Hi,

I made an error on my last PR (#2670). I was sending a JSON-formatted string to a lambda instead of the actual dictionary. This fixes that error. If this isn't fixed, you'll get errors in `services/awslambda/labmda_executors.py`, line 69, `get_from_event`.

Sorry for the error.