### PR TITLE
EventPattern matching does not allow matched events to be empty

### DIFF
--- a/localstack/services/events/events_starter.py
+++ b/localstack/services/events/events_starter.py
@@ -71,7 +71,7 @@ def filter_event_based_on_event_format(self, rule, event):
     def filter_event(event_pattern_filter, event):
         for key, value in event_pattern_filter.items():
             event_value = event.get(key.lower())
-            if not event_value:
+            if event_value is None:
                 return False
 
             if event_value and isinstance(event_value, dict):


### PR DESCRIPTION
Certain event fields could be empty strings, but the current filter does not allow that.

For example, 'source' _could_ be empty, and the eventpattern could allow that, but the filter would not permit that.