### PR TITLE
Refactor shutdown procedure

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -200,6 +200,9 @@ LOCALSTACK_BUILD_DATE = os.environ.get('LOCALSTACK_BUILD_DATE', '').strip() or N
 # whether to skip S3 presign URL signature validation (TODO: currently enabled, until all issues are resolved)
 S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false('S3_SKIP_SIGNATURE_VALIDATION')
 
+# whether to skip waiting for the infrastructure to shut down, or exit immediately
+FORCE_SHUTDOWN = is_env_not_false('FORCE_SHUTDOWN')
+
 
 def has_docker():
     try:

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import json
+import threading
 import time
 import signal
 import logging
@@ -15,14 +16,14 @@ from localstack.utils import common, persistence
 from localstack.constants import (
     ENV_DEV, LOCALSTACK_VENV_FOLDER, LOCALSTACK_INFRA_PROCESS, DEFAULT_SERVICE_PORTS)
 from localstack.utils.common import (TMP_THREADS, run, get_free_tcp_port, is_linux, start_thread,
-    ShellCommandThread, in_docker, is_port_open, sleep_forever, edge_ports_info)
+    ShellCommandThread, in_docker, is_port_open, edge_ports_info)
 from localstack.utils.server import multiserver
 from localstack.utils.testutil import is_local_test_mode
 from localstack.utils.bootstrap import (
     setup_logging, canonicalize_api_names, load_plugins, in_ci)
 from localstack.utils.analytics import event_publisher
 from localstack.services import generic_proxy, install
-from localstack.services.plugins import SERVICE_PLUGINS, record_service_health, check_infra
+from localstack.services.plugins import SERVICE_PLUGINS, record_service_health, check_infra, wait_for_infra_shutdown
 from localstack.services.firehose import firehose_api
 from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener, start_proxy_server
@@ -45,6 +46,9 @@ PROXY_LISTENERS = {}
 
 # set up logger
 LOG = logging.getLogger(__name__)
+
+# event flag indicating that the infrastructure has been shut down
+SHUTDOWN_INFRA = threading.Event()
 
 
 # -----------------------
@@ -228,9 +232,12 @@ def register_signal_handlers():
         return
 
     # register signal handlers
-    def signal_handler(signal, frame):
+    def signal_handler(sig, frame):
+        LOG.debug('[shutdown] signal received %s', sig)
         stop_infra()
-        os._exit(0)
+        if config.FORCE_SHUTDOWN:
+            sys.exit(0)
+
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
     SIGNAL_HANDLERS_SETUP = True
@@ -311,18 +318,24 @@ def stop_infra():
 
     event_publisher.fire_event(event_publisher.EVENT_STOP_INFRA)
 
-    generic_proxy.QUIET = True
-    LOG.debug('[shutdown] Cleaning up files ...')
-    common.cleanup(files=True, quiet=True)
-    LOG.debug('[shutdown] Cleaning up resources ...')
-    common.cleanup_resources()
-    LOG.debug('[shutdown] Cleaning up Lambda resources ...')
-    lambda_api.cleanup()
-    LOG.debug('[shutdown] Waiting for infrastructure to shut down ...')
-    time.sleep(2)
-    # TODO: optimize this (takes too long currently)
-    # check_infra(retries=2, expect_shutdown=True)
-    LOG.debug('[shutdown] Infrastructure is shut down')
+    try:
+        generic_proxy.QUIET = True
+        LOG.debug('[shutdown] Cleaning up files ...')
+        common.cleanup(files=True, quiet=True)
+        LOG.debug('[shutdown] Cleaning up resources ...')
+        common.cleanup_resources()
+        LOG.debug('[shutdown] Cleaning up Lambda resources ...')
+        lambda_api.cleanup()
+
+        if config.FORCE_SHUTDOWN:
+            LOG.debug('[shutdown] Force shutdown, not waiting for infrastructure to shut down')
+            return
+
+        LOG.debug('[shutdown] Waiting for infrastructure to shut down ...')
+        wait_for_infra_shutdown()
+        LOG.debug('[shutdown] Infrastructure is shut down')
+    finally:
+        SHUTDOWN_INFRA.set()
 
 
 def log_startup_message(service):
@@ -376,10 +389,10 @@ def start_infra(asynchronous=False, apis=None):
         thread = do_start_infra(asynchronous, apis, is_in_docker)
 
         if not asynchronous and thread:
-            # this is a bit of an ugly hack, but we need to make sure that we
-            # stay in the execution context of the main thread, otherwise our
-            # signal handlers don't work
-            sleep_forever()
+            # We're making sure that we stay in the execution context of the
+            # main thread, otherwise our signal handlers don't work
+            SHUTDOWN_INFRA.wait()
+
         return thread
 
     except KeyboardInterrupt:

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -15,7 +15,7 @@ from localstack.utils import common, persistence
 from localstack.constants import (
     ENV_DEV, LOCALSTACK_VENV_FOLDER, LOCALSTACK_INFRA_PROCESS, DEFAULT_SERVICE_PORTS)
 from localstack.utils.common import (TMP_THREADS, run, get_free_tcp_port, is_linux, start_thread,
-    ShellCommandThread, in_docker, is_port_open, sleep_forever, print_debug, edge_ports_info)
+    ShellCommandThread, in_docker, is_port_open, sleep_forever, edge_ports_info)
 from localstack.utils.server import multiserver
 from localstack.utils.testutil import is_local_test_mode
 from localstack.utils.bootstrap import (
@@ -304,7 +304,7 @@ def start_local_api(name, port, api, method, asynchronous=False):
         method(port)
 
 
-def stop_infra(debug=False):
+def stop_infra():
     if common.INFRA_STOPPED:
         return
     common.INFRA_STOPPED = True
@@ -312,15 +312,17 @@ def stop_infra(debug=False):
     event_publisher.fire_event(event_publisher.EVENT_STOP_INFRA)
 
     generic_proxy.QUIET = True
-    print_debug('[shutdown] Cleaning up files ...', debug)
+    LOG.debug('[shutdown] Cleaning up files ...')
     common.cleanup(files=True, quiet=True)
-    print_debug('[shutdown] Cleaning up resources ...', debug)
-    common.cleanup_resources(debug=debug)
-    print_debug('[shutdown] Cleaning up Lambda resources ...', debug)
+    LOG.debug('[shutdown] Cleaning up resources ...')
+    common.cleanup_resources()
+    LOG.debug('[shutdown] Cleaning up Lambda resources ...')
     lambda_api.cleanup()
+    LOG.debug('[shutdown] Waiting for infrastructure to shut down ...')
     time.sleep(2)
     # TODO: optimize this (takes too long currently)
     # check_infra(retries=2, expect_shutdown=True)
+    LOG.debug('[shutdown] Infrastructure is shut down')
 
 
 def log_startup_message(service):

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -99,7 +99,7 @@ def check_infra(retries=10, expect_shutdown=False, apis=None, additional_checks=
         # loop through plugins and check service status
         for name, plugin in SERVICE_PLUGINS.items():
             if name in apis:
-                check_service_health(api=name, print_error=print_error)
+                check_service_health(api=name, print_error=print_error, expect_shutdown=expect_shutdown)
 
         for additional in additional_checks:
             additional(expect_shutdown=expect_shutdown)
@@ -117,7 +117,10 @@ def check_service_health(api, print_error=False, expect_shutdown=False):
         plugin.check(expect_shutdown=expect_shutdown, print_error=print_error)
         record_service_health(api, 'running')
     except Exception as e:
-        LOG.warning('Service "%s" not yet available, retrying...' % api)
+        if not expect_shutdown:
+            LOG.warning('Service "%s" not yet available, retrying...' % api)
+        else:
+            LOG.warning('Service "%s" still shutting down, retrying...' % api)
         raise e
 
 

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -40,7 +40,7 @@ def check_s3(expect_shutdown=False, print_error=False):
     if expect_shutdown:
         assert out is None
     else:
-        assert isinstance(out['Buckets'], list)
+        assert out and isinstance(out.get('Buckets'), list)
 
 
 def start_s3(port=None, backend_port=None, asynchronous=None, update_listener=None):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1093,11 +1093,11 @@ def cleanup(files=True, env=ENV_DEV, quiet=True):
         cleanup_tmp_files()
 
 
-def cleanup_threads_and_processes(quiet=True, debug=False):
+def cleanup_threads_and_processes(quiet=True):
     for thread in TMP_THREADS:
         if thread:
             try:
-                print_debug('[shutdown] Cleaning up thread: %s' % thread, debug)
+                LOG.debug('[shutdown] Cleaning up thread: %s', thread)
                 if hasattr(thread, 'shutdown'):
                     thread.shutdown()
                     continue
@@ -1109,7 +1109,7 @@ def cleanup_threads_and_processes(quiet=True, debug=False):
                 print(e)
     for proc in TMP_PROCESSES:
         try:
-            print_debug('[shutdown] Cleaning up process: %s' % proc, debug)
+            LOG.debug('[shutdown] Cleaning up process: %s', proc)
             kill_process_tree(proc.pid)
             # proc.terminate()
         except Exception as e:
@@ -1119,16 +1119,16 @@ def cleanup_threads_and_processes(quiet=True, debug=False):
         import asyncio
         for task in asyncio.all_tasks():
             try:
-                print_debug('[shutdown] Canceling asyncio task: %s' % task, debug)
+                LOG.debug('[shutdown] Canceling asyncio task: %s', task)
                 task.cancel()
             except Exception as e:
                 print(e)
     except Exception:
         pass
-    print_debug('[shutdown] Done cleaning up threads / processes / tasks', debug)
+    LOG.debug('[shutdown] Done cleaning up threads / processes / tasks')
     # clear lists
-    clear_list(TMP_THREADS)
-    clear_list(TMP_PROCESSES)
+    TMP_THREADS.clear()
+    TMP_PROCESSES.clear()
 
 
 def kill_process_tree(parent_pid):
@@ -1142,11 +1142,6 @@ def kill_process_tree(parent_pid):
         except Exception:
             pass
     parent.kill()
-
-
-def clear_list(list_obj):
-    while len(list_obj):
-        del list_obj[0]
 
 
 def items_equivalent(list1, list2, comparator):
@@ -1283,14 +1278,9 @@ def is_root():
     return out == 'root'
 
 
-def cleanup_resources(debug=False):
+def cleanup_resources():
     cleanup_tmp_files()
-    cleanup_threads_and_processes(debug=debug)
-
-
-def print_debug(msg, debug=False):
-    if debug:
-        print(msg)
+    cleanup_threads_and_processes()
 
 
 @synchronized(lock=SSL_CERT_LOCK)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1097,7 +1097,7 @@ def cleanup_threads_and_processes(quiet=True):
     for thread in TMP_THREADS:
         if thread:
             try:
-                LOG.debug('[shutdown] Cleaning up thread: %s', thread)
+                # LOG.debug('[shutdown] Cleaning up thread: %s', thread)
                 if hasattr(thread, 'shutdown'):
                     thread.shutdown()
                     continue
@@ -1109,7 +1109,7 @@ def cleanup_threads_and_processes(quiet=True):
                 print(e)
     for proc in TMP_PROCESSES:
         try:
-            LOG.debug('[shutdown] Cleaning up process: %s', proc)
+            # LOG.debug('[shutdown] Cleaning up process: %s', proc)
             kill_process_tree(proc.pid)
             # proc.terminate()
         except Exception as e:
@@ -1119,7 +1119,7 @@ def cleanup_threads_and_processes(quiet=True):
         import asyncio
         for task in asyncio.all_tasks():
             try:
-                LOG.debug('[shutdown] Canceling asyncio task: %s', task)
+                # LOG.debug('[shutdown] Canceling asyncio task: %s', task)
                 task.cancel()
             except Exception as e:
                 print(e)


### PR DESCRIPTION
This PR refactors the shutdown procedure and allows a shutdown without a call to `exit`

The major changes are:
* a dedicated `wait_for_infra_shutdown` method that was extracted from `check_infra` and now waits in parallel for services to shut down
* a flag `FORCE_SHUTDOWN` that is true per default, and circumvents `wait_for_infra_shutdown` but rather calls `sys.exit` immediately in the TERM/INT signal handler (as previously)
* replaced the `sleep_forever` call in `start_infra` with a proper threading flag that now returns correctly after `stop_infra` has been called
* minor related refactoring and unused code removal
