### PR TITLE
Use path addressing when host starts with localhost ip as well as hos…

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -18,7 +18,7 @@ from botocore.client import ClientError
 from requests.models import Response, Request
 from six.moves.urllib import parse as urlparse
 from localstack import config, constants
-from localstack.config import HOSTNAME, HOSTNAME_EXTERNAL
+from localstack.config import HOSTNAME, HOSTNAME_EXTERNAL, LOCALHOST_IP
 from localstack.utils.aws import aws_stack
 from localstack.services.s3 import multipart_content
 from localstack.utils.common import (
@@ -828,7 +828,7 @@ def get_key_name(path, headers):
 
 def uses_path_addressing(headers):
     host = headers.get(constants.HEADER_LOCALSTACK_EDGE_URL, '').split('://')[-1] or headers['host']
-    return host.startswith(HOSTNAME) or host.startswith(HOSTNAME_EXTERNAL)
+    return host.startswith(HOSTNAME) or host.startswith(HOSTNAME_EXTERNAL) or host.startswith(LOCALHOST_IP)
 
 
 def get_bucket_name(path, headers):


### PR DESCRIPTION
When making a s3 get object request with the `range` keyword, the `fix_range_content_type` function is called which can accidently change the request from looking for `s3://mybucket/myfile` to `s3://mybucket/mybucket` if `uses_path_addressing` is false.

Currently this returns true if the host is `http://localhost` but not if the host is `http://127.0.0.1`.

This pull request updates the check to also return true if the localhost ip is listed as the host.