### PR TITLE
more attributes in subscribeToShard response

### DIFF
--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -284,7 +284,14 @@ def subscribe_to_shard(data, headers):
                 time.sleep(1)
                 continue
 
-            result = json.dumps({'Records': json_safe(records)})
+            response = {
+                'ChildShards': [],
+                'ContinuationSequenceNumber': iter,
+                'MillisBehindLatest': 0,
+                'Records': json_safe(records),
+            }
+
+            result = json.dumps(response)
             yield convert_to_binary_event_payload(result, event_type='SubscribeToShardEvent')
 
     headers = {}


### PR DESCRIPTION
This PR adds more attributes to the Subscribe To Shard Response, according to [This Doc](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SubscribeToShard.html#API_SubscribeToShard_ResponseSyntax)
Addresses #3822 
