### PR TITLE
Fix sqs messages not being sent in specific conditions

### DIFF
--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -168,6 +168,11 @@ def patch_moto():
                 queue.pending_messages.add(message)
                 message.mark_received(visibility_timeout=visibility_timeout)
                 _filter_message_attributes(message, message_attribute_names)
+
+                if not self.is_message_valid_based_on_retention_period(
+                    queue_name, message
+                ):
+                    break
                 result.append(message)
                 if len(result) >= count:
                     break


### PR DESCRIPTION
With this patch the moto SQS backend stops that weird behaviour about not sending the messages of a queue in certain conditions.

Addresses #3766 and requires spulec/moto#3924