### PR TITLE
KinesisConsumerDescription and Header added to binary messages

### DIFF
--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -68,7 +68,7 @@ class ProxyListenerKinesis(ProxyListener):
             consumer_to_locate = find_consumer(consumer_arn, consumer_name, stream_arn)
 
             if(not consumer_to_locate):
-                error_msg = 'Consumer %s not found.' % consumer_arn or consumer_name
+                error_msg = 'Consumer %s not found.' % (consumer_arn or consumer_name)
 
                 return simple_error_response(error_msg, 400, 'ResourceNotFoundException')
 

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -1,4 +1,3 @@
-from localstack.services.apigateway.helpers import make_error_response
 import re
 import json
 import time
@@ -12,7 +11,7 @@ from localstack.utils.common import to_str, json_safe, clone, epoch_timestamp, n
 from localstack.utils.analytics import event_publisher
 from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener
-from localstack.utils.aws.aws_responses import convert_to_binary_event_payload, flask_error_response_json
+from localstack.utils.aws.aws_responses import convert_to_binary_event_payload
 
 # action headers (should be left here - imported/required by other files)
 ACTION_PREFIX = 'Kinesis_20131202'


### PR DESCRIPTION
Now Localstack returns if a Stream Consumer really exists and also a new header was added to the binary messages.
With this changes, KCL can correctly register a Stream Consumer and read the binary messages without crashing.

Progress to fixing #3487 