### PR TITLE
Fix: SSM wrong output when referencing secretsmanager

### DIFF
--- a/localstack/services/ssm/ssm_listener.py
+++ b/localstack/services/ssm/ssm_listener.py
@@ -24,7 +24,7 @@ def get_secrets_information(name, resource_name):
         secret_info = client.get_secret_value(SecretId=resource_name)
         if secret_info:
             secret_info = json.dumps(secret_info)
-        
+
         del secret_info['ResponseMetadata']
         created_date_timestamp = time.mktime(secret_info['CreatedDate'].timetuple())
         secret_info['CreatedDate'] = created_date_timestamp

--- a/localstack/services/ssm/ssm_listener.py
+++ b/localstack/services/ssm/ssm_listener.py
@@ -22,13 +22,11 @@ def get_secrets_information(name, resource_name):
     client = aws_stack.connect_to_service('secretsmanager')
     try:
         secret_info = client.get_secret_value(SecretId=resource_name)
-        if secret_info:
-            secret_info = json.dumps(secret_info)
 
         del secret_info['ResponseMetadata']
         created_date_timestamp = time.mktime(secret_info['CreatedDate'].timetuple())
         secret_info['CreatedDate'] = created_date_timestamp
-        result = {'Parameter': {'SourceResult': secret_info, 'Name': name, 'Value':
+        result = {'Parameter': {'SourceResult': json.dumps(secret_info, default=str), 'Name': name, 'Value':
                 secret_info.get('SecretString'), 'Type': 'SecureString',
                             'LastModifiedDate': created_date_timestamp}}
         return result

--- a/localstack/services/ssm/ssm_listener.py
+++ b/localstack/services/ssm/ssm_listener.py
@@ -22,6 +22,9 @@ def get_secrets_information(name, resource_name):
     client = aws_stack.connect_to_service('secretsmanager')
     try:
         secret_info = client.get_secret_value(SecretId=resource_name)
+        if secret_info:
+            secret_info = json.dumps(secret_info)
+            
         del secret_info['ResponseMetadata']
         created_date_timestamp = time.mktime(secret_info['CreatedDate'].timetuple())
         secret_info['CreatedDate'] = created_date_timestamp

--- a/localstack/services/ssm/ssm_listener.py
+++ b/localstack/services/ssm/ssm_listener.py
@@ -24,7 +24,7 @@ def get_secrets_information(name, resource_name):
         secret_info = client.get_secret_value(SecretId=resource_name)
         if secret_info:
             secret_info = json.dumps(secret_info)
-            
+        
         del secret_info['ResponseMetadata']
         created_date_timestamp = time.mktime(secret_info['CreatedDate'].timetuple())
         secret_info['CreatedDate'] = created_date_timestamp

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -52,7 +52,7 @@ class SSMTest(unittest.TestCase):
 
         self.assertEqual(result.get('Parameter').get('Name'), '/aws/reference/secretsmanager/{0}'.format(secret_name))
         self.assertEqual(result.get('Parameter').get('Value'), 'my_secret')
-        
+
         source_result = result.get('Parameter').get('SourceResult')
         self.assertTrue(source_result is not None, 'SourceResult should be present')
         self.assertTrue(type(source_result) is str, 'SourceResult should be a string')

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -52,6 +52,10 @@ class SSMTest(unittest.TestCase):
 
         self.assertEqual(result.get('Parameter').get('Name'), '/aws/reference/secretsmanager/{0}'.format(secret_name))
         self.assertEqual(result.get('Parameter').get('Value'), 'my_secret')
+        
+        source_result = result.get('Parameter').get('SourceResult')
+        self.assertTrue(source_result is not None, 'SourceResult should be present')
+        self.assertTrue(type(source_result) is str, 'SourceResult should be a string')
 
     def test_get_inexistent_secret(self):
         ssm_client = aws_stack.connect_to_service('ssm')


### PR DESCRIPTION
This PR stringify the secretsmanager response to mirror SSM behaviour when getting a parameter that references a secret.
[3496](https://github.com/localstack/localstack/issues/3496)