### PR TITLE
Added support for lambda concurrency api

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1522,17 +1522,23 @@ def list_aliases(function):
                                       key=lambda x: x['Name'])})
 
 
-@app.route('/<version>/functions/<function>/concurrency', methods=['PUT'])
-def put_concurrency(version, function):
+@app.route('/<version>/functions/<function>/concurrency', methods=['GET', 'PUT', 'DELETE'])
+def function_concurrency(version, function):
     # the version for put_concurrency != PATH_ROOT, at the time of this
     # writing it's: /2017-10-31 for this endpoint
     # https://docs.aws.amazon.com/lambda/latest/dg/API_PutFunctionConcurrency.html
     arn = func_arn(function)
-    data = json.loads(request.data)
     lambda_details = ARN_TO_LAMBDA.get(arn)
     if not lambda_details:
         return not_found_error(arn)
-    lambda_details.concurrency = data
+    if request.method == 'GET':
+        data = lambda_details.concurrency
+    if request.method == 'PUT':
+        data = json.loads(request.data)
+        lambda_details.concurrency = data
+    if request.method == 'DELETE':
+        lambda_details.concurrency = None
+        return Response('', status=204)
     return jsonify(data)
 
 

--- a/tests/integration/terraform/provider.tf
+++ b/tests/integration/terraform/provider.tf
@@ -1,4 +1,5 @@
 provider "aws" {
+  version = "~> 3.16.0"
   region                      = "us-east-1"
   access_key                  = "aws_mock_key"
   secret_key                  = "aws_mock_key"

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -493,7 +493,7 @@ class TestLambdaAPI(unittest.TestCase):
         name = executor.get_container_name('arn:aws:lambda:us-east-1:00000000:function:my_function_name')
         self.assertEqual(name, 'localstack_lambda_arn_aws_lambda_us-east-1_00000000_function_my_function_name')
 
-    def test_put_concurrency(self):
+    def test_concurrency(self):
         with self.app.test_request_context():
             self._create_function(self.FUNCTION_NAME)
             # note: PutFunctionConcurrency is mounted at: /2017-10-31
@@ -505,6 +505,12 @@ class TestLambdaAPI(unittest.TestCase):
 
             result = json.loads(response.get_data())
             self.assertDictEqual(concurrency_data, result)
+
+            response = self.client.get('/2017-10-31/functions/{0}/concurrency'.format(self.FUNCTION_NAME))
+            self.assertDictEqual(concurrency_data, result)
+
+            response = self.client.delete('/2017-10-31/functions/{0}/concurrency'.format(self.FUNCTION_NAME))
+            self.assertIsNotNone('ReservedConcurrentExecutions', result)
 
     def test_concurrency_get_function(self):
         with self.app.test_request_context():

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -506,7 +506,7 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(response.get_data())
             self.assertDictEqual(concurrency_data, result)
 
-            response = self.client.get('/2017-10-31/functions/{0}/concurrency'.format(self.FUNCTION_NAME))
+            response = self.client.get('/2019-09-30/functions/{0}/concurrency'.format(self.FUNCTION_NAME))
             self.assertDictEqual(concurrency_data, result)
 
             response = self.client.delete('/2017-10-31/functions/{0}/concurrency'.format(self.FUNCTION_NAME))


### PR DESCRIPTION
**Added:**


* GetFunctionConcurrency: Added Support for `GetFunctionConcurrency` api - [Reference](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConcurrency.html)
* DeleteFunctionConcurrency: Added Support for `DeleteFunctionConcurrency` api - [Reference](https://docs.aws.amazon.com/lambda/latest/dg/API_DeleteFunctionConcurrency.html)

Test:


* Added Unit test cases for `GetFunctionConcurrency` and `DeleteFunctionConcurrency`
* Added Ingtegration test cases for `GetFunctionConcurrency` and `DeleteFunctionConcurrency`

This PR will also fix issue #3260.



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-346) by [Unito](https://www.unito.io/learn-more)
