### PR TITLE
S3 listener: fix nonzero content length for gzipped 204 status

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1365,9 +1365,7 @@ class ProxyListenerS3(PersistingProxyListener):
             # convert to chunked encoding, for compatibility with certain SDKs (e.g., AWS PHP SDK)
             convert_to_chunked_encoding(method, path, response)
 
-            if headers.get('Accept-Encoding') == 'gzip':
-                if response._content is None:
-                    response._content = ''
+            if headers.get('Accept-Encoding') == 'gzip' and response._content:
                 response._content = gzip.compress(to_bytes(response._content))
                 response.headers['Content-Length'] = str(len(response._content))
                 response.headers['Content-Encoding'] = 'gzip'


### PR DESCRIPTION
This change disables compression for falsy S3 response bodies.

If an HTTP request has an `Accept-Encoding: gzip` header when an S3 response has a 204 status code, the empty body is compressed with gzip into a non-empty body. This causes some HTTP clients, [like tornado](https://github.com/tornadoweb/tornado/blob/b120df9b584dc59881b72854a4b8e73b16b25159/tornado/http1connection.py#L630-L638), to raise an exception.