### PR TITLE
Fix issue when deploying CF template with FN::Sub

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -329,7 +329,15 @@ def apply_patches():
                         if not isinstance(val, str):
                             continue
 
+                        for k, v in resource_json['Fn::Sub'][1].items():
+                            if isinstance(v, dict) and 'Ref' in v:
+                                if v['Ref'] == key:
+                                    resource_json['Fn::Sub'][1][k] = val
+
                         resource_json['Fn::Sub'][0] = resource_json['Fn::Sub'][0].replace('${%s}' % key, val)
+
+                    for k, v in resource_json['Fn::Sub'][1].items():
+                        resource_json['Fn::Sub'][0] = resource_json['Fn::Sub'][0].replace('${%s}' % k, v)
 
                     return resource_json['Fn::Sub'][0]
 

--- a/localstack/stepfunctions/models.py
+++ b/localstack/stepfunctions/models.py
@@ -7,7 +7,6 @@ from moto.core import BaseModel
 
 
 class StateMachine(BaseModel):
-
     def __init__(self, name, definition=None, role_arn=None):
         super(StateMachine, self).__init__()
         self.name = name

--- a/tests/integration/templates/template23.yaml
+++ b/tests/integration/templates/template23.yaml
@@ -5,6 +5,10 @@ Parameters:
     Type: String
     Description: Environment name
     Default: 'Test'
+  ApiKey:
+    Type: String
+    Description: API key
+
 Resources:
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -51,3 +55,54 @@ Resources:
             - logs:PutLogEvents
             Resource: '*'
       Path: "/"
+
+  # IAM role for running the step function
+  StateMachineExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service: !Sub states.${AWS::Region}.amazonaws.com
+          Action: "sts:AssumeRole"
+      Policies:
+      - PolicyName: StatesExecutionPolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action: "lambda:InvokeFunction"
+            Resource: "*"
+
+  # Step function that executes the workflow
+  StateMachine:
+    Type: "AWS::StepFunctions::StateMachine"
+    Properties:
+      RoleArn: !GetAtt StateMachineExecutionRole.Arn
+      DefinitionString:
+        !Sub
+      - |-
+        {
+          "Comment": "",
+          "StartAt": "time-series-update",
+          "States": {
+            "time-series-update": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+              "HeartbeatSeconds": 3600,
+              "Parameters": {
+                "FunctionName": "some-lambda",
+                "Payload": {
+                  "key": "${apiKey}"
+                }
+              },
+              "ResultPath": "$.timeSeriesUpdateResult",
+              "End": true
+            }
+          }
+        }
+      - {
+        apiKey: !Ref ApiKey
+      }

--- a/tests/integration/templates/template24.yaml
+++ b/tests/integration/templates/template24.yaml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  Environment:
+    Type: String
+    Description: Environment name
+    Default: 'Test'
+
+Resources:
+  ExecutionRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service: "lambda.amazonaws.com"
+          Action: "sts:AssumeRole"
+      Policies:
+      - PolicyName: ExecutionPolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Allow
+            Action: "logs:PutLogEvents"
+            Resource: "*"
+
+  LambdaFunction:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Code:
+        S3Bucket: '%s'
+        S3Key: '%s'
+      FunctionName:
+        Fn::Sub: localstack-websockets-${Environment}-connectionHandler
+      Handler: lambda_echo.handler
+      MemorySize: 1024
+      Role:
+        Fn::GetAtt:
+        - ExecutionRole
+        - Arn
+      Runtime: nodejs12.x
+      Timeout: 30

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -513,6 +513,7 @@ def _await_stack_status(stack_name, expected_status, retries=3, sleep=2):
         stack = get_stack_details(stack_name)
         assert stack['StackStatus'] == expected_status
         return stack
+
     return retry(check_stack, retries, sleep)
 
 
@@ -579,8 +580,8 @@ class CloudFormationTest(unittest.TestCase):
         # assert that subscription attributes are added properly
         attrs = sns.get_subscription_attributes(SubscriptionArn=subs[0]['SubscriptionArn'])['Attributes']
         self.assertEqual(attrs, {'Endpoint': subs[0]['Endpoint'], 'Protocol': 'sqs',
-            'SubscriptionArn': subs[0]['SubscriptionArn'], 'TopicArn': subs[0]['TopicArn'],
-            'FilterPolicy': json.dumps({'eventType': ['created']})})
+                                 'SubscriptionArn': subs[0]['SubscriptionArn'], 'TopicArn': subs[0]['TopicArn'],
+                                 'FilterPolicy': json.dumps({'eventType': ['created']})})
 
         # assert that Gateway responses have been created
         test_api_name = 'test-api'
@@ -1728,14 +1729,73 @@ class CloudFormationTest(unittest.TestCase):
                 {
                     'ParameterKey': 'Environment',
                     'ParameterValue': environment
+                },
+                {
+                    'ParameterKey': 'ApiKey',
+                    'ParameterValue': '12345'
                 }
             ]
         )
         iam_client = aws_stack.connect_to_service('iam')
         rs = iam_client.list_roles()
 
-        # Role created successfully
-        self.assertEqual(len([role for role in rs['Roles'] if role['RoleName'] == 'cf-{}-Role'.format(stack_name)]), 1)
+        # 2 roles created successfully
+        roles = [role for role in rs['Roles']
+                 if role['RoleName'] in ['cf-{}-Role'.format(stack_name),
+                                         'cf-{}-StateMachineExecutionRole'.format(stack_name)]]
+
+        self.assertEqual(len(roles), 2)
+
+        sfn_client = aws_stack.connect_to_service('stepfunctions')
+        state_machines_after = sfn_client.list_state_machines()['stateMachines']
+
+        state_machines = [sm for sm in state_machines_after if '{}-StateMachine-'.format(stack_name) in sm['name']]
+
+        self.assertEqual(len(state_machines), 1)
+        rs = sfn_client.describe_state_machine(stateMachineArn=state_machines[0]['stateMachineArn'])
+
+        definition = json.loads(rs['definition'].replace('\n', ''))
+        payload = definition['States']['time-series-update']['Parameters']['Payload']
+        self.assertEqual(payload, {'key': '12345'})
+
+        # clean up
+        cloudformation.delete_stack(StackName=stack_name)
+
+    def test_sub_in_lambda_function_name(self):
+        stack_name = 'stack-%s' % short_uid()
+        environment = 'env-%s' % short_uid()
+        bucket = 'bucket-%s' % short_uid()
+        key = 'key-%s' % short_uid()
+
+        package_path = os.path.join(THIS_FOLDER, 'lambdas', 'lambda_echo.js')
+
+        s3 = aws_stack.connect_to_service('s3')
+        s3.create_bucket(Bucket=bucket, ACL='public-read')
+        s3.put_object(Bucket=bucket, Key=key, Body=create_zip_file(package_path, True))
+        time.sleep(1)
+
+        template = load_file(os.path.join(THIS_FOLDER, 'templates', 'template24.yaml')) % (bucket, key)
+
+        cloudformation = aws_stack.connect_to_service('cloudformation')
+        cloudformation.create_stack(
+            StackName=stack_name,
+            TemplateBody=template,
+            Parameters=[
+                {
+                    'ParameterKey': 'Environment',
+                    'ParameterValue': environment
+                }
+            ]
+        )
+
+        lambda_client = aws_stack.connect_to_service('lambda')
+        func_name = 'localstack-websockets-{}-connectionHandler'.format(environment)
+
+        resp = lambda_client.list_functions()
+
+        # lambda function created with expected name
+        functions = [func for func in resp['Functions'] if func['FunctionName'] == func_name]
+        self.assertEqual(len(functions), 1)
 
         # clean up
         cloudformation.delete_stack(StackName=stack_name)


### PR DESCRIPTION
* Handle FN::Sub in resource properties (stepfunctions' definition, lambda function name)
* Add integration test for template

Issue fixed:
#3293 CloudFormation template substitution using !sub not working in latest
#3294 CloudFormation - the use of intrinsic functions in AWS::Lambda::Function FunctionName...
