### PR TITLE
Fix issue when deploying cfn template contains Fn:Sub with variable map and Fn:GetAZs

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1046,6 +1046,14 @@ def resolve_refs_recursively(stack_name, value, resources):
             string = resolve_refs_recursively(stack_name, string, resources)
             return string.split(delimiter)
 
+        if stripped_fn_lower == 'getazs':
+            region = resolve_refs_recursively(stack_name, value['Fn::GetAZs'], resources) or aws_stack.get_region()
+            azs = []
+            for az in ('a', 'b', 'c', 'd'):
+                azs.append('%s%s' % (region, az))
+
+            return azs
+
         if stripped_fn_lower == 'base64':
             value_to_encode = value[keys_list[0]]
             value_to_encode = resolve_refs_recursively(stack_name, value_to_encode, resources)

--- a/tests/integration/templates/template28.yaml
+++ b/tests/integration/templates/template28.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  Environment:
+    Type: String
+    Default: 'companyname-ci'
+Resources:
+  SnsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub
+        - '${Env}-slack-topic'
+        - { Env: !Select [0, !Split ["-" , !Ref Environment]] }
+
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock: "100.0.0.0/20"
+
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - 0
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock: "100.0.0.0/24"
+      VpcId:
+        Ref: VPC
+
+Outputs:
+  PublicSubnetA:
+    Value:
+      Ref: PublicSubnetA
+    Export:
+      Name: 'public-sn-a'


### PR DESCRIPTION
* Add handle for function GetAZs
* Add integration test

Issues fixed:
#3331 CloudFormation - Pseudo parameter AWS::Region doesn't work in function Fn::GetAZs
#3333 CloudFormation - Sub Intrinsic Function doesn't support variable map
