### PR TITLE
add support for user specified s3 bucket used to run lambda using loc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ You can pass the following environment variables to LocalStack:
       host on the same machine. Also, `HOST_TMP_FOLDER` must be set properly, and a volume
       mount like `${HOST_TMP_FOLDER}:/tmp/localstack` needs to be configured if you're using
       docker-compose.
+* `BUCKET_MARKER_LOCAL`: Optional bucket name for running lambdas locally.
 * `LAMBDA_DOCKER_NETWORK`: Optional Docker network for the container running your lambda function.
 * `LAMBDA_DOCKER_DNS`: Optional DNS server for the container running your lambda function.
 * `LAMBDA_DOCKER_FLAGS`: Additional flags passed to Lambda Docker `run`/`create` commands (e.g., useful for specifying custom volume mounts)
@@ -455,7 +456,7 @@ You can use [Terraform](https://www.terraform.io) to provision your resources lo
 
 ## Using local code with Lambda
 
-In order to mount a local folder, ensure that `LAMBDA_REMOTE_DOCKER` is set to `false` then set the S3 bucket name to `__local__` and the S3 key to your local path:
+In order to mount a local folder, ensure that `LAMBDA_REMOTE_DOCKER` is set to `false` then set the S3 bucket name to `__local__` or `BUCKET_MARKER_LOCAL` if it is set, and the S3 key to your local path:
 
 ```
 awslocal lambda create-function --function-name myLambda \

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -12,7 +12,8 @@ import six
 from boto3 import Session
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS, LOCALHOST, LOCALHOST_IP, DEFAULT_PORT_WEB_UI, TRUE_STRINGS, FALSE_STRINGS,
-    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1, LOG_LEVELS, DEFAULT_DEVELOP_PORT)
+    DEFAULT_LAMBDA_CONTAINER_REGISTRY, DEFAULT_PORT_EDGE, AWS_REGION_US_EAST_1, LOG_LEVELS, DEFAULT_DEVELOP_PORT,
+    DEFAULT_BUCKET_MARKER_LOCAL)
 
 # keep track of start time, for performance debugging
 load_start_time = time.time()
@@ -80,6 +81,10 @@ HOSTNAME_FROM_LAMBDA = os.environ.get('HOSTNAME_FROM_LAMBDA', '').strip()
 
 # whether to remotely copy the lambda code or locally mount a volume
 LAMBDA_REMOTE_DOCKER = is_env_true('LAMBDA_REMOTE_DOCKER')
+
+# Marker name to indicate that a bucket represents the local file system. This is used for testing
+# Serverless applications where we mount the Lambda code directly into the container from the host OS.
+BUCKET_MARKER_LOCAL = os.environ.get('BUCKET_MARKER_LOCAL', '').strip() or DEFAULT_BUCKET_MARKER_LOCAL
 
 # network that the docker lambda container will be joining
 LAMBDA_DOCKER_NETWORK = os.environ.get('LAMBDA_DOCKER_NETWORK', '').strip()
@@ -241,7 +246,7 @@ CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOST
                    'LAMBDA_CONTAINER_REGISTRY', 'TEST_AWS_ACCOUNT_ID', 'DISABLE_EVENTS', 'EDGE_PORT', 'LS_LOG',
                    'EDGE_PORT_HTTP', 'SKIP_INFRA_DOWNLOADS', 'STEPFUNCTIONS_LAMBDA_ENDPOINT',
                    'WINDOWS_DOCKER_MOUNT_PREFIX', 'HOSTNAME_FROM_LAMBDA', 'LOG_LICENSE_ISSUES',
-                   'SYNCHRONOUS_API_GATEWAY_EVENTS', 'SYNCHRONOUS_KINESIS_EVENTS',
+                   'SYNCHRONOUS_API_GATEWAY_EVENTS', 'SYNCHRONOUS_KINESIS_EVENTS', 'BUCKET_MARKER_LOCAL',
                    'SYNCHRONOUS_SNS_EVENTS', 'SYNCHRONOUS_SQS_EVENTS', 'SYNCHRONOUS_DYNAMODB_EVENTS',
                    'DYNAMODB_HEAP_SIZE', 'MAIN_CONTAINER_NAME', 'LAMBDA_DOCKER_DNS', 'PERSISTENCE_SINGLE_FILE',
                    'S3_SKIP_SIGNATURE_VALIDATION', 'DEVELOP', 'DEVELOP_PORT', 'WAIT_FOR_DEBUGGER']

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -149,3 +149,6 @@ S3_STATIC_WEBSITE_HOSTNAME = 's3-website.%s' % LOCALHOST_HOSTNAME
 
 # port for debug py
 DEFAULT_DEVELOP_PORT = 5678
+
+# Default bucket name of the s3 bucket used for local lambda development
+DEFAULT_BUCKET_MARKER_LOCAL = '__local__'

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -98,10 +98,6 @@ IAM_POLICY_VERSION = '2012-10-17'
 # Whether to check if the handler function exists while creating lambda function
 CHECK_HANDLER_ON_CREATION = False
 
-# Marker name to indicate that a bucket represents the local file system. This is used for testing
-# Serverless applications where we mount the Lambda code directly into the container from the host OS.
-BUCKET_MARKER_LOCAL = '__local__'
-
 
 class LambdaRegion(RegionBackend):
     def __init__(self):
@@ -735,11 +731,11 @@ def set_archive_code(code, lambda_name, zip_file_content=None):
     # get metadata
     lambda_arn = func_arn(lambda_name)
     lambda_details = region.lambdas[lambda_arn]
-    is_local_mount = code.get('S3Bucket') == BUCKET_MARKER_LOCAL
+    is_local_mount = code.get('S3Bucket') == config.BUCKET_MARKER_LOCAL
 
     if is_local_mount and config.LAMBDA_REMOTE_DOCKER:
         msg = 'Please note that Lambda mounts (bucket name "%s") cannot be used with LAMBDA_REMOTE_DOCKER=1'
-        raise Exception(msg % BUCKET_MARKER_LOCAL)
+        raise Exception(msg % config.BUCKET_MARKER_LOCAL)
 
     # Stop/remove any containers that this arn uses.
     LAMBDA_EXECUTOR.cleanup(lambda_arn)
@@ -794,7 +790,7 @@ def do_set_function_code(code, lambda_name, lambda_cwd=None):
     handler_name = lambda_details.handler = lambda_details.handler or LAMBDA_DEFAULT_HANDLER
     code_passed = code
     code = code or lambda_details.code
-    is_local_mount = code.get('S3Bucket') == BUCKET_MARKER_LOCAL
+    is_local_mount = code.get('S3Bucket') == config.BUCKET_MARKER_LOCAL
     zip_file_content = None
 
     if code_passed:

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -12,7 +12,6 @@ from localstack.utils.server import multiserver
 from localstack.utils.common import wait_for_port_open, get_free_tcp_port
 from localstack.utils.generic.dict_utils import get_safe
 from localstack.services.infra import start_moto_server
-from localstack.services.awslambda.lambda_api import BUCKET_MARKER_LOCAL
 from urllib.parse import urlparse
 
 LOG = logging.getLogger(__name__)
@@ -109,7 +108,7 @@ def apply_patches():
     # patch S3Bucket.get_bucket(..)
     def get_bucket(self, bucket_name, *args, **kwargs):
         bucket_name = s3_listener.normalize_bucket_name(bucket_name)
-        if bucket_name == BUCKET_MARKER_LOCAL:
+        if bucket_name == config.BUCKET_MARKER_LOCAL:
             return None
         return get_bucket_orig(bucket_name, *args, **kwargs)
 


### PR DESCRIPTION
Adding another environment variable to the config so users can specify the bucket name when mounting local files to lambdas. CDK/Cloudformation cannot deploy local resources successfully when the only available S3 bucket name is `__local__`. This change allows people to use a bucket name like `local` instead.