### PR TITLE
Add KINESIS_INITIALIZE_STREAMS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ You can pass the following environment variables to LocalStack:
   - MergeShards
   - SplitShard
   - UpdateShardCount
+* `KINESIS_INITIALIZE_STREAMS`: A comma-delimited string of stream names and its corresponding shard count to initialize during startup. For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1". Only works
+with the `kinesis-mock` KINESIS_PROVIDER.
 * `DYNAMODB_ERROR_PROBABILITY`: Decimal value between 0.0 (default) and 1.0 to randomly inject `ProvisionedThroughputExceededException` errors into DynamoDB API responses.
 * `DYNAMODB_HEAP_SIZE`: Sets the JAVA EE maximum memory size for dynamodb values are (integer)m for MB, (integer)G for GB default(256m), full table scans require more memory
 * `STEPFUNCTIONS_LAMBDA_ENDPOINT`: URL to use as the Lambda service endpoint in Step Functions. By default this is the LocalStack Lambda endpoint. Use `default` to select the original AWS Lambda endpoint.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -244,7 +244,7 @@ LAMBDA_FORWARD_URL = os.environ.get('LAMBDA_FORWARD_URL', '').strip()
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup.
 # For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
-KINESIS_INITIALIZE_STREAMS = os.environ.get('KINESIS_INITIALIZE_STREAMS', None).strip()
+KINESIS_INITIALIZE_STREAMS = os.environ.get('KINESIS_INITIALIZE_STREAMS', '').strip()
 
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -241,6 +241,11 @@ LAMBDA_FALLBACK_URL = os.environ.get('LAMBDA_FALLBACK_URL', '').strip()
 # endpoint (can use useful for advanced test setups)
 LAMBDA_FORWARD_URL = os.environ.get('LAMBDA_FORWARD_URL', '').strip()
 
+# A comma-delimited string of stream names and its corresponding shard count to
+# initialize during startup.
+# For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
+KINESIS_INITIALIZE_STREAMS = os.environ.get('KINESIS_INITIALIZE_STREAMS', '').strip
+
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
@@ -255,7 +260,8 @@ CONFIG_ENV_VARS = ['SERVICES', 'HOSTNAME', 'HOSTNAME_EXTERNAL', 'LOCALSTACK_HOST
                    'SYNCHRONOUS_API_GATEWAY_EVENTS', 'SYNCHRONOUS_KINESIS_EVENTS', 'BUCKET_MARKER_LOCAL',
                    'SYNCHRONOUS_SNS_EVENTS', 'SYNCHRONOUS_SQS_EVENTS', 'SYNCHRONOUS_DYNAMODB_EVENTS',
                    'DYNAMODB_HEAP_SIZE', 'MAIN_CONTAINER_NAME', 'LAMBDA_DOCKER_DNS', 'PERSISTENCE_SINGLE_FILE',
-                   'S3_SKIP_SIGNATURE_VALIDATION', 'DEVELOP', 'DEVELOP_PORT', 'WAIT_FOR_DEBUGGER']
+                   'S3_SKIP_SIGNATURE_VALIDATION', 'DEVELOP', 'DEVELOP_PORT', 'WAIT_FOR_DEBUGGER',
+                   'KINESIS_INITIALIZE_STREAMS']
 
 for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
     clean_key = key.upper().replace('-', '_')

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -244,7 +244,7 @@ LAMBDA_FORWARD_URL = os.environ.get('LAMBDA_FORWARD_URL', '').strip()
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup.
 # For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
-KINESIS_INITIALIZE_STREAMS = os.environ.get('KINESIS_INITIALIZE_STREAMS', '').strip
+KINESIS_INITIALIZE_STREAMS = os.environ.get('KINESIS_INITIALIZE_STREAMS', None).strip()
 
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -55,15 +55,20 @@ def start_kinesis_mock(port=None, asynchronous=False, update_listener=None):
         'UPDATE_SHARD_COUNT_DURATION=%s' \
         % (latency, latency, latency, latency, latency, latency, latency, latency, latency)
 
+    if config.KINESIS_INITIALIZE_STREAMS != '':
+        initialize_streams_param = 'INITIALIZE_STREAMS=%s' % (config.KINESIS_INITIALIZE_STREAMS)
+    else:
+        initialize_streams_param = ''
+
     if kinesis_mock_bin.endswith('.jar'):
-        cmd = 'KINESIS_MOCK_PLAIN_PORT=%s SHARD_LIMIT=%s %s %s %s java -XX:+UseG1GC -jar %s' \
+        cmd = 'KINESIS_MOCK_PLAIN_PORT=%s SHARD_LIMIT=%s %s %s %s %s java -XX:+UseG1GC -jar %s' \
               % (backend_port, config.KINESIS_SHARD_LIMIT, latency_param, kinesis_data_dir_param,
-                 log_level_param, kinesis_mock_bin)
+                 log_level_param, initialize_streams_param, kinesis_mock_bin)
     else:
         chmod_r(kinesis_mock_bin, 0o777)
-        cmd = 'KINESIS_MOCK_PLAIN_PORT=%s SHARD_LIMIT=%s %s %s %s %s --gc=G1' \
+        cmd = 'KINESIS_MOCK_PLAIN_PORT=%s SHARD_LIMIT=%s %s %s %s %s %s --gc=G1' \
               % (backend_port, config.KINESIS_SHARD_LIMIT, latency_param, kinesis_data_dir_param,
-                 log_level_param, kinesis_mock_bin)
+                 log_level_param, initialize_streams_param, kinesis_mock_bin)
     LOGGER.info('starting kinesis-mock proxy %d:%d with cmd: %s', port, backend_port, cmd)
     start_proxy_for_service('kinesis', port, backend_port, update_listener)
     return do_run(cmd, asynchronous)

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -55,7 +55,7 @@ def start_kinesis_mock(port=None, asynchronous=False, update_listener=None):
         'UPDATE_SHARD_COUNT_DURATION=%s' \
         % (latency, latency, latency, latency, latency, latency, latency, latency, latency)
 
-    if config.KINESIS_INITIALIZE_STREAMS is not None:
+    if config.KINESIS_INITIALIZE_STREAMS != '':
         initialize_streams_param = 'INITIALIZE_STREAMS=%s' % (config.KINESIS_INITIALIZE_STREAMS)
     else:
         initialize_streams_param = ''

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -55,7 +55,7 @@ def start_kinesis_mock(port=None, asynchronous=False, update_listener=None):
         'UPDATE_SHARD_COUNT_DURATION=%s' \
         % (latency, latency, latency, latency, latency, latency, latency, latency, latency)
 
-    if config.KINESIS_INITIALIZE_STREAMS != '':
+    if config.KINESIS_INITIALIZE_STREAMS is not None:
         initialize_streams_param = 'INITIALIZE_STREAMS=%s' % (config.KINESIS_INITIALIZE_STREAMS)
     else:
         initialize_streams_param = ''


### PR DESCRIPTION
Adds a KINESIS_INITIALIZE_STREAMS environment variable, which allows kinesis-mock to be initialized with streams that are already created. This is a common pattern for a lot of users, so it makes sense to add here.
