### PR TITLE
Fix SSM & SecretsManager integration with secrets named with slashes (#3237)

### DIFF
--- a/localstack/services/ssm/ssm_listener.py
+++ b/localstack/services/ssm/ssm_listener.py
@@ -56,9 +56,9 @@ class ProxyListenerSSM(PersistingProxyListener):
 
                     if len(details) > 4:
                         service = details[3]
-                        resource_name = details[4]
 
                         if service == 'secretsmanager':
+                            resource_name = '/'.join(details[4:])
                             return get_secrets_information(name, resource_name)
 
             data = json.dumps(data)


### PR DESCRIPTION
Fixing issue where SSM couldn't get parameters created from SecretsManager when the name contains slashes (#3237)
