### PR TITLE
Fix invalid account ID in CloudWatch logs listener ARNs

### DIFF
--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -1,7 +1,7 @@
 import re
 from requests.models import Request
 from localstack.utils.common import to_str
-from localstack.constants import APPLICATION_AMZ_JSON_1_1
+from localstack.constants import APPLICATION_AMZ_JSON_1_1, TEST_AWS_ACCOUNT_ID
 from localstack.services.generic_proxy import ProxyListener
 
 
@@ -18,8 +18,13 @@ class ProxyListenerCloudWatchLogs(ProxyListener):
     def return_response(self, method, path, data, headers, response):
         # Fix Incorrect response content-type header from cloudwatch logs #1343
         response.headers['content-type'] = APPLICATION_AMZ_JSON_1_1
-
-        if 'nextToken' in to_str(response.content or ''):
+        str_content = re.sub(
+            r':1:',
+            ':{}:'.format(TEST_AWS_ACCOUNT_ID),
+            to_str(response.content or '')
+        )
+        response._content = str.encode(str_content)
+        if 'nextToken' in str_content:
             self._fix_next_token_response(response)
             response.headers['content-length'] = str(len(response._content))
 

--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -19,8 +19,8 @@ class ProxyListenerCloudWatchLogs(ProxyListener):
         # Fix Incorrect response content-type header from cloudwatch logs #1343
         response.headers['content-type'] = APPLICATION_AMZ_JSON_1_1
         str_content = re.sub(
-            r':1:',
-            ':{}:'.format(TEST_AWS_ACCOUNT_ID),
+            r'arn:aws:logs:([^:]+):1:',
+            r'arn:aws:logs:\1:%s:' % TEST_AWS_ACCOUNT_ID,
             to_str(response.content or '')
         )
         response._content = str.encode(str_content)

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
-from localstack.constants import APPLICATION_AMZ_JSON_1_1
+from localstack.constants import APPLICATION_AMZ_JSON_1_1, TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack
 from localstack.utils import testutil
 from localstack.utils.common import short_uid, retry
@@ -18,6 +18,10 @@ class CloudWatchLogsTest(unittest.TestCase):
 
         response = self.logs_client.create_log_group(logGroupName=group)
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
+        response = self.logs_client.describe_log_groups()
+        arn = response['logGroups'][0]['arn']
+        self.assertEqual(arn, 'arn:aws:logs:us-east-1:{}:log-group:{}'.format(TEST_AWS_ACCOUNT_ID, group))
 
         response = self.logs_client.create_log_stream(logGroupName=group, logStreamName=stream)
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)


### PR DESCRIPTION
Fix invalid account ID in CloudWatch logs listener ARNs

Addresses #2883