### PR TITLE
debugpy integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt >> /etc/ss
 
 # install basic tools
 RUN pip install awscli awscli-local requests --upgrade
-RUN apk add iputils gcc python3-dev musl-dev
+RUN apk add iputils
 
 # add files required to install virtualenv dependencies
 ADD Makefile requirements.txt ./
@@ -51,7 +51,7 @@ RUN make install-web
 ADD bin/supervisord.conf /etc/supervisord.conf
 ADD bin/docker-entrypoint.sh /usr/local/bin/
 
-# expose edge service, ElasticSearch & web dashboard ports
+# expose edge service, ElasticSearch, debugpy & web dashboard ports
 EXPOSE 4566 4571 8080 5678
 
 # define command at startup

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt >> /etc/ss
 
 # install basic tools
 RUN pip install awscli awscli-local requests --upgrade
-RUN apk add iputils gcc python3-dev linux-headers musl-dev
+RUN apk add iputils gcc python3-dev musl-dev
 
 # add files required to install virtualenv dependencies
 ADD Makefile requirements.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt >> /etc/ss
 
 # install basic tools
 RUN pip install awscli awscli-local requests --upgrade
-RUN apk add iputils
+RUN apk add iputils gcc python3-dev linux-headers musl-dev
 
 # add files required to install virtualenv dependencies
 ADD Makefile requirements.txt ./
@@ -52,7 +52,7 @@ ADD bin/supervisord.conf /etc/supervisord.conf
 ADD bin/docker-entrypoint.sh /usr/local/bin/
 
 # expose edge service, ElasticSearch & web dashboard ports
-EXPOSE 4566 4571 8080
+EXPOSE 4566 4571 8080 5678
 
 # define command at startup
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ You can pass the following environment variables to LocalStack:
 * `MAIN_CONTAINER_NAME`: Specify the main docker container name (default: `localstack_main`).
 * `INIT_SCRIPTS_PATH`: Specify the path to the initializing files with extensions .sh that are found default in `/docker-entrypoint-initaws.d`.
 * `DEBUG`: For troubleshooting LocalStack start issues
+* `DEVELOP`: Starts a debugpy server before starting Localstack services
+* `DEVELOP_PORT`:  Port number for debugpy server
+* `WAIT_FOR_DEBUGGER`:  Forces localstack to wait for a debugger to start the services
 * `LS_LOG`: Specify the log level('trace', 'debug', 'info', 'warn', 'error', 'warning') currently overrides the `DEBUG` configuration. Enable `LS_LOG=trace` to print detailed request/response messages.
 
 The following environment configurations are *deprecated*:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -12,7 +12,7 @@ import six
 from boto3 import Session
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS, LOCALHOST, LOCALHOST_IP, DEFAULT_PORT_WEB_UI, TRUE_STRINGS, FALSE_STRINGS,
-    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1, LOG_LEVELS)
+    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1, LOG_LEVELS, DEFAULT_DEVELOP_PORT)
 
 # keep track of start time, for performance debugging
 load_start_time = time.time()
@@ -119,6 +119,15 @@ HOST_TMP_FOLDER = os.environ.get('HOST_TMP_FOLDER', TMP_FOLDER)
 # whether to enable verbose debug logging
 LS_LOG = eval_log_type('LS_LOG')
 DEBUG = is_env_true('DEBUG') or LS_LOG == 'trace'
+
+# whether to enable debugpy
+DEVELOP = is_env_true('DEVELOP')
+
+# PORT FOR DEBUGGER
+DEVELOP_PORT = int(os.environ.get('DEVELOP_PORT', '').strip() or DEFAULT_DEVELOP_PORT)
+
+# whether to make debugpy wait for a debbuger client
+WAIT_FOR_DEBUGGER = is_env_true('WAIT_FOR_DEBUGGER')
 
 # whether to use SSL encryption for the services
 USE_SSL = is_env_true('USE_SSL')
@@ -232,7 +241,7 @@ CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOST
                    'SYNCHRONOUS_API_GATEWAY_EVENTS', 'SYNCHRONOUS_KINESIS_EVENTS',
                    'SYNCHRONOUS_SNS_EVENTS', 'SYNCHRONOUS_SQS_EVENTS', 'SYNCHRONOUS_DYNAMODB_EVENTS',
                    'DYNAMODB_HEAP_SIZE', 'MAIN_CONTAINER_NAME', 'LAMBDA_DOCKER_DNS', 'PERSISTENCE_SINGLE_FILE',
-                   'S3_SKIP_SIGNATURE_VALIDATION']
+                   'S3_SKIP_SIGNATURE_VALIDATION', 'DEVELOP', 'DEVELOP_PORT', 'WAIT_FOR_DEBUGGER']
 
 for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
     clean_key = key.upper().replace('-', '_')

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -146,3 +146,6 @@ OFFICIAL_IMAGES = ['localstack/localstack', 'localstack/localstack-light', 'loca
 # s3 virtual host name
 S3_VIRTUAL_HOSTNAME = 's3.%s' % LOCALHOST_HOSTNAME
 S3_STATIC_WEBSITE_HOSTNAME = 's3-website.%s' % LOCALHOST_HOSTNAME
+
+# port for debug py
+DEFAULT_DEVELOP_PORT = 5678

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -401,6 +401,14 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     # set up logging
     setup_logging()
 
+    if config.DEVELOP:
+        import debugpy
+        LOG.info('Starting debug server at: %s:%s' % (constants.BIND_HOST, config.DEVELOP_PORT))
+        debugpy.listen((constants.BIND_HOST, config.DEVELOP_PORT))
+
+        if config.WAIT_FOR_DEBUGGER:
+            debugpy.wait_for_client()
+
     # prepare APIs
     apis = canonicalize_api_names(apis)
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -402,6 +402,7 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     setup_logging()
 
     if config.DEVELOP:
+        install.install_debugpy_and_dependencies()
         import debugpy
         LOG.info('Starting debug server at: %s:%s' % (constants.BIND_HOST, config.DEVELOP_PORT))
         debugpy.listen((constants.BIND_HOST, config.DEVELOP_PORT))

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -44,6 +44,9 @@ ARTIFACTS_REPO = 'https://github.com/localstack/localstack-artifacts'
 SFN_PATCH_CLASS = 'com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class'
 SFN_PATCH_CLASS_URL = '%s/raw/master/stepfunctions-local-patch/%s' % (ARTIFACTS_REPO, SFN_PATCH_CLASS)
 
+DEBUGPY_MODULE='debugpy'
+DEBUGPY_DEPENDENCIES=['gcc', 'python3-dev', 'musl-dev']
+
 # Target version for javac, to ensure compatibility with earlier JREs
 JAVAC_TARGET_VERSION = '1.8'
 
@@ -179,6 +182,8 @@ def install_stepfunctions_local():
         run(cmd)
 
 
+
+
 def install_dynamodb_local():
     if OVERWRITE_DDB_FILES_IN_DOCKER and in_docker():
         rm_rf(INSTALL_DIR_DDB)
@@ -265,6 +270,13 @@ def install_all_components():
     bootstrap.load_plugins()
     # install all components
     install_components(DEFAULT_SERVICE_PORTS.keys())
+
+def install_debugpy_and_dependencies():
+    try:
+        import debugpy
+    except:
+        run('apk add %s' %  (" ".join(DEBUGPY_DEPENDENCIES)) )
+        run('pip install %s' % DEBUGPY_MODULE )
 
 
 # -----------------

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -274,8 +274,9 @@ def install_all_components():
 def install_debugpy_and_dependencies():
     try:
         import debugpy
-    except:
-        run('apk add %s' %  (" ".join(DEBUGPY_DEPENDENCIES)) )
+    except ModuleNotFoundError:
+        run('apk fetch %s --output %s'%  (' '.join(DEBUGPY_DEPENDENCIES), config.TMP_FOLDER))
+        run('apk add %s --cache-dir %s' %  (' '.join(DEBUGPY_DEPENDENCIES), config.TMP_FOLDER ) )
         run('pip install %s' % DEBUGPY_MODULE )
 
 

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -606,6 +606,9 @@ def start_infra_in_docker():
         for port in [config.PORT_WEB_UI, config.PORT_WEB_UI_SSL]:
             port_mappings.add(port)
 
+    if config.DEVELOP:
+        port_mappings.add(config.DEVELOP_PORT)
+
     docker_cmd = ('%s run %s%s%s%s%s' +
         '--rm --privileged ' +
         '--name %s ' +

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ requests-aws4auth==0.9
 sasl>=0.2.1
 six>=1.12.0                    #basic-lib
 xmltodict>=0.11.0
+debugpy>=1.3.0                 #extended-lib

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,3 @@ requests-aws4auth==0.9
 sasl>=0.2.1
 six>=1.12.0                    #basic-lib
 xmltodict>=0.11.0
-debugpy>=1.3.0                 #extended-lib


### PR DESCRIPTION
This PR adds the debugpy library to Localstack.
It provides more insight while debugging a running Localstack container.

To start the debugpy server the env variable DEVELOP must be true.
Also there are other env vars to setup debugpy explained in the README file.

