### PR TITLE
Fix: Adding IAM exception response when calling DeletePolicy on non existent policy

### DIFF
--- a/localstack/services/iam/iam_starter.py
+++ b/localstack/services/iam/iam_starter.py
@@ -152,12 +152,14 @@ def apply_patches():
 
     def iam_response_delete_policy(self):
         policy_arn = self._get_param("PolicyArn")
-        moto_iam_backend.managed_policies.pop(policy_arn, None)
-        template = self.response_template(GENERIC_EMPTY_TEMPLATE)
-        return template.render(name="DeletePolicyResponse")
+        if moto_iam_backend.managed_policies.get(policy_arn):
+            moto_iam_backend.managed_policies.pop(policy_arn, None)
+            template = self.response_template(GENERIC_EMPTY_TEMPLATE)
+            return template.render(name="DeletePolicy")
+        else:
+            raise IAMNotFoundException("Policy {0} was not found.".format(policy_arn))
 
-    if not hasattr(IamResponse, "delete_policy"):
-        IamResponse.delete_policy = iam_response_delete_policy
+    IamResponse.delete_policy = iam_response_delete_policy
 
     def iam_backend_detach_role_policy(policy_arn, role_name):
         try:

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -74,8 +74,8 @@ class TestIAMIntegrations(unittest.TestCase):
     def test_delete_non_existent_policy_returns_no_such_entity(self):
         non_existent_policy_arn = "arn:aws:iam::000000000000:policy/non-existent-policy"
         with self.assertRaises(ClientError) as ctx:
-          self.iam_client.delete_policy(PolicyArn=non_existent_policy_arn)
-          self.assertEqual("NoSuchEntity", ctx.exception.response["Error"]["Code"])
+            self.iam_client.delete_policy(PolicyArn=non_existent_policy_arn)
+        self.assertEqual("NoSuchEntity", ctx.exception.response["Error"]["Code"])
 
     def test_recreate_iam_role(self):
         role_name = "role-{}".format(short_uid())

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -75,7 +75,7 @@ class TestIAMIntegrations(unittest.TestCase):
         non_existent_policy_arn = "arn:aws:iam::000000000000:policy/non-existent-policy"
         with self.assertRaises(ClientError) as ctx:
           self.iam_client.delete_policy(PolicyArn=non_existent_policy_arn)
-        self.assertEqual("NoSuchEntity", ctx.exception.response["Error"]["Code"])
+          self.assertEqual("NoSuchEntity", ctx.exception.response["Error"]["Code"])
 
     def test_recreate_iam_role(self):
         role_name = "role-{}".format(short_uid())

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -71,6 +71,13 @@ class TestIAMIntegrations(unittest.TestCase):
         self.iam_client.delete_policy(PolicyArn=test_policy_arn)
         self.iam_client.delete_user(UserName=test_user_name)
 
+    def test_delete_non_existent_policy_returns_no_such_entity(self):
+        non_existent_policy_arn = "arn:aws:iam::000000000000:policy/non-existent-policy"
+        try:
+            self.iam_client.delete_policy(PolicyArn=non_existent_policy_arn)
+        except ClientError as e:
+            self.assertEqual("NoSuchEntity", e.response["Error"]["Code"])
+
     def test_recreate_iam_role(self):
         role_name = "role-{}".format(short_uid())
 

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -73,10 +73,9 @@ class TestIAMIntegrations(unittest.TestCase):
 
     def test_delete_non_existent_policy_returns_no_such_entity(self):
         non_existent_policy_arn = "arn:aws:iam::000000000000:policy/non-existent-policy"
-        try:
-            self.iam_client.delete_policy(PolicyArn=non_existent_policy_arn)
-        except ClientError as e:
-            self.assertEqual("NoSuchEntity", e.response["Error"]["Code"])
+        with self.assertRaises(ClientError) as ctx:
+          self.iam_client.delete_policy(PolicyArn=non_existent_policy_arn)
+        self.assertEqual("NoSuchEntity", ctx.exception.response["Error"]["Code"])
 
     def test_recreate_iam_role(self):
         role_name = "role-{}".format(short_uid())


### PR DESCRIPTION
Fixes #4291 
The right response for a non existent policy should be raise an `IAMNotFoundException` instead of 500 (not implemented). A little monkey patching solves this.

Example hitting AWS for real:
```
aws --profile localstack iam delete-policy --policy-arn arn:aws:iam::000000000000:policy/non-existent-policy
An error occurred (NoSuchEntity) when calling the DeletePolicy operation: Policy arn:aws:iam::000000000000:policy/non-existent-policy was not found.
```