### PR TITLE
Allow setting max_pool_connections via environment variable

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -107,3 +107,9 @@ AWS_REGION_US_EAST_1 = 'us-east-1'
 
 # Default lambda registry
 DEFAULT_LAMBDA_CONTAINER_REGISTRY = 'lambci/lambda'
+
+# Environment variable to override max pool connections
+try:
+    MAX_POOL_CONNECTIONS = int(os.environ['MAX_POOL_CONNECTIONS'])
+except (KeyError, ValueError):
+    MAX_POOL_CONNECTIONS = 150

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -9,7 +9,8 @@ import botocore
 from localstack import config
 from localstack.constants import (
     REGION_LOCAL, LOCALHOST, MOTO_ACCOUNT_ID, ENV_DEV, APPLICATION_AMZ_JSON_1_1,
-    APPLICATION_AMZ_JSON_1_0, APPLICATION_X_WWW_FORM_URLENCODED, TEST_AWS_ACCOUNT_ID)
+    APPLICATION_AMZ_JSON_1_0, APPLICATION_X_WWW_FORM_URLENCODED, TEST_AWS_ACCOUNT_ID,
+    MAX_POOL_CONNECTIONS)
 from localstack.utils.aws import templating
 from localstack.utils.common import (
     run_safe, to_str, is_string, is_string_or_bytes, make_http_request, is_port_open, get_service_protocol)
@@ -229,8 +230,9 @@ def connect_to_service(service_name, client=True, env=None, region_name=None, en
         # configure S3 path style addressing
         if service_name == 's3':
             config.s3 = {'addressing_style': 'path'}
-        # prevent error "Connection pool is full, discarding connection ..."
-        config.max_pool_connections = 150
+        # To, prevent error "Connection pool is full, discarding connection ...",
+        # set the environment variable MAX_POOL_CONNECTIONS. Default is 150.
+        config.max_pool_connections = MAX_POOL_CONNECTIONS
         BOTO_CLIENTS_CACHE[cache_key] = method(service_name, region_name=region,
             endpoint_url=endpoint_url, verify=verify, config=config)
 


### PR DESCRIPTION
Add MAX_POOL_CONNECTIONS environment variable for customizing the number of connections (default remains at 150 as before)