### PR TITLE
fix response structure for Integration and IntegrationResponse

### DIFF
--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -177,7 +177,9 @@ def apply_patches():
             method_type = url_path_parts[6]
             status_code = url_path_parts[9]
 
-            integration_response = self.backend.get_integration_response(function_id, resource_id, method_type, status_code)
+            integration_response = self.backend.get_integration_response(
+                function_id, resource_id, method_type, status_code
+            )
 
             integration_response['responseParameters'] = response_parameters
 

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -52,23 +52,22 @@ def apply_patches():
 
         return {}
 
-    def apigateway_models_Integration_init(
-            self, integration_type, uri, http_method,
-            request_templates=None, pass_through_behavior='WHEN_NO_MATCH', cache_key_parameters=[]
-    ):
-        super(apigateway_models.Integration, self).__init__()
-        self['type'] = integration_type
-        self['uri'] = uri
-        self['httpMethod'] = http_method
+    def apigateway_models_Integration_init(self, integration_type, uri, http_method,
+            request_templates=None, pass_through_behavior='WHEN_NO_MATCH', cache_key_parameters=[], *args, **kwargs):
+        apigateway_models_Integration_init_orig(
+            self, integration_type=integration_type, uri=uri, http_method=http_method,
+            request_templates=request_templates, *args, **kwargs
+        )
+
         self['passthroughBehavior'] = pass_through_behavior
         self['cacheKeyParameters'] = cache_key_parameters
         self['cacheNamespace'] = short_uid()
-        self['timeoutInMillis'] = None
-        self['integrationResponses'] = {'200': apigateway_models.IntegrationResponse(200)}
+
+        # httpMethod not present in response if integration_type is None, verified against AWS
+        if integration_type == 'MOCK':
+            self['httpMethod'] = None
         if request_templates:
             self['requestTemplates'] = request_templates
-
-    apigateway_models.Integration.__init__ = apigateway_models_Integration_init
 
     def apigateway_models_backend_put_rest_api(self, function_id, body):
         rest_api = self.get_rest_api(function_id)
@@ -131,6 +130,7 @@ def apply_patches():
 
     def apigateway_response_resource_methods(self, request, *args, **kwargs):
         result = apigateway_response_resource_methods_orig(self, request, *args, **kwargs)
+
         if len(result) != 3:
             return result
         authorization_type = self._get_param('authorizationType')
@@ -143,24 +143,68 @@ def apply_patches():
                     result = result[0], result[1], json.dumps(data)
         return result
 
-    apigateway_response_integrations_orig = APIGatewayResponse.integrations
-
-    def apigateway_response_integrations(self, request, full_url, headers):
-        result = apigateway_response_integrations_orig(self, request, full_url, headers)
+    def apigateway_response_integrations(self, request, *args, **kwargs):
+        result = apigateway_response_integrations_orig(self, request, *args, **kwargs)
         timeout_milliseconds = self._get_param('timeoutInMillis')
+        request_parameters = self._get_param('requestParameters') or {}
+        cache_key_parameters = self._get_param('cacheKeyParameters') or []
+        content_handling = self._get_param('contentHandling')
 
-        if self.method == 'PUT' and timeout_milliseconds:
+        if self.method == 'PUT':
             url_path_parts = self.path.split('/')
             function_id = url_path_parts[2]
             resource_id = url_path_parts[4]
             method_type = url_path_parts[6]
 
-            resource = self.backend.get_resource(function_id, resource_id)
-            resource.resource_methods[method_type]['methodIntegration'] = (
-                resource.resource_methods[method_type].get('methodIntegration') or {})
-            resource.resource_methods[method_type]['methodIntegration']['timeoutInMillis'] = timeout_milliseconds
+            integration_response = self.backend.get_integration(function_id, resource_id, method_type)
 
-            return result[0], result[1], json.dumps(resource.resource_methods[method_type]['methodIntegration'])
+            integration_response['timeoutInMillis'] = timeout_milliseconds
+            integration_response['requestParameters'] = request_parameters
+            integration_response['cacheKeyParameters'] = cache_key_parameters
+            integration_response['contentHandling'] = content_handling
+            return 200, {}, json.dumps(integration_response)
+
+        return result
+
+    def apigateway_response_integration_responses(self, request, *args, **kwargs):
+        result = apigateway_response_integration_responses_orig(self, request, *args, **kwargs)
+        response_parameters = self._get_param('responseParameters')
+
+        if self.method == 'PUT' and response_parameters:
+            url_path_parts = self.path.split('/')
+            function_id = url_path_parts[2]
+            resource_id = url_path_parts[4]
+            method_type = url_path_parts[6]
+            status_code = url_path_parts[9]
+
+            integration_response = self.backend.get_integration_response(
+                function_id, resource_id, method_type, status_code
+            )
+
+            integration_response['responseParameters'] = response_parameters
+
+            return 200, {}, json.dumps(integration_response)
+
+        return result
+
+    def apigateway_response_resource_method_responses(self, request, *args, **kwargs):
+        result = apigateway_response_resource_method_responses_orig(self, request, *args, **kwargs)
+        response_parameters = self._get_param('responseParameters')
+
+        if self.method == 'PUT' and response_parameters:
+            url_path_parts = self.path.split('/')
+            function_id = url_path_parts[2]
+            resource_id = url_path_parts[4]
+            method_type = url_path_parts[6]
+            response_code = url_path_parts[8]
+
+            method_response = self.backend.get_method_response(
+                function_id, resource_id, method_type, response_code
+            )
+
+            method_response['responseParameters'] = response_parameters
+
+            return 200, {}, json.dumps(method_response)
 
         return result
 
@@ -177,7 +221,14 @@ def apply_patches():
     apigateway_models.Resource.delete_integration = apigateway_models_resource_delete_integration
     apigateway_response_resource_methods_orig = APIGatewayResponse.resource_methods
     APIGatewayResponse.resource_methods = apigateway_response_resource_methods
+    apigateway_response_integrations_orig = APIGatewayResponse.integrations
     APIGatewayResponse.integrations = apigateway_response_integrations
+    apigateway_response_integration_responses_orig = APIGatewayResponse.integration_responses
+    APIGatewayResponse.integration_responses = apigateway_response_integration_responses
+    apigateway_response_resource_method_responses_orig = APIGatewayResponse.resource_method_responses
+    APIGatewayResponse.resource_method_responses = apigateway_response_resource_method_responses
+    apigateway_models_Integration_init_orig = apigateway_models.Integration.__init__
+    apigateway_models.Integration.__init__ = apigateway_models_Integration_init
 
 
 def start_apigateway(port=None, backend_port=None, asynchronous=None, update_listener=None):

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -180,10 +180,6 @@ def apply_patches():
             integration_response = self.backend.get_integration_response(
                 function_id, resource_id, method_type, status_code
             )
-<<<<<<< HEAD
-
-=======
->>>>>>> b55316ee1724465d66bf0c8e4eaab0da4bce0581
             integration_response['responseParameters'] = response_parameters
 
             return 200, {}, json.dumps(integration_response)

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -177,9 +177,7 @@ def apply_patches():
             method_type = url_path_parts[6]
             status_code = url_path_parts[9]
 
-            integration_response = self.backend.get_integration_response(
-                function_id, resource_id, method_type, status_code
-            )
+            integration_response = self.backend.get_integration_response(function_id, resource_id, method_type, status_code)
 
             integration_response['responseParameters'] = response_parameters
 
@@ -198,9 +196,7 @@ def apply_patches():
             method_type = url_path_parts[6]
             response_code = url_path_parts[8]
 
-            method_response = self.backend.get_method_response(
-                function_id, resource_id, method_type, response_code
-            )
+            method_response = self.backend.get_method_response(function_id, resource_id, method_type, response_code)
 
             method_response['responseParameters'] = response_parameters
 

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -394,12 +394,16 @@ class TestAPIGateway(unittest.TestCase):
             integrationHttpMethod='POST',
             type='AWS',
             uri=target_uri,
+            timeoutInMillis=3000,
+            contentHandling='CONVERT_TO_BINARY',
             requestTemplates={
                 'application/json': '{"param1": "$input.params(\'param1\')"}'
             }
         )
+        integration_keys = ['httpMethod', 'type', 'passthroughBehavior', 'cacheKeyParameters', 'uri', 'cacheNamespace',
+            'timeoutInMillis', 'contentHandling', 'requestParameters']
         self.assertEqual(rs['ResponseMetadata']['HTTPStatusCode'], 200)
-        for key in ['httpMethod', 'type', 'passthroughBehavior', 'cacheKeyParameters', 'uri', 'cacheNamespace']:
+        for key in integration_keys:
             self.assertIn(key, rs)
         self.assertNotIn('responseTemplates', rs)
 


### PR DESCRIPTION
This PR will fix response structure for Integration/IntegrationResponse
Improved Support for `APIGateway `in terraform

**Refractored:**


* `apigateway_models_Integration_init` for backward compatibility
* streamline patching pattern

**Fixed:**


* APIGateway `put_integration` response
* APIGateway `put_integration_response` response

**Test:**


* Extended test case for improved response structure

This PR will address issue mentioned in #1984 .



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-322) by [Unito](https://www.unito.io/learn-more)
