### PR TITLE
#3255: Fix EventBridge edge support for Go SDK

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -165,6 +165,8 @@ def get_api_from_headers(headers, path=None):
         result = result_before = 'dynamodbstreams', config.PORT_DYNAMODBSTREAMS
     elif ls_target == 'web':
         result = 'web', config.PORT_WEB_UI
+    elif result[0] == 'EventBridge':
+        result = 'events', config.PORT_EVENTS
 
     return result[0], result_before[1] or result[1], path, host
 


### PR DESCRIPTION
This should fix #3255.

I added a fallback for the edge-service, so that the service `EventBridge` will be mapped to `events`, because `EventBridge` will be used by the AWS Go SDK.



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-333) by [Unito](https://www.unito.io/learn-more)
