### PR TITLE
replace unparse with custom xml serializer for aws responses

### DIFF
--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -150,7 +150,7 @@ class Stack(object):
         result["Outputs"] = self.outputs
         result["Parameters"] = self.stack_parameters()
         for attr in ["Capabilities", "Tags", "Outputs", "Parameters"]:
-            result[attr] = {"member": result.get(attr, [])}
+            result[attr] = result.get(attr, [])
         return result
 
     def set_stack_status(self, status):
@@ -568,7 +568,7 @@ def describe_stacks(req_params):
             code=400,
             code_string="ValidationError",
         )
-    result = {"Stacks": {"member": stacks}}
+    result = {"Stacks": stacks}
     return result
 
 
@@ -597,7 +597,7 @@ def list_stacks(req_params):
         "DriftInformation",
     ]
     stacks = [select_attributes(stack, attrs) for stack in stacks]
-    result = {"StackSummaries": {"member": stacks}}
+    result = {"StackSummaries": stacks}
     return result
 
 
@@ -627,7 +627,7 @@ def describe_stack_resources(req_params):
         for res_id, _ in stack.resource_states.items()
         if resource_id in [res_id, None]
     ]
-    return {"StackResources": {"member": statuses}}
+    return {"StackResources": statuses}
 
 
 def list_stack_resources(req_params):
@@ -646,7 +646,7 @@ def list_stack_instances(req_params):
         return not_found_error('Stack set named "%s" does not exist' % set_name)
     stack_set = stack_set[0]
     result = [inst.metadata for inst in stack_set.stack_instances]
-    result = {"Summaries": {"member": result}}
+    result = {"Summaries": result}
     return result
 
 
@@ -705,14 +705,14 @@ def list_change_sets(req_params):
     if not stack:
         return not_found_error('Unable to find stack "%s"' % stack_name)
     result = [cs.metadata for cs in stack.change_sets]
-    result = {"Summaries": {"member": result}}
+    result = {"Summaries": result}
     return result
 
 
 def list_stack_sets(req_params):
     state = CloudFormationRegion.get()
     result = [sset.metadata for sset in state.stack_sets.values()]
-    result = {"Summaries": {"member": result}}
+    result = {"Summaries": result}
     return result
 
 
@@ -762,7 +762,7 @@ def describe_stack_set_operation(req_params):
 
 def list_exports(req_params):
     state = CloudFormationRegion.get()
-    result = {"Exports": {"member": state.exports}}
+    result = {"Exports": state.exports}
     return result
 
 
@@ -773,7 +773,7 @@ def list_imports(req_params):
     for stack in state.stacks.values():
         if export_name in stack.imports:
             importing_stack_names.append(stack.stack_name)
-    result = {"Imports": {"member": importing_stack_names}}
+    result = {"Imports": importing_stack_names}
     return result
 
 
@@ -794,7 +794,7 @@ def describe_stack_events(req_params):
     for stack_id, stack in state.stacks.items():
         if stack_name in [None, stack.stack_name, stack.stack_id]:
             events.extend(stack.events)
-    return {"StackEvents": {"member": events}}
+    return {"StackEvents": events}
 
 
 def delete_change_set(req_params):
@@ -843,8 +843,7 @@ def get_template_summary(req_params):
         id_summaries[res_type].append(resource_id)
     result["ResourceTypes"] = list(id_summaries.keys())
     result["ResourceIdentifierSummaries"] = [
-        {"ResourceType": key, "LogicalResourceIds": {"member": values}}
-        for key, values in id_summaries.items()
+        {"ResourceType": key, "LogicalResourceIds": values} for key, values in id_summaries.items()
     ]
     return result
 

--- a/localstack/services/cloudwatch/cloudwatch_listener.py
+++ b/localstack/services/cloudwatch/cloudwatch_listener.py
@@ -30,7 +30,7 @@ class ProxyListenerCloudWatch(ProxyListener):
         if action == "ListTagsForResource":
             arn = req_data.get("ResourceARN")
             tags = TAGS.list_tags_for_resource(arn)
-            result = {"Tags": {"member": tags.get("Tags", [])}}
+            result = {"Tags": tags.get("Tags", [])}
             return aws_responses.requests_response_xml(action, result, xmlns=XMLNS_CLOUDWATCH)
         if path.startswith(PATH_GET_RAW_METRICS):
             result = cloudwatch_backends[aws_stack.get_region()].metric_data

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -2,6 +2,7 @@ import binascii
 import datetime
 import json
 import re
+import xml.etree.ElementTree as ET
 from binascii import crc32
 from struct import pack
 
@@ -59,13 +60,37 @@ def requests_error_response_xml(
     return response
 
 
+def to_xml(data: dict, memberize: bool = True) -> ET.Element:
+    """Generate XML element hierarchy out of dict. Wraps list items in <member> tags by default"""
+    if type(data) != dict or len(data.keys()) != 1:
+        raise
+
+    def _to_xml(parent_el: ET.Element, data_rest) -> None:
+        if type(data_rest) == list:
+            if len(data_rest) == 0:
+                pass
+            for i in data_rest:
+                member_el = ET.SubElement(parent_el, "member") if memberize else parent_el
+                _to_xml(member_el, i)
+        elif type(data_rest) == dict:
+            for key in data_rest:
+                value = data_rest[key]
+                curr_el = ET.SubElement(parent_el, key)
+                _to_xml(curr_el, value)
+        else:
+            parent_el.text = data_rest if type(data_rest) == str else str(data_rest)
+
+    root_key = list(data.keys())[0]
+    root = ET.Element(root_key)
+    _to_xml(root, data[root_key])
+    return root
+
+
 def requests_response_xml(action, response, xmlns=None, service=None):
     xmlns = xmlns or "http://%s.amazonaws.com/doc/2010-03-31/" % service
     response = json_safe(response)
     response = {"{action}Result".format(action=action): response}
-    response = xmltodict.unparse(response)
-    if response.startswith("<?xml"):
-        response = re.sub(r"<\?xml [^\?]+\?>", "", response)
+    response = ET.tostring(to_xml(response), short_empty_elements=True)
     result = (
         """
         <{action}Response xmlns="{xmlns}">
@@ -105,7 +130,6 @@ def requests_error_response_xml_signature_calculation(
     response.status_code = code
 
     if signature and string_to_sign or code_string == "SignatureDoesNotMatch":
-
         bytes_signature = binascii.hexlify(bytes(signature, encoding="utf-8"))
         parsed_response["Error"]["Code"] = code_string
         parsed_response["Error"]["AWSAccessKeyId"] = aws_access_token
@@ -115,7 +139,6 @@ def requests_error_response_xml_signature_calculation(
         set_response_content(response, xmltodict.unparse(parsed_response))
 
     if expires and code_string == "AccessDenied":
-
         server_time = datetime.datetime.utcnow().isoformat()[:-4]
         expires_isoformat = datetime.datetime.fromtimestamp(int(expires)).isoformat()[:-4]
         parsed_response["Error"]["Code"] = code_string
@@ -124,7 +147,6 @@ def requests_error_response_xml_signature_calculation(
         set_response_content(response, xmltodict.unparse(parsed_response))
 
     if not signature and not expires and code_string == "AccessDenied":
-
         set_response_content(response, xmltodict.unparse(parsed_response))
 
     if response._content:
@@ -215,7 +237,6 @@ def make_error(*args, **kwargs):
 
 
 def create_sqs_system_attributes(headers):
-
     system_attributes = {}
     if "X-Amzn-Trace-Id" in headers:
         system_attributes["AWSTraceHeader"] = {

--- a/tests/unit/utils/aws/test_aws_responses.py
+++ b/tests/unit/utils/aws/test_aws_responses.py
@@ -1,0 +1,27 @@
+import xml.etree.ElementTree as ET
+
+from localstack.utils.aws.aws_responses import to_xml
+
+
+def test_to_xml():
+    response = {
+        "DescribeChangeSetResult": {
+            # ...
+            "Changes": [
+                {
+                    "ResourceChange": {
+                        "Replacement": False,
+                        "Scope": ["Tags"],
+                    },
+                    "Type": "Resource",
+                }
+            ]
+        }
+    }
+
+    result = to_xml(response)
+    result_str = str(ET.tostring(result))
+    assert (
+        "<member><ResourceChange><Replacement>False</Replacement><Scope><member>Tags</member></Scope></ResourceChange><Type>Resource</Type></member>"
+        in result_str
+    )

--- a/tests/unit/utils/aws/test_aws_responses.py
+++ b/tests/unit/utils/aws/test_aws_responses.py
@@ -1,27 +1,65 @@
 import xml.etree.ElementTree as ET
 
+import pytest
+
 from localstack.utils.aws.aws_responses import to_xml
 
-
-def test_to_xml():
-    response = {
-        "DescribeChangeSetResult": {
-            # ...
-            "Changes": [
-                {
-                    "ResourceChange": {
-                        "Replacement": False,
-                        "Scope": ["Tags"],
-                    },
-                    "Type": "Resource",
-                }
-            ]
-        }
+result_raw = {
+    "DescribeChangeSetResult": {
+        # ...
+        "Changes": [
+            {
+                "ResourceChange": {
+                    "Replacement": False,
+                    "Scope": ["Tags"],
+                },
+                "Type": "Resource",
+            }
+        ]
     }
+}
 
-    result = to_xml(response)
-    result_str = str(ET.tostring(result))
-    assert (
-        "<member><ResourceChange><Replacement>False</Replacement><Scope><member>Tags</member></Scope></ResourceChange><Type>Resource</Type></member>"
-        in result_str
-    )
+result_raw_none_element = {"a": {"b": None}}
+
+result_raw_empty_list = {"a": {"b": []}}
+result_raw_multiple_members = {"a": {"b": ["c", "d"]}}
+
+
+@pytest.mark.parametrize(
+    "test_input,included",
+    [
+        (
+            result_raw,
+            "<member><ResourceChange><Replacement>False</Replacement><Scope><member>Tags</member></Scope></ResourceChange><Type>Resource</Type></member>",
+        ),
+        (result_raw_none_element, "<b />"),
+        (result_raw_multiple_members, "<b><member>c</member><member>d</member></b>"),
+    ],
+)
+def test_to_xml(test_input, included):
+    result = to_xml(test_input)
+    result_str = str(ET.tostring(result, short_empty_elements=True))
+    assert included in result_str
+
+
+@pytest.mark.parametrize(
+    "test_input", [lambda: None, lambda: [], lambda: "", lambda: 0]
+)  # direct literals here trip up pytest
+def test_to_xml_raise_error_simpleinputs(test_input):
+    with pytest.raises(Exception):
+        to_xml(test_input())
+
+
+class SomeClass:
+    pass
+
+
+result_raw_class_value = {"a": {"b": SomeClass()}}
+multiple_root = {"a": "b", "c": "d"}
+empty_dict = {}
+
+
+@pytest.mark.parametrize("test_input", [multiple_root, empty_dict, result_raw_class_value])
+def test_to_xml_raise_error_malformeddict(test_input):
+    with pytest.raises(Exception):
+        to_xml(test_input)

--- a/tests/unit/utils/aws/test_aws_responses.py
+++ b/tests/unit/utils/aws/test_aws_responses.py
@@ -33,6 +33,7 @@ result_raw_multiple_members = {"a": {"b": ["c", "d"]}}
             "<member><ResourceChange><Replacement>False</Replacement><Scope><member>Tags</member></Scope></ResourceChange><Type>Resource</Type></member>",
         ),
         (result_raw_none_element, "<b />"),
+        (result_raw_empty_list, "<b />"),
         (result_raw_multiple_members, "<b><member>c</member><member>d</member></b>"),
     ],
 )


### PR DESCRIPTION
Background: Some AWS API endpoints use member tags to wrap list instances in XML (see sample response here: https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeChangeSet.html)

Some of the AWS API XML responses need a bit more custom serialization logic that xmltodict.unparse doesn't support.
I've also noticed that a lot of the current "member" wrapping was usually only applied on the top level of the responses. We also need a more flexible way to handle empty tags for some endpoints which might require changes to this xml serialization (more customization) in the future as well.