### PR TITLE
Detect ARM systems for kinesis-mock installation

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -172,9 +172,11 @@ def install_kinesis_mock():
 
     machine = platform.machine().lower()
     system = platform.system().lower()
+    version = platform.version().lower()
 
     LOG.debug('getting kinesis-mock for %s %s', system, machine)
-    if machine == 'x86_64' or machine == 'amd64':
+    if ((machine == 'x86_64' or machine == 'amd64') and
+        "arm64" not in version and "arm32" not in version):
         if system == 'windows':
             bin_file = 'kinesis-mock-mostly-static.exe'
         elif system == 'linux':

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -174,9 +174,10 @@ def install_kinesis_mock():
     system = platform.system().lower()
     version = platform.version().lower()
 
+    is_probably_m1 = system == 'darwin' and ('arm64' in version or 'arm32' in version)
+
     LOG.debug('getting kinesis-mock for %s %s', system, machine)
-    if ((machine == 'x86_64' or machine == 'amd64') and
-        "arm64" not in version and "arm32" not in version):
+    if ((machine == 'x86_64' or machine == 'amd64') and not is_probably_m1):
         if system == 'windows':
             bin_file = 'kinesis-mock-mostly-static.exe'
         elif system == 'linux':


### PR DESCRIPTION
An [issue](https://github.com/etspaceman/kinesis-mock/issues/128) was raised in Kinesis Mock in which M1 Macbooks were getting a segfault. This is due to the binary file for MacOS being compiled for AMD64.

This PR will detect ARM machines and ensure that they fallback to the JAR file. 

Unfortunately Kinesis Mock will not be able to build M1 compliant binary executables until GitHub Actions supports a virtual environment for this, as GraalVM requires this for linking the libraries properly:

https://github.com/actions/virtual-environments/issues/2187
