### PR TITLE
add CI step to test docker client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,15 @@ jobs:
             docker pull -q lambci/lambda:java8
             docker pull -q lambci/lambda:python3.8
       - run:
+          name: Test docker client
+          environment:
+            DEUBG: 1
+            TEST_PATH: "tests/integration/docker"
+            TEST_SKIP_LOCALSTACK_START: 1
+            PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/docker-client.xml -o junit_suite_name='docker-client'"
+            COVERAGE_ARGS: "-p"
+          command: make test-coverage
+      - run:
           name: Test docker lambda executor
           environment:
             DEUBG: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - run:
           name: Test docker client
           environment:
-            DEUBG: 1
+            DEBUG: 1
             TEST_PATH: "tests/integration/docker"
             TEST_SKIP_LOCALSTACK_START: 1
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/docker-client.xml -o junit_suite_name='docker-client'"
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Test docker lambda executor
           environment:
-            DEUBG: 1
+            DEBUG: 1
             LAMBDA_EXECUTOR: "docker"
             USE_SSL: 1
             TEST_ERROR_INJECTION: 1
@@ -102,6 +102,7 @@ jobs:
       - run:
           name: Test docker-reuse lambda executor
           environment:
+            DEBUG: 1
             LAMBDA_EXECUTOR: "docker-reuse"
             TEST_PATH: "tests/integration/test_lambda.py tests/integration/test_integration.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker-reuse.xml -o junit_suite_name='lambda-docker-reuse'"


### PR DESCRIPTION
This PR adds a build step to the CI pipeline, specifically the job that tests the lambda docker executors, that also runs the tests for the docker client. these are not skipped in the Dockerfile, since `docker` as a command is not available during docker build. Thanks for @dfangl for the hint!
