### PR TITLE
fix: key name with special char and multipart upload in presign url auth

### DIFF
--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -168,11 +168,11 @@ def authenticate_presign_url(method, path, headers, data=None):
             key_lower = key.lower()
             if key_lower not in presign_params_lower:
                 if (key_lower not in (header[0].lower() for header in headers) and
-                        key_lower not in params_header_override and
-                        key_lower != 'versionid'):
-                    sign_headers[key] = query_params[key][0]
-                if key_lower == 'versionid':
-                    query_string[key] = query_params[key][0]
+                        key_lower not in params_header_override):
+                    if key_lower in ['versionid', 'uploadid', 'partnumber']:
+                        query_string[key] = query_params[key][0]
+                    else:
+                        sign_headers[key] = query_params[key][0]
 
     for header_name, header_value in headers.items():
         header_name_lower = header_name.lower()

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -183,7 +183,7 @@ def authenticate_presign_url(method, path, headers, data=None):
                 sign_headers[header_name] = header_value
 
     # Preparnig dictionary of request to build AWSRequest's object of the botocore
-    request_url = '{}://{}{}'.format(parsed.scheme, parsed.netloc, parsed.path)
+    request_url = '{}://{}{}'.format(parsed.scheme, parsed.netloc, urlparse.quote(parsed.path))
     request_url = \
         ('%s?%s' % (request_url, urlencode(query_string)) if query_string else request_url)
 
@@ -193,7 +193,7 @@ def authenticate_presign_url(method, path, headers, data=None):
     bucket_name = extract_bucket_name(headers, parsed.path)
 
     request_dict = {
-        'url_path': parsed.path,
+        'url_path': urlparse.quote(parsed.path),
         'query_string': query_string,
         'method': method,
         'headers': sign_headers,

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1722,6 +1722,12 @@ class TestS3(unittest.TestCase):
         response = requests.delete(presign_delete_url_v4)
         self.assertEqual(response.status_code, 403)
 
+        # Multipart uploading
+        response = self._perform_multipart_upload_with_presign(BUCKET, OBJECT_KEY, client)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        response = self._perform_multipart_upload_with_presign(BUCKET, OBJECT_KEY, client_v4)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
         client.delete_object(Bucket=BUCKET, Key=OBJECT_KEY)
         client.delete_bucket(Bucket=BUCKET)
 
@@ -1938,6 +1944,12 @@ class TestS3(unittest.TestCase):
         response = requests.delete(presign_delete_url_v4)
         self.assertEqual(response.status_code, 403)
 
+        # Multipart uploading
+        response = self._perform_multipart_upload_with_presign(BUCKET, OBJECT_KEY, client)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+        response = self._perform_multipart_upload_with_presign(BUCKET, OBJECT_KEY, client_v4)
+        self.assertEqual(response['ResponseMetadata']['HTTPStatusCode'], 200)
+
         client.delete_object(Bucket=BUCKET, Key=OBJECT_KEY)
         client.delete_bucket(Bucket=BUCKET)
 
@@ -2139,6 +2151,33 @@ class TestS3(unittest.TestCase):
         multipart_upload_parts = [{'ETag': response['ETag'], 'PartNumber': 1}]
 
         return self.s3_client.complete_multipart_upload(
+            Bucket=bucket, Key=key, MultipartUpload={'Parts': multipart_upload_parts}, UploadId=upload_id
+        )
+
+    def _perform_multipart_upload_with_presign(self, bucket, key, s3_client=None, data=None, zip=False, acl=None):
+        if not s3_client:
+            s3_client = self.s3_client
+
+        kwargs = {'ACL': acl} if acl else {}
+        multipart_upload_dict = self.s3_client.create_multipart_upload(Bucket=bucket, Key=key, **kwargs)
+        upload_id = multipart_upload_dict['UploadId']
+
+        # Write contents to memory rather than a file.
+        data = data or (5 * short_uid())
+        data = to_bytes(data)
+        upload_file_object = BytesIO(data)
+        if zip:
+            upload_file_object = BytesIO()
+            with gzip.GzipFile(fileobj=upload_file_object, mode='w') as filestream:
+                filestream.write(data)
+
+        signed_url = s3_client.generate_presigned_url(ClientMethod='upload_part',
+            Params={'Bucket': bucket, 'Key': key, 'UploadId': upload_id, 'PartNumber': 1})
+        response = requests.put(signed_url, data=upload_file_object)
+
+        multipart_upload_parts = [{'ETag': response.headers['ETag'], 'PartNumber': 1}]
+
+        return s3_client.complete_multipart_upload(
             Bucket=bucket, Key=key, MultipartUpload={'Parts': multipart_upload_parts}, UploadId=upload_id
         )
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1524,7 +1524,7 @@ class TestS3(unittest.TestCase):
             config=Config(signature_version='s3v4'), aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY)
 
-        OBJECT_KEY = 'temp.txt'
+        OBJECT_KEY = 'temp 1.txt'
         OBJECT_DATA = 'this should be found in when you download {}.'.format(OBJECT_KEY)
         BUCKET = 'test'
         EXPIRES = 4
@@ -1555,6 +1555,7 @@ class TestS3(unittest.TestCase):
 
         client.put_object(Key=OBJECT_KEY, Bucket=BUCKET, Body='123')
 
+        # GET requests
         presign_get_url = client.generate_presigned_url(
             'get_object',
             Params={'Bucket': BUCKET, 'Key': OBJECT_KEY},
@@ -1736,7 +1737,7 @@ class TestS3(unittest.TestCase):
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY)
 
-        OBJECT_KEY = 'temp.txt'
+        OBJECT_KEY = 'temp .txt'
         OBJECT_DATA = 'this should be found in when you download {}.'.format(OBJECT_KEY)
         BUCKET = 'test'
         EXPIRES = 4

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1743,7 +1743,7 @@ class TestS3(unittest.TestCase):
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY)
 
-        OBJECT_KEY = 'temp .txt'
+        OBJECT_KEY = 'temp.txt'
         OBJECT_DATA = 'this should be found in when you download {}.'.format(OBJECT_KEY)
         BUCKET = 'test'
         EXPIRES = 4


### PR DESCRIPTION
### Things fixed in this PR
- presign authentication failing when key contains special char in the name
- presign authentication failing while multipart uploading  

### Added
- test cases for multipart upload and special char as a key name

### Fix for issues
#3713 
#3759 

