### PR TITLE
#3608 Regression: listObjects does not work with phpsdk

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -29,7 +29,6 @@ from localstack.utils.common import (
     short_uid, timestamp_millis, to_str, to_bytes, clone, md5, get_service_protocol, now_utc, is_base64
 )
 from localstack.utils.analytics import event_publisher
-from localstack.utils.http_utils import uses_chunked_encoding
 from localstack.utils.persistence import PersistingProxyListener
 from localstack.utils.aws.aws_responses import requests_response
 from localstack.services.cloudformation.service_models import S3Bucket
@@ -424,9 +423,6 @@ def add_response_metadata_headers(response):
         response.headers['content-language'] = 'en-US'
     if response.headers.get('cache-control') is None:
         response.headers['cache-control'] = 'no-cache'
-    if response.headers.get('content-encoding') is None:
-        if not uses_chunked_encoding(response):
-            response.headers['content-encoding'] = 'identity'
 
 
 def append_last_modified_headers(response, content=None):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -558,7 +558,8 @@ class TestS3(unittest.TestCase):
         self.assertIn('x-amz-id-2', resp['ResponseMetadata']['HTTPHeaders'])
         self.assertIn('content-language', resp['ResponseMetadata']['HTTPHeaders'])
         self.assertIn('cache-control', resp['ResponseMetadata']['HTTPHeaders'])
-        self.assertIn('content-encoding', resp['ResponseMetadata']['HTTPHeaders'])
+        # Do not send a content-encoding header as discussed in Issue #3608
+        self.assertNotIn('content-encoding', resp['ResponseMetadata']['HTTPHeaders'])
 
         # clean up
         self._delete_bucket(bucket_name, [object_key])


### PR DESCRIPTION
Fixes #3608 Regression: listObjects does not work with phpsdk

The AWS PHP SDK when used with Guzzle 6 is unable to parse the response
XML when it encounters a 'content-encoding: identity' HTTP header.
