### PR TITLE
Tell supervisord where to run the command

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -3,6 +3,7 @@ nodaemon=true
 logfile=/tmp/supervisord.log
 
 [program:infra]
+directory=/opt/code/localstack
 command=make infra
 autostart=true
 autorestart=true


### PR DESCRIPTION
WORKDIR is not enough, it can be overriden by k8s or docker or anything else really.

**Please refer to the contribution guidelines in the README when submitting PRs.**



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-336) by [Unito](https://www.unito.io/learn-more)
