### PR TITLE
improve kinesis startup routine

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -12,7 +12,7 @@ import time
 import requests
 
 from localstack import config
-from localstack.config import KINESIS_PROVIDER
+from localstack.config import KINESIS_PROVIDER, is_env_true
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS,
     DYNAMODB_JAR_URL,
@@ -224,7 +224,11 @@ def install_kinesis_mock():
     is_probably_m1 = system == "darwin" and ("arm64" in version or "arm32" in version)
 
     LOG.debug("getting kinesis-mock for %s %s", system, machine)
-    if (machine == "x86_64" or machine == "amd64") and not is_probably_m1:
+
+    if is_env_true("KINESIS_MOCK_FORCE_JAVA"):
+        # sometimes the static binaries may have problems, and we want to fal back to Java
+        bin_file = "kinesis-mock.jar"
+    elif (machine == "x86_64" or machine == "amd64") and not is_probably_m1:
         if system == "windows":
             bin_file = "kinesis-mock-mostly-static.exe"
         elif system == "linux":

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import time
-import traceback
 from concurrent.futures import ThreadPoolExecutor
 
 import requests
@@ -110,10 +109,7 @@ def check_infra(retries=10, expect_shutdown=False, apis=None, additional_checks=
             additional(expect_shutdown=expect_shutdown)
     except Exception as e:
         if retries <= 0:
-            LOG.error(
-                "Error checking state of local environment (after some retries): %s"
-                % traceback.format_exc()
-            )
+            LOG.exception("Error checking state of local environment (after some retries)")
             raise e
         time.sleep(3)
         check_infra(

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -789,6 +789,7 @@ class FuncThread(threading.Thread):
                 kwargs["_thread"] = self
             result = self.func(self.params, **kwargs)
         except Exception as e:
+            self.result_future.set_exception(e)
             result = e
             if not self.quiet:
                 LOG.info(

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -142,7 +142,7 @@ class ShellCommandThread(FuncThread):
                 or not self.process
                 or self.process.returncode == 0
             ):
-                return
+                return self.process.returncode if self.process else None
             LOG.info(
                 "Restarting process (received exit code %s): %s"
                 % (self.process.returncode, self.cmd)
@@ -199,6 +199,7 @@ class ShellCommandThread(FuncThread):
             else:
                 self.process.communicate()
         except Exception as e:
+            self.result_future.set_exception(e)
             if self.process and not self.quiet:
                 LOG.warning('Shell command error "%s": %s' % (e, self.cmd))
         if self.process and not self.quiet and self.process.returncode != 0:


### PR DESCRIPTION
This PR fixes #4340 

* we noticed that, if docker is running on quemu (for example when running localstack in docker on an M1 with arm64 chip), the amd64 binary will be (correctly) selected, but fails due to a segmentation fault. as a workaround, this PR introduces a `KINESIS_MOCK_FORCE_JAVA` flag to force the use of a jar file
* use the `result_future` from `FuncThread` in the `ShellFuncThread` to transport the return code of the process
* this allows us to check in the `kinesis_start` whether the process has terminated, and if so, we short circuit the health check to avoid the unhelpful urllib exceptions.

the last two points give yet another nudge to a more generalized and event-driven service manager 