### PR TITLE
Fix: Fixing PATCH method missing on API GW CORS configuration

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -480,7 +480,7 @@ def get_cors_response(headers):
     response = Response()
     response.status_code = 200
     response.headers['Access-Control-Allow-Origin'] = '*'
-    response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE'
+    response.headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, PATCH'
     response.headers['Access-Control-Allow-Headers'] = '*'
     response._content = ''
     return response

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -215,6 +215,7 @@ class TestAPIGateway(unittest.TestCase):
         self.assertEqual(result.status_code, 200)
         self.assertTrue(re.match(result.headers['Access-Control-Allow-Origin'].replace('*', '.*'), origin))
         self.assertIn('POST', result.headers['Access-Control-Allow-Methods'])
+        self.assertIn('PATCH', result.headers['Access-Control-Allow-Methods'])
 
         custom_result = json.dumps({'foo': 'bar'})
 


### PR DESCRIPTION
Addresses #3964 where PATCH method is not included in `Access-Control-Allow-Methods` header
