### PR TITLE
Update Lambda Configuration Update 

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1276,8 +1276,11 @@ def update_function_configuration(function):
         lambda_details.vpc_config = data['VpcConfig']
     if data.get('KMSKeyArn'):
         lambda_details.kms_key_arn = data['KMSKeyArn']
+    result = data
+    func_details = region.lambdas.get(arn)
+    result.update(format_func_details(func_details))
 
-    return jsonify(data)
+    return jsonify(result)
 
 
 def generate_policy_statement(sid, action, arn, sourcearn, principal):

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -651,6 +651,25 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(response.get_data())
             self.assertTrue('Tags' in result)
             self.assertDictEqual({'hello': 'world'}, result['Tags'])
+    
+    def test_update_configuration(self):
+        self._create_function(self.FUNCTION_NAME)
+
+        updated_config = {'Description': 'lambda_description'}
+        response = json.loads(self.client.put('{0}/functions/{1}/configuration'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME), json=updated_config).get_data())
+
+        expected_response = dict()
+        expected_response['LastUpdateStatus'] = 'Successful'
+        expected_response['FunctionName'] = str(self.FUNCTION_NAME)
+        expected_response['Runtime'] = str(self.RUNTIME)
+        expected_response['CodeSize'] = self.CODE_SIZE
+        expected_response['CodeSha256'] = self.CODE_SHA_256
+        expected_response['Handler'] = self.HANDLER
+        expected_response.update(updated_config)
+        self.assertDictContainsSubset(expected_response, response)
+
+        get_response = json.loads(self.client.get('{0}/functions/{1}/configuration'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME)).get_data())
+        self.assertDictEqual(response, get_response)
 
     def test_java_options_empty_return_empty_value(self):
         lambda_executors.config.LAMBDA_JAVA_OPTS = ''

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -651,12 +651,13 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(response.get_data())
             self.assertTrue('Tags' in result)
             self.assertDictEqual({'hello': 'world'}, result['Tags'])
-    
+
     def test_update_configuration(self):
         self._create_function(self.FUNCTION_NAME)
 
         updated_config = {'Description': 'lambda_description'}
-        response = json.loads(self.client.put('{0}/functions/{1}/configuration'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME), json=updated_config).get_data())
+        response = json.loads(self.client.put('{0}/functions/{1}/configuration'.format(lambda_api.PATH_ROOT,
+                            self.FUNCTION_NAME), json=updated_config).get_data())
 
         expected_response = dict()
         expected_response['LastUpdateStatus'] = 'Successful'
@@ -668,7 +669,8 @@ class TestLambdaAPI(unittest.TestCase):
         expected_response.update(updated_config)
         self.assertDictContainsSubset(expected_response, response)
 
-        get_response = json.loads(self.client.get('{0}/functions/{1}/configuration'.format(lambda_api.PATH_ROOT, self.FUNCTION_NAME)).get_data())
+        get_response = json.loads(self.client.get('{0}/functions/{1}/configuration'.format(lambda_api.PATH_ROOT,
+                            self.FUNCTION_NAME)).get_data())
         self.assertDictEqual(response, get_response)
 
     def test_java_options_empty_return_empty_value(self):


### PR DESCRIPTION
The lambda configuration update function did behave differently from other endpoints, and differently from AWS.

This breaks chalice-local (related to #4084).

Pull request adds test and aligns the endpoint with AWS and other lambda localstack endpoints.