### PR TITLE
Fix: Remove SQS policy if empty attribute is passed

### DIFF
--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -65,6 +65,9 @@ def patch_moto():
     def _set_attributes(self, attributes, now=None):
         _set_attributes_orig(self, attributes, now)
 
+        if attributes == {}:
+            self.policy = None
+
         integer_fields = [
             'ReceiveMessageWaitTimeSeconds'
         ]

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -233,9 +233,11 @@ class SQSTest(unittest.TestCase):
         attrs = self.client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['Policy'])['Attributes']
         self.assertIn('sqs:SendMessage', attrs['Policy'])
 
-        # Passing empty attributes resets the to defaults attributes with no Policy
-        empty_attributes = {}
-        self.client.set_queue_attributes(QueueUrl=queue_url, Attributes=empty_attributes)
+        # Passing a Policy with empty string resets the policy of the queue
+        reset_policy_attributes = {
+            'Policy': ''
+        }
+        self.client.set_queue_attributes(QueueUrl=queue_url, Attributes=reset_policy_attributes)
         attrs = self.client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['All'])['Attributes']
         self.assertNotIn('Policy', attrs)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -233,6 +233,11 @@ class SQSTest(unittest.TestCase):
         attrs = self.client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['Policy'])['Attributes']
         self.assertIn('sqs:SendMessage', attrs['Policy'])
 
+        # Passing empty attributes resets the to defaults attributes with no Policy
+        empty_attributes = {}
+        self.client.set_queue_attributes(QueueUrl=queue_url, Attributes=empty_attributes)
+        self.assertNotIn('sqs:SendMessage', attrs['Policy'])
+
         # clean up
         self.client.delete_queue(QueueUrl=queue_url)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -236,7 +236,8 @@ class SQSTest(unittest.TestCase):
         # Passing empty attributes resets the to defaults attributes with no Policy
         empty_attributes = {}
         self.client.set_queue_attributes(QueueUrl=queue_url, Attributes=empty_attributes)
-        self.assertNotIn('sqs:SendMessage', attrs['Policy'])
+        attrs = self.client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=['All'])['Attributes']
+        self.assertNotIn('Policy', attrs)
 
         # clean up
         self.client.delete_queue(QueueUrl=queue_url)


### PR DESCRIPTION
Fixes #4225 .

Description:
There is a problem when trying to remove an SQS queue if it has policy attached, and it is basically because terraform tries to set `Policy=None` before actually removing the queue.

[This explanation](https://github.com/localstack/localstack/issues/4225#issuecomment-871415857) states pretty well the issue coming from [this piece of terraform code](https://github.com/hashicorp/terraform-provider-aws/blob/ccc13f55709c860a2130ecee6e21acde2318e936/aws/resource_aws_sqs_queue_policy.go#L104)

Main issue for us is the `_set_attributes` function does not detect the attribute being passed an empty K/V if passing i.e. `Policy=""` or `DelaySeconds=""` which is the behaviour by design on the AWS CLI.

**Pros:**
Actually removing the policy if we pass an empty attribute.

**Cons:**
`Any` empty attribute will actually remove the policy.
Example:
```
awslocal sqs set-queue-attributes --queue-url http://localhost:4566/000000000000/myqueue  --attributes DelaySeconds=""
```

One side note is that no should pass empty parameters, but if it would be the case (by mistake for example) it would remove their policy.

Suggestions are welcome