### PR TITLE
SSM & SecretsManager - GetParameters integration (with caveat)

### DIFF
--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -37,7 +37,7 @@ class SSMTest(unittest.TestCase):
         self._assert('/a//b//c', '/a/b/c')
         self._assert('a/b//c', '/a/b/c')
 
-    def test_get_paramter(self):
+    def test_get_secret_parameter(self):
         ssm_client = aws_stack.connect_to_service('ssm')
         sec_client = aws_stack.connect_to_service('secretsmanager')
 
@@ -52,6 +52,42 @@ class SSMTest(unittest.TestCase):
 
         self.assertEqual(result.get('Parameter').get('Name'), '/aws/reference/secretsmanager/{0}'.format(secret_name))
         self.assertEqual(result.get('Parameter').get('Value'), 'my_secret')
+
+    def test_get_inexistent_secret(self):
+        ssm_client = aws_stack.connect_to_service('ssm')
+        self.assertRaises(ssm_client.exceptions.ParameterNotFound,
+            ssm_client.get_parameter, Name='/aws/reference/secretsmanager/inexistent')
+
+    def test_get_parameters_and_secrets(self):
+        ssm_client = aws_stack.connect_to_service('ssm')
+        sec_client = aws_stack.connect_to_service('secretsmanager')
+        secret_path = '/aws/reference/secretsmanager/'
+
+        param_name = 'test_param'
+        ssm_client.put_parameter(
+            Name=param_name,
+            Description='test',
+            Value='123',
+            Type='String',
+        )
+
+        secret_name = 'test_secret_params'
+        sec_client.create_secret(
+            Name=secret_name,
+            SecretString='my_secret',
+            Description='testing creation of secrets'
+        )
+
+        complete_secret = secret_path + secret_name
+        response = ssm_client.get_parameters(Names=[param_name, complete_secret,
+            'inexistent_param', secret_path + 'inexistent_secret'])
+        found = response.get('Parameters')
+        notFound = response.get('InvalidParameters')
+
+        for param in found:
+            self.assertTrue(param['Name'] in [param_name, complete_secret])
+        for param in notFound:
+            self.assertTrue(param in ['inexistent_param', secret_path + 'inexistent_secret'])
 
     def _assert(self, search_name, param_name):
         ssm_client = aws_stack.connect_to_service('ssm')

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -82,12 +82,12 @@ class SSMTest(unittest.TestCase):
         response = ssm_client.get_parameters(Names=[param_name, complete_secret,
             'inexistent_param', secret_path + 'inexistent_secret'])
         found = response.get('Parameters')
-        notFound = response.get('InvalidParameters')
+        not_found = response.get('InvalidParameters')
 
         for param in found:
-            self.assertTrue(param['Name'] in [param_name, complete_secret])
-        for param in notFound:
-            self.assertTrue(param in ['inexistent_param', secret_path + 'inexistent_secret'])
+            self.assertIn(param['Name'], [param_name, complete_secret])
+        for param in not_found:
+            self.assertIn(param, ['inexistent_param', secret_path + 'inexistent_secret'])
 
     def _assert(self, search_name, param_name):
         ssm_client = aws_stack.connect_to_service('ssm')


### PR DESCRIPTION
Patched SSM so **GetRequests** requests can support having SecretsManager secres in it. Also, slightly modified the method so when an inexistent secret is requested a 400 is managed instead of having the 500 thrown.

**NOTE:** I'm not much acquainted with Python so sorry if I'm not doing some things the most recommended Python way

## Caveat
The patch works as expected when making requests through the aws-cli or HTTP request (with postman) like so:

1) Create the param and secret


```
aws --endpoint-url http://localstack:4566 secretsmanager create-secret --name test_secret --secret-string 'test_secret' && \
aws --endpoint-url http://localstack:4566 ssm put-parameter --name test_parameter --value 'test_parameter'
```

2) Get existent and non existent params and secrets


```
aws --endpoint-url http://localstack:4566 ssm get-parameters \
    --names /aws/reference/secretsmanager/test_secret /aws/reference/secretsmanager/no_secret \
            test_parameter no_parameter
```

Response:


```
{
    "Parameters": [
        {
            "Name": "/aws/reference/secretsmanager/test_secret",
            "Type": "SecureString",
            "Value": "test_secret",
            "SourceResult": {
                "ARN": "arn:aws:secretsmanager:us-east-1:1234567890:secret:test_secret-HHFCE",
                "Name": "test_secret",
                "VersionId": "d9dd4abe-66aa-491e-b124-63258e7c33cc",
                "SecretString": "test_secret",
                "VersionStages": [
                    "AWSCURRENT"
                ],
                "CreatedDate": "2020-11-15T20:54:28.000Z"
            },
            "LastModifiedDate": "2020-11-15T20:54:28+00:00"
        },
        {
            "Name": "test_parameter",
            "Value": "test_parameter",
            "Version": 1,
            "LastModifiedDate": "2020-11-15T20:54:29.656000+00:00",
            "ARN": "arn:aws:ssm:us-east-1:1234567890:parameter/test_parameter"
        }
    ],
    "InvalidParameters": [
        "/aws/reference/secretsmanager/no_secret",
        "no_parameter"
    ]
}
```

**BUT**
When requesting through an SDK (Java in this case) there are problems in parsing the JSON response. I would like to request some help as of why this is the case. I believe that is because when secrets are involved, the response is sent directly in the listener instead of returning a Request.


```
Caused by: java.lang.RuntimeException: We expected a VALUE token but got: START_OBJECT
  at com.amazonaws.transform.JsonUnmarshallerContextImpl.readCurrentJsonTokenValue(JsonUnmarshallerContextImpl.java:152)
  at com.amazonaws.transform.JsonUnmarshallerContextImpl.readText(JsonUnmarshallerContextImpl.java:135)
  at com.amazonaws.transform.SimpleTypeJsonUnmarshallers$StringJsonUnmarshaller.unmarshall(SimpleTypeJsonUnmarshallers.java:34)
  at com.amazonaws.transform.SimpleTypeJsonUnmarshallers$StringJsonUnmarshaller.unmarshall(SimpleTypeJsonUnmarshallers.java:32)
... and so on
```



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-323) by [Unito](https://www.unito.io/learn-more)
