### PR TITLE
Support PutRecord kinesis endpoint in apigateway

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -367,6 +367,8 @@ def invoke_rest_api_integration(api_id, stage, integration, method, path, invoca
 
     elif integration_type == 'AWS':
         if 'kinesis:action/' in uri:
+            if uri.endswith('kinesis:action/PutRecord'):
+                target = kinesis_listener.ACTION_PUT_RECORD
             if uri.endswith('kinesis:action/PutRecords'):
                 target = kinesis_listener.ACTION_PUT_RECORDS
             if uri.endswith('kinesis:action/ListStreams'):

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -16,6 +16,7 @@ from localstack.utils.aws.aws_responses import convert_to_binary_event_payload
 
 # action headers (should be left here - imported/required by other files)
 ACTION_PREFIX = 'Kinesis_20131202'
+ACTION_PUT_RECORD = '%s.PutRecord' % ACTION_PREFIX
 ACTION_PUT_RECORDS = '%s.PutRecords' % ACTION_PREFIX
 ACTION_LIST_STREAMS = '%s.ListStreams' % ACTION_PREFIX
 


### PR DESCRIPTION
Unless there's a good reason not to, it seems to work as intended

