### PR TITLE
support json message structure with raw delivery

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -555,15 +555,15 @@ def create_sns_message_body(subscriber, req_data, message_id=None):
         # fix non-ascii unicode characters under Python 2
         message = message.encode('raw-unicode-escape')
 
-    if is_raw_message_delivery(subscriber):
-        return message
-
     if req_data.get('MessageStructure') == ['json']:
         message = json.loads(message)
         try:
             message = message.get(protocol, message['default'])
         except KeyError:
             raise Exception("Unable to find 'default' key in message payload")
+
+    if is_raw_message_delivery(subscriber):
+        return message
 
     data = {
         'Type': req_data.get('Type', ['Notification'])[0],

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -142,6 +142,17 @@ class SNSTests(unittest.TestCase):
 
         self.assertEqual(result['Message'], {'message': 'abc'})
 
+    def test_create_sns_message_body_json_structure_raw_delivery(self):
+        self.subscriber['RawMessageDelivery'] = 'true'
+        action = {
+            'Message': ['{"default": {"message": "abc"}}'],
+            'MessageStructure': ['json']
+        }
+        result_str = sns_listener.create_sns_message_body(self.subscriber, action)
+        result = json.loads(result_str)
+
+        self.assertEqual(result, {'message': 'abc'})
+
     def test_create_sns_message_body_json_structure_without_default_key(self):
         action = {
             'Message': ['{"message": "abc"}'],
@@ -160,6 +171,17 @@ class SNSTests(unittest.TestCase):
         result = json.loads(result_str)
 
         self.assertEqual(result['Message'], 'sqs message')
+
+    def test_create_sns_message_body_json_structure_raw_delivery_sqs_protocol(self):
+        self.subscriber['RawMessageDelivery'] = 'true'
+        action = {
+            'Message': ['{"default": {"message": "default version"}, "sqs": {"message": "sqs version"}}'],
+            'MessageStructure': ['json']
+        }
+        result_str = sns_listener.create_sns_message_body(self.subscriber, action)
+        result = json.loads(result_str)
+
+        self.assertEqual(result, {'message': 'sqs version'})
 
     def test_create_sqs_message_attributes(self):
         self.subscriber['RawMessageDelivery'] = 'true'


### PR DESCRIPTION
# Detailed description
This is mostly copy pasted from https://github.com/localstack/localstack/issues/3594 which I submitted.

The MessageStructure json for SNS messages does not work as expected with raw message delivery enabled. The fix added [in this pull request](https://github.com/localstack/localstack/pull/668) gets most of the way there. The bug is the `if` block on [line 558](https://github.com/localstack/localstack/blob/master/localstack/services/sns/sns_listener.py#L558) needs to be _AFTER_ the `if` block on [line 561](https://github.com/localstack/localstack/blob/master/localstack/services/sns/sns_listener.py#L561) that parses out the default block.

## Expected behavior
A SQS subscription to an SNS topic with raw message delivery enabled should strip out the `default` top level json key. So the `Body` field should look like this: `{"hello":"world"}`. This is how AWS actually works with this setup.

## Actual behavior
Message body looks like this: `{"default":"{\"hello\":\"world\"}"}`. This is different from how AWS works.

# Steps to reproduce
With this setup script:
```
awslocal sns create-topic --name MyEvents
awslocal sqs create-queue --queue-name MyQueue
awslocal sns subscribe \
    --topic-arn arn:aws:sns:us-east-1:000000000000:MyEvents \
    --protocol sqs \
    --attributes RawMessageDelivery=true \
    --notification-endpoint http://localhost:4566/000000000000/MyQueue
```

And this publish message (typescript):
```
const myData = { hello: 'world' };
const snsMsg: AWS.SNS.PublishInput = {
  TopicArn: 'arn:aws:sns:us-east-1:000000000000:MyEvents',
  Message: JSON.stringify({ default: JSON.stringify(myData) }),
  MessageStructure: 'json'
}
```

## Command used to start LocalStack
Docker compose:
```
version: '3.7'

services:
  localstack:
    container_name: '${LOCALSTACK_DOCKER_NAME-localstack}'
    image: localstack/localstack
    networks:
      - localstack-net
    healthcheck:
      test: awslocal sns list-topics && awslocal sqs list-queues
      interval: 3s
      timeout: 10s
    ports:
      - '4566-4599:4566-4599'
      - '8081:8080'
    environment:
      - DEFAULT_REGION=us-east-1
      - SERVICES=sns:4575,sqs:4576
      - DEBUG=${DEBUG- }
      - DATA_DIR=${DATA_DIR- }
      - PORT_WEB_UI=8081
      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
      - DOCKER_HOST=unix:///var/run/docker.sock
      - HOST_TMP_FOLDER=${TMPDIR}
    volumes:
      - '${TMPDIR:-/tmp/localstack}:/tmp/localstack'
      - '/var/run/docker.sock:/var/run/docker.sock'
      - ./bin:/docker-entrypoint-initaws.d

networks:
  localstack-net:
    external: false
    driver: bridge
    name: localstack-net
```