### PR TITLE
fix "TypeName" as optional param for es7

### DIFF
--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -61,7 +61,10 @@ def put_records(stream_name, records):
         if 'ESDestinationDescription' in dest:
             es_dest = dest['ESDestinationDescription']
             es_index = es_dest['IndexName']
-            es_type = es_dest['TypeName']
+            try:
+                es_type = es_dest['TypeName']
+            except KeyError:
+                es_type = None
             es = connect_elasticsearch()
             for record in records:
                 obj_id = uuid.uuid4()

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -61,10 +61,7 @@ def put_records(stream_name, records):
         if 'ESDestinationDescription' in dest:
             es_dest = dest['ESDestinationDescription']
             es_index = es_dest['IndexName']
-            try:
-                es_type = es_dest['TypeName']
-            except KeyError:
-                es_type = None
+            es_type = es_dest.get('TypeName')
             es = connect_elasticsearch()
             for record in records:
                 obj_id = uuid.uuid4()


### PR DESCRIPTION
This PR was implemented to fix issue #2544 .
Added expectation handling for `es_type` that is used as `doc_type` which is deprecated in es 7.