### PR TITLE
Use a mock client to prevent moto Lambda objects from talking to Docker

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -71,6 +71,11 @@ CACHE = {}
 SSL_CERT_LOCK = threading.RLock()
 
 
+class Mock(object):
+    """ Dummy class that can be used for mocking custom attributes. """
+    pass
+
+
 class CustomEncoder(json.JSONEncoder):
     """ Helper class to convert JSON documents with datetime, decimals, or bytes. """
 


### PR DESCRIPTION
Use a mock client to prevent `moto` Lambda objects from talking to Docker - should fix recent build errors on `master`.