### PR TITLE
Updated Configuration section with an environment variable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ Additionally, the following *read-only* environment variables are available:
   Use this hostname as endpoint (e.g., `http://${LOCALSTACK_HOSTNAME}:4566`) in order
   to **access the services from within your Lambda functions**
   (e.g., to store an item to DynamoDB or S3 from a Lambda).
+  
+An example passing the above environment variables to LocalStack to start Kinesis, Lambda, Dynamodb and SQS:
+
+```
+SERVICES=kinesis,lambda,sqs,dynamodb localstack start
+```
 
 ### Dynamically updating configuration at runtime
 


### PR DESCRIPTION
I always forget to pass environment variables especially for being selective which services to start. I put this tiny example at the end of configuration section.
I'm hoping this could be useful for future.

**Please refer to the contribution guidelines in the README when submitting PRs.**
