### PR TITLE
Revert "fixed location constraint value for specific region"

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -483,7 +483,7 @@ def fix_location_constraint(response):
         content = to_str(response.content or '') or ''
     except Exception:
         content = ''
-    if aws_stack.get_region() != 'us-east-1' and 'LocationConstraint' in content:
+    if 'LocationConstraint' in content:
         pattern = r'<LocationConstraint([^>]*)>\s*</LocationConstraint>'
         replace = r'<LocationConstraint\1>%s</LocationConstraint>' % aws_stack.get_region()
         response._content = re.sub(pattern, replace, content)
@@ -1054,6 +1054,14 @@ class ProxyListenerS3(PersistingProxyListener):
                 return response
 
         modified_data = None
+
+        # TODO: For some reason, moto doesn't allow us to put a location constraint on us-east-1
+        to_find1 = to_bytes('<LocationConstraint>us-east-1</LocationConstraint>')
+        to_find2 = to_bytes('<CreateBucketConfiguration')
+        if data and data.startswith(to_bytes('<')) and to_find1 in data and to_find2 in data:
+            # Note: with the latest version, <CreateBucketConfiguration> must either
+            # contain a valid <LocationConstraint>, or not be present at all in the body.
+            modified_data = b''
 
         # If this request contains streaming v4 authentication signatures, strip them from the message
         # Related isse: https://github.com/localstack/localstack/issues/98


### PR DESCRIPTION
Reverts localstack/localstack#3750 - fixes a regression with Node.js AWS SDK that was introduced by this change.