### PR TITLE
Added missed endpoint and domain for es connect call from firehose

### DIFF
--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -62,7 +62,7 @@ def put_records(stream_name, records):
             es_dest = dest['ESDestinationDescription']
             es_index = es_dest['IndexName']
             es_type = es_dest.get('TypeName')
-            es = connect_elasticsearch()
+            es = connect_elasticsearch(endpoint=es_dest.get('ClusterEndpoint'), domain=es_dest.get('DomainARN'))
             for record in records:
                 obj_id = uuid.uuid4()
 


### PR DESCRIPTION
@whummer I don't see this as fully completed PR and it's a starting point. 

There is a general issue with elasticsearch after it has got a dynamic port.  `connect_elasticsearch` used without any parameters and as result `endpoint` is defined as`http://localhost:0` and firehose is not able to put records. Firehose tries to connect on 9200 port while Elasticsearch is running on another port.

There is another issue in es_starter.py with in `check_elasticsearch`. This method also calls  `connect_elasticsearch`  with no inputs and fails with this error 
```
localstack_1    |   File "/opt/code/localstack/localstack/services/plugins.py", line 99, in check_infra
localstack_1    |     additional(expect_shutdown=expect_shutdown)
localstack_1    |   File "/opt/code/localstack/localstack/services/es/es_starter.py", line 97, in check_elasticsearch
localstack_1    |     assert isinstance(out, six.string_types)
localstack_1    | AssertionError
```
I don't know what is the best way to pass port to that method.

I used image localstack/localstack-full:0.12.4 . I would like to get your suggestions and know more about `TEST_ELASTICSEARCH_URL`. 
