### PR TITLE
fixed lambda add permission

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1151,6 +1151,17 @@ def add_permission(function):
     data = json.loads(to_str(request.data))
     iam_client = aws_stack.connect_to_service('iam')
     sid = data.get('StatementId')
+    action = data.get('Action')
+    principal = data.get('Principal')
+    sourcearn = data.get('SourceArn')
+    arn = func_arn(function)
+
+    if not re.match(r'lambda:[*]|lambda:[a-zA-Z]+|[*]', action):
+        return error_response('1 validation error detected: Value "%s" at "action" failed to satisfy '
+                              'constraint: Member must satisfy regular expression pattern: '
+                              '(lambda:[*]|lambda:[a-zA-Z]+|[*])' % action,
+                              400, error_type='ValidationException')
+
     policy = {
         'Version': IAM_POLICY_VERSION,
         'Id': 'LambdaFuncAccess-%s' % sid,
@@ -1159,15 +1170,31 @@ def add_permission(function):
             'Effect': 'Allow',
             # TODO: 'Principal' in policies not yet supported in upstream moto
             # 'Principal': data.get('Principal') or {'AWS': TEST_AWS_ACCOUNT_ID},
-            'Action': data.get('Action'),
-            'Resource': func_arn(function)
+            'Action': action,
+            'Resource': arn,
         }]
     }
+
+    # Adds SourceArn only if SourceArn is present
+    if sourcearn:
+        condition = {
+            'ArnLike': {
+                'AWS:SourceArn': sourcearn
+            }
+        }
+        policy['Statement'][0]['Condition'] = condition
+
+    # Adds Principal only if Principal is present
+    if principal:
+        principal = {
+            'Service': principal
+        }
+        policy['Statement'][0]['Principal'] = principal
+
     iam_client.create_policy(PolicyName=POLICY_NAME_PATTERN % (function, sid),
                              PolicyDocument=json.dumps(policy),
                              Description='Policy for Lambda function "%s"' % function)
-    result = {'Statement': sid}
-    return jsonify(result)
+    return jsonify(policy)
 
 
 @app.route('%s/functions/<function>/policy/<statement>' % PATH_ROOT, methods=['DELETE'])

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1168,8 +1168,6 @@ def add_permission(function):
         'Statement': [{
             'Sid': sid,
             'Effect': 'Allow',
-            # TODO: 'Principal' in policies not yet supported in upstream moto
-            # 'Principal': data.get('Principal') or {'AWS': TEST_AWS_ACCOUNT_ID},
             'Action': action,
             'Resource': arn,
         }]
@@ -1194,7 +1192,8 @@ def add_permission(function):
     iam_client.create_policy(PolicyName=POLICY_NAME_PATTERN % (function, sid),
                              PolicyDocument=json.dumps(policy),
                              Description='Policy for Lambda function "%s"' % function)
-    return jsonify(policy)
+    result = {'Statement': json.dumps(policy['Statement'][0])}
+    return jsonify(result) 
 
 
 @app.route('%s/functions/<function>/policy/<statement>' % PATH_ROOT, methods=['DELETE'])

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1193,7 +1193,7 @@ def add_permission(function):
                              PolicyDocument=json.dumps(policy),
                              Description='Policy for Lambda function "%s"' % function)
     result = {'Statement': json.dumps(policy['Statement'][0])}
-    return jsonify(result) 
+    return jsonify(result)
 
 
 @app.route('%s/functions/<function>/policy/<statement>' % PATH_ROOT, methods=['DELETE'])

--- a/localstack/services/iam/iam_starter.py
+++ b/localstack/services/iam/iam_starter.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from urllib.parse import quote
 
 from moto.iam.responses import IamResponse, GENERIC_EMPTY_TEMPLATE, LIST_ROLES_TEMPLATE
+from moto.iam.policy_validation import VALID_STATEMENT_ELEMENTS
 from moto.iam.models import (
     iam_backend as moto_iam_backend, aws_managed_policies, AWSManagedPolicy, IAMNotFoundException, Policy, User
 )
@@ -105,6 +106,9 @@ def apply_patches():
         AWSManagedPolicy.from_data(k, v)
         for k, v in ADDITIONAL_MANAGED_POLICIES.items()
     ])
+
+    if 'Principal' not in VALID_STATEMENT_ELEMENTS:
+        VALID_STATEMENT_ELEMENTS.append('Principal')
 
     def iam_response_create_user(self):
         user = moto_iam_backend.create_user(


### PR DESCRIPTION
This PR fixed (adds support) for add-permission in lambda. Also this will add resolve the issue reported by #3040 .
Fixed: Response for `lambda add-permission`.
Extended test case for `add-permission`.