### PR TITLE
Fix: API GW only validates API Keys against one previously configured key

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -158,8 +158,7 @@ def authorize_invocation(api_id, headers):
 
 def validate_api_key(api_key, stage):
 
-    key = None
-    usage_plan_id = None
+    usage_plan_ids = []
 
     client = aws_stack.connect_to_service('apigateway')
     usage_plans = client.get_usage_plans()
@@ -167,18 +166,15 @@ def validate_api_key(api_key, stage):
         api_stages = item.get('apiStages', [])
         for api_stage in api_stages:
             if api_stage.get('stage') == stage:
-                usage_plan_id = item.get('id')
-    if not usage_plan_id:
-        return False
+                usage_plan_ids.append(item.get('id'))
 
-    usage_plan_keys = client.get_usage_plan_keys(usagePlanId=usage_plan_id)
-    for item in usage_plan_keys.get('items', []):
-        key = item.get('value')
+    for usage_plan_id in usage_plan_ids:
+        usage_plan_keys = client.get_usage_plan_keys(usagePlanId=usage_plan_id)
+        for key in usage_plan_keys.get('items', []):
+            if key.get('value') == api_key:
+                return True
 
-    if key != api_key:
-        return False
-
-    return True
+    return False
 
 
 def is_api_key_valid(is_api_key_required, headers, stage):

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -779,6 +779,55 @@ class TestAPIGateway(unittest.TestCase):
         # when the api key is passed as part of the header
         self.assertEqual(response.status_code, 200)
 
+    def test_multiple_api_keys_validate(self):
+        response_templates = {'application/json': json.dumps({'TableName': 'MusicCollection',
+                                                              'Item': {'id': '$.Id', 'data': '$.data'}})}
+
+        api_id = self.create_api_gateway_and_deploy(response_templates, True)
+        url = gateway_request_url(api_id=api_id, stage_name='staging', path='/')
+
+        client = aws_stack.connect_to_service('apigateway')
+
+        # Create multiple usage plans
+        usage_plan_ids = []
+        for i in range(2):
+            payload = {
+                'name': 'APIKEYTEST-PLAN-{}'.format(i),
+                'description': 'Description',
+                'quota': {'limit': 10, 'period': 'DAY', 'offset': 0},
+                'throttle': {'rateLimit': 2, 'burstLimit': 1},
+                'apiStages': [{'apiId': api_id, 'stage': 'staging'}],
+                'tags': {'tag_key': 'tag_value'},
+            }
+            usage_plan_ids.append(client.create_usage_plan(**payload)['id'])
+
+        api_keys = []
+        key_type = 'API_KEY'
+        # Create multiple API Keys in each usage plan
+        for usage_plan_id in usage_plan_ids:
+            for i in range(2):
+                api_key = client.create_api_key(name='testMultipleApiKeys{}'.format(i))
+                payload = {'usagePlanId': usage_plan_id, 'keyId': api_key['id'], 'keyType': key_type}
+                client.create_usage_plan_key(**payload)
+                api_keys.append(api_key['value'])
+
+        response = requests.put(
+            url,
+            json.dumps({'id': 'id1', 'data': 'foobar123'}),
+        )
+        # when the api key is not passed as part of the header
+        self.assertEqual(response.status_code, 403)
+
+        # Check All API Keys work
+        for key in api_keys:
+            response = requests.put(
+                url,
+                json.dumps({'id': 'id1', 'data': 'foobar123'}),
+                headers={'X-API-Key': key}
+            )
+            # when the api key is passed as part of the header
+            self.assertEqual(response.status_code, 200)
+
     def test_import_rest_api(self):
         rest_api_name = 'restapi-%s' % short_uid()
 


### PR DESCRIPTION
The code to `validate_api_key` only compared the key in the request headers to one api key configured for the API Gateway. All usage plans were iterated over for the stage, however only the last found one was recorded. Similarly, all keys for the usage plan were iterated over, but only the last one was compared to the request.

This PR changes `validate_api_key` to create a list of usage plans, then iterate over each plan until an api key is found that matches the key in the request, or return False if no match is found.
