### PR TITLE
Feature test invoke method apigw

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -59,20 +59,19 @@ class ProxyListenerApiGateway(ProxyListener):
                 return put_gateway_response(api_id, response_type, data)
 
         match = re.match(PATH_REGEX_TEST_INVOKE_API, path)
-        if match:
-            if method == 'POST':
-                kwargs = {}
+        if match and method == 'POST':
+            kwargs = {}
 
-                # if call is from test_invoke_api then use http_method to find the integration,
-                # as test_invoke_api make POST call to interect
-                method = match[3]
-                if data:
-                    orig_data = data
-                    path_with_query_string = orig_data.get('pathWithQueryString', None)
-                    data = data.get('body', None)
-                    headers = orig_data.get('headers', {})
-                    kwargs = {'path_with_query_string': path_with_query_string} if path_with_query_string else {}
-                return invoke_rest_api_from_request(method=method, path=path, data=data, headers=headers, **kwargs)
+            # if call is from test_invoke_api then use http_method to find the integration,
+            # as test_invoke_api make POST call to interect
+            method = match[3]
+            if data:
+                orig_data = data
+                path_with_query_string = orig_data.get('pathWithQueryString', None)
+                data = data.get('body', None)
+                headers = orig_data.get('headers', {})
+                kwargs = {'path_with_query_string': path_with_query_string} if path_with_query_string else {}
+            return invoke_rest_api_from_request(method=method, path=path, data=data, headers=headers, **kwargs)
         return True
 
     def return_response(self, method, path, data, headers, response):

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -260,7 +260,6 @@ def invoke_rest_api(api_id, stage, method, invocation_path, data, headers, path=
     authorize_invocation(api_id, headers)
     path_map = helpers.get_rest_api_paths(rest_api_id=api_id)
     try:
-        # print('path:', relative_path, 'path_map', path_map)
         extracted_path, resource = get_resource_for_path(path=relative_path, path_map=path_map)
     except Exception:
         return make_error_response('Unable to find path %s' % path, 404)

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -250,7 +250,7 @@ def get_resource_for_path(path, path_map):
             matches.append((api_path, details))
     if not matches:
         return None
-    if len(matches) >= 1:
+    if len(matches) > 1:
         # check if we have an exact match
         for match in matches:
             if match[0] == path:

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -211,6 +211,8 @@ def extract_query_string_params(path):
             query_string_params[query_param_name] = query_param_values
 
     # strip trailing slashes from path to fix downstream lookups
+    if path.endswith('None') and len(path.split('None')) > 0:
+        path = path.split('None')[0]
     path = path.rstrip('/') or '/'
     return [path, query_string_params]
 
@@ -248,7 +250,7 @@ def get_resource_for_path(path, path_map):
             matches.append((api_path, details))
     if not matches:
         return None
-    if len(matches) > 1:
+    if len(matches) >= 1:
         # check if we have an exact match
         for match in matches:
             if match[0] == path:

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -303,8 +303,9 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
             'queryStringParameters': query_string_params,
             'multiValueQueryStringParameters': multi_value_dict_for_list(query_string_params),
             'requestContext': request_context,
-            'stageVariables': get_stage_variables(api_id, stage),
         }
+        if stage:
+            event['stageVariables'] = get_stage_variables(api_id, stage)
         LOG.debug('Running Lambda function %s from API Gateway invocation: %s %s' % (func_arn, method or 'GET', path))
         return run_lambda(event=event, context=event_context, func_arn=func_arn,
             asynchronous=not config.SYNCHRONOUS_API_GATEWAY_EVENTS)

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -931,20 +931,26 @@ class TestAPIGateway(unittest.TestCase):
             description='test'
         )
 
-        resources = client.get_resources(
+        root_resource = client.get_resources(
             restApiId=rest_api['id']
+        )
+
+        resource = client.create_resource(
+            restApiId=rest_api['id'],
+            parentId=root_resource['items'][0]['id'],
+            pathPart='foo'
         )
 
         client.put_method(
             restApiId=rest_api['id'],
-            resourceId=resources['items'][0]['id'],
+            resourceId=resource['id'],
             httpMethod='GET',
             authorizationType='NONE'
         )
 
         client.put_integration(
             restApiId=rest_api['id'],
-            resourceId=resources['items'][0]['id'],
+            resourceId=resource['id'],
             httpMethod='GET',
             type='AWS',
             uri='arn:aws:apigateway:{}:lambda:path//2015-03-31/functions/{}/invocations'.format(
@@ -954,15 +960,16 @@ class TestAPIGateway(unittest.TestCase):
 
         response = client.test_invoke_method(
             restApiId=rest_api['id'],
-            resourceId=resources['items'][0]['id'],
-            httpMethod='GET'
+            resourceId=resource['id'],
+            httpMethod='GET',
+            pathWithQueryString='/foo'
         )
         self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
         response = client.test_invoke_method(
             restApiId=rest_api['id'],
-            resourceId=resources['items'][0]['id'],
+            resourceId=resource['id'],
             httpMethod='GET',
-            pathWithQueryString='/',
+            pathWithQueryString='/foo',
             body='{"test": "val"}',
             headers={
                 'content-type': 'application/json'


### PR DESCRIPTION
Added support for the test-invoke-method feature. It tests the integrated method before making the deployment of the api-gateway.
Also added simulated method, headers, body, and pathWithQueryString.
Added test cases for test-invoke-method.
Fix for #3291 