### PR TITLE
add workaround for kinesis-mock persistence startup failure

### DIFF
--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -633,6 +633,27 @@ class KinesisStream(GenericBaseModel):
         result = aws_stack.connect_to_service('kinesis').describe_stream(StreamName=stream_name)
         return result
 
+    @staticmethod
+    def get_deploy_templates():
+        def get_delete_params(params, **kwargs):
+            return {'StreamName': params['Name'], 'EnforceConsumerDeletion': True}
+        return {
+            'create': {
+                'function': 'create_stream',
+                'parameters': {
+                    'StreamName': 'Name',
+                    'ShardCount': 'ShardCount'
+                },
+                'defaults': {
+                    'ShardCount': 1
+                }
+            },
+            'delete': {
+                'function': 'delete_stream',
+                'parameters': get_delete_params
+            }
+        }
+
 
 class KinesisStreamConsumer(GenericBaseModel):
     @staticmethod
@@ -649,6 +670,7 @@ class KinesisStreamConsumer(GenericBaseModel):
         result = [r for r in result['Consumers'] if r['ConsumerName'] == props['ConsumerName']]
         return (result or [None])[0]
 
+    @staticmethod
     def get_deploy_templates():
         return {
             'create': {
@@ -675,6 +697,7 @@ class Route53RecordSet(GenericBaseModel):
         result = [r for r in result if r['Name'] == props['Name'] and r['Type'] == props['Type']]
         return (result or [None])[0]
 
+    @staticmethod
     def get_deploy_templates():
         def param_change_batch(params, **kwargs):
             attr_names = ['Name', 'Type', 'SetIdentifier', 'Weight', 'Region', 'GeoLocation',

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -50,7 +50,7 @@ SFN_PATCH_CLASS = 'com/amazonaws/stepfunctions/local/runtime/executors/task/Lamb
 SFN_PATCH_CLASS_URL = '%s/raw/master/stepfunctions-local-patch/%s' % (ARTIFACTS_REPO, SFN_PATCH_CLASS)
 
 # kinesis-mock version
-KINESIS_MOCK_VERSION = os.environ.get('KINESIS_MOCK_VERSION') or '0.1.0'
+KINESIS_MOCK_VERSION = os.environ.get('KINESIS_MOCK_VERSION') or '0.1.2'
 KINESIS_MOCK_RELEASE_URL = 'https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/' + KINESIS_MOCK_VERSION
 
 DEBUGPY_MODULE = 'debugpy'
@@ -212,6 +212,7 @@ def install_kinesis_mock():
     mkdir(target_dir)
     LOG.info('downloading kinesis-mock binary from %s', download_url)
     download(download_url, bin_file_path)
+    chmod_r(bin_file_path, 0o777)
     return bin_file_path
 
 

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import traceback
 from localstack import config
 from localstack.services import install
@@ -40,6 +41,13 @@ def start_kinesis_mock(port=None, asynchronous=False, update_listener=None):
     if config.DATA_DIR:
         kinesis_data_dir = '%s/kinesis' % config.DATA_DIR
         mkdir(kinesis_data_dir)
+
+        # FIXME: workaround for https://github.com/localstack/localstack/issues/4227
+        streams_file = os.path.join(kinesis_data_dir, 'kinesis-data.json')
+        if not os.path.exists(streams_file):
+            with open(streams_file, 'w') as fd:
+                fd.write('{"streams":{}}')
+
         kinesis_data_dir_param = 'SHOULD_PERSIST_DATA=true PERSIST_PATH=%s' % kinesis_data_dir
     if not config.LS_LOG:
         log_level = 'INFO'

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -287,24 +287,6 @@ RESOURCE_TO_FUNCTION = {
             }
         }
     },
-    'Kinesis::Stream': {
-        'create': {
-            'function': 'create_stream',
-            'parameters': {
-                'StreamName': 'Name',
-                'ShardCount': 'ShardCount'
-            },
-            'defaults': {
-                'ShardCount': 1
-            }
-        },
-        'delete': {
-            'function': 'delete_stream',
-            'parameters': {
-                'StreamName': 'Name'
-            }
-        }
-    },
     'StepFunctions::StateMachine': {
         'create': {
             'function': 'create_state_machine',

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -104,7 +104,7 @@ class TestKinesis(unittest.TestCase):
 
         # clean up
         client.deregister_stream_consumer(StreamARN=stream_arn, ConsumerName='c1')
-        client.delete_stream(StreamName=stream_name)
+        client.delete_stream(StreamName=stream_name, EnforceConsumerDeletion=True)
 
     def test_subscribe_to_shard_with_sequence_number_as_iterator(self):
         client = aws_stack.connect_to_service('kinesis')
@@ -146,7 +146,7 @@ class TestKinesis(unittest.TestCase):
 
         # clean up
         client.deregister_stream_consumer(StreamARN=stream_arn, ConsumerName='c1')
-        client.delete_stream(StreamName=stream_name)
+        client.delete_stream(StreamName=stream_name, EnforceConsumerDeletion=True)
 
     def test_get_records(self):
         client = aws_stack.connect_to_service('kinesis')


### PR DESCRIPTION
This PR introduces a workaround for the issue that localstack startup fails with `DATA_DIR` and kinesis-mock provider