### PR TITLE
Fix missing AWS credential environment variables in AWS stack

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -413,7 +413,6 @@ def fix_account_id_in_arns(response, colon_delimiter=":", existing=None, replace
 
 
 def inject_test_credentials_into_env(env):
-    env = env or {}
     if ENV_ACCESS_KEY not in env and ENV_SECRET_KEY not in env:
         env[ENV_ACCESS_KEY] = "test"
         env[ENV_SECRET_KEY] = "test"


### PR DESCRIPTION
Remove shadowing env parameter, preventing addition of missing environment variables.

The `inject_test_credentials_into_env` was shadowing the `env` argument therefore not actually updating it in the caller.

Ah, mutation.

Sadly I could not find any tests that are impacted or check for this. I'm not a pythonista.

This may also fix the TODO in [lamba_integration.py](https://github.com/localstack/localstack/blob/9977b14999981ebcbbb54c346b7121702eeeda7d/tests/integration/lambdas/lambda_integration.py#L21) and may help some of the issues with Docker execution mode lambdas not having permission to access services in LocalStack (even though they should be able to) - see #3702