### PR TITLE
Fix policy expiration format for S3 signing

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -79,7 +79,7 @@ OBJECT_METADATA_KEY_PREFIX = 'x-amz-meta-'
 
 # STS policy expiration date format
 POLICY_EXPIRATION_FORMAT1 = '%Y-%m-%dT%H:%M:%SZ'
-POLICY_EXPIRATION_FORMAT2 = '%Y-%m-%dT%H:%M:%S.%IZ'
+POLICY_EXPIRATION_FORMAT2 = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 # ignored_headers_lower conatins headers which don't get involved in signature calculations process
 # these headers are being sent by the localstack by default.


### PR DESCRIPTION
I found an error while using the lib, I got something like this from localstack logs:

```
localstack_1  | Traceback (most recent call last):
localstack_1  |   File "/opt/code/localstack/localstack/utils/bootstrap.py", line 671, in run
localstack_1  |     result = self.func(self.params)
localstack_1  |   File "/opt/code/localstack/localstack/utils/async_utils.py", line 28, in _run
localstack_1  |     return fn(*args, **kwargs)
localstack_1  |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 607, in handler
localstack_1  |     response = modify_and_forward(method=method, path=path_with_params, data_bytes=data, headers=headers,
localstack_1  |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 373, in modify_and_forward
localstack_1  |     listener_result = listener.forward_request(method=method,
localstack_1  |   File "/opt/code/localstack/localstack/services/edge.py", line 108, in forward_request
localstack_1  |     return do_forward_request(api, method, path, data, headers, port=port)
localstack_1  |   File "/opt/code/localstack/localstack/services/edge.py", line 119, in do_forward_request
localstack_1  |     result = do_forward_request_inmem(api, method, path, data, headers, port=port)
localstack_1  |   File "/opt/code/localstack/localstack/services/edge.py", line 139, in do_forward_request_inmem
localstack_1  |     response = modify_and_forward(method=method, path=path, data_bytes=data, headers=headers,
localstack_1  |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 373, in modify_and_forward
localstack_1  |     listener_result = listener.forward_request(method=method,
localstack_1  |   File "/opt/code/localstack/localstack/services/s3/s3_listener.py", line 1108, in forward_request
localstack_1  |     expiration_datetime = self.parse_policy_expiration_date(expiration_string)
localstack_1  |   File "/opt/code/localstack/localstack/services/s3/s3_listener.py", line 1015, in parse_policy_expiration_date
localstack_1  |     return datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT2)
localstack_1  |   File "/usr/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
localstack_1  |     tt, fraction, gmtoff_fraction = _strptime(data_string, format)
localstack_1  |   File "/usr/lib/python3.8/_strptime.py", line 349, in _strptime
localstack_1  |     raise ValueError("time data %r does not match format %r" %
localstack_1  | ValueError: time data '2021-03-24T02:51:36.365Z' does not match format '%Y-%m-%dT%H:%M:%S.%IZ'
```

This same date works in aws S3, from reading the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html):

>The expiration element specifies the expiration date and time of the POST policy in ISO8601 GMT date format. For example, 2013-08-01T12:00:00.000Z specifies that the POST policy is not valid after midnight GMT on August 1, 2013.