### PR TITLE
sqs RedrivePolicy removed from UNSUPPORTED_ATTRIBUTE_NAMES

### DIFF
--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -28,7 +28,7 @@ UNSUPPORTED_ATTRIBUTE_NAMES = [
     # elasticmq store 'FifoQueue', 'ContentBasedDeduplication' as queue's properties
     # currently can't get them as queue attributes
     'FifoQueue', 'ContentBasedDeduplication',
-    'DelaySeconds', 'MaximumMessageSize', 'MessageRetentionPeriod', 'Policy', 'RedrivePolicy',
+    'DelaySeconds', 'MaximumMessageSize', 'MessageRetentionPeriod', 'Policy',
     'KmsMasterKeyId', 'KmsDataKeyReusePeriodSeconds'
 ]
 


### PR DESCRIPTION
Fix for issue #2701 . Removed RedrivePolicy from UNSUPPORTED_ATTRIBUTE_NAMES in sqs_listener.py