### PR TITLE
Fix: S3 notifications `Id` field not being handled properly

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -929,7 +929,7 @@ def handle_notification_request(bucket, method, data):
                     s3_filter['FilterRule'] = [s3_filter['FilterRule']]
                 # create final details dict
                 notification_details = {
-                    'Id': config.get('Id', uuid.uuid4()),
+                    'Id': config.get('Id', str(uuid.uuid4())),
                     'Event': events,
                     dest: config.get(dest),
                     'Filter': event_filter

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -901,7 +901,7 @@ def handle_notification_request(bucket, method, data):
                     if dest in notif:
                         dest_dict = {
                             '%sConfiguration' % dest: {
-                                'Id': uuid.uuid4(),
+                                'Id': notif['Id'],
                                 dest: notif[dest],
                                 'Event': notif['Event'],
                                 'Filter': notif['Filter']
@@ -929,7 +929,7 @@ def handle_notification_request(bucket, method, data):
                     s3_filter['FilterRule'] = [s3_filter['FilterRule']]
                 # create final details dict
                 notification_details = {
-                    'Id': config.get('Id'),
+                    'Id': config.get('Id', uuid.uuid4()),
                     'Event': events,
                     dest: config.get(dest),
                     'Filter': event_filter


### PR DESCRIPTION
Currently, when fetching s3 notifications `Id` field is generated on response so it differs from call to call, also ID that is provided when creating notification is ignored.

This fix should make use of provided `Id` when notifications are created (defaults to UUID) and return the said `Id` on `GET`.