### PR TITLE
Add possibility to subscribe to config changes from services

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -2240,3 +2240,29 @@ def serve(port):
     LAMBDA_EXECUTOR.startup()
 
     generic_proxy.serve_flask_app(app=app, port=port)
+
+
+# Config listener
+def on_config_change(config_key: str, config_newvalue: str) -> None:
+    global LAMBDA_EXECUTOR
+    if config_key != "LAMBDA_EXECUTOR":
+        return
+    LOG.debug(
+        "Recieved config event for lambda executor! Key: {} Value: {}".format(
+            config_key, config_newvalue
+        )
+    )
+    LAMBDA_EXECUTOR.cleanup()
+    LAMBDA_EXECUTOR = lambda_executors.AVAILABLE_EXECUTORS.get(
+        config_newvalue, lambda_executors.DEFAULT_EXECUTOR
+    )
+    LAMBDA_EXECUTOR.startup()
+
+
+def register_config_listener():
+    from localstack.utils import config_listener
+
+    config_listener.CONFIG_LISTENERS.append(on_config_change)
+
+
+register_config_listener()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -11,7 +10,6 @@ import traceback
 
 import boto3
 from moto import core as moto_core
-from requests.models import Response
 
 from localstack import config, constants
 from localstack.constants import (
@@ -25,14 +23,14 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.cloudformation import cloudformation_api
 from localstack.services.dynamodbstreams import dynamodbstreams_api
 from localstack.services.firehose import firehose_api
-from localstack.services.generic_proxy import ProxyListener, start_proxy_server
+from localstack.services.generic_proxy import start_proxy_server
 from localstack.services.plugins import (
     SERVICE_PLUGINS,
     check_infra,
     record_service_health,
     wait_for_infra_shutdown,
 )
-from localstack.utils import common, persistence
+from localstack.utils import common, config_listener, persistence
 from localstack.utils.analytics import event_publisher
 from localstack.utils.analytics.profiler import log_duration
 from localstack.utils.bootstrap import canonicalize_api_names, in_ci, load_plugins, setup_logging
@@ -73,42 +71,8 @@ INFRA_READY = threading.Event()
 SHUTDOWN_INFRA = threading.Event()
 
 
-# -----------------------
-# CONFIG UPDATE BACKDOOR
-# -----------------------
-
-
-def update_config_variable(variable, new_value):
-    if new_value is not None:
-        LOG.info('Updating value of config variable "%s": %s' % (variable, new_value))
-        setattr(config, variable, new_value)
-
-
-class ConfigUpdateProxyListener(ProxyListener):
-    """Default proxy listener that intercepts requests to retrieve or update config variables."""
-
-    def forward_request(self, method, path, data, headers):
-        if path != constants.CONFIG_UPDATE_PATH or method != "POST":
-            return True
-        response = Response()
-        data = json.loads(data)
-        variable = data.get("variable", "")
-        response._content = "{}"
-        response.status_code = 200
-        if not re.match(r"^[_a-zA-Z0-9]+$", variable):
-            response.status_code = 400
-            return response
-        new_value = data.get("value")
-        update_config_variable(variable, new_value)
-        value = getattr(config, variable, None)
-        result = {"variable": variable, "value": value}
-        response._content = json.dumps(result)
-        return response
-
-
-if config.ENABLE_CONFIG_UPDATES:
-    ProxyListener.DEFAULT_LISTENERS.append(ConfigUpdateProxyListener())
-
+# Start config update backdoor
+config_listener.start_listener()
 
 # -----------------
 # API ENTRY POINTS
@@ -250,7 +214,7 @@ def set_service_status(data):
         contained = [s for s in services if s.startswith(service)]
         if not contained:
             services.append(service)
-        update_config_variable(port_variable, port)
+        config_listener.update_config_variable(port_variable, port)
         new_service_list = ",".join(services)
         os.environ["SERVICES"] = new_service_list
         # TODO: expensive operation - check if we need to do this here for each service, should be optimized!

--- a/localstack/utils/config_listener.py
+++ b/localstack/utils/config_listener.py
@@ -1,0 +1,53 @@
+import json
+import logging
+import re
+from typing import Callable, List
+
+from requests.models import Response
+
+from localstack import config, constants
+from localstack.services.generic_proxy import ProxyListener
+
+LOG = logging.getLogger(__name__)
+
+CONFIG_LISTENERS: List[Callable[[str, str], None]] = []
+
+
+def trigger_config_listeners(variable, new_value):
+    LOG.debug("Updating config listeners")
+    for listener in CONFIG_LISTENERS:
+        listener(variable, new_value)
+
+
+def update_config_variable(variable, new_value):
+    if new_value is not None:
+        LOG.info('Updating value of config variable "%s": %s' % (variable, new_value))
+        setattr(config, variable, new_value)
+        trigger_config_listeners(variable, new_value)
+
+
+class ConfigUpdateProxyListener(ProxyListener):
+    """Default proxy listener that intercepts requests to retrieve or update config variables."""
+
+    def forward_request(self, method, path, data, headers):
+        if path != constants.CONFIG_UPDATE_PATH or method != "POST":
+            return True
+        response = Response()
+        data = json.loads(data)
+        variable = data.get("variable", "")
+        response._content = "{}"
+        response.status_code = 200
+        if not re.match(r"^[_a-zA-Z0-9]+$", variable):
+            response.status_code = 400
+            return response
+        new_value = data.get("value")
+        update_config_variable(variable, new_value)
+        value = getattr(config, variable, None)
+        result = {"variable": variable, "value": value}
+        response._content = json.dumps(result)
+        return response
+
+
+def start_listener():
+    if config.ENABLE_CONFIG_UPDATES:
+        ProxyListener.DEFAULT_LISTENERS.append(ConfigUpdateProxyListener())

--- a/localstack/utils/config_listener.py
+++ b/localstack/utils/config_listener.py
@@ -48,6 +48,17 @@ class ConfigUpdateProxyListener(ProxyListener):
         return response
 
 
+CONFIG_UPDATE_LISTENER = ConfigUpdateProxyListener()
+
+
 def start_listener():
     if config.ENABLE_CONFIG_UPDATES:
-        ProxyListener.DEFAULT_LISTENERS.append(ConfigUpdateProxyListener())
+        ProxyListener.DEFAULT_LISTENERS.append(CONFIG_UPDATE_LISTENER)
+
+
+def remove_listener():
+    if not config.ENABLE_CONFIG_UPDATES:
+        try:
+            ProxyListener.DEFAULT_LISTENERS.remove(CONFIG_UPDATE_LISTENER)
+        except ValueError:
+            pass

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -1,0 +1,37 @@
+import pytest
+import requests
+
+from localstack import config
+from localstack.utils import config_listener
+
+
+@pytest.fixture
+def config_endpoint():
+    cur_value = config.ENABLE_CONFIG_UPDATES
+    config.ENABLE_CONFIG_UPDATES = True
+    config_listener.start_listener()
+    yield
+    config.ENABLE_CONFIG_UPDATES = cur_value
+    config_listener.remove_listener()
+
+
+def test_config_endpoint(config_endpoint):
+    key = value = None
+
+    def custom_listener(config_key, config_value):
+        nonlocal key, value
+        key = config_key
+        value = config_value
+
+    config.FOO = None
+    body = {"variable": "FOO", "value": "BAR"}
+    config_listener.CONFIG_LISTENERS.append(custom_listener)
+    url = f"{config.get_edge_url()}/?_config_"
+    print(url)
+    response = requests.post(url, json=body)
+    assert 200 == response.status_code
+    response_body = response.json()
+    assert body == response_body
+    assert body["value"] == config.FOO
+    assert body["variable"] == key
+    assert body["value"] == value

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -10,7 +10,7 @@ from requests.models import Response
 from localstack import config
 from localstack.services import infra
 from localstack.services.generic_proxy import GenericProxy, ProxyListener
-from localstack.utils import async_utils
+from localstack.utils import async_utils, config_listener
 from localstack.utils.aws import aws_stack
 from localstack.utils.bootstrap import PortMappings
 from localstack.utils.common import TMP_FILES, download, json_safe, load_file, now_utc, parallelize
@@ -79,7 +79,7 @@ class TestMisc(unittest.TestCase):
         self.assertGreater(len(env), 0)
 
     def test_update_config_variable(self):
-        infra.update_config_variable("foo", "bar")
+        config_listener.update_config_variable("foo", "bar")
         self.assertEqual("bar", config.foo)
 
     def test_async_parallelization(self):


### PR DESCRIPTION
Adds the possibility to subscribe to config changes via the _config_ endpoint, for services where direct dependencies to the config values is not feasable.

Fixes #4363 

Adds the possibility for further services to enable live changes of the config. Could be useful for testing etc.

- [x] Add options to listen to config changes
- [x] Add config subscription for lambda executors
- [x] Add test for the config endpoint