### PR TITLE
Endless loop when error document is missing

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1204,13 +1204,14 @@ class ProxyListenerS3(PersistingProxyListener):
                 s3_client.head_bucket(Bucket=bucket_name)
                 website_config = s3_client.get_bucket_website(Bucket=bucket_name)
                 error_doc_key = website_config.get('ErrorDocument', {}).get('Key')
-                error_doc_path = '/' + bucket_name + '/' + error_doc_key
 
-                if error_doc_key and parsed.path != error_doc_path:
-                    error_object = s3_client.get_object(Bucket=bucket_name, Key=error_doc_key)
-                    response.status_code = 200
-                    response._content = error_object['Body'].read()
-                    response.headers['Content-Length'] = str(len(response._content))
+                if error_doc_key:
+                    error_doc_path = '/' + bucket_name + '/' + error_doc_key
+                    if parsed.path != error_doc_path:
+                        error_object = s3_client.get_object(Bucket=bucket_name, Key=error_doc_key)
+                        response.status_code = 200
+                        response._content = error_object['Body'].read()
+                        response.headers['Content-Length'] = str(len(response._content))
             except ClientError:
                 # Pass on the 404 as usual
                 pass

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1204,8 +1204,9 @@ class ProxyListenerS3(PersistingProxyListener):
                 s3_client.head_bucket(Bucket=bucket_name)
                 website_config = s3_client.get_bucket_website(Bucket=bucket_name)
                 error_doc_key = website_config.get('ErrorDocument', {}).get('Key')
+                error_doc_path = '/' + bucket_name + '/' + error_doc_key
 
-                if error_doc_key:
+                if error_doc_key and parsed.path != error_doc_path:
                     error_object = s3_client.get_object(Bucket=bucket_name, Key=error_doc_key)
                     response.status_code = 200
                     response._content = error_object['Body'].read()

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -860,6 +860,22 @@ class S3ListenerTest(unittest.TestCase):
         # cleanup
         self.s3_client.delete_bucket(Bucket=bucket_name)
 
+    def test_s3_website_errordocument_missing(self):
+        # check that 404 is returned when error document is configured but missing
+        bucket_name = 'test-bucket-%s' % short_uid()
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={'ErrorDocument': {'Key': 'error.html'}}
+        )
+        url = self.s3_client.generate_presigned_url(
+            'get_object', Params={'Bucket': bucket_name, 'Key': 'nonexistent'}
+        )
+        response = requests.get(url, verify=False)
+        self.assertEqual(response.status_code, 404)
+
+        self.s3_client.delete_bucket(Bucket=bucket_name)
+
     def test_s3_event_notification_with_sqs(self):
         key_by_path = 'aws/bucket=2020/test1.txt'
 


### PR DESCRIPTION
When 404 is returned and ErrorDocument is defined, the error
document object is fetched from the bucket, but if the document is
missing we get an endless loop.


