### PR TITLE
Patch: the api-gw response.resource_methods method

### DIFF
--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -117,6 +117,39 @@ def apply_patches():
 
         return 400, {}, ''
 
+    def apigateway_response_resource_methods(self, request, full_url, headers):
+        self.setup_class(request, full_url, headers)
+        url_path_parts = self.path.split('/')
+        function_id = url_path_parts[2]
+        resource_id = url_path_parts[4]
+        method_type = url_path_parts[6]
+
+        if self.method == 'GET':
+            method = self.backend.get_method(function_id, resource_id, method_type)
+            return 200, {}, json.dumps(method)
+        elif self.method == 'PUT':
+            authorization_type = self._get_param('authorizationType')
+            api_key_required = self._get_param('apiKeyRequired')
+            method = self.backend.create_method(
+                function_id,
+                resource_id,
+                method_type,
+                authorization_type,
+                api_key_required,
+            )
+            if authorization_type in ['CUSTOM', 'COGNITO_USER_POOLS']:
+                method['authorizerId'] = json.loads(request.data.decode('utf-8'))['authorizerId']
+            return 200, {}, json.dumps(method)
+
+        elif self.method == 'DELETE':
+            self.backend.delete_method(
+                function_id, resource_id, method_type
+            )
+
+            return 200, {}, ''
+
+        return 200, {}, ''
+
     if not hasattr(apigateway_models.APIGatewayBackend, 'put_rest_api'):
         apigateway_response_restapis_individual_orig = APIGatewayResponse.restapis_individual
         APIGatewayResponse.restapis_individual = apigateway_response_restapis_individual
@@ -125,6 +158,7 @@ def apply_patches():
     if not hasattr(apigateway_models.APIGatewayBackend, 'delete_method'):
         apigateway_models.APIGatewayBackend.delete_method = apigateway_models_backend_delete_method
 
+    APIGatewayResponse.resource_methods = apigateway_response_resource_methods
     apigateway_models.Resource.get_method = apigateway_models_resource_get_method
     apigateway_models.Resource.get_integration = apigateway_models_resource_get_integration
     apigateway_models.Resource.delete_integration = apigateway_models_resource_delete_integration

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -121,11 +121,9 @@ def apply_patches():
         result = apigateway_response_resource_methods_orig(self, request, *args, **kwargs)
         if len(result) != 3:
             return result
-        print(result)
         authorization_type = self._get_param('authorizationType')
         if authorization_type in ['CUSTOM', 'COGNITO_USER_POOLS']:
             data = json.loads(result[2])
-            print(data)
             if not data.get('authorizerId'):
                 data['authorizerId'] = json.loads(request.data.decode('utf-8'))['authorizerId']
                 result = result[0], result[1], json.dumps(data)


### PR DESCRIPTION
This PR has been created to fix the upstream response. If the authorization type is 'CUSTOM' or 'COGNITO_USER_POOLS', then the request should be responded with 'authorizationId' parameter

Issue Ref: #1315 