### PR TITLE
Use the correct region when getting CloudFormation stack resources to delete.

### DIFF
--- a/localstack/services/cloudformation/cloudformation_listener.py
+++ b/localstack/services/cloudformation/cloudformation_listener.py
@@ -193,7 +193,10 @@ class ProxyListenerCloudFormation(ProxyListener):
                 )
 
             if action == 'DeleteStack':
-                client = aws_stack.connect_to_service('cloudformation')
+                client = aws_stack.connect_to_service(
+                    'cloudformation',
+                    region_name=aws_stack.extract_region_from_auth_header(headers)
+                )
                 stack_resources = client.list_stack_resources(StackName=stack_name)['StackResourceSummaries']
                 template_deployer.delete_stack(stack_name, stack_resources)
 

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1718,3 +1718,16 @@ class CloudFormationTest(unittest.TestCase):
 
         cloudformation.delete_stack(StackName='myteststack2')
         cloudformation.delete_stack(StackName='myteststack')
+
+    def test_delete_stack_across_regions(self):
+        domain_name = 'es-%s' % short_uid()
+
+        cloudformation = aws_stack.connect_to_service('cloudformation', region_name='eu-central-1')
+
+        cloudformation.create_stack(
+            StackName='myteststack',
+            TemplateBody=TEST_TEMPLATE_3,
+            Parameters=[{'ParameterKey': 'DomainName', 'ParameterValue': domain_name}]
+        )
+
+        cloudformation.delete_stack(StackName='myteststack')


### PR DESCRIPTION
CloudFormation's DeleteStack wrapper would create an `aws_stack` client in
order to list the resources contained in the stack for deletion. This
client was created without specifying a `region_name` parameter which meant
that even if the stack was created in a given region the deletion would
always be attempted in us-east-1.

This change fixes that by specifying the region name sent in the request
itself.