### PR TITLE
Fix:Events put events on No detail

### DIFF
--- a/localstack/services/events/events_starter.py
+++ b/localstack/services/events/events_starter.py
@@ -155,7 +155,7 @@ def apply_patches():
                 'time': datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
                 'region': self.region,
                 'resources': event.get('Resources', []),
-                'detail': json.loads(event.get('Detail')),
+                'detail': json.loads(event.get('Detail', '{}')),
             }
 
             targets = []

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -701,6 +701,18 @@ class EventsTest(unittest.TestCase):
         )
         self.assertIn('Entries', response)
 
+    def test_put_event_without_detail(self):
+        self.events_client = aws_stack.connect_to_service('events', Region='eu-west-1')
+
+        response = self.events_client.put_events(
+            Entries=[
+                {
+                    'DetailType': 'Test',
+                }
+            ]
+        )
+        self.assertIn('Entries', response)
+
     def test_put_event_with_content_base_rule_in_pattern(self):
         queue_name = 'queue-{}'.format(short_uid())
         rule_name = 'rule-{}'.format(short_uid())


### PR DESCRIPTION
Fixed case of `PutEvents` with no `Detail`. Fix  #3682