### PR TITLE
Refactor CloudFormation dependency resolution mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/jvm/java-11/lib:/usr/lib/jvm/java-11/lib/server
 
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
-RUN LAMBDA_EXECUTOR=local make test
+RUN LAMBDA_EXECUTOR=local DEBUG=1 make test
 # clean up temporary files created during test execution
 RUN apk del --purge git;
 RUN rm -rf /tmp/localstack/*elasticsearch* /tmp/localstack.* tests/ /root/.npm/*cache /opt/terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ ENV LD_LIBRARY_PATH=/usr/lib/jvm/java-11/lib:/usr/lib/jvm/java-11/lib/server
 
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
-RUN LAMBDA_EXECUTOR=local DEBUG=1 make test
+RUN LAMBDA_EXECUTOR=local make test
 # clean up temporary files created during test execution
 RUN apk del --purge git;
 RUN rm -rf /tmp/localstack/*elasticsearch* /tmp/localstack.* tests/ /root/.npm/*cache /opt/terraform

--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,11 @@ test-docker:       ## Run automated tests in Docker
 	ENTRYPOINT="--entrypoint=" CMD="make test" make docker-run
 
 test-docker-mount:
+	ENTRYPOINT="-v `pwd`/tests:/opt/code/localstack/tests" make test-docker-mount-code
+
+test-docker-mount-code:
 	MOTO_DIR=$$(echo $$(pwd)/.venv/lib/python*/site-packages/moto | awk '{print $$NF}'); \
-	ENTRYPOINT="--entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/tests:/opt/code/localstack/tests -v `pwd`/Makefile:/opt/code/localstack/Makefile -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/ -e TEST_PATH=$(TEST_PATH) -e NOSE_ARGS=-v -e LAMBDA_JAVA_OPTS=$(LAMBDA_JAVA_OPTS)" CMD="make test" make docker-run
+	ENTRYPOINT="--entrypoint= -v `pwd`/localstack/config.py:/opt/code/localstack/localstack/config.py -v `pwd`/localstack/constants.py:/opt/code/localstack/localstack/constants.py -v `pwd`/localstack/utils:/opt/code/localstack/localstack/utils -v `pwd`/localstack/services:/opt/code/localstack/localstack/services -v `pwd`/Makefile:/opt/code/localstack/Makefile -v $$MOTO_DIR:/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/ -e TEST_PATH=$(TEST_PATH) -e NOSE_ARGS=-v -e LAMBDA_JAVA_OPTS=$(LAMBDA_JAVA_OPTS) $(ENTRYPOINT)" CMD="make test" make docker-run
 
 reinstall-p2:      ## Re-initialize the virtualenv with Python 2.x
 	rm -rf $(VENV_DIR)

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -13,18 +13,15 @@ LOG = logging.getLogger(__name__)
 
 
 def apply_patches():
-    apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
 
-    def apigateway_models_Stage_init(
-        self, name=None, deployment_id=None, variables=None, description='',
-        cacheClusterEnabled=False, cacheClusterSize=None
-    ):
-        apigateway_models_Stage_init_orig(self, name=None, deployment_id=None, variables=None, description='',
-            cacheClusterEnabled=False, cacheClusterSize=None)
+    def apigateway_models_Stage_init(self, cacheClusterEnabled=False, cacheClusterSize=None, **kwargs):
+        apigateway_models_Stage_init_orig(self, cacheClusterEnabled=cacheClusterEnabled,
+            cacheClusterSize=cacheClusterSize, **kwargs)
 
         if (cacheClusterSize or cacheClusterEnabled) and not self.get('cacheClusterStatus'):
             self['cacheClusterStatus'] = 'AVAILABLE'
 
+    apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init
 
     def apigateway_models_backend_delete_method(self, function_id, resource_id, method_type):

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -156,6 +156,8 @@ def apply_patches():
             method_type = url_path_parts[6]
 
             resource = self.backend.get_resource(function_id, resource_id)
+            resource.resource_methods[method_type]['methodIntegration'] = (
+                resource.resource_methods[method_type].get('methodIntegration') or {})
             resource.resource_methods[method_type]['methodIntegration']['timeoutInMillis'] = timeout_milliseconds
 
             return result[0], result[1], json.dumps(resource.resource_methods[method_type]['methodIntegration'])

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -638,7 +638,7 @@ def get_handler_function_from_name(handler_name, runtime=LAMBDA_DEFAULT_RUNTIME)
 
 
 def error_response(msg, code=500, error_type='InternalFailure'):
-    LOG.warning(msg)
+    LOG.info(msg)
     return aws_responses.flask_error_response_json(msg, code=code, error_type=error_type)
 
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -633,8 +633,7 @@ def get_handler_function_from_name(handler_name, runtime=LAMBDA_DEFAULT_RUNTIME)
     # TODO: support Java Lambdas in the future
     if runtime.startswith(tuple(DOTNET_LAMBDA_RUNTIMES)):
         return handler_name.split(':')[-1]
-    else:
-        return handler_name.split('.')[-1]
+    return handler_name.split('.')[-1]
 
 
 def error_response(msg, code=500, error_type='InternalFailure'):

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -421,7 +421,6 @@ def apply_patches():
                 all_satisfied = template_deployer.all_resource_dependencies_satisfied(
                     logical_id, resource_map_new, stack_name
                 )
-                # TODO enable?
                 if not all_satisfied:
                     register_unresolved_refs(logical_id, resource_json, resources_map, region_name)
                 else:

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -624,11 +624,7 @@ def apply_patches():
         resources_diff = resource_map_diff_orig(self, template, parameters)
         if resources_diff['Add'] or resources_diff['Remove'] or resources_diff['Modify']:
             return resources_diff
-
-        raise ValidationError(
-            name_or_id='',
-            message='No updates are to be performed.'
-        )
+        raise ValidationError(name_or_id='', message='No updates are to be performed.')
 
     parsing.ResourceMap.diff = resource_map_diff
 
@@ -1032,7 +1028,8 @@ def apply_patches():
                 resource = stack_resource
                 break
         else:
-            raise ValidationError(logical_resource_id)
+            raise ValidationError(stack_name,
+                message='Unable to find resource "%s" in stack "%s"' % (logical_resource_id, stack_name))
 
         template = self.response_template(
             responses.DESCRIBE_STACK_RESOURCE_RESPONSE_TEMPLATE)

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -120,7 +120,7 @@ class ProxyListenerSNS(PersistingProxyListener):
                 # No need to create a topic to send SMS or single push notifications with SNS
                 # but we can't mock a sending so we only return that it went well
                 if 'PhoneNumber' not in req_data and 'TargetArn' not in req_data:
-                    if topic_arn not in SNS_SUBSCRIPTIONS.keys():
+                    if topic_arn not in SNS_SUBSCRIPTIONS:
                         return make_error(code=404, code_string='NotFound', message='Topic does not exist')
 
                 message_id = publish_message(topic_arn, req_data)
@@ -144,6 +144,7 @@ class ProxyListenerSNS(PersistingProxyListener):
             elif req_action == 'CreateTopic':
                 topic_arn = aws_stack.sns_topic_arn(req_data['Name'][0])
                 tag_resource_success = self._extract_tags(topic_arn, req_data, True)
+                SNS_SUBSCRIPTIONS[topic_arn] = SNS_SUBSCRIPTIONS.get(topic_arn) or []
                 # in case if there is an error it returns an error , other wise it will continue as expected.
                 if not tag_resource_success:
                     return make_error(code=400, code_string='InvalidParameter',
@@ -391,9 +392,11 @@ def do_confirm_subscription(topic_arn, token):
 
 
 def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, filter_policy=None):
+    topic_subs = SNS_SUBSCRIPTIONS[topic_arn] = SNS_SUBSCRIPTIONS.get(topic_arn) or []
+
     # An endpoint may only be subscribed to a topic once. Subsequent
     # subscribe calls do nothing (subscribe is idempotent).
-    for existing_topic_subscription in SNS_SUBSCRIPTIONS.get(topic_arn, []):
+    for existing_topic_subscription in topic_subs:
         if existing_topic_subscription.get('Endpoint') == endpoint:
             return
 
@@ -406,10 +409,9 @@ def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, fi
         'FilterPolicy': filter_policy
     }
     subscription.update(attributes)
-    SNS_SUBSCRIPTIONS[topic_arn] = SNS_SUBSCRIPTIONS.get(topic_arn) or []
-    SNS_SUBSCRIPTIONS[topic_arn].append(subscription)
+    topic_subs.append(subscription)
 
-    if subscription_arn not in SUBSCRIPTION_STATUS.keys():
+    if subscription_arn not in SUBSCRIPTION_STATUS:
         SUBSCRIPTION_STATUS[subscription_arn] = {}
 
     SUBSCRIPTION_STATUS[subscription_arn].update(
@@ -434,8 +436,7 @@ def do_subscribe(topic_arn, endpoint, protocol, subscription_arn, attributes, fi
 
 
 def do_unsubscribe(subscription_arn):
-    for topic_arn in SNS_SUBSCRIPTIONS:
-        existing_subs = SNS_SUBSCRIPTIONS.get(topic_arn) or []
+    for topic_arn, existing_subs in SNS_SUBSCRIPTIONS.items():
         SNS_SUBSCRIPTIONS[topic_arn] = [
             sub for sub in existing_subs
             if sub['SubscriptionArn'] != subscription_arn
@@ -483,10 +484,6 @@ def do_untag_resource(topic_arn, tag_keys):
 # ---------------
 # HELPER METHODS
 # ---------------
-
-
-def get_topic_by_arn(topic_arn):
-    return SNS_SUBSCRIPTIONS.get(topic_arn)
 
 
 def get_subscription_by_arn(sub_arn):

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1454,7 +1454,8 @@ def get_unsatisfied_dependencies_for_resources(
     for resource_id, resource in iteritems(resources):
         if is_deployable_resource(resource):
             if not is_deployed(resource_id, all_resources, stack_name):
-                LOG.debug('Dependency for resource %s not yet deployed: %s' % (depending_resource, resource_id))
+                LOG.debug('Dependency for resource %s not yet deployed: %s %s' %
+                    (depending_resource, resource_id, resource))
                 result[resource_id] = resource
                 if return_first:
                     break

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -816,7 +816,7 @@ def retrieve_resource_details(resource_id, resource_status, resources, stack_nam
             return aws_stack.connect_to_service('dynamodb').describe_table(TableName=table_name)
         elif resource_type == 'ApiGateway::RestApi':
             apis = aws_stack.connect_to_service('apigateway').get_rest_apis()['items']
-            api_name = resource_props['Name'] if resource else resource_id
+            api_name = resource_props.get('Name') or resource_id
             api_name = resolve_refs_recursively(stack_name, api_name, resources)
             result = list(filter(lambda api: api['name'] == api_name, apis))
             return result[0] if result else None

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1435,18 +1435,27 @@ def is_updateable(resource_id, resources, stack_name):
 
 
 def all_resource_dependencies_satisfied(resource_id, resources, stack_name):
+    unsatisfied = get_unsatisfied_dependencies(resource_id, resources, stack_name)
+    return not unsatisfied
+
+
+def get_unsatisfied_dependencies(resource_id, resources, stack_name):
     resource = resources[resource_id]
     res_deps = get_resource_dependencies(resource_id, resource, resources)
-    return all_dependencies_satisfied(res_deps, stack_name, resources, resource_id)
+    return get_unsatisfied_dependencies_for_resources(res_deps, stack_name, resources, resource_id)
 
 
-def all_dependencies_satisfied(resources, stack_name, all_resources, depending_resource=None):
+def get_unsatisfied_dependencies_for_resources(
+        resources, stack_name, all_resources, depending_resource=None, return_first=True):
+    result = {}
     for resource_id, resource in iteritems(resources):
         if is_deployable_resource(resource):
             if not is_deployed(resource_id, all_resources, stack_name):
                 LOG.debug('Dependency for resource %s not yet deployed: %s' % (depending_resource, resource_id))
-                return False
-    return True
+                result[resource_id] = resource
+                if return_first:
+                    break
+    return result
 
 
 def resources_to_deploy_next(resources, stack_name):

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -802,9 +802,12 @@ def retrieve_resource_details(resource_id, resource_status, resources, stack_nam
             if not mapping:
                 raise Exception('ResourceNotFound')
             return mapping[0]
+        elif resource_type == 'Events::Rule':
+            rule_name = resolve_refs_recursively(stack_name, resource_props.get('Name'), resources)
+            result = aws_stack.connect_to_service('events').describe_rule(Name=rule_name) or {}
+            return result if result.get('Name') else None
         elif resource_type == 'IAM::Role':
-            role_name = resource_props.get('RoleName')
-            role_name = resolve_refs_recursively(stack_name, role_name, resources)
+            role_name = resolve_refs_recursively(stack_name, resource_props.get('RoleName'), resources)
             return aws_stack.connect_to_service('iam').get_role(RoleName=role_name)['Role']
         elif resource_type == 'SSM::Parameter':
             param_name = resource_props.get('Name') or resource_id

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1018,14 +1018,14 @@ def resolve_ref(stack_name, ref, resources, attribute):
     # second, resolve resource references
     resource_status = {}
 
-    # TODO: check if the logic below (calling describe_stack_resource during deployment) is still required
-    if stack_name:
-        resource_status = describe_stack_resource(stack_name, ref)
-        if not resource_status:
-            return
-        attr_value = resource_status.get(attribute)
-        if attr_value not in [None, '']:
-            return attr_value
+    # TODO: check if the logic below (calling describe_stack_resource during deployment) is still required!
+    # if stack_name:
+    #     resource_status = describe_stack_resource(stack_name, ref)
+    #     if not resource_status:
+    #         return
+    #     attr_value = resource_status.get(attribute)
+    #     if attr_value not in [None, '']:
+    #         return attr_value
 
     if not resource_status and ref in resources:
         resource_status = resources[ref].get('__details__', {})

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1015,14 +1015,14 @@ def resolve_ref(stack_name, ref, resources, attribute):
     # second, resolve resource references
     resource_status = {}
 
-    # !!TODO!! - disabling for now, as calling "describe" is problematic if currently deploying
-    # if False and stack_name:
-    #     resource_status = describe_stack_resource(stack_name, ref)
-    #     if not resource_status:
-    #         return
-    #     attr_value = resource_status.get(attribute)
-    #     if attr_value not in [None, '']:
-    #         return attr_value
+    # TODO: check if the logic below (calling describe_stack_resource during deployment) is still required
+    if stack_name:
+        resource_status = describe_stack_resource(stack_name, ref)
+        if not resource_status:
+            return
+        attr_value = resource_status.get(attribute)
+        if attr_value not in [None, '']:
+            return attr_value
 
     if not resource_status and ref in resources:
         resource_status = resources[ref].get('__details__', {})

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -554,6 +554,18 @@ def recurse_object(obj, func, path=''):
     return obj
 
 
+def keys_to_lower(obj):
+    """ Recursively changes all dict keys to first character lowercase. """
+    def fix_keys(o, **kwargs):
+        if isinstance(o, dict):
+            for k, v in dict(o).items():
+                o.pop(k)
+                o[first_char_to_lower(k)] = v
+        return o
+    result = recurse_object(obj, fix_keys)
+    return result
+
+
 def base64_to_hex(b64_string):
     return binascii.hexlify(base64.b64decode(b64_string))
 

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1457,11 +1457,7 @@ class CloudFormationTest(unittest.TestCase):
 
         cloudformation = aws_stack.connect_to_service('cloudformation')
 
-        rs = cloudformation.create_stack(
-            StackName=stack_name,
-            TemplateBody=TEST_TEMPLATE_22,
-        )
-        self.assertEqual(200, rs['ResponseMetadata']['HTTPStatusCode'])
+        _deploy_stack(stack_name=stack_name, template_body=TEST_TEMPLATE_22)
 
         res = cloudformation.list_stack_resources(StackName=stack_name)['StackResourceSummaries']
         rest_api_ids = [r['PhysicalResourceId'] for r in res if r['ResourceType'] == 'AWS::ApiGateway::RestApi']

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -67,12 +67,10 @@ class TestServerless(unittest.TestCase):
         function = [fn for fn in resp['Functions'] if fn['FunctionName'] == function_name][0]
         self.assertEqual(function['Handler'], 'handler.processKinesis')
 
-        resp = lambda_client.list_event_source_mappings(
-            FunctionName=function_name,
-        )
-        events = resp['EventSourceMappings']
-        self.assertEqual(len(events), 1)
-        event_source_arn = events[0]['EventSourceArn']
+        resp = lambda_client.list_event_source_mappings(FunctionName=function_name)
+        mappings = resp['EventSourceMappings']
+        self.assertEqual(len(mappings), 1)
+        event_source_arn = mappings[0]['EventSourceArn']
 
         resp = kinesis_client.describe_stream(StreamName=stream_name)
         self.assertEqual(resp['StreamDescription']['StreamARN'], event_source_arn)

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -74,9 +74,7 @@ class TestServerless(unittest.TestCase):
         self.assertEqual(len(events), 1)
         event_source_arn = events[0]['EventSourceArn']
 
-        resp = kinesis_client.describe_stream(
-            StreamName=stream_name
-        )
+        resp = kinesis_client.describe_stream(StreamName=stream_name)
         self.assertEqual(resp['StreamDescription']['StreamARN'], event_source_arn)
 
     def test_queue_handler_deployed(self):

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -27,8 +27,6 @@ class SNSTests(unittest.TestCase):
         sub_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic:45e61c7f-dca5-4fcd-be2b-4e1b0d6eef72'
         topic_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic'
 
-        self.assertFalse(sns_listener.get_topic_by_arn(topic_arn))
-        self.assertTrue(sns_listener.get_topic_by_arn(topic_arn) is not None)
         sns_listener.do_subscribe(
             topic_arn,
             'arn:aws:sqs:us-east-1:000000000000:test-queue',
@@ -210,8 +208,6 @@ class SNSTests(unittest.TestCase):
         sub_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic:45e61c7f-dca5-4fcd-be2b-4e1b0d6eef72'
         topic_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic'
 
-        self.assertFalse(sns_listener.get_topic_by_arn(topic_arn))
-        self.assertTrue(sns_listener.get_topic_by_arn(topic_arn) is not None)
         for i in [1, 2]:
             sns_listener.do_subscribe(
                 topic_arn,

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -28,7 +28,6 @@ class SNSTests(unittest.TestCase):
         topic_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic'
 
         self.assertFalse(sns_listener.get_topic_by_arn(topic_arn))
-        sns_listener.do_create_topic(topic_arn)
         self.assertTrue(sns_listener.get_topic_by_arn(topic_arn) is not None)
         sns_listener.do_subscribe(
             topic_arn,
@@ -212,7 +211,6 @@ class SNSTests(unittest.TestCase):
         topic_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic'
 
         self.assertFalse(sns_listener.get_topic_by_arn(topic_arn))
-        sns_listener.do_create_topic(topic_arn)
         self.assertTrue(sns_listener.get_topic_by_arn(topic_arn) is not None)
         for i in [1, 2]:
             sns_listener.do_subscribe(


### PR DESCRIPTION
Refactor CloudFormation dependency resolution mechanism - this fixes some issues with CDK templates that could not be deployed with the current logic.

This PR contains a couple of smaller changes, mostly:
* minor refactorings of the current logic
* enhanced CF deployment support for various resource types
* assigning default resource names where missing (prior to the deployment loop, to make it more stable)

The **main change** in this PR is to introduce an exception class `DependencyNotYetSatisfied` which is raised whenever a resource dependency can not (yet) be resolved (this can be an intermittent error, as the stack resources are deployed in multiple steps/iterations to resolve all dependencies). The resource deployment loop has been adapted to be able to deal with this type of exception. This fixes an issue where we were seeing various resource references/attributes replaced with `None` values if the corresponding resources have not been deployed yet. Overall, these changes should (hopefully) make complex stacks with various resource dependencies deploy more reliably and consistently.