### PR TITLE
Fix incorrect test case for destinations

### DIFF
--- a/localstack/utils/aws/lambda_destinations.py
+++ b/localstack/utils/aws/lambda_destinations.py
@@ -25,13 +25,12 @@ def lambda_result_to_destination(func_details, event, result, is_async, error):
         'responsePayload': {}
     }
 
-    if is_async:
-        payload['responsePayload']['statusCode'] = 200
-        payload['responsePayload']['headers'] = None
-        payload['responsePayload']['multiValueHeaders'] = None
-        payload['responsePayload']['body'] = ''
-    else:
-        payload['responsePayload'] = result.result
+    if result and result.result:
+        try:
+            payload['requestContext']['condition'] = 'Success'
+            payload['responsePayload'] = json.loads(result.result)
+        except Exception:
+            payload['responsePayload'] = result.result
 
     if error:
         payload['responseContext']['functionError'] = 'Unhandled'


### PR DESCRIPTION
- set the response payload for both success and failed invoications
- handle json and string responses from lambda
- use the correct lambda handler to raise error
- addresses https://github.com/localstack/localstack/issues/3373
