### PR TITLE
Set the INTERNAL_AWS_ACCESS_KEY_ID in the header when replaying a non HMAC request.

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -194,6 +194,14 @@ def is_internal_call_context(headers):
 def set_internal_auth(headers):
     authorization = headers.get('Authorization') or ''
     authorization = re.sub(r'Credential=[^/]+/', 'Credential=%s/' % INTERNAL_AWS_ACCESS_KEY_ID, authorization)
+    if authorization.startswith('AWS '):
+        authorization = re.sub(r'AWS [^/]+',  # Cover Non HMAC Authentication
+                               'Credential=%s' % INTERNAL_AWS_ACCESS_KEY_ID,
+                               authorization)
+    else:
+        authorization = re.sub(r'Credential=[^/]+/',
+                               'Credential=%s/' % INTERNAL_AWS_ACCESS_KEY_ID,
+                               authorization)
     headers['Authorization'] = authorization
     return headers
 


### PR DESCRIPTION
This fixes https://github.com/localstack/localstack/issues/4010


