### PR TITLE
fix(s3): Handle x-id for s3:DeleteObjects

### DIFF
--- a/localstack/utils/generic/dict_utils.py
+++ b/localstack/utils/generic/dict_utils.py
@@ -1,3 +1,6 @@
+import re
+
+
 def get_safe(dictionary, path, default_value=None):
     """
     Performs a safe navigation on a Dictionary object and
@@ -28,7 +31,13 @@ def get_safe(dictionary, path, default_value=None):
     for path_node in attribute_path:
         if path_node == '$':
             continue
-        elif isinstance(current_value, dict) and path_node in current_value:
+
+        if re.compile('^\\d+$').search(str(path_node)):
+            path_node = int(path_node)
+
+        if isinstance(current_value, dict) and path_node in current_value:
+            current_value = current_value[path_node]
+        elif isinstance(current_value, list) and path_node < len(current_value):
             current_value = current_value[path_node]
         else:
             current_value = None

--- a/tests/unit/utils/generic/test_dict_utils.py
+++ b/tests/unit/utils/generic/test_dict_utils.py
@@ -8,7 +8,8 @@ class GenericDictUtilsTest(unittest.TestCase):
         dictionary = {
             'level_one_1': {
                 'level_two_1': {
-                    'level_three_1': 'level_three_1_value'
+                    'level_three_1': 'level_three_1_value',
+                    'level_three_2': ['one', 'two']
                 },
                 'level_two_2': 'level_two_2_value'
             },
@@ -43,6 +44,16 @@ class GenericDictUtilsTest(unittest.TestCase):
         self.assertEqual(
             get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value'], 'default_value'),
             'default_value'
+        )
+
+        self.assertEqual(
+            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'level_three_2', '0']),
+            'one'
+        )
+
+        self.assertEqual(
+            get_safe(dictionary, '$.level_one_1.level_two_1.level_three_2.1'),
+            'two'
         )
 
     def test_set_safe_mutable(self):


### PR DESCRIPTION
## Summary

As reported by @arciisine in https://github.com/localstack/localstack/issues/3931 AWS has introduced `x-id` query parameter in their requests (just to say, I couldn't find any documentation). This makes `DeleteObjects` request look like the following:

```
POST /?delete=&x-id=DeleteObjects
...
```

This request is bypassed by moto (since DeleteObjects is unsupported) and our `s3_response_is_delete_keys` since underlying `is_delete_keys` is making a full string check for `/?delete`, whereas the path now includes `x-id` query parameter.