### PR TITLE
Compute Auth Headers from Get Parameters (fixes #3716)

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -149,11 +149,13 @@ def do_forward_request_network(port, method, path, data, headers):
     response = function(url, data=data, headers=headers, verify=False, stream=True)
     return response
 
+
 def get_auth_string(headers, data=None):
     """
     Get Auth header from Header (this is how aws client's like boto typically
     provide it) or from query string or url encoded parameters (sometimes
-    happens with presigned requests. Always return in the Authorization Header form.
+    happens with presigned requests. Always return in the Authorization Header
+    form.
 
     Typically an auth string comes in as a header:
 
@@ -162,7 +164,6 @@ def get_auth_string(headers, data=None):
         SignedHeaders=content-type;host;x-amz-date, \
         Signature=9277c941f4ecafcc0f290728e50cd7a3fa0e41763fbd2373fcdd3faf2dbddc2e
 
-    
     Here's what Authorization looks like as part of an presigned GET request:
 
        &X-Amz-Algorithm=AWS4-HMAC-SHA256\
@@ -174,12 +175,12 @@ def get_auth_string(headers, data=None):
 
     auth_header = headers.get('authorization', '')
 
-    if auth_header is not '':
+    if auth_header != '':
         return auth_header
-    
+
     if data is None:
         return ''
-    
+
     data_components = urllib.parse.parse_qs(data)
     algorithm = data_components.get(b'X-Amz-Algorithm', [None])[0]
     credential = data_components.get(b'X-Amz-Credential', [None])[0]
@@ -187,7 +188,11 @@ def get_auth_string(headers, data=None):
     signed_headers = data_components.get(b'X-Amz-SignedHeaders', [None])[0]
 
     if algorithm and credential and signature and signed_headers:
-        return f"{algorithm.decode()} Credential={credential.decode()}, SignedHeaders={signed_headers.decode()}, Signature={signature.decode()}"
+        return (
+            f'{algorithm.decode()} Credential={credential.decode()}, ' +
+            f'SignedHeaders={signed_headers.decode()}, ' +
+            f'Signature={signature.decode()}'
+        )
 
     return ''
 

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -175,10 +175,10 @@ def get_auth_string(headers, data=None):
 
     auth_header = headers.get('authorization', '')
 
-    if auth_header != '':
+    if auth_header:
         return auth_header
 
-    if data is None:
+    if not data:
         return ''
 
     data_components = urllib.parse.parse_qs(data)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -491,7 +491,7 @@ def wait_for_port_open(port, http_path=None, expect_success=True, retries=10, sl
         If 'http_path' is set, make a GET request to this path and assert a non-error response. """
     def check():
         if not is_port_open(port, http_path=http_path, expect_success=expect_success):
-            raise Exception()
+            raise Exception(f"Port {port} (path: {http_path or 'no path'}) was not open")
 
     return retry(check, sleep=sleep_time, retries=retries)
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -491,7 +491,7 @@ def wait_for_port_open(port, http_path=None, expect_success=True, retries=10, sl
         If 'http_path' is set, make a GET request to this path and assert a non-error response. """
     def check():
         if not is_port_open(port, http_path=http_path, expect_success=expect_success):
-            raise Exception(f"Port {port} (path: {http_path or 'no path'}) was not open")
+            raise Exception('Port %s (path: %s) was not open' % (port, http_path))
 
     return retry(check, sleep=sleep_time, retries=retries)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -871,7 +871,7 @@ class SQSTest(unittest.TestCase):
 
     def test_list_queue_with_auth_in_presigned_url(self):
         base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SQS)
-        # encoded_url = urlencode()
+
         req = AWSRequest(method='GET', url=base_url, params={
             'Action': 'ListQueues',
             'Version': '2012-11-05'

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -873,13 +873,13 @@ class SQSTest(unittest.TestCase):
             'Version': '2012-11-05'
         })
 
-        # boto doesn't support querystring-style auth, so we'll have to do some weird logic
-        # to use boto's signing functions, to understand what's going on here look at the
-        # internals of the SigV4Auth.add_auth method. It mainly operates by mutating a request,
-        # but we don't want it to mutate our request and add any headers.
+        # boto doesn't support querystring-style auth, so we have to do some
+        # weird logic to use boto's signing functions, to understand what's
+        # going on here look at the internals of the SigV4Auth.add_auth
+        # method.
         datetime_now = datetime.datetime.utcnow()
         req.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
-        signer = SigV4Auth(Credentials("test", "test"), "sqs", "us-east-1")
+        signer = SigV4Auth(Credentials('test', 'test'), 'sqs', 'us-east-1')
         canonical_request = signer.canonical_request(req)
         string_to_sign = signer.string_to_sign(req, canonical_request)
 
@@ -887,16 +887,17 @@ class SQSTest(unittest.TestCase):
             'Action': 'ListQueues',
             'Version': '2012-11-05',
             'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-            "X-Amz-Credential": signer.scope(req),
-            "X-Amz-SignedHeaders": ";".join(signer.headers_to_sign(req).keys()),
-            "X-Amz-Signature": signer.signature(string_to_sign, req)
+            'X-Amz-Credential': signer.scope(req),
+            'X-Amz-SignedHeaders': ';'.join(
+                signer.headers_to_sign(req).keys()
+            ),
+            'X-Amz-Signature': signer.signature(string_to_sign, req)
         })
 
         res = requests.get(url=base_url, data=encoded_url)
         self.assertEqual(res.status_code, 200)
-        self.assertTrue(b"<ListQueuesResponse>" in res.content)
+        self.assertTrue(b'<ListQueuesResponse>' in res.content)
 
-    
     # ---------------
     # HELPER METHODS
     # ---------------

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -868,7 +868,7 @@ class SQSTest(unittest.TestCase):
     def test_list_queue_with_auth_in_presigned_url(self):
         base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SQS)
         # encoded_url = urlencode()
-        req  = AWSRequest(method="GET", url=base_url, params={
+        req = AWSRequest(method='GET', url=base_url, params={
             'Action': 'ListQueues',
             'Version': '2012-11-05'
         })

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -902,7 +902,7 @@ class SQSTest(unittest.TestCase):
             'X-Amz-Signature': signer.signature(string_to_sign, req)
         })
 
-        res = requests.get(url=base_url, data=encoded_url)
+        res = requests.post(url=base_url, data=encoded_url)
         self.assertEqual(res.status_code, 200)
         self.assertTrue(b'<ListQueuesResponse>' in res.content)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -9,7 +9,11 @@ from botocore.exceptions import ClientError
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
 from botocore.auth import SigV4Auth, SIGV4_TIMESTAMP
-from localstack.constants import TEST_AWS_ACCOUNT_ID
+from localstack.constants import (
+    TEST_AWS_ACCOUNT_ID,
+    TEST_AWS_ACCESS_KEY_ID,
+    TEST_AWS_SECRET_ACCESS_KEY
+)
 from six.moves.urllib.parse import urlencode
 
 from localstack import config
@@ -879,7 +883,11 @@ class SQSTest(unittest.TestCase):
         # method.
         datetime_now = datetime.datetime.utcnow()
         req.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
-        signer = SigV4Auth(Credentials('test', 'test'), 'sqs', 'us-east-1')
+        signer = SigV4Auth(
+            Credentials(TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY),
+            'sqs',
+            aws_stack.get_region()
+        )
         canonical_request = signer.canonical_request(req)
         string_to_sign = signer.string_to_sign(req, canonical_request)
 

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -84,16 +84,16 @@ class EdgeServiceTest(unittest.TestCase):
             b'test%2F20210313%2Fus-east-1%2Fsqs%2Faws4_request&' +
             b'X-Amz-Date=20210313T011059Z&' +
             b'X-Amz-Expires=86400000&' +
-            b'X-Amz-SignedHeaders=content-type;host;x-amz-date&' +
+            b'X-Amz-SignedHeaders=content-type%3Bhost%3Bx-amz-date&' +
             b'X-Amz-Signature=' +
             b'3cba88ae6cbb8036126d2ba18ba8ded5eea9e5484d70822affce9dad03be5993'
         )
 
         self.assertEqual(
-            get_auth_string(headers_with_auth, b''),
+            get_auth_string('POST', '/', headers_with_auth, b''),
             headers_with_auth.get('authorization')
         )
         self.assertEqual(
-            get_auth_string(Headers(), body_with_auth),
+            get_auth_string('POST', '/', Headers(), body_with_auth),
             headers_with_auth.get('authorization')
         )

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -66,7 +66,14 @@ class EdgeServiceTest(unittest.TestCase):
                 ('X-Amz-Date', '20210313T160953Z'),
                 (
                     'Authorization',
-                    'AWS4-HMAC-SHA256 Credential=test/20210313/us-east-1/sqs/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=3cba88ae6cbb8036126d2ba18ba8ded5eea9e5484d70822affce9dad03be5993',
+                    (
+                        'AWS4-HMAC-SHA256 Credential='
+                        'test/20210313/us-east-1/sqs/aws4_request, '
+                        'SignedHeaders=content-type;host;x-amz-date, '
+                        'Signature='
+                        '3cba88ae6cbb8036126d2ba18ba8ded5'
+                        'eea9e5484d70822affce9dad03be5993'
+                    )
                 ),
             ]
         )

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -82,5 +82,11 @@ class EdgeServiceTest(unittest.TestCase):
             b'3cba88ae6cbb8036126d2ba18ba8ded5eea9e5484d70822affce9dad03be5993'
         )
 
-        assert get_auth_string(headers_with_auth, b"") == headers_with_auth.get("authorization")
-        assert get_auth_string(Headers(), body_with_auth) == headers_with_auth.get("authorization")
+        self.assertEqual(
+            get_auth_string(headers_with_auth, b''),
+            headers_with_auth.get('authorization')
+        )
+        self.assertEqual(
+            get_auth_string(Headers(), body_with_auth),
+            headers_with_auth.get('authorization')
+        )

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -1,5 +1,6 @@
 import unittest
-from localstack.services.edge import is_s3_form_data
+from localstack.services.edge import is_s3_form_data, get_auth_string
+from werkzeug.datastructures import Headers
 
 
 class EdgeServiceTest(unittest.TestCase):
@@ -57,3 +58,29 @@ class EdgeServiceTest(unittest.TestCase):
         --28f72589b2be0c9de84386b52c615990--
         """
         self.assertEqual(is_s3_form_data(data_bytes), False)
+
+    def test_get_auth_string(self):
+        # Typical Header with Authorization
+        headers_with_auth = Headers(
+            [
+                ('X-Amz-Date', '20210313T160953Z'),
+                (
+                    'Authorization',
+                    'AWS4-HMAC-SHA256 Credential=test/20210313/us-east-1/sqs/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=3cba88ae6cbb8036126d2ba18ba8ded5eea9e5484d70822affce9dad03be5993',
+                ),
+            ]
+        )
+
+        body_with_auth = (
+            b'X-Amz-Algorithm=AWS4-HMAC-SHA256&' +
+            b'X-Amz-Credential=' +
+            b'test%2F20210313%2Fus-east-1%2Fsqs%2Faws4_request&' +
+            b'X-Amz-Date=20210313T011059Z&' +
+            b'X-Amz-Expires=86400000&' +
+            b'X-Amz-SignedHeaders=content-type;host;x-amz-date&' +
+            b'X-Amz-Signature=' +
+            b'3cba88ae6cbb8036126d2ba18ba8ded5eea9e5484d70822affce9dad03be5993'
+        )
+
+        assert get_auth_string(headers_with_auth, b"") == headers_with_auth.get("authorization")
+        assert get_auth_string(Headers(), body_with_auth) == headers_with_auth.get("authorization")


### PR DESCRIPTION
Fixes #3716 

Authorization GET Parameters are read and turned into an `Authorization` header.