### PR TITLE
APIGateway should send the method it was called with.

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -253,10 +253,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
             data_str = json.dumps(data) if isinstance(data, (dict, list)) else to_str(data)
             account_id = uri.split(':lambda:path')[1].split(':function:')[0].split(':')[-1]
             source_ip = headers['X-Forwarded-For'].split(',')[-2]
-            integration_method = integration.get('httpMethod')
-            # Intergration Method HAS to be POST for AWS or AWS_PROXY, AWS returns an error if not.
-            integration_method = method if integration_method in [None, 'ANY'] else integration_method
-
+            
             try:
                 path_params = extract_path_params(path=relative_path, extracted_path=extracted_path)
             except Exception:
@@ -289,7 +286,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
             result = lambda_api.process_apigateway_invocation(func_arn, relative_path, data_str, stage, api_id,
                                                               headers, path_params=path_params,
                                                               query_string_params=query_string_params,
-                                                              method=integration_method, resource_path=path,
+                                                              method=method, resource_path=path,
                                                               request_context=request_context)
 
             if isinstance(result, FlaskResponse):

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -279,7 +279,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
                     'sourceIp': source_ip,
                     'userAgent': headers['User-Agent'],
                 },
-                'httpMethod': integration_method,
+                'httpMethod': method,
                 'protocol': 'HTTP/1.1',
                 'requestTime': datetime.datetime.utcnow(),
                 'requestTimeEpoch': int(time.time() * 1000),

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -253,7 +253,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
             data_str = json.dumps(data) if isinstance(data, (dict, list)) else to_str(data)
             account_id = uri.split(':lambda:path')[1].split(':function:')[0].split(':')[-1]
             source_ip = headers['X-Forwarded-For'].split(',')[-2]
-            
+
             try:
                 path_params = extract_path_params(path=relative_path, extracted_path=extracted_path)
             except Exception:

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -254,6 +254,7 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
             account_id = uri.split(':lambda:path')[1].split(':function:')[0].split(':')[-1]
             source_ip = headers['X-Forwarded-For'].split(',')[-2]
             integration_method = integration.get('httpMethod')
+            # Intergration Method HAS to be POST for AWS or AWS_PROXY, AWS returns an error if not.
             integration_method = method if integration_method in [None, 'ANY'] else integration_method
 
             try:

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -283,7 +283,7 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
             'body': payload,
             'isBase64Encoded': False,
             'resource': resource_path,
-            'httpMethod': request_context['httpMethod'],
+            'httpMethod': method,
             'queryStringParameters': query_string_params,
             'multiValueQueryStringParameters': multi_value_dict_for_list(query_string_params),
             'requestContext': request_context,

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -283,7 +283,7 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
             'body': payload,
             'isBase64Encoded': False,
             'resource': resource_path,
-            'httpMethod': method,
+            'httpMethod': request_context['httpMethod'],
             'queryStringParameters': query_string_params,
             'multiValueQueryStringParameters': multi_value_dict_for_list(query_string_params),
             'requestContext': request_context,

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -845,8 +845,8 @@ class TestAPIGateway(unittest.TestCase):
             restApiId=api_id,
             resourceId=root_id,
             httpMethod='PUT',
-            integrationHttpMethod='POST'
-            type='AWS_PROXY'
+            integrationHttpMethod='POST',
+            type='AWS_PROXY',
             uri='arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection',
             integrationHttpMethod='PUT',
         )

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -434,7 +434,7 @@ class TestAPIGateway(unittest.TestCase):
         response = requests.get('%s?param1=foobar' % url)
         self.assertLess(response.status_code, 400)
         content = json.loads(to_str(response.content))
-        self.assertEqual(content.get('httpMethod'), 'POST')
+        self.assertEqual(content.get('httpMethod'), 'GET')
         self.assertEqual(content.get('requestContext', {}).get('resourceId'), api_resource['id'])
         self.assertEqual(content.get('requestContext', {}).get('stage'), self.TEST_STAGE_NAME)
         self.assertEqual(content.get('body'), '{"param1": "foobar"}')

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -840,7 +840,7 @@ class TestAPIGateway(unittest.TestCase):
 
         aws_stack.create_dynamodb_table('MusicCollection', partition_key='id')
 
-        # Ensure that it works fine when providing the integrationHttpMethod-argument (should always be POST for AWS_PROXY)
+        # Ensure that it works fine when providing the integrationHttpMethod-argument
         apigw_client.put_integration(
             restApiId=api_id,
             resourceId=root_id,

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -848,7 +848,6 @@ class TestAPIGateway(unittest.TestCase):
             integrationHttpMethod='POST',
             type='AWS_PROXY',
             uri='arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection',
-            integrationHttpMethod='PUT',
         )
 
         apigw_client.put_integration_response(

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -845,6 +845,7 @@ class TestAPIGateway(unittest.TestCase):
             restApiId=api_id,
             resourceId=root_id,
             httpMethod='PUT',
+            integrationHttpMethod='POST'
             type='AWS_PROXY',
             uri='arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection',
             integrationHttpMethod='PUT',

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -587,7 +587,8 @@ class TestAPIGateway(unittest.TestCase):
                 'httpMethod': method,
                 'integrations': [{
                     'type': 'AWS_PROXY',
-                    'uri': target_uri
+                    'uri': target_uri,
+                    'httpMethod': 'POST'
                 }]
             })
         return aws_stack.create_api_gateway(

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -840,12 +840,12 @@ class TestAPIGateway(unittest.TestCase):
 
         aws_stack.create_dynamodb_table('MusicCollection', partition_key='id')
 
-        # Ensure that it works fine when providing the integrationHttpMethod-argument
+        # Ensure that it works fine when providing the integrationHttpMethod-argument (should always be POST for AWS_PROXY)
         apigw_client.put_integration(
             restApiId=api_id,
             resourceId=root_id,
             httpMethod='PUT',
-            integrationHttpMethod='POST',
+            integrationHttpMethod='PUT',
             type='AWS_PROXY',
             uri='arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection',
         )

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -846,7 +846,7 @@ class TestAPIGateway(unittest.TestCase):
             resourceId=root_id,
             httpMethod='PUT',
             integrationHttpMethod='POST'
-            type='AWS_PROXY',
+            type='AWS_PROXY'
             uri='arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection',
             integrationHttpMethod='PUT',
         )


### PR DESCRIPTION
Fix for #2970 
 * APIGateway should send the method it is called with to the backend not the method the backend is called with 