### PR TITLE
fixing .NET SDK error - SNS message format doesn't allow null values

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -526,7 +526,6 @@ def make_error(message, code=400, code_string='InvalidParameter'):
 
 def create_sns_message_body(subscriber, req_data, message_id=None):
     message = req_data['Message'][0]
-    subject = req_data.get('Subject', [None])[0]
     protocol = subscriber['Protocol']
 
     if six.PY2 and type(message).__name__ == 'unicode':
@@ -546,10 +545,8 @@ def create_sns_message_body(subscriber, req_data, message_id=None):
     data = {
         'Type': req_data.get('Type', ['Notification'])[0],
         'MessageId': message_id,
-        'Token': req_data.get('Token', [None])[0],
         'TopicArn': subscriber['TopicArn'],
         'Message': message,
-        'SubscribeURL': req_data.get('SubscribeURL', [None])[0],
         'Timestamp': timestamp_millis(),
         'SignatureVersion': '1',
         # TODO Add a more sophisticated solution with an actual signature
@@ -558,8 +555,9 @@ def create_sns_message_body(subscriber, req_data, message_id=None):
         'SigningCertURL': 'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem'
     }
 
-    if subject is not None:
-        data['Subject'] = subject
+    for key in ['Subject', 'SubscribeURL', 'Token']:
+        if req_data.get(key):
+            data[key] = req_data[key][0]
 
     attributes = get_message_attributes(req_data)
     if attributes:

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -89,8 +89,6 @@ class SNSTests(unittest.TestCase):
             'SignatureVersion': '1',
             'SigningCertURL':
                 'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem',
-            'SubscribeURL': None,
-            'Token': None,
             'TopicArn': 'arn',
             'Type': 'Notification'
         })
@@ -119,8 +117,6 @@ class SNSTests(unittest.TestCase):
             'SignatureVersion': '1',
             'SigningCertURL':
                 'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem',
-            'SubscribeURL': None,
-            'Token': None,
             'TopicArn': 'arn',
             'Type': 'Notification',
             'MessageAttributes': {


### PR DESCRIPTION
As discussed in #2165, the AWS .NET SDK has problems with null values in the response JSON.

So I edited the code to only add this fields if they are not null.