### PR TITLE
Fix dynamodb stream lambda integration

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -429,7 +429,7 @@ def modify_and_forward(method=None, path=None, data_bytes=None, headers=None, fo
         kwargs = {
             'method': method,
             'path': path,
-            'data': data_bytes,
+            'data': data,
             'headers': headers,
             'response': response
         }


### PR DESCRIPTION
Using the integration between dynamodb stream and lambda with the pro version of localstack I ran into the problem that the lambdas were not invoked.
I found that inside the modified_and_forward function of the generic_proxy module, when it updates listeners, the dictionary "kwargs" is created using the possibly outdated variable "data_bytes", instead it should be "data".
