### PR TITLE
fix timezone issues in timestamp calculation and datetime comparisons

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -164,7 +164,7 @@ def stream_name_from_stream_arn(stream_arn):
 
 
 def shard_id(stream_arn, kinesis_shard_id):
-    timestamp = str(now_utc())
+    timestamp = str(int(now_utc()))
     timestamp = '%s00000000' % timestamp[:-5]
     timestamp = '%s%s' % ('0' * (20 - len(timestamp)), timestamp)
     suffix = kinesis_shard_id.replace('shardId-', '')[:32]

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1117,7 +1117,6 @@ class ProxyListenerS3(PersistingProxyListener):
         # if the Expires key in the url is already expired then return error
         if method == 'GET' and 'Expires' in query_map:
             ts = datetime.datetime.fromtimestamp(int(query_map.get('Expires')[0]), tz=datetime.timezone.utc)
-            print(ts)
             if is_expired(ts):
                 return token_expired_error(path, headers.get('x-amz-request-id'), 400)
 

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -6,6 +6,8 @@ import codecs
 import random
 import logging
 import datetime
+
+import pytz
 import xmltodict
 import collections
 import dateutil.parser
@@ -1026,9 +1028,13 @@ class ProxyListenerS3(PersistingProxyListener):
     @staticmethod
     def parse_policy_expiration_date(expiration_string):
         try:
-            return datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT1)
+            dt = datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT1)
         except Exception:
-            return datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT2)
+            dt = datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT2)
+
+        # both date formats assume a UTC timezone ('Z' suffix), but it's not parsed as tzinfo into the datetime object
+        dt = dt.replace(tzinfo=pytz.UTC)
+        return dt
 
     def forward_request(self, method, path, data, headers):
         # Create list of query parameteres from the url

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1129,8 +1129,7 @@ class ProxyListenerS3(PersistingProxyListener):
                 expiration_string = policy.get('expiration', None)  # Example: 2020-06-05T13:37:12Z
                 if expiration_string:
                     expiration_datetime = self.parse_policy_expiration_date(expiration_string)
-                    expiration_timestamp = expiration_datetime.timestamp()
-                    if is_expired(expiration_timestamp):
+                    if is_expired(expiration_datetime):
                         return token_expired_error(path, headers.get('x-amz-request-id'), 400)
 
         if query == 'cors' or 'cors' in query_map:

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -7,7 +7,6 @@ import random
 import logging
 import datetime
 
-import pytz
 import xmltodict
 import collections
 import dateutil.parser
@@ -1027,7 +1026,7 @@ class ProxyListenerS3(PersistingProxyListener):
             dt = datetime.datetime.strptime(expiration_string, POLICY_EXPIRATION_FORMAT2)
 
         # both date formats assume a UTC timezone ('Z' suffix), but it's not parsed as tzinfo into the datetime object
-        dt = dt.replace(tzinfo=pytz.UTC)
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
         return dt
 
     def forward_request(self, method, path, data, headers):
@@ -1117,7 +1116,7 @@ class ProxyListenerS3(PersistingProxyListener):
 
         # if the Expires key in the url is already expired then return error
         if method == 'GET' and 'Expires' in query_map:
-            ts = datetime.datetime.fromtimestamp(int(query_map.get('Expires')[0]), tz=pytz.utc)
+            ts = datetime.datetime.fromtimestamp(int(query_map.get('Expires')[0]), tz=datetime.timezone.utc)
             print(ts)
             if is_expired(ts):
                 return token_expired_error(path, headers.get('x-amz-request-id'), 400)

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -14,7 +14,6 @@ from localstack.utils.auth import HmacV1QueryAuth, S3SigV4QueryAuth
 from localstack.utils.aws.aws_responses import requests_error_response_xml_signature_calculation
 from localstack.constants import (
     S3_VIRTUAL_HOSTNAME, S3_STATIC_WEBSITE_HOSTNAME, TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY)
-from localstack.utils.common import mktime, now
 
 LOGGER = logging.getLogger(__name__)
 
@@ -151,9 +150,9 @@ def is_real_s3_url(url):
     return re.match(r'.*s3(\-website)?\.([^\.]+\.)?amazonaws.com.*', url or '')
 
 
-def is_expired(expiry_timestamp):
-    print('is_expired? X < Y?', expiry_timestamp, mktime(expiry_timestamp), now(tz=expiry_timestamp.tzinfo))
-    return int(now(tz=expiry_timestamp.tzinfo)) > int(mktime(expiry_timestamp))
+def is_expired(expiry_datetime):
+    now_datetime = datetime.datetime.now(tz=expiry_datetime.tzinfo)
+    return now_datetime > expiry_datetime
 
 
 def authenticate_presign_url(method, path, headers, data=None):

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -3,8 +3,6 @@ import time
 import logging
 import datetime
 
-import pytz
-
 from localstack import config
 from collections import namedtuple
 from botocore.compat import urlsplit
@@ -335,7 +333,7 @@ def authenticate_presign_url_signv4(method, path, headers, data, url, query_para
 
         expiration_time = datetime.datetime.strptime(query_params['X-Amz-Date'][0], '%Y%m%dT%H%M%SZ') + \
             datetime.timedelta(seconds=int(query_params['X-Amz-Expires'][0]))
-        expiration_time = expiration_time.replace(tzinfo=pytz.UTC)
+        expiration_time = expiration_time.replace(tzinfo=datetime.timezone.utc)
 
         # Comparing the signature in url with signature we calculated
         query_sig = urlparse.unquote(query_params['X-Amz-Signature'][0])

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -152,6 +152,7 @@ def is_real_s3_url(url):
 
 
 def is_expired(expiry_timestamp):
+    print('is_expired? X < Y?', expiry_timestamp, mktime(expiry_timestamp), now(tz=expiry_timestamp.tzinfo))
     return int(now(tz=expiry_timestamp.tzinfo)) > int(mktime(expiry_timestamp))
 
 

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -2,6 +2,9 @@ import re
 import time
 import logging
 import datetime
+
+import pytz
+
 from localstack import config
 from collections import namedtuple
 from botocore.compat import urlsplit
@@ -329,6 +332,7 @@ def authenticate_presign_url_signv4(method, path, headers, data, url, query_para
 
         expiration_time = datetime.datetime.strptime(query_params['X-Amz-Date'][0], '%Y%m%dT%H%M%SZ') + \
             datetime.timedelta(seconds=int(query_params['X-Amz-Expires'][0]))
+        expiration_time = expiration_time.replace(tzinfo=pytz.UTC)
 
         # Comparing the signature in url with signature we calculated
         query_sig = urlparse.unquote(query_params['X-Amz-Signature'][0])

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -19,6 +19,8 @@ import tempfile
 import functools
 import threading
 import subprocess
+
+import pytz
 import six
 import shutil
 import requests
@@ -719,11 +721,11 @@ def obj_to_xml(obj):
 
 
 def now_utc(millis=False):
-    return mktime(datetime.utcnow(), millis=millis)
+    return now(millis, pytz.utc)
 
 
-def now(millis=False):
-    return mktime(datetime.now(), millis=millis)
+def now(millis=False, tz=None):
+    return mktime(datetime.now(tz=tz), millis=millis)
 
 
 def mktime(ts, millis=False):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -728,8 +728,8 @@ def now(millis=False):
 
 def mktime(ts, millis=False):
     if millis:
-        return time.mktime(ts.timetuple()) * 1e3 + ts.microsecond / 1e3
-    return time.mktime(ts.timetuple())
+        return ts.timestamp() * 1000
+    return ts.timestamp()
 
 
 def mkdir(folder):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -20,14 +20,13 @@ import functools
 import threading
 import subprocess
 
-import pytz
 import six
 import shutil
 import requests
 import dns.resolver
 import platform
 from io import BytesIO
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from contextlib import closing
 from six import with_metaclass
 from six.moves import cStringIO as StringIO
@@ -721,7 +720,7 @@ def obj_to_xml(obj):
 
 
 def now_utc(millis=False):
-    return now(millis, pytz.utc)
+    return now(millis, timezone.utc)
 
 
 def now(millis=False, tz=None):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -15,7 +15,6 @@ import logging
 import tarfile
 import zipfile
 import binascii
-import calendar
 import tempfile
 import functools
 import threading
@@ -727,11 +726,10 @@ def now(millis=False):
     return mktime(datetime.now(), millis=millis)
 
 
-def mktime(timestamp, millis=False):
+def mktime(ts, millis=False):
     if millis:
-        epoch = datetime.utcfromtimestamp(0)
-        return (timestamp - epoch).total_seconds()
-    return calendar.timegm(timestamp.timetuple())
+        return time.mktime(ts.timetuple()) * 1e3 + ts.microsecond / 1e3
+    return time.mktime(ts.timetuple())
 
 
 def mkdir(folder):

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,6 @@ pympler>=0.6
 pyopenssl==17.5.0
 python-coveralls>=2.9.1
 pyyaml>=5.1                    #basic-lib
-pytz>=2021.1
 Quart>=0.6.15
 requests>=2.20.0               #basic-lib
 requests-aws4auth==0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ pympler>=0.6
 pyopenssl==17.5.0
 python-coveralls>=2.9.1
 pyyaml>=5.1                    #basic-lib
+pytz>=2021.1
 Quart>=0.6.15
 requests>=2.20.0               #basic-lib
 requests-aws4auth==0.9

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -56,7 +56,7 @@ BATCH_DELETE_BODY = """
 class PutRequest(Request):
     """ Class to handle putting with urllib """
     def __init__(self, *args, **kwargs):
-        return Request.__init__(self, *args, **kwargs)
+        Request.__init__(self, *args, **kwargs)
 
     def get_method(self, *args, **kwargs):
         return 'PUT'

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1812,7 +1812,7 @@ class TestS3(unittest.TestCase):
         self.assertEqual(response.status_code, 403)
 
         # Expired requests
-        time.sleep(4)
+        time.sleep(4.5)
 
         # GET
         response = requests.get(presign_get_url)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,3 +1,5 @@
+import time
+
 import yaml
 import unittest
 from datetime import datetime, date
@@ -43,8 +45,12 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(env, None)
 
     def test_mktime(self):
-        env = common.mktime(datetime(2010, 3, 20, 7, 24, 00, 0), True)
-        self.assertEqual(env, 1269069840.0)
+        now = common.mktime(datetime.now())
+        self.assertEquals(int(time.time()), int(now))
+
+    def test_mktime_millis(self):
+        now = common.mktime(datetime.now(), millis=True)
+        self.assertEquals(int(time.time()), int(now / 1000))
 
     def test_timestamp_millis(self):
         result = common.timestamp_millis(datetime.now())

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,5 +1,6 @@
 import time
 
+import pytz
 import yaml
 import unittest
 from datetime import datetime, date
@@ -28,7 +29,12 @@ class TestCommon(unittest.TestCase):
     def test_now(self):
         env = common.now()
         test = common.mktime(datetime.now())
-        self.assertEqual(env, test)
+        self.assertAlmostEqual(env, test, delta=1)
+
+    def test_now_utc(self):
+        env = common.now_utc()
+        test = common.mktime(datetime.utcnow())
+        self.assertAlmostEqual(env, test, delta=1)
 
     def test_is_number(self):
         env = common.is_number(5)
@@ -47,6 +53,22 @@ class TestCommon(unittest.TestCase):
     def test_mktime(self):
         now = common.mktime(datetime.now())
         self.assertEquals(int(time.time()), int(now))
+
+    def test_mktime_with_tz(self):
+        # see https://en.wikipedia.org/wiki/File:1000000000seconds.jpg
+        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.UTC)
+        self.assertEquals(1000000000, int(common.mktime(dt)))
+
+        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.timezone('EST'))
+        self.assertEquals(1000000000 + (5 * 60 * 60), int(common.mktime(dt)))  # EST is UTC-5
+
+    def test_mktime_millis_with_tz(self):
+        # see https://en.wikipedia.org/wiki/File:1000000000
+        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.UTC)
+        self.assertEquals(1000000000, int(common.mktime(dt, millis=True) / 1000))
+
+        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.timezone('EST'))
+        self.assertEquals(1000000000 + (5 * 60 * 60), int(common.mktime(dt, millis=True)) / 1000)  # EST is UTC-5
 
     def test_mktime_millis(self):
         now = common.mktime(datetime.now(), millis=True)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -28,12 +28,12 @@ class TestCommon(unittest.TestCase):
 
     def test_now(self):
         env = common.now()
-        test = common.mktime(datetime.now())
+        test = time.time()
         self.assertAlmostEqual(env, test, delta=1)
 
     def test_now_utc(self):
         env = common.now_utc()
-        test = common.mktime(datetime.utcnow())
+        test = datetime.now(pytz.UTC).timestamp()
         self.assertAlmostEqual(env, test, delta=1)
 
     def test_is_number(self):
@@ -56,7 +56,7 @@ class TestCommon(unittest.TestCase):
 
     def test_mktime_with_tz(self):
         # see https://en.wikipedia.org/wiki/File:1000000000seconds.jpg
-        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.UTC)
+        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.utc)
         self.assertEquals(1000000000, int(common.mktime(dt)))
 
         dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.timezone('EST'))
@@ -64,7 +64,7 @@ class TestCommon(unittest.TestCase):
 
     def test_mktime_millis_with_tz(self):
         # see https://en.wikipedia.org/wiki/File:1000000000
-        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.UTC)
+        dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.utc)
         self.assertEquals(1000000000, int(common.mktime(dt, millis=True) / 1000))
 
         dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.timezone('EST'))

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -48,8 +48,8 @@ class TestMisc(unittest.TestCase):
 
     def test_timstamp_millis(self):
         t1 = now_utc()
-        t2 = now_utc(millis=True)
-        self.assertLessEqual(t2 - t1, 1)
+        t2 = now_utc(millis=True) / 1000
+        self.assertAlmostEqual(t1, t2, delta=1)
 
     def test_port_mappings(self):
         map = PortMappings()

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -1,4 +1,7 @@
+import datetime
 import unittest
+
+import pytz
 from moto.s3 import models as s3_models
 from localstack.services.s3 import s3_listener, s3_starter, multipart_content, s3_utils
 from requests.models import Response
@@ -187,6 +190,16 @@ class S3UtilsTest (unittest.TestCase):
 
         for bucket_name, expected_result in bucket_names:
             self.assertEqual(expected_result, s3_utils.validate_bucket_name(bucket_name))
+
+    def test_is_expired(self):
+        offset = datetime.timedelta(seconds=5)
+        self.assertTrue(s3_utils.is_expired(datetime.datetime.now() - offset))
+        self.assertFalse(s3_utils.is_expired(datetime.datetime.now() + offset))
+
+    def test_is_expired_with_tz(self):
+        offset = datetime.timedelta(seconds=5)
+        self.assertTrue(s3_utils.is_expired(datetime.datetime.now(tz=pytz.timezone('EST')) - offset))
+        self.assertFalse(s3_utils.is_expired(datetime.datetime.now(tz=pytz.timezone('EST')) + offset))
 
     def test_bucket_name(self):
         # array description : 'path', 'header', 'expected_ouput'


### PR DESCRIPTION
This PR fixes an issue in common.mktime where the unixtime would be calculated from GMT rather than the timezone of the datetime object being passed. i also simplified the calculation of millseconds unixtime, based on [this stackoverflow post](https://stackoverflow.com/a/8160307/804840)

this was apparently the root cause for issues surrounding expiry calculations, for example `is_url_already_expired` in `s3_listener.py`

/cc @macnev2013 