### PR TITLE
create env INIT_SCRIPTS_PATH for specify path for init files in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ You can pass the following environment variables to LocalStack:
 * `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Expose-Headers` CORS header
 * `LAMBDA_JAVA_OPTS`: Allow passing custom JVM options (e.g., `-Xmx512M`) to Java Lambdas executed in Docker. Use `_debug_port_` placeholder to configure the debug port (e.g., `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=_debug_port_`).
 * `MAIN_CONTAINER_NAME`: Specify the main docker container name (default: `localstack_main`).
+* `INIT_SCRIPTS_PATH`: Specify the path to the initializing files with extensions .sh that are found default in `/docker-entrypoint-initaws.d`.
 
 The following environment configurations are *deprecated*:
 * `USE_SSL`: Whether to use `https://...` URLs with SSL encryption (default: `false`). Deprecated as of version 0.11.3 - each service endpoint now supports multiplexing HTTP/HTTPS traffic over the same port.
@@ -251,7 +252,7 @@ The service `/health` check endpoint on the edge port (`http://localhost:4566/he
 
 ### Initializing a fresh instance
 
-When a container is started for the first time, it will execute files with extensions .sh that are found in `/docker-entrypoint-initaws.d`. Files will be executed in alphabetical order. You can easily create aws resources on localstack using `awslocal` (or `aws`) cli tool in the initialization scripts.
+When a container is started for the first time, it will execute files with extensions .sh that are found in `/docker-entrypoint-initaws.d` or an alternate path defined in `INIT_SCRIPTS_PATH`. Files will be executed in alphabetical order. You can easily create aws resources on localstack using `awslocal` (or `aws`) cli tool in the initialization scripts.
 
 ## Using custom SSL certificates
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -3,6 +3,11 @@
 set -eo pipefail
 shopt -s nullglob
 
+if [[ ! $INIT_SCRIPTS_PATH ]]
+then
+  INIT_SCRIPTS_PATH=/docker-entrypoint-initaws.d
+fi
+
 # Strip `LOCALSTACK_` prefix in environment variables name (except LOCALSTACK_HOSTNAME)
 source <(
   env |
@@ -22,7 +27,7 @@ function run_startup_scripts {
     sleep 7
   done
 
-  for f in /docker-entrypoint-initaws.d/*; do
+  for f in $INIT_SCRIPTS_PATH/*; do
     case "$f" in
       *.sh)     echo "$0: running $f"; . "$f" ;;
       *)        echo "$0: ignoring $f" ;;


### PR DESCRIPTION
I am proposing to create a variable `INIT_SCRIPTS_PATH` to define the path of the initialization files.

This solves a problem for me where pipelines mount the volume with the files from the repository, however I must not manipulate these files, but I can reference the existing path.