### PR TITLE
Fix issue when deploying cfn template related to cfn backend set_exports method

### DIFF
--- a/tests/integration/templates/template26.yaml
+++ b/tests/integration/templates/template26.yaml
@@ -35,6 +35,11 @@ Resources:
             Action:
             - ec2:GetPasswordData
 
+  SnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub '${Environment}-slack-sns-topic'
+
 Outputs:
   VpcId:
     Value: !Ref VPC
@@ -45,4 +50,9 @@ Outputs:
     Value: !GetAtt InstanceRole.Arn
     Export:
       Name: RoleArn
+
+  TopicArn:
+    Value: !Ref SnsTopic
+    Export:
+      Name: !Ref SnsTopic
 

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1819,5 +1819,9 @@ class CloudFormationTest(unittest.TestCase):
         self.assertIn('VpcId', outputs)
         self.assertEqual(outputs['VpcId'].get('export'), '{}-vpc-id'.format(environment))
 
+        topic_arn = aws_stack.sns_topic_arn('{}-slack-sns-topic'.format(environment))
+        self.assertIn('TopicArn', outputs)
+        self.assertEqual(outputs['TopicArn'].get('export'), topic_arn)
+
         # clean up
         cfn.delete_stack(StackName=stack_name)


### PR DESCRIPTION
* Patch cfn backend missing method (This patched has provided in moto-ext==1.3.15.45)
* Update integration test

Issue fixed:
#3375 CloudFormation - All deployed stacks have StackStatus: CREATE_FAILED
