### PR TITLE
Potential bugfix for #4295

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -251,7 +251,7 @@ def build_mapping_obj(data):
 
 def format_timestamp(timestamp=None):
     timestamp = timestamp or datetime.utcnow()
-    return isoformat_milliseconds(timestamp) + "+0000"
+    return timestamp.timestamp()
 
 
 def add_event_source(data):

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -39,6 +39,7 @@ from localstack.utils.common import (
     ensure_readable,
     first_char_to_lower,
     is_zip_file,
+    isoformat_milliseconds,
     json_safe,
     load_file,
     long_uid,
@@ -232,7 +233,8 @@ def build_mapping_obj(data):
     mapping["FunctionArn"] = func_arn(function_name)
     mapping["LastProcessingResult"] = "OK"
     mapping["StateTransitionReason"] = "User action"
-    mapping["LastModified"] = format_timestamp()
+    mapping["LastModified"] = datetime.utcnow().timestamp()
+    # mapping["LastModified"] = format_timestamp()
     mapping["State"] = "Enabled" if enabled in [True, None] else "Disabled"
     if "SelfManagedEventSource" in data:
         source_arn = data["SourceAccessConfigurations"][0]["URI"]
@@ -250,7 +252,7 @@ def build_mapping_obj(data):
 
 def format_timestamp(timestamp=None):
     timestamp = timestamp or datetime.utcnow()
-    return timestamp.timestamp()
+    return isoformat_milliseconds(timestamp) + "+0000"
 
 
 def add_event_source(data):
@@ -280,7 +282,8 @@ def update_event_source(uuid_value, data):
                     mapping["EventSourceArn"], batch_size or mapping["BatchSize"]
                 )
             mapping["State"] = "Enabled" if enabled in [True, None] else "Disabled"
-            mapping["LastModified"] = format_timestamp()
+            mapping["LastModified"] = datetime.utcnow().timestamp()
+            # mapping["LastModified"] = format_timestamp()
             mapping["BatchSize"] = batch_size
             if "SourceAccessConfigurations" in (mapping and data):
                 mapping["SourceAccessConfigurations"] = data["SourceAccessConfigurations"]

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -39,7 +39,6 @@ from localstack.utils.common import (
     ensure_readable,
     first_char_to_lower,
     is_zip_file,
-    isoformat_milliseconds,
     json_safe,
     load_file,
     long_uid,

--- a/tests/integration/terraform/event_source_mapping.tf
+++ b/tests/integration/terraform/event_source_mapping.tf
@@ -1,0 +1,4 @@
+resource "aws_lambda_event_source_mapping" "tf_event_source_mapping" {
+  event_source_arn = aws_sqs_queue.tf_queue.arn
+  function_name = aws_lambda_function.tf_lambda.arn
+}

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -122,10 +122,8 @@ class TestTerraform(unittest.TestCase):
 
     def test_event_source_mapping(self):
         lambda_client = aws_stack.connect_to_service("lambda")
-        all_mappings = lambda_client.list_event_source_mappings(
-            EventSourceArn=QUEUE_ARN,
-            FunctionName=LAMBDA_NAME
-        )
+        all_mappings = lambda_client.list_event_source_mappings(EventSourceArn=QUEUE_ARN,
+                                                                FunctionName=LAMBDA_NAME)
         function_mapping = all_mappings.get("EventSourceMappings")[0]
         assert function_mapping["FunctionArn"] == LAMBDA_ARN
         assert function_mapping["EventSourceArn"] == QUEUE_ARN

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -122,8 +122,9 @@ class TestTerraform(unittest.TestCase):
 
     def test_event_source_mapping(self):
         lambda_client = aws_stack.connect_to_service("lambda")
-        all_mappings = lambda_client.list_event_source_mappings(EventSourceArn=QUEUE_ARN,
-                                                                FunctionName=LAMBDA_NAME)
+        all_mappings = lambda_client.list_event_source_mappings(
+            EventSourceArn=QUEUE_ARN, FunctionName=LAMBDA_NAME
+        )
         function_mapping = all_mappings.get("EventSourceMappings")[0]
         assert function_mapping["FunctionArn"] == LAMBDA_ARN
         assert function_mapping["EventSourceArn"] == QUEUE_ARN

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -11,9 +11,11 @@ from localstack.utils.common import is_command_available, rm_rf, run, start_work
 
 BUCKET_NAME = "tf-bucket"
 QUEUE_NAME = "tf-queue"
+QUEUE_ARN = "arn:aws:sqs:us-east-1:000000000000:tf-queue"
 
 # lambda Testing Variables
 LAMBDA_NAME = "tf-lambda"
+LAMBDA_ARN = f"arn:aws:lambda:us-east-1:000000000000:function:{LAMBDA_NAME}"
 LAMBDA_HANDLER = "DotNetCore2::DotNetCore2.Lambda.Function::SimpleFunctionHandler"
 LAMBDA_RUNTIME = "dotnetcore2.0"
 LAMBDA_ROLE = "arn:aws:iam::000000000000:role/iam_for_lambda"
@@ -117,6 +119,16 @@ class TestTerraform(unittest.TestCase):
         self.assertEqual(LAMBDA_HANDLER, response["Configuration"]["Handler"])
         self.assertEqual(LAMBDA_RUNTIME, response["Configuration"]["Runtime"])
         self.assertEqual(LAMBDA_ROLE, response["Configuration"]["Role"])
+
+    def test_event_source_mapping(self):
+        lambda_client = aws_stack.connect_to_service("lambda")
+        all_mappings = lambda_client.list_event_source_mappings(
+            EventSourceArn=QUEUE_ARN,
+            FunctionName=LAMBDA_NAME
+        )
+        function_mapping = all_mappings.get("EventSourceMappings")[0]
+        assert function_mapping["FunctionArn"] == LAMBDA_ARN
+        assert function_mapping["EventSourceArn"] == QUEUE_ARN
 
     def test_apigateway(self):
         apigateway_client = aws_stack.connect_to_service("apigateway")

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -10,7 +10,7 @@ import mock
 from localstack.constants import LAMBDA_TEST_ROLE
 from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.utils.aws.aws_models import LambdaFunction
-from localstack.utils.common import mkdir, new_tmp_dir, save_file
+from localstack.utils.common import isoformat_milliseconds, mkdir, new_tmp_dir, save_file
 
 TEST_EVENT_SOURCE_ARN = "arn:aws:sqs:eu-west-1:000000000000:testq"
 TEST_SECRETSMANANAGER_EVENT_SOURCE_ARN = (
@@ -384,7 +384,7 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result["Role"] = self.ROLE
             expected_result["KMSKeyArn"] = None
             expected_result["VpcConfig"] = None
-            expected_result["LastModified"] = self.LAST_MODIFIED.timestamp()
+            expected_result["LastModified"] = isoformat_milliseconds(self.LAST_MODIFIED) + "+0000"
             expected_result["TracingConfig"] = self.TRACING_CONFIG
             expected_result["Version"] = "1"
             expected_result["State"] = "Active"
@@ -417,7 +417,7 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result["Role"] = self.ROLE
             expected_result["KMSKeyArn"] = None
             expected_result["VpcConfig"] = None
-            expected_result["LastModified"] = self.LAST_MODIFIED.timestamp()
+            expected_result["LastModified"] = isoformat_milliseconds(self.LAST_MODIFIED) + "+0000"
             expected_result["TracingConfig"] = self.TRACING_CONFIG
             expected_result["Version"] = "2"
             expected_result["State"] = "Active"
@@ -461,7 +461,7 @@ class TestLambdaAPI(unittest.TestCase):
             latest_version["Role"] = self.ROLE
             latest_version["KMSKeyArn"] = None
             latest_version["VpcConfig"] = None
-            latest_version["LastModified"] = self.LAST_MODIFIED.timestamp()
+            latest_version["LastModified"] = isoformat_milliseconds(self.LAST_MODIFIED) + "+0000"
             latest_version["TracingConfig"] = self.TRACING_CONFIG
             latest_version["Version"] = "$LATEST"
             latest_version["State"] = "Active"

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -384,7 +384,7 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result["Role"] = self.ROLE
             expected_result["KMSKeyArn"] = None
             expected_result["VpcConfig"] = None
-            expected_result["LastModified"] = isoformat_milliseconds(self.LAST_MODIFIED) + "+0000"
+            expected_result["LastModified"] = self.LAST_MODIFIED.timestamp()
             expected_result["TracingConfig"] = self.TRACING_CONFIG
             expected_result["Version"] = "1"
             expected_result["State"] = "Active"
@@ -417,7 +417,7 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result["Role"] = self.ROLE
             expected_result["KMSKeyArn"] = None
             expected_result["VpcConfig"] = None
-            expected_result["LastModified"] = isoformat_milliseconds(self.LAST_MODIFIED) + "+0000"
+            expected_result["LastModified"] = self.LAST_MODIFIED.timestamp()
             expected_result["TracingConfig"] = self.TRACING_CONFIG
             expected_result["Version"] = "2"
             expected_result["State"] = "Active"
@@ -461,7 +461,7 @@ class TestLambdaAPI(unittest.TestCase):
             latest_version["Role"] = self.ROLE
             latest_version["KMSKeyArn"] = None
             latest_version["VpcConfig"] = None
-            latest_version["LastModified"] = isoformat_milliseconds(self.LAST_MODIFIED) + "+0000"
+            latest_version["LastModified"] = self.LAST_MODIFIED.timestamp()
             latest_version["TracingConfig"] = self.TRACING_CONFIG
             latest_version["Version"] = "$LATEST"
             latest_version["State"] = "Active"

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -10,7 +10,7 @@ import mock
 from localstack.constants import LAMBDA_TEST_ROLE
 from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.utils.aws.aws_models import LambdaFunction
-from localstack.utils.common import isoformat_milliseconds, mkdir, new_tmp_dir, save_file
+from localstack.utils.common import mkdir, new_tmp_dir, save_file
 
 TEST_EVENT_SOURCE_ARN = "arn:aws:sqs:eu-west-1:000000000000:testq"
 TEST_SECRETSMANANAGER_EVENT_SOURCE_ARN = (


### PR DESCRIPTION
So after much delving into the Terraform AWS provider, AWS Go SDK, and the AWS API docs themselves, I think I've identified the core issue. The error that is cropping up occurs when the AWS Go SDK runs the [GetEventSourceMapping](https://github.com/aws/aws-sdk-go/blob/e54742b5910e84b907c8a555b265c20c143b6b95/service/lambda/api.go#L1861) operation against the AWS API. Diving through the internals of the Go SDK we arrive at the function that [sends the actual request](https://github.com/aws/aws-sdk-go/blob/e54742b5910e84b907c8a555b265c20c143b6b95/aws/request/request.go#L589-L620) to AWS. The line of code which is failing is at [611](https://github.com/aws/aws-sdk-go/blob/e54742b5910e84b907c8a555b265c20c143b6b95/aws/request/request.go#L611) since the error logging matches the [code block](https://github.com/aws/aws-sdk-go/blob/e54742b5910e84b907c8a555b265c20c143b6b95/aws/request/request.go#L613-L615) for when an error is returned by that function.

So, the issue must be that the response of the API isn't matching the SDK's unmarshalling code. This means what is being returned on the wire by Localstack must differ in some way from the actual AWS API. Within the Go SDK there's a comment above the `GetEventSourceMapping` function with a reference to the [AWS API docs](https://docs.aws.amazon.com/goto/WebAPI/lambda-2015-03-31/GetEventSourceMapping). The docs specify that the Response object's LastModified element is `The date that the event source mapping was last updated or that its state changed, in Unix time seconds.`

This PR modifies the timestamp that way provided to match this specification. I haven't actually been able to test this however since my machine isn't currently capable of building the Localstack container for some reason.