### PR TITLE
Fix: Extend ACM ARN integration test when importing certificates

### DIFF
--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -38,6 +38,10 @@ class TestACM(unittest.TestCase):
         result = acm.import_certificate(Certificate=DIGICERT_ROOT_CERT, PrivateKey=private_key)
         self.assertIn("CertificateArn", result)
 
+        current_region = aws_stack.get_region()
+        acm_cert_region = result['CertificateArn'].split(':')[3]
+        self.assertEqual(current_region, acm_cert_region)
+
         certs_after = acm.list_certificates().get("CertificateSummaryList", [])
         self.assertEqual(len(certs_before) + 1, len(certs_after))
 

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -39,8 +39,8 @@ class TestACM(unittest.TestCase):
         result = acm.import_certificate(Certificate=DIGICERT_ROOT_CERT, PrivateKey=private_key)
         self.assertIn("CertificateArn", result)
 
-        expected_arn = 'arn:aws:acm:{0}:{1}:certificate'.format(str(aws_stack.get_region()), TEST_AWS_ACCOUNT_ID)
-        acm_cert_arn = result['CertificateArn'].split('/')[0]
+        expected_arn = "arn:aws:acm:{0}:{1}:certificate".format(str(aws_stack.get_region()), TEST_AWS_ACCOUNT_ID)
+        acm_cert_arn = result["CertificateArn"].split("/")[0]
         self.assertEqual(expected_arn, acm_cert_arn)
 
         certs_after = acm.list_certificates().get("CertificateSummaryList", [])

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -2,9 +2,9 @@ import unittest
 
 from moto.ec2 import utils as ec2_utils
 
+from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
-from localstack.constants import TEST_AWS_ACCOUNT_ID
 
 DIGICERT_ROOT_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -39,7 +39,7 @@ class TestACM(unittest.TestCase):
         result = acm.import_certificate(Certificate=DIGICERT_ROOT_CERT, PrivateKey=private_key)
         self.assertIn("CertificateArn", result)
 
-        expected_arn = "arn:aws:acm:{0}:{1}:certificate".format(str(aws_stack.get_region()), TEST_AWS_ACCOUNT_ID)
+        expected_arn = "arn:aws:acm:{0}:{1}:certificate".format(aws_stack.get_region(), TEST_AWS_ACCOUNT_ID)
         acm_cert_arn = result["CertificateArn"].split("/")[0]
         self.assertEqual(expected_arn, acm_cert_arn)
 

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -39,7 +39,8 @@ class TestACM(unittest.TestCase):
         result = acm.import_certificate(Certificate=DIGICERT_ROOT_CERT, PrivateKey=private_key)
         self.assertIn("CertificateArn", result)
 
-        expected_arn = "arn:aws:acm:{0}:{1}:certificate".format(aws_stack.get_region(), TEST_AWS_ACCOUNT_ID)
+        expected_arn = "arn:aws:acm:{0}:{1}:certificate".format(
+          aws_stack.get_region(), TEST_AWS_ACCOUNT_ID)
         acm_cert_arn = result["CertificateArn"].split("/")[0]
         self.assertEqual(expected_arn, acm_cert_arn)
 

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -40,7 +40,8 @@ class TestACM(unittest.TestCase):
         self.assertIn("CertificateArn", result)
 
         expected_arn = "arn:aws:acm:{0}:{1}:certificate".format(
-          aws_stack.get_region(), TEST_AWS_ACCOUNT_ID)
+            aws_stack.get_region(), TEST_AWS_ACCOUNT_ID
+        )
         acm_cert_arn = result["CertificateArn"].split("/")[0]
         self.assertEqual(expected_arn, acm_cert_arn)
 

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -6,7 +6,6 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 
-
 DIGICERT_ROOT_CERT = """
 -----BEGIN CERTIFICATE-----
 MIICRjCCAc2gAwIBAgIQC6Fa+h3foLVJRK/NJKBs7DAKBggqhkjOPQQDAzBlMQsw

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -4,6 +4,8 @@ from moto.ec2 import utils as ec2_utils
 
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
+from localstack.constants import TEST_AWS_ACCOUNT_ID
+
 
 DIGICERT_ROOT_CERT = """
 -----BEGIN CERTIFICATE-----
@@ -38,9 +40,9 @@ class TestACM(unittest.TestCase):
         result = acm.import_certificate(Certificate=DIGICERT_ROOT_CERT, PrivateKey=private_key)
         self.assertIn("CertificateArn", result)
 
-        current_region = aws_stack.get_region()
-        acm_cert_region = result['CertificateArn'].split(':')[3]
-        self.assertEqual(current_region, acm_cert_region)
+        expected_arn = 'arn:aws:acm:{0}:{1}:certificate'.format(str(aws_stack.get_region()), TEST_AWS_ACCOUNT_ID)
+        acm_cert_arn = result['CertificateArn'].split('/')[0]
+        self.assertEqual(expected_arn, acm_cert_arn)
 
         certs_after = acm.list_certificates().get("CertificateSummaryList", [])
         self.assertEqual(len(certs_before) + 1, len(certs_after))


### PR DESCRIPTION
Adding integration tests for #4313.
Please only merge after https://github.com/localstack/moto/pull/31

Adds an ARN check to the certificate import integration test.