### PR TITLE
Support for local execution of node lambda

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -869,6 +869,16 @@ def do_set_function_code(code, lambda_name, lambda_cwd=None):
             except Exception as e:
                 raise ClientError('Unable to get handler function from lambda code.', e)
 
+        if runtime.startswith('node') and not use_docker():
+            ensure_readable(main_file)
+            zip_file_content = load_file(main_file, mode='rb')
+
+            def execute(event, context):
+                result = lambda_executors.EXECUTOR_LOCAL.execute_javascript_lambda(
+                    event, context, main_file=main_file, func_details=lambda_details)
+                return result
+            lambda_handler = execute
+
     return lambda_handler
 
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -885,6 +885,16 @@ class LambdaExecutorLocal(LambdaExecutor):
         result = self.run_lambda_executor(cmd, func_details=func_details)
         return result
 
+    def execute_javascript_lambda(self, event, context, main_file, func_details=None):
+        handler = func_details.handler
+        function = handler.split('.')[-1]
+        event_json_string = '%s' % (json.dumps(event) if event else '{}')
+        context_json_string = '%s' % (json.dumps(context.__dict__) if context else '{}')
+        cmd = 'node -e \'require("%s").%s(%s,%s)\'' % (main_file, function, event_json_string, context_json_string)
+        LOG.info(cmd)
+        result = self.run_lambda_executor(cmd, func_details=func_details)
+        return result
+
 
 class Util:
     debug_java_port = False


### PR DESCRIPTION
Since the base image already has the node runtime, I made a similar process to the python local execution.
I'm considering doing the rest in the same way but with a validation that the runtime exist and if not, do the installation with an **apk** command. 

I tested this feature this running this nodejs lambda: 

```javascript
exports.handler =  async function(event, context) {
  console.log("EVENT:" + JSON.stringify(event, null, 2))
  console.log("CONTEXT:" + JSON.stringify(context, null, 2))
  return null;
}
```

and I get this logs: 
```
2021-06-29T16:55:11:INFO:localstack.services.awslambda.lambda_executors: node -e 'require("/tmp/localstack/zipfile.f1009281/index.js").handler({"name": "Bob"},{"function_name": "crist-test", "function_version": "$LATEST", "client_context": null, "invoked_function_arn": "arn:aws:lambda:us-east-1:000000000000:function:crist-test", "cognito_identity": null, "aws_request_id": "b0cad9f5-14fc-48a5-8989-e28ccea2311e", "memory_limit_in_mb": 1536, "log_group_name": "/aws/lambda/crist-test", "log_stream_name": "2021/06/29/[1]786bf82f"})'
2021-06-29T16:55:11:DEBUG:localstack.services.awslambda.lambda_executors: Lambda arn:aws:lambda:us-east-1:000000000000:function:crist-test result / log output:
}
> EVENT:{
>   "name": "Bob"
> }
> CONTEXT:{
>   "function_name": "crist-test",
>   "function_version": "$LATEST",
>   "client_context": null,
>   "invoked_function_arn": "arn:aws:lambda:us-east-1:000000000000:function:crist-test",
>   "cognito_identity": null,
>   "aws_request_id": "b0cad9f5-14fc-48a5-8989-e28ccea2311e",
>   "memory_limit_in_mb": 1536,
>   "log_group_name": "/aws/lambda/crist-test",
>   "log_stream_name": "2021/06/29/[1]786bf82f"
```

I think this PR could be the foundation for issue #4113 
[reproduzer.zip](https://github.com/localstack/localstack/files/6736834/reproduzer.zip)