### PR TITLE
enable docker layer caching for circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ jobs:
   docker-build:
     machine:
       image: ubuntu-2004:202101-01
+      docker_layer_caching: true
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:


### PR DESCRIPTION
this PR enables docker layer caching which should speed up the docker build command
