### PR TITLE
Gzip decoding

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_listener.py
+++ b/localstack/services/cloudwatch/cloudwatch_listener.py
@@ -1,8 +1,21 @@
+import gzip
+from requests.models import Request
 from localstack.utils.common import _replace
 from localstack.services.generic_proxy import ProxyListener
 
+GZIP_ENCODING = 'GZIP'
+IDENTITY_ENCODING = 'IDENTITY'
+
 
 class ProxyListenerCloudWatch(ProxyListener):
+    def forward_request(self, method, path, data, headers):
+        encoding_type = headers.get('content-encoding') or ''
+        if encoding_type.upper() == GZIP_ENCODING:
+            headers.set('content-encoding', IDENTITY_ENCODING)
+            data = gzip.decompress(data)
+            return Request(data=data, headers=headers, method=method)
+
+        return True
 
     def return_response(self, method, path, data, headers, response):
         # Fix Incorrect date format to iso 8601

--- a/localstack/services/cloudwatch/cloudwatch_listener.py
+++ b/localstack/services/cloudwatch/cloudwatch_listener.py
@@ -1,21 +1,8 @@
-import gzip
-from requests.models import Request
 from localstack.utils.common import _replace
 from localstack.services.generic_proxy import ProxyListener
 
-GZIP_ENCODING = 'GZIP'
-IDENTITY_ENCODING = 'IDENTITY'
-
 
 class ProxyListenerCloudWatch(ProxyListener):
-    def forward_request(self, method, path, data, headers):
-        encoding_type = headers.get('content-encoding') or ''
-        if encoding_type.upper() == GZIP_ENCODING:
-            headers.set('content-encoding', IDENTITY_ENCODING)
-            data = gzip.decompress(data)
-            return Request(data=data, headers=headers, method=method)
-
-        return True
 
     def return_response(self, method, path, data, headers, response):
         # Fix Incorrect date format to iso 8601

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -34,10 +34,18 @@ HEADER_KILL_SIGNAL = 'x-localstack-kill'
 # lock obtained during boostrapping (persistence restoration) to avoid concurrency issues
 BOOTSTRAP_LOCK = threading.RLock()
 
+GZIP_ENCODING = 'GZIP'
+IDENTITY_ENCODING = 'IDENTITY'
+
 
 class ProxyListenerEdge(ProxyListener):
 
     def forward_request(self, method, path, data, headers):
+
+        encoding_type = headers.get('content-encoding') or ''
+        if encoding_type.upper() == GZIP_ENCODING:
+            headers.set('content-encoding', IDENTITY_ENCODING)
+            data = gzip.decompress(data)
 
         if path.split('?')[0] == '/health':
             return serve_health_endpoint(method, path, data)

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -78,6 +78,14 @@ class CloudWatchTest(unittest.TestCase):
         request = Request(url, encoded_data, headers, method='POST')
         urlopen(request)
 
+        client = aws_stack.connect_to_service('cloudwatch')
+        rs = client.list_metrics(
+            Namespace=namespace,
+            MetricName=metric_name
+        )
+        self.assertEqual(len(rs['Metrics']), 1)
+        self.assertEqual(rs['Metrics'][0]['Namespace'], namespace)
+
     def test_get_metric_data(self):
 
         conn = aws_stack.connect_to_service('cloudwatch')

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -59,26 +59,29 @@ class CloudWatchTest(unittest.TestCase):
     def test_put_metric_data_gzip(self):
         metric_name = 'test-metric'
         namespace = 'namespace'
-        data = 'Action=PutMetricData&MetricData.member.1.MetricName=%s&\
-            MetricData.member.1.Value=1&Namespace=%s&Version=2010-08-01'\
-             % (metric_name, namespace)
+        data = 'Action=PutMetricData&MetricData.member.1.' \
+            'MetricName=%s&MetricData.member.1.Value=1&' \
+            'Namespace=%s&Version=2010-08-01' \
+            % (metric_name, namespace)
         bytes_data = bytes(data, encoding='utf-8')
         encoded_data = gzip.compress(bytes_data)
 
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers('cloudwatch')
 
+        authorization = 'AWS4-HMAC-SHA256 Credential=test/20201230/' \
+            'us-east-1/monitoring/aws4_request, ' \
+            'SignedHeaders=content-encoding;host;' \
+            'x-amz-content-sha256;x-amz-date, Signature='\
+            'bb31fc5f4e58040ede9ed751133fe'\
+            '839668b27290bc1406b6ffadc4945c705dc'
+
         headers.update({
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             'Content-Length': len(encoded_data),
             'Content-Encoding': 'GZIP',
             'User-Agent': 'aws-sdk-nodejs/2.819.0 linux/v12.18.2 callback',
-            'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20201230/\
-                us-east-1/monitoring/aws4_request, \
-                SignedHeaders=content-encoding;host;x-amz-content-sha256;\
-                x-amz-date, \
-                Signature=bb31fc5f4e58040ede9ed751133fe83\
-                9668b27290bc1406b6ffadc4945c705dc',
+            'Authorization': authorization,
         })
         request = Request(url, encoded_data, headers, method='POST')
         urlopen(request)

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -1,11 +1,9 @@
 import unittest
 import gzip
-import hmac
-import hashlib
 from localstack.utils.aws import aws_stack
 from datetime import datetime, timedelta
 from dateutil.tz import tzutc
-from localstack.utils.common import short_uid, to_str
+from localstack.utils.common import short_uid
 from localstack import config
 from six.moves.urllib.request import Request, urlopen
 
@@ -61,7 +59,9 @@ class CloudWatchTest(unittest.TestCase):
     def test_put_metric_data_gzip(self):
         metric_name = 'test-metric'
         namespace = 'namespace'
-        data = 'Action=PutMetricData&MetricData.member.1.MetricName=%s&MetricData.member.1.Value=1&Namespace=%s&Version=2010-08-01' % (metric_name, namespace)
+        data = 'Action=PutMetricData&MetricData.member.1.MetricName=%s&\
+            MetricData.member.1.Value=1&Namespace=%s&Version=2010-08-01'\
+             % (metric_name, namespace)
         bytes_data = bytes(data, encoding='utf-8')
         encoded_data = gzip.compress(bytes_data)
 
@@ -73,8 +73,13 @@ class CloudWatchTest(unittest.TestCase):
             'Content-Length': len(encoded_data),
             'Content-Encoding': 'GZIP',
             'User-Agent': 'aws-sdk-nodejs/2.819.0 linux/v12.18.2 callback',
-            'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20201230/us-east-1/monitoring/aws4_request, SignedHeaders=content-encoding;host;x-amz-content-sha256;x-amz-date, Signature=bb31fc5f4e58040ede9ed751133fe839668b27290bc1406b6ffadc4945c705dc',
-            })
+            'Authorization': 'AWS4-HMAC-SHA256 Credential=test/20201230/\
+                us-east-1/monitoring/aws4_request, \
+                SignedHeaders=content-encoding;host;x-amz-content-sha256;\
+                x-amz-date, \
+                Signature=bb31fc5f4e58040ede9ed751133fe83\
+                9668b27290bc1406b6ffadc4945c705dc',
+        })
         request = Request(url, encoded_data, headers, method='POST')
         urlopen(request)
 

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -59,7 +59,9 @@ class CloudWatchTest(unittest.TestCase):
         self.assertEqual(rs['Metrics'][0]['Namespace'], namespace)
 
     def test_put_metric_data_gzip(self):
-        data = 'Action=PutMetricData&MetricData.member.1.MetricName=test-metric&MetricData.member.1.Value=1&Namespace=test_namespace&Version=2010-08-01'
+        metric_name = 'test-metric'
+        namespace = 'namespace'
+        data = 'Action=PutMetricData&MetricData.member.1.MetricName=%s&MetricData.member.1.Value=1&Namespace=%s&Version=2010-08-01' % (metric_name, namespace)
         bytes_data = bytes(data, encoding='utf-8')
         encoded_data = gzip.compress(bytes_data)
 


### PR DESCRIPTION
This PR adds the functionality to read GZIP encoded data in a PutMetricsData request for the CloudWatch service. 

It should fix the issue #3385 

