### PR TITLE
patch-script exec patch script before lanuching services

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -14,6 +14,11 @@ source <(
 cat /dev/null > /tmp/localstack_infra.log
 cat /dev/null > /tmp/localstack_infra.err
 
+if [[ -x "$LOCALSTACK_PATCH_SCRIPT" && -f "$LOCALSTACK_PATCH_SCRIPT" ]] ; then
+    echo "Run patch script [$LOCALSTACK_PATCH_SCRIPT]"
+    $LOCALSTACK_PATCH_SCRIPT
+fi
+
 supervisord -c /etc/supervisord.conf &
 
 function run_startup_scripts {


### PR DESCRIPTION

LOCALSTACK_PATCH_SCRIPT variable to customize existing docker image (patching python code before service start) without rebuilding and dealing with docker infrastructure. 
