### PR TITLE
Remove shadowing env parameter

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -413,7 +413,6 @@ def fix_account_id_in_arns(response, colon_delimiter=":", existing=None, replace
 
 
 def inject_test_credentials_into_env(env):
-    env = env or {}
     if ENV_ACCESS_KEY not in env and ENV_SECRET_KEY not in env:
         env[ENV_ACCESS_KEY] = "test"
         env[ENV_SECRET_KEY] = "test"

--- a/tests/unit/utils/aws/test_aws_stack.py
+++ b/tests/unit/utils/aws/test_aws_stack.py
@@ -1,44 +1,43 @@
-import pytest
-
-from localstack.utils.aws.aws_stack import inject_test_credentials_into_env, ENV_ACCESS_KEY, ENV_SECRET_KEY, inject_region_into_env
-
-
-class SomeClass:
-    pass
+from localstack.utils.aws.aws_stack import (
+    ENV_ACCESS_KEY,
+    ENV_SECRET_KEY,
+    inject_region_into_env,
+    inject_test_credentials_into_env,
+)
 
 
 def test_inject_test_credentials_into_env_already_with_none_adds_both():
     env = {}
     inject_test_credentials_into_env(env)
-    assert env[ENV_ACCESS_KEY] == "test"
-    assert env[ENV_SECRET_KEY] == "test"
+    assert env.get(ENV_ACCESS_KEY) == "test"
+    assert env.get(ENV_SECRET_KEY) == "test"
 
 
 def test_inject_test_credentials_into_env_already_with_access_key_does_nothing():
     access_key = "an-access-key"
-    env = {ENV_ACCESS_KEY: access_key}
+    expected_env = {ENV_ACCESS_KEY: access_key}
+    env = expected_env.copy()
     inject_test_credentials_into_env(env)
-    assert env[ENV_ACCESS_KEY] == access_key
-    assert ENV_SECRET_KEY not in env
+    assert env == expected_env
 
 
 def test_inject_test_credentials_into_env_already_with_secret_key_does_nothing():
     secret_key = "a-secret-key"
-    env = {ENV_SECRET_KEY: secret_key}
+    expected_env = {ENV_SECRET_KEY: secret_key}
+    env = expected_env.copy()
     inject_test_credentials_into_env(env)
-    assert env[ENV_SECRET_KEY] == secret_key
-    assert ENV_ACCESS_KEY not in env
+    assert env == expected_env
 
 
 def test_inject_region_into_env_already_with_none_adds_region():
     env = {}
     region = "a-test-region"
     inject_region_into_env(env, region)
-    assert env["AWS_REGION"] == region
+    assert env.get("AWS_REGION") == region
 
 
 def test_inject_region_into_env_already_with_region_overwrites_it():
     env = {"AWS_REGION": "another-region"}
     region = "a-test-region"
     inject_region_into_env(env, region)
-    assert env["AWS_REGION"] == region
+    assert env.get("AWS_REGION") == region

--- a/tests/unit/utils/aws/test_aws_stack.py
+++ b/tests/unit/utils/aws/test_aws_stack.py
@@ -1,0 +1,44 @@
+import pytest
+
+from localstack.utils.aws.aws_stack import inject_test_credentials_into_env, ENV_ACCESS_KEY, ENV_SECRET_KEY, inject_region_into_env
+
+
+class SomeClass:
+    pass
+
+
+def test_inject_test_credentials_into_env_already_with_none_adds_both():
+    env = {}
+    inject_test_credentials_into_env(env)
+    assert env[ENV_ACCESS_KEY] == "test"
+    assert env[ENV_SECRET_KEY] == "test"
+
+
+def test_inject_test_credentials_into_env_already_with_access_key_does_nothing():
+    access_key = "an-access-key"
+    env = {ENV_ACCESS_KEY: access_key}
+    inject_test_credentials_into_env(env)
+    assert env[ENV_ACCESS_KEY] == access_key
+    assert ENV_SECRET_KEY not in env
+
+
+def test_inject_test_credentials_into_env_already_with_secret_key_does_nothing():
+    secret_key = "a-secret-key"
+    env = {ENV_SECRET_KEY: secret_key}
+    inject_test_credentials_into_env(env)
+    assert env[ENV_SECRET_KEY] == secret_key
+    assert ENV_ACCESS_KEY not in env
+
+
+def test_inject_region_into_env_already_with_none_adds_region():
+    env = {}
+    region = "a-test-region"
+    inject_region_into_env(env, region)
+    assert env["AWS_REGION"] == region
+
+
+def test_inject_region_into_env_already_with_region_overwrites_it():
+    env = {"AWS_REGION": "another-region"}
+    region = "a-test-region"
+    inject_region_into_env(env, region)
+    assert env["AWS_REGION"] == region


### PR DESCRIPTION
See https://github.com/localstack/localstack/pull/4259

This PR removes the erroneous line that prevents the AWS credential environment variables being made available to dockerized Lambdas, which then prevents them from accessing other LocalStack services.

An additional commit will, with the guidance of @dominikschubert, add tests to verify correct behavior.
