### PR TITLE
Add domain name to the request context in apigateway proxy request to lambda function

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -19,7 +19,7 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.apigateway import helpers
 from localstack.services.generic_proxy import ProxyListener
 from localstack.utils.aws.aws_responses import flask_to_requests_response, requests_response, LambdaResponse
-from localstack.services.apigateway.helpers import (get_resource_for_path, handle_authorizers, handle_validators, 
+from localstack.services.apigateway.helpers import (get_resource_for_path, handle_authorizers, handle_validators,
     handle_accounts, extract_query_string_params, extract_path_params, make_error_response,
     get_cors_response, hande_base_path_mappings)
 

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -10,7 +10,7 @@ from six.moves.urllib_parse import urljoin
 from moto.apigateway.models import apigateway_backends
 from localstack.utils import common
 from localstack.config import TEST_KINESIS_URL, TEST_SQS_URL
-from localstack.constants import APPLICATION_JSON, PATH_USER_REQUEST, TEST_AWS_ACCOUNT_ID
+from localstack.constants import APPLICATION_JSON, PATH_USER_REQUEST, TEST_AWS_ACCOUNT_ID, LOCALHOST_HOSTNAME
 from localstack.utils.aws import aws_stack, aws_responses
 from localstack.utils.common import to_str, to_bytes
 from localstack.utils.analytics import event_publisher
@@ -19,8 +19,8 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.apigateway import helpers
 from localstack.services.generic_proxy import ProxyListener
 from localstack.utils.aws.aws_responses import flask_to_requests_response, requests_response, LambdaResponse
-from localstack.services.apigateway.helpers import (get_resource_for_path, get_domain_from_path, handle_authorizers,
-    handle_validators, handle_accounts, extract_query_string_params, extract_path_params, make_error_response,
+from localstack.services.apigateway.helpers import (get_resource_for_path, handle_authorizers, handle_validators, 
+    handle_accounts, extract_query_string_params, extract_path_params, make_error_response,
     get_cors_response, hande_base_path_mappings)
 
 # set up logger
@@ -502,17 +502,19 @@ def get_stage_variables(api_id, stage):
 
 def get_lambda_event_request_context(method, path, data, headers,
                                      integration_uri=None, resource_id=None, resource_path=None):
-    _, stage, relative_path_w_query_params = get_api_id_stage_invocation_path(path, headers)
+    api_id, stage, relative_path_w_query_params = get_api_id_stage_invocation_path(path, headers)
     relative_path, query_string_params = extract_query_string_params(path=relative_path_w_query_params)
     source_ip = headers.get('X-Forwarded-For', ',').split(',')[-2].strip()
     integration_uri = integration_uri or ''
     account_id = integration_uri.split(':lambda:path')[-1].split(':function:')[0].split(':')[-1]
-    domain_name = get_domain_from_path(path)
+    domain_name = f'{api_id}.execute-api.{LOCALHOST_HOSTNAME}'
     request_context = {
         # adding stage to the request context path.
         # https://github.com/localstack/localstack/issues/2210
         'path': '/' + stage + relative_path,
         'resourcePath': resource_path or relative_path,
+        'apiId': api_id,
+        'domainPrefix': api_id,
         'domainName': domain_name,
         'accountId': account_id,
         'resourceId': resource_id,

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -19,9 +19,9 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.apigateway import helpers
 from localstack.services.generic_proxy import ProxyListener
 from localstack.utils.aws.aws_responses import flask_to_requests_response, requests_response, LambdaResponse
-from localstack.services.apigateway.helpers import (get_resource_for_path, handle_authorizers, handle_validators,
-    handle_accounts, extract_query_string_params, extract_path_params, make_error_response, get_cors_response,
-    hande_base_path_mappings)
+from localstack.services.apigateway.helpers import (get_resource_for_path, get_domain_from_path, handle_authorizers,
+    handle_validators, handle_accounts, extract_query_string_params, extract_path_params, make_error_response,
+    get_cors_response, hande_base_path_mappings)
 
 # set up logger
 LOGGER = logging.getLogger(__name__)
@@ -506,11 +506,13 @@ def get_lambda_event_request_context(method, path, data, headers, integration_ur
     source_ip = headers.get('X-Forwarded-For', ',').split(',')[-2].strip()
     integration_uri = integration_uri or ''
     account_id = integration_uri.split(':lambda:path')[-1].split(':function:')[0].split(':')[-1]
+    domain_name = get_domain_from_path(path)
     request_context = {
         # adding stage to the request context path.
         # https://github.com/localstack/localstack/issues/2210
         'path': '/' + stage + relative_path,
         'resourcePath': relative_path,
+        'domainName': domain_name,
         'accountId': account_id,
         'resourceId': resource_id,
         'stage': stage,

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -204,7 +204,10 @@ def handle_authorizers(method, path, data, headers):
 # -----------------------
 
 def get_domain_from_path(path):
-    return re.match(PATH_REGEX_PATH_MAPPING, path).group(1)
+    matched = re.match(PATH_REGEX_PATH_MAPPING, path)
+    if matched and len(matched.groups) >= 1:
+        return matched.group(1)
+    return None
 
 
 def get_base_path_from_path(path):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -205,9 +205,7 @@ def handle_authorizers(method, path, data, headers):
 
 def get_domain_from_path(path):
     matched = re.match(PATH_REGEX_PATH_MAPPING, path)
-    if matched and len(matched.groups) >= 1:
-        return matched.group(1)
-    return None
+    return matched.group(1) if matched else None
 
 
 def get_base_path_from_path(path):


### PR DESCRIPTION
Missing domain name value when apigateway sends a request to lambda function.

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html