### PR TITLE
Centos 8 fix (Service "ANY_SERVICE_HERE" not yet available, retrying...)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,4 +88,4 @@ RUN apk del --purge git;
 RUN rm -rf /tmp/localstack/*elasticsearch* /tmp/localstack.* tests/ /root/.npm/*cache /opt/terraform
 
 # Fix for Centos host OS
-echo "127.0.0.1 localhost.localdomain" >> /etc/hosts
+RUN echo "127.0.0.1 localhost.localdomain" >> /etc/hosts

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,3 +86,6 @@ RUN LAMBDA_EXECUTOR=local make test
 # clean up temporary files created during test execution
 RUN apk del --purge git;
 RUN rm -rf /tmp/localstack/*elasticsearch* /tmp/localstack.* tests/ /root/.npm/*cache /opt/terraform
+
+# Fix for Centos host OS
+echo "127.0.0.1 localhost.localdomain" >> /etc/hosts

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pympler>=0.6
 pyopenssl==17.5.0
 python-coveralls>=2.9.1
 pyyaml>=3.13,<=5.1
-Quart>=0.12.0
+Quart>=0.6.15
 requests>=2.20.0               #basic-lib
 requests-aws4auth==0.9
 sasl>=0.2.1


### PR DESCRIPTION
This is a fix for Centos 8 that solves: Service "ANY_SERVICE_HERE" not yet available, retrying...

#808



┆Issue is synchronized with this [Jira Bug](https://localstack.atlassian.net/browse/LOC-353) by [Unito](https://www.unito.io/learn-more)
