### PR TITLE
fix deprecation warnings

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1,6 +1,6 @@
 import re
 import os
-import imp
+import importlib.machinery
 import sys
 import json
 import uuid
@@ -621,6 +621,10 @@ def run_lambda(func_arn, event, context={}, version=None,
     return result
 
 
+def load_source(name, file):
+    return importlib.machinery.SourceFileLoader(name, file).load_module()
+
+
 def exec_lambda_code(script, handler_function='handler', lambda_cwd=None, lambda_env=None):
     if lambda_cwd or lambda_env:
         EXEC_MUTEX.acquire()
@@ -641,7 +645,7 @@ def exec_lambda_code(script, handler_function='handler', lambda_cwd=None, lambda
     try:
         pre_sys_modules_keys = set(sys.modules.keys())
         try:
-            handler_module = imp.load_source(lambda_id, lambda_file)
+            handler_module = load_source(lambda_id, lambda_file)
             module_vars = handler_module.__dict__
         finally:
             # the above import can bring files for the function

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -260,7 +260,7 @@ def modify_and_forward(method=None, path=None, data_bytes=None, headers=None, fo
             'headers': headers,
             'response': response
         }
-        if 'request_handler' in inspect.getargspec(update_listener.return_response)[0]:
+        if 'request_handler' in inspect.getfullargspec(update_listener.return_response).args:
             # some listeners (e.g., sqs_listener.py) require additional details like the original
             # request port, hence we pass in a reference to this request handler as well.
             kwargs['request_handler'] = request_handler

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -835,7 +835,7 @@ def cp_r(src, dst, rm_dest_on_conflict=False):
     if os.path.isfile(src):
         return shutil.copy(src, dst)
     kwargs = {}
-    if 'dirs_exist_ok' in inspect.getargspec(shutil.copytree)[0]:
+    if 'dirs_exist_ok' in inspect.getfullargspec(shutil.copytree).args:
         kwargs['dirs_exist_ok'] = True
     try:
         return shutil.copytree(src, dst, **kwargs)

--- a/localstack/utils/kinesis/kinesis_util.py
+++ b/localstack/utils/kinesis/kinesis_util.py
@@ -44,7 +44,7 @@ class EventFileReaderThread(FuncThread):
                 event = json.loads(line)
                 records = event['records']
                 shard_id = event['shard_id']
-                method_args = inspect.getargspec(self.callback)[0]
+                method_args = inspect.getfullargspec(self.callback).args
                 if len(method_args) > 2:
                     self.callback(records, shard_id=shard_id, fh_d_stream=self.fh_d_stream)
                 elif len(method_args) > 1:

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -285,8 +285,8 @@ class TestAPIGateway(unittest.TestCase):
             data_mutator_fn=_mutate_data)
 
         # Ensure that `invoke_rest_api_integration_backend` correctly decodes the base64 content
-        self.assertEquals(test_result.result.status_code, 203)
-        self.assertEquals(test_result.result.content, content)
+        self.assertEqual(test_result.result.status_code, 203)
+        self.assertEqual(test_result.result.content, content)
 
     def _test_api_gateway_lambda_proxy_integration_no_asserts(
         self,

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -100,7 +100,7 @@ class IntegrationTest(unittest.TestCase):
         # check file layout in target bucket
         all_objects = testutil.map_all_s3_objects(buckets=[TEST_BUCKET_NAME])
         for key in all_objects.keys():
-            self.assertRegexpMatches(key, r'.*/\d{4}/\d{2}/\d{2}/\d{2}/.*\-\d{4}\-\d{2}\-\d{2}\-\d{2}.*')
+            self.assertRegex(key, r'.*/\d{4}/\d{2}/\d{2}/\d{2}/.*\-\d{4}\-\d{2}\-\d{2}\-\d{2}.*')
 
     def test_firehose_kinesis_to_s3(self):
         kinesis = aws_stack.connect_to_service('kinesis')


### PR DESCRIPTION
This PR fixes a couple of deprecation warnings of using `imp` and `getargspec`.