### PR TITLE
Fix profiler log_duration unit

### DIFF
--- a/localstack/utils/analytics/profiler.py
+++ b/localstack/utils/analytics/profiler.py
@@ -157,7 +157,7 @@ def log_duration(name=None):
             finally:
                 end_time = now_utc(millis=True)
                 func_name = name or f.__name__
-                duration = (end_time - start_time)
+                duration = end_time - start_time
                 if duration > 500:
                     LOG.info('Execution of "%s" took %.2fms', func_name, duration)
         return wrapped

--- a/localstack/utils/analytics/profiler.py
+++ b/localstack/utils/analytics/profiler.py
@@ -157,7 +157,7 @@ def log_duration(name=None):
             finally:
                 end_time = now_utc(millis=True)
                 func_name = name or f.__name__
-                duration = (end_time - start_time) * 1000
+                duration = (end_time - start_time)
                 if duration > 500:
                     LOG.info('Execution of "%s" took %.2fms', func_name, duration)
         return wrapped


### PR DESCRIPTION
Start and endtime is already in milliseconds, no need to multiply by 1000 here. 
We basically output nanoseconds currently.