### PR TITLE
Handle host name for in-memory routing

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -889,7 +889,9 @@ def get_key_name(path, headers):
 
 
 def uses_path_addressing(headers):
-    host = headers.get(constants.HEADER_LOCALSTACK_EDGE_URL, '').split('://')[-1] or headers['host']
+    # we can assume that the host header we are receiving here is actually the header we originally recieved
+    # from the client (because the edge service is forwarding the request in memory)
+    host = headers.get('host') or headers.get(constants.HEADER_LOCALSTACK_EDGE_URL, '').split('://')[-1]
     return host.startswith(HOSTNAME) or host.startswith(HOSTNAME_EXTERNAL) or host.startswith(LOCALHOST_IP)
 
 

--- a/tests/integration/lambdas/lambda_triggered_by_sqs_download_s3_file.py
+++ b/tests/integration/lambdas/lambda_triggered_by_sqs_download_s3_file.py
@@ -1,0 +1,13 @@
+import boto3
+import os
+
+EDGE_PORT = 4566
+
+
+def handler(event, context):
+    protocol = 'https' if os.environ.get('USE_SSL') else 'http'
+    endpoint_url = '{}://{}:{}'.format(protocol, os.environ['LOCALSTACK_HOSTNAME'], EDGE_PORT)
+    s3 = boto3.client('s3', endpoint_url=endpoint_url, region_name='us-east-1', verify=False)
+    s3.download_file(os.environ['BUCKET_NAME'], os.environ['OBJECT_NAME'], os.environ['LOCAL_FILE_NAME'])
+    print('success')
+    return

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -349,7 +349,7 @@ class SQSTest(unittest.TestCase):
         self.assertEqual(len(rs.get('Messages', [])), 0)
 
         # assert that message has been put on the DLQ
-        retry(lambda: self.receive_dlq(queue_url1, False), retries=8, sleep=2)
+        retry(lambda: self.receive_dlq(queue_url1, assert_receive_count=2), retries=8, sleep=2)
 
     def test_set_queue_attribute_at_creation(self):
         queue_name = 'queue-%s' % short_uid()
@@ -865,7 +865,7 @@ class SQSTest(unittest.TestCase):
     # HELPER METHODS
     # ---------------
 
-    def receive_dlq(self, queue_url, assert_error_details=True):
+    def receive_dlq(self, queue_url, assert_error_details=False, assert_receive_count=None):
         """ Assert that a message has been received on the given DLQ """
         result = self.client.receive_message(QueueUrl=queue_url, MessageAttributeNames=['All'])
         self.assertGreater(len(result['Messages']), 0)
@@ -876,4 +876,5 @@ class SQSTest(unittest.TestCase):
             self.assertIn('ErrorCode', msg_attrs)
             self.assertIn('ErrorMessage', msg_attrs)
         else:
-            self.assertEqual('2', msg_attrs.get('ApproximateReceiveCount'))
+            if assert_receive_count is not None:
+                self.assertEqual(str(assert_receive_count), msg_attrs.get('ApproximateReceiveCount'))


### PR DESCRIPTION
Addresses the issue: https://github.com/localstack/localstack/issues/3160