### PR TITLE
fix apigateway cachingclusterstatus

### DIFF
--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -14,15 +14,16 @@ LOG = logging.getLogger(__name__)
 
 def apply_patches():
     apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
-    
+
     def apigateway_models_Stage_init(
-        self, name=None, deployment_id=None, variables=None, description="",
+        self, name=None, deployment_id=None, variables=None, description='',
         cacheClusterEnabled=False, cacheClusterSize=None
-        ):
-        apigateway_models_Stage_init_orig(self, name=None, deployment_id=None, variables=None, description="",
-        cacheClusterEnabled=False, cacheClusterSize=None)
+    ):
+        apigateway_models_Stage_init_orig(self, name=None, deployment_id=None, variables=None, description='',
+            cacheClusterEnabled=False, cacheClusterSize=None)
+
         if cacheClusterSize or cacheClusterEnabled:
-            self['cacheClusterStatus'] = "AVAILABLE"
+            self['cacheClusterStatus'] = 'AVAILABLE'
 
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init
 

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -22,7 +22,7 @@ def apply_patches():
         apigateway_models_Stage_init_orig(self, name=None, deployment_id=None, variables=None, description='',
             cacheClusterEnabled=False, cacheClusterSize=None)
 
-        if cacheClusterSize or cacheClusterEnabled:
+        if (cacheClusterSize or cacheClusterEnabled) and not self.get('cacheClusterStatus'):
             self['cacheClusterStatus'] = 'AVAILABLE'
 
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -13,6 +13,19 @@ LOG = logging.getLogger(__name__)
 
 
 def apply_patches():
+    apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
+    
+    def apigateway_models_Stage_init(
+        self, name=None, deployment_id=None, variables=None, description="",
+        cacheClusterEnabled=False, cacheClusterSize=None
+        ):
+        apigateway_models_Stage_init_orig(self, name=None, deployment_id=None, variables=None, description="",
+        cacheClusterEnabled=False, cacheClusterSize=None)
+        if cacheClusterSize or cacheClusterEnabled:
+            self['cacheClusterStatus'] = "AVAILABLE"
+
+    apigateway_models.Stage.__init__ = apigateway_models_Stage_init
+
     def apigateway_models_backend_delete_method(self, function_id, resource_id, method_type):
         resource = self.get_resource(function_id, resource_id)
         method = resource.get_method(method_type)

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -174,6 +174,7 @@ def func_qualifier(function_name, qualifier=None):
     arn = aws_stack.lambda_function_arn(function_name)
     if ARN_TO_LAMBDA.get(arn).qualifier_exists(qualifier):
         return '{}:{}'.format(arn, qualifier)
+    return arn
 
 
 def check_batch_size_range(source_arn, batch_size=None):

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -169,6 +169,10 @@ def cleanup():
 def func_arn(function_name):
     return aws_stack.lambda_function_arn(function_name)
 
+def func_qualifier(function_name, qualifier=None):
+    arn = aws_stack.lambda_function_arn(function_name)
+    if ARN_TO_LAMBDA.get(arn).qualifier_exists(qualifier):
+        return '{}:{}'.format(arn, qualifier)
 
 def check_batch_size_range(source_arn, batch_size=None):
     batch_size_entry = BATCH_SIZE_RANGES.get(source_arn.split(':')[2].lower())
@@ -890,7 +894,7 @@ def forward_to_fallback_url(func_arn, data):
     raise ClientError('Unexpected value for LAMBDA_FALLBACK_URL: %s' % config.LAMBDA_FALLBACK_URL)
 
 
-def get_lambda_policy(function):
+def get_lambda_policy(function, qualifier=None):
     iam_client = aws_stack.connect_to_service('iam')
     policies = iam_client.list_policies(Scope='Local', MaxItems=500)['Policies']
     docs = []
@@ -908,7 +912,7 @@ def get_lambda_policy(function):
         doc['PolicyArn'] = p['Arn']
         doc['Id'] = 'default'
         docs.append(doc)
-    policy = [d for d in docs if d['Statement'][0]['Resource'] == func_arn(function)]
+    policy = [d for d in docs if d['Statement'][0]['Resource'] == func_qualifier(function, qualifier)]
     return (policy or [None])[0]
 
 
@@ -1192,9 +1196,9 @@ def add_permission(function):
     action = data.get('Action')
     principal = data.get('Principal')
     sourcearn = data.get('SourceArn')
+    qualifier = request.args.get('Qualifier')
     arn = func_arn(function)
     previous_policy = get_lambda_policy(function)
-
     if arn not in ARN_TO_LAMBDA:
         return not_found_error(func_arn(function))
 
@@ -1204,7 +1208,8 @@ def add_permission(function):
                               '(lambda:[*]|lambda:[a-zA-Z]+|[*])' % action,
                               400, error_type='ValidationException')
 
-    new_policy = generate_policy(sid, action, arn, sourcearn, principal)
+    q_arn = func_qualifier(function, qualifier)
+    new_policy = generate_policy(sid, action, q_arn, sourcearn, principal)
     if previous_policy:
         statment_with_sid = next((statement for statement in previous_policy['Statement'] if statement['Sid'] == sid),
             None)
@@ -1213,11 +1218,9 @@ def add_permission(function):
                         ' or remove the existing statement.' % sid, 400, error_type='ResourceConflictException')
         new_policy['Statement'].extend(previous_policy['Statement'])
         iam_client.delete_policy(PolicyArn=previous_policy['PolicyArn'])
-
     iam_client.create_policy(PolicyName=POLICY_NAME_PATTERN % function,
                             PolicyDocument=json.dumps(new_policy),
                             Description='Policy for Lambda function "%s"' % function)
-
     result = {'Statement': json.dumps(new_policy['Statement'][0])}
     return jsonify(result)
 
@@ -1241,7 +1244,8 @@ def remove_permission(function, statement):
 
 @app.route('%s/functions/<function>/policy' % PATH_ROOT, methods=['GET'])
 def get_policy(function):
-    policy = get_lambda_policy(function)
+    qualifier = request.args.get('Qualifier')
+    policy = get_lambda_policy(function, qualifier)
     if not policy:
         return error_response('The resource you requested does not exist.',
             404, error_type='ResourceNotFoundException')


### PR DESCRIPTION
This PR fixed the issue mentioned in #3209 .

`cacheClusterStatus` variable was missing in the response in `CreateStage` api when the `cacheCluster` is enable.

Lamda IAM policy should contain qualifier in the ARN.