### PR TITLE
fix: cloudformation stack status when using execute-change

### DIFF
--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -436,6 +436,8 @@ def execute_change_set(req_params):
     deployer = template_deployer.TemplateDeployer(change_set.stack)
     deployer.apply_change_set(change_set)
     change_set.stack.metadata['ChangeSetId'] = change_set.change_set_id
+    stack = find_stack(stack_name)
+    stack.set_stack_status('CREATE_COMPLETE')
     return {}
 
 

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -61,3 +61,18 @@ def params_list_to_dict(param_name, key_attr_name='Key', value_attr_name='Value'
 
 def lambda_keys_to_lower(key=None):
     return lambda params, **kwargs: common.keys_to_lower(params.get(key) if key else params)
+
+
+def merge_parameters(func1, func2):
+    return lambda params, **kwargs: common.merge_dicts(func1(params, **kwargs), func2(params, **kwargs))
+
+
+def params_dict_to_list(param_name, key_attr_name='Key', value_attr_name='Value', wrapper=None):
+    def do_replace(params, **kwargs):
+        result = []
+        for key, value in params.get(param_name, {}).items():
+            result.append({key_attr_name: key, value_attr_name: value})
+        if wrapper:
+            result = {wrapper: result}
+        return result
+    return do_replace

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -10,7 +10,8 @@ from localstack.constants import AWS_REGION_US_EAST_1, LOCALHOST
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import camel_to_snake_case, select_attributes
 from localstack.services.cloudformation.deployment_utils import (
-    PLACEHOLDER_RESOURCE_NAME, remove_none_values, params_list_to_dict, lambda_keys_to_lower, select_parameters)
+    PLACEHOLDER_RESOURCE_NAME, remove_none_values, params_list_to_dict, lambda_keys_to_lower,
+    merge_parameters, params_dict_to_list, select_parameters)
 
 LOG = logging.getLogger(__name__)
 
@@ -1113,10 +1114,8 @@ class SSMParameter(GenericBaseModel):
         return {
             'create': {
                 'function': 'put_parameter',
-                'parameters': select_parameters(
-                    'Name', 'Description', 'Value', 'KeyId', 'Overwrite',
-                    'AllowedPattern' 'Tags', 'Tier', 'Policies', 'DataType'
-                )
+                'parameters': merge_parameters(params_dict_to_list('Tags', wrapper='Tags'), select_parameters(
+                    'Name', 'Type', 'Value', 'Description', 'AllowedPattern', 'Policies', 'Tier'))
             }
         }
 

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -10,7 +10,7 @@ from localstack.constants import AWS_REGION_US_EAST_1, LOCALHOST
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import camel_to_snake_case, select_attributes
 from localstack.services.cloudformation.deployment_utils import (
-    PLACEHOLDER_RESOURCE_NAME, remove_none_values, params_list_to_dict, lambda_keys_to_lower)
+    PLACEHOLDER_RESOURCE_NAME, remove_none_values, params_list_to_dict, lambda_keys_to_lower, select_parameters)
 
 LOG = logging.getLogger(__name__)
 
@@ -1100,10 +1100,22 @@ class SSMParameter(GenericBaseModel):
     def cloudformation_type():
         return 'AWS::SSM::Parameter'
 
+    def get_physical_resource_id(self, attribute=None, **kwargs):
+        return self.props.get('Name') or self.resource_id
+
     def fetch_state(self, stack_name, resources):
         param_name = self.props.get('Name') or self.resource_id
         param_name = self.resolve_refs_recursively(stack_name, param_name, resources)
         return aws_stack.connect_to_service('ssm').get_parameter(Name=param_name)['Parameter']
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            'create': {
+                'function': 'put_parameter',
+                'parameters': select_parameters('Name', 'Type', 'Value')
+            }
+        }
 
 
 class SecretsManagerSecret(GenericBaseModel):

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1113,7 +1113,10 @@ class SSMParameter(GenericBaseModel):
         return {
             'create': {
                 'function': 'put_parameter',
-                'parameters': select_parameters('Name', 'Type', 'Value')
+                'parameters': select_parameters(
+                    'Name', 'Description', 'Value', 'KeyId', 'Overwrite',
+                    'AllowedPattern' 'Tags', 'Tier', 'Policies', 'DataType'
+                )
             }
         }
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -232,13 +232,6 @@ RESOURCE_TO_FUNCTION = {
             }
         }
     },
-    'SSM::Parameter': {
-        'create': {
-            'function': 'put_parameter',
-            'parameters': merge_parameters(params_dict_to_list('Tags', wrapper='Tags'), params_select_attributes(
-                'Name', 'Type', 'Value', 'Description', 'AllowedPattern', 'Policies', 'Tier'))
-        }
-    },
     'SecretsManager::Secret': {
         'create': {
             'function': 'create_secret',

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -78,17 +78,6 @@ def rename_params(func, rename_map):
     return do_rename
 
 
-def params_dict_to_list(param_name, key_attr_name='Key', value_attr_name='Value', wrapper=None):
-    def do_replace(params, **kwargs):
-        result = []
-        for key, value in params.get(param_name, {}).items():
-            result.append({key_attr_name: key, value_attr_name: value})
-        if wrapper:
-            result = {wrapper: result}
-        return result
-    return do_replace
-
-
 def get_lambda_code_param(params, **kwargs):
     code = params.get('Code', {})
     zip_file = code.get('ZipFile')
@@ -137,10 +126,6 @@ def es_add_tags_params(params, **kwargs):
     es_arn = aws_stack.es_domain_arn(params.get('DomainName'))
     tags = params.get('Tags', [])
     return {'ARN': es_arn, 'TagList': tags}
-
-
-def merge_parameters(func1, func2):
-    return lambda params, **kwargs: common.merge_dicts(func1(params, **kwargs), func2(params, **kwargs))
 
 
 def lambda_permission_params(params, **kwargs):


### PR DESCRIPTION
**Fixed**
- Cloudformation stack status when using `ExecuteChangeSet` to 'CREATE_COMPLETE'. Which was causing `cloudformation deploy` command to fail.

**Refractored**
- Refractored `SSM::Parameters` from `template_deployer` to `service_models`

**Issue**
- [760](https://github.com/localstack/localstack/issues/760)