### PR TITLE
Use current_thread instead of currentThread method that was deprecated in Python 3.10.

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -289,7 +289,7 @@ class CaptureOutput(object):
         return proxy
 
     def _ident(self):
-        return threading.currentThread().ident
+        return threading.current_thread().ident
 
     def stdout(self):
         return self._stdout.getvalue() if hasattr(self._stdout, 'getvalue') else self._stdout


### PR DESCRIPTION
Fixes #3988 