### PR TITLE
Added asynchronous invocation support

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1498,6 +1498,7 @@ def untag_resource(version, arn):
 
 @app.route('/2019-09-25/functions/<function>/event-invoke-config', methods=['PUT', 'POST'])
 def put_function_event_invoke_config(function):
+    # TODO: resouce validation required to check if resource exists
     """ Add/Updates the configuration for asynchronous invocation for a function
         ---
         operationId: PutFunctionEventInvokeConfig | UpdateFunctionEventInvokeConfig
@@ -1515,7 +1516,7 @@ def put_function_event_invoke_config(function):
 
     if request.method == 'PUT':
         response = lambda_obj.clear_function_event_invoke_config()
-    response = lambda_obj.put_function_event_invoke_config(data, request.method)
+    response = lambda_obj.put_function_event_invoke_config(data)
 
     return jsonify({
         'LastModified': response.last_modified,

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1496,11 +1496,11 @@ def untag_resource(version, arn):
     return jsonify({})
 
 
-@app.route('/2019-09-25/functions/<function>/event-invoke-config', methods=['PUT'])
+@app.route('/2019-09-25/functions/<function>/event-invoke-config', methods=['PUT', 'POST'])
 def put_function_event_invoke_config(function):
-    """ Updates the configuration for asynchronous invocation for a function
+    """ Add/Updates the configuration for asynchronous invocation for a function
         ---
-        operationId: PutFunctionEventInvokeConfig
+        operationId: PutFunctionEventInvokeConfig | UpdateFunctionEventInvokeConfig
         parameters:
             - name: 'function'
               in: path
@@ -1512,7 +1512,10 @@ def put_function_event_invoke_config(function):
     data = json.loads(to_str(request.data))
     function_arn = func_arn(function)
     lambda_obj = ARN_TO_LAMBDA[function_arn]
-    response = lambda_obj.put_function_event_invoke_config(data)
+
+    if request.method == 'PUT':
+        response = lambda_obj.clear_function_event_invoke_config()
+    response = lambda_obj.put_function_event_invoke_config(data, request.method)
 
     return jsonify({
         'LastModified': response.last_modified,
@@ -1551,6 +1554,18 @@ def get_function_event_invoke_config(function):
 
     response = lambda_obj.get_function_event_invoke_config()
     return jsonify(response)
+
+
+@app.route('/2019-09-25/functions/<function>/event-invoke-config', methods=['DELETE'])
+def delete_function_event_invoke_config(function):
+    try:
+        function_arn = func_arn(function)
+        lambda_obj = ARN_TO_LAMBDA[function_arn]
+    except Exception as e:
+        return error_response(str(e), 400)
+
+    lambda_obj.clear_function_event_invoke_config()
+    return Response('', status=204)
 
 
 def serve(port, quiet=True):

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -220,6 +220,16 @@ class LambdaFunction(Component):
 
         return response
 
+    def clear_function_event_invoke_config(self):
+        if hasattr(self, 'dead_letter_config'):
+            self.dead_letter_config = None
+        if hasattr(self, 'on_successful_invocation'):
+            self.on_successful_invocation = None
+        if hasattr(self, 'max_retry_attempts'):
+            self.max_retry_attempts = None
+        if hasattr(self, 'max_event_age'):
+            self.max_event_age = None
+
     def put_function_event_invoke_config(self, data):
         if not isinstance(data, dict):
             return

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -702,6 +702,7 @@ class TestLambdaEventInvokeConfig(unittest.TestCase):
         self.LAMBDA_OBJ.role = self.ROLE
         self.LAMBDA_OBJ.memory_size = self.MEMORY_SIZE
 
+    # TODO: remove this test case. Already added it in integration test case
     def test_put_function_event_invoke_config(self):
         # creating a lambda function
         self._create_function(self.FUNCTION_NAME)


### PR DESCRIPTION
This PR adds more API supports for `Lambda Asynchronous invocation`.
**APIs Added:**
- UpdateFunctionEventInvokeConfig
- DeleteFunctionEventInvokeConfig

**Fixed API behaviour:**
- PutFunctionEventInvokeConfig

Added features requested by issue: #2926 .