### PR TITLE
Fix cfn deploy serverless api resource

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -435,7 +435,10 @@ def apply_patches():
             api.resources = {}
             for res in resources:
                 res_path_part = res.get('pathPart') or res.get('path')
-                res_method_path = resource_props['Body']['paths'].get(res_path_part)
+                res_method_path = resource_props.get('Body', {}).get('paths', {}).get(res_path_part)
+                if not res_method_path:
+                    continue
+
                 child = api.add_child(res_path_part, res.get('parentId'))
                 for key in res_method_path:
                     method_type = key.upper()

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -178,6 +178,9 @@ def update_physical_resource_id(resource):
         elif isinstance(resource, dynamodb2_models.Table):
             resource.physical_resource_id = resource.name
 
+        elif isinstance(resource, apigw_models.RestAPI):
+            resource.physical_resource_id = resource.id
+
         else:
             LOG.warning('Unable to determine physical_resource_id for resource %s' % type(resource))
 
@@ -391,8 +394,10 @@ def apply_patches():
             LOG.debug('Updating resource id: %s - %s, %s - %s' % (existing_id, new_res_id, resource, resource_json))
             if new_res_id:
                 LOG.info('Updating resource ID from %s to %s (%s)' % (existing_id, new_res_id, region_name))
-                update_resource_id(resource, new_res_id, props,
-                    region_name, stack_name, resources_map._resource_json_map)
+                update_resource_id(
+                    resource, new_res_id, props, region_name, stack_name, resources_map._resource_json_map,
+                    resource_json.get('Properties')
+                )
             else:
                 LOG.warning('Unable to extract id for resource %s: %s' % (logical_id, result))
 
@@ -401,7 +406,7 @@ def apply_patches():
 
         return resource
 
-    def update_resource_id(resource, new_id, props, region_name, stack_name, resource_map):
+    def update_resource_id(resource, new_id, props, region_name, stack_name, resource_map, resource_props={}):
         """ Update and fix the ID(s) of the given resource. """
 
         # NOTE: this is a bit of a hack, which is required because
@@ -417,35 +422,57 @@ def apply_patches():
 
         backend = apigw_models.apigateway_backends[region_name]
         if isinstance(resource, apigw_models.RestAPI):
-            backend.apis.pop(resource.id, None)
-            backend.apis[new_id] = resource
+            api = resource
+            backend.apis.pop(api.id, None)
+            api.id = new_id
+            backend.apis[new_id] = api
             # We also need to fetch the resources to replace the root resource
             # that moto automatically adds to newly created RestAPI objects
             client = aws_stack.connect_to_service('apigateway')
             resources = client.get_resources(restApiId=new_id, limit=500)['items']
             # make sure no resources have been added in addition to the root /
-            assert len(resource.resources) == 1
-            resource.resources = {}
+            assert len(api.resources) == 1
+            api.resources = {}
             for res in resources:
                 res_path_part = res.get('pathPart') or res.get('path')
-                child = resource.add_child(res_path_part, res.get('parentId'))
-                resource.resources.pop(child.id)
+                res_method_path = resource_props['Body']['paths'].get(res_path_part)
+                child = api.add_child(res_path_part, res.get('parentId'))
+                for key in res_method_path:
+                    method_type = key.upper()
+                    method = child.resource_methods.get(method_type)
+                    if not method:
+                        child.add_method(method_type, None, None)
+
+                    child.add_integration(
+                        method_type,
+                        res_method_path[key]['x-amazon-apigateway-integration']['type'],
+                        res_method_path[key]['x-amazon-apigateway-integration']['uri'],
+                        None,
+                        res_method_path[key]['x-amazon-apigateway-integration']['httpMethod']
+                    )
+
+                api.resources.pop(child.id)
                 child.id = res['id']
                 child.api_id = new_id
-                resource.resources[child.id] = child
-            resource.id = new_id
+                api.resources[child.id] = child
+
         elif isinstance(resource, apigw_models.Resource):
             api_id = props['RestApiId']
             api_id = template_deployer.resolve_refs_recursively(stack_name, api_id, resource_map)
             backend.apis[api_id].resources.pop(resource.id, None)
             backend.apis[api_id].resources[new_id] = resource
             resource.id = new_id
+
         elif isinstance(resource, apigw_models.Deployment):
             api_id = props['RestApiId']
             api_id = template_deployer.resolve_refs_recursively(stack_name, api_id, resource_map)
+            if not api_id:
+                api_id = resource_props['RestApiId']
+
             backend.apis[api_id].deployments.pop(resource['id'], None)
             backend.apis[api_id].deployments[new_id] = resource
             resource['id'] = new_id
+
         else:
             LOG.warning('Unexpected resource type when updating ID: %s' % type(resource))
 

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -446,13 +446,9 @@ def apply_patches():
                     if not method:
                         child.add_method(method_type, None, None)
 
+                    path_int = res_method_path[key]['x-amazon-apigateway-integration']
                     child.add_integration(
-                        method_type,
-                        res_method_path[key]['x-amazon-apigateway-integration']['type'],
-                        res_method_path[key]['x-amazon-apigateway-integration']['uri'],
-                        None,
-                        res_method_path[key]['x-amazon-apigateway-integration']['httpMethod']
-                    )
+                        method_type, path_int['type'], path_int['uri'], None, path_int['httpMethod'])
 
                 api.resources.pop(child.id)
                 child.id = res['id']

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -305,6 +305,7 @@ def publish_message(topic_arn, req_data, subscription_arn=None, skip_checks=Fals
                     MessageAttributes=create_sqs_message_attributes(subscriber, message_attributes)
                 )
             except Exception as exc:
+                LOG.warning('Unable to forward SNS message to SQS: %s %s' % (exc, traceback.format_exc()))
                 sns_error_to_dead_letter_queue(subscriber['SubscriptionArn'], req_data, str(exc))
                 if 'NonExistentQueue' in str(exc):
                     LOG.info('Removing non-existent queue "%s" subscribed to topic "%s"' % (queue_url, topic_arn))

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -220,6 +220,28 @@ def param_defaults(param_func, defaults):
     return replace
 
 
+def get_ddb_provisioned_throughput(params, **kwargs):
+    args = params.get('ProvisionedThroughput')
+    if args:
+        if isinstance(args['ReadCapacityUnits'], str):
+            args['ReadCapacityUnits'] = int(args['ReadCapacityUnits'])
+        if isinstance(args['WriteCapacityUnits'], str):
+            args['WriteCapacityUnits'] = int(args['WriteCapacityUnits'])
+    return args
+
+
+def get_ddb_global_sec_indexes(params, **kwargs):
+    args = params.get('GlobalSecondaryIndexes')
+    if args:
+        for index in args:
+            provisoned_throughput = index['ProvisionedThroughput']
+            if isinstance(provisoned_throughput['ReadCapacityUnits'], str):
+                provisoned_throughput['ReadCapacityUnits'] = int(provisoned_throughput['ReadCapacityUnits'])
+            if isinstance(provisoned_throughput['WriteCapacityUnits'], str):
+                provisoned_throughput['WriteCapacityUnits'] = int(provisoned_throughput['WriteCapacityUnits'])
+    return args
+
+
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
     'S3::Bucket': {
@@ -406,9 +428,9 @@ RESOURCE_TO_FUNCTION = {
                 'TableName': 'TableName',
                 'AttributeDefinitions': 'AttributeDefinitions',
                 'KeySchema': 'KeySchema',
-                'ProvisionedThroughput': 'ProvisionedThroughput',
+                'ProvisionedThroughput': get_ddb_provisioned_throughput,
                 'LocalSecondaryIndexes': 'LocalSecondaryIndexes',
-                'GlobalSecondaryIndexes': 'GlobalSecondaryIndexes',
+                'GlobalSecondaryIndexes': get_ddb_global_sec_indexes,
                 'StreamSpecification': lambda params, **kwargs: (
                     common.merge_dicts(params.get('StreamSpecification'), {'StreamEnabled': True}, default=None))
             },

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -493,6 +493,12 @@ RESOURCE_TO_FUNCTION = {
                 'name': 'Name',
                 'description': 'Description'
             }
+        },
+        'delete': {
+            'function': 'delete_rest_api',
+            'parameters': {
+                'restApiId': 'PhysicalResourceId',
+            }
         }
     },
     'ApiGateway::Resource': {

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -723,6 +723,33 @@ TEST_TEMPLATE_21 = {
     }
 }
 
+TEST_TEMPLATE_22 = """
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template with a simple API definition
+Resources:
+  Api:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+  Lambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+            RestApiId:
+              Ref: Api
+      Runtime: python3.7
+      Handler: index.handler
+      InlineCode: |
+        def handler(event, context):
+            return {'body': 'Hello World!', 'statusCode': 200}
+"""
+
 
 def bucket_exists(name):
     s3_client = aws_stack.connect_to_service('s3')
@@ -1759,6 +1786,38 @@ class CloudFormationTest(unittest.TestCase):
         # clean up
         cloudformation.delete_stack(StackName=stack_name)
         iam.delete_role(RoleName=role_name)
+
+    def test_cfn_handle_serverless_api_resource(self):
+        stack_name = 'stack-%s' % short_uid()
+
+        cloudformation = aws_stack.connect_to_service('cloudformation')
+
+        rs = cloudformation.create_stack(
+            StackName=stack_name,
+            TemplateBody=TEST_TEMPLATE_22,
+        )
+        self.assertEqual(200, rs['ResponseMetadata']['HTTPStatusCode'])
+
+        res = cloudformation.list_stack_resources(StackName=stack_name)['StackResourceSummaries']
+        rest_api_ids = [r['PhysicalResourceId'] for r in res if r['ResourceType'] == 'AWS::ApiGateway::RestApi']
+        lambda_func_names = [r['PhysicalResourceId'] for r in res if r['ResourceType'] == 'AWS::Lambda::Function']
+
+        self.assertEqual(len(rest_api_ids), 1)
+        self.assertEqual(len(lambda_func_names), 1)
+
+        apigw_client = aws_stack.connect_to_service('apigateway')
+        rs = apigw_client.get_resources(
+            restApiId=rest_api_ids[0]
+        )
+        self.assertEqual(len(rs['items']), 1)
+        resource = rs['items'][0]
+
+        uri = resource['resourceMethods']['GET']['methodIntegration']['uri']
+        lambda_arn = aws_stack.lambda_function_arn(lambda_func_names[0])
+        self.assertIn(lambda_arn, uri)
+
+        # clean up
+        cloudformation.delete_stack(StackName=stack_name)
 
     def test_delete_stack(self):
         domain_name = 'es-%s' % short_uid()

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -557,8 +557,8 @@ Resources:
       - AttributeName: startTime
         KeyType: RANGE
       ProvisionedThroughput:
-        ReadCapacityUnits: 5
-        WriteCapacityUnits: 5
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
       StreamSpecification:
         StreamViewType: NEW_IMAGE
       GlobalSecondaryIndexes:
@@ -571,8 +571,8 @@ Resources:
         Projection:
           ProjectionType: ALL
         ProvisionedThroughput:
-          ReadCapacityUnits: 5
-          WriteCapacityUnits: 5
+          ReadCapacityUnits: '5'
+          WriteCapacityUnits: '5'
 Outputs:
   Name:
     Value:
@@ -1793,8 +1793,8 @@ class CloudFormationTest(unittest.TestCase):
 
         cloudformation.delete_stack(StackName='myteststack')
 
-    def test_cft_with_on_deman_dynamodb_resource(self):
-        cloudformation = aws_stack.connect_to_service('cloudformation', region_name='eu-central-1')
+    def test_cft_with_on_demand_dynamodb_resource(self):
+        cloudformation = aws_stack.connect_to_service('cloudformation')
 
         response = cloudformation.create_stack(
             StackName='myteststack',
@@ -1804,3 +1804,41 @@ class CloudFormationTest(unittest.TestCase):
         self.assertEqual(200, response['ResponseMetadata']['HTTPStatusCode'])
 
         cloudformation.delete_stack(StackName='myteststack')
+
+    def test_globalindex_read_write_provisioned_throughput_dynamodb_table(self):
+        cf_client = aws_stack.connect_to_service('cloudformation')
+        ddb_client = aws_stack.connect_to_service('dynamodb')
+        stack_name = 'test_dynamodb'
+
+        response = cf_client.create_stack(
+            StackName=stack_name,
+            TemplateBody=TEST_DEPLOY_BODY_3,
+            Parameters=[
+                {
+                    'ParameterKey': 'tableName',
+                    'ParameterValue': 'dynamodb'
+                },
+                {
+                    'ParameterKey': 'env',
+                    'ParameterValue': 'test'
+                }
+            ]
+        )
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        response = ddb_client.describe_table(
+            TableName='dynamodb-test'
+        )
+
+        if response['Table']['ProvisionedThroughput']:
+            throughput = response['Table']['ProvisionedThroughput']
+            self.assertTrue(isinstance(throughput['ReadCapacityUnits'], int))
+            self.assertTrue(isinstance(throughput['WriteCapacityUnits'], int))
+
+        for global_index in response['Table']['GlobalSecondaryIndexes']:
+            index_provisioned = global_index['ProvisionedThroughput']
+            test_read_capacity = index_provisioned['ReadCapacityUnits']
+            test_write_capacity = index_provisioned['WriteCapacityUnits']
+
+            self.assertTrue(isinstance(test_read_capacity, int))
+            self.assertTrue(isinstance(test_write_capacity, int))
+        cf_client.delete_stack(StackName=stack_name)


### PR DESCRIPTION
* Handle delete action for restApi resource
* Fix missing physical resource id for restApi
* Fix issue with restApi's resource, deployment
* Add integration test: cfn handle serverless api resource

Issues fixed:
#2641 Serverless Api resource creation errors without explicit Name property in CloudFormation template
#2642 Error during CreateDeployment call when trying to create a Serverless Api in CloudFormation template