### PR TITLE
remove superfluous coveralls config, now managed via CI env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,8 +154,6 @@ jobs:
     machine:
       image: ubuntu-2004:202101-01
     working_directory: /tmp/workspace/repo
-    environment:
-      COVERALLS_REPO_TOKEN: D9Tg4c2TGmHUBQIWbixm9NtIosNUDJeRo
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-service_name: circleci
-repo_token: D9Tg4c2TGmHUBQIWbixm9NtIosNUDJeRo


### PR DESCRIPTION
Remove coveralls token information from repo. Config is now fully over CI environment variables 