### PR TITLE
Fix: Fetch lambda using ARN or partial ARN

### DIFF
--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -152,8 +152,8 @@ class LambdaTestBase(unittest.TestCase):
         self.assertEqual(rs['Tags'], tags)
 
         # Get funtion by partial ARN
-        # us-east-1:000000000000:function:{function_name}
-        partial_function_arn = function_arn.split(':')[3:-1]
+        # i.e. us-east-1:000000000000:function:{function_name}
+        partial_function_arn = function_arn.split(':')[3:]
         partial_function_arn = ':'.join(partial_function_arn)
         rs = client.get_function(
             FunctionName=function_arn

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -133,7 +133,7 @@ class LambdaTestBase(unittest.TestCase):
         client = aws_stack.connect_to_service('lambda')
         client.create_function(**kwargs)
 
-        function_arn = 'arn:aws:kms:us-east-1:000000000000:function:' + func_name
+        function_arn = 'arn:aws:lambda:us-east-1:000000000000:function:' + func_name
         partial_function_arn = ':'.join(function_arn.split(':')[3:])
 
         # Get function by Name, ARN and partial ARN

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -133,8 +133,7 @@ class LambdaTestBase(unittest.TestCase):
         client = aws_stack.connect_to_service('lambda')
         client.create_function(**kwargs)
 
-        rs = client.get_function(FunctionName=func_name)
-        function_arn = rs['Configuration'].get('FunctionArn')
+        function_arn = 'arn:aws:kms:us-east-1:000000000000:function:' + func_name
         partial_function_arn = ':'.join(function_arn.split(':')[3:])
 
         # Get function by Name, ARN and partial ARN

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -133,10 +133,31 @@ class LambdaTestBase(unittest.TestCase):
         client = aws_stack.connect_to_service('lambda')
         client.create_function(**kwargs)
 
+        # Get funtion by name
         rs = client.get_function(
             FunctionName=func_name
         )
 
+        self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
+        self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
+        self.assertEqual(rs['Tags'], tags)
+
+        # Get funtion by ARN
+        function_arn = rs['Configuration'].get('FunctionArn')
+        rs = client.get_function(
+            FunctionName=function_arn
+        )
+        self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
+        self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
+        self.assertEqual(rs['Tags'], tags)
+
+        # Get funtion by partial ARN
+        # us-east-1:000000000000:function:{function_name}
+        partial_function_arn = function_arn.split(':')[3:-1]
+        partial_function_arn = ':'.join(partial_function_arn)
+        rs = client.get_function(
+            FunctionName=function_arn
+        )
         self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
         self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
         self.assertEqual(rs['Tags'], tags)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -133,6 +133,7 @@ class LambdaTestBase(unittest.TestCase):
         client = aws_stack.connect_to_service('lambda')
         client.create_function(**kwargs)
 
+        rs = client.get_function(FunctionName=func_name)
         function_arn = rs['Configuration'].get('FunctionArn')
         partial_function_arn = ':'.join(function_arn.split(':')[3:])
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -133,34 +133,15 @@ class LambdaTestBase(unittest.TestCase):
         client = aws_stack.connect_to_service('lambda')
         client.create_function(**kwargs)
 
-        # Get funtion by name
-        rs = client.get_function(
-            FunctionName=func_name
-        )
-
-        self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
-        self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
-        self.assertEqual(rs['Tags'], tags)
-
-        # Get funtion by ARN
         function_arn = rs['Configuration'].get('FunctionArn')
-        rs = client.get_function(
-            FunctionName=function_arn
-        )
-        self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
-        self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
-        self.assertEqual(rs['Tags'], tags)
+        partial_function_arn = ':'.join(function_arn.split(':')[3:])
 
-        # Get funtion by partial ARN
-        # i.e. us-east-1:000000000000:function:{function_name}
-        partial_function_arn = function_arn.split(':')[3:]
-        partial_function_arn = ':'.join(partial_function_arn)
-        rs = client.get_function(
-            FunctionName=function_arn
-        )
-        self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
-        self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
-        self.assertEqual(rs['Tags'], tags)
+        # Get function by Name, ARN and partial ARN
+        for func_ref in [func_name, function_arn, partial_function_arn]:
+            rs = client.get_function(FunctionName=func_ref)
+            self.assertEqual(rs['Configuration'].get('KMSKeyArn', ''), kms_key_arn)
+            self.assertEqual(rs['Configuration'].get('VpcConfig', {}), vpc_config)
+            self.assertEqual(rs['Tags'], tags)
 
         client.delete_function(FunctionName=func_name)
 


### PR DESCRIPTION
Addresses #3954 where it is not possible to fetch Lambda function's via ARN or partial ARN. Also minor test extension.