### PR TITLE
#3038 Option to log at different level (e.g. WARN or ERROR rather than INFO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ You can pass the following environment variables to LocalStack:
 * `LAMBDA_JAVA_OPTS`: Allow passing custom JVM options (e.g., `-Xmx512M`) to Java Lambdas executed in Docker. Use `_debug_port_` placeholder to configure the debug port (e.g., `-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=_debug_port_`).
 * `MAIN_CONTAINER_NAME`: Specify the main docker container name (default: `localstack_main`).
 * `INIT_SCRIPTS_PATH`: Specify the path to the initializing files with extensions .sh that are found default in `/docker-entrypoint-initaws.d`.
+* `DEBUG`: For troubleshooting LocalStack start issues
+* `LS_LOG`: Specify the log level('debug', 'info', 'warn', 'error', 'warning') currently overrides the `DEBUG` configuration.
 
 The following environment configurations are *deprecated*:
 * `USE_SSL`: Whether to use `https://...` URLs with SSL encryption (default: `false`). Deprecated as of version 0.11.3 - each service endpoint now supports multiplexing HTTP/HTTPS traffic over the same port.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -10,12 +10,18 @@ import six
 from boto3 import Session
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS, LOCALHOST, LOCALHOST_IP, DEFAULT_PORT_WEB_UI, TRUE_STRINGS, FALSE_STRINGS,
-    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1)
+    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1, LOG_LEVELS)
 
 
 def is_env_true(env_var_name):
     """ Whether the given environment variable has a truthy value. """
     return os.environ.get(env_var_name, '').lower().strip() in TRUE_STRINGS
+
+
+def eval_log_type(env_var_name):
+    """get the log type from environment variable"""
+    ls_log = os.environ.get(env_var_name, '').lower().strip()
+    return ls_log if ls_log in LOG_LEVELS else False
 
 
 def is_env_not_false(env_var_name):
@@ -110,6 +116,7 @@ HOST_TMP_FOLDER = os.environ.get('HOST_TMP_FOLDER', TMP_FOLDER)
 
 # whether to enable verbose debug logging
 DEBUG = is_env_true('DEBUG')
+LS_LOG = eval_log_type('LS_LOG')
 
 # whether to use SSL encryption for the services
 USE_SSL = is_env_true('USE_SSL')
@@ -381,8 +388,22 @@ def get_edge_url():
 # initialize config values
 populate_configs()
 
-# set log levels
-if DEBUG:
+# set log levels LS_LOG should be able to overwrite DEBUG env variable
+if LS_LOG:
+    LS_LOG = str(LS_LOG).upper()
+    if LS_LOG == 'ERROR':
+        logging.getLogger('').setLevel(logging.ERROR)
+        logging.getLogger('localstack').setLevel(logging.ERROR)
+    elif LS_LOG in ('WARN', 'WARNING'):
+        logging.getLogger('').setLevel(logging.WARNING)
+        logging.getLogger('localstack').setLevel(logging.WARNING)
+    elif LS_LOG == 'INFO':
+        logging.getLogger('').setLevel(logging.INFO)
+        logging.getLogger('localstack').setLevel(logging.INFO)
+    else:
+        logging.getLogger('').setLevel(logging.DEBUG)
+        logging.getLogger('localstack').setLevel(logging.DEBUG)
+elif DEBUG:
     logging.getLogger('').setLevel(logging.DEBUG)
     logging.getLogger('localstack').setLevel(logging.DEBUG)
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -388,22 +388,8 @@ def get_edge_url():
 # initialize config values
 populate_configs()
 
-# set log levels LS_LOG should be able to overwrite DEBUG env variable
-if LS_LOG:
-    LS_LOG = str(LS_LOG).upper()
-    if LS_LOG == 'ERROR':
-        logging.getLogger('').setLevel(logging.ERROR)
-        logging.getLogger('localstack').setLevel(logging.ERROR)
-    elif LS_LOG in ('WARN', 'WARNING'):
-        logging.getLogger('').setLevel(logging.WARNING)
-        logging.getLogger('localstack').setLevel(logging.WARNING)
-    elif LS_LOG == 'INFO':
-        logging.getLogger('').setLevel(logging.INFO)
-        logging.getLogger('localstack').setLevel(logging.INFO)
-    else:
-        logging.getLogger('').setLevel(logging.DEBUG)
-        logging.getLogger('localstack').setLevel(logging.DEBUG)
-elif DEBUG:
+# set log levels
+if DEBUG:
     logging.getLogger('').setLevel(logging.DEBUG)
     logging.getLogger('localstack').setLevel(logging.DEBUG)
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -2,7 +2,7 @@ import os
 import localstack_client.config
 
 # LocalStack version
-VERSION = '0.12.5'
+VERSION = '0.12.6'
 
 # constant to represent the "local" region, i.e., local machine
 REGION_LOCAL = 'local'

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -2,7 +2,7 @@ import os
 import localstack_client.config
 
 # LocalStack version
-VERSION = '0.12.6'
+VERSION = '0.12.5'
 
 # constant to represent the "local" region, i.e., local machine
 REGION_LOCAL = 'local'
@@ -70,6 +70,7 @@ APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded'
 # strings to indicate truthy/falsy values
 TRUE_STRINGS = ('1', 'true', 'True')
 FALSE_STRINGS = ('0', 'false', 'False')
+LOG_LEVELS = ('debug', 'info', 'warn', 'error', 'warning')
 
 # Lambda defaults
 LAMBDA_TEST_ROLE = 'arn:aws:iam::%s:role/lambda-test-role' % TEST_AWS_ACCOUNT_ID

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -263,7 +263,7 @@ def setup_logging(log_level=None):
     # log level set by DEBUG env variable
     log_level = log_level or (logging.DEBUG if config.DEBUG else logging.INFO)
 
-    # overriding the DEBUG env variable if LS_LOG has been set
+    # overriding the log level if LS_LOG has been set
     if config.LS_LOG:
         LS_LOG = str(config.LS_LOG).upper()
         LS_LOG = 'WARNING' if LS_LOG == 'WARN' else LS_LOG

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -260,7 +260,17 @@ def setup_logging(log_level=None):
         return
     PLUGINS_LOADED['_logging_'] = True
 
+    # log level set by DEBUG env variable
     log_level = log_level or (logging.DEBUG if config.DEBUG else logging.INFO)
+
+    # overriding the DEBUG env variable if LS_LOG has been set
+    if config.LS_LOG:
+        LS_LOG = str(config.LS_LOG).upper()
+        LS_LOG = 'WARNING' if LS_LOG == 'WARN' else LS_LOG
+        log_level = getattr(logging, LS_LOG)
+        logging.getLogger('').setLevel(log_level)
+        logging.getLogger('localstack').setLevel(log_level)
+
     logging.basicConfig(level=log_level, format=LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
 
     # set up werkzeug logger


### PR DESCRIPTION
1) LS_LOG env. variable which allows log levels to be specified ('debug', 'info', 'warn', 'error', 'warning')
2) Currently overrides the DEBUG env. variable if LS_LOG is set