### PR TITLE
`HEAD` object should not return 416

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1211,8 +1211,12 @@ class ProxyListenerS3(PersistingProxyListener):
                 response.headers['Content-Length'] = str(len(response._content))
                 response.headers['Content-Type'] = 'application/xml; charset=utf-8'
                 return response
-        if method == 'GET' and response.status_code == 416:
-            return error_response('The requested range cannot be satisfied.', 'InvalidRange', 416)
+        if response.status_code == 416:
+            if method == 'GET':
+                return error_response('The requested range cannot be satisfied.', 'InvalidRange', 416)
+            elif method == 'HEAD':
+                response.status_code = 200
+                return response
 
         parsed = urlparse.urlparse(path)
         bucket_name_in_host = uses_host_addressing(headers)


### PR DESCRIPTION
When using `aws-sdk-cpp::TransferManager`, I noiced there is a different in the behavior of `localstack` and production.
- `localstack`: When we do a `HeadObjectRequest` with `range` headers, `localstack` respects this header and return `416` if there is a mismatch in `range` and object's size.
- On the other hands, production doesn't return `416` even if there is mismatch. As long as the questioning object is accessible, it will return 200 along with other data.

For more informations, you could take a look at [`TransferManager::InitializePartsForDownload`](https://github.com/aws/aws-sdk-cpp/blob/3fe07dc617103886c3051bd7cd529456f2011dfe/aws-cpp-sdk-transfer/source/transfer/TransferManager.cpp#L718-L793), I've tested it with many different offsets and sizes, and the production server always returns 200. With an object 7 bytes:

```
▶ aws s3api head-object --bucket bucketvnvo --key TEST
{
    "AcceptRanges": "bytes",
    "LastModified": "2021-03-28T22:20:00+00:00",
    "ContentLength": 7,
    "ETag": "\"fcea920f7412b5da7be0cf42b8c93759\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
▶ aws s3api head-object --bucket bucketvnvo --key TEST --range 0-499
{
    "AcceptRanges": "bytes",
    "LastModified": "2021-03-28T22:20:00+00:00",
    "ContentLength": 7,
    "ETag": "\"fcea920f7412b5da7be0cf42b8c93759\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
▶ aws s3api head-object --bucket bucketvnvo --key TEST --range 100-499
{
    "AcceptRanges": "bytes",
    "LastModified": "2021-03-28T22:20:00+00:00",
    "ContentLength": 7,
    "ETag": "\"fcea920f7412b5da7be0cf42b8c93759\"",
    "ContentType": "binary/octet-stream",
    "Metadata": {}
}
```