### PR TITLE
Feat: Adding docs for kafka and elasticsearch external services integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You can pass the following environment variables to LocalStack:
 * `PORT_WEB_UI`: Port for the Web user interface / dashboard (default: `8080`). Note that the Web UI is now deprecated (needs to be activated with `START_WEB=1`), and requires to use the `localstack/localstack-full` Docker image.
 * `<SERVICE>_BACKEND`: Custom endpoint URL to use for a specific service, where `<SERVICE>` is the uppercase
   service name (currently works for: `APIGATEWAY`, `CLOUDFORMATION`, `DYNAMODB`, `ELASTICSEARCH`,
-  `KINESIS`, `S3`, `SNS`, `SQS`). This allows to easily integrate third-party services into LocalStack.
+  `KINESIS`, `S3`, `SNS`, `SQS`). This allows to easily integrate third-party services into LocalStack. You can take a look at an [elasticsearch example here](https://github.com/localstack/localstack/tree/master/doc/external_services_integration/elasticsearch/HOWTO.md).
 * `FORCE_NONINTERACTIVE`: when running with Docker, disables the `--interactive` and `--tty` flags. Useful when running headless.
 * `DOCKER_FLAGS`: Allows to pass custom flags (e.g., volume mounts) to "docker run" when running LocalStack in Docker.
 * `DOCKER_CMD`: Shell command used to run Docker containers, e.g., set to `"sudo docker"` to run as sudo (default: `docker`).

--- a/doc/external_services_integration/elasticsearch/HOWTO.md
+++ b/doc/external_services_integration/elasticsearch/HOWTO.md
@@ -1,0 +1,66 @@
+## Using custom Elasticsearch endpoint
+
+This is a guide to use your own custom ES endpoint, please note this is not a how-to configure or setup Elasticsearch, to do that refer to the [official documentation](https://www.elastic.co/guide/index.html)
+
+
+## Why is this useful?
+
+Localstack downloads elasticserach asynchronously the first time you run the `aws es create-elasticsearch-domain`, so you will get the response from localstack first and then (after download/install) you will have your elasticsearch cluster running locally. 
+
+In order to mitigate this you can run your own elasticsearch cluster locally and point localstack to it, so you can customize your setup and reduce waiting times.
+
+## How to run it?
+
+You can find the [example docker compose](docker-compose.yml) file which contains a single-noded elasticsearch cluster and a simple localstack setup, that should be enough for you to run the setup.
+
+1. Run docker compose:
+```
+$ docker-compose up -d
+```
+
+2. Create the Elasticsearch domain:
+```
+$ awslocal es create-elasticsearch-domain --domain-name mylogs-2 --elasticsearch-version 7.10 --elasticsearch-cluster-config '{ "InstanceType": "m3.xlarge.elasticsearch", "InstanceCount": 4, "DedicatedMasterEnabled": true, "ZoneAwarenessEnabled": true, "DedicatedMasterType": "m3.xlarge.elasticsearch", "DedicatedMasterCount": 3}'
+
+{
+    "DomainStatus": {
+        "DomainId": "000000000000/mylogs-2",
+        "DomainName": "mylogs-2",
+        "ARN": "arn:aws:es:us-east-1:000000000000:domain/mylogs-2",
+        "Created": true,
+        "Deleted": false,
+        "Endpoint": "http://localhost:4571",
+        "Processing": false,
+        "ElasticsearchVersion": "7.10",
+        "ElasticsearchClusterConfig": {
+            "InstanceType": "m3.xlarge.elasticsearch",
+            "InstanceCount": 4,
+            "DedicatedMasterEnabled": true,
+            "ZoneAwarenessEnabled": true,
+            "DedicatedMasterType": "m3.xlarge.elasticsearch",
+            "DedicatedMasterCount": 3
+        },
+        "EBSOptions": {
+            "EBSEnabled": true,
+            "VolumeType": "gp2",
+            "VolumeSize": 10,
+            "Iops": 0
+        },
+        "CognitoOptions": {
+            "Enabled": false
+        }
+    }
+}
+```
+
+3. Check the cluster health endpoint and create indices:
+```
+$ curl http://localhost:4571/_cluster/health
+{"cluster_name":"es-docker-cluster","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"active_primary_shards":0,"active_shards":0,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}[~]
+```
+
+4. Create an example index:
+```
+$ curl -X PUT  http://localhost:4571/my-index
+{"acknowledged":true,"shards_acknowledged":true,"index":"my-index"}
+```

--- a/doc/external_services_integration/elasticsearch/docker-compose.yml
+++ b/doc/external_services_integration/elasticsearch/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.9"
+
+services:
+  elasticsearch:
+    container_name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    network_mode: bridge
+    environment:
+      - node.name=elasticsearch
+      - cluster.name=es-docker-cluster
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
+    network_mode: bridge
+    ports:
+      - "4566:4566"
+      - "4571:4571"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    depends_on:
+      - elasticsearch
+    environment:
+      - SERVICES=es
+      - ELASTICSEARCH_BACKEND=http://elasticsearch:9200
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    links:
+      - elasticsearch
+
+volumes:
+  data01:
+    driver: local

--- a/doc/external_services_integration/kafka_self_managed_cluster/HOWTO.md
+++ b/doc/external_services_integration/kafka_self_managed_cluster/HOWTO.md
@@ -1,0 +1,99 @@
+## Using Localstack lambda with self-managed kafka cluster
+
+This is a guide to use your own custom Kafka cluster endpoint, please note this is not a how-to configure or setup Kafka, to do that refer to the [official documentation](https://kafka.apache.org/documentation/)
+
+## Why is this useful?
+
+Localstack OSS does not currently support AWS MSK out of the box, but you can run your own self-managed kafka cluster and integrate it with your own applications.
+
+## How to run it?
+
+You can find the [example docker compose](docker-compose.yml) file which contains a single-noded zookeeper and kafka cluster and a simple localstack setup as well as [kowl](https://github.com/cloudhut/kowl), an Apache Kafka Web UI.
+
+1. Run docker compose:
+```
+$ docker-compose up -d
+```
+
+2. Create the lambda function:
+```
+$ awslocal lambda create-function \
+    --function-name fun1 \
+    --handler lambda.handler \
+    --runtime python3.8 \
+    --role r1 \
+    --zip-file fileb://lambda.zip
+{
+    "FunctionName": "fun1",
+    "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:fun1",
+    "Runtime": "python3.8",
+    "Role": "r1",
+    "Handler": "lambda.handler",
+    "CodeSize": 294,
+    "Description": "",
+    "Timeout": 3,
+    "LastModified": "2021-05-19T02:01:06.617+0000",
+    "CodeSha256": "/GPsiNXaq4tBA4QpxPCwgpeVfP7j+1tTH6zdkJ3jiU4=",
+    "Version": "$LATEST",
+    "VpcConfig": {},
+    "TracingConfig": {
+        "Mode": "PassThrough"
+    },
+    "RevisionId": "d85469d2-8558-4d75-bc0e-5926f373e12c",
+    "State": "Active",
+    "LastUpdateStatus": "Successful",
+    "PackageType": "Zip"
+}
+```
+
+3. Create an example secret:
+```
+$ awslocal secretsmanager create-secret --name localstack
+{
+    "ARN": "arn:aws:secretsmanager:us-east-1:000000000000:secret:localstack-TDIuI",
+    "Name": "localstack",
+    "VersionId": "32bbb8e2-46ee-4322-b3d5-b6459d54513b"
+}
+```
+
+4. Create an example kafka topic:
+```
+$ docker exec -ti kafka kafka-topics --zookeeper zookeeper:2181 --create --replication-factor 1 --partitions 1 --topic t1
+Created topic t1.
+```
+
+5. Create the event source mapping to your local kafka cluster:
+```
+$ awslocal lambda create-event-source-mapping \
+    --topics t1 \
+    --source-access-configuration Type=SASL_SCRAM_512_AUTH,URI=arn:aws:secretsmanager:us-east-1:000000000000:secret:localstack-TDIuI \
+    --function-name arn:aws:lambda:us-east-1:000000000000:function:fun1 \
+    --self-managed-event-source '{"Endpoints":{"KAFKA_BOOTSTRAP_SERVERS":["localhost:9092"]}}'
+{
+    "UUID": "4a2b0ea6-960c-4847-8684-465876dd6dbd",
+    "BatchSize": 100,
+    "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:fun1",
+    "LastModified": "2021-05-19T04:02:49+02:00",
+    "LastProcessingResult": "OK",
+    "State": "Enabled",
+    "StateTransitionReason": "User action",
+    "Topics": [
+        "t1"
+    ],
+    "SourceAccessConfigurations": [
+        {
+            "Type": "SASL_SCRAM_512_AUTH",
+            "URI": "arn:aws:secretsmanager:us-east-1:000000000000:secret:localstack-TDIuI"
+        }
+    ],
+    "SelfManagedEventSource": {
+        "Endpoints": {
+            "KAFKA_BOOTSTRAP_SERVERS": [
+                "localhost:9092"
+            ]
+        }
+    }
+}
+```
+
+6. Aditionally check `http://localhost:8080` for kowl's UI.

--- a/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
+++ b/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3.9'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.0.2
+    container_name: zookeeper
+    hostname: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:6.0.2
+    container_name: kafka
+    hostname: kafka
+    restart: always
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9101:9101"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: kafka:29092
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+
+  kowl:
+    image: quay.io/cloudhut/kowl:v1.3.1
+    container_name: kowl
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - kafka
+    environment:
+      - KAFKA_BROKERS=kafka:29092
+
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
+    network_mode: bridge
+    ports:
+      - "4566:4566"
+    depends_on:
+      - kafka
+      - kowl
+    environment:
+      - SERVICES=lambda,secretsmanager
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
As some of our customers have been asking (#3534, #4023, #4041) it would be nice to add some documentation on how to integrate some external services to localstack, These guides aim to achieve this.