### PR TITLE
refactor(events): Allow EventBus tag operations to be forwarded to moto

### DIFF
--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -143,17 +143,6 @@ class ProxyListenerEvents(ProxyListener):
             elif action == "AWSEvents.DeleteRule":
                 handle_delete_rule(rule_name=parsed_data.get("Name", None))
 
-            elif action == "AWSEvents.ListTagsForResource":
-                return self.svc.list_tags_for_resource(parsed_data["ResourceARN"]) or {}
-
-            elif action == "AWSEvents.TagResource":
-                self.svc.tag_resource(parsed_data["ResourceARN"], parsed_data["Tags"])
-                return {}
-
-            elif action == "AWSEvents.UntagResource":
-                self.svc.untag_resource(parsed_data["ResourceARN"], parsed_data["TagKeys"])
-                return {}
-
             elif action == "AWSEvents.DisableRule":
                 handle_disable_rule(rule_name=parsed_data.get("Name", None))
 


### PR DESCRIPTION
Work Done
--- 
Remove proxy of: 
- `AWSEvents.ListTagsForResource`
- `AWSEvents.TagResource`
- `AWSEvents.UntagResource`

This allows the moto events backend to resolve the operations instead. Using its own tagging service. 
Check this PR: localstack/moto#38

I've checked the sources where these tags are used, and it seems that there are no consumers in localstack that access this directly. Still this is open to discussion and any feedback is welcome! 
