### PR TITLE
update kinesis_starter.py to pin kinesis mock version to 0.0.16

### DIFF
--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -13,7 +13,7 @@ from localstack.services.infra import start_proxy_for_service, do_run, log_start
 
 LOGGER = logging.getLogger(__name__)
 
-KINESIS_MOCK_RELEASES = 'https://api.github.com/repos/etspaceman/kinesis-mock/releases/latest'
+KINESIS_MOCK_RELEASES = 'https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/0.0.16'
 
 
 def apply_patches_kinesalite():


### PR DESCRIPTION
This PR fixes a build issue that was caused by the latest release of kinesis-mock: https://github.com/etspaceman/kinesis-mock/releases/tag/0.1.0

i pinned the version to a specific tag that we know had worked before.
