### PR TITLE
pin serverless version to 2.48.0

### DIFF
--- a/tests/integration/serverless/package.json
+++ b/tests/integration/serverless/package.json
@@ -8,7 +8,7 @@
     "version": "serverless --version"
   },
   "devDependencies": {
-    "serverless": "^2.35.0",
+    "serverless": "2.48.0",
     "serverless-localstack": "^0.4.30"
   }
 }


### PR DESCRIPTION
this PR fixues the current build failures happening in `tests/integration/test_serverless.py`, which seem to have to do with the latest serverless release 2.48.1