### PR TITLE
Ignore trailing slash in event-source-map route

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1513,7 +1513,7 @@ def invoke_function(function):
                           code=400, error_type='InvalidParameterValueException')
 
 
-@app.route('%s/event-source-mappings/' % PATH_ROOT, methods=['GET'])
+@app.route('%s/event-source-mappings' % PATH_ROOT, methods=['GET'], strict_slashes=False)
 def get_event_source_mappings():
     """ List event source mappings
         ---
@@ -1554,7 +1554,7 @@ def get_event_source_mapping(mapping_uuid):
     return jsonify(mappings[0])
 
 
-@app.route('%s/event-source-mappings/' % PATH_ROOT, methods=['POST'])
+@app.route('%s/event-source-mappings' % PATH_ROOT, methods=['POST'], strict_slashes=False)
 def create_event_source_mapping():
     """ Create new event source mapping
         ---


### PR DESCRIPTION
With this PR the lambda enpoint ignores the trailing slash in the corresponding routes, so the requests with both `http://localstack:4566/2015-03-31/event-source-mappings/` or `http://localstack:4566/2015-03-31/event-source-mappings` are accepted.

Addresses #4124 
