### PR TITLE
Update readme.md with proper dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ localstack start
 
 ### Using `docker-compose`
 
-You can also use the `docker-compose.yml` file from the repository and use this command (currently requires `docker-compose` version 2.1+):
+You can also use the `docker-compose.yml` file from the repository and use this command (currently requires `docker-compose` version 1.9.0+):
 
 ```
 docker-compose up


### PR DESCRIPTION
The docker-compose.yml file in the root director is using the version 2.1 file spec. This requires Compose 1.9.0+. Updating readme.md to reflect this. docker-compose latest version is currently at 1.27.4 
See: https://docs.docker.com/compose/compose-file/compose-versioning/#version-21

**Please refer to the contribution guidelines in the README when submitting PRs.**
