### PR TITLE
Add .NET Client Library info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ $ ▶ laws lambda list-functions
 
 * Python: https://github.com/localstack/localstack-python-client
   * alternatively, you can also use `boto3` and use the `endpoint_url` parameter when creating a connection
+* .NET: https://github.com/localstack-dotnet/localstack-dotnet-client
+  * alternatively, you can also use `AWS SDK for .NET` and change `ClientConfig` properties when creating a service client.
 * (more coming soon...)
 
 ### Invoking API Gateway


### PR DESCRIPTION
We have been developing [LocalStack .Net Client Library](https://github.com/localstack-dotnet/localstack-dotnet-client) for two years and updating it regularly. We thought it might be useful to other AWS and .NET users like us. 