### PR TITLE
Fix issues when deploying CF template with FN::ImportValue short-form FN::Sub

### DIFF
--- a/localstack/services/cloudformation/cloudformation_listener.py
+++ b/localstack/services/cloudformation/cloudformation_listener.py
@@ -201,7 +201,6 @@ class ProxyListenerCloudFormation(ProxyListener):
 
         req_data = None
         if method == 'POST' and path == '/':
-
             req_data = urlparse.parse_qs(to_str(data))
             req_data = dict([(k, v[0]) for k, v in req_data.items()])
             action = req_data.get('Action')

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -29,7 +29,6 @@ class EventsRule(BaseModel):
 
 
 class LogsLogGroup(BaseModel):
-
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == 'Arn':
             return self.params.get('Arn') or aws_stack.log_group_arn(self.params.get('LogGroupName'))

--- a/tests/integration/templates/template23.yaml
+++ b/tests/integration/templates/template23.yaml
@@ -1,0 +1,53 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Template which showcases dependency resolution failure with shorthand Sub
+Parameters:
+  Environment:
+    Type: String
+    Description: Environment name
+    Default: 'Test'
+Resources:
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      # This does not work
+      LogGroupName: !Sub "aws/lambda/${Environment}-function"
+      # This also does not work
+#      LogGroupName:
+#        Fn::Sub: "aws/lambda/${Environment}-function"
+      # This does work
+#      LogGroupName:
+#        Fn::Sub:
+#          - "aws/lambda/${Environment}-function"
+#          - {}
+      # This works too
+#      LogGroupName:
+#        Fn::Join:
+#        - ''
+#        - - aws/lambda/
+#          - !Ref Environment
+#          - -function
+
+  Role:
+    Type: AWS::IAM::Role
+    DependsOn:
+    - LogGroup
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:PutLogEvents
+            Resource: '*'
+      Path: "/"


### PR DESCRIPTION
* Handle physical resource id from Resource
* Handle FN::ImportValue
* Handle short form FN::Sub
* Add integration test for template with short form FN::Sub

Issue fixed:
#3251 CloudFormation YAML short form !Sub / Fn::Sub in dependent resource causes dependency resolution failure
#3184 CF template FN::ImportValue fails on parameter validation.

**Please refer to the contribution guidelines in the README when submitting PRs.**
