### PR TITLE
refactor(tests): Invert asserts in unit test #4197

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ For pull requests, please stick to the following guidelines:
 * Add tests for any new features and bug fixes. Ideally, each PR should increase the test coverage.
 * Follow the existing code style (e.g., indents). A PEP8 code linting target is included in the Makefile.
 * Put a reasonable amount of comments into the code.
-* Fork localstack on your github user account, do your changes there and then create a PR against main localstack repository.
+* Fork localstack on your GitHub user account, do your changes there and then create a PR against main localstack repository.
 * Separate unrelated changes into multiple pull requests.
 * 1 commit per PR: Please squash/rebase multiple commits into one single commit (to keep the history clean).
 

--- a/tests/integration/serverless/package.json
+++ b/tests/integration/serverless/package.json
@@ -8,7 +8,7 @@
     "version": "serverless --version"
   },
   "devDependencies": {
-    "serverless": "^2.35.0",
+    "serverless": "2.48.0",
     "serverless-localstack": "^0.4.30"
   }
 }

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -9,61 +9,61 @@ class ApiGatewayPathsTest(unittest.TestCase):
         path, query_params = apigateway_listener.extract_query_string_params(
             '/foo/bar?foo=foo&bar=bar&bar=baz'
         )
-        self.assertEqual(path, '/foo/bar')
-        self.assertEqual(query_params, {'foo': 'foo', 'bar': ['bar', 'baz']})
+        self.assertEqual('/foo/bar', path)
+        self.assertEqual({'foo': 'foo', 'bar': ['bar', 'baz']}, query_params)
 
     def test_extract_path_params(self):
         params = apigateway_listener.extract_path_params('/foo/bar', '/foo/{param1}')
-        self.assertEqual(params, {'param1': 'bar'})
+        self.assertEqual({'param1': 'bar'}, params)
 
         params = apigateway_listener.extract_path_params('/foo/bar1/bar2', '/foo/{param1}/{param2}')
-        self.assertEqual(params, {'param1': 'bar1', 'param2': 'bar2'})
+        self.assertEqual({'param1': 'bar1', 'param2': 'bar2'}, params)
 
         params = apigateway_listener.extract_path_params('/foo/bar', '/foo/bar')
-        self.assertEqual(params, {})
+        self.assertEqual({}, params)
 
         params = apigateway_listener.extract_path_params('/foo/bar/baz', '/foo/{proxy+}')
-        self.assertEqual(params, {'proxy+': 'bar/baz'})
+        self.assertEqual({'proxy+': 'bar/baz'}, params)
 
     def test_path_matches(self):
         path, details = apigateway_listener.get_resource_for_path('/foo/bar', {'/foo/{param1}': {}})
-        self.assertEqual(path, '/foo/{param1}')
+        self.assertEqual('/foo/{param1}', path)
 
         path, details = apigateway_listener.get_resource_for_path('/foo/bar', {'/foo/bar': {}, '/foo/{param1}': {}})
-        self.assertEqual(path, '/foo/bar')
+        self.assertEqual('/foo/bar', path)
 
         path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', {'/foo/bar': {}, '/foo/{proxy+}': {}})
-        self.assertEqual(path, '/foo/{proxy+}')
+        self.assertEqual('/foo/{proxy+}', path)
 
         result = apigateway_listener.get_resource_for_path('/foo/bar', {'/foo/bar1': {}, '/foo/bar2': {}})
-        self.assertEqual(result, None)
+        self.assertEqual(None, result)
 
         result = apigateway_listener.get_resource_for_path('/foo/bar', {'/{param1}/bar1': {}, '/foo/bar2': {}})
-        self.assertEqual(result, None)
+        self.assertEqual(None, result)
 
         path_args = {'/{param1}/{param2}/foo/{param3}': {}, '/{param}/bar': {}}
         path, details = apigateway_listener.get_resource_for_path('/foo/bar', path_args)
-        self.assertEqual(path, '/{param}/bar')
+        self.assertEqual('/{param}/bar', path)
 
         path_args = {'/{param1}/{param2}': {}, '/{param}/bar': {}}
         path, details = apigateway_listener.get_resource_for_path('/foo/bar', path_args)
-        self.assertEqual(path, '/{param}/bar')
+        self.assertEqual('/{param}/bar', path)
 
         path_args = {'/{param1}/{param2}': {}, '/{param1}/bar': {}}
         path, details = apigateway_listener.get_resource_for_path('/foo/baz', path_args)
-        self.assertEqual(path, '/{param1}/{param2}')
+        self.assertEqual('/{param1}/{param2}', path)
 
         path_args = {'/{param1}/{param2}/baz': {}, '/{param1}/bar/{param2}': {}}
         path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
-        self.assertEqual(path, '/{param1}/{param2}/baz')
+        self.assertEqual('/{param1}/{param2}/baz', path)
 
         path_args = {'/{param1}/{param2}/baz': {}, '/{param1}/{param2}/{param2}': {}}
         path, details = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
-        self.assertEqual(path, '/{param1}/{param2}/baz')
+        self.assertEqual('/{param1}/{param2}/baz', path)
 
         path_args = {'/foo123/{param1}/baz': {}}
         result = apigateway_listener.get_resource_for_path('/foo/bar/baz', path_args)
-        self.assertEqual(result, None)
+        self.assertEqual(None, result)
 
 
 class TestVelocityUtil(unittest.TestCase):
@@ -72,10 +72,10 @@ class TestVelocityUtil(unittest.TestCase):
         util = templating.VelocityUtil()
 
         encoded = util.urlEncode('x=a+b')
-        self.assertEqual(encoded, 'x%3Da%2Bb')
+        self.assertEqual('x%3Da%2Bb', encoded)
 
         decoded = util.urlDecode('x=a+b')
-        self.assertEqual(decoded, 'x=a b')
+        self.assertEqual('x=a b', decoded)
 
         escaped = util.escapeJavaScript("it's")
-        self.assertEqual(escaped, r"it\'s")
+        self.assertEqual(r"it\'s", escaped)

--- a/tests/unit/test_cloudwatch.py
+++ b/tests/unit/test_cloudwatch.py
@@ -22,4 +22,4 @@ class CloudWatchTest(unittest.TestCase):
                             '<StateUpdatedTimestamp>'
                             '2020-10-15T21:33:48.343651Z'
                             '</StateUpdatedTimestamp>')
-        self.assertEqual(response.content, response_content)
+        self.assertEqual(response_content, response.content)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -12,47 +12,47 @@ class TestCommon(unittest.TestCase):
 
     def test_first_char_to_lower(self):
         env = common.first_char_to_lower('Foobar')
-        self.assertEqual(env, 'foobar')
+        self.assertEqual('foobar', env)
 
     def test_truncate(self):
         env = common.truncate('foobar', 3)
-        self.assertEqual(env, 'foo...')
+        self.assertEqual('foo...', env)
 
     def test_isoformat_milliseconds(self):
         env = common.isoformat_milliseconds(datetime(2010, 3, 20, 7, 24, 00, 0))
-        self.assertEqual(env, '2010-03-20T07:24:00.000')
+        self.assertEqual('2010-03-20T07:24:00.000', env)
 
     def test_base64_to_hex(self):
         env = common.base64_to_hex('Zm9vIGJhcg ==')
-        self.assertEqual(env, b'666f6f20626172')
+        self.assertEqual(b'666f6f20626172', env)
 
     def test_now(self):
         env = common.now()
         test = time.time()
-        self.assertAlmostEqual(env, test, delta=1)
+        self.assertAlmostEqual(test, env, delta=1)
 
     def test_now_utc(self):
         env = common.now_utc()
         test = datetime.now(pytz.UTC).timestamp()
-        self.assertAlmostEqual(env, test, delta=1)
+        self.assertAlmostEqual(test, env, delta=1)
 
     def test_is_number(self):
         env = common.is_number(5)
-        self.assertEqual(env, True)
+        self.assertEqual(True, env)
 
     def test_is_ip_address(self):
         env = common.is_ip_address('10.0.0.1')
-        self.assertEqual(env, True)
+        self.assertEqual(True, env)
         env = common.is_ip_address('abcde')
-        self.assertEqual(env, False)
+        self.assertEqual(False, env)
 
     def test_is_base64(self):
         env = common.is_base64('foobar')
-        self.assertEqual(env, None)
+        self.assertEqual(None, env)
 
     def test_mktime(self):
         now = common.mktime(datetime.now())
-        self.assertEqual(int(time.time()), int(now))
+        self.assertEqual(int(now), int(time.time()))
 
     def test_mktime_with_tz(self):
         # see https://en.wikipedia.org/wiki/File:1000000000seconds.jpg
@@ -72,7 +72,7 @@ class TestCommon(unittest.TestCase):
 
     def test_mktime_millis(self):
         now = common.mktime(datetime.now(), millis=True)
-        self.assertEqual(int(time.time()), int(now / 1000))
+        self.assertEqual(int(now / 1000), int(time.time()))
 
     def test_timestamp_millis(self):
         result = common.timestamp_millis(datetime.now())
@@ -84,24 +84,24 @@ class TestCommon(unittest.TestCase):
     def test_extract_jsonpath(self):
         obj = {'a': {'b': [{'c': 123}, 'foo']}, 'e': 234}
         result = common.extract_jsonpath(obj, '$.a.b')
-        self.assertEqual(result, [{'c': 123}, 'foo'])
+        self.assertEqual([{'c': 123}, 'foo'], result)
         result = common.extract_jsonpath(obj, '$.a.b.c')
         self.assertFalse(result)
         result = common.extract_jsonpath(obj, '$.foobar')
         self.assertFalse(result)
         result = common.extract_jsonpath(obj, '$.e')
-        self.assertEqual(result, 234)
+        self.assertEqual(234, result)
         result = common.extract_jsonpath(obj, '$.a.b[0]')
-        self.assertEqual(result, {'c': 123})
+        self.assertEqual({'c': 123}, result)
         result = common.extract_jsonpath(obj, '$.a.b[0].c')
-        self.assertEqual(result, 123)
+        self.assertEqual(123, result)
         result = common.extract_jsonpath(obj, '$.a.b[1]')
-        self.assertEqual(result, 'foo')
+        self.assertEqual('foo', result)
 
     def test_parse_yaml_nodes(self):
         obj = {'test': yaml.ScalarNode('tag:yaml.org,2002:int', '123')}
         result = common.clone_safe(obj)
-        self.assertEqual(result, {'test': 123})
+        self.assertEqual({'test': 123}, result)
         obj = {'foo': [
             yaml.ScalarNode('tag:yaml.org,2002:str', 'value'),
             yaml.ScalarNode('tag:yaml.org,2002:int', '123'),
@@ -109,7 +109,7 @@ class TestCommon(unittest.TestCase):
             yaml.ScalarNode('tag:yaml.org,2002:bool', 'true')
         ]}
         result = common.clone_safe(obj)
-        self.assertEqual(result, {'foo': ['value', 123, 1.23, True]})
+        self.assertEqual({'foo': ['value', 123, 1.23, True]}, result)
 
 
 class TestCommandLine(unittest.TestCase):

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -38,17 +38,17 @@ class TestCommon(unittest.TestCase):
 
     def test_is_number(self):
         env = common.is_number(5)
-        self.assertEqual(True, env)
+        self.assertTrue(env)
 
     def test_is_ip_address(self):
         env = common.is_ip_address('10.0.0.1')
-        self.assertEqual(True, env)
+        self.assertTrue(env)
         env = common.is_ip_address('abcde')
-        self.assertEqual(False, env)
+        self.assertFalse(env)
 
     def test_is_base64(self):
         env = common.is_base64('foobar')
-        self.assertEqual(None, env)
+        self.assertIsNone(env)
 
     def test_mktime(self):
         now = common.mktime(datetime.now())

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -7,7 +7,7 @@ class EdgeServiceTest(unittest.TestCase):
 
     def test_data_contains_key_equal_is_true(self):
         data_bytes = b'AWSAccessKeyId=someId&policy=somePolicy&key=someKey&signature=someSig'
-        self.assertEqual(is_s3_form_data(data_bytes), True)
+        self.assertEqual(True, is_s3_form_data(data_bytes))
 
     def test_s3_form_data_is_true(self):
         data_bytes = b"""--28f72589b2be0c9de84386b52c615990
@@ -36,11 +36,11 @@ class EdgeServiceTest(unittest.TestCase):
         Hello World!
         --28f72589b2be0c9de84386b52c615990--
         """
-        self.assertEqual(is_s3_form_data(data_bytes), True)
+        self.assertEqual(True, is_s3_form_data(data_bytes))
 
     def test_other_query_params_is_false(self):
         data_bytes = b'AWSAccessKeyId=someId&policy=somePolicy&param=value&signature=someSig'
-        self.assertEqual(is_s3_form_data(data_bytes), False)
+        self.assertEqual(False, is_s3_form_data(data_bytes))
 
     def test_other_form_data_is_false(self):
         data_bytes = b"""--28f72589b2be0c9de84386b52c615990
@@ -57,7 +57,7 @@ class EdgeServiceTest(unittest.TestCase):
         hTahNRfuCxL5HEKdhXxJPwvC6IQ=
         --28f72589b2be0c9de84386b52c615990--
         """
-        self.assertEqual(is_s3_form_data(data_bytes), False)
+        self.assertEqual(False, is_s3_form_data(data_bytes))
 
     def test_get_auth_string(self):
         # Typical Header with Authorization
@@ -91,12 +91,12 @@ class EdgeServiceTest(unittest.TestCase):
 
         # check getting auth string from header with Authorization header
         self.assertEqual(
-            get_auth_string('POST', '/', headers_with_auth, b''),
-            headers_with_auth.get('authorization')
+            headers_with_auth.get('authorization'),
+            get_auth_string('POST', '/', headers_with_auth, b'')
         )
 
         # check getting auth string from body with authorization params
         self.assertEqual(
-            get_auth_string('POST', '/', Headers(), body_with_auth),
-            headers_with_auth.get('authorization')
+            headers_with_auth.get('authorization'),
+            get_auth_string('POST', '/', Headers(), body_with_auth)
         )

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -7,7 +7,7 @@ class EdgeServiceTest(unittest.TestCase):
 
     def test_data_contains_key_equal_is_true(self):
         data_bytes = b'AWSAccessKeyId=someId&policy=somePolicy&key=someKey&signature=someSig'
-        self.assertEqual(True, is_s3_form_data(data_bytes))
+        self.assertTrue(is_s3_form_data(data_bytes))
 
     def test_s3_form_data_is_true(self):
         data_bytes = b"""--28f72589b2be0c9de84386b52c615990
@@ -36,11 +36,11 @@ class EdgeServiceTest(unittest.TestCase):
         Hello World!
         --28f72589b2be0c9de84386b52c615990--
         """
-        self.assertEqual(True, is_s3_form_data(data_bytes))
+        self.assertTrue(is_s3_form_data(data_bytes))
 
     def test_other_query_params_is_false(self):
         data_bytes = b'AWSAccessKeyId=someId&policy=somePolicy&param=value&signature=someSig'
-        self.assertEqual(False, is_s3_form_data(data_bytes))
+        self.assertFalse(is_s3_form_data(data_bytes))
 
     def test_other_form_data_is_false(self):
         data_bytes = b"""--28f72589b2be0c9de84386b52c615990
@@ -57,7 +57,7 @@ class EdgeServiceTest(unittest.TestCase):
         hTahNRfuCxL5HEKdhXxJPwvC6IQ=
         --28f72589b2be0c9de84386b52c615990--
         """
-        self.assertEqual(False, is_s3_form_data(data_bytes))
+        self.assertFalse(is_s3_form_data(data_bytes))
 
     def test_get_auth_string(self):
         # Typical Header with Authorization

--- a/tests/unit/test_firehose.py
+++ b/tests/unit/test_firehose.py
@@ -24,4 +24,4 @@ class FirehoseApiTest(unittest.TestCase):
         self.assertEqual([TEST_TAG_2], result['Tags'])
         result = firehose_api.get_delivery_stream_tags(TEST_STREAM_NAME, limit=1)
         self.assertEqual([TEST_TAG_1], result['Tags'])
-        self.assertEqual(True, result['HasMore'])
+        self.assertTrue(result['HasMore'])

--- a/tests/unit/test_kinesis.py
+++ b/tests/unit/test_kinesis.py
@@ -17,7 +17,7 @@ class KinesisListenerTest(unittest.TestCase):
             response = UPDATE_KINESIS.forward_request('POST', '/', TEST_DATA,
                 describe_stream_summary_header)
 
-            self.assertEqual(response, True)
+            self.assertEqual(True, response)
         else:
             self.assertTrue(True)
 
@@ -29,8 +29,8 @@ class KinesisListenerTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 400)
         resp_json = json.loads(to_str(response.content))
-        self.assertEqual(resp_json['ErrorCode'], 'ProvisionedThroughputExceededException')
-        self.assertEqual(resp_json['ErrorMessage'], 'Rate exceeded for shard X in stream Y under account Z.')
+        self.assertEqual('ProvisionedThroughputExceededException', resp_json['ErrorCode'])
+        self.assertEqual('Rate exceeded for shard X in stream Y under account Z.', resp_json['ErrorMessage'])
 
     def test_random_error_on_put_records(self):
         put_records_header = {'X-Amz-Target': 'Kinesis_20131202.PutRecords'}
@@ -39,13 +39,13 @@ class KinesisListenerTest(unittest.TestCase):
 
         response = UPDATE_KINESIS.forward_request('POST', '/', data_with_one_record, put_records_header)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(200, response.status_code)
         resp_json = json.loads(to_str(response.content))
-        self.assertEqual(resp_json['FailedRecordCount'], 1)
-        self.assertEqual(len(resp_json['Records']), 1)
+        self.assertEqual(1, resp_json['FailedRecordCount'])
+        self.assertEqual(1, len(resp_json['Records']))
         failed_record = resp_json['Records'][0]
-        self.assertEqual(failed_record['ErrorCode'], 'ProvisionedThroughputExceededException')
-        self.assertEqual(failed_record['ErrorMessage'], 'Rate exceeded for shard X in stream Y under account Z.')
+        self.assertEqual('ProvisionedThroughputExceededException', failed_record['ErrorCode'])
+        self.assertEqual('Rate exceeded for shard X in stream Y under account Z.', failed_record['ErrorMessage'])
 
     def test_overwrite_update_shard_count_on_error(self):
         if config.KINESIS_PROVIDER == 'kinesalite':
@@ -57,10 +57,10 @@ class KinesisListenerTest(unittest.TestCase):
             response = UPDATE_KINESIS.return_response('POST', '/', request_data, update_shard_count_header,
                 error_response)
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(200, response.status_code)
             resp_json = json.loads(to_str(response.content))
-            self.assertEqual(resp_json['StreamName'], 'TestStream')
-            self.assertEqual(resp_json['CurrentShardCount'], 1)
-            self.assertEqual(resp_json['TargetShardCount'], 2)
+            self.assertEqual('TestStream', resp_json['StreamName'])
+            self.assertEqual(1, resp_json['CurrentShardCount'])
+            self.assertEqual(2, resp_json['TargetShardCount'])
         else:
             self.assertTrue(True)

--- a/tests/unit/test_kinesis.py
+++ b/tests/unit/test_kinesis.py
@@ -17,7 +17,7 @@ class KinesisListenerTest(unittest.TestCase):
             response = UPDATE_KINESIS.forward_request('POST', '/', TEST_DATA,
                 describe_stream_summary_header)
 
-            self.assertEqual(True, response)
+            self.assertTrue(response)
         else:
             self.assertTrue(True)
 

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -425,8 +425,10 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             result = json.loads(lambda_api.list_versions(self.FUNCTION_NAME).get_data())
             self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
-            self.assertEqual(self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
-                             result['message'])
+            self.assertEqual(
+                self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
+                result['message']
+            )
 
     def test_create_alias(self):
         self._create_function(self.FUNCTION_NAME)
@@ -446,8 +448,10 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             result = json.loads(lambda_api.create_alias(self.FUNCTION_NAME).get_data())
             self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
-            self.assertEqual(self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
-                             result['message'])
+            self.assertEqual(
+                self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
+                result['message']
+            )
 
     def test_create_alias_returns_error_if_already_exists(self):
         self._create_function(self.FUNCTION_NAME)
@@ -461,8 +465,10 @@ class TestLambdaAPI(unittest.TestCase):
 
         alias_arn = lambda_api.func_arn(self.FUNCTION_NAME) + ':' + self.ALIAS_NAME
         self.assertEqual(self.ALIASEXISTS_EXCEPTION, result['__type'])
-        self.assertEqual(self.ALIASEXISTS_MESSAGE % alias_arn,
-                         result['message'])
+        self.assertEqual(
+            self.ALIASEXISTS_MESSAGE % alias_arn,
+            result['message']
+        )
 
     def test_update_alias(self):
         self._create_function(self.FUNCTION_NAME)
@@ -486,8 +492,10 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             result = json.loads(lambda_api.update_alias(self.FUNCTION_NAME, self.ALIAS_NAME).get_data())
             self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
-            self.assertEqual(self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
-                             result['message'])
+            self.assertEqual(
+                self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
+                result['message']
+            )
 
     def test_update_alias_on_non_existant_alias_returns_error(self):
         with self.app.test_request_context():
@@ -518,8 +526,10 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             result = json.loads(lambda_api.get_alias(self.FUNCTION_NAME, self.ALIAS_NAME).get_data())
             self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
-            self.assertEqual(self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
-                             result['message'])
+            self.assertEqual(
+                self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
+                result['message']
+            )
 
     def test_get_alias_on_non_existant_alias_returns_error(self):
         with self.app.test_request_context():
@@ -563,8 +573,10 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             result = json.loads(lambda_api.list_aliases(self.FUNCTION_NAME).get_data())
             self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
-            self.assertEqual(self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
-                             result['message'])
+            self.assertEqual(
+                self.RESOURCENOTFOUND_MESSAGE % lambda_api.func_arn(self.FUNCTION_NAME),
+                result['message']
+            )
 
     def test_get_container_name(self):
         executor = lambda_executors.EXECUTOR_CONTAINERS_REUSE
@@ -640,7 +652,8 @@ class TestLambdaAPI(unittest.TestCase):
             self.assertEqual(self.RESOURCENOTFOUND_EXCEPTION, result['__type'])
             self.assertEqual(
                 self.RESOURCENOTFOUND_MESSAGE % arn,
-                result['message'])
+                result['message']
+            )
 
     def test_untag_resource(self):
         with self.app.test_request_context():
@@ -868,7 +881,7 @@ class TestLambdaEventInvokeConfig(unittest.TestCase):
         response = self.LAMBDA_OBJ.get_function_event_invoke_config()
 
         # verifying set values
-        self.assertEqual(response['FunctionArn'], self.LAMBDA_OBJ.id)
-        self.assertEqual(response['MaximumRetryAttempts'], self.RETRY_ATTEMPTS)
-        self.assertEqual(response['MaximumEventAgeInSeconds'], self.EVENT_AGE)
-        self.assertEqual(response['DestinationConfig']['OnFailure']['Destination'], self.DL_QUEUE)
+        self.assertEqual(self.LAMBDA_OBJ.id, response['FunctionArn'])
+        self.assertEqual(self.RETRY_ATTEMPTS, response['MaximumRetryAttempts'])
+        self.assertEqual(self.EVENT_AGE, response['MaximumEventAgeInSeconds'])
+        self.assertEqual(self.DL_QUEUE, response['DestinationConfig']['OnFailure']['Destination'])

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -19,9 +19,9 @@ class TestMisc(unittest.TestCase):
 
     def test_environment(self):
         env = aws_stack.Environment.from_json({'prefix': 'foobar1'})
-        self.assertEqual(env.prefix, 'foobar1')
+        self.assertEqual('foobar1', env.prefix)
         env = aws_stack.Environment.from_string('foobar2')
-        self.assertEqual(env.prefix, 'foobar2')
+        self.assertEqual('foobar2', env.prefix)
 
     def test_parse_chunked_data(self):
         # See: https://en.wikipedia.org/wiki/Chunked_transfer_encoding
@@ -30,12 +30,12 @@ class TestMisc(unittest.TestCase):
 
         # test parsing
         parsed = parse_chunked_data(chunked)
-        self.assertEqual(parsed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), parsed.strip())
 
         # test roundtrip
         chunked_computed = create_chunked_data(expected)
         parsed = parse_chunked_data(chunked_computed)
-        self.assertEqual(parsed.strip(), expected.strip())
+        self.assertEqual(expected.strip(), parsed.strip())
 
     def test_convert_yaml_date_strings(self):
         yaml_source = 'Version: 2012-10-17'
@@ -43,8 +43,8 @@ class TestMisc(unittest.TestCase):
         self.assertIn(type(obj['Version']), (datetime.date, str))
         if isinstance(obj['Version'], datetime.date):
             obj = json_safe(obj)
-            self.assertEqual(type(obj['Version']), str)
-            self.assertEqual(obj['Version'], '2012-10-17')
+            self.assertEqual(str, type(obj['Version']))
+            self.assertEqual('2012-10-17', obj['Version'])
 
     def test_timstamp_millis(self):
         t1 = now_utc()
@@ -54,21 +54,21 @@ class TestMisc(unittest.TestCase):
     def test_port_mappings(self):
         map = PortMappings()
         map.add(123)
-        self.assertEqual(map.to_str(), '-p 123:123')
+        self.assertEqual('-p 123:123', map.to_str())
         map.add(124)
-        self.assertEqual(map.to_str(), '-p 123-124:123-124')
+        self.assertEqual('-p 123-124:123-124', map.to_str())
         map.add(234)
-        self.assertEqual(map.to_str(), '-p 123-124:123-124 -p 234:234')
+        self.assertEqual('-p 123-124:123-124 -p 234:234', map.to_str())
         map.add(345, 346)
-        self.assertEqual(map.to_str(), '-p 123-124:123-124 -p 234:234 -p 345:346')
+        self.assertEqual('-p 123-124:123-124 -p 234:234 -p 345:346', map.to_str())
         map.add([456, 458])
-        self.assertEqual(map.to_str(), '-p 123-124:123-124 -p 234:234 -p 345:346 -p 456-458:456-458')
+        self.assertEqual('-p 123-124:123-124 -p 234:234 -p 345:346 -p 456-458:456-458', map.to_str())
 
         map = PortMappings()
         map.add([123, 124])
-        self.assertEqual(map.to_str(), '-p 123-124:123-124')
+        self.assertEqual('-p 123-124:123-124', map.to_str())
         map.add([234, 237], [345, 348])
-        self.assertEqual(map.to_str(), '-p 123-124:123-124 -p 234-237:345-348')
+        self.assertEqual('-p 123-124:123-124 -p 234-237:345-348', map.to_str())
 
     def test_get_service_status(self):
         env = infra.get_services_status()
@@ -77,7 +77,7 @@ class TestMisc(unittest.TestCase):
 
     def test_update_config_variable(self):
         infra.update_config_variable('foo', 'bar')
-        self.assertEqual(config.foo, 'bar')
+        self.assertEqual('bar', config.foo)
 
     def test_async_parallelization(self):
         def handler():
@@ -93,7 +93,7 @@ class TestMisc(unittest.TestCase):
         num_items = 1000
         handlers = [run() for i in range(num_items)]
         loop.run_until_complete(asyncio.gather(*handlers))
-        self.assertEqual(len(results), num_items)
+        self.assertEqual(num_items, len(results))
         thread_pool.shutdown()
 
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -13,10 +13,10 @@ class S3ListenerTest (unittest.TestCase):
 
     def test_expand_redirect_url(self):
         url1 = s3_listener.expand_redirect_url('http://example.org', 'K', 'B')
-        self.assertEqual(url1, 'http://example.org?key=K&bucket=B')
+        self.assertEqual('http://example.org?key=K&bucket=B', url1)
 
         url2 = s3_listener.expand_redirect_url('http://example.org/?id=I', 'K', 'B')
-        self.assertEqual(url2, 'http://example.org/?id=I&key=K&bucket=B')
+        self.assertEqual('http://example.org/?id=I&key=K&bucket=B', url2)
 
     def test_find_multipart_key_value(self):
         headers = {'Host': '10.0.1.19:4572', 'User-Agent': 'curl/7.51.0',
@@ -43,13 +43,13 @@ class S3ListenerTest (unittest.TestCase):
 
         key1, url1 = multipart_content.find_multipart_key_value(data1, headers)
 
-        self.assertEqual(key1, 'uploads/20170826T181315.679087009Z/upload/pixel.png')
-        self.assertEqual(url1, 'http://127.0.0.1:5000/?id=20170826T181315.679087009Z')
+        self.assertEqual('uploads/20170826T181315.679087009Z/upload/pixel.png', key1)
+        self.assertEqual('http://127.0.0.1:5000/?id=20170826T181315.679087009Z', url1)
 
         key2, url2 = multipart_content.find_multipart_key_value(data2, headers)
 
-        self.assertEqual(key2, 'uploads/20170826T181315.679087009Z/upload/pixel.png')
-        self.assertIsNone(url2, 'Should not get a redirect URL without success_action_redirect')
+        self.assertEqual('uploads/20170826T181315.679087009Z/upload/pixel.png', key2)
+        self.assertIsNone('Should not get a redirect URL without success_action_redirect', url2)
 
         key3, url3 = multipart_content.find_multipart_key_value(data3, headers)
 
@@ -58,8 +58,8 @@ class S3ListenerTest (unittest.TestCase):
 
         key4, status_code = multipart_content.find_multipart_key_value(data4, headers, 'success_action_status')
 
-        self.assertEqual(key4, 'uploads/20170826T181315.679087009Z/upload/pixel.png')
-        self.assertEqual(status_code, '201')
+        self.assertEqual('uploads/20170826T181315.679087009Z/upload/pixel.png', key4)
+        self.assertEqual('201', status_code)
 
     def test_expand_multipart_filename(self):
         headers = {'Host': '10.0.1.19:4572', 'User-Agent': 'curl/7.51.0',
@@ -304,9 +304,9 @@ class S3BackendTest (unittest.TestCase):
 
         key = s3_backend.get_object(bucket_name, file2_name)
 
-        self.assertEqual(key in (key.instances or []), False)
+        self.assertFalse(key in (key.instances or []))
 
-    def test_no_bucket_in_instances_(self):
+    def test_no_bucket_in_instances(self):
         s3_backend = s3_models.S3Backend()
 
         bucket_name = 'test'
@@ -317,4 +317,4 @@ class S3BackendTest (unittest.TestCase):
         s3_backend.delete_bucket(bucket_name)
         bucket = s3_backend.create_bucket(bucket_name, region)
 
-        self.assertGreaterEqual(bucket in (bucket.instances or []), False)
+        self.assertIn(bucket, (bucket.instances or []))

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -9,7 +9,7 @@ from localstack.constants import S3_VIRTUAL_HOSTNAME, LOCALHOST
 from localstack.services.infra import patch_instance_tracker_meta
 
 
-class S3ListenerTest (unittest.TestCase):
+class S3ListenerTest(unittest.TestCase):
 
     def test_expand_redirect_url(self):
         url1 = s3_listener.expand_redirect_url('http://example.org', 'K', 'B')
@@ -20,8 +20,8 @@ class S3ListenerTest (unittest.TestCase):
 
     def test_find_multipart_key_value(self):
         headers = {'Host': '10.0.1.19:4572', 'User-Agent': 'curl/7.51.0',
-            'Accept': '*/*', 'Content-Length': '992', 'Expect': '100-continue',
-            'Content-Type': 'multipart/form-data; boundary=------------------------3c48c744237517ac'}
+                   'Accept': '*/*', 'Content-Length': '992', 'Expect': '100-continue',
+                   'Content-Type': 'multipart/form-data; boundary=------------------------3c48c744237517ac'}
 
         data1 = (b'--------------------------3c48c744237517ac\r\nContent-Disposition: form-data; name="key"\r\n\r\n'
                  b'uploads/20170826T181315.679087009Z/upload/pixel.png\r\n--------------------------3c48c744237517ac'
@@ -63,8 +63,8 @@ class S3ListenerTest (unittest.TestCase):
 
     def test_expand_multipart_filename(self):
         headers = {'Host': '10.0.1.19:4572', 'User-Agent': 'curl/7.51.0',
-            'Accept': '*/*', 'Content-Length': '992', 'Expect': '100-continue',
-            'Content-Type': 'multipart/form-data; boundary=------------------------3c48c744237517ac'}
+                   'Accept': '*/*', 'Content-Length': '992', 'Expect': '100-continue',
+                   'Content-Type': 'multipart/form-data; boundary=------------------------3c48c744237517ac'}
 
         data1 = (b'--------------------------3c48c744237517ac\r\nContent-Disposition: form-data; name="key"\r\n\r\n'
                  b'uploads/20170826T181315.679087009Z/upload/${filename}\r\n--------------------------3c48c744237517ac'
@@ -108,7 +108,7 @@ class S3ListenerTest (unittest.TestCase):
         expanded1 = multipart_content.expand_multipart_filename(data1, headers)
         self.assertIsNot(expanded1, data1, 'Should have changed content of data with filename to interpolate')
         self.assertIn(b'uploads/20170826T181315.679087009Z/upload/pixel.png', expanded1,
-            'Should see the interpolated filename')
+                      'Should see the interpolated filename')
 
         expanded2 = multipart_content.expand_multipart_filename(data2, headers)
         self.assertIs(expanded2, data2, 'Should not have changed content of data with no filename to interpolate')
@@ -116,7 +116,7 @@ class S3ListenerTest (unittest.TestCase):
         expanded3 = multipart_content.expand_multipart_filename(data3, headers)
         self.assertIsNot(expanded3, data3, 'Should have changed content of string data with filename to interpolate')
         self.assertIn(b'uploads/20170826T181315.679087009Z/upload/pixel.txt', expanded3,
-            'Should see the interpolated filename')
+                      'Should see the interpolated filename')
 
     def test_event_type_matching(self):
         match = s3_listener.event_type_matches
@@ -172,7 +172,7 @@ class S3ListenerTest (unittest.TestCase):
         self.assertNotEqual('No header', response.headers.get('Last-Modified', 'No header'))
 
 
-class S3UtilsTest (unittest.TestCase):
+class S3UtilsTest(unittest.TestCase):
 
     def test_s3_bucket_name(self):
         # array description : 'bucket_name', 'expected_ouput'
@@ -281,7 +281,7 @@ class S3UtilsTest (unittest.TestCase):
             self.assertEqual(expected_result, s3_utils.extract_key_name(headers, path))
 
 
-class S3BackendTest (unittest.TestCase):
+class S3BackendTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -304,7 +304,7 @@ class S3BackendTest (unittest.TestCase):
 
         key = s3_backend.get_object(bucket_name, file2_name)
 
-        self.assertFalse(key in (key.instances or []))
+        self.assertNotIn(key, key.instances or [])
 
     def test_no_bucket_in_instances(self):
         s3_backend = s3_models.S3Backend()
@@ -317,4 +317,4 @@ class S3BackendTest (unittest.TestCase):
         s3_backend.delete_bucket(bucket_name)
         bucket = s3_backend.create_bucket(bucket_name, region)
 
-        self.assertGreaterEqual(bucket in (bucket.instances or []), False)
+        self.assertNotIn(bucket, (bucket.instances or []))

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -49,7 +49,7 @@ class S3ListenerTest (unittest.TestCase):
         key2, url2 = multipart_content.find_multipart_key_value(data2, headers)
 
         self.assertEqual('uploads/20170826T181315.679087009Z/upload/pixel.png', key2)
-        self.assertIsNone('Should not get a redirect URL without success_action_redirect', url2)
+        self.assertIsNone(url2, 'Should not get a redirect URL without success_action_redirect')
 
         key3, url3 = multipart_content.find_multipart_key_value(data3, headers)
 
@@ -317,4 +317,4 @@ class S3BackendTest (unittest.TestCase):
         s3_backend.delete_bucket(bucket_name)
         bucket = s3_backend.create_bucket(bucket_name, region)
 
-        self.assertIn(bucket, (bucket.instances or []))
+        self.assertGreaterEqual(bucket in (bucket.instances or []), False)

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -20,7 +20,7 @@ class SNSTests(unittest.TestCase):
         sns = sns_listener.ProxyListenerSNS()
         error = sns.forward_request('POST', '/', 'Action=Unsubscribe', '')
         self.assertTrue(error is not None)
-        self.assertEqual(error.status_code, 400)
+        self.assertEqual(400, error.status_code)
 
     def test_unsubscribe_should_remove_listener(self):
         sub_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic:45e61c7f-dca5-4fcd-be2b-4e1b0d6eef72'
@@ -58,7 +58,7 @@ class SNSTests(unittest.TestCase):
             'Message': ['msg']
         }
         result = sns_listener.create_sns_message_body(self.subscriber, action)
-        self.assertEqual(result, 'msg')
+        self.assertEqual('msg', result)
 
     def test_create_sns_message_body(self):
         action = {
@@ -81,7 +81,7 @@ class SNSTests(unittest.TestCase):
         except ValueError:
             assert False, 'SNS response Timestamp not a valid ISO 8601 date'
 
-        self.assertEqual(result, {
+        expected_sns_body = {
             'Message': 'msg',
             'Signature': 'EXAMPLEpH+..',
             'SignatureVersion': '1',
@@ -89,7 +89,8 @@ class SNSTests(unittest.TestCase):
                 'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem',
             'TopicArn': 'arn',
             'Type': 'Notification'
-        })
+        }
+        self.assertEqual(expected_sns_body, result)
 
         # Now add a subject
         action = {
@@ -127,8 +128,7 @@ class SNSTests(unittest.TestCase):
                 }
             }
         }
-        expected = json.dumps(msg)
-        self.assertEqual(result, json.loads(expected))
+        self.assertEqual(msg, result)
 
     def test_create_sns_message_body_json_structure(self):
         action = {
@@ -138,7 +138,7 @@ class SNSTests(unittest.TestCase):
         result_str = sns_listener.create_sns_message_body(self.subscriber, action)
         result = json.loads(result_str)
 
-        self.assertEqual(result['Message'], {'message': 'abc'})
+        self.assertEqual({'message': 'abc'}, result['Message'])
 
     def test_create_sns_message_body_json_structure_raw_delivery(self):
         self.subscriber['RawMessageDelivery'] = 'true'
@@ -148,7 +148,7 @@ class SNSTests(unittest.TestCase):
         }
         result = sns_listener.create_sns_message_body(self.subscriber, action)
 
-        self.assertEqual(result, {'message': 'abc'})
+        self.assertEqual({'message': 'abc'}, result)
 
     def test_create_sns_message_body_json_structure_without_default_key(self):
         action = {
@@ -157,7 +157,7 @@ class SNSTests(unittest.TestCase):
         }
         with self.assertRaises(Exception) as exc:
             sns_listener.create_sns_message_body(self.subscriber, action)
-        self.assertEqual(str(exc.exception), "Unable to find 'default' key in message payload")
+        self.assertEqual("Unable to find 'default' key in message payload", str(exc.exception))
 
     def test_create_sns_message_body_json_structure_sqs_protocol(self):
         action = {
@@ -167,7 +167,7 @@ class SNSTests(unittest.TestCase):
         result_str = sns_listener.create_sns_message_body(self.subscriber, action)
         result = json.loads(result_str)
 
-        self.assertEqual(result['Message'], 'sqs message')
+        self.assertEqual('sqs message', result['Message'])
 
     def test_create_sns_message_body_json_structure_raw_delivery_sqs_protocol(self):
         self.subscriber['RawMessageDelivery'] = 'true'
@@ -177,7 +177,7 @@ class SNSTests(unittest.TestCase):
         }
         result = sns_listener.create_sns_message_body(self.subscriber, action)
 
-        self.assertEqual(result, {'message': 'sqs version'})
+        self.assertEqual({'message': 'sqs version'}, result)
 
     def test_create_sqs_message_attributes(self):
         self.subscriber['RawMessageDelivery'] = 'true'
@@ -199,12 +199,12 @@ class SNSTests(unittest.TestCase):
         attributes = sns_listener.get_message_attributes(action)
         result = sns_listener.create_sqs_message_attributes(self.subscriber, attributes)
 
-        self.assertEqual(result['attr1']['DataType'], 'String')
-        self.assertEqual(result['attr1']['StringValue'], 'value1')
-        self.assertEqual(result['attr2']['DataType'], 'Binary')
-        self.assertEqual(result['attr2']['BinaryValue'], 'value2'.encode('utf-8'))
-        self.assertEqual(result['attr3']['DataType'], 'Number')
-        self.assertEqual(result['attr3']['StringValue'], '3')
+        self.assertEqual('String', result['attr1']['DataType'])
+        self.assertEqual('value1', result['attr1']['StringValue'])
+        self.assertEqual('Binary', result['attr2']['DataType'])
+        self.assertEqual('value2'.encode('utf-8'), result['attr2']['BinaryValue'])
+        self.assertEqual('Number', result['attr3']['DataType'])
+        self.assertEqual('3', result['attr3']['StringValue'])
 
     def test_create_sns_message_timestamp_millis(self):
         action = {
@@ -216,7 +216,7 @@ class SNSTests(unittest.TestCase):
         end = timestamp[-5:]
         matcher = re.compile(r'\.[0-9]{3}Z')
         match = matcher.match(end)
-        self.assertTrue(match is not None)
+        self.assertIsNotNone(match)
 
     def test_only_one_subscription_per_topic_per_endpoint(self):
         sub_arn = 'arn:aws:sns:us-east-1:000000000000:test-topic:45e61c7f-dca5-4fcd-be2b-4e1b0d6eef72'
@@ -230,7 +230,7 @@ class SNSTests(unittest.TestCase):
                 sub_arn,
                 {}
             )
-            self.assertEqual(len(sns_backend.sns_subscriptions[topic_arn]), 1)
+            self.assertEqual(1, len(sns_backend.sns_subscriptions[topic_arn]))
 
     def test_filter_policy(self):
         test_data = [
@@ -517,7 +517,7 @@ class SNSTests(unittest.TestCase):
             filter_policy = test[1]
             attributes = test[2]
             expected = test[3]
-            self.assertEqual(sns_listener.check_filter_policy(filter_policy, attributes), expected, test_name)
+            self.assertEqual(expected, sns_listener.check_filter_policy(filter_policy, attributes), test_name)
 
     def test_is_raw_message_delivery(self):
         valid_true_values = ['true', 'True', True]

--- a/tests/unit/test_sqs.py
+++ b/tests/unit/test_sqs.py
@@ -10,4 +10,4 @@ class SQSListenerTest (unittest.TestCase):
             'MessageAttribute.1.Value.DataType': 'Number'
         }
         md5 = sqs_listener.ProxyListenerSQS.get_message_attributes_md5(msg_attrs)
-        self.assertEqual(md5, '235c5c510d26fb653d073faed50ae77c')
+        self.assertEqual('235c5c510d26fb653d073faed50ae77c', md5)

--- a/tests/unit/test_tagging.py
+++ b/tests/unit/test_tagging.py
@@ -7,7 +7,7 @@ class TestTaggingService(unittest.TestCase):
 
     def test_list_empty(self):
         result = self.svc.list_tags_for_resource('test')
-        self.assertEqual(result, {'Tags': []})
+        self.assertEqual({'Tags': []}, result)
 
     def test_create_tag(self):
         tags = [{'Key': 'key_key', 'Value': 'value_value'}]
@@ -21,11 +21,9 @@ class TestTaggingService(unittest.TestCase):
         self.svc.tag_resource('arn', tags)
         self.svc.untag_resource('arn', ['key_key'])
         result = self.svc.list_tags_for_resource('arn')
-        self.assertEqual(
-            result, {'Tags': []})
+        self.assertEqual({'Tags': []}, result)
 
     def test_list_empty_delete(self):
         self.svc.untag_resource('arn', ['key_key'])
         result = self.svc.list_tags_for_resource('arn')
-        self.assertEqual(
-            result, {'Tags': []})
+        self.assertEqual({'Tags': []}, result)

--- a/tests/unit/utils/generic/test_dict_utils.py
+++ b/tests/unit/utils/generic/test_dict_utils.py
@@ -17,43 +17,43 @@ class GenericDictUtilsTest(unittest.TestCase):
         }
 
         self.assertEqual(
-            get_safe(dictionary, '$.level_one_1.level_two_1'),
-            dictionary['level_one_1']['level_two_1']
+            dictionary['level_one_1']['level_two_1'],
+            get_safe(dictionary, '$.level_one_1.level_two_1')
         )
 
         self.assertEqual(
-            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1']),
-            dictionary['level_one_1']['level_two_1']
+            dictionary['level_one_1']['level_two_1'],
+            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1'])
         )
 
         self.assertEqual(
-            get_safe(dictionary, '$.level_one_1.level_two_1.level_three_1'),
-            'level_three_1_value'
+            'level_three_1_value',
+            get_safe(dictionary, '$.level_one_1.level_two_1.level_three_1')
         )
 
         self.assertEqual(
-            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'level_three_1']),
-            'level_three_1_value'
+            'level_three_1_value',
+            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'level_three_1'])
         )
 
         self.assertEqual(
-            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value']),
-            None
+            None,
+            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value'])
         )
 
         self.assertEqual(
-            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value'], 'default_value'),
-            'default_value'
+            'default_value',
+            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value'], 'default_value')
         )
 
         self.assertEqual(
-            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'level_three_2', '0']),
-            'one'
+            'one',
+            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'level_three_2', '0'])
         )
 
         self.assertEqual(
-            get_safe(dictionary, '$.level_one_1.level_two_1.level_three_2.1'),
-            'two'
+            'two',
+            get_safe(dictionary, '$.level_one_1.level_two_1.level_three_2.1')
         )
 
     def test_set_safe_mutable(self):
@@ -72,7 +72,7 @@ class GenericDictUtilsTest(unittest.TestCase):
         set_safe_mutable(mutable_dictionary, ['$', 'level_one_1', 'level_two_2'], 'level_two_2_value')
         set_safe_mutable(mutable_dictionary, '$.level_one_2', 'level_one_2_value')
 
-        self.assertEqual(mutable_dictionary, expected_dictionary)
+        self.assertEqual(expected_dictionary, mutable_dictionary)
 
     def test_pick_attributes(self):
         dictionary = {
@@ -94,11 +94,12 @@ class GenericDictUtilsTest(unittest.TestCase):
             ]
         )
 
-        self.assertEqual(whitelisted_dictionary, {
+        expected_whitelisted_dictionary = {
             'level_one_1': {
                 'level_two_1': {
                     'level_three_1': 'level_three_1_value'
                 },
             },
             'level_one_2': 'level_one_2_value'
-        })
+        }
+        self.assertEqual(expected_whitelisted_dictionary, whitelisted_dictionary)

--- a/tests/unit/utils/generic/test_dict_utils.py
+++ b/tests/unit/utils/generic/test_dict_utils.py
@@ -36,10 +36,7 @@ class GenericDictUtilsTest(unittest.TestCase):
             get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'level_three_1'])
         )
 
-        self.assertEqual(
-            None,
-            get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value'])
-        )
+        self.assertIsNone(get_safe(dictionary, ['$', 'level_one_1', 'level_two_1', 'random', 'value']))
 
         self.assertEqual(
             'default_value',


### PR DESCRIPTION
## Issue
#4197

## Work done
- [x] Flip asserts to comply with `(expected, actual)`
- [x] Change `assertEquals(<Constant>, obj)` to `assert<Constant>(obj)`
- [x] Minor style refactors on multiline statements