### PR TITLE
ses listener and xmlns for error responses

### DIFF
--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -40,7 +40,7 @@ def do_register_localstack_plugins():
         from localstack.services.iam import iam_listener, iam_starter
         from localstack.services.route53 import route53_listener, route53_starter
         from localstack.services.sts import sts_starter, sts_listener
-        from localstack.services.ses import ses_starter
+        from localstack.services.ses import ses_starter, ses_listener
         from localstack.services.ssm import ssm_listener
         from localstack.services.logs import logs_listener, logs_starter
         from localstack.services.infra import (
@@ -165,7 +165,8 @@ def do_register_localstack_plugins():
 
         register_plugin(Plugin(
             'ses',
-            start=ses_starter.start_ses))
+            start=ses_starter.start_ses,
+            listener=ses_listener.UPDATE_SES))
 
         register_plugin(Plugin(
             'sns',

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -108,11 +108,6 @@ def start_acm(port=None, asynchronous=False):
     return start_moto_server('acm', port, name='ACM', asynchronous=asynchronous)
 
 
-def start_ses(port=None, asynchronous=False, update_listener=None):
-    port = port or config.PORT_SES
-    return start_moto_server('ses', port, name='SES', asynchronous=asynchronous, update_listener=update_listener)
-
-
 # TODO move to es_starter.py?
 def start_elasticsearch_service(port=None, asynchronous=False):
     port = port or config.PORT_ES

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -108,6 +108,11 @@ def start_acm(port=None, asynchronous=False):
     return start_moto_server('acm', port, name='ACM', asynchronous=asynchronous)
 
 
+def start_ses(port=None, asynchronous=False, update_listener=None):
+    port = port or config.PORT_SES
+    return start_moto_server('ses', port, name='SES', asynchronous=asynchronous, update_listener=update_listener)
+
+
 # TODO move to es_starter.py?
 def start_elasticsearch_service(port=None, asynchronous=False):
     port = port or config.PORT_ES

--- a/localstack/services/ses/ses_listener.py
+++ b/localstack/services/ses/ses_listener.py
@@ -1,28 +1,28 @@
 import re
-import xmltodict
-from localstack.utils.common import to_str
-from localstack.utils.aws.aws_responses import make_error
+from localstack.utils.common import to_str, to_bytes
 from localstack.services.generic_proxy import ProxyListener
 
 
 class ProxyListenerSES(ProxyListener):
-    def forward_request(self, method, path, data, headers):
-        return True
 
     def return_response(self, method, path, data, headers, response):
-        has_xmlns = self.response_has_xmlns(to_str(response.content))
-        if not has_xmlns and response.status_code >= 400:
-            content_dict = xmltodict.parse(to_str(response.content))
-            error_description = content_dict['ErrorResponse']['Errors']['Error']
-            code = error_description['Code']
-            message = error_description['Message']
-            new_response = make_error(message=message, code=response.status_code, code_string=code, service='ses')
-            response._content = new_response.data
+        xml = to_str(response.content)
+        has_xmlns = self.response_has_xmlns(xml)
+        if len(xml) > 0 and not has_xmlns:
+            xmlns = 'http://ses.amazonaws.com/doc/2010-01-31/'
+            response_type = re.findall(r'<(\w+)\s?>', xml)[0]
+            response_xmlns = '%s xmlns="%s"' % (response_type, xmlns)
+
+            new_xml = re.sub(r'<\?xml.+\?>\n\s*', '', xml)
+            new_xml = re.sub(r'</?Errors>\n\s*', '', new_xml)
+            new_xml = re.sub(response_type, response_xmlns, new_xml, 1)
+
+            response._content = to_bytes(new_xml)
+            response.headers.update({'Content-Length': str(len(new_xml))})
+        return response
 
     def response_has_xmlns(self, xml_string):
-        if re.match(r'xmlns', xml_string):
-            return True
-        return False
+        return re.search(r'\s+xmlns="\S+"', xml_string)
 
 
 # instantiate listener

--- a/localstack/services/ses/ses_listener.py
+++ b/localstack/services/ses/ses_listener.py
@@ -1,0 +1,29 @@
+import re
+import xmltodict
+from localstack.utils.common import to_str
+from localstack.utils.aws.aws_responses import make_error
+from localstack.services.generic_proxy import ProxyListener
+
+
+class ProxyListenerSES(ProxyListener):
+    def forward_request(self, method, path, data, headers):
+        return True
+
+    def return_response(self, method, path, data, headers, response):
+        has_xmlns = self.response_has_xmlns(to_str(response.content))
+        if not has_xmlns and response.status_code >= 400:
+            content_dict = xmltodict.parse(to_str(response.content))
+            error_description = content_dict['ErrorResponse']['Errors']['Error']
+            code = error_description['Code']
+            message = error_description['Message']
+            new_response = make_error(message=message, code=response.status_code, code_string=code, service='ses')
+            response._content = new_response.data
+
+    def response_has_xmlns(self, xml_string):
+        if re.match(r'xmlns', xml_string):
+            return True
+        return False
+
+
+# instantiate listener
+UPDATE_SES = ProxyListenerSES()

--- a/localstack/services/ses/ses_starter.py
+++ b/localstack/services/ses/ses_starter.py
@@ -1,6 +1,6 @@
 import base64
-
 import logging
+import localstack.config as config
 from datetime import date, datetime
 from moto.ses.responses import EmailResponse as email_responses
 from moto.ses.responses import ses_backend
@@ -82,12 +82,14 @@ def apply_patches():
     email_responses.list_templates = list_templates
 
 
-def start_ses(port=None, backend_port=None, asynchronous=None):
+def start_ses(port=None, backend_port=None, asynchronous=None, update_listener=None):
+    port = port or config.PORT_SES
     apply_patches()
     return start_moto_server(
         key='ses',
         name='SES',
         port=port,
         backend_port=backend_port,
-        asynchronous=asynchronous
+        asynchronous=asynchronous,
+        update_listener=update_listener
     )


### PR DESCRIPTION
With this patch, the ses-listener patches the xml error responses. Now the java -sdk can show the correct error messages.

this fixes the issue #3466 
