### PR TITLE
Refactor cfn integration test: remove duplicated test

### DIFF
--- a/tests/integration/templates/template27.yaml
+++ b/tests/integration/templates/template27.yaml
@@ -6,8 +6,8 @@ Resources:
   SQSQueue2:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: cf-test-queue-2
-  SNSTopic1:
+      QueueName: !Sub local-${AWS::Region}-DLQ
+  SNSTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: cf-test-topic-1
@@ -19,8 +19,8 @@ Resources:
           Endpoint:
             "Fn::GetAtt": ["SQSQueue2", "Arn"]
 Outputs:
-  T27SQSQueue1URL:
+  T27SQSQueueURL:
     Value:
-      Ref: SQSQueue1
+      Ref: SQSQueue2
     Export:
-      Name: T27SQSQueue1-URL
+      Name: T27SQSQueue-URL

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -700,9 +700,8 @@ class CloudFormationTest(unittest.TestCase):
                 self.assertEqual(err.response['Error']['Message'], 'Template Validation Error')
 
     def test_list_stack_resources_returns_queue_urls(self):
-        template = template_preparer.template_to_json(load_file(TEST_TEMPLATE_2))
         stack_name = 'stack-%s' % short_uid()
-        details = create_and_await_stack(StackName=stack_name, TemplateBody=template)
+        details = create_and_await_stack(StackName=stack_name, TemplateBody=load_file(TEST_TEMPLATE_27))
 
         stack_summaries = list_stack_resources(stack_name)
         queue_urls = get_queue_urls()
@@ -719,7 +718,11 @@ class CloudFormationTest(unittest.TestCase):
         # assert that stack outputs are returned properly
         outputs = details.get('Outputs', [])
         self.assertEqual(len(outputs), 1)
-        self.assertEqual(outputs[0]['ExportName'], 'SQSQueue1-URL')
+        self.assertEqual(outputs[0]['ExportName'], 'T27SQSQueue-URL')
+        self.assertIn(config.DEFAULT_REGION, outputs[0]['OutputValue'])
+
+        # clean up
+        self.cleanup(stack_name)
 
     def test_create_change_set(self):
         cloudformation = aws_stack.connect_to_service('cloudformation')
@@ -1808,26 +1811,6 @@ class CloudFormationTest(unittest.TestCase):
         topic_arn = aws_stack.sns_topic_arn('{}-slack-sns-topic'.format(environment))
         self.assertIn('TopicArn', outputs)
         self.assertEqual(outputs['TopicArn'].get('export'), topic_arn)
-
-        # clean up
-        self.cleanup(stack_name)
-
-    def test_list_exports_correctly_returns_exports(self):
-        cloudformation = aws_stack.connect_to_service('cloudformation')
-
-        # fetch initial list of exports
-        exports_before = cloudformation.list_exports()['Exports']
-
-        template = load_file(TEST_TEMPLATE_27)
-        stack_name = 'stack-%s' % short_uid()
-        deploy_cf_stack(stack_name, template_body=template)
-
-        response = cloudformation.list_exports()
-
-        exports = response['Exports']
-        self.assertEqual(len(exports), len(exports_before) + 1)
-        export_names = [e['Name'] for e in exports]
-        self.assertIn('T27SQSQueue1-URL', export_names)
 
         # clean up
         self.cleanup(stack_name)


### PR DESCRIPTION
Issue already fixed:
#2115 Region ignored when using ${AWS::Region} in template
