### PR TITLE
fix(lambda): Fix apigw event paths

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -327,7 +327,7 @@ def invoke_rest_api_integration(api_id, stage, integration, method, path, invoca
             # Sample request context:
             # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html#api-gateway-create-api-as-simple-proxy-for-lambda-test
             request_context = get_lambda_event_request_context(method, path, data, headers,
-                integration_uri=uri, resource_id=resource_id)
+                integration_uri=uri, resource_id=resource_id, resource_path=resource_path)
             stage_variables = get_stage_variables(api_id, stage)
 
             result = lambda_api.process_apigateway_invocation(func_arn, relative_path, data_str,
@@ -500,7 +500,8 @@ def get_stage_variables(api_id, stage):
     return response.get('variables', None)
 
 
-def get_lambda_event_request_context(method, path, data, headers, integration_uri=None, resource_id=None):
+def get_lambda_event_request_context(method, path, data, headers,
+                                     integration_uri=None, resource_id=None, resource_path=None):
     _, stage, relative_path_w_query_params = get_api_id_stage_invocation_path(path, headers)
     relative_path, query_string_params = extract_query_string_params(path=relative_path_w_query_params)
     source_ip = headers.get('X-Forwarded-For', ',').split(',')[-2].strip()
@@ -510,7 +511,7 @@ def get_lambda_event_request_context(method, path, data, headers, integration_ur
         # adding stage to the request context path.
         # https://github.com/localstack/localstack/issues/2210
         'path': '/' + stage + relative_path,
-        'resourcePath': relative_path,
+        'resourcePath': resource_path or relative_path,
         'accountId': account_id,
         'resourceId': resource_id,
         'stage': stage,

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -295,7 +295,7 @@ def process_apigateway_invocation(func_arn, path, payload, stage, api_id, header
                                   stage_variables={}, request_context={}, event_context={}):
     try:
         resource_path = resource_path or path
-        event = construct_invocation_event(method, resource_path, headers, payload, query_string_params)
+        event = construct_invocation_event(method, path, headers, payload, query_string_params)
         path_params = dict(path_params)
         fix_proxy_path_params(path_params)
         event['pathParameters'] = path_params

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -42,6 +42,9 @@ def handler(event, context):
             body = json.loads(event['body'])
         except Exception:
             body = {}
+
+        body['path'] = event.get('path')
+        body['resource'] = event.get('resource')
         body['pathParameters'] = event.get('pathParameters')
         body['requestContext'] = event.get('requestContext')
         body['queryStringParameters'] = event.get('queryStringParameters')


### PR DESCRIPTION
## Summary

Fix paths for apigw events

Here are samples of real events (tested scenarios):

/{proxy+}
```
request: ANY /api/v2/hello/world

event.path: /api/v2/hello/world
event.resource: /{proxy+}
event.requestContext.path: /<stage>/api/v2/hello/world
event.requestContext.resourcePath: /{proxy+}
```

/api/v2/{proxy+}
```
request: ANY /api/v2/hello/world

event.path: /api/v2/hello/world
event.resource: /api/v2/{proxy+}
event.requestContext.path: /<stage>/api/v2/hello/world
event.requestContext.resourcePath:  /api/v2/{proxy+}
```

/api/v2/hello/world (no proxy)
```
request: ANY /api/v2/hello/world

event.path: /api/v2/hello/world
event.resource: /api/v2/hello/world
event.requestContext.path: /<stage>/api/v2/hello/world
event.requestContext.resourcePath: /api/v2/hello/world
```

Related issue: https://github.com/localstack/localstack/issues/3923