### PR TITLE
Add cloudwatch as a static dependency for Lambda API

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -46,7 +46,7 @@ PLUGIN_SCOPE_COMMANDS = 'commands'
 API_DEPENDENCIES = {
     'dynamodbstreams': ['kinesis'],
     'es': ['elasticsearch'],
-    'lambda': ['logs'],
+    'lambda': ['logs', 'cloudwatch'],
     'kinesis': ['dynamodb'],
     'firehose': ['kinesis']
 }

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -37,7 +37,7 @@ def publish_lambda_metric(metric, value, kwargs):
             }]
         )
     except Exception as e:
-        LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %e' % (metric, e))
+        LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %s' % (metric, e))
 
 
 def publish_lambda_duration(time_before, kwargs):

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -27,14 +27,18 @@ def publish_lambda_metric(metric, value, kwargs):
     if not config.service_port('cloudwatch'):
         return
     cw_client = aws_stack.connect_to_service('cloudwatch')
-    cw_client.put_metric_data(Namespace='AWS/Lambda',
-        MetricData=[{
-            'MetricName': metric,
-            'Dimensions': dimension_lambda(kwargs),
-            'Timestamp': datetime.now(),
-            'Value': value
-        }]
-    )
+    try:
+        cw_client.put_metric_data(Namespace='AWS/Lambda',
+            MetricData=[{
+                'MetricName': metric,
+                'Dimensions': dimension_lambda(kwargs),
+                'Timestamp': datetime.now(),
+                'Value': value
+            }]
+        )
+    except:
+        print("INFO: cloudwatch has not started, it seems.")
+
 
 
 def publish_lambda_duration(time_before, kwargs):

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -36,9 +36,8 @@ def publish_lambda_metric(metric, value, kwargs):
                 'Value': value
             }]
         )
-    except:
-        print("INFO: cloudwatch has not started, it seems.")
-
+    except Exception as e:
+        LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %e' % (metric, e))
 
 
 def publish_lambda_duration(time_before, kwargs):


### PR DESCRIPTION
Issue addressed: #3037

Added cloudwatch as a dependency in bootstrap.py, to start whenever lambda is enabled.