### PR TITLE
Fixing Cloudformation ListExport Result Malformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ requirements.copy.txt
 *.tfstate
 *.tfstate.*
 *tfplan
+
+.python-version

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -431,7 +431,7 @@ def describe_change_set(req_params):
 
 def list_exports(req_params):
     state = CloudFormationRegion.get()
-    result = {'Exports': state.exports}
+    result = {'Exports': {'member': state.exports}}
     return result
 
 

--- a/tests/integration/templates/template27.yaml
+++ b/tests/integration/templates/template27.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Simple CloudFormation Test Template
+Resources:
+  SQSQueue1:
+    Type: AWS::SQS::Queue
+  SQSQueue2:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: cf-test-queue-2
+  SNSTopic1:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: cf-test-topic-1
+      Subscription:
+        - Protocol: sqs
+          Endpoint:
+            "Fn::GetAtt": ["SQSQueue1", "Arn"]
+        - Protocol: sqs
+          Endpoint:
+            "Fn::GetAtt": ["SQSQueue2", "Arn"]
+Outputs:
+  T27SQSQueue1URL:
+    Value:
+      Ref: SQSQueue1
+    Export:
+      Name: T27SQSQueue1-URL

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -418,6 +418,8 @@ TEST_TEMPLATE_24 = os.path.join(THIS_FOLDER, 'templates', 'template24.yaml')
 
 TEST_TEMPLATE_25 = os.path.join(THIS_FOLDER, 'templates', 'template25.yaml')
 
+TEST_TEMPLATE_27 = os.path.join(THIS_FOLDER, 'templates', 'template27.yaml')
+
 TEST_UPDATE_LAMBDA_FUNCTION_TEMPLATE = os.path.join(THIS_FOLDER, 'templates', 'update_lambda_template.json')
 
 SQS_TEMPLATE = os.path.join(THIS_FOLDER, 'templates', 'fifo_queue.json')
@@ -1737,3 +1739,20 @@ class CloudFormationTest(unittest.TestCase):
 
     def expected_change_set_status(self):
         return 'CREATE_COMPLETE'
+
+    def test_list_exports_correctly_returns_exports(self):
+        stack_name = 'stack-%s' % short_uid()
+
+        template = load_file(TEST_TEMPLATE_27)
+
+        deploy_cf_stack(stack_name, template_body=template)
+
+        cloudformation = aws_stack.connect_to_service('cloudformation')
+        response = cloudformation.list_exports()
+
+        exports = response['Exports']
+        self.assertEqual(len(exports), 1)
+        self.assertEqual(exports[0]['Name'], 'T27SQSQueue1-URL')
+
+        # clean up
+        self.cleanup(stack_name)


### PR DESCRIPTION
This PR will fix the issue https://github.com/localstack/localstack/issues/3442 just opened. 

When we call the listExports method for cloudformation api the result is malformed. This cause issued in aws js sdk as it returns an empty array. The python sdk manages to parse it even if it is malformed, so you can't see the bug using the aws command line interface.