### PR TITLE
Update Kinesis-Mock to 0.1.4

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -81,7 +81,7 @@ SFN_PATCH_CLASS_URL = "%s/raw/master/stepfunctions-local-patch/%s" % (
 )
 
 # kinesis-mock version
-KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.1.3"
+KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.1.4"
 KINESIS_MOCK_RELEASE_URL = (
     "https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/" + KINESIS_MOCK_VERSION
 )


### PR DESCRIPTION
See https://github.com/etspaceman/kinesis-mock/releases/tag/0.1.4

0.1.4 fixes a bug in the UpdateShardCount API. 
