### PR TITLE
addreesing style auto in default aws clients

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -247,7 +247,7 @@ def connect_to_service(service_name, client=True, env=None, region_name=None, en
         if service_name == 's3':
             if re.match(r'https?://localhost(:[0-9]+)?', endpoint_url):
                 endpoint_url = endpoint_url.replace('localhost', S3_VIRTUAL_HOSTNAME)
-                config.s3 = {'addressing_style': 'virtual'}
+                config.s3 = {'addressing_style': 'auto'}
         # To, prevent error "Connection pool is full, discarding connection ...",
         # set the environment variable MAX_POOL_CONNECTIONS. Default is 150.
         config.max_pool_connections = MAX_POOL_CONNECTIONS


### PR DESCRIPTION
Changed addressing style to auto for the common default aws client of the s3 service.