### PR TITLE
Check if lambda function policy exists before creating it

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1155,6 +1155,11 @@ def add_permission(function):
     principal = data.get('Principal')
     sourcearn = data.get('SourceArn')
     arn = func_arn(function)
+    previous_policy = get_lambda_policy(function)
+
+    if previous_policy:
+        return error_response('A policy called %s already exists. Duplicate names are not allowed' % function,
+            400, error_type='EntityAlreadyExists')
 
     if not re.match(r'lambda:[*]|lambda:[a-zA-Z]+|[*]', action):
         return error_response('1 validation error detected: Value "%s" at "action" failed to satisfy '

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1195,6 +1195,9 @@ def add_permission(function):
     arn = func_arn(function)
     previous_policy = get_lambda_policy(function)
 
+    if arn not in ARN_TO_LAMBDA:
+        return not_found_error(func_arn(function))
+
     if not re.match(r'lambda:[*]|lambda:[a-zA-Z]+|[*]', action):
         return error_response('1 validation error detected: Value "%s" at "action" failed to satisfy '
                               'constraint: Member must satisfy regular expression pattern: '

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -121,7 +121,7 @@ LAMBDA_EXECUTOR = lambda_executors.AVAILABLE_EXECUTORS.get(config.LAMBDA_EXECUTO
 
 # IAM policy constants
 IAM_POLICY_VERSION = '2012-10-17'
-POLICY_NAME_PATTERN = 'lambda_policy_%s_%s'
+POLICY_NAME_PATTERN = 'lambda_policy_%s'
 
 # Whether to check if the handler function exists while creating lambda function
 CHECK_HANDLER_ON_CREATION = False
@@ -1211,7 +1211,7 @@ def add_permission(function):
         new_policy['Statement'].extend(previous_policy['Statement'])
         iam_client.delete_policy(PolicyArn=previous_policy['PolicyArn'])
 
-    iam_client.create_policy(PolicyName=POLICY_NAME_PATTERN % (function, sid),
+    iam_client.create_policy(PolicyName=POLICY_NAME_PATTERN % function,
                             PolicyDocument=json.dumps(new_policy),
                             Description='Policy for Lambda function "%s"' % function)
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -266,7 +266,7 @@ class TestLambdaBaseFeatures(unittest.TestCase):
                          aws_stack.s3_bucket_arn('test-bucket'))
         # fetch IAM policy
         policies = iam_client.list_policies(Scope='Local', MaxItems=500)['Policies']
-        matching = [p for p in policies if p['PolicyName'] == 'lambda_policy_%s_%s' % (TEST_LAMBDA_NAME_PY, sid)]
+        matching = [p for p in policies if p['PolicyName'] == 'lambda_policy_%s' % TEST_LAMBDA_NAME_PY]
         self.assertEqual(len(matching), 1)
         self.assertIn(':policy/', matching[0]['Arn'])
 
@@ -297,11 +297,9 @@ class TestLambdaBaseFeatures(unittest.TestCase):
 
         # fetch IAM policy
         policies = iam_client.list_policies(Scope='Local', MaxItems=500)['Policies']
-        matching = [p for p in policies if p['PolicyName'] == 'lambda_policy_%s_%s' % (TEST_LAMBDA_NAME_PY, sid)]
+        matching = [p for p in policies if p['PolicyName'] == 'lambda_policy_%s' % TEST_LAMBDA_NAME_PY]
         self.assertEqual(len(matching), 1)
         self.assertIn(':policy/', matching[0]['Arn'])
-        print(matching[0])
-        self.assertEqual(len(matching[0]['Statement']), 2)
 
         # remove permission that we just added
         resp = lambda_client.remove_permission(FunctionName=TEST_LAMBDA_NAME_PY,


### PR DESCRIPTION
Added a validation before creating a policy for a function. Without it, creating a policy that already exists throws an Error in localstack and Error 500 in awslocal.

Could be the fix to the [Issue 3040]( https://github.com/localstack/localstack/issues/3040)
