### PR TITLE
Fix docker detection on hosts with cgroup v2 (unified hierachy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Please be aware that the following configurations may have severe security impli
 
 * `DISABLE_CORS_CHECKS`: Whether to disable all CSRF mitigations (default: 0).
 * `DISABLE_CUSTOM_CORS_S3`: Whether to disable CORS override by S3 (default: 0).
-* `DISABLE_CUSTOM_CORS_APIGATEWAY`: Whteher to disable CORS override by apigateway (default: 0).
+* `DISABLE_CUSTOM_CORS_APIGATEWAY`: Whether to disable CORS override by apigateway (default: 0).
 * `EXTRA_CORS_ALLOWED_ORIGINS`: Comma-separated list of origins that are allowed to communicate with localstack.
 * `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header
 * `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Expose-Headers` CORS header
@@ -277,11 +277,12 @@ Please be aware that the following configurations may have severe security impli
 
 * `SKIP_INFRA_DOWNLOADS`: Whether to skip downloading additional infrastructure components (e.g., specific Elasticsearch versions).
 * `IGNORE_ES_DOWNLOAD_ERRORS`: Whether to ignore errors (e.g., network/SSL) when downloading Elasticsearch plugins.
+* `OVERRIDE_IN_DOCKER`: Overrides the check whether LocalStack is executed within a docker container. If set to true, LocalStack assumes it runs in a docker container. Should not be set unless necessary.
 
 ### Debugging Configurations
 
 The following environment configurations can be useful for debugging:
-* `DEVELOP`: Starts a debugpy server before starting Localstack services
+* `DEVELOP`: Starts a debugpy server before starting LocalStack services
 * `DEVELOP_PORT`:  Port number for debugpy server
 * `WAIT_FOR_DEBUGGER`:  Forces LocalStack to wait for a debugger to start the services
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -59,6 +59,8 @@ KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
 # Kinesis provider - either "kinesis-mock" or "kinesalite"
 KINESIS_PROVIDER = os.environ.get("KINESIS_PROVIDER") or "kinesis-mock"
 
+LOG = logging.getLogger(__name__)
+
 # default AWS region
 if "DEFAULT_REGION" not in os.environ:
     os.environ["DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or AWS_REGION_US_EAST_1
@@ -241,6 +243,9 @@ S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false("S3_SKIP_SIGNATURE_VALIDATION")
 # whether to skip waiting for the infrastructure to shut down, or exit immediately
 FORCE_SHUTDOWN = is_env_not_false("FORCE_SHUTDOWN")
 
+# whether the in_docker check should always return true
+OVERRIDE_IN_DOCKER = is_env_true("OVERRIDE_IN_DOCKER")
+
 
 def has_docker():
     try:
@@ -356,6 +361,10 @@ def in_docker():
     Returns True if running in a docker container, else False
     Ref. https://docs.docker.com/config/containers/runmetrics/#control-groups
     """
+    if OVERRIDE_IN_DOCKER:
+        return True
+    if os.path.exists("/.dockerenv"):
+        return True
     if not os.path.exists("/proc/1/cgroup"):
         return False
     try:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -59,8 +59,6 @@ KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
 # Kinesis provider - either "kinesis-mock" or "kinesalite"
 KINESIS_PROVIDER = os.environ.get("KINESIS_PROVIDER") or "kinesis-mock"
 
-LOG = logging.getLogger(__name__)
-
 # default AWS region
 if "DEFAULT_REGION" not in os.environ:
     os.environ["DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or AWS_REGION_US_EAST_1


### PR DESCRIPTION
This PR fixes the docker detection on hosts with only cgroup unified hierachy enabled.

Thanks @dominikschubert and @thrau for helping to fix this.

Similar issue and solution as here: https://github.com/GoogleContainerTools/kaniko/issues/1592

Systemd also uses this mechanism: https://github.com/systemd/systemd/blob/6604fb0207ee10e8dc05d67f6fe45de0b193b5c4/src/basic/virt.c#L523-L548

Option for overriding the check with a true value, to be able to handle the case all the detection mechanisms fail.