### PR TITLE
Fix S3 S3_SKIP_SIGNATURE_VALIDATION

### DIFF
--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -341,6 +341,7 @@ def authenticate_presign_url_signv4(method, path, headers, data, url, query_para
         if not is_presign_valid:
             LOGGER.warning('Signatures do not match, but not raising an error, as S3_SKIP_SIGNATURE_VALIDATION=1')
         signature = query_sig
+        is_presign_valid = True
 
     if not is_presign_valid:
 


### PR DESCRIPTION
Due to changes in https://github.com/localstack/localstack/commit/3fe01cf6699a4fb71153b582715b4ec21560e4e1 `S3_SKIP_SIGNATURE_VALIDATION` flag is not working anymore, here is the proposed fix

**Please refer to the contribution guidelines in the README when submitting PRs.**
