### PR TITLE
fixed location constraint value for specific region

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1048,7 +1048,6 @@ class ProxyListenerS3(PersistingProxyListener):
 
         modified_data = None
 
-
         # If this request contains streaming v4 authentication signatures, strip them from the message
         # Related isse: https://github.com/localstack/localstack/issues/98
         # TODO we should evaluate whether to replace moto s3 with scality/S3:

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -95,11 +95,6 @@ CORS_HEADERS = [
     'Access-Control-Request-Headers', 'Access-Control-Request-Method'
 ]
 
-LOCATION_CONSTRAINT_VALID_REGION = ['af-south-1', 'ap-east-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
-    'ap-south-1', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'cn-north-1', 'cn-northwest-1, EU',
-    'eu-central-1', 'eu-north-1', 'eu-south-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'me-south-1', 'sa-east-1',
-    'us-east-2', 'us-gov-east-1', 'us-gov-west-1', 'us-west-1', 'us-west-2']
-
 
 def event_type_matches(events, action, api_method):
     """ check whether any of the event types in `events` matches the
@@ -481,7 +476,7 @@ def fix_location_constraint(response):
         content = to_str(response.content or '') or ''
     except Exception:
         content = ''
-    if aws_stack.get_region() in LOCATION_CONSTRAINT_VALID_REGION and 'LocationConstraint' in content:
+    if aws_stack.get_region() != 'us-east-1' and 'LocationConstraint' in content:
         pattern = r'<LocationConstraint([^>]*)>\s*</LocationConstraint>'
         replace = r'<LocationConstraint\1>%s</LocationConstraint>' % aws_stack.get_region()
         response._content = re.sub(pattern, replace, content)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -95,6 +95,11 @@ CORS_HEADERS = [
     'Access-Control-Request-Headers', 'Access-Control-Request-Method'
 ]
 
+LOCATION_CONSTRAINT_VALID_REGION = ['af-south-1', 'ap-east-1', 'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3',
+    'ap-south-1', 'ap-southeast-1', 'ap-southeast-2', 'ca-central-1', 'cn-north-1', 'cn-northwest-1, EU',
+    'eu-central-1', 'eu-north-1', 'eu-south-1', 'eu-west-1', 'eu-west-2', 'eu-west-3', 'me-south-1', 'sa-east-1',
+    'us-east-2', 'us-gov-east-1', 'us-gov-west-1', 'us-west-1', 'us-west-2']
+
 
 def event_type_matches(events, action, api_method):
     """ check whether any of the event types in `events` matches the
@@ -476,7 +481,7 @@ def fix_location_constraint(response):
         content = to_str(response.content or '') or ''
     except Exception:
         content = ''
-    if 'LocationConstraint' in content:
+    if aws_stack.get_region() in LOCATION_CONSTRAINT_VALID_REGION and 'LocationConstraint' in content:
         pattern = r'<LocationConstraint([^>]*)>\s*</LocationConstraint>'
         replace = r'<LocationConstraint\1>%s</LocationConstraint>' % aws_stack.get_region()
         response._content = re.sub(pattern, replace, content)
@@ -1250,7 +1255,7 @@ class ProxyListenerS3(PersistingProxyListener):
             append_cors_headers(bucket_name, request_method=method, request_headers=headers, response=response)
             append_last_modified_headers(response=response)
             append_list_objects_marker(method, path, data, response)
-            # fix_location_constraint(response)
+            fix_location_constraint(response)
             fix_range_content_type(bucket_name, path, headers, response)
             fix_delete_objects_response(bucket_name, method, parsed, data, headers, response)
             fix_metadata_key_underscores(response=response)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1049,12 +1049,12 @@ class ProxyListenerS3(PersistingProxyListener):
         modified_data = None
 
         # TODO: For some reason, moto doesn't allow us to put a location constraint on us-east-1
-        to_find1 = to_bytes('<LocationConstraint>us-east-1</LocationConstraint>')
-        to_find2 = to_bytes('<CreateBucketConfiguration')
-        if data and data.startswith(to_bytes('<')) and to_find1 in data and to_find2 in data:
-            # Note: with the latest version, <CreateBucketConfiguration> must either
-            # contain a valid <LocationConstraint>, or not be present at all in the body.
-            modified_data = b''
+        # to_find1 = to_bytes('<LocationConstraint>us-east-1</LocationConstraint>')
+        # to_find2 = to_bytes('<CreateBucketConfiguration')
+        # if data and data.startswith(to_bytes('<')) and to_find1 in data and to_find2 in data:
+        #     # Note: with the latest version, <CreateBucketConfiguration> must either
+        #     # contain a valid <LocationConstraint>, or not be present at all in the body.
+        #     modified_data = b''
 
         # If this request contains streaming v4 authentication signatures, strip them from the message
         # Related isse: https://github.com/localstack/localstack/issues/98
@@ -1250,7 +1250,7 @@ class ProxyListenerS3(PersistingProxyListener):
             append_cors_headers(bucket_name, request_method=method, request_headers=headers, response=response)
             append_last_modified_headers(response=response)
             append_list_objects_marker(method, path, data, response)
-            fix_location_constraint(response)
+            # fix_location_constraint(response)
             fix_range_content_type(bucket_name, path, headers, response)
             fix_delete_objects_response(bucket_name, method, parsed, data, headers, response)
             fix_metadata_key_underscores(response=response)

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1048,13 +1048,6 @@ class ProxyListenerS3(PersistingProxyListener):
 
         modified_data = None
 
-        # TODO: For some reason, moto doesn't allow us to put a location constraint on us-east-1
-        # to_find1 = to_bytes('<LocationConstraint>us-east-1</LocationConstraint>')
-        # to_find2 = to_bytes('<CreateBucketConfiguration')
-        # if data and data.startswith(to_bytes('<')) and to_find1 in data and to_find2 in data:
-        #     # Note: with the latest version, <CreateBucketConfiguration> must either
-        #     # contain a valid <LocationConstraint>, or not be present at all in the body.
-        #     modified_data = b''
 
         # If this request contains streaming v4 authentication signatures, strip them from the message
         # Related isse: https://github.com/localstack/localstack/issues/98


### PR DESCRIPTION
Fixed:
- Location Constraint returns `null` for selected region
- Valid Values: `af-south-1 | ap-east-1 | ap-northeast-1 | ap-northeast-2 | ap-northeast-3 | ap-south-1 | ap-southeast-1 | ap-southeast-2 | ca-central-1 | cn-north-1 | cn-northwest-1 | EU | eu-central-1 | eu-north-1 | eu-south-1 | eu-west-1 | eu-west-2 | eu-west-3 | me-south-1 | sa-east-1 | us-east-2 | us-gov-east-1 | us-gov-west-1 | us-west-1 | us-west-2`