### PR TITLE
Fix: Dynamodb streams sequence number mismatch

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -104,7 +104,9 @@ def post_request():
         kinesis_records = kinesis.get_records(**data)
         result = {'Records': [], 'NextShardIterator': kinesis_records.get('NextShardIterator')}
         for record in kinesis_records['Records']:
-            result['Records'].append(json.loads(to_str(record['Data'])))
+            record_data = json.loads(to_str(record['Data']))
+            record_data['dynamodb']['SequenceNumber'] = record['SequenceNumber']
+            result['Records'].append(record_data)
     else:
         print('WARNING: Unknown operation "%s"' % action)
     return jsonify(result)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -528,7 +528,7 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         self.assertEqual(200, response['ResponseMetadata']['HTTPStatusCode'])
         self.assertEqual(1, len(response['StreamDescription']['Shards']))
         shard_id = response['StreamDescription']['Shards'][0]['ShardId']
-        starting_sequence_number = int(response['StreamDescription']['Shards'][0]\
+        starting_sequence_number = int(response['StreamDescription']['Shards'][0]
             .get('SequenceNumberRange').get('StartingSequenceNumber'))
 
         response = ddbstreams.get_shard_iterator(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -326,7 +326,7 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         dynamodb = aws_stack.connect_to_service('dynamodb')
         ddbstreams = aws_stack.connect_to_service('dynamodbstreams')
 
-        table_name = 'table_with_stream'
+        table_name = 'table_with_stream-%s' % short_uid()
         table = dynamodb.create_table(
             TableName=table_name,
             KeySchema=[{'AttributeName': 'id', 'KeyType': 'HASH'}],
@@ -528,6 +528,8 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         self.assertEqual(200, response['ResponseMetadata']['HTTPStatusCode'])
         self.assertEqual(1, len(response['StreamDescription']['Shards']))
         shard_id = response['StreamDescription']['Shards'][0]['ShardId']
+        starting_sequence_number = int(response['StreamDescription']['Shards'][0]\
+            .get('SequenceNumberRange').get('StartingSequenceNumber'))
 
         response = ddbstreams.get_shard_iterator(
             StreamArn=table.latest_stream_arn,
@@ -559,10 +561,12 @@ class DynamoDBIntegrationTest (unittest.TestCase):
         self.assertEqual('1.1', records['Records'][0]['eventVersion'])
         self.assertEqual('INSERT', records['Records'][0]['eventName'])
         self.assertNotIn('OldImage', records['Records'][0]['dynamodb'])
+        self.assertGreater(int(records['Records'][0]['dynamodb']['SequenceNumber']), starting_sequence_number)
         self.assertTrue(isinstance(records['Records'][1]['dynamodb']['ApproximateCreationDateTime'], datetime))
         self.assertEqual('1.1', records['Records'][1]['eventVersion'])
         self.assertEqual('MODIFY', records['Records'][1]['eventName'])
         self.assertIn('OldImage', records['Records'][1]['dynamodb'])
+        self.assertGreater(int(records['Records'][1]['dynamodb']['SequenceNumber']), starting_sequence_number)
 
         dynamodb.delete_table(TableName=table_name)
 


### PR DESCRIPTION
The dynamodb streams' record sequence number is mismatched from the shard's starting and end sequence number.

When we call ddbstreams.describe_stream(...) we get shards with SequenceNumber that looks like the following:
{'ShardId': 'shardId-00000001603400000000-000000000000', 'SequenceNumberRange': {**'StartingSequenceNumber': '49611974300205315735694662545343431332397447507475431426'**}}

But when we call ddbstreams.get_records(...) we get records with SequenceNumber that looks like this:
{'ApproximateCreationDateTime': datetime.datetime(2020, 10, 22, 17, 37, 41, 162566, tzinfo=tzlocal()), 'Keys': {'id': {'S': 'a1c3bd2e'}}, 'NewImage': {'attr1': {'S': 'value1'}, 'attr2': {'S': 'value2'}, 'id': {'S': 'a1c3bd2e'}}, **'SequenceNumber': '1',** 'SizeBytes': 77, 'StreamViewType': 'NEW_AND_OLD_IMAGES'}

This violate the contract that the records's sequence number should be greater than the shard's starting sequence number and equal or smaller than the end sequence number.