### PR TITLE
feature: resource policy support for secretsmanager

### DIFF
--- a/localstack/services/secretsmanager/secretsmanager_starter.py
+++ b/localstack/services/secretsmanager/secretsmanager_starter.py
@@ -31,8 +31,12 @@ def apply_patches():
             result = {
                 'ARN': self.secrets[secret_id].arn,
                 'Name': self.secrets[secret_id].secret_id,
-                'ResourcePolicy': json.dumps(getattr(self.secrets[secret_id], 'policy', None))
             }
+
+            policy = getattr(self.secrets[secret_id], 'policy', None)
+            if policy:
+                result['ResourcePolicy'] = json.dumps(policy)
+
             return json.dumps(result)
         else:
             raise SecretNotFoundException()
@@ -43,6 +47,7 @@ def apply_patches():
         return secretsmanager_backends[self.region].get_resource_policy(
             secret_id=secret_id
         )
+
     setattr(SecretsManagerResponse, 'get_resource_policy', get_resource_policy_response)
 
     def delete_resource_policy_model(self, secret_id):

--- a/localstack/services/secretsmanager/secretsmanager_starter.py
+++ b/localstack/services/secretsmanager/secretsmanager_starter.py
@@ -2,7 +2,8 @@ import logging
 import json
 from moto.secretsmanager import models as secretsmanager_models
 from moto.secretsmanager.responses import SecretsManagerResponse
-from moto.secretsmanager.models import secretsmanager_backends, SecretsManagerBackend, secret_arn
+from moto.secretsmanager.models import secretsmanager_backends, SecretsManagerBackend
+from moto.secretsmanager.exceptions import SecretNotFoundException
 from moto.iam.policy_validation import IAMPolicyDocumentValidator
 from localstack.services.infra import start_moto_server
 from localstack.utils.aws import aws_stack
@@ -25,73 +26,73 @@ def apply_patches():
     secretsmanager_models.secret_arn = secretsmanager_models_secret_arn
 
     # patching resource policy in moto
-    for secretsmanager_backend in secretsmanager_backends.values():
-        if not hasattr(secretsmanager_backend, 'resource_policy'):
-            print('adding')
-            setattr(secretsmanager_backend, 'resource_policy', None)
-        if not hasattr(secretsmanager_backend, 'block_public_policy'):
-            print('adding2')
-            setattr(secretsmanager_backend, 'block_public_policy', None)
-        
     def get_resource_policy_model(self, secret_id):
-        region = aws_stack.get_region()
-        result = {
-                "ARN": self.secrets[secret_id].arn,
-                "Name": secret_id
-        }
-        
-        if secret_id in self.secrets.keys() and self.secrets[secret_id].get('resource_policy'):
-            result["ResourcePolicy"] = json.dumps(self.resource_policy)
-        
-        return json.dumps(result)
+        if self._is_valid_identifier(secret_id):
+            result = {
+                'ARN': self.secrets[secret_id].arn,
+                'Name': self.secrets[secret_id].secret_id,
+                'ResourcePolicy': json.dumps(getattr(self.secrets[secret_id], 'policy', None))
+            }
+            return json.dumps(result)
+        else:
+            raise SecretNotFoundException()
     setattr(SecretsManagerBackend, 'get_resource_policy', get_resource_policy_model)
 
     def get_resource_policy_response(self):
-        secret_id = self._get_param("SecretId")
+        secret_id = self._get_param('SecretId')
         return secretsmanager_backends[self.region].get_resource_policy(
             secret_id=secret_id
         )
     setattr(SecretsManagerResponse, 'get_resource_policy', get_resource_policy_response)
 
-
     def delete_resource_policy_model(self, secret_id):
-        if secret_id in self.secrets.keys():
+        if self._is_valid_identifier(secret_id):
             self.secrets[secret_id].policy = None
-        return json.dumps(
-            {
-                "ARN": self.secrets[secret_id].arn,
-                "Name": secret_id
-            }
-        )
+            return json.dumps(
+                {
+                    'ARN': self.secrets[secret_id].arn,
+                    'Name': self.secrets[secret_id].secret_id
+                }
+            )
+        else:
+            raise SecretNotFoundException()
     if not hasattr(SecretsManagerBackend, 'delete_resource_policy'):
         setattr(SecretsManagerBackend, 'delete_resource_policy', delete_resource_policy_model)
 
     def delete_resource_policy_response(self):
-        secret_id = self._get_param("SecretId")
+        secret_id = self._get_param('SecretId')
         return secretsmanager_backends[self.region].delete_resource_policy(
             secret_id=secret_id
         )
     if not hasattr(SecretsManagerResponse, 'delete_resource_policy'):
         setattr(SecretsManagerResponse, 'delete_resource_policy', delete_resource_policy_response)
 
-
-    def put_resource_policy_model(self, secret_id, resource_policy, block_public_policy=None):
-        self.block_public_policy = block_public_policy
-        policy_validator =IAMPolicyDocumentValidator(resource_policy)
-        policy_validator.validate()
-        if secret_id in self.secrets.keys():
+    def put_resource_policy_model(self, secret_id, resource_policy):
+        policy_validator = IAMPolicyDocumentValidator(resource_policy)
+        policy_validator._validate_top_elements()
+        policy_validator._validate_version_syntax()
+        if self._is_valid_identifier(secret_id):
             self.secrets[secret_id].policy = resource_policy
-        return json.dumps(
-            {
-                "ARN": secret_arn(region, secret_id),
-                "Name": secret_id
-            }
-        )
+            return json.dumps(
+                {
+                    'ARN': self.secrets[secret_id].arn,
+                    'Name': self.secrets[secret_id].secret_id
+                }
+            )
+        else:
+            raise SecretNotFoundException()
+    if not hasattr(SecretsManagerBackend, 'put_resource_policy'):
+        setattr(SecretsManagerBackend, 'put_resource_policy', put_resource_policy_model)
 
     def put_resource_policy_response(self):
-        secret_id = self._get_param("SecretId")
-        resource_policy = self._get_param("ResourcePolicy")
-        secret_id = self._get_param("BlockPublicPolicy")
+        secret_id = self._get_param('SecretId')
+        resource_policy = self._get_param('ResourcePolicy')
+        return secretsmanager_backends[self.region].put_resource_policy(
+            secret_id=secret_id,
+            resource_policy=json.loads(resource_policy)
+        )
+    if not hasattr(SecretsManagerResponse, 'put_resource_policy'):
+        setattr(SecretsManagerResponse, 'put_resource_policy', put_resource_policy_response)
 
 
 def start_secretsmanager(port=None, asynchronous=None, backend_port=None, update_listener=None):


### PR DESCRIPTION
**Patched:**
- Moto implementation for secretsmanager `get-resource-policy`

**Added:**
- API implementation for secretsmanager `put-resource-policy`
- API implementation for secretsmanager `delete-resource-policy`

**Test:**
- Added test cases for `get-resource-policy` `put-resource-policy` `delete-resource-policy`

This PR will fix the issue #3195 .