### PR TITLE
patching IntanceTrackerMeta to avoid memory leak

### DIFF
--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -169,6 +169,26 @@ def patch_urllib3_connection_pool(**constructor_kwargs):
         pass
 
 
+def patch_instance_tracker_meta():
+    """
+    Avoid instance collection for moto dashboard
+    """
+    def new_intance(meta, name, bases, dct):
+        cls = super(moto_core.models.InstanceTrackerMeta, meta).__new__(meta, name, bases, dct)
+        if name == 'BaseModel':
+            return cls
+        cls.instances = []
+        return cls
+
+    moto_core.models.InstanceTrackerMeta.__new__ = new_intance
+
+    def new_basemodel(cls, *args, **kwargs):
+        instance = super(moto_core.models.BaseModel, cls).__new__(cls)
+        return instance
+
+    moto_core.models.BaseModel.__new__ = new_basemodel
+
+
 def set_service_status(data):
     command = data.get('command')
     service = data.get('service')
@@ -358,6 +378,7 @@ def start_infra(asynchronous=False, apis=None):
 
         # apply patches
         patch_urllib3_connection_pool(maxsize=128)
+        patch_instance_tracker_meta()
 
         # load plugins
         load_plugins()

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -66,28 +66,6 @@ def apply_patches():
 
     s3_models.DEFAULT_KEY_BUFFER_SIZE = S3_MAX_FILE_SIZE_MB * 1024 * 1024
 
-    def init(self, name, value, storage='STANDARD', etag=None,
-            is_versioned=False, version_id=0, max_buffer_size=None, *args, **kwargs):
-        original_init(self, name, value, storage=storage, etag=etag, is_versioned=is_versioned,
-            version_id=version_id, max_buffer_size=s3_models.DEFAULT_KEY_BUFFER_SIZE, *args, **kwargs)
-        try:
-            (self.instances or []).remove(self)
-        except Exception:
-            pass
-
-    original_init = s3_models.FakeKey.__init__
-    s3_models.FakeKey.__init__ = init
-
-    def bucket_init(self, name, region_name, *args, **kwargs):
-        original_bucket_init(self, name, region_name, *args, **kwargs)
-        try:
-            (self.instances or []).remove(self)
-        except Exception:
-            pass
-
-    original_bucket_init = s3_models.FakeBucket.__init__
-    s3_models.FakeBucket.__init__ = bucket_init
-
     def s3_update_acls(self, request, query, bucket_name, key_name):
         # fix for - https://github.com/localstack/localstack/issues/1733
         #         - https://github.com/localstack/localstack/issues/1170

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -4,6 +4,7 @@ from localstack.services.s3 import s3_listener, s3_starter, multipart_content
 from requests.models import CaseInsensitiveDict, Response
 from localstack.config import HOSTNAME, HOSTNAME_EXTERNAL, LOCALHOST_IP
 from localstack.constants import HEADER_LOCALSTACK_EDGE_URL
+from localstack.services.infra import patch_instance_tracker_meta
 
 
 class S3ListenerTest (unittest.TestCase):
@@ -255,6 +256,7 @@ class S3BackendTest (unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         s3_starter.apply_patches()
+        patch_instance_tracker_meta()
 
     def test_key_instances_before_removing(self):
         s3_backend = s3_models.S3Backend()


### PR DESCRIPTION
the objective of this patch is to avoid the instance collection every time a new object is created, which can be the reason of the memory leaks mentioned in the issues #3143 and #3233 .



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-327) by [Unito](https://www.unito.io/learn-more)
