### PR TITLE
Update DynamodbStreams event vesiron to 1.1 and add ApproximateCreati…

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -3,6 +3,7 @@ import json
 import random
 import logging
 import threading
+import time
 from binascii import crc32
 from requests.models import Request, Response
 from localstack import config
@@ -210,10 +211,12 @@ class ProxyListenerDynamoDB(ProxyListener):
         if not action:
             return
 
+        # upgrade event version to 1.1
         record = {
             'eventID': '1',
-            'eventVersion': '1.0',
+            'eventVersion': '1.1',
             'dynamodb': {
+                'ApproximateCreationDateTime': time.time(),
                 'StreamViewType': 'NEW_AND_OLD_IMAGES',
                 'SizeBytes': -1
             },

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -2,6 +2,7 @@
 
 import unittest
 import json
+from datetime import datetime
 
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.utils import testutil
@@ -417,7 +418,7 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         table_list = dynamodb.list_tables()
         self.assertEqual(tables_before, len(table_list['TableNames']))
 
-    def test_dynamodb_stream_records_with_update_time(self):
+    def test_dynamodb_stream_records_with_update_item(self):
         table_name = 'test-ddb-table-%s' % short_uid()
         dynamodb = aws_stack.connect_to_service('dynamodb')
         ddbstreams = aws_stack.connect_to_service('dynamodbstreams')
@@ -460,10 +461,15 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         records = ddbstreams.get_records(ShardIterator=iterator_id)
         self.assertEqual(200, records['ResponseMetadata']['HTTPStatusCode'])
         self.assertEqual(2, len(records['Records']))
+        self.assertTrue(isinstance(records['Records'][0]['dynamodb']['ApproximateCreationDateTime'], datetime))
+        self.assertEqual('1.1', records['Records'][0]['eventVersion'])
         self.assertEqual('INSERT', records['Records'][0]['eventName'])
         self.assertNotIn('OldImage', records['Records'][0]['dynamodb'])
+        self.assertTrue(isinstance(records['Records'][1]['dynamodb']['ApproximateCreationDateTime'], datetime))
+        self.assertEqual('1.1', records['Records'][1]['eventVersion'])
         self.assertEqual('MODIFY', records['Records'][1]['eventName'])
         self.assertIn('OldImage', records['Records'][1]['dynamodb'])
+        self.assertTrue(isinstance(records['Records'][1]['dynamodb']['ApproximateCreationDateTime'], datetime))
 
         dynamodb.delete_table(TableName=table_name)
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -469,7 +469,6 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         self.assertEqual('1.1', records['Records'][1]['eventVersion'])
         self.assertEqual('MODIFY', records['Records'][1]['eventName'])
         self.assertIn('OldImage', records['Records'][1]['dynamodb'])
-        self.assertTrue(isinstance(records['Records'][1]['dynamodb']['ApproximateCreationDateTime'], datetime))
 
         dynamodb.delete_table(TableName=table_name)
 


### PR DESCRIPTION
- Update DynamodbStreams event version to 1.1 and add ApproximateCreationDateTime to record data
- Update integration test to verify
Fix issued:
https://github.com/localstack/localstack/issues/2780