### PR TITLE
Fix the showing of Flask API Logs according to which service is started

### DIFF
--- a/localstack/dashboard/api.py
+++ b/localstack/dashboard/api.py
@@ -143,4 +143,4 @@ def serve(port):
     backend_url = "http://localhost:%s" % port
     services_infra.start_proxy(config.PORT_WEB_UI_SSL, backend_url, use_ssl=True)
 
-    generic_proxy.serve_flask_app(app=app, port=port, quiet=True)
+    generic_proxy.serve_flask_app(app=app, port=port)

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -2201,10 +2201,10 @@ def update_code_signing_config(arn):
     return Response(json.dumps(result), status=200)
 
 
-def serve(port, quiet=True):
+def serve(port):
     from localstack.services import generic_proxy  # moved here to fix circular import errors
 
     # initialize the Lambda executor
     LAMBDA_EXECUTOR.startup()
 
-    generic_proxy.serve_flask_app(app=app, port=port, quiet=quiet)
+    generic_proxy.serve_flask_app(app=app, port=port)

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -957,7 +957,7 @@ def _response(action, result):
 def serve(port, quiet=True):
     from localstack.services import generic_proxy  # moved here to fix circular import errors
 
-    return generic_proxy.serve_flask_app(app=app, port=port, quiet=quiet)
+    return generic_proxy.serve_flask_app(app=app, port=port)
 
 
 def _get_status_filter_members(req_params):

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -189,4 +189,4 @@ def kinesis_shard_id(dynamodbstream_shard_id):
 
 
 def serve(port, quiet=True):
-    generic_proxy.serve_flask_app(app=app, port=port, quiet=quiet)
+    generic_proxy.serve_flask_app(app=app, port=port)

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -360,4 +360,4 @@ def add_list_tags():
 
 
 def serve(port, quiet=True):
-    generic_proxy.serve_flask_app(app=app, port=port, quiet=quiet)
+    generic_proxy.serve_flask_app(app=app, port=port)

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -380,4 +380,4 @@ def post_request():
 
 
 def serve(port, quiet=True):
-    generic_proxy.serve_flask_app(app=app, port=port, quiet=quiet)
+    generic_proxy.serve_flask_app(app=app, port=port)

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -534,10 +534,10 @@ def start_proxy_server(
     )
 
 
-def serve_flask_app(app, port, quiet=True, host=None, cors=True):
+def serve_flask_app(app, port, host=None, cors=True):
     if cors:
         CORS(app)
-    if quiet:
+    if not config.DEBUG:
         logging.getLogger("werkzeug").setLevel(logging.ERROR)
     if not host:
         host = "0.0.0.0"


### PR DESCRIPTION
The starting or not of certain services based on Flask, makes the logs inconsistent, with this PR the quieting of those logs are mostly depended on the DEBUG variable.

I think we should consider removing completly the `quiet` param since just quieting one service, quiets all the other Flask APi's, because they share the **werkzeug** logger.

This PR  addresses #4162 