### PR TITLE
Fix 404 with presigned GET requests with querystring auth parameters and add test

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -54,7 +54,7 @@ class ProxyListenerEdge(ProxyListener):
 
         target = headers.get('x-amz-target', '')
         auth_header = get_auth_string(method, path, headers, data)
-        if auth_header and not headers.get('authorization', ''):
+        if auth_header and not headers.get('authorization'):
             headers['authorization'] = auth_header
         host = headers.get('host', '')
         headers[HEADER_LOCALSTACK_EDGE_URL] = 'https://%s' % host
@@ -177,9 +177,6 @@ def get_auth_string(method, path, headers, data=None):
 
     if auth_header:
         return auth_header
-
-    if not data:
-        return ''
 
     data_components = parse_request_data(method, path, data)
     algorithm = data_components.get('X-Amz-Algorithm')

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -869,7 +869,7 @@ class SQSTest(unittest.TestCase):
         result = self.client.list_queues()
         self.assertNotIn(queue_url.get('QueueUrl'), result.get('QueueUrls'))
 
-    def test_post_list_queue_with_auth_in_presigned_url(self):
+    def test_post_list_queues_with_auth_in_presigned_url(self):
         base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SQS)
 
         req = AWSRequest(method='POST', url=base_url, data={
@@ -906,7 +906,7 @@ class SQSTest(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertTrue(b'<ListQueuesResponse>' in res.content)
 
-    def test_get_list_queue_with_auth_in_presigned_url(self):
+    def test_get_list_queues_with_auth_in_presigned_url(self):
         base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SQS)
 
         req = AWSRequest(method='GET', url=base_url, params={

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -869,10 +869,10 @@ class SQSTest(unittest.TestCase):
         result = self.client.list_queues()
         self.assertNotIn(queue_url.get('QueueUrl'), result.get('QueueUrls'))
 
-    def test_post_list_queues_with_auth_in_presigned_url(self):
+    def list_queues_with_auth_in_presigned_url(self, method):
         base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SQS)
 
-        req = AWSRequest(method='POST', url=base_url, data={
+        req = AWSRequest(method=method, url=base_url, data={
             'Action': 'ListQueues',
             'Version': '2012-11-05'
         })
@@ -891,41 +891,7 @@ class SQSTest(unittest.TestCase):
         canonical_request = signer.canonical_request(req)
         string_to_sign = signer.string_to_sign(req, canonical_request)
 
-        encoded_url = urlencode({
-            'Action': 'ListQueues',
-            'Version': '2012-11-05',
-            'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
-            'X-Amz-Credential': signer.scope(req),
-            'X-Amz-SignedHeaders': ';'.join(
-                signer.headers_to_sign(req).keys()
-            ),
-            'X-Amz-Signature': signer.signature(string_to_sign, req)
-        })
-
-        res = requests.post(url=base_url, data=encoded_url)
-        self.assertEqual(res.status_code, 200)
-        self.assertTrue(b'<ListQueuesResponse>' in res.content)
-
-    def test_get_list_queues_with_auth_in_presigned_url(self):
-        base_url = '{}://{}:{}'.format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, config.PORT_SQS)
-
-        req = AWSRequest(method='GET', url=base_url, params={
-            'Action': 'ListQueues',
-            'Version': '2012-11-05'
-        })
-
-        # manually construct signed parameters
-        datetime_now = datetime.datetime.utcnow()
-        req.context['timestamp'] = datetime_now.strftime(SIGV4_TIMESTAMP)
-        signer = SigV4Auth(
-            Credentials(TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY),
-            'sqs',
-            aws_stack.get_region()
-        )
-        canonical_request = signer.canonical_request(req)
-        string_to_sign = signer.string_to_sign(req, canonical_request)
-
-        params_with_auth = {
+        payload = {
             'Action': 'ListQueues',
             'Version': '2012-11-05',
             'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
@@ -936,7 +902,18 @@ class SQSTest(unittest.TestCase):
             'X-Amz-Signature': signer.signature(string_to_sign, req)
         }
 
-        res = requests.get(url=base_url, params=params_with_auth)
+        if method == 'GET':
+            return requests.get(url=base_url, params=payload)
+        else:
+            return requests.post(url=base_url, data=urlencode(payload))
+
+    def test_post_list_queues_with_auth_in_presigned_url(self):
+        res = self.list_queues_with_auth_in_presigned_url(method='POST')
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(b'<ListQueuesResponse>' in res.content)
+
+    def test_get_list_queues_with_auth_in_presigned_url(self):
+        res = self.list_queues_with_auth_in_presigned_url(method='GET')
         self.assertEqual(res.status_code, 200)
         self.assertTrue(b'<ListQueuesResponse>' in res.content)
 

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -89,10 +89,13 @@ class EdgeServiceTest(unittest.TestCase):
             b'3cba88ae6cbb8036126d2ba18ba8ded5eea9e5484d70822affce9dad03be5993'
         )
 
+        # check getting auth string from header with Authorization header
         self.assertEqual(
             get_auth_string('POST', '/', headers_with_auth, b''),
             headers_with_auth.get('authorization')
         )
+
+        # check getting auth string from body with authorization params
         self.assertEqual(
             get_auth_string('POST', '/', Headers(), body_with_auth),
             headers_with_auth.get('authorization')


### PR DESCRIPTION
Sorry for the double-PR in a day @whummer, and thanks for the help on the last one.

This PR fixes an issue where the Authorization parameters couldn't be sent as GET parameters. I meant to include in in the last PR, but well the test suite takes a bit to run and I stepped away :)