### PR TITLE
Add gzip encoding of response payloads to edge service

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -1,6 +1,7 @@
 import re
 import os
 import sys
+import gzip
 import json
 import signal
 import logging
@@ -82,6 +83,12 @@ class ProxyListenerEdge(ProxyListener):
             data = json.dumps(data)
 
         return do_forward_request(api, port, method, path, data, headers)
+
+    def return_response(self, method, path, data, headers, response, request_handler=None):
+        if headers.get('Accept-Encoding') == 'gzip' and response._content:
+            response._content = gzip.compress(to_bytes(response._content))
+            response.headers['Content-Length'] = str(len(response._content))
+            response.headers['Content-Encoding'] = 'gzip'
 
 
 def do_forward_request(api, port, method, path, data, headers):

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1,5 +1,4 @@
 import time
-import gzip
 import re
 import json
 import uuid
@@ -1374,11 +1373,6 @@ class ProxyListenerS3(PersistingProxyListener):
 
             # convert to chunked encoding, for compatibility with certain SDKs (e.g., AWS PHP SDK)
             convert_to_chunked_encoding(method, path, response)
-
-            if headers.get('Accept-Encoding') == 'gzip' and response._content:
-                response._content = gzip.compress(to_bytes(response._content))
-                response.headers['Content-Length'] = str(len(response._content))
-                response.headers['Content-Encoding'] = 'gzip'
 
 
 def authenticate_presign_url(method, path, headers, data=None):


### PR DESCRIPTION
Add gzip encoding of response payloads to edge service - based on the `Accept-Encoding` HTTP header.