### PR TITLE
fixed get-bucket-cors for no config exsist

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -264,8 +264,10 @@ def get_cors(bucket_name):
         response.status_code = int(code)
         return response
 
+    response.status_code = 200
     cors = BUCKET_CORS.get(bucket_name)
     if not cors:
+        response.status_code = 404
         cors = {
             'Error': {
                 'Code': 'NoSuchCORSConfiguration',
@@ -277,7 +279,6 @@ def get_cors(bucket_name):
         }
     body = xmltodict.unparse(cors)
     response._content = body
-    response.status_code = 404
     return response
 
 

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -267,11 +267,17 @@ def get_cors(bucket_name):
     cors = BUCKET_CORS.get(bucket_name)
     if not cors:
         cors = {
-            'CORSConfiguration': []
+            'Error': {
+                'Code': 'NoSuchCORSConfiguration',
+                'Message': 'The CORS configuration does not exist',
+                'BucketName': bucket_name,
+                'RequestId': short_uid(),
+                'HostId': short_uid()
+            }
         }
     body = xmltodict.unparse(cors)
     response._content = body
-    response.status_code = 200
+    response.status_code = 404
     return response
 
 

--- a/tests/integration/files/s3.requests.txt
+++ b/tests/integration/files/s3.requests.txt
@@ -39,15 +39,6 @@ X-Amz-Date: 20210202T193629Z
 Accept-Encoding: gzip
 
 ---
-GET /my-bucket1?cors= HTTP/1.1
-Host: localhost:4566
-User-Agent: aws-sdk-go/1.37.0 (go1.15.5; darwin; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.13.5 (+https://www.terraform.io)
-Authorization: AWS4-HMAC-SHA256 Credential=mock_access_key/20210202/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=75f8a12677ac1d0a67b96c9573ed61c9432fa777a5470f895e4d3808dbcb7c67
-X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-X-Amz-Date: 20210202T193629Z
-Accept-Encoding: gzip
-
----
 GET /my-bucket1?versioning= HTTP/1.1
 Host: localhost:4566
 User-Agent: aws-sdk-go/1.37.0 (go1.15.5; darwin; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.13.5 (+https://www.terraform.io)


### PR DESCRIPTION
**fixed**
- Response for get-bucket-cors when the configuration is non existent

**issue**
- [3755](https://github.com/localstack/localstack/issues/3755)