### PR TITLE
Fix serverless deploy: set bucket name if missing in resource_props

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -224,6 +224,9 @@ def add_default_resource_props(resource_props, stack_name, resource_name=None):
     if res_type == 'AWS::DynamoDB::Table':
         update_dynamodb_index_resource(resource_props)
 
+    if res_type == 'AWS::S3::Bucket':
+        props['BucketName'] = props.get('BucketName') or resource_name
+
     # generate default names for certain resource types
     default_attrs = (('AWS::IAM::Role', 'RoleName'), ('AWS::Events::Rule', 'Name'))
     for entry in default_attrs:

--- a/tests/integration/serverless/package.json
+++ b/tests/integration/serverless/package.json
@@ -7,7 +7,6 @@
   },
   "devDependencies": {
     "serverless": "^1.67.1",
-    "serverless-localstack": "^0.4.24",
-    "serverless-deployment-bucket": "^1.1.2"
+    "serverless-localstack": "^0.4.24"
   }
 }

--- a/tests/integration/serverless/serverless.yml
+++ b/tests/integration/serverless/serverless.yml
@@ -7,8 +7,6 @@ provider:
   versionFunctions: false
   timeout: 900
   runtime: "nodejs12.x"
-  deploymentBucket:
-    name: custom-sls-depl-bucket-123
 
 functions:
   test:
@@ -29,7 +27,6 @@ functions:
           integration: lambda-proxy
 
 plugins:
-  - serverless-deployment-bucket
   - serverless-localstack
 
 custom:


### PR DESCRIPTION
addresses https://github.com/localstack/serverless-localstack/issues/105

It seems that in the refactor of moto, they no longer return `BucketName` in the `Properties` when you call `parse_resource_and_generate_name`

It seems that we're already handling cases like this in `add_default_resource_props` so I've added another case to handle this.