### PR TITLE
Fix installation of debugpy

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -340,10 +340,14 @@ def install_debugpy_and_dependencies():
     try:
         import debugpy
         assert debugpy
+        logging.debug('Debugpy module already Installed')
     except ModuleNotFoundError:
-        run('apk fetch %s --output %s' % (' '.join(DEBUGPY_DEPENDENCIES), config.TMP_FOLDER))
-        run('apk add %s --cache-dir %s' % (' '.join(DEBUGPY_DEPENDENCIES), config.TMP_FOLDER))
-        run('pip install %s' % DEBUGPY_MODULE)
+        logging.debug('Installing Debugpy module')
+        import pip
+        if hasattr(pip, 'main'):
+            pip.main(['install', DEBUGPY_MODULE])
+        else:
+            pip._internal.main(['install', DEBUGPY_MODULE])
 
 
 # -----------------


### PR DESCRIPTION
I think the recent change in the base image made pip not accessible from the command line.
This PR  makes the installation process of **debugpy** to be done through the pip module.  