### PR TITLE
Use pre-commit to automatically lint/format files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/psf/black
+    rev: 21.6b0
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,22 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://github.com/pycqa/isort
+    rev: 5.9.1
+    hooks:
+      - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-isort]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,13 @@ repos:
     rev: 21.6b0
     hooks:
       - id: black
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-isort]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,9 @@ format:
 format-modified:
 	($(VENV_RUN); python -m isort `git ls-files -m | grep '\.py$$' | xargs`; python -m black `git ls-files -m | grep '\.py$$' | xargs` )
 
+init-precommit:
+	($(VENV_RUN); pre-commit install)
+
 clean:             ## Clean up (npm dependencies, downloaded infrastructure code, compiled Java classes)
 	rm -rf localstack/dashboard/web/node_modules/
 	rm -rf localstack/infra/amazon-kinesis-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ localstack-ext[full]>=0.12.9.30
 localstack-ext>=0.12.9.30      #basic-lib
 localstack-client>=1.20        #basic-lib
 moto-ext[all]>=2.0.3.23
+pre-commit==2.13.0             #extended-lib
 psutil>=5.4.8,<6.0.0
 pympler>=0.6
 pyopenssl==17.5.0


### PR DESCRIPTION
This PR adds a pre-commit config to automatically run black/flake8 on commit. 

`pip install -r requirements.txt`
`make init-precommit` or `pre-commit install` will add the hook to `./.git/hooks`

To test it simply change a python file in `tests/` to be incompatible with the back format (e.g. use `'` quotes for a string) and try to commit the changes. It should fail the commit and automatically format the file for you.

