### PR TITLE
Fix: Updating localstack-client libraries to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN pip uninstall -y awscli boto3 botocore localstack_client idna s3transfer
 RUN rm -rf /usr/share/maven .venv/lib/python3.*/site-packages/cfnlint
 RUN rm -rf /tmp/* /root/.cache /opt/yarn-* /root/.npm/*cache; mkdir -p /tmp/localstack
 RUN ln -s /opt/code/localstack/.venv/bin/aws /usr/bin/aws
-ENV PYTHONPATH=/opt/code/localstack/.venv/lib/python3.8/site-packages
+ENV PYTHONPATH=/opt/code/localstack/.venv/lib/python3.8/site-packages:/opt/code/localstack/.venv/lib/python3.7/site-packages
 
 # add rest of the code
 ADD localstack/ localstack/

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,9 +35,9 @@ forbiddenfruit==0.1.3
 jsondiff>=1.2.0
 jsonpatch>=1.24,<2.0
 jsonpath-rw>=1.4.0,<2.0.0
-localstack-ext[full]>=0.12.5
-localstack-ext>=0.12.5         #basic-lib
-localstack-client>=1.15        #basic-lib
+localstack-ext[full]>=0.12.9.30
+localstack-ext>=0.12.9.30      #basic-lib
+localstack-client>=1.20        #basic-lib
 moto-ext[all]>=2.0.0
 nose>=1.3.7
 nose-timer>=0.7.5


### PR DESCRIPTION
Fixes #4108 where devs can't use the internal `awslocal` command line as the `localstack_client` library is missing, a temporary workaround for this is to just install it beforehand as specified [here](https://github.com/localstack/localstack/issues/4108#issuecomment-855826709).

One guess is that the `localstack-client` library got old in our `requirements.txt` (should be `1.20`), that is why updating it, as you can see it is not even inside the app container:

```
$ docker exec -ti localstack_main bash
bash-5.0# pip freeze
appdirs==1.4.4
awscli-local==0.14
certifi==2021.5.30
chardet==4.0.0
colorama==0.4.3
distlib==0.3.2
docutils==0.15.2
filelock==3.0.12
importlib-metadata==4.5.0
jmespath==0.10.0
pyasn1==0.4.8
python-dateutil==2.8.1
PyYAML==5.4.1
requests==2.25.1
rsa==4.7.2
six==1.16.0
supervisor==4.2.2
typing-extensions==3.10.0.0
urllib3==1.26.5
virtualenv==20.4.7
zipp==3.4.1
```