### PR TITLE
Add initial draft integration of kinesis-mock

### DIFF
--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -1,16 +1,24 @@
+import os
+import json
 import logging
 import traceback
+import requests
 from localstack import config
 from localstack.services import install
-from localstack.constants import MODULE_MAIN_PATH
+from localstack.constants import MODULE_MAIN_PATH, INSTALL_DIR_INFRA
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import mkdir, get_free_tcp_port, replace_in_file
+from localstack.utils.common import mkdir, get_free_tcp_port, replace_in_file, to_str, download
 from localstack.services.infra import start_proxy_for_service, do_run, log_startup_message
 
 LOGGER = logging.getLogger(__name__)
 
+KINESIS_MOCK_RELEASES = 'https://api.github.com/repos/etspaceman/kinesis-mock/releases/latest'
 
-def appy_patches():
+# Kinesis provider - either "kinesis-mock" or "kinesalite"
+KINESIS_PROVIDER = os.environ.get('KINESIS_PROVIDER') or 'kinesis-mock'
+
+
+def apply_patches_kinesalite():
     files = [
         '%s/node_modules/kinesalite/validations/decreaseStreamRetentionPeriod.js',
         '%s/node_modules/kinesalite/validations/increaseStreamRetentionPeriod.js'
@@ -21,9 +29,32 @@ def appy_patches():
 
 
 def start_kinesis(port=None, asynchronous=False, update_listener=None):
+    if KINESIS_PROVIDER == 'kinesis-mock':
+        return start_kinesis_mock(port=port, asynchronous=asynchronous, update_listener=update_listener)
+    if KINESIS_PROVIDER == 'kinesalite':
+        return start_kinesalite(port=port, asynchronous=asynchronous, update_listener=update_listener)
+    raise Exception('Unsupported Kinesis provider "%s"' % KINESIS_PROVIDER)
+
+
+def start_kinesis_mock(port=None, asynchronous=False, update_listener=None):
+    target_dir = os.path.join(INSTALL_DIR_INFRA, 'kinesis-mock')
+    target_jar = os.path.join(target_dir, 'kinesis-mock.jar')
+    if not os.path.exists(target_jar):
+        response = requests.get(KINESIS_MOCK_RELEASES)
+        content = json.loads(to_str(response.content))
+        archive_url = content.get('assets', [])[0].get('browser_download_url')
+        download(archive_url, target_jar)
+    port = port or config.PORT_KINESIS
+    backend_port = get_free_tcp_port()
+    cmd = 'KINESIS_MOCK_HTTP1_PLAIN_PORT=%s java -jar %s' % (backend_port, target_jar)
+    start_proxy_for_service('kinesis', port, backend_port, update_listener)
+    return do_run(cmd, asynchronous)
+
+
+def start_kinesalite(port=None, asynchronous=False, update_listener=None):
     # install and apply patches
     install.install_kinesalite()
-    appy_patches()
+    apply_patches_kinesalite()
     # start up process
     port = port or config.PORT_KINESIS
     backend_port = get_free_tcp_port()


### PR DESCRIPTION
Add initial integration of `kinesis-mock` - addresses #4137. 

This is only a first PoC - we still need to make a deeper evaluation of the tradeoffs regarding missing/supported features (e.g., persistence support), parity with AWS (e.g., API coverage, multi-region support, etc), and performance (e.g., JVM vs Node.js process; disk space of the required binaries in the Docker image), to select the best default implementation option for Kinesis in the future.