### PR TITLE
add regex matching to check_terraform_version

### DIFF
--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -5,6 +5,7 @@ import re
 
 import pytest
 
+from packaging import version
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import run, start_worker_thread, is_command_available, rm_rf
 
@@ -25,19 +26,10 @@ def check_terraform_version():
         return False, None
 
     ver_string = run('terraform -version')
-    ver_string = re.search(r'v(\d+)\.(\d+)\.(\d+)', ver_string).group()
+    ver_string = re.search(r'v(\d+\.\d+\.\d+)', ver_string).group(1)
     if ver_string is None:
         return False, None
-
-    ver = ver_string.lstrip('v')
-    ver = [int(i) for i in ver.split('.')]
-
-    if ver[0] > 0:
-        return False, ver_string
-    if ver[1] > 14:
-        return False, ver_string
-
-    return True, ver_string
+    return version.parse(ver_string) < version.parse('0.15'), ver_string
 
 
 class TestTerraform(unittest.TestCase):

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -1,6 +1,7 @@
 import os
 import threading
 import unittest
+import re
 
 import pytest
 
@@ -23,7 +24,11 @@ def check_terraform_version():
     if not is_command_available('terraform'):
         return False, None
 
-    ver_string = run('terraform -version').split()[1]
+    ver_string = run('terraform -version')
+    ver_string = re.search(r'v(\d+)\.(\d+)\.(\d+)', ver_string).group()
+    if ver_string is None:
+        return False, None
+
     ver = ver_string.lstrip('v')
     ver = [int(i) for i in ver.split('.')]
 


### PR DESCRIPTION
Changes terraform version check to a regex match.

`terraform -version` can also show out-of-date notices like this:

```
Your version of Terraform is out of date! The latest version
is 1.0.1. You can update by downloading from https://www.terraform.io/downloads.html
Terraform v0.13.0
```

This PR matches directly to the version string, so the check passes even when terraform displays this message.