### PR TITLE
Add CORS headers needed for AWS SDK v3

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -54,6 +54,9 @@ CORS_ALLOWED_HEADERS = [
     "x-amz-version-id",
     "x-localstack-target",
     "x-amz-tagging",
+    # For AWS SDK v3
+    "amz-sdk-invocation-id",
+    "amz-sdk-request",
 ]
 if EXTRA_CORS_ALLOWED_HEADERS:
     CORS_ALLOWED_HEADERS += EXTRA_CORS_ALLOWED_HEADERS.split(",")


### PR DESCRIPTION
The JavaScript AWS SDK v3 requires the added headers in the browser, CORS errors otherwise.