### PR TITLE
Improve CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
           name: Install prerequisites
       - run:
           command: |
-            which npm
-            which docker
             /usr/bin/python3.8 -m venv .venv
             source .venv/bin/activate
             which python
@@ -66,6 +64,7 @@ jobs:
 
       - run:
           command: |
+            make init
             docker pull lambci/lambda:20191117-nodejs8.10
             docker pull lambci/lambda:20191117-ruby2.5
             docker pull lambci/lambda:20210129-ruby2.7
@@ -77,6 +76,8 @@ jobs:
             docker pull lambci/lambda:java8
             docker pull lambci/lambda:python3.8
           name: pull lambda runtimes
+      - run:
+          command: docker image ls
       - run:
           command: DEBUG=1 LAMBDA_EXECUTOR=docker USE_SSL=1 TEST_ERROR_INJECTION=1 TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
           name: test docker executor
@@ -103,7 +104,14 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
+          command: docker image ls
+      - run:
+          command: make init
+          name: Initialize build environment
+      - run:
           command: make docker-build
+          name: Build localstack docker image
+
 
   docker-push:
     machine:
@@ -116,6 +124,7 @@ jobs:
           command: |
             echo "docker-push: $(pwd)"
             ls -la .
+            docker image ls
 
 workflows:
   main:
@@ -134,9 +143,9 @@ workflows:
           requires:
             - preflight
       - docker-push:
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
           requires:
             - itest-lambda-docker
             - itest-elasticmq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 jobs:
   install:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: buildpack-deps:focal
     working_directory: /tmp/workspace/repo
     steps:
       - checkout
@@ -16,15 +16,14 @@ jobs:
       - run:
           command: |
             sudo apt-get update
-            sudo apt install -y python3.8 libsasl2-dev
+            sudo apt install -y libsasl2-dev
           name: Install prerequisites
       - run:
           command: |
             python3 -m venv .venv
             source .venv/bin/activate
             pip install wheel
-            # pip install -r requirements.txt
-            ls -la ~/.cache/pip
+            pip install -r requirements.txt
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -35,6 +34,7 @@ jobs:
             /tmp/workspace
           paths:
             - repo
+
   preflight:
     docker:
       - image: buildpack-deps:focal
@@ -43,21 +43,18 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: |
-            echo "preflight: $(pwd)"
-            python3 --version
-            ls -la .
-            ls -la workspace || true
-            ls -la repo || true
+          command: make lint
+
   unit-tests:
     docker:
       - image: buildpack-deps:focal
+    working_directory: /tmp/workspace/repo
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
-          command: |
-            echo "unit-tests: $(pwd)"
-            sleep 2
-            ls -la .
+          command: DEBUG=0 TEST_PATH=tests/unit make test
+
   integration-tests:
     machine:
       image: ubuntu-2004:202101-01
@@ -70,19 +67,27 @@ jobs:
             echo "integration-tests: $(pwd)"
             sleep 5
             ls -la .
+
   docker-build:
     machine:
       image: ubuntu-2004:202101-01
+    working_directory: /tmp/workspace/repo
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           command: |
             echo "docker-build: $(pwd)"
             sleep 10
             ls -la .
+
   docker-push:
     machine:
       image: ubuntu-2004:202101-01
+    working_directory: /tmp/workspace/repo
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           command: |
             echo "docker-push: $(pwd)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 jobs:
   install:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: buildpack-deps:focal
     working_directory: /tmp/workspace/repo
     steps:
       - checkout
@@ -11,8 +11,8 @@ jobs:
           key: python-requirements-{{ checksum "requirements.txt" }}
       - run:
           command: |
-            sudo apt-get update
-            sudo apt install -y libsasl2-dev python3.8-venv
+            apt-get update
+            apt-get install -y libsasl2-dev python3-venv python3-dev
           name: Install prerequisites
       - run:
           command: |
@@ -20,6 +20,8 @@ jobs:
             source .venv/bin/activate
             which python
             realpath $(which python)
+            pip install --upgrade pip
+            pip install wheel setuptools
             pip install -r requirements.txt
             # python -m localstack.services.install libs
             # python -m localstack.services.install testlibs
@@ -42,12 +44,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: |
-            source .venv/bin/activate
-            which python || true
-            which flake8 || true
-            python --version
-            make lint
+          command: make lint
 
   unit-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,36 @@ jobs:
       image: ubuntu-2004:202101-01
     steps:
       - checkout
+      - restore_cache:
+          key: python-requirements-{{ checksum "requirements.txt" }}
       - run:
           command: |
             sudo apt-get update
             sudo apt install -y python3.8 libsasl2-dev
           name: Install prerequisites
       - run:
-          command: virtualenv --python=`which python3.8` .venv; make ci-build-prepare
+          command: |
+            python3 -m venv .venv
+            source .venv/bin/activate
+            pip3 install -r requirements.txt
+            ls -la ~/.cache/pip
           name: Setup environment
+      - save_cache:
+          key: python-requirements-{{ checksum "requirements.txt" }}
+          paths:
+            - "~/.cache/pip"
   preflight:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: buildpack-deps:trusty
     steps:
       - run:
           command: |
             echo "preflight: $(pwd)"
+            python3 --version
             ls -la .
   unit-tests:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: buildpack-deps:trusty
     steps:
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,7 @@ jobs:
     working_directory: /tmp/workspace
     steps:
       - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-          at: localstack
+          at: /tmp/workspace
       - run:
           command: |
             echo "preflight: $(pwd)"
@@ -60,7 +59,10 @@ jobs:
   integration-tests:
     machine:
       image: ubuntu-2004:202101-01
+    working_directory: /tmp/workspace
     steps:
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           command: |
             echo "integration-tests: $(pwd)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,8 @@ jobs:
             pip install --upgrade pip
             pip install wheel setuptools
             pip install -r requirements.txt
+            python -m localstack.services.install libs
+            python -m localstack.services.install testlibs
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -43,10 +45,12 @@ jobs:
           at: /tmp/workspace
       - run:
           command: make lint
+          name: run linter
       - run:
           command: DEBUG=0 TEST_PATH=tests/unit make test
+          name: run unit tests
 
-  integration-tests:
+  itest-lambda-reuse:
     machine:
       image: ubuntu-2004:202101-01
     working_directory: /tmp/workspace/repo
@@ -54,7 +58,30 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: DEBUG=0 TEST_PATH=tests/integration make test
+          command: LAMBDA_EXECUTOR=docker-reuse TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
+          name: test docker-reuse executor
+
+  itest-lambda-docker:
+    machine:
+      image: ubuntu-2004:202101-01
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          command: DEBUG=1 LAMBDA_EXECUTOR=docker USE_SSL=1 TEST_ERROR_INJECTION=1 TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
+          name: test docker executor
+
+  itest-elasticmq:
+    docker:
+      - image: buildpack-deps:focal
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          command: DEBUG=1 SQS_PROVIDER=elasticmq TEST_PATH="tests/integration/test_sns.py:SNSTest.test_publish_sqs_from_sns_with_xray_propagation" make test
+          name: test elasticmq sqs provider
 
   docker-build:
     machine:
@@ -88,7 +115,13 @@ workflows:
       - preflight:
           requires:
             - install
-      - integration-tests:
+      - itest-lambda-docker:
+          requires:
+            - preflight
+      - itest-lambda-reuse:
+          requires:
+            - preflight
+      - itest-elasticmq:
           requires:
             - preflight
       - docker-build:
@@ -99,5 +132,7 @@ workflows:
             branches:
               only: main
           requires:
-            - integration-tests
+            - itest-lambda-docker
+            - itest-lambda-reuse
+            - itest-elasticmq
             - docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 jobs:
   install:
-    docker:
-      - image: buildpack-deps:focal
+    machine:
+      image: ubuntu-2004:202101-01
     working_directory: /tmp/workspace/repo
     steps:
       - checkout
@@ -11,11 +11,13 @@ jobs:
           key: python-requirements-{{ checksum "requirements.txt" }}
       - run:
           command: |
-            apt-get update
-            apt-get install -y libsasl2-dev python3-venv python3-dev
+            sudo apt-get update
+            sudo apt-get install -y libsasl2-dev python3.8-venv python3.8-dev
           name: Install prerequisites
       - run:
           command: |
+            which npm
+            which docker
             /usr/bin/python3.8 -m venv .venv
             source .venv/bin/activate
             which python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,11 @@ jobs:
       - run:
           command: |
             ls -la .venv/lib/python*/site-packages/
+            which python
+            which python3
             source .venv/bin/activate
-            pip install flake8
+            which python
+            which python3
             make lint
 
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run:
           command: |
             apt-get update
-            apt-get install -y libsasl2-dev
+            apt-get install -y python3-venv libsasl2-dev
           name: Install prerequisites
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,12 @@ jobs:
   install:
     machine:
       image: ubuntu-2004:202101-01
+    working_directory: /workspace
     steps:
+      - run:
+          command: |
+            pwd
+            ls -la .
       - checkout
       - restore_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -24,10 +29,19 @@ jobs:
           key: python-requirements-{{ checksum "requirements.txt" }}
           paths:
             - "~/.cache/pip"
+      - persist_to_workspace:
+          root:
+            /workspace
+          paths:
+            - localstack
   preflight:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:focal
+    working_directory: /workspace
     steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: localstack
       - run:
           command: |
             echo "preflight: $(pwd)"
@@ -35,7 +49,7 @@ jobs:
             ls -la .
   unit-tests:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:focal
     steps:
       - run:
           command: |
@@ -86,6 +100,9 @@ workflows:
           requires:
             - preflight
       - docker-push:
+          filters:
+            branches:
+              only: main
           requires:
             - unit-tests
             - integration-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,11 @@ jobs:
       image: ubuntu-2004:202101-01
     working_directory: /tmp/workspace
     steps:
+      - checkout
       - run:
           command: |
             pwd
             ls -la .
-      - checkout
       - restore_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
       - run:
@@ -22,7 +22,8 @@ jobs:
           command: |
             python3 -m venv .venv
             source .venv/bin/activate
-            pip3 install -r requirements.txt
+            pip install wheel
+            # pip install -r requirements.txt
             ls -la ~/.cache/pip
           name: Setup environment
       - save_cache:
@@ -31,9 +32,9 @@ jobs:
             - "~/.cache/pip"
       - persist_to_workspace:
           root:
-            /tmp/workspace
+            /tmp/
           paths:
-            - localstack
+            - workspace
   preflight:
     docker:
       - image: buildpack-deps:focal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,17 +52,6 @@ jobs:
           command: DEBUG=0 TEST_PATH=tests/unit make test
           name: run unit tests
 
-  itest-lambda-reuse:
-    machine:
-      image: ubuntu-2004:202101-01
-    working_directory: /tmp/workspace/repo
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          command: LAMBDA_EXECUTOR=docker-reuse TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
-          name: test docker-reuse executor
-
   itest-lambda-docker:
     machine:
       image: ubuntu-2004:202101-01
@@ -70,13 +59,30 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+
+      - run:
+          command: |
+            docker pull lambci/lambda:20191117-nodejs8.10
+            docker pull lambci/lambda:20191117-ruby2.5
+            docker pull lambci/lambda:20210129-ruby2.7
+            docker pull lambci/lambda:20191117-python2.7
+            docker pull lambci/lambda:20191117-python3.6
+            docker pull lambci/lambda:20191117-dotnetcore2.0
+            docker pull lambci/lambda:dotnetcore3.1
+            docker pull lambci/lambda:20191117-provided
+            docker pull lambci/lambda:java8
+            docker pull lambci/lambda:python3.8
+          name: pull lambda runtimes
       - run:
           command: DEBUG=1 LAMBDA_EXECUTOR=docker USE_SSL=1 TEST_ERROR_INJECTION=1 TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
           name: test docker executor
+      - run:
+          command: LAMBDA_EXECUTOR=docker-reuse TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
+          name: test docker-reuse executor
 
   itest-elasticmq:
-    docker:
-      - image: buildpack-deps:focal
+    machine:
+      image: ubuntu-2004:202101-01
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -120,9 +126,6 @@ workflows:
       - itest-lambda-docker:
           requires:
             - preflight
-      - itest-lambda-reuse:
-          requires:
-            - preflight
       - itest-elasticmq:
           requires:
             - preflight
@@ -135,6 +138,5 @@ workflows:
               only: main
           requires:
             - itest-lambda-docker
-            - itest-lambda-reuse
             - itest-elasticmq
             - docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,10 @@ jobs:
           name: Install prerequisites
       - run:
           command: |
-            make setup-venv
+            python3 -m venv .venv
+            export PIP_CMD=pip3
+            export VENV_OPTS="-p '`which python3`'"
+            make install
             make init
           name: Setup environment
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             which python
             realpath $(which python)
             pip install --upgrade pip
-            pip install wheel setuptools
+            pip install wheel setuptools pytest
             pip install -r requirements.txt
             python -m localstack.services.install libs
             python -m localstack.services.install testlibs
@@ -49,8 +49,12 @@ jobs:
           command: make lint
           name: run linter
       - run:
-          command: DEBUG=0 TEST_PATH=tests/unit make test
+          command: |
+            source .venv/bin/activate
+            pytest tests/unit --junitxml=target/tests/TESTS-unit.xml -o junit_suite_name=unit-tests
           name: run unit tests
+      - store_test_results:
+          path: target/tests/
 
   itest-lambda-docker:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,11 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: make lint
+          command: |
+            ls -la .venv/lib/python*/site-packages/
+            source .venv/bin/activate
+            pip install flake8
+            make lint
 
   unit-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,17 @@ version: 2.1
 
 jobs:
   install:
-    docker:
-      - image: buildpack-deps:focal
+    machine:
+      image: ubuntu-2004:202101-01
     working_directory: /tmp/workspace/repo
     steps:
       - checkout
-      - run:
-          command: |
-            pwd
-            ls -la .
       - restore_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
       - run:
           command: |
-            apt-get update
-            apt-get install -y python3-venv libsasl2-dev
+            sudo apt-get update
+            sudo apt install -y libsasl2-dev
           name: Install prerequisites
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,8 @@ jobs:
           name: Install prerequisites
       - run:
           command: |
-            python3 -m venv .venv
-            source .venv/bin/activate
-            pip install wheel
-            pip install -r requirements.txt
+            make setup-venv
+            make init
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ jobs:
             pip install --upgrade pip
             pip install wheel setuptools
             pip install -r requirements.txt
-            # python -m localstack.services.install libs
-            # python -m localstack.services.install testlibs
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -45,14 +43,6 @@ jobs:
           at: /tmp/workspace
       - run:
           command: make lint
-
-  unit-tests:
-    docker:
-      - image: buildpack-deps:focal
-    working_directory: /tmp/workspace/repo
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
       - run:
           command: DEBUG=0 TEST_PATH=tests/unit make test
 
@@ -64,10 +54,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: |
-            echo "integration-tests: $(pwd)"
-            sleep 5
-            ls -la .
+          command: DEBUG=0 TEST_PATH=tests/integration make test
 
   docker-build:
     machine:
@@ -101,9 +88,6 @@ workflows:
       - preflight:
           requires:
             - install
-      - unit-tests:
-          requires:
-            - preflight
       - integration-tests:
           requires:
             - preflight
@@ -115,6 +99,5 @@ workflows:
             branches:
               only: main
           requires:
-            - unit-tests
             - integration-tests
             - docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   install:
     machine:
       image: ubuntu-2004:202101-01
-    working_directory: /workspace
+    working_directory: /tmp/workspace
     steps:
       - run:
           command: |
@@ -31,13 +31,13 @@ jobs:
             - "~/.cache/pip"
       - persist_to_workspace:
           root:
-            /workspace
+            /tmp/workspace
           paths:
             - localstack
   preflight:
     docker:
       - image: buildpack-deps:focal
-    working_directory: /workspace
+    working_directory: /tmp/workspace
     steps:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
           key: python-requirements-{{ checksum "requirements.txt" }}
       - run:
           command: |
-            sudo apt-get update
-            sudo apt install -y libsasl2-dev
+            apt-get update
+            apt-get install -y libsasl2-dev
           name: Install prerequisites
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 jobs:
-  build-test-push:
+  install:
     machine:
       image: ubuntu-2004:202101-01
     steps:
@@ -14,14 +14,68 @@ jobs:
       - run:
           command: virtualenv --python=`which python3.8` .venv; make ci-build-prepare
           name: Setup environment
+  preflight:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
       - run:
-          command: . /opt/circleci/.nvm/nvm.sh; make ci-build-test
-          name: Run integration tests
+          command: |
+            echo "preflight: $(pwd)"
+            ls -la .
+  unit-tests:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
       - run:
-          command: make ci-build-push
-          name: Build and push Docker image
+          command: |
+            echo "unit-tests: $(pwd)"
+            sleep 2
+            ls -la .
+  integration-tests:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - run:
+          command: |
+            echo "integration-tests: $(pwd)"
+            sleep 5
+            ls -la .
+  docker-build:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - run:
+          command: |
+            echo "docker-build: $(pwd)"
+            sleep 10
+            ls -la .
+  docker-push:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - run:
+          command: |
+            echo "docker-push: $(pwd)"
+            ls -la .
 
 workflows:
   main:
     jobs:
-      - build-test-push
+      - install
+      - preflight:
+          requires:
+            - install
+      - unit-tests:
+          requires:
+            - preflight
+      - integration-tests:
+          requires:
+            - preflight
+      - docker-build:
+          requires:
+            - preflight
+      - docker-push:
+          requires:
+            - unit-tests
+            - integration-tests
+            - docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,10 +99,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: |
-            echo "docker-build: $(pwd)"
-            sleep 10
-            ls -la .
+          command: make docker-build
 
   docker-push:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,19 @@ jobs:
       - run:
           command: |
             sudo apt-get update
-            sudo apt install -y libsasl2-dev
+            sudo apt install -y libsasl2-dev python3.8-venv
           name: Install prerequisites
       - run:
           command: |
-            python3 -m venv .venv
-            export PIP_CMD=pip3
-            export VENV_OPTS="-p '`which python3`'"
-            make install
-            make init
+            which python3
+            which python3.8
+            realpath $(which python3.8)
+            /usr/bin/python3.8 -m venv .venv
+            ls -la .venv/bin
+            # export PIP_CMD=pip3
+            # export VENV_OPTS="-p '`which python3`'"
+            # make install
+            # make init
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -41,13 +45,12 @@ jobs:
           at: /tmp/workspace
       - run:
           command: |
-            ls -la .venv/lib/python*/site-packages/
-            which python
             which python3
-            source .venv/bin/activate
-            which python
-            which python3
-            make lint
+            which python3.8
+            realpath $(which python3.8)
+            python3.8 -m venv --help
+            ls -la /opt/circleci/.pyenv/versions
+            ls -la .venv/bin
 
   unit-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   install:
     machine:
       image: ubuntu-2004:202101-01
-    working_directory: /tmp/workspace
+    working_directory: /tmp/workspace/repo
     steps:
       - checkout
       - run:
@@ -32,13 +32,13 @@ jobs:
             - "~/.cache/pip"
       - persist_to_workspace:
           root:
-            /tmp/
+            /tmp/workspace
           paths:
-            - workspace
+            - repo
   preflight:
     docker:
       - image: buildpack-deps:focal
-    working_directory: /tmp/workspace
+    working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -47,6 +47,8 @@ jobs:
             echo "preflight: $(pwd)"
             python3 --version
             ls -la .
+            ls -la workspace || true
+            ls -la repo || true
   unit-tests:
     docker:
       - image: buildpack-deps:focal
@@ -59,7 +61,7 @@ jobs:
   integration-tests:
     machine:
       image: ubuntu-2004:202101-01
-    working_directory: /tmp/workspace
+    working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,13 @@ jobs:
           name: Install prerequisites
       - run:
           command: |
-            which python3
-            which python3.8
-            realpath $(which python3.8)
             /usr/bin/python3.8 -m venv .venv
-            ls -la .venv/bin
-            # export PIP_CMD=pip3
-            # export VENV_OPTS="-p '`which python3`'"
-            # make install
-            # make init
+            source .venv/bin/activate
+            which python
+            realpath $(which python)
+            pip install -r requirements.txt
+            # python -m localstack.services.install libs
+            # python -m localstack.services.install testlibs
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -45,12 +43,11 @@ jobs:
           at: /tmp/workspace
       - run:
           command: |
-            which python3
-            which python3.8
-            realpath $(which python3.8)
-            python3.8 -m venv --help
-            ls -la /opt/circleci/.pyenv/versions
-            ls -la .venv/bin
+            source .venv/bin/activate
+            which python || true
+            which flake8 || true
+            python --version
+            make lint
 
   unit-tests:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,12 @@ jobs:
           command: make docker-build
           name: Build localstack docker image
       - run:
-          command: docker pull localstack/localstack:latest
-          name: Build localstack docker image
+          command: |
+            cid=$(docker create localstack/localstack)
+            docker cp ${cid}:/opt/code/localstack/.coverage target/
+            docker cp ${cid}:/opt/code/localstack/nosetests.xml target/reports
+            docker rm ${cid}
+          name: Extract build reports
       - run:
           command: |
             test "$CIRCLE_BRANCH" = "master" \
@@ -129,6 +133,8 @@ jobs:
             /tmp/workspace
           paths:
             - repo
+      - store_test_results:
+          path: target/reports/
 
   docker-push:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,9 +161,9 @@ workflows:
           requires:
             - preflight
       - docker-push:
-           filters:
-             branches:
-               only: main
+          filters:
+            branches:
+              only: main
           requires:
             - itest-lambda-docker
             - itest-elasticmq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,12 @@ jobs:
           at: /tmp/workspace
       - run:
           command: make lint
-          name: run linter
+          name: Run linter
       - run:
           command: |
             source .venv/bin/activate
             pytest tests/unit --junitxml=target/tests/TESTS-unit.xml -o junit_suite_name=unit-tests
-          name: run unit tests
+          name: Unit tests
       - store_test_results:
           path: target/tests/
 
@@ -64,11 +64,9 @@ jobs:
           at: /tmp/workspace
       - run:
           command: make ci-build-prepare
-          name: preparing ci tests
+          name: Preparing CI tests
       - run:
-          command: docker image ls
-      - run:
-          name: test docker executor
+          name: Test docker lambda executor
           environment:
             DEUBG: 1
             LAMBDA_EXECUTOR: "docker"
@@ -78,7 +76,7 @@ jobs:
             NOSE_ARGS: "--with-xunit --xunit-testsuite-name='lambda-docker' --xunit-file=target/reports/lambda-docker.xml"
           command: make test
       - run:
-          name: test docker-reuse executor
+          name: Test docker-reuse lambda executor
           environment:
             LAMBDA_EXECUTOR: "docker-reuse"
             TEST_PATH: "tests/integration/test_lambda.py tests/integration/test_integration.py"
@@ -95,7 +93,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: test elasticmq sqs provider
+          name: Test elasticmq SQS provider
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"
@@ -113,14 +111,24 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: docker image ls
-      - run:
           command: make init
-          name: Initialize build environment
+          name: Initializing build environment
       - run:
           command: make docker-build
           name: Build localstack docker image
-
+      - run:
+          command: docker pull localstack/localstack:latest
+          name: Build localstack docker image
+      - run:
+          command: |
+            test "$CIRCLE_BRANCH" = "master" \
+              && docker save localstack/localstack:latest -o target/localstack-docker-image.tar || true
+          name: Saving docker image
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo
 
   docker-push:
     machine:
@@ -130,10 +138,11 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: |
-            echo "docker-push: $(pwd)"
-            ls -la .
-            docker image ls
+          name: Loading docker image
+          command: docker load -i target/localstack-docker-image.tar
+      - run:
+          name: Push docker image
+          command: make docker-push-master
 
 workflows:
   main:
@@ -152,9 +161,9 @@ workflows:
           requires:
             - preflight
       - docker-push:
-          # filters:
-          #   branches:
-          #     only: main
+           filters:
+             branches:
+               only: main
           requires:
             - itest-lambda-docker
             - itest-elasticmq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             pip install -r requirements.txt
             python -m localstack.services.install libs
             python -m localstack.services.install testlibs
+            mkdir -p target/reports
           name: Setup environment
       - save_cache:
           key: python-requirements-{{ checksum "requirements.txt" }}
@@ -62,9 +63,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: |
-            make ci-build-prepare
-            mkdir -p target/reports
+          command: make ci-build-prepare
           name: preparing ci tests
       - run:
           command: docker image ls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,18 +61,32 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-
       - run:
-          command: make ci-build-prepare
+          command: |
+            make ci-build-prepare
+            mkdir -p target/reports
           name: preparing ci tests
       - run:
           command: docker image ls
       - run:
-          command: DEBUG=1 LAMBDA_EXECUTOR=docker USE_SSL=1 TEST_ERROR_INJECTION=1 TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
           name: test docker executor
+          environment:
+            DEUBG: 1
+            LAMBDA_EXECUTOR: "docker"
+            USE_SSL: 1
+            TEST_ERROR_INJECTION: 1
+            TEST_PATH: "tests/integration/test_lambda.py tests/integration/test_integration.py"
+            NOSE_ARGS: "--with-xunit --xunit-testsuite-name='lambda-docker' --xunit-file=target/reports/lambda-docker.xml"
+          command: make test
       - run:
-          command: LAMBDA_EXECUTOR=docker-reuse TEST_PATH="tests/integration/test_lambda.py tests/integration/test_integration.py" make test
           name: test docker-reuse executor
+          environment:
+            LAMBDA_EXECUTOR: "docker-reuse"
+            TEST_PATH: "tests/integration/test_lambda.py tests/integration/test_integration.py"
+            NOSE_ARGS: "--with-xunit --xunit-testsuite-name='lambda-docker-reuse' --xunit-file=target/reports/lambda-docker-reuse.xml"
+          command: make test
+      - store_test_results:
+          path: target/reports/
 
   itest-elasticmq:
     machine:
@@ -82,8 +96,15 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: DEBUG=1 SQS_PROVIDER=elasticmq TEST_PATH="tests/integration/test_sns.py:SNSTest.test_publish_sqs_from_sns_with_xray_propagation" make test
           name: test elasticmq sqs provider
+          environment:
+            DEBUG: 1
+            SQS_PROVIDER: "elasticmq"
+            TEST_PATH: "tests/integration/test_sns.py:SNSTest.test_publish_sqs_from_sns_with_xray_propagation"
+            NOSE_ARGS: "--with-xunit --xunit-testsuite-name='elasticmq' --xunit-file=target/reports/elasticmq.xml"
+          command:  make test
+      - store_test_results:
+          path: target/reports/
 
   docker-build:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,19 +63,8 @@ jobs:
           at: /tmp/workspace
 
       - run:
-          command: |
-            make init
-            docker pull lambci/lambda:20191117-nodejs8.10
-            docker pull lambci/lambda:20191117-ruby2.5
-            docker pull lambci/lambda:20210129-ruby2.7
-            docker pull lambci/lambda:20191117-python2.7
-            docker pull lambci/lambda:20191117-python3.6
-            docker pull lambci/lambda:20191117-dotnetcore2.0
-            docker pull lambci/lambda:dotnetcore3.1
-            docker pull lambci/lambda:20191117-provided
-            docker pull lambci/lambda:java8
-            docker pull lambci/lambda:python3.8
-          name: pull lambda runtimes
+          command: make ci-build-prepare
+          name: preparing ci tests
       - run:
           command: docker image ls
       - run:

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ reinstall-p3:      ## Re-initialize the virtualenv with Python 3.x
 	PIP_CMD=pip3 VENV_OPTS="-p '`which python3`'" make install
 
 lint:              ## Run code linter to check code style
-	($(VENV_RUN); flake8 --inline-quotes=single --show-source --max-line-length=120 --ignore=E128,W504 --exclude=node_modules,$(VENV_DIR)*,dist,fixes .)
+	($(VENV_RUN); python -m flake8 --inline-quotes=single --show-source --max-line-length=120 --ignore=E128,W504 --exclude=node_modules,$(VENV_DIR)*,dist,fixes .)
 
 clean:             ## Clean up (npm dependencies, downloaded infrastructure code, compiled Java classes)
 	rm -rf localstack/dashboard/web/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,6 @@ ci-build-prepare:
 	nohup docker pull lambci/lambda:20191117-nodejs8.10 > /dev/null &
 	nohup docker pull lambci/lambda:20191117-ruby2.5 > /dev/null &
 	nohup docker pull lambci/lambda:20210129-ruby2.7 > /dev/null &
-	nohup docker pull lambci/lambda:20191117-python2.7 > /dev/null &
 	nohup docker pull lambci/lambda:20191117-python3.6 > /dev/null &
 	nohup docker pull lambci/lambda:20191117-dotnetcore2.0 > /dev/null &
 	nohup docker pull lambci/lambda:dotnetcore3.1 > /dev/null &

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -666,7 +666,8 @@ def exec_lambda_code(script, handler_function='handler', lambda_cwd=None, lambda
     return module_vars[handler_function]
 
 
-def get_handler_function_from_name(handler_name, runtime=LAMBDA_DEFAULT_RUNTIME):
+def get_handler_function_from_name(handler_name, runtime=None):
+    runtime = runtime or LAMBDA_DEFAULT_RUNTIME
     if runtime.startswith(tuple(DOTNET_LAMBDA_RUNTIMES)):
         return handler_name.split(':')[-1]
     return handler_name.split('.')[-1]

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -919,8 +919,8 @@ class Util:
         docker_tag = runtime
         docker_image = config.LAMBDA_CONTAINER_REGISTRY
         # TODO: remove prefix once execution issues are fixed with dotnetcore/python lambdas
-        # See https://github.com/lambci/docker-lambda/pull/218
-        lambdas_to_add_prefix = ['dotnetcore2.0', 'dotnetcore2.1', 'python2.7', 'python3.6', 'python3.7']
+        #  See https://github.com/lambci/docker-lambda/pull/218
+        lambdas_to_add_prefix = ['dotnetcore2.0', 'dotnetcore2.1', 'python3.6', 'python3.7']
         if docker_image == 'lambci/lambda' and any(img in docker_tag for img in lambdas_to_add_prefix):
             docker_tag = '20191117-%s' % docker_tag
         if runtime == 'nodejs14.x':

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -26,7 +26,7 @@ LAMBDA_RUNTIME_PROVIDED = 'provided'
 
 # default handler and runtime
 LAMBDA_DEFAULT_HANDLER = 'handler.handler'
-LAMBDA_DEFAULT_RUNTIME = 'python3.8'
+LAMBDA_DEFAULT_RUNTIME = LAMBDA_RUNTIME_PYTHON37
 LAMBDA_DEFAULT_STARTING_POSITION = 'LATEST'
 
 # List of Dotnet Lambda runtime names

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from localstack.utils.common import to_str
 
 # Lambda runtime constants
-LAMBDA_RUNTIME_PYTHON27 = 'python2.7'
 LAMBDA_RUNTIME_PYTHON36 = 'python3.6'
 LAMBDA_RUNTIME_PYTHON37 = 'python3.7'
 LAMBDA_RUNTIME_PYTHON38 = 'python3.8'

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -13,7 +13,6 @@ from localstack.utils.common import (
     load_file, save_file, short_uid, clone, to_bytes, to_str, run_safe, retry, new_tmp_file)
 from localstack.utils.kinesis import kinesis_connector
 from localstack.utils.testutil import get_lambda_log_events
-from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON27
 from .lambdas import lambda_integration
 from .test_lambda import TEST_LAMBDA_PYTHON, TEST_LAMBDA_PYTHON_ECHO, TEST_LAMBDA_LIBS, LambdaTestBase
 
@@ -365,7 +364,7 @@ class IntegrationTest(unittest.TestCase):
         # deploy test lambda connected to DynamoDB Stream
         testutil.create_lambda_function(
             handler_file=TEST_LAMBDA_PYTHON, libs=TEST_LAMBDA_LIBS, func_name=TEST_LAMBDA_NAME_DDB,
-            event_source_arn=ddb_event_source_arn, runtime=LAMBDA_RUNTIME_PYTHON27, delete=True)
+            event_source_arn=ddb_event_source_arn, delete=True)
 
         # submit a batch with writes
         dynamodb.batch_write_item(RequestItems={table_name: [
@@ -504,11 +503,11 @@ class IntegrationTest(unittest.TestCase):
 
         # deploy test lambdas connected to Kinesis streams
         zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_PYTHON), get_content=True,
-            libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
+            libs=TEST_LAMBDA_LIBS)
         testutil.create_lambda_function(func_name=TEST_CHAIN_LAMBDA1_NAME, zip_file=zip_file,
-            event_source_arn=get_event_source_arn(TEST_CHAIN_STREAM1_NAME), runtime=LAMBDA_RUNTIME_PYTHON27)
+            event_source_arn=get_event_source_arn(TEST_CHAIN_STREAM1_NAME))
         testutil.create_lambda_function(func_name=TEST_CHAIN_LAMBDA2_NAME, zip_file=zip_file,
-            event_source_arn=get_event_source_arn(TEST_CHAIN_STREAM2_NAME), runtime=LAMBDA_RUNTIME_PYTHON27)
+            event_source_arn=get_event_source_arn(TEST_CHAIN_STREAM2_NAME))
 
         # publish test record
         test_data = {'test_data': 'forward_chain_data_%s with \'quotes\\"' % short_uid()}
@@ -540,7 +539,6 @@ class IntegrationTest(unittest.TestCase):
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             func_name=lambda_name_queue_batch,
             event_source_arn=sqs_queue_info['QueueArn'],
-            runtime=LAMBDA_RUNTIME_PYTHON27,
             libs=TEST_LAMBDA_LIBS
         )
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -30,7 +30,7 @@ from localstack.services.awslambda.lambda_api import (
     use_docker, BATCH_SIZE_RANGES, INVALID_PARAMETER_VALUE_EXCEPTION, LAMBDA_DEFAULT_HANDLER)
 from localstack.services.awslambda.lambda_utils import (
     LAMBDA_RUNTIME_DOTNETCORE2, LAMBDA_RUNTIME_DOTNETCORE31, LAMBDA_RUNTIME_RUBY27,
-    LAMBDA_RUNTIME_PYTHON27, LAMBDA_RUNTIME_PYTHON36, LAMBDA_RUNTIME_JAVA8, LAMBDA_RUNTIME_JAVA11,
+    LAMBDA_RUNTIME_PYTHON36, LAMBDA_RUNTIME_JAVA8, LAMBDA_RUNTIME_JAVA11,
     LAMBDA_RUNTIME_NODEJS810, LAMBDA_RUNTIME_PROVIDED, LAMBDA_RUNTIME_PYTHON37, LAMBDA_RUNTIME_NODEJS14X)
 from .lambdas import lambda_integration
 
@@ -841,8 +841,7 @@ class TestPythonRuntimes(LambdaTestBase):
         cls.s3_client = aws_stack.connect_to_service('s3')
         cls.sns_client = aws_stack.connect_to_service('sns')
 
-        Util.create_function(TEST_LAMBDA_PYTHON, TEST_LAMBDA_NAME_PY,
-                             runtime=LAMBDA_RUNTIME_PYTHON27, libs=TEST_LAMBDA_LIBS)
+        Util.create_function(TEST_LAMBDA_PYTHON, TEST_LAMBDA_NAME_PY, libs=TEST_LAMBDA_LIBS)
 
     @classmethod
     def tearDownClass(cls):
@@ -893,7 +892,7 @@ class TestPythonRuntimes(LambdaTestBase):
     def test_lambda_environment(self):
         vars = {'Hello': 'World'}
         testutil.create_lambda_function(handler_file=TEST_LAMBDA_ENV, libs=TEST_LAMBDA_LIBS,
-                                        func_name=TEST_LAMBDA_NAME_ENV, runtime=LAMBDA_RUNTIME_PYTHON27, envvars=vars)
+                                        func_name=TEST_LAMBDA_NAME_ENV, envvars=vars)
 
         # invoke function and assert result contains env vars
         result = self.lambda_client.invoke(
@@ -918,14 +917,14 @@ class TestPythonRuntimes(LambdaTestBase):
         # upload zip file to S3
         zip_file = testutil.create_lambda_archive(
             load_file(TEST_LAMBDA_PYTHON), get_content=True,
-            libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
+            libs=TEST_LAMBDA_LIBS)
         self.s3_client.create_bucket(Bucket=bucket_name)
         self.s3_client.upload_fileobj(
             BytesIO(zip_file), bucket_name, bucket_key)
 
         # create lambda function
         response = self.lambda_client.create_function(
-            FunctionName=lambda_name, Runtime=LAMBDA_RUNTIME_PYTHON27, Role='r1', Publish=True,
+            FunctionName=lambda_name, Role='r1', Publish=True,
             Handler='handler.handler', Code={'S3Bucket': bucket_name, 'S3Key': bucket_key}
         )
         self.assertIn('Version', response)
@@ -999,15 +998,14 @@ class TestPythonRuntimes(LambdaTestBase):
         # upload zip file to S3
         zip_file = testutil.create_lambda_archive(
             load_file(TEST_LAMBDA_PYTHON), get_content=True,
-            libs=TEST_LAMBDA_LIBS, runtime=LAMBDA_RUNTIME_PYTHON27)
+            libs=TEST_LAMBDA_LIBS)
         self.s3_client.create_bucket(Bucket=bucket_name)
         self.s3_client.upload_fileobj(
             BytesIO(zip_file), bucket_name, bucket_key)
 
         # create lambda function
         self.lambda_client.create_function(
-            FunctionName=lambda_name, Handler='handler.handler',
-            Runtime=LAMBDA_RUNTIME_PYTHON27, Role='r1',
+            FunctionName=lambda_name, Handler='handler.handler', Role='r1',
             Code={'S3Bucket': bucket_name, 'S3Key': bucket_key}
         )
 
@@ -1684,8 +1682,7 @@ class TestDockerBehaviour(LambdaTestBase):
 
         # deploy and invoke lambda without Docker
         testutil.create_lambda_function(
-            func_name=func_name, handler_file=TEST_LAMBDA_ENV, libs=TEST_LAMBDA_LIBS,
-            runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
+            func_name=func_name, handler_file=TEST_LAMBDA_ENV, libs=TEST_LAMBDA_LIBS, envvars={'Hello': 'World'})
 
         self.assertEqual(len(executor.get_all_container_names()), 0)
         self.assertDictEqual(executor.function_invoke_times, {})
@@ -1782,8 +1779,7 @@ class TestDockerBehaviour(LambdaTestBase):
 
         # deploy and invoke lambda without Docker
         testutil.create_lambda_function(
-            func_name=func_name, handler_file=TEST_LAMBDA_ENV, libs=TEST_LAMBDA_LIBS,
-            runtime=LAMBDA_RUNTIME_PYTHON27, envvars={'Hello': 'World'})
+            func_name=func_name, handler_file=TEST_LAMBDA_ENV, libs=TEST_LAMBDA_LIBS, envvars={'Hello': 'World'})
 
         self.assertEqual(len(executor.get_all_container_names()), 0)
 
@@ -1806,6 +1802,6 @@ class TestDockerBehaviour(LambdaTestBase):
 class Util(object):
     @classmethod
     def create_function(cls, file, name, runtime=None, libs=None):
-        runtime = runtime or LAMBDA_RUNTIME_PYTHON27
+        runtime = runtime or LAMBDA_RUNTIME_PYTHON37
         testutil.create_lambda_function(
-            func_name=name, handler_file=file, libs=TEST_LAMBDA_LIBS, runtime=runtime)
+            func_name=name, handler_file=file, libs=libs, runtime=runtime)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -924,7 +924,7 @@ class TestPythonRuntimes(LambdaTestBase):
 
         # create lambda function
         response = self.lambda_client.create_function(
-            FunctionName=lambda_name, Role='r1', Publish=True,
+            FunctionName=lambda_name, Runtime=LAMBDA_RUNTIME_PYTHON37, Role='r1', Publish=True,
             Handler='handler.handler', Code={'S3Bucket': bucket_name, 'S3Key': bucket_key}
         )
         self.assertIn('Version', response)
@@ -1005,7 +1005,7 @@ class TestPythonRuntimes(LambdaTestBase):
 
         # create lambda function
         self.lambda_client.create_function(
-            FunctionName=lambda_name, Handler='handler.handler', Role='r1',
+            FunctionName=lambda_name, Runtime=LAMBDA_RUNTIME_PYTHON37, Handler='handler.handler', Role='r1',
             Code={'S3Bucket': bucket_name, 'S3Key': bucket_key}
         )
 
@@ -1803,5 +1803,5 @@ class Util(object):
     @classmethod
     def create_function(cls, file, name, runtime=None, libs=None):
         runtime = runtime or LAMBDA_RUNTIME_PYTHON37
-        testutil.create_lambda_function(
-            func_name=name, handler_file=file, libs=libs, runtime=runtime)
+        libs = libs or TEST_LAMBDA_LIBS
+        testutil.create_lambda_function(func_name=name, handler_file=file, libs=libs, runtime=runtime)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -52,27 +52,27 @@ class TestCommon(unittest.TestCase):
 
     def test_mktime(self):
         now = common.mktime(datetime.now())
-        self.assertEquals(int(time.time()), int(now))
+        self.assertEqual(int(time.time()), int(now))
 
     def test_mktime_with_tz(self):
         # see https://en.wikipedia.org/wiki/File:1000000000seconds.jpg
         dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.utc)
-        self.assertEquals(1000000000, int(common.mktime(dt)))
+        self.assertEqual(1000000000, int(common.mktime(dt)))
 
         dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.timezone('EST'))
-        self.assertEquals(1000000000 + (5 * 60 * 60), int(common.mktime(dt)))  # EST is UTC-5
+        self.assertEqual(1000000000 + (5 * 60 * 60), int(common.mktime(dt)))  # EST is UTC-5
 
     def test_mktime_millis_with_tz(self):
         # see https://en.wikipedia.org/wiki/File:1000000000
         dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.utc)
-        self.assertEquals(1000000000, int(common.mktime(dt, millis=True) / 1000))
+        self.assertEqual(1000000000, int(common.mktime(dt, millis=True) / 1000))
 
         dt = datetime(2001, 9, 9, 1, 46, 40, 0, tzinfo=pytz.timezone('EST'))
-        self.assertEquals(1000000000 + (5 * 60 * 60), int(common.mktime(dt, millis=True)) / 1000)  # EST is UTC-5
+        self.assertEqual(1000000000 + (5 * 60 * 60), int(common.mktime(dt, millis=True)) / 1000)  # EST is UTC-5
 
     def test_mktime_millis(self):
         now = common.mktime(datetime.now(), millis=True)
-        self.assertEquals(int(time.time()), int(now / 1000))
+        self.assertEqual(int(time.time()), int(now / 1000))
 
     def test_timestamp_millis(self):
         result = common.timestamp_millis(datetime.now())


### PR DESCRIPTION
this PR will create a more streamlined circleci workflow as per #4169. just opened it so i can start running builds 

things left to do:

- [x] get integration tests to work
- [x] hand docker image downstream to docker-push job
- [x] extract test report from docker build with [custom build outputs](https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs)
- (postponed) aggregate coverage data
- (postponed)  use pip cache with pyenv as per circleci documentation
