### PR TITLE
Save e-mail contents in easy, machine-readable format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,9 +90,6 @@ RUN ES_BASE_DIR=localstack/infra/elasticsearch; \
     chown -R localstack:localstack . /tmp/localstack && \
     ln -s `pwd` /tmp/localstack_install_dir
 
-# Fix for Centos host OS
-RUN echo "127.0.0.1 localhost.localdomain" >> /etc/hosts
-
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
 RUN LAMBDA_EXECUTOR=local make test

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,10 @@ docker-build:      ## Build Docker image
 	# prepare
 	test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
 	# start build
+	# --add-host: Fix for Centos host OS
 	docker build --build-arg LOCALSTACK_BUILD_GIT_HASH=$(shell git rev-parse --short HEAD) \
-	--build-arg=LOCALSTACK_BUILD_DATE=$(shell date -u +"%Y-%m-%d") -t $(IMAGE_NAME) .
+	  --build-arg=LOCALSTACK_BUILD_DATE=$(shell date -u +"%Y-%m-%d") -t $(IMAGE_NAME) \
+	  --add-host="localhost.localdomain:127.0.0.1" .
 
 docker-squash:
 	# squash entire image

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -31,11 +31,12 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.utils.analytics import event_publisher
 from localstack.utils.http_utils import parse_chunked_data
 from localstack.utils.aws.aws_models import LambdaFunction, CodeSigningConfig
-from localstack.services.cloudformation.service_models import LAMBDA_POLICY_NAME_PATTERN
 
 # logger
 LOG = logging.getLogger(__name__)
 
+# name pattern of IAM policies associated with Lambda functions
+LAMBDA_POLICY_NAME_PATTERN = 'lambda_policy_%s'
 # constants
 APP_NAME = 'lambda_api'
 PATH_ROOT = '/2015-03-31'

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -15,16 +15,14 @@ from localstack.utils.common import (
     camel_to_snake_case, select_attributes, canonical_json, md5, is_base64,
     new_tmp_dir, save_file, rm_rf, mkdir, cp_r, short_uid)
 from localstack.utils.testutil import create_zip_file
-from localstack.services.awslambda.lambda_api import get_handler_file_from_name
+from localstack.services.awslambda.lambda_api import (
+    get_handler_file_from_name, LAMBDA_POLICY_NAME_PATTERN)
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME, remove_none_values, params_list_to_dict, lambda_keys_to_lower,
     merge_parameters, params_dict_to_list, select_parameters, params_select_attributes,
     lambda_select_params, get_cfn_response_mod_file)
 
 LOG = logging.getLogger(__name__)
-
-# name pattern of IAM policies associated with Lambda functions
-LAMBDA_POLICY_NAME_PATTERN = 'lambda_policy_%s'
 
 # dict key used to store the deployment state of a resource
 KEY_RESOURCE_STATE = '_state_'


### PR DESCRIPTION
When using loclstack for development an even for easier integration/local testing
of interaction with AWS services, a feature is missing to check if an e-mail
was sent correctly.

Issue #2514 was closed with a patch that dumped the e-mail contents to the
log output. However, in most cases, this is not reliably useable for testing,
as it would require to parse the log-stream of localstack.

This commit now adds a feature where a sent e-mail is persisted to the local
file system. It re-uses the specified data directory (DATA_DIR) and falls back
to the temp directory to save e-mails into an `ses` subdirectory. Each
successfully sent message is saved in a JSON file named after the message ID.
The contents are the Source, Subject, Body, Destinations (To, CCs, BCCs) as
well as the region.

Co-Authored-By: Arne Wohlert <arne.wohlert@oss.volkswagen.com>