### PR TITLE
Fix: Fixing datetime format for put-function-event-invoke-config call

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -59,6 +59,8 @@ BATCH_SIZE_RANGES = {
     'sqs': (10, 10)
 }
 
+DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f+00:00'
+
 app = Flask(APP_NAME)
 
 # mutex for access to CWD and ENV
@@ -1753,7 +1755,7 @@ def put_function_event_invoke_config(function):
     response = lambda_obj.put_function_event_invoke_config(data)
 
     return jsonify({
-        'LastModified': response.last_modified.strftime('%Y-%m-%dT%H:%M:%S.%f') + '+00:00',
+        'LastModified': response.last_modified.strftime(DATE_FORMAT),
         'FunctionArn': str(function_arn),
         'MaximumRetryAttempts': response.max_retry_attempts,
         'MaximumEventAgeInSeconds': response.max_event_age,

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1753,7 +1753,7 @@ def put_function_event_invoke_config(function):
     response = lambda_obj.put_function_event_invoke_config(data)
 
     return jsonify({
-        'LastModified': timestamp_millis(response.last_modified),
+        'LastModified': response.last_modified.strftime('%Y-%m-%dT%H:%M:%S.%f') + '+00:00',
         'FunctionArn': str(function_arn),
         'MaximumRetryAttempts': response.max_retry_attempts,
         'MaximumEventAgeInSeconds': response.max_event_age,


### PR DESCRIPTION
Fixes #4079 where datetime format on `aws lambda put-function-event-invoke-config`, previous it was:
`2021-05-28T16:02:30.018Z`

Now:
`2021-06-07T02:21:46.871370+00:00`

As it is a very specific fix, I am just adding it to lambda, but if you think it is worth adding it to utils/common let me know.

```
$ awslocal lambda put-function-event-invoke-config --function-name SampleFunction --maximum-event-age-in-seconds 3600 --maximum-retry-attempts 0
{
    "LastModified": "2021-06-07T02:21:46.871370+00:00",
    "FunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:SampleFunction",
    "MaximumRetryAttempts": 0,
    "MaximumEventAgeInSeconds": 3600,
    "DestinationConfig": {
        "OnSuccess": {
            "Destination": "None"
        },
        "OnFailure": {
            "Destination": "None"
        }
    }
}
```