### PR TITLE
add feature to save localstack version info into data dir

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -67,6 +67,9 @@ CONFIG_UPDATE_PATH = "/?_config_"
 # environment variable name to tag local test runs
 ENV_INTERNAL_TEST_RUN = "LOCALSTACK_INTERNAL_TEST_RUN"
 
+# environment variable that flags whether pro was activated. do not use for security purposes!
+ENV_PRO_ACTIVATED = "PRO_ACTIVATED"
+
 # content types
 APPLICATION_AMZ_JSON_1_0 = "application/x-amz-json-1.0"
 APPLICATION_AMZ_JSON_1_1 = "application/x-amz-json-1.1"

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -571,6 +571,10 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     prepare_installation()
     with BOOTSTRAP_LOCK:
         thread = start_api_services()
+
+        if config.DATA_DIR:
+            persistence.save_startup_info()
+
     print(READY_MARKER_OUTPUT)
     sys.stdout.flush()
 

--- a/tests/unit/utils/test_persistence.py
+++ b/tests/unit/utils/test_persistence.py
@@ -1,0 +1,73 @@
+import json
+import unittest
+
+import pytest
+from localstack_ext import constants as ext_constants
+
+from localstack import constants
+from localstack.utils import persistence
+from localstack.utils.persistence import StartupInfo, _append_startup_info, save_startup_info
+
+
+class TestStartupInfo(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def init_tmpdir(self, tmpdir):
+        self.tmpdir = tmpdir
+
+    def test_append_startup_info_to_new_file(self):
+        file_path = self.tmpdir.join("testfile_1.json")
+
+        _append_startup_info(
+            file_path, StartupInfo("2021-07-07T14:25:36.0", "1.0.0", "0.1.0", False)
+        )
+
+        with file_path.open("r") as fd:
+            doc = json.load(fd)
+
+        assert len(doc) == 1
+
+        d = doc[0]
+        assert d["timestamp"] == "2021-07-07T14:25:36.0"
+        assert d["localstack_version"] == "1.0.0"
+        assert d["localstack_ext_version"] == "0.1.0"
+        assert d["pro_activated"] is False
+
+    def test_append_startup_info_maintains_order(self):
+        file_path = self.tmpdir.join("testfile_2.json")
+
+        _append_startup_info(
+            file_path, StartupInfo("2021-07-07T14:25:36.0", "1.0.0", "0.1.0", False)
+        )
+        _append_startup_info(
+            file_path, StartupInfo("2021-07-13T11:48:15.1", "1.0.0", "0.1.0", False)
+        )
+
+        with file_path.open("r") as fd:
+            doc = json.load(fd)
+
+        assert len(doc) == 2
+
+        d = doc[1]
+        assert d["timestamp"] == "2021-07-13T11:48:15.1"
+
+    def test_save_startup_info(self):
+        old_data_dir = persistence.DATA_DIR
+        try:
+            persistence.DATA_DIR = self.tmpdir
+            save_startup_info()
+
+            file_path = self.tmpdir.join(persistence.STARTUP_INFO_FILE)
+
+            with file_path.open("r") as fd:
+                doc = json.load(fd)
+
+            assert len(doc) == 1
+            d = doc[0]
+
+            assert d["timestamp"]
+            assert d["localstack_version"] == constants.VERSION
+            assert d["localstack_ext_version"] == ext_constants.VERSION
+            assert d["pro_activated"] in [False, True]
+
+        finally:
+            persistence.DATA_DIR = old_data_dir


### PR DESCRIPTION
this PR introduces a new file `startup_info.json` into the `DATA_DIR`. Each time localstack is started with this data dir, the file is amended with a record that contains: the timestamp when it was started, the localstack version, the localstack_ext version, and whether the pro license key was activated.

it will look something like this:
```json
[{"timestamp": "2021-07-13T13:01:39.980737", "localstack_version": "0.12.15", "localstack_ext_version": "0.12.12.4", "pro_activated": false}]
```