### PR TITLE
Fixed and added 'location' in 201 and 204 responses

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -555,7 +555,7 @@ class S3ListenerTest(unittest.TestCase):
                     <ETag>{etag}</ETag>
                 </PostResponse>
                 """.format(
-            location='http://localhost/key-my-file',
+            location='http://localhost:4566/' + bucket_name + '/key-my-file',
             bucket=bucket_name,
             key='key-my-file',
             etag='d41d8cd98f00b204e9800998ecf8427f'


### PR DESCRIPTION
When making a POST request to AWS S3 the HTTP 204 response includes a "Location" header where the uploaded object can be found. This header is missing in LocalStack.
This PR adds the missing header.

Current behavior:
**Amazon S3**

Request:
```
POST / HTTP/1.1
Host: mybucket.s3.eu-central-1.amazonaws.com
Content-Type: multipart/form-data; boundary=----WebKitFormBoundary3wktu4fYIB8OnZBK
...
```

Response:
```
HTTP/1.1 204 No Content
x-amz-id-2: 8OSqzYyCkY6eaUc5PaklRnHzlbta8cXDTNXTJfQkb3CA4iexjRcEw4HGhk6TU5+Kp+sasKWCFv0=
x-amz-request-id: 1AEBFFF1F332A912
Server: AmazonS3
Location: https://mybucket.s3.eu-central-1.amazonaws.com/test.zip
...
```

**LocalStack**

Request:
```
POST /mybucket HTTP/1.1
Host: localhost:4566
Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryC2enEWmAhB0PzOAL
...
```

Response:
```
HTTP/1.1 204
content-type: text/html; charset=utf-8
content-length: 0
server: hypercorn-h11
...
```

With this fix applied the LocalStack response would include the header
`location: https://localhost:4566/mybucket/test.zip`