### PR TITLE
Fix returning LogResult from synchronous Lambda invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ install-basic:     ## Install basic dependencies for CLI usage in virtualenv
 		($(VENV_RUN); cat requirements.txt | grep -ve '^#' | grep '#\(basic\|extended\)' | sed 's/ #.*//' \
 			| xargs $(PIP_CMD) install)
 
-install-web:       ## Install npm dependencies for dashboard Web UI
+# deprecated - TODO remove
+install-web:
 	(cd localstack/dashboard/web && (test ! -e package.json || npm install --silent > /dev/null))
 
 publish:           ## Publish the library to the central PyPi repository
@@ -128,17 +129,18 @@ docker-cp-coverage:
 		docker cp $$id:/opt/code/localstack/.coverage .coverage; \
 		docker rm -v $$id
 
-web:               ## Start web application (dashboard)
+# deprecated - TODO remove
+web:
 	($(VENV_RUN); bin/localstack web)
 
 test:              ## Run automated tests
 	make lint && \
 		($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests $(NOSE_ARGS) --with-timer --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py' $(TEST_PATH))
 
-test-docker:       ## Run automated tests in Docker
+test-docker:
 	ENTRYPOINT="--entrypoint=" CMD="make test" make docker-run
 
-test-docker-mount:
+test-docker-mount: ## Run automated tests in Docker (mounting local code)
 	ENTRYPOINT="-v `pwd`/tests:/opt/code/localstack/tests" make test-docker-mount-code
 
 test-docker-mount-code:

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -309,8 +309,11 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
             'stageVariables': get_stage_variables(api_id, stage),
         }
         LOG.debug('Running Lambda function %s from API Gateway invocation: %s %s' % (func_arn, method or 'GET', path))
-        return run_lambda(event=event, context=event_context, func_arn=func_arn,
-            asynchronous=not config.SYNCHRONOUS_API_GATEWAY_EVENTS)
+        asynchronous = not config.SYNCHRONOUS_API_GATEWAY_EVENTS
+        result = run_lambda(event=event, context=event_context, func_arn=func_arn, asynchronous=asynchronous)
+        if not asynchronous:
+            result, log_output = result
+        return result
     except Exception as e:
         LOG.warning('Unable to run Lambda function on API Gateway message: %s %s' % (e, traceback.format_exc()))
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -310,10 +310,8 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
         }
         LOG.debug('Running Lambda function %s from API Gateway invocation: %s %s' % (func_arn, method or 'GET', path))
         asynchronous = not config.SYNCHRONOUS_API_GATEWAY_EVENTS
-        result = run_lambda(event=event, context=event_context, func_arn=func_arn, asynchronous=asynchronous)
-        if not asynchronous:
-            result, log_output = result
-        return result
+        inv_result = run_lambda(event=event, context=event_context, func_arn=func_arn, asynchronous=asynchronous)
+        return inv_result.result
     except Exception as e:
         LOG.warning('Unable to run Lambda function on API Gateway message: %s %s' % (e, traceback.format_exc()))
 
@@ -342,7 +340,8 @@ def process_sns_notification(func_arn, topic_arn, subscription_arn, message, mes
             }
         }]
     }
-    return run_lambda(event=event, context={}, func_arn=func_arn, asynchronous=not config.SYNCHRONOUS_SNS_EVENTS)
+    inv_result = run_lambda(event=event, context={}, func_arn=func_arn, asynchronous=not config.SYNCHRONOUS_SNS_EVENTS)
+    return inv_result.result
 
 
 def process_kinesis_records(records, stream_name):
@@ -557,10 +556,10 @@ def run_lambda(event, context, func_arn, version=None, suppress_output=False, as
         func_arn = aws_stack.fix_arn(func_arn)
         func_details = ARN_TO_LAMBDA.get(func_arn)
         if not func_details:
-            return not_found_error(msg='The resource specified in the request does not exist.')
+            result = not_found_error(msg='The resource specified in the request does not exist.')
+            return lambda_executors.InvocationResult(result)
 
         context = LambdaContext(func_details, version, context)
-
         result = LAMBDA_EXECUTOR.execute(func_arn, func_details, event, context=context,
             version=version, asynchronous=asynchronous, callback=callback)
 
@@ -1336,11 +1335,12 @@ def invoke_function(function):
     invocation_type = request.headers.get('X-Amz-Invocation-Type', 'RequestResponse')
     log_type = request.headers.get('X-Amz-Log-Type')
 
-    def _create_response(result, status_code=200, headers={}):
+    def _create_response(invocation_result, status_code=200, headers={}):
         """ Create the final response for the given invocation result. """
-        log_output = ''
-        if isinstance(result, tuple):
-            result, log_output = result
+        if not isinstance(invocation_result, lambda_executors.InvocationResult):
+            invocation_result = lambda_executors.InvocationResult(invocation_result)
+        result = invocation_result.result
+        log_output = invocation_result.log_output
         details = {
             'StatusCode': status_code,
             'Payload': result,

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -144,9 +144,10 @@ class LambdaExecutor(object):
                 # start the execution
                 raised_error = None
                 result = None
+                log_output = None
                 dlq_sent = None
                 try:
-                    result = self._execute(func_arn, func_details, event, context, version)
+                    result, log_output = self._execute(func_arn, func_details, event, context, version)
                 except Exception as e:
                     raised_error = e
                     if asynchronous:
@@ -163,7 +164,9 @@ class LambdaExecutor(object):
                     self.function_invoke_times[func_arn] = invocation_time
                     callback and callback(result, func_arn, event, error=raised_error, dlq_sent=dlq_sent)
                 # return final result
-                return result
+                if asynchronous:
+                    return result
+                return result, log_output
 
             return _run(func_arn=func_arn)
 
@@ -230,7 +233,7 @@ class LambdaExecutor(object):
             raise Exception('Lambda process returned error status code: %s. Result: %s. Output:\n%s' %
                 (return_code, result, log_output))
 
-        return result
+        return result, log_output
 
 
 class ContainerInfo:

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -18,8 +18,8 @@ from localstack import config
 from localstack.utils import bootstrap
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
-    CaptureOutput, FuncThread, TMP_FILES, short_uid, save_file, rm_rf, in_docker,
-    to_str, to_bytes, run, cp_r, json_safe, get_free_tcp_port)
+    CaptureOutput, FuncThread, TMP_FILES, short_uid, save_file, rm_rf, in_docker, long_uid,
+    now, to_str, to_bytes, run, cp_r, json_safe, get_free_tcp_port)
 from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR
 from localstack.utils.aws.dead_letter_queue import lambda_error_to_dead_letter_queue, sqs_error_to_dead_letter_queue
 from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs, cloudwatched
@@ -118,6 +118,14 @@ def get_main_endpoint_from_container():
     return DOCKER_MAIN_CONTAINER_IP or config.DOCKER_HOST_FROM_CONTAINER
 
 
+class InvocationResult(object):
+    def __init__(self, result, log_output=''):
+        if isinstance(result, InvocationResult):
+            raise Exception('Unexpected invocation result type: %s' % result)
+        self.result = result
+        self.log_output = log_output or ''
+
+
 class LambdaExecutor(object):
     """ Base class for Lambda executors. Subclasses must overwrite the _execute method """
     def __init__(self):
@@ -162,12 +170,7 @@ class LambdaExecutor(object):
                 finally:
                     self.function_invoke_times[func_arn] = invocation_time
                     callback and callback(result, func_arn, event, error=raised_error, dlq_sent=dlq_sent)
-                # construct and return final result
-                if not asynchronous:
-                    log_output = ''
-                    if isinstance(result, tuple) and len(result) == 2:
-                        result, log_output = result
-                    return result, log_output
+                # return final result
                 return result
 
             return _run(func_arn=func_arn)
@@ -176,7 +179,7 @@ class LambdaExecutor(object):
         if asynchronous:
             LOG.debug('Lambda executed in Event (asynchronous) mode, no response will be returned to caller')
             FuncThread(do_execute).start()
-            return None, 'Lambda executed asynchronously.'
+            return InvocationResult(None, log_output='Lambda executed asynchronously.')
 
         return do_execute()
 
@@ -235,7 +238,8 @@ class LambdaExecutor(object):
             raise Exception('Lambda process returned error status code: %s. Result: %s. Output:\n%s' %
                 (return_code, result, log_output))
 
-        return result, log_output
+        invocation_result = InvocationResult(result, log_output=log_output)
+        return invocation_result
 
 
 class ContainerInfo:
@@ -756,21 +760,28 @@ class LambdaExecutorLocal(LambdaExecutor):
                 sys.path = path_before
 
         process = Process(target=do_execute)
+        start_time = now(millis=True)
         with CaptureOutput() as c:
             process.run()
         result = queue.get()
+        end_time = now(millis=True)
 
         # Make sure to keep the log line below, to ensure the log stream gets created
-        log_output = 'START: Lambda %s started via "local" executor ...' % func_arn
+        request_id = long_uid()
+        log_output = 'START %s: Lambda %s started via "local" executor ...' % (request_id, func_arn)
         # TODO: Interweaving stdout/stderr currently not supported
         for stream in (c.stdout(), c.stderr()):
             if stream:
                 log_output += ('\n' if log_output else '') + stream
+        log_output += '\nEND RequestId: %s' % request_id
+        log_output += '\nREPORT RequestId: %s Duration: %s ms' % (request_id, int((end_time - start_time) * 1000))
 
         # store logs to CloudWatch
         _store_logs(func_details, log_output)
 
-        return result
+        result = result.result if isinstance(result, InvocationResult) else result
+        invocation_result = InvocationResult(result, log_output=log_output)
+        return invocation_result
 
     def execute_java_lambda(self, event, context, main_file, func_details=None):
         handler = func_details.handler

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -144,10 +144,9 @@ class LambdaExecutor(object):
                 # start the execution
                 raised_error = None
                 result = None
-                log_output = None
                 dlq_sent = None
                 try:
-                    result, log_output = self._execute(func_arn, func_details, event, context, version)
+                    result = self._execute(func_arn, func_details, event, context, version)
                 except Exception as e:
                     raised_error = e
                     if asynchronous:
@@ -163,10 +162,13 @@ class LambdaExecutor(object):
                 finally:
                     self.function_invoke_times[func_arn] = invocation_time
                     callback and callback(result, func_arn, event, error=raised_error, dlq_sent=dlq_sent)
-                # return final result
-                if asynchronous:
-                    return result
-                return result, log_output
+                # construct and return final result
+                if not asynchronous:
+                    log_output = ''
+                    if isinstance(result, tuple) and len(result) == 2:
+                        result, log_output = result
+                    return result, log_output
+                return result
 
             return _run(func_arn=func_arn)
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -727,12 +727,20 @@ class TestPythonRuntimes(LambdaTestBase):
         testutil.delete_lambda_function(TEST_LAMBDA_NAME_PY)
 
     def test_invocation_type_not_set(self):
-        result = self.lambda_client.invoke(
-            FunctionName=TEST_LAMBDA_NAME_PY, Payload=b'{}')
+        result = self.lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_PY, Payload=b'{}', LogType='Tail')
         result_data = json.loads(result['Payload'].read())
 
+        # assert response details
         self.assertEqual(result['StatusCode'], 200)
         self.assertEqual(result_data['event'], {})
+
+        # assert that logs are contained in response
+        logs = result.get('LogResult', '')
+        logs = to_str(base64.b64decode(to_str(logs)))
+        self.assertIn('START', logs)
+        self.assertIn('Lambda log message', logs)
+        self.assertIn('END', logs)
+        self.assertIn('REPORT', logs)
 
     def test_invocation_type_request_response(self):
         result = self.lambda_client.invoke(

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -646,7 +646,7 @@ class TestLambdaBaseFeatures(unittest.TestCase):
 
         testutil.delete_lambda_function(name=function_name)
 
-    def test_function_code_singing_config(self):
+    def test_function_code_signing_config(self):
         lambda_client = aws_stack.connect_to_service('lambda')
         function_name = 'lambda_func-{}'.format(short_uid())
 


### PR DESCRIPTION
Fix returning `LogResult` from synchronous Lambda invocations - addresses #1630