### PR TITLE
add feature test-invoke-method to API-GW

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -468,6 +468,9 @@ def extract_query_string_params(path):
         else:
             query_string_params[query_param_name] = query_param_values
 
+    if path.endswith('None') and len(path.split('None')) > 0:
+        path = path.split('None')[0]
+
     # strip trailing slashes from path to fix downstream lookups
     path = path.rstrip('/') or '/'
     return [path, query_string_params]

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -297,6 +297,8 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
         event['resource'] = resource_path
         event['requestContext'] = request_context
         event['stageVariables'] = stage_variables
+        if stage_variables:
+            event['stageVariables'] = stage_variables
         LOG.debug('Running Lambda function %s from API Gateway invocation: %s %s' % (func_arn, method or 'GET', path))
         asynchronous = not config.SYNCHRONOUS_API_GATEWAY_EVENTS
         inv_result = run_lambda(event=event, context=event_context, func_arn=func_arn, asynchronous=asynchronous)


### PR DESCRIPTION
Added support for the test-invoke-method feature. It tests the integrated method before making the deployment of the api-gateway.
Also added simulated method, headers, body, and pathWithQueryString.
Added test cases for test-invoke-method.
Fix for #3291 