### PR TITLE
Remove default cache-control value

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -419,8 +419,6 @@ def is_url_already_expired(expiry_timestamp):
 def add_response_metadata_headers(response):
     if response.headers.get('content-language') is None:
         response.headers['content-language'] = 'en-US'
-    if response.headers.get('cache-control') is None:
-        response.headers['cache-control'] = 'no-cache'
 
 
 def append_last_modified_headers(response, content=None):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -554,7 +554,10 @@ class TestS3(unittest.TestCase):
         self.assertIn('x-amz-request-id', resp['ResponseMetadata']['HTTPHeaders'])
         self.assertIn('x-amz-id-2', resp['ResponseMetadata']['HTTPHeaders'])
         self.assertIn('content-language', resp['ResponseMetadata']['HTTPHeaders'])
-        self.assertIn('cache-control', resp['ResponseMetadata']['HTTPHeaders'])
+        # We used to return `cache-control: no-cache` if the header wasn't set
+        # by the client, but this was a bug because s3 doesn't do that. It simply
+        # omits it.
+        self.assertNotIn('cache-control', resp['ResponseMetadata']['HTTPHeaders'])
         # Do not send a content-encoding header as discussed in Issue #3608
         self.assertNotIn('content-encoding', resp['ResponseMetadata']['HTTPHeaders'])
 


### PR DESCRIPTION
LocalStack was returning `cache-control: no-cache` if the header
wasn't set by the client, but this is a bug because s3 doesn't do
that. It simply omits it.
