### PR TITLE
Run CF deployments asynchronously in the background

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ docker-build:      ## Build Docker image
 	test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
 	# start build
 	docker build --build-arg LOCALSTACK_BUILD_GIT_HASH=$(shell git rev-parse --short HEAD) \
-	--build-arg=LOCALSTACK_BUILD_DATE=$(shell date -u +"%Y%m%d") -t $(IMAGE_NAME) .
+	--build-arg=LOCALSTACK_BUILD_DATE=$(shell date -u +"%Y-%m-%d") -t $(IMAGE_NAME) .
 
 docker-squash:
 	# squash entire image

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You can pass the following environment variables to LocalStack:
   Kinesis, DynamoDB, Elasticsearch, S3, Secretsmanager, SSM, SQS, SNS). Set it to `/tmp/localstack/data` to enable persistence
   (`/tmp/localstack` is mounted into the Docker container), leave blank to disable
   persistence (default).
-* `PORT_WEB_UI`: Port for the Web user interface / dashboard (default: `8080`). Note that the Web UI is now deprecated, and requires to use the `localstack/localstack-full` Docker image.
+* `PORT_WEB_UI`: Port for the Web user interface / dashboard (default: `8080`). Note that the Web UI is now deprecated (needs to be activated with `START_WEB=1`), and requires to use the `localstack/localstack-full` Docker image.
 * `<SERVICE>_BACKEND`: Custom endpoint URL to use for a specific service, where `<SERVICE>` is the uppercase
   service name (currently works for: `APIGATEWAY`, `CLOUDFORMATION`, `DYNAMODB`, `ELASTICSEARCH`,
   `KINESIS`, `S3`, `SNS`, `SQS`). This allows to easily integrate third-party services into LocalStack.
@@ -244,7 +244,7 @@ You can pass the following environment variables to LocalStack:
 * `DOCKER_FLAGS`: Allows to pass custom flags (e.g., volume mounts) to "docker run" when running LocalStack in Docker.
 * `DOCKER_CMD`: Shell command used to run Docker containers, e.g., set to `"sudo docker"` to run as sudo (default: `docker`).
 * `SKIP_INFRA_DOWNLOADS`: Whether to skip downloading additional infrastructure components (e.g., specific Elasticsearch versions).
-* `START_WEB`: Flag to control whether the Web UI should be started in Docker (values: `0`/`1`; default: `1`).
+* `START_WEB`: Flag to control whether the Web UI should be started in Docker (default: `0`; deprecated).
 * `LAMBDA_FALLBACK_URL`: Fallback URL to use when a non-existing Lambda is invoked. Either records invocations in DynamoDB (value `dynamodb://<table_name>`) or forwards invocations as a POST request (value `http(s)://...`).
 * `LAMBDA_FORWARD_URL`: URL used to forward all Lambda invocations (useful to run Lambdas via an external service).
 * `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can pass the following environment variables to LocalStack:
 * `DOCKER_FLAGS`: Allows to pass custom flags (e.g., volume mounts) to "docker run" when running LocalStack in Docker.
 * `DOCKER_CMD`: Shell command used to run Docker containers, e.g., set to `"sudo docker"` to run as sudo (default: `docker`).
 * `SKIP_INFRA_DOWNLOADS`: Whether to skip downloading additional infrastructure components (e.g., specific Elasticsearch versions).
-* `START_WEB`: Flag to control whether the Web UI should be started in Docker (default: `0`; deprecated).
+* `START_WEB`: Flag to control whether the Web UI should be started in Docker (default: `false`; deprecated).
 * `LAMBDA_FALLBACK_URL`: Fallback URL to use when a non-existing Lambda is invoked. Either records invocations in DynamoDB (value `dynamodb://<table_name>`) or forwards invocations as a POST request (value `http(s)://...`).
 * `LAMBDA_FORWARD_URL`: URL used to forward all Lambda invocations (useful to run Lambdas via an external service).
 * `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -76,7 +76,7 @@ SQS_PORT_EXTERNAL = int(os.environ.get('SQS_PORT_EXTERNAL') or 0)
 # name of the host under which the LocalStack services are available
 LOCALSTACK_HOSTNAME = os.environ.get('LOCALSTACK_HOSTNAME', '').strip() or HOSTNAME
 
-# whether to remotely copy the lambda or locally mount a volume
+# whether to remotely copy the lambda code or locally mount a volume
 LAMBDA_REMOTE_DOCKER = is_env_true('LAMBDA_REMOTE_DOCKER')
 
 # network that the docker lambda container will be joining
@@ -134,7 +134,7 @@ DOCKER_FLAGS = os.environ.get('DOCKER_FLAGS', '').strip()
 DOCKER_CMD = os.environ.get('DOCKER_CMD', '').strip() or 'docker'
 
 # whether to start the web API
-START_WEB = os.environ.get('START_WEB', '').strip() not in FALSE_STRINGS
+START_WEB = os.environ.get('START_WEB', '').strip() in TRUE_STRINGS
 
 # whether to forward edge requests in-memory (instead of via proxy servers listening on backend ports)
 # TODO: this will likely become the default and may get removed in the future

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -21,7 +21,7 @@ from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack, aws_responses
 from localstack.utils.common import (
     to_str, to_bytes, load_file, save_file, TMP_FILES, ensure_readable, short_uid, long_uid, json_safe,
-    mkdir, unzip, is_zip_file, run, run_safe, first_char_to_lower, run_for_max_seconds,
+    mkdir, unzip, is_zip_file, run, run_safe, first_char_to_lower, run_for_max_seconds, parse_request_data,
     timestamp_millis, now_utc, safe_requests, FuncThread, isoformat_milliseconds, synchronized)
 from localstack.services.awslambda import lambda_executors
 from localstack.services.generic_proxy import RegionBackend
@@ -290,28 +290,34 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
                                   stage_variables={}, request_context={}, event_context={}):
     try:
         resource_path = resource_path or path
+        event = construct_invocation_event(method, resource_path, headers, payload, query_string_params)
         path_params = dict(path_params)
         fix_proxy_path_params(path_params)
-        event = {
-            'path': path,
-            'headers': dict(headers),
-            'multiValueHeaders': multi_value_dict_for_list(headers),
-            'pathParameters': path_params,
-            'body': payload,
-            'isBase64Encoded': False,
-            'resource': resource_path,
-            'httpMethod': method,
-            'queryStringParameters': query_string_params,
-            'multiValueQueryStringParameters': multi_value_dict_for_list(query_string_params),
-            'requestContext': request_context,
-            'stageVariables': stage_variables,
-        }
+        event['pathParameters'] = path_params
+        event['resource'] = resource_path
+        event['requestContext'] = request_context
+        event['stageVariables'] = stage_variables
         LOG.debug('Running Lambda function %s from API Gateway invocation: %s %s' % (func_arn, method or 'GET', path))
         asynchronous = not config.SYNCHRONOUS_API_GATEWAY_EVENTS
         inv_result = run_lambda(event=event, context=event_context, func_arn=func_arn, asynchronous=asynchronous)
         return inv_result.result
     except Exception as e:
         LOG.warning('Unable to run Lambda function on API Gateway message: %s %s' % (e, traceback.format_exc()))
+
+
+def construct_invocation_event(method, path, headers, data, query_string_params={}):
+    query_string_params = query_string_params or parse_request_data(method, path, '')
+    event = {
+        'path': path,
+        'headers': dict(headers),
+        'multiValueHeaders': multi_value_dict_for_list(headers),
+        'body': data,
+        'isBase64Encoded': False,
+        'httpMethod': method,
+        'queryStringParameters': query_string_params,
+        'multiValueQueryStringParameters': multi_value_dict_for_list(query_string_params)
+    }
+    return event
 
 
 def process_sns_notification(func_arn, topic_arn, subscription_arn, message, message_id,

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -67,6 +67,10 @@ def merge_parameters(func1, func2):
     return lambda params, **kwargs: common.merge_dicts(func1(params, **kwargs), func2(params, **kwargs))
 
 
+def str_or_none(o):
+    return o if o is None else json.dumps(o) if isinstance(o, (dict, list)) else str(o)
+
+
 def params_dict_to_list(param_name, key_attr_name='Key', value_attr_name='Value', wrapper=None):
     def do_replace(params, **kwargs):
         result = []
@@ -76,3 +80,13 @@ def params_dict_to_list(param_name, key_attr_name='Key', value_attr_name='Value'
             result = {wrapper: result}
         return result
     return do_replace
+
+
+def params_select_attributes(*attrs):
+    def do_select(params, **kwargs):
+        result = {}
+        for attr in attrs:
+            if params.get(attr) is not None:
+                result[attr] = str_or_none(params.get(attr))
+        return result
+    return do_select

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1325,6 +1325,9 @@ class EC2Subnet(GenericBaseModel):
             }
         }
 
+    def get_physical_resource_id(self, attribute=None, **kwargs):
+        return self.props.get('SubnetId')
+
 
 class InstanceProfile(GenericBaseModel):
     @staticmethod

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -955,17 +955,19 @@ def deploy_cf_stack(stack_name, template_body):
     return await_stack_completion(stack_name)
 
 
-def await_stack_status(stack_name, expected_statuses, retries=3, sleep=2):
+def await_stack_status(stack_name, expected_statuses, retries=10, sleep=2):
     def check_stack():
         stack = get_stack_details(stack_name)
-        assert stack['StackStatus'] in expected_statuses
+        if stack['StackStatus'] not in expected_statuses:
+            raise Exception('Status "%s" for stack "%s" not in expected list: %s' % (
+                stack['StackStatus'], stack_name, expected_statuses))
         return stack
 
     expected_statuses = expected_statuses if isinstance(expected_statuses, list) else [expected_statuses]
     return retry(check_stack, retries, sleep)
 
 
-def await_stack_completion(stack_name, retries=3, sleep=2, statuses=None):
+def await_stack_completion(stack_name, retries=10, sleep=2, statuses=None):
     statuses = statuses or ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
     return await_stack_status(stack_name, statuses, retries=retries, sleep=sleep)
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -342,11 +342,17 @@ def sqs_queue_url_for_arn(queue_arn):
         return queue_arn
     if queue_arn in SQS_ARN_TO_URL_CACHE:
         return SQS_ARN_TO_URL_CACHE[queue_arn]
-    sqs_client = connect_to_service('sqs')
-    parts = queue_arn.split(':')
-    result = sqs_client.get_queue_url(QueueName=parts[5], QueueOwnerAWSAccountId=parts[4])['QueueUrl']
+    region_name = extract_region_from_arn(queue_arn)
+    sqs_client = connect_to_service('sqs', region_name=region_name)
+    queue_name = sqs_queue_name(queue_arn)
+    result = sqs_client.get_queue_url(QueueName=queue_name)['QueueUrl']
     SQS_ARN_TO_URL_CACHE[queue_arn] = result
     return result
+
+
+# TODO: remove and merge with sqs_queue_url_for_arn(..) above!!
+def get_sqs_queue_url(queue_arn):
+    return sqs_queue_url_for_arn(queue_arn)
 
 
 def extract_region_from_auth_header(headers):
@@ -628,14 +634,6 @@ def sqs_queue_name(queue_arn):
 def sns_topic_arn(topic_name, account_id=None):
     account_id = get_account_id(account_id)
     return ('arn:aws:sns:%s:%s:%s' % (get_region(), account_id, topic_name))
-
-
-def get_sqs_queue_url(queue_arn):
-    region_name = extract_region_from_arn(queue_arn)
-    queue_name = sqs_queue_name(queue_arn)
-    client = connect_to_service('sqs', region_name=region_name)
-    response = client.get_queue_url(QueueName=queue_name)
-    return response['QueueUrl']
 
 
 def sqs_receive_message(queue_arn):
@@ -955,7 +953,7 @@ def deploy_cf_stack(stack_name, template_body):
     return await_stack_completion(stack_name)
 
 
-def await_stack_status(stack_name, expected_statuses, retries=15, sleep=2):
+def await_stack_status(stack_name, expected_statuses, retries=20, sleep=2):
     def check_stack():
         stack = get_stack_details(stack_name)
         if stack['StackStatus'] not in expected_statuses:
@@ -967,7 +965,7 @@ def await_stack_status(stack_name, expected_statuses, retries=15, sleep=2):
     return retry(check_stack, retries, sleep)
 
 
-def await_stack_completion(stack_name, retries=15, sleep=2, statuses=None):
+def await_stack_completion(stack_name, retries=20, sleep=2, statuses=None):
     statuses = statuses or ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
     return await_stack_status(stack_name, statuses, retries=retries, sleep=sleep)
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -955,7 +955,7 @@ def deploy_cf_stack(stack_name, template_body):
     return await_stack_completion(stack_name)
 
 
-def await_stack_status(stack_name, expected_statuses, retries=10, sleep=2):
+def await_stack_status(stack_name, expected_statuses, retries=15, sleep=2):
     def check_stack():
         stack = get_stack_details(stack_name)
         if stack['StackStatus'] not in expected_statuses:
@@ -967,7 +967,7 @@ def await_stack_status(stack_name, expected_statuses, retries=10, sleep=2):
     return retry(check_stack, retries, sleep)
 
 
-def await_stack_completion(stack_name, retries=10, sleep=2, statuses=None):
+def await_stack_completion(stack_name, retries=15, sleep=2, statuses=None):
     statuses = statuses or ['CREATE_COMPLETE', 'UPDATE_COMPLETE']
     return await_stack_status(stack_name, statuses, retries=retries, sleep=sleep)
 

--- a/localstack/utils/cli.py
+++ b/localstack/utils/cli.py
@@ -87,7 +87,7 @@ Usage:
   localstack web <subcommand> [options]
 
 Commands:
-  web start           Start the Web dashboard
+  web start           Start the Web dashboard (Note: deprecated and no longer supported!)
 
 Options:
   --port=<>           Network port for running the Web server (default: 8080)

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -547,22 +547,6 @@ RESOURCE_TO_FUNCTION = {
             }
         }
     },
-    'EC2::SecurityGroup': {
-        'create': {
-            'function': 'create_security_group',
-            'parameters': {
-                'GroupName': 'GroupName',
-                'VpcId': 'VpcId',
-                'Description': 'GroupDescription'
-            }
-        },
-        'delete': {
-            'function': 'delete_security_group',
-            'parameters': {
-                'GroupId': 'PhysicalResourceId'
-            }
-        }
-    },
     'IAM::InstanceProfile': {
         'create': {
             'function': 'create_instance_profile',

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -2005,10 +2005,7 @@ class TemplateDeployer(object):
                 new_stack.metadata['Status'] = status
 
         # run deployment in background loop, to avoid client network timeouts
-        run_thread = True
-        if run_thread:
-            return start_worker_thread(_run)
-        return _run()
+        return start_worker_thread(_run)
 
     def do_apply_changes_in_loop(self, changes, stack, stack_name):
         # apply changes in a retry loop, to resolve resource dependencies and converge to the target state


### PR DESCRIPTION
Run CF deployments asynchronously in the background. This is required for large stacks with long-running deployment loops, to prevent network timeouts in the client connection.