### PR TITLE
#3038 Option to log at different level (e.g. WARN or ERROR rather than INFO)

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -10,12 +10,18 @@ import six
 from boto3 import Session
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS, LOCALHOST, LOCALHOST_IP, DEFAULT_PORT_WEB_UI, TRUE_STRINGS, FALSE_STRINGS,
-    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1)
+    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1, LOG_LEVELS)
 
 
 def is_env_true(env_var_name):
     """ Whether the given environment variable has a truthy value. """
     return os.environ.get(env_var_name, '').lower().strip() in TRUE_STRINGS
+
+
+def eval_log_type(env_var_name):
+    """get the log type from environment variable"""
+    ls_log = os.environ.get(env_var_name, '').lower().strip()
+    return ls_log if ls_log in LOG_LEVELS else False
 
 
 def is_env_not_false(env_var_name):
@@ -110,6 +116,7 @@ HOST_TMP_FOLDER = os.environ.get('HOST_TMP_FOLDER', TMP_FOLDER)
 
 # whether to enable verbose debug logging
 DEBUG = is_env_true('DEBUG')
+LS_LOG = eval_log_type('LS_LOG')
 
 # whether to use SSL encryption for the services
 USE_SSL = is_env_true('USE_SSL')
@@ -381,8 +388,22 @@ def get_edge_url():
 # initialize config values
 populate_configs()
 
-# set log levels
-if DEBUG:
+# set log levels LS_LOG should be able to overwrite DEBUG env variable
+if LS_LOG:
+    LS_LOG = str(LS_LOG).upper()
+    if LS_LOG == 'ERROR':
+        logging.getLogger('').setLevel(logging.ERROR)
+        logging.getLogger('localstack').setLevel(logging.ERROR)
+    elif LS_LOG in ('WARN', 'WARNING'):
+        logging.getLogger('').setLevel(logging.WARNING)
+        logging.getLogger('localstack').setLevel(logging.WARNING)
+    elif LS_LOG == 'INFO':
+        logging.getLogger('').setLevel(logging.INFO)
+        logging.getLogger('localstack').setLevel(logging.INFO)
+    else:
+        logging.getLogger('').setLevel(logging.DEBUG)
+        logging.getLogger('localstack').setLevel(logging.DEBUG)
+elif DEBUG:
     logging.getLogger('').setLevel(logging.DEBUG)
     logging.getLogger('localstack').setLevel(logging.DEBUG)
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -70,6 +70,7 @@ APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded'
 # strings to indicate truthy/falsy values
 TRUE_STRINGS = ('1', 'true', 'True')
 FALSE_STRINGS = ('0', 'false', 'False')
+LOG_LEVELS = ('debug', 'info', 'warn', 'error', 'warning')
 
 # Lambda defaults
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID


### PR DESCRIPTION
1) Added a new environment variable LS_LOG that accepts log levels ('debug', 'info', 'warn', 'error', 'warning').
2) Over rides and takes precedence over the still available DEBUG env. variable.
