### PR TITLE
updated regex to support hostname_external

### DIFF
--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -21,8 +21,9 @@ REGION_REGEX = r'[a-z]{2}-[a-z]+-[0-9]{1,}'
 PORT_REGEX = r'(:[\d]{0,6})?'
 S3_STATIC_WEBSITE_HOST_REGEX = r'^([^.]+)\.s3-website\.localhost\.localstack\.cloud(:[\d]{0,6})?$'
 S3_VIRTUAL_HOSTNAME_REGEX = (r'^(http(s)?://)?([^\.]+)\.s3((-website)|(-external-1))?[\.-](dualstack\.)?'
-                             r'((localhost\.localstack\.cloud)|'
-                             r'(({}\.)?amazonaws\.com(.cn)?)){}$'.format(REGION_REGEX, PORT_REGEX))
+                             r'((localhost\.localstack\.cloud)|({})|'
+                             r'(({}\.)?amazonaws\.com(.cn)?)){}$'
+                             .format(config.HOSTNAME_EXTERNAL, REGION_REGEX, PORT_REGEX))
 BUCKET_NAME_REGEX = (r'(?=^.{3,63}$)(?!^(\d+\.)+\d+$)' +
     r'(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)')
 


### PR DESCRIPTION
**Fixed**
- Updated the s3 virtual host name regex to support `HOSTNAME_EXTERNAL` environment variable.

**Rendered Regex**
- `^(http(s)?://)?([^\.]+)\.s3((-website)|(-external-1))?[\.-](dualstack\.)?((localhost\.localstack\.cloud)|(localhost)|(([a-z]{2}-[a-z]+-[0-9]{1,}\.)?amazonaws\.com(.cn)?))(:[\d]{0,6})?$`

**Note**
- To use s3 with host based addressing the request must be sent with the host header with `s3.xxxx:xxx`

`(http(s))://(bucketname).<s3>.<hostname>(:port)`
- ( ) -> Optional
- <> -> Required