### PR TITLE
adds sns xray propagation to sqs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ ci-build-test:
 	if [ "$$CUSTOM_CMD" = rebuild-base-image ]; then make docker-build-base-ci; exit; fi
 	# run tests using Python 3 (limit the set of tests to reduce test duration)
 	DEBUG=1 LAMBDA_EXECUTOR=docker USE_SSL=1 TEST_ERROR_INJECTION=1 TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
+	DEBUG=1 SQS_PROVIDER=elasticmq TEST_PATH="tests/integration/test_sns.py:SNSTest.test_publish_sqs_from_sns_with_xray_propagation" make test
 	# start pulling Docker base image in the background
 	nohup docker pull localstack/java-maven-node-python > /dev/null &
 	LAMBDA_EXECUTOR=docker-reuse TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,10 @@ docker-cp-coverage:
 web:
 	($(VENV_RUN); bin/localstack web)
 
-test:              ## Run automated tests
+## Run automated tests
+test:
+	# elasticmq is required as SQS backend for X-Ray testing
+	export SQS_PROVIDER=elasticmq; \
 	make lint && \
 		($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests $(NOSE_ARGS) --with-timer --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py' $(TEST_PATH))
 

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,6 @@ web:
 
 ## Run automated tests
 test:
-	# elasticmq is required as SQS backend for X-Ray testing
-	export SQS_PROVIDER=elasticmq; \
 	make lint && \
 		($(VENV_RUN); DEBUG=$(DEBUG) PYTHONPATH=`pwd` nosetests $(NOSE_ARGS) --with-timer --with-coverage --logging-level=WARNING --nocapture --no-skip --exe --cover-erase --cover-tests --cover-inclusive --cover-package=localstack --with-xunit --exclude='$(VENV_DIR).*' --ignore-files='lambda_python3.py' $(TEST_PATH))
 

--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -91,7 +91,7 @@ RUN mkdir -p /opt/code/localstack/localstack/infra && \
     curl -L -o /tmp/localstack.es.tar.gz \
         https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.7.0-linux-x86_64.tar.gz && \
     curl -L -o /tmp/elasticmq-server.jar \
-        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.7.jar && \
+        https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar && \
     (cd localstack/infra/ && tar -xf /tmp/localstack.es.tar.gz && \
         mv elasticsearch* elasticsearch && rm /tmp/localstack.es.tar.gz) && \
     (cd localstack/infra/elasticsearch/ && \

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -90,7 +90,7 @@ ELASTICSEARCH_PLUGIN_LIST = ['analysis-icu', 'ingest-attachment', 'analysis-kuro
  'mapper-murmur3', 'mapper-size', 'analysis-phonetic', 'analysis-smartcn', 'analysis-stempel', 'analysis-ukrainian']
 # Default ES modules to exclude (save apprx 66MB in the final image)
 ELASTICSEARCH_DELETE_MODULES = ['ingest-geoip']
-ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-0.15.7.jar'
+ELASTICMQ_JAR_URL = 'https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar'
 STS_JAR_URL = 'https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar'
 STEPFUNCTIONS_ZIP_URL = 'https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip'
 KMS_URL_PATTERN = 'https://s3-eu-west-2.amazonaws.com/local-kms/localstack/v3/local-kms.<arch>.bin'

--- a/localstack/package.json
+++ b/localstack/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "dependencies": {
     "kinesalite": "3.3.3",
+    "leveldown": "^5.2.1",
     "serverless-iot-offline": "git+https://github.com/whummer/serverless-iot-offline.git"
   },
   "optionalDependencies": {

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -20,6 +20,7 @@ from localstack.services.generic_proxy import ProxyListener
 from localstack.services.sns import sns_listener
 from .lambdas import lambda_integration
 from .test_lambda import TEST_LAMBDA_PYTHON, LAMBDA_RUNTIME_PYTHON36, TEST_LAMBDA_LIBS
+from localstack.services.install import SQS_BACKEND_IMPL
 
 TEST_TOPIC_NAME = 'TestTopic_snsTest'
 TEST_QUEUE_NAME = 'TestQueue_snsTest'
@@ -791,6 +792,8 @@ class SNSTest(unittest.TestCase):
             'Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1'
 
     def test_publish_sqs_from_sns_with_xray_propagation(self):
+        if SQS_BACKEND_IMPL != 'elasticmq':
+            return
 
         self.sns_client.meta.events.register('before-send.sns.Publish', self.add_xray_header)
 


### PR DESCRIPTION
Closes #3669 

- adds propagation of xray tracing header from sns to sqs message
- adds relevant test case
- bumps elasticmq version to enable XRay propagation support in SQS itself (moto does not seem to support XRay propagation at all)

**Please refer to the contribution guidelines in the README when submitting PRs.**
