### PR TITLE
[breaking] Use edge as single entry point; performance improvements; forward requests in-memory instead of opening port per service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ADD localstack/services/install.py localstack/services/
 ADD localstack/utils/common.py localstack/utils/bootstrap.py localstack/utils/
 ADD localstack/utils/aws/ localstack/utils/aws/
 ADD localstack/utils/kinesis/ localstack/utils/kinesis/
+ADD localstack/utils/analytics/ localstack/utils/analytics/
 
 # install dependencies
 RUN make install

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -340,6 +340,11 @@ def populate_configs(service_ports=None):
 
 def service_port(service_key):
     if FORWARD_EDGE_INMEM:
+        if service_key == 'elasticsearch':
+            # TODO Elasticsearch domains are a special case - we do not want to route them through
+            # the edge service, as that would require too many route mappings. In the future, we
+            # should integrate them with.
+            return SERVICE_PORTS.get(service_key, 0)
         return EDGE_PORT
     return SERVICE_PORTS.get(service_key, 0)
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -121,6 +121,7 @@ DOCKER_CMD = os.environ.get('DOCKER_CMD', '').strip() or 'docker'
 # whether to start the web API
 START_WEB = os.environ.get('START_WEB', '').strip() not in FALSE_STRINGS
 
+USE_ONLY_EDGE_PORT = True
 # port number for the edge service, the main entry point for all API invocations
 EDGE_PORT = int(os.environ.get('EDGE_PORT') or 0) or DEFAULT_PORT_EDGE
 # fallback port for non-SSL HTTP edge service (in case HTTPS edge service cannot be used)
@@ -335,6 +336,8 @@ def populate_configs(service_ports=None):
 
 
 def service_port(service_key):
+    if USE_ONLY_EDGE_PORT:
+        return EDGE_PORT
     return SERVICE_PORTS.get(service_key, 0)
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -54,6 +54,7 @@ DYNAMODB_ERROR_PROBABILITY = float(os.environ.get('DYNAMODB_ERROR_PROBABILITY', 
 DYNAMODB_HEAP_SIZE = os.environ.get('DYNAMODB_HEAP_SIZE', '').strip() or '256m'
 
 # expose services on a specific host internally
+# TODO: evaluate whether this should be hardcoded as HOSTNAME=LOCALHOST ..?
 HOSTNAME = os.environ.get('HOSTNAME', '').strip() or LOCALHOST
 
 # expose services on a specific host externally

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -9,7 +9,7 @@ from os.path import expanduser
 import six
 from boto3 import Session
 from localstack.constants import (
-    DEFAULT_SERVICE_PORTS, LOCALHOST, DEFAULT_PORT_WEB_UI, TRUE_STRINGS, FALSE_STRINGS,
+    DEFAULT_SERVICE_PORTS, LOCALHOST, LOCALHOST_IP, DEFAULT_PORT_WEB_UI, TRUE_STRINGS, FALSE_STRINGS,
     DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1)
 
 
@@ -264,7 +264,7 @@ if not is_in_docker:
     CONFIG_FILE_PATH = os.path.join(expanduser('~'), '.localstack')
 
 # set variables no_proxy, i.e., run internal service calls directly
-no_proxy = ','.join(set((LOCALSTACK_HOSTNAME, HOSTNAME, LOCALHOST, '127.0.0.1', '[::1]')))
+no_proxy = ','.join(set((LOCALSTACK_HOSTNAME, HOSTNAME, LOCALHOST, LOCALHOST_IP, '[::1]')))
 if os.environ.get('no_proxy'):
     os.environ['no_proxy'] += ',' + no_proxy
 elif os.environ.get('NO_PROXY'):

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -121,7 +121,9 @@ DOCKER_CMD = os.environ.get('DOCKER_CMD', '').strip() or 'docker'
 # whether to start the web API
 START_WEB = os.environ.get('START_WEB', '').strip() not in FALSE_STRINGS
 
-USE_ONLY_EDGE_PORT = True
+# whether to forward edge requests in-memory (instead of via proxy servers listening on backend ports)
+# TODO: this will likely become the default and may get removed in the future
+FORWARD_EDGE_INMEM = True
 # port number for the edge service, the main entry point for all API invocations
 EDGE_PORT = int(os.environ.get('EDGE_PORT') or 0) or DEFAULT_PORT_EDGE
 # fallback port for non-SSL HTTP edge service (in case HTTPS edge service cannot be used)
@@ -336,7 +338,7 @@ def populate_configs(service_ports=None):
 
 
 def service_port(service_key):
-    if USE_ONLY_EDGE_PORT:
+    if FORWARD_EDGE_INMEM:
         return EDGE_PORT
     return SERVICE_PORTS.get(service_key, 0)
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -345,7 +345,7 @@ def service_port(service_key):
             # the edge service, as that would require too many route mappings. In the future, we
             # should integrate them with.
             return SERVICE_PORTS.get(service_key, 0)
-        return EDGE_PORT
+        return EDGE_PORT_HTTP or EDGE_PORT
     return SERVICE_PORTS.get(service_key, 0)
 
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -20,6 +20,7 @@ DEFAULT_PORT_WEB_UI = 8080
 
 # host name for localhost
 LOCALHOST = 'localhost'
+LOCALHOST_IP = '127.0.0.1'
 
 # version of the Maven dependency with Java utility code
 LOCALSTACK_MAVEN_VERSION = '0.2.1'

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -252,7 +252,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
             func_arn = uri.split(':lambda:path')[1].split('functions/')[1].split('/invocations')[0]
             data_str = json.dumps(data) if isinstance(data, (dict, list)) else to_str(data)
             account_id = uri.split(':lambda:path')[1].split(':function:')[0].split(':')[-1]
-            source_ip = headers['X-Forwarded-For'].split(',')[-2]
+            source_ip = headers['X-Forwarded-For'].split(',')[-2].strip()
 
             try:
                 path_params = extract_path_params(path=relative_path, extracted_path=extracted_path)

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -1,17 +1,13 @@
 import json
 import logging
-
 from moto.apigateway import models as apigateway_models
 from moto.apigateway.models import Resource, Integration
 from moto.apigateway.responses import APIGatewayResponse
-from moto.apigateway.exceptions import (
-    MethodNotFoundException, NoIntegrationDefined
-)
+from moto.apigateway.exceptions import MethodNotFoundException, NoIntegrationDefined
 from moto.apigateway.utils import create_id
-
 from localstack import config
 from localstack.utils.common import short_uid, to_str
-from localstack.services.infra import start_moto_server
+from localstack.services.infra import start_moto_server, PROXY_LISTENERS
 
 LOG = logging.getLogger(__name__)
 
@@ -136,10 +132,10 @@ def apply_patches():
 
 def start_apigateway(port=None, backend_port=None, asynchronous=None, update_listener=None):
     port = port or config.PORT_APIGATEWAY
-
     apply_patches()
-
-    return start_moto_server(
+    result = start_moto_server(
         key='apigateway', name='API Gateway', asynchronous=asynchronous,
         port=port, backend_port=backend_port, update_listener=update_listener
     )
+    PROXY_LISTENERS['execute-api'] = PROXY_LISTENERS['apigateway']
+    return result

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -7,7 +7,7 @@ from moto.apigateway.exceptions import MethodNotFoundException, NoIntegrationDef
 from moto.apigateway.utils import create_id
 from localstack import config
 from localstack.utils.common import short_uid, to_str
-from localstack.services.infra import start_moto_server, PROXY_LISTENERS
+from localstack.services.infra import start_moto_server
 
 LOG = logging.getLogger(__name__)
 
@@ -137,5 +137,4 @@ def start_apigateway(port=None, backend_port=None, asynchronous=None, update_lis
         key='apigateway', name='API Gateway', asynchronous=asynchronous,
         port=port, backend_port=backend_port, update_listener=update_listener
     )
-    PROXY_LISTENERS['execute-api'] = PROXY_LISTENERS['apigateway']
     return result

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -72,8 +72,8 @@ MODEL_MAP = {
 
 def start_cloudformation(port=None, asynchronous=False, update_listener=None):
     port = port or config.PORT_CLOUDFORMATION
-    print('Starting mock CloudFormation service in %s ports %s (recommended) and %s (deprecated)...' % (
-        get_service_protocol(), config.EDGE_PORT, port))
+    print('Starting mock CloudFormation service on %s port %s ...' % (
+        get_service_protocol(), config.EDGE_PORT))
     backend_port = get_free_tcp_port()
     start_proxy_for_service('cloudformation', port, backend_port, update_listener)
     if RUN_SERVER_IN_PROCESS:

--- a/localstack/services/dynamodb/dynamodb_starter.py
+++ b/localstack/services/dynamodb/dynamodb_starter.py
@@ -42,7 +42,6 @@ def start_dynamodb(port=None, asynchronous=False, update_listener=None):
     cmd = ('cd %s/infra/dynamodb/; java -Djava.library.path=./DynamoDBLocal_lib ' +
         '-Xmx%s -jar DynamoDBLocal.jar -sharedDb -port %s %s') % (
         ROOT_PATH, config.DYNAMODB_HEAP_SIZE, PORT_DYNAMODB_BACKEND, ddb_data_dir_param)
-    print('Starting mock DynamoDB service in %s ports %s (recommended) and %s (deprecated)...' % (
-        get_service_protocol(), config.EDGE_PORT, port))
+    print('Starting mock DynamoDB service on %s port %s ...' % (get_service_protocol(), config.EDGE_PORT))
     start_proxy_for_service('dynamodb', port, backend_port=PORT_DYNAMODB_BACKEND, update_listener=update_listener)
     return do_run(cmd, asynchronous)

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -57,15 +57,17 @@ def forward_events(records):
 
 @app.route('/', methods=['POST'])
 def post_request():
-    action = request.headers.get('x-amz-target')
+    action = request.headers.get('x-amz-target', '')
+    action = action.split('.')[-1]
     data = json.loads(to_str(request.data))
     result = {}
     kinesis = aws_stack.connect_to_service('kinesis')
-    if action == '%s.ListStreams' % ACTION_HEADER_PREFIX:
+    if action == 'ListStreams':
         result = {
             'Streams': list(DDB_STREAMS.values())
         }
-    elif action == '%s.DescribeStream' % ACTION_HEADER_PREFIX:
+
+    elif action == 'DescribeStream':
         for stream in DDB_STREAMS.values():
             if stream['StreamArn'] == data['StreamArn']:
                 result = {
@@ -88,7 +90,8 @@ def post_request():
                 break
         if not result:
             return error_response('Requested resource not found', error_type='ResourceNotFoundException')
-    elif action == '%s.GetShardIterator' % ACTION_HEADER_PREFIX:
+
+    elif action == 'GetShardIterator':
         # forward request to Kinesis API
         stream_name = stream_name_from_stream_arn(data['StreamArn'])
         stream_shard_id = kinesis_shard_id(data['ShardId'])
@@ -97,7 +100,7 @@ def post_request():
         result = kinesis.get_shard_iterator(StreamName=stream_name, ShardId=stream_shard_id,
                                             ShardIteratorType=data['ShardIteratorType'], **kwargs)
 
-    elif action == '%s.GetRecords' % ACTION_HEADER_PREFIX:
+    elif action == 'GetRecords':
         kinesis_records = kinesis.get_records(**data)
         result = {'Records': [], 'NextShardIterator': kinesis_records.get('NextShardIterator')}
         for record in kinesis_records['Records']:

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -75,9 +75,9 @@ class ProxyListenerEdge(ProxyListener):
 
 
 def do_forward_request(api, method, url, data, headers):
-    # function = getattr(requests, method.lower())
-    # return do_forward_request_network(method, path, data, headers, port)
-    return do_forward_request_inmem(method, path, data, headers, api, port)
+    if config.FORWARD_EDGE_INMEM:
+        return do_forward_request_inmem(method, path, data, headers, api, port)
+    return do_forward_request_network(method, path, data, headers, port)
 
 
 def do_forward_request_inmem(method, path, data, headers, api, port):
@@ -95,7 +95,6 @@ def do_forward_request_inmem(method, path, data, headers, api, port):
 def do_forward_request_network(method, path, data, headers, port):
     connect_host = '%s:%s' % (config.HOSTNAME, port)
     url = '%s://%s%s' % (get_service_protocol(), connect_host, path)
-
     function = getattr(requests, method.lower())
     response = function(url, data=data, headers=headers, verify=False, stream=True)
     return response

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -204,7 +204,7 @@ def get_api_from_custom_rules(method, path, data, headers):
 
     data_bytes = to_bytes(data or '')
 
-    if path == '/' and to_bytes('QueueName=') in data_bytes:
+    if path == '/' and b'QueueName=' in data_bytes:
         return 'sqs', config.PORT_SQS
 
     # TODO: move S3 public URLs to a separate port/endpoint, OR check ACLs here first
@@ -231,6 +231,10 @@ def get_api_from_custom_rules(method, path, data, headers):
 
     # detect S3 requests sent from aws-cli using --no-sign-request option
     if 'aws-cli/' in headers.get('User-Agent', ''):
+        return 's3', config.PORT_S3
+
+    # S3 delete object requests
+    if method == 'POST' and 'delete=' in path and b'<Delete' in data_bytes and b'<Key>' in data_bytes:
         return 's3', config.PORT_S3
 
 

--- a/localstack/services/es/es_starter.py
+++ b/localstack/services/es/es_starter.py
@@ -26,7 +26,8 @@ def stop_elasticsearch():
         return
     LOG.info('Terminating Elasticsearch instance, as all clusters have been removed')
     thread.stop()
-    STATE['_proxy_'].stop()
+    if STATE['_proxy_']:
+        STATE['_proxy_'].stop()
     del STATE['_thread_']
     del STATE['_proxy_']
 

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -370,7 +370,7 @@ def modify_and_forward(method=None, path=None, data_bytes=None, headers=None, fo
 
         requests_method = getattr(requests, method.lower())
         response = requests_method(request_url, data=data_to_send,
-            headers=headers, stream=True)
+            headers=headers, stream=True, verify=False)
 
     # prevent requests from processing response body (e.g., to pass-through gzip encoded content unmodified)
     pass_raw = ((hasattr(response, '_content_consumed') and not response._content_consumed) or
@@ -574,7 +574,9 @@ def serve_flask_app(app, port, quiet=True, host=None, cors=True):
         logging.getLogger('werkzeug').setLevel(logging.ERROR)
     if not host:
         host = '0.0.0.0'
-    ssl_context = GenericProxy.get_flask_ssl_context(serial_number=port)
+    ssl_context = None
+    if not config.FORWARD_EDGE_INMEM:
+        ssl_context = GenericProxy.get_flask_ssl_context(serial_number=port)
     app.config['ENV'] = 'development'
 
     def noecho(*args, **kwargs):

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -534,6 +534,7 @@ def start_proxy_server(port, forward_url=None, use_ssl=None, update_listener=Non
 
 
 def start_proxy_server_http2(port, forward_url=None, use_ssl=None, update_listener=None, quiet=False, params={}):
+    print('!!!start_proxy_server http2', port, forward_url, use_ssl, update_listener)
     proxy_thread = run_proxy_server_http2(port=port, use_ssl=use_ssl,
         listener=update_listener, forward_url=forward_url, asynchronous=True)
     return proxy_thread

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -534,7 +534,6 @@ def start_proxy_server(port, forward_url=None, use_ssl=None, update_listener=Non
 
 
 def start_proxy_server_http2(port, forward_url=None, use_ssl=None, update_listener=None, quiet=False, params={}):
-    print('!!!start_proxy_server http2', port, forward_url, use_ssl, update_listener)
     proxy_thread = run_proxy_server_http2(port=port, use_ssl=use_ssl,
         listener=update_listener, forward_url=forward_url, asynchronous=True)
     return proxy_thread

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -368,6 +368,8 @@ def modify_and_forward(method=None, path=None, data_bytes=None, headers=None, fo
                 request_url = '%s%s' % (forward_base_url, modified_request.url)
             data_to_send = modified_request.data
 
+        # make sure we drop "chunked" transfer encoding from the headers to be forwarded
+        headers.pop('Transfer-Encoding', None)
         requests_method = getattr(requests, method.lower())
         response = requests_method(request_url, data=data_to_send,
             headers=headers, stream=True, verify=False)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -245,8 +245,9 @@ def do_run(cmd, asynchronous, print_output=None, env_vars={}):
 
 
 def start_proxy_for_service(service_name, port, backend_port, update_listener, quiet=False, params={}):
-    PROXY_LISTENERS[service_name] = (service_name, backend_port, update_listener)
-    return
+    if config.FORWARD_EDGE_INMEM:
+        PROXY_LISTENERS[service_name] = (service_name, backend_port, update_listener)
+        return
     # check if we have a custom backend configured
     custom_backend_url = os.environ.get('%s_BACKEND' % service_name.upper())
     backend_url = custom_backend_url or ('http://%s:%s' % (DEFAULT_BACKEND_HOST, backend_port))
@@ -265,11 +266,11 @@ def start_moto_server(key, port, name=None, backend_port=None, asynchronous=Fals
         name = key
     print('Starting mock %s service on %s port %s ...' % (name, get_service_protocol(), config.EDGE_PORT))
     if not backend_port and (config.USE_SSL or update_listener):
-        # TODO remove?
-        backend_port = get_free_tcp_port()
-    backend_port = multiserver.get_multi_server_port()
+        if config.FORWARD_EDGE_INMEM:
+            backend_port = multiserver.get_moto_server_port()
+        else:
+            backend_port = get_free_tcp_port()
     if backend_port:
-        # print('!!!start_proxy_for_service', key, backend_port, port)
         start_proxy_for_service(key, port, backend_port, update_listener)
     if config.BUNDLE_API_PROCESSES:
         return multiserver.start_api_server(key, backend_port or port)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -247,7 +247,8 @@ def do_run(cmd, asynchronous, print_output=None, env_vars={}):
 
 def start_proxy_for_service(service_name, port, backend_port, update_listener, quiet=False, params={}):
     if config.FORWARD_EDGE_INMEM:
-        PROXY_LISTENERS[service_name] = (service_name, backend_port, update_listener)
+        if backend_port:
+            PROXY_LISTENERS[service_name] = (service_name, backend_port, update_listener)
         return
     # check if we have a custom backend configured
     custom_backend_url = os.environ.get('%s_BACKEND' % service_name.upper())
@@ -266,12 +267,12 @@ def start_moto_server(key, port, name=None, backend_port=None, asynchronous=Fals
     if not name:
         name = key
     print('Starting mock %s service on %s port %s ...' % (name, get_service_protocol(), config.EDGE_PORT))
-    if not backend_port and (config.USE_SSL or update_listener):
+    if not backend_port:
         if config.FORWARD_EDGE_INMEM:
             backend_port = multiserver.get_moto_server_port()
-        else:
+        elif config.USE_SSL or update_listener:
             backend_port = get_free_tcp_port()
-    if backend_port:
+    if backend_port or config.FORWARD_EDGE_INMEM:
         start_proxy_for_service(key, port, backend_port, update_listener)
     if config.BUNDLE_API_PROCESSES:
         return multiserver.start_api_server(key, backend_port or port)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -123,22 +123,23 @@ def start_ses(port=None, asynchronous=False):
 
 def start_elasticsearch_service(port=None, asynchronous=False):
     port = port or config.PORT_ES
-    return start_local_api('ES', port, method=es_api.serve, asynchronous=asynchronous)
+    return start_local_api('ES', port, api='es', method=es_api.serve, asynchronous=asynchronous)
 
 
 def start_firehose(port=None, asynchronous=False):
     port = port or config.PORT_FIREHOSE
-    return start_local_api('Firehose', port, method=firehose_api.serve, asynchronous=asynchronous)
+    return start_local_api('Firehose', port, api='firehose', method=firehose_api.serve, asynchronous=asynchronous)
 
 
 def start_dynamodbstreams(port=None, asynchronous=False):
     port = port or config.PORT_DYNAMODBSTREAMS
-    return start_local_api('DynamoDB Streams', port, method=dynamodbstreams_api.serve, asynchronous=asynchronous)
+    return start_local_api('DynamoDB Streams', port, api='dynamodbstreams',
+        method=dynamodbstreams_api.serve, asynchronous=asynchronous)
 
 
 def start_lambda(port=None, asynchronous=False):
     port = port or config.PORT_LAMBDA
-    return start_local_api('Lambda', port, method=lambda_api.serve, asynchronous=asynchronous)
+    return start_local_api('Lambda', port, api='lambda', method=lambda_api.serve, asynchronous=asynchronous)
 
 
 def start_ssm(port=None, asynchronous=False, update_listener=None):
@@ -285,9 +286,11 @@ def start_moto_server_separate(key, port, name=None, backend_port=None, asynchro
     return do_run(cmd, asynchronous)
 
 
-def start_local_api(name, port, method, asynchronous=False):
-    print('Starting mock %s service on %s port %s ...' % (
-        name, get_service_protocol(), config.EDGE_PORT))
+def start_local_api(name, port, api, method, asynchronous=False):
+    print('Starting mock %s service on %s port %s ...' % (name, get_service_protocol(), config.EDGE_PORT))
+    if config.FORWARD_EDGE_INMEM:
+        port = get_free_tcp_port()
+        PROXY_LISTENERS[api] = (api, port, None)
     if asynchronous:
         thread = start_thread(method, port, quiet=True)
         return thread

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -246,7 +246,8 @@ def do_run(cmd, asynchronous, print_output=None, env_vars={}):
 
 
 def start_proxy_for_service(service_name, port, backend_port, update_listener, quiet=False, params={}):
-    if config.FORWARD_EDGE_INMEM:
+    # TODO: remove special switch for Elasticsearch (see also note in service_port(...) in config.py)
+    if config.FORWARD_EDGE_INMEM and service_name != 'elasticsearch':
         if backend_port:
             PROXY_LISTENERS[service_name] = (service_name, backend_port, update_listener)
         return

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -218,6 +218,12 @@ def get_service_status(service, port=None):
     return status
 
 
+def get_multiserver_or_free_service_port():
+    if config.FORWARD_EDGE_INMEM:
+        return multiserver.get_moto_server_port()
+    return get_free_tcp_port()
+
+
 def register_signal_handlers():
     global SIGNAL_HANDLERS_SETUP
     if SIGNAL_HANDLERS_SETUP:

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -17,8 +17,8 @@ if __name__ == '__main__':
     bootstrap.bootstrap_installation()
 # flake8: noqa: E402
 from localstack.utils.common import (
-    download, parallelize, run, mkdir, load_file, save_file, unzip, untar, rm_rf, chmod_r, is_alpine,
-    in_docker, get_arch)
+    download, parallelize, run, mkdir, load_file, save_file, unzip, untar, rm_rf,
+    chmod_r, is_alpine, in_docker, get_arch)
 
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = os.path.realpath(os.path.join(THIS_PATH, '..'))
@@ -146,11 +146,12 @@ def install_kinesalite():
 
 
 def install_local_kms():
-    binary_path = INSTALL_PATH_KMS_BINARY_PATTERN.replace('<arch>', get_arch())
+    local_arch = get_arch()
+    binary_path = INSTALL_PATH_KMS_BINARY_PATTERN.replace('<arch>', local_arch)
     if not os.path.exists(binary_path):
         log_install_msg('KMS')
         mkdir(INSTALL_DIR_KMS)
-        kms_url = KMS_URL_PATTERN.replace('<arch>', get_arch())
+        kms_url = KMS_URL_PATTERN.replace('<arch>', local_arch)
         download(kms_url, binary_path)
         chmod_r(binary_path, 0o777)
 

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -27,8 +27,7 @@ def start_kinesis(port=None, asynchronous=False, update_listener=None):
         ROOT_PATH, config.KINESIS_SHARD_LIMIT, backend_port,
         latency, latency, latency, kinesis_data_dir_param
     )
-    print('Starting mock Kinesis service in %s ports %s (recommended) and %s (deprecated)...' % (
-        get_service_protocol(), config.EDGE_PORT, port))
+    print('Starting mock Kinesis service on %s port %s...' % (get_service_protocol(), config.EDGE_PORT))
     start_proxy_for_service('kinesis', port, backend_port, update_listener)
     return do_run(cmd, asynchronous)
 

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -1,7 +1,7 @@
 import logging
 from localstack import config
 from localstack.constants import TEST_AWS_ACCOUNT_ID
-from localstack.utils.common import get_arch, get_free_tcp_port
+from localstack.utils.common import get_arch, get_free_tcp_port, wait_for_port_open
 from localstack.services.infra import (
     get_service_protocol, start_proxy_for_service, do_run)
 from localstack.services.install import INSTALL_PATH_KMS_BINARY_PATTERN
@@ -23,4 +23,6 @@ def start_kms(port=None, backend_port=None, asynchronous=None, update_listener=N
         'KMS_ACCOUNT_ID': TEST_AWS_ACCOUNT_ID,
         'ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
     }
-    return do_run(kms_binary, asynchronous, env_vars=env_vars)
+    result = do_run(kms_binary, asynchronous, env_vars=env_vars)
+    wait_for_port_open(backend_port)
+    return result

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -13,8 +13,8 @@ def start_kms(port=None, backend_port=None, asynchronous=None, update_listener=N
     port = port or config.PORT_KMS
     backend_port = get_free_tcp_port()
     kms_binary = INSTALL_PATH_KMS_BINARY_PATTERN.replace('<arch>', get_arch())
-    print('Starting mock KMS service in %s ports %s (recommended) and %s (deprecated)...' % (
-        get_service_protocol(), config.EDGE_PORT, port))
+    print('Starting mock KMS service on %s port %s ...' % (
+        get_service_protocol(), config.EDGE_PORT))
     start_proxy_for_service('kms', port, backend_port, update_listener)
     env_vars = {
         'PORT': str(backend_port),

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -19,6 +19,8 @@ def start_kms(port=None, backend_port=None, asynchronous=None, update_listener=N
     env_vars = {
         'PORT': str(backend_port),
         'KMS_REGION': config.DEFAULT_REGION,
-        'KMS_ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
+        'REGION': config.DEFAULT_REGION,
+        'KMS_ACCOUNT_ID': TEST_AWS_ACCOUNT_ID,
+        'ACCOUNT_ID': TEST_AWS_ACCOUNT_ID
     }
     return do_run(kms_binary, asynchronous, env_vars=env_vars)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1117,7 +1117,6 @@ class ProxyListenerS3(PersistingProxyListener):
         if path == path_new:
             return
 
-        # TODO fix PORT_S3_BACKEND!
         url = 'http://%s:%s%s' % (constants.LOCALHOST, PORT_S3_BACKEND, path_new)
         return url
 

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1117,6 +1117,7 @@ class ProxyListenerS3(PersistingProxyListener):
         if path == path_new:
             return
 
+        # TODO fix PORT_S3_BACKEND!
         url = 'http://%s:%s%s' % (constants.LOCALHOST, PORT_S3_BACKEND, path_new)
         return url
 

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -10,7 +10,8 @@ from moto.s3bucket_path import utils as s3bucket_path_utils
 from localstack import config
 from localstack.utils.aws import aws_stack
 from localstack.services.s3 import s3_listener
-from localstack.utils.common import wait_for_port_open, get_free_tcp_port
+from localstack.utils.server import multiserver
+from localstack.utils.common import wait_for_port_open
 from localstack.services.infra import start_moto_server
 from localstack.services.awslambda.lambda_api import BUCKET_MARKER_LOCAL
 
@@ -26,11 +27,12 @@ TMP_STATE = {}
 def check_s3(expect_shutdown=False, print_error=False):
     out = None
     try:
-        # wait for port to be opened
+        # # wait for port to be opened
         wait_for_port_open(s3_listener.PORT_S3_BACKEND)
         # check S3
         out = aws_stack.connect_to_service(service_name='s3').list_buckets()
     except Exception as e:
+        print(e, type(e), traceback.format_exc())
         if print_error:
             LOG.error('S3 health check failed: %s %s' % (e, traceback.format_exc()))
     if expect_shutdown:
@@ -41,7 +43,8 @@ def check_s3(expect_shutdown=False, print_error=False):
 
 def start_s3(port=None, backend_port=None, asynchronous=None, update_listener=None):
     port = port or config.PORT_S3
-    backend_port = s3_listener.PORT_S3_BACKEND = backend_port or get_free_tcp_port()
+    # backend_port = s3_listener.PORT_S3_BACKEND = backend_port or get_free_tcp_port()
+    backend_port = s3_listener.PORT_S3_BACKEND = backend_port or multiserver.get_moto_server_port()
 
     apply_patches()
 

--- a/localstack/services/secretsmanager/secretsmanager_starter.py
+++ b/localstack/services/secretsmanager/secretsmanager_starter.py
@@ -1,12 +1,7 @@
 import logging
 from moto.secretsmanager import models as secretsmanager_models
-from localstack import config
 from localstack.services.infra import start_moto_server
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import wait_for_port_open, get_free_tcp_port
-
-# backend port (configured at startup)
-PORT_SECRETSMANAGER_BACKEND = None
 
 # maps key names to ARNs
 SECRET_ARN_STORAGE = {}
@@ -27,11 +22,6 @@ def apply_patches():
 
 
 def start_secretsmanager(port=None, asynchronous=None, backend_port=None, update_listener=None):
-    global PORT_SECRETSMANAGER_BACKEND
-
-    port = port or config.PORT_SECRETSMANAGER
-    backend_port = PORT_SECRETSMANAGER_BACKEND = backend_port or get_free_tcp_port()
-
     apply_patches()
     return start_moto_server(
         key='secretsmanager',
@@ -48,7 +38,6 @@ def check_secretsmanager(expect_shutdown=False, print_error=False):
 
     # noinspection PyBroadException
     try:
-        wait_for_port_open(PORT_SECRETSMANAGER_BACKEND)
         out = aws_stack.connect_to_service(service_name='secretsmanager').list_secrets()
     except Exception:
         if print_error:

--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -27,7 +27,8 @@ def check_sqs(expect_shutdown=False, print_error=False):
     out = None
     try:
         # wait for port to be opened
-        wait_for_port_open(PORT_SQS_BACKEND)
+        if PORT_SQS_BACKEND:
+            wait_for_port_open(PORT_SQS_BACKEND)
         # check SQS
         out = aws_stack.connect_to_service(service_name='sqs').list_queues()
     except Exception as e:
@@ -105,11 +106,9 @@ def patch_moto():
 
 
 def start_sqs_moto(port=None, asynchronous=False, update_listener=None):
-    global PORT_SQS_BACKEND
     port = port or config.PORT_SQS
-    PORT_SQS_BACKEND = get_free_tcp_port()
     patch_moto()
-    return start_moto_server('sqs', port, backend_port=PORT_SQS_BACKEND, name='SQS',
+    return start_moto_server('sqs', port, name='SQS',
         asynchronous=asynchronous, update_listener=update_listener)
 
 
@@ -141,7 +140,6 @@ def start_sqs_elasticmq(port=None, asynchronous=False, update_listener=None):
     # start process
     cmd = ('java -Dconfig.file=%s -Xmx%s -jar %s/elasticmq-server.jar' % (
         config_file, MAX_HEAP_SIZE, INSTALL_DIR_ELASTICMQ))
-    print('Starting mock SQS service in %s ports %s (recommended) and %s (deprecated)...' % (
-        get_service_protocol(), config.EDGE_PORT, port))
+    print('Starting mock SQS service on %s port %s ...' % (get_service_protocol(), config.EDGE_PORT))
     start_proxy_for_service('sqs', port, PORT_SQS_BACKEND, update_listener)
     return do_run(cmd, asynchronous)

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -33,7 +33,6 @@ def start_stepfunctions(port=None, asynchronous=False, update_listener=None):
     # TODO: local port is currently hard coded in Step Functions Local :/
     backend_port = 8083
     cmd = get_command()
-    print('Starting mock StepFunctions service in %s ports %s (recommended) and %s (deprecated)...' % (
-        get_service_protocol(), config.EDGE_PORT, port))
+    print('Starting mock StepFunctions service on %s port %s...' % (get_service_protocol(), config.EDGE_PORT))
     start_proxy_for_service('stepfunctions', port, backend_port, update_listener)
     return do_run(cmd, asynchronous)

--- a/localstack/utils/analytics/profiler.py
+++ b/localstack/utils/analytics/profiler.py
@@ -158,6 +158,7 @@ def log_duration(name=None):
                 end_time = now_utc(millis=True)
                 func_name = name or f.__name__
                 duration = (end_time - start_time) * 1000
-                LOG.info('Execution of "%s" took %sms' % (func_name, duration))
+                if duration > 500:
+                    LOG.info('Execution of "%s" took %sms' % (func_name, duration))
         return wrapped
     return wrapper

--- a/localstack/utils/analytics/profiler.py
+++ b/localstack/utils/analytics/profiler.py
@@ -143,3 +143,21 @@ def profiled_via_yappi(lines=50):
                 print(result)
         return wrapped
     return wrapper
+
+
+def log_duration(name=None):
+    """ Function decorator to log the duration of function invocations. """
+    def wrapper(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            from localstack.utils.common import now_utc
+            start_time = now_utc(millis=True)
+            try:
+                return f(*args, **kwargs)
+            finally:
+                end_time = now_utc(millis=True)
+                func_name = name or f.__name__
+                duration = (end_time - start_time) * 1000
+                LOG.info('Execution of "%s" took %sms' % (func_name, duration))
+        return wrapped
+    return wrapper

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -15,6 +15,7 @@ import pip as pip_mod
 from datetime import datetime
 from concurrent.futures._base import Future
 from localstack import constants, config
+from localstack.utils.analytics.profiler import log_duration
 
 # set up logger
 LOG = logging.getLogger(os.path.basename(__file__))
@@ -98,6 +99,7 @@ def run_pip_main(args):
     return pip._internal.main.main(args)
 
 
+@log_duration()
 def load_plugin_from_path(file_path, scope=None):
     if os.path.exists(file_path):
         module = re.sub(r'(^|.+/)([^/]+)/plugins.py', r'\2', file_path)
@@ -122,6 +124,13 @@ def load_plugin_from_path(file_path, scope=None):
                 LOG.warning('Unable to load plugins from file %s: %s' % (file_path, e))
 
 
+def should_load_module(module, scope):
+    if module == 'localstack_ext' and not os.environ.get('LOCALSTACK_API_KEY'):
+        return False
+    return True
+
+
+@log_duration()
 def load_plugins(scope=None):
     scope = scope or PLUGIN_SCOPE_SERVICES
     if PLUGINS_LOADED.get(scope):
@@ -138,6 +147,8 @@ def load_plugins(scope=None):
     search_modules = PLUGIN_MODULES
 
     for module in search_modules:
+        if not should_load_module(module, scope):
+            continue
         file_path = None
         if isinstance(module, six.string_types):
             loader = pkgutil.get_loader(module)

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -47,7 +47,8 @@ API_DEPENDENCIES = {
     'dynamodbstreams': ['kinesis'],
     'es': ['elasticsearch'],
     'lambda': ['logs'],
-    'kinesis': ['dynamodb']
+    'kinesis': ['dynamodb'],
+    'firehose': ['kinesis']
 }
 # composites define an abstract name like "serverless" that maps to a set of services
 API_COMPOSITES = {
@@ -318,7 +319,7 @@ class PortMappings(object):
             for i in range(port[1] - port[0] + 1):
                 self.add(port[0] + i, mapped[0] + i)
             return
-        if int(port) <= 0:
+        if port is None or int(port) <= 0:
             raise Exception('Unable to add mapping for invalid port: %s' % port)
         if self.contains(port):
             return

--- a/localstack/utils/server/multiserver.py
+++ b/localstack/utils/server/multiserver.py
@@ -97,13 +97,13 @@ def start_server(port, asynchronous=False):
 
 
 def start_api_server(api, port, server_port=None):
-    print('start_api_server', api, port, server_port, get_moto_server_port())
-    server_port = server_port or get_moto_server_port()
+    print('!!start_api_server', api, port, server_port, get_moto_server_port())
+    server_port = server_port or get_multi_server_port()
     thread = start_server_process(server_port)
     url = 'http://localhost:%s%s' % (server_port, API_PATH_SERVERS)
     payload = {
         'api': api,
-        'port': port
+        'port': get_moto_server_port()
     }
     result = requests.post(url, json=payload)
     if result.status_code >= 400:

--- a/localstack/utils/server/multiserver.py
+++ b/localstack/utils/server/multiserver.py
@@ -44,9 +44,10 @@ def patch_moto_server():
 
 def start_api_server_locally(request):
 
-    if '__started__' in API_SERVERS:
-        return
-    API_SERVERS['__started__'] = True
+    if localstack_config.FORWARD_EDGE_INMEM:
+        if '__started__' in API_SERVERS:
+            return
+        API_SERVERS['__started__'] = True
 
     api = request.get('api')
     port = request.get('port')
@@ -100,9 +101,11 @@ def start_api_server(api, port, server_port=None):
     server_port = server_port or get_multi_server_port()
     thread = start_server_process(server_port)
     url = 'http://localhost:%s%s' % (server_port, API_PATH_SERVERS)
+    if localstack_config.FORWARD_EDGE_INMEM:
+        port = get_moto_server_port()
     payload = {
         'api': api,
-        'port': get_moto_server_port()
+        'port': port
     }
     result = requests.post(url, json=payload)
     if result.status_code >= 400:

--- a/localstack/utils/server/multiserver.py
+++ b/localstack/utils/server/multiserver.py
@@ -34,6 +34,9 @@ RUN_SERVER_IN_PROCESS = False
 def patch_moto_server():
 
     def create_backend_app(service):
+        if not service:
+            LOG.warning('Unable to create moto backend app for empty service: "%s"' % service)
+            return None
         backend_app = create_backend_app_orig(service)
         CORS(backend_app)
         return backend_app

--- a/tests/integration/lambdas/lambda_put_item.py
+++ b/tests/integration/lambdas/lambda_put_item.py
@@ -1,13 +1,15 @@
 import boto3
 import os
 
+# TODO - merge this file with lambda_send_message.py, to avoid duplication
+
+EDGE_PORT = 4566
+
 
 def handler(event, context):
     protocol = 'https' if os.environ.get('USE_SSL') else 'http'
-    ddb = boto3.resource('dynamodb',
-                         endpoint_url='{}://{}:4569'.format(protocol, os.environ['LOCALSTACK_HOSTNAME']),
-                         region_name=event['region_name'],
-                         verify=False)
+    endpoint_url = '{}://{}:{}'.format(protocol, os.environ['LOCALSTACK_HOSTNAME'], EDGE_PORT)
+    ddb = boto3.resource('dynamodb', endpoint_url=endpoint_url, region_name=event['region_name'], verify=False)
 
     table_name = event['table_name']
     for item in event['items']:

--- a/tests/integration/lambdas/lambda_send_message.py
+++ b/tests/integration/lambdas/lambda_send_message.py
@@ -1,13 +1,13 @@
 import boto3
 import os
 
+EDGE_PORT = 4566
+
 
 def handler(event, context):
     protocol = 'https' if os.environ.get('USE_SSL') else 'http'
-    sqs = boto3.client('sqs',
-                       endpoint_url='{}://{}:4576'.format(protocol, os.environ['LOCALSTACK_HOSTNAME']),
-                       region_name=event['region_name'],
-                       verify=False)
+    endpoint_url = '{}://{}:{}'.format(protocol, os.environ['LOCALSTACK_HOSTNAME'], EDGE_PORT)
+    sqs = boto3.client('sqs', endpoint_url=endpoint_url, region_name=event['region_name'], verify=False)
 
     queue_url = sqs.get_queue_url(QueueName=event['queue_name'])['QueueUrl']
     rs = sqs.send_message(

--- a/tests/integration/lambdas/lambda_start_execution.py
+++ b/tests/integration/lambdas/lambda_start_execution.py
@@ -2,13 +2,15 @@ import boto3
 import json
 import os
 
+# TODO - merge this file with lambda_send_message.py, to avoid duplication
+
+EDGE_PORT = 4566
+
 
 def handler(event, context):
     protocol = 'https' if os.environ.get('USE_SSL') else 'http'
-    sf = boto3.client('stepfunctions',
-                      endpoint_url='{}://{}:4585'.format(protocol, os.environ['LOCALSTACK_HOSTNAME']),
-                      region_name=event['region_name'],
-                      verify=False)
+    endpoint_url = '{}://{}:{}'.format(protocol, os.environ['LOCALSTACK_HOSTNAME'], EDGE_PORT)
+    sf = boto3.client('stepfunctions', endpoint_url=endpoint_url, region_name=event['region_name'], verify=False)
 
     sf.start_execution(
         stateMachineArn=event['state_machine_arn'],

--- a/tests/integration/lambdas/lambda_triggered_by_s3.py
+++ b/tests/integration/lambdas/lambda_triggered_by_s3.py
@@ -2,6 +2,10 @@ import boto3
 import os
 import uuid
 
+# TODO - merge this file with lambda_send_message.py, to avoid duplication
+
+EDGE_PORT = 4566
+
 
 def handler(event, context):
     # Parse s3 event
@@ -12,10 +16,8 @@ def handler(event, context):
     table_name = s3_metadata['key']
 
     protocol = 'https' if os.environ.get('USE_SSL') else 'http'
-    ddb = boto3.resource('dynamodb',
-                         endpoint_url='{}://{}:4569'.format(protocol, os.environ['LOCALSTACK_HOSTNAME']),
-                         region_name=region,
-                         verify=False)
+    endpoint_url = '{}://{}:{}'.format(protocol, os.environ['LOCALSTACK_HOSTNAME'], EDGE_PORT)
+    ddb = boto3.resource('dynamodb', endpoint_url=endpoint_url, region_name=region, verify=False)
 
     ddb.Table(table_name).put_item(
         Item={

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -487,8 +487,7 @@ class TestAPIGateway(unittest.TestCase):
         target_uri = aws_stack.apigateway_invocations_arn(lambda_uri)
 
         result = self.connect_api_gateway_to_http_with_lambda_proxy(
-            'test_gateway3', target_uri, methods=['ANY'], path=path
-        )
+            'test_gateway3', target_uri, methods=['ANY'], path=path)
 
         # make test request to gateway and check response
         path = path.replace('{test_param1}', 'foo1')

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -457,12 +457,12 @@ class S3ListenerTest(unittest.TestCase):
         self.s3_client.create_bucket(Bucket=bucket_name)
         body = 'Hello\r\n\r\n\r\n\r\n'
         headers = """
-            Authorization: foobar
+            Authorization: %s
             Content-Type: audio/mpeg
             X-Amz-Content-Sha256: STREAMING-AWS4-HMAC-SHA256-PAYLOAD
             X-Amz-Date: 20190918T051509Z
             X-Amz-Decoded-Content-Length: %s
-        """ % len(body)
+        """ % (aws_stack.mock_aws_request_headers('s3')['Authorization'], len(body))
         headers = dict([[field.strip() for field in pair.strip().split(':', 1)]
             for pair in headers.strip().split('\n')])
         data = ('d;chunk-signature=af5e6c0a698b0192e9aa5d9083553d4d241d81f69ec62b184d05c509ad5166af\r\n' +
@@ -1285,10 +1285,7 @@ class S3ListenerTest(unittest.TestCase):
 
         base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_S3)
         url = '{}/{}?delete='.format(base_url, bucket_name)
-        r = requests.post(
-            url=url,
-            data=BATCH_DELETE_BODY % (object_key_1, object_key_2)
-        )
+        r = requests.post(url=url, data=BATCH_DELETE_BODY % (object_key_1, object_key_2))
 
         self.assertEqual(r.status_code, 200)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -821,10 +821,7 @@ class SQSTest(unittest.TestCase):
             'QueueUrl': '{}/{}/{}/'.format(base_url, TEST_AWS_ACCOUNT_ID, queue_name),
             'MessageBody': 'test body'
         })
-        r = requests.post(
-            url=base_url,
-            data=encoded_url
-        )
+        r = requests.post(url=base_url, data=encoded_url)
         self.assertEqual(r.status_code, 200)
 
         # We can get the message back


### PR DESCRIPTION
**Note:** :warning: **This is a breaking change - after this change, services are no longer accessible via the legacy service ports, but ONLY via the edge port** :warning:

---
This PR introduces a couple of performance improvements which aim to improve the startup time and reduce the overall resource usage/footprint (e.g., less open network ports).

* Forward edge requests in-memory instead of opening port per service
* Remove proxies and backend ports where not needed anymore
* Apply basic time profiling to provide some insights into the performance of different parts of the startup procedure.