### PR TITLE
encode Data as string in kinesis ACTION_GET_RECORDS

### DIFF
--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -1,3 +1,4 @@
+import base64
 import re
 import json
 import random
@@ -150,7 +151,7 @@ class ProxyListenerKinesis(ProxyListener):
                 if sdk_v2:
                     record['ApproximateArrivalTimestamp'] = int(record['ApproximateArrivalTimestamp'])
                 if not isinstance(record['Data'], str):
-                    record['Data'] = bytearray(record['Data']['data'])
+                    record['Data'] = base64.b64encode(bytes(record['Data']['data'])).decode('utf-8')
 
             if encoding_type == APPLICATION_CBOR:
                 response._content = cbor2.dumps(results)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -1525,7 +1525,7 @@ class TestJavaRuntimes(LambdaTestBase):
 
         self.assertEqual(result['StatusCode'], 200)
         self.assertDictEqual(
-            json.loads(to_str(result_data)),
+            json.loads(result_data),
             {'validated': True, 'bucket': 'test_bucket', 'key': 'test_key'}
         )
 


### PR DESCRIPTION
Fixes the error `Object of type bytearray is not JSON serializable` in line 158: `response._content = json.dumps(results)`.


Error Stack:
```
localstack            | 2021-02-03T16:07:48:WARNING:localstack.utils.server.http2_server: Error in proxy handler for request POST http://localhost:4800/: Object of type bytearray is not JSON serializable Traceback (most recent call last):
localstack            |   File "/opt/code/localstack/localstack/utils/server/http2_server.py", line 107, in index
localstack            |     raise result
localstack            |   File "/opt/code/localstack/localstack/utils/bootstrap.py", line 593, in run
localstack            |     result = self.func(self.params)
localstack            |   File "/opt/code/localstack/localstack/utils/async_utils.py", line 28, in _run
localstack            |     return fn(*args, **kwargs)
localstack            |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 605, in handler
localstack            |     response = modify_and_forward(method=method, path=path_with_params, data_bytes=data, headers=headers,
localstack            |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 373, in modify_and_forward
localstack            |     listener_result = listener.forward_request(method=method,
localstack            |   File "/opt/code/localstack/localstack/services/edge.py", line 105, in forward_request
localstack            |     return do_forward_request(api, method, path, data, headers, port=port)
localstack            |   File "/opt/code/localstack/localstack/services/edge.py", line 116, in do_forward_request
localstack            |     result = do_forward_request_inmem(api, method, path, data, headers, port=port)
localstack            |   File "/opt/code/localstack/localstack/services/edge.py", line 136, in do_forward_request_inmem
localstack            |     response = modify_and_forward(method=method, path=path, data_bytes=data, headers=headers,
localstack            |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 441, in modify_and_forward
localstack            |     updated_response = update_listener.return_response(**kwargs)
localstack            |   File "/opt/code/localstack/localstack/services/kinesis/kinesis_listener.py", line 158, in return_response
localstack            |     response._content = json.dumps(results)
localstack            |   File "/usr/lib/python3.8/json/__init__.py", line 231, in dumps
localstack            |     return _default_encoder.encode(obj)
localstack            |   File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
localstack            |     chunks = self.iterencode(o, _one_shot=True)
localstack            |   File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
localstack            |     return _iterencode(o, 0)
localstack            |   File "/usr/lib/python3.8/json/encoder.py", line 179, in default
localstack            |     raise TypeError(f'Object of type {o.__class__.__name__} '
localstack            | TypeError: Object of type bytearray is not JSON serializable
```


