### PR TITLE
md5 check on multipart upload

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1069,7 +1069,7 @@ class ProxyListenerS3(PersistingProxyListener):
         if 's3.amazonaws.com' not in headers.get('host', ''):
             headers['host'] = 'localhost'
 
-        # check content md5 hash integrity if not a copy request
+        # check content md5 hash integrity if not a copy request or multipart initialization
         if 'Content-MD5' in headers and not self.is_s3_copy_request(headers, path) \
                 and not self.is_create_multipart_request(parsed_path.query):
             response = check_content_md5(data, headers)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1002,6 +1002,14 @@ class ProxyListenerS3(PersistingProxyListener):
         return 'x-amz-copy-source' in headers or 'x-amz-copy-source' in path
 
     @staticmethod
+    def is_create_multipart_request(query):
+        return query.startswith('uploads')
+
+    @staticmethod
+    def is_multipart_upload(query):
+        return query.startswith('uploadId')
+
+    @staticmethod
     def get_201_response(key, bucket_name):
         return """
                 <PostResponse>
@@ -1062,7 +1070,8 @@ class ProxyListenerS3(PersistingProxyListener):
             headers['host'] = 'localhost'
 
         # check content md5 hash integrity if not a copy request
-        if 'Content-MD5' in headers and not self.is_s3_copy_request(headers, path):
+        if 'Content-MD5' in headers and not self.is_s3_copy_request(headers, path) \
+                and not self.is_create_multipart_request(parsed_path.query):
             response = check_content_md5(data, headers)
             if response is not None:
                 return response


### PR DESCRIPTION
#3347  skip checking content md5 upon create-multipart-request as it return uploadID which is used at the time of actual object upload.