### PR TITLE
add ses support on `email` acronym

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -256,6 +256,8 @@ def get_api_from_headers(headers, method=None, path=None, data=None):
         result = 'route53', config.PORT_ROUTE53
     elif result[0] == 'monitoring':
         result = 'cloudwatch', config.PORT_CLOUDWATCH
+    elif result[0] == 'email':
+        result = 'ses', config.PORT_SES
     elif result[0] == 'execute-api' or '.execute-api.' in host:
         result = 'apigateway', config.PORT_APIGATEWAY
     elif target.startswith('Firehose_'):


### PR DESCRIPTION
When using SES service from an AWS Client, the `api` is not identified by the `ProxyListenerEdge`, because in the Authorization headers it's marked as `email`.
# Request
```
localstack_main     | 2021-05-20T06:33:34:DEBUG:localstack.services.edge: IN(email): "POST /" - headers: {'Remote-Addr': '172.20.0.1', 'Accept-Encoding': 'gzip', 'Content-Length': '114147', 'Host': 'localhost', 'X-Amz-Date': '20210520T063334Z', 'X-Amz-Content-Sha256': 'a9c08cd9d528688a2d0557ed0337db1c8ed719b5019c1920bb928fd7f286aa36', 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8', 'Authorization': 'AWS4-HMAC-SHA256 Credential=AKIAJQZL3AQH4K743T7A/20210520/eu-central-1/email/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=3a11e8a2698f9310435a6f6f3c0579ef3abcc7ec31c45c7fe85588f24f08b918', 'X-Forwarded-For': '172.20.0.1, localhost', 'x-localstack-edge': 'http://localhost'} - data: b'Action=SendRawEmail&RawMessage.Data=RnJvbTogPT91dGYtOD9RP2tvcHBscj89IDxoZWxsb0Brb3BwbHIuY29tP.....
```
# Stacktrace
```
localstack_main     | 2021-05-20T06:33:34:WARNING:localstack.services.edge: Unable to find listener for service "email" - please make sure to include it in $SERVICES
localstack_main     | 2021-05-20T06:33:34:WARNING:bootstrap.py: Thread run method <function AdaptiveThreadPool.submit.<locals>._run at 0x7efd175ff160>(None) failed: Unable to find listener for service "email" - please make sure to include it in $SERVICES Traceback (most recent call last):
localstack_main     |   File "/opt/code/localstack/localstack/utils/bootstrap.py", line 689, in run
localstack_main     |     result = self.func(self.params)
localstack_main     |   File "/opt/code/localstack/localstack/utils/async_utils.py", line 28, in _run
localstack_main     |     return fn(*args, **kwargs)
localstack_main     |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 364, in handler
localstack_main     |     response = modify_and_forward(method=method, path=path_with_params, data_bytes=data, headers=headers,
localstack_main     |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 183, in modify_and_forward
localstack_main     |     listener_result = listener.forward_request(method=method,
localstack_main     |   File "/opt/code/localstack/localstack/services/edge.py", line 122, in forward_request
localstack_main     |     return do_forward_request(api, method, path, data, headers, port=port)
localstack_main     |   File "/opt/code/localstack/localstack/services/edge.py", line 143, in do_forward_request
localstack_main     |     result = do_forward_request_inmem(api, method, path, data, headers, port=port)
localstack_main     |   File "/opt/code/localstack/localstack/services/edge.py", line 157, in do_forward_request_inmem
localstack_main     |     raise HTTPErrorResponse(message, code=400)
localstack_main     | localstack.utils.server.http2_server.HTTPErrorResponse: Unable to find listener for service "email" - please make sure to include it in $SERVICES
localstack_main     | 
localstack_main     | 2021-05-20T06:33:34:WARNING:localstack.utils.server.http2_server: Error in proxy handler for request POST http://localhost/: Unable to find listener for service "email" - please make sure to include it in $SERVICES Traceback (most recent call last):
localstack_main     |   File "/opt/code/localstack/localstack/utils/server/http2_server.py", line 129, in index
localstack_main     |     raise result
localstack_main     |   File "/opt/code/localstack/localstack/utils/bootstrap.py", line 689, in run
localstack_main     |     result = self.func(self.params)
localstack_main     |   File "/opt/code/localstack/localstack/utils/async_utils.py", line 28, in _run
localstack_main     |     return fn(*args, **kwargs)
localstack_main     |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 364, in handler
localstack_main     |     response = modify_and_forward(method=method, path=path_with_params, data_bytes=data, headers=headers,
localstack_main     |   File "/opt/code/localstack/localstack/services/generic_proxy.py", line 183, in modify_and_forward
localstack_main     |     listener_result = listener.forward_request(method=method,
localstack_main     |   File "/opt/code/localstack/localstack/services/edge.py", line 122, in forward_request
localstack_main     |     return do_forward_request(api, method, path, data, headers, port=port)
localstack_main     |   File "/opt/code/localstack/localstack/services/edge.py", line 143, in do_forward_request
localstack_main     |     result = do_forward_request_inmem(api, method, path, data, headers, port=port)
localstack_main     |   File "/opt/code/localstack/localstack/services/edge.py", line 157, in do_forward_request_inmem
localstack_main     |     raise HTTPErrorResponse(message, code=400)
localstack_main     | localstack.utils.server.http2_server.HTTPErrorResponse: Unable to find listener for service "email" - please make sure to include it in $SERVICES
localstack_main     | 

```