### PR TITLE
fixed missing attribute in cloudwatch

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_listener.py
+++ b/localstack/services/cloudwatch/cloudwatch_listener.py
@@ -46,6 +46,14 @@ class ProxyListenerCloudWatch(ProxyListener):
         # Fix Incorrect date format to the correct format
         # the dictionary contains the tag as the key and the value is a
         # tuple (pattern, replacement)
+
+        req_data = parse_request_data(method, path, data)
+        action = req_data.get('Action')
+        if action == 'PutMetricAlarm':
+            name = req_data.get('AlarmName')
+            treat_missing_data = req_data.get('TreatMissingData', 'ignore')
+            cloudwatch_backends[aws_stack.get_region()].alarms[name].treat_missing_data = treat_missing_data
+
         regexes1 = (r'<{}>([^<]+) ([^<+]+)(\+[^<]*)?</{}>', r'<{}>\1T\2Z</{}>')
         regexes2 = (r'<{}>([^<]+) ([^<+.]+)(\.[^<]*)?</{}>', r'<{}>\1T\2Z</{}>')
         timestamp_tags = {

--- a/localstack/services/cloudwatch/cloudwatch_starter.py
+++ b/localstack/services/cloudwatch/cloudwatch_starter.py
@@ -1,9 +1,20 @@
 from localstack import config
 from localstack.services.infra import start_moto_server
+import moto.cloudwatch.responses as cloudwatch_responses
+
+
+def patch_lambda():
+
+    if '<TreatMissingData>' not in cloudwatch_responses.DESCRIBE_ALARMS_TEMPLATE:
+        cloudwatch_responses.DESCRIBE_ALARMS_TEMPLATE = cloudwatch_responses.DESCRIBE_ALARMS_TEMPLATE.replace(
+            '</AlarmName>',
+            '</AlarmName><TreatMissingData>{{ alarm.treat_missing_data }}</TreatMissingData>'
+        )
 
 
 def start_cloudwatch(port=None, asynchronous=False, update_listener=None):
     port = port or config.PORT_CLOUDWATCH
+    patch_lambda()
     return start_moto_server(
         'cloudwatch', port, name='CloudWatch',
         update_listener=update_listener, asynchronous=asynchronous


### PR DESCRIPTION
**fixed**
- added attribute `TreatMissingData` in Cloudwatch `PutMetricAlarm`

**Reference**
- [PutMetricAlarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html)