### PR TITLE
avoid instance collection

### DIFF
--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -21,6 +21,9 @@ S3_MAX_FILE_SIZE_MB = 2048
 # temporary state
 TMP_STATE = {}
 
+# Key for tracking patch applience
+PATCHES_APPLIED = 'S3_PATCHED'
+
 
 def check_s3(expect_shutdown=False, print_error=False):
     out = None
@@ -56,6 +59,11 @@ def start_s3(port=None, backend_port=None, asynchronous=None, update_listener=No
 
 
 def apply_patches():
+    if TMP_STATE.get(PATCHES_APPLIED, False):
+        return
+
+    TMP_STATE[PATCHES_APPLIED] = True
+
     s3_models.DEFAULT_KEY_BUFFER_SIZE = S3_MAX_FILE_SIZE_MB * 1024 * 1024
 
     def init(self, name, value, storage='STANDARD', etag=None,

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -60,8 +60,10 @@ def apply_patches():
 
     def init(self, name, value, storage='STANDARD', etag=None,
             is_versioned=False, version_id=0, max_buffer_size=None, *args, **kwargs):
-        if self.instances:
-            self.instances.remove(self)
+        try:
+            (self.instances or []).remove(self)
+        except Exception:
+            pass
         return original_init(self, name, value, storage=storage, etag=etag, is_versioned=is_versioned,
             version_id=version_id, max_buffer_size=s3_models.DEFAULT_KEY_BUFFER_SIZE, *args, **kwargs)
 
@@ -69,8 +71,10 @@ def apply_patches():
     s3_models.FakeKey.__init__ = init
 
     def bucket_init(self, name, region_name, *args, **kwargs):
-        if self.instances:
-            self.instances.remove(self)
+        try:
+            (self.instances or []).remove(self)
+        except Exception:
+            pass
         return original_bucket_init(self, name, region_name, *args, **kwargs)
 
     original_bucket_init = s3_models.FakeBucket.__init__

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -68,22 +68,22 @@ def apply_patches():
 
     def init(self, name, value, storage='STANDARD', etag=None,
             is_versioned=False, version_id=0, max_buffer_size=None, *args, **kwargs):
+        original_init(self, name, value, storage=storage, etag=etag, is_versioned=is_versioned,
+            version_id=version_id, max_buffer_size=s3_models.DEFAULT_KEY_BUFFER_SIZE, *args, **kwargs)
         try:
             (self.instances or []).remove(self)
         except Exception:
             pass
-        return original_init(self, name, value, storage=storage, etag=etag, is_versioned=is_versioned,
-            version_id=version_id, max_buffer_size=s3_models.DEFAULT_KEY_BUFFER_SIZE, *args, **kwargs)
 
     original_init = s3_models.FakeKey.__init__
     s3_models.FakeKey.__init__ = init
 
     def bucket_init(self, name, region_name, *args, **kwargs):
+        original_bucket_init(self, name, region_name, *args, **kwargs)
         try:
             (self.instances or []).remove(self)
         except Exception:
             pass
-        return original_bucket_init(self, name, region_name, *args, **kwargs)
 
     original_bucket_init = s3_models.FakeBucket.__init__
     s3_models.FakeBucket.__init__ = bucket_init

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -60,11 +60,21 @@ def apply_patches():
 
     def init(self, name, value, storage='STANDARD', etag=None,
             is_versioned=False, version_id=0, max_buffer_size=None, *args, **kwargs):
+        if self.instances:
+            self.instances.remove(self)
         return original_init(self, name, value, storage=storage, etag=etag, is_versioned=is_versioned,
             version_id=version_id, max_buffer_size=s3_models.DEFAULT_KEY_BUFFER_SIZE, *args, **kwargs)
 
     original_init = s3_models.FakeKey.__init__
     s3_models.FakeKey.__init__ = init
+
+    def bucket_init(self, name, region_name, *args, **kwargs):
+        if self.instances:
+            self.instances.remove(self)
+        return original_bucket_init(self, name, region_name, *args, **kwargs)
+
+    original_bucket_init = s3_models.FakeBucket.__init__
+    s3_models.FakeBucket.__init__ = bucket_init
 
     def s3_update_acls(self, request, query, bucket_name, key_name):
         # fix for - https://github.com/localstack/localstack/issues/1733

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,8 +1,11 @@
 import unittest
-from localstack.services.s3 import s3_listener, multipart_content
+from moto.s3 import models as s3_models
+from localstack.services.s3 import s3_listener, s3_starter, multipart_content
 from requests.models import CaseInsensitiveDict, Response
 from localstack.config import HOSTNAME, HOSTNAME_EXTERNAL, LOCALHOST_IP
 from localstack.constants import HEADER_LOCALSTACK_EDGE_URL
+
+s3_starter.apply_patches()
 
 
 class S3ListenerTest (unittest.TestCase):
@@ -247,3 +250,48 @@ class S3ListenerTest (unittest.TestCase):
         ]
         for example_header, expected_result in headers:
             assert expected_result == s3_listener.uses_path_addressing(example_header)
+
+
+class S3BackendTest (unittest.TestCase):
+
+    def test_no_key_instances_after_removed(self):
+        s3_backend = s3_models.S3Backend()
+
+        bucket_name = 'test'
+        region = 'us-east-1'
+
+        file1_name = 'file.txt'
+        file_value = b'content'
+        s3_backend.create_bucket(bucket_name, region)
+        s3_backend.set_object(bucket_name, file1_name, file_value)
+        s3_backend.delete_object(bucket_name, file1_name)
+
+        s3_backend.set_object(bucket_name, file1_name, file_value)
+        self.assertEqual(len(s3_backend.get_object(bucket_name, file1_name).instances), 0)
+
+    def test_key_instances_before_removing(self):
+        s3_backend = s3_models.S3Backend()
+
+        bucket_name = 'test'
+        region = 'us-east-1'
+
+        file1_name = 'file.txt'
+        file2_name = 'file2.txt'
+        file_value = b'content'
+
+        s3_backend.create_bucket(bucket_name, region)
+        s3_backend.set_object(bucket_name, file1_name, file_value)
+        s3_backend.set_object(bucket_name, file2_name, file_value)
+
+        self.assertEqual(len(s3_backend.get_object(bucket_name, file2_name).instances), 0)
+
+    def test_no_bucket_instances_after_removed(self):
+        s3_backend = s3_models.S3Backend()
+
+        bucket_name = 'test'
+        region = 'us-east-1'
+
+        s3_backend.create_bucket(bucket_name, region)
+        s3_backend.delete_bucket(bucket_name)
+        s3_backend.create_bucket(bucket_name, region)
+        self.assertEqual(len(s3_backend.get_bucket(bucket_name).instances), 0)

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -285,7 +285,7 @@ class S3BackendTest (unittest.TestCase):
         s3_backend.set_object(bucket_name, file1_name, file_value)
         s3_backend.set_object(bucket_name, file2_name, file_value)
 
-        self.assertEqual(len(s3_backend.get_object(bucket_name, file2_name).instances), 0)
+        self.assertEqual(len(s3_backend.get_object(bucket_name, file2_name).instances), 1)
 
     def test_no_bucket_instances_after_removed(self):
         s3_backend = s3_models.S3Backend()
@@ -296,4 +296,4 @@ class S3BackendTest (unittest.TestCase):
         s3_backend.create_bucket(bucket_name, region)
         s3_backend.delete_bucket(bucket_name)
         s3_backend.create_bucket(bucket_name, region)
-        self.assertEqual(len(s3_backend.get_bucket(bucket_name).instances), 0)
+        self.assertEqual(len(s3_backend.get_bucket(bucket_name).instances), 1)

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -5,8 +5,6 @@ from requests.models import CaseInsensitiveDict, Response
 from localstack.config import HOSTNAME, HOSTNAME_EXTERNAL, LOCALHOST_IP
 from localstack.constants import HEADER_LOCALSTACK_EDGE_URL
 
-s3_starter.apply_patches()
-
 
 class S3ListenerTest (unittest.TestCase):
 
@@ -253,6 +251,10 @@ class S3ListenerTest (unittest.TestCase):
 
 
 class S3BackendTest (unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        s3_starter.apply_patches()
 
     def test_no_key_instances_after_removed(self):
         s3_backend = s3_models.S3Backend()

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -256,21 +256,6 @@ class S3BackendTest (unittest.TestCase):
     def setUpClass(cls):
         s3_starter.apply_patches()
 
-    def test_no_key_instances_after_removed(self):
-        s3_backend = s3_models.S3Backend()
-
-        bucket_name = 'test'
-        region = 'us-east-1'
-
-        file1_name = 'file.txt'
-        file_value = b'content'
-        s3_backend.create_bucket(bucket_name, region)
-        s3_backend.set_object(bucket_name, file1_name, file_value)
-        s3_backend.delete_object(bucket_name, file1_name)
-
-        s3_backend.set_object(bucket_name, file1_name, file_value)
-        self.assertEqual(len(s3_backend.get_object(bucket_name, file1_name).instances), 0)
-
     def test_key_instances_before_removing(self):
         s3_backend = s3_models.S3Backend()
 
@@ -283,23 +268,21 @@ class S3BackendTest (unittest.TestCase):
 
         s3_backend.create_bucket(bucket_name, region)
         s3_backend.set_object(bucket_name, file1_name, file_value)
-        first_instances = len(s3_backend.get_object(bucket_name, file1_name).instances)
         s3_backend.set_object(bucket_name, file2_name, file_value)
-        second_instances = len(s3_backend.get_object(bucket_name, file2_name).instances)
 
-        self.assertGreaterEqual(second_instances, first_instances)
+        key = s3_backend.get_object(bucket_name, file2_name)
 
-    def test_no_bucket_instances_after_removed(self):
+        self.assertEqual(key in (key.instances or []), False)
+
+    def test_no_bucket_in_instances_(self):
         s3_backend = s3_models.S3Backend()
 
         bucket_name = 'test'
         region = 'us-east-1'
 
         s3_backend.create_bucket(bucket_name, region)
-        bucket_instances = len(s3_backend.get_bucket(bucket_name).instances)
 
         s3_backend.delete_bucket(bucket_name)
-        s3_backend.create_bucket(bucket_name, region)
+        bucket = s3_backend.create_bucket(bucket_name, region)
 
-        bucket_instances2 = len(s3_backend.get_bucket(bucket_name).instances)
-        self.assertGreaterEqual(bucket_instances2, bucket_instances)
+        self.assertGreaterEqual(bucket in (bucket.instances or []), False)

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -283,9 +283,11 @@ class S3BackendTest (unittest.TestCase):
 
         s3_backend.create_bucket(bucket_name, region)
         s3_backend.set_object(bucket_name, file1_name, file_value)
+        first_instances = len(s3_backend.get_object(bucket_name, file1_name).instances)
         s3_backend.set_object(bucket_name, file2_name, file_value)
+        second_instances = len(s3_backend.get_object(bucket_name, file2_name).instances)
 
-        self.assertEqual(len(s3_backend.get_object(bucket_name, file2_name).instances), 1)
+        self.assertGreaterEqual(second_instances, first_instances)
 
     def test_no_bucket_instances_after_removed(self):
         s3_backend = s3_models.S3Backend()
@@ -294,6 +296,10 @@ class S3BackendTest (unittest.TestCase):
         region = 'us-east-1'
 
         s3_backend.create_bucket(bucket_name, region)
+        bucket_instances = len(s3_backend.get_bucket(bucket_name).instances)
+
         s3_backend.delete_bucket(bucket_name)
         s3_backend.create_bucket(bucket_name, region)
-        self.assertEqual(len(s3_backend.get_bucket(bucket_name).instances), 1)
+
+        bucket_instances2 = len(s3_backend.get_bucket(bucket_name).instances)
+        self.assertGreaterEqual(bucket_instances2, bucket_instances)


### PR DESCRIPTION
Now the instances of  **FakeKey** and  **FakeBucket** are being remove from the attribute instances on creation, to avoid storing the object references even after the object was deleted.

posible solution to [issue 3143](https://github.com/localstack/localstack/issues/3143) 