### PR TITLE
S3 Object Notifications: handle explicit nulls in filters

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -973,7 +973,7 @@ def handle_notification_request(bucket, method, data):
                 events = config.get('Event')
                 if isinstance(events, six.string_types):
                     events = [events]
-                event_filter = config.get('Filter', {})
+                event_filter = config.get('Filter') or {}
                 # make sure FilterRule is an array
                 s3_filter = _get_s3_filter(event_filter)
                 if s3_filter and not isinstance(s3_filter.get('FilterRule', []), list):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1635,7 +1635,8 @@ class TestS3(unittest.TestCase):
                 'QueueConfigurations': [
                     {
                         'QueueArn': queue_attributes['Attributes']['QueueArn'],
-                        'Events': ['s3:ObjectCreated:*']
+                        'Events': ['s3:ObjectCreated:*'],
+                        'Filter': None,
                     }
                 ]
             }


### PR DESCRIPTION
The `config.get('Filter')` can return `None` if the configuration had one
there, which isn't correct, instead it should treat it as an empty filter set.

---

I'm happy to refactor the tests to make it possible to separate this behavior out, this seemed like the smallest change I could make that would run your full CI suite and validate the change.