### PR TITLE
Feat: Adding integration test for route table association

### DIFF
--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -21,6 +21,8 @@ class TestEc2Integrations(unittest.TestCase):
         for route_tables in ec2.describe_route_tables()["RouteTables"]:
             for association in route_tables["Associations"]:
                 if association["RouteTableId"] == route_table["RouteTable"]["RouteTableId"]:
+                    self.assertEqual(association["VpcId"], vpc["Vpc"]["VpcId"])
+                    self.assertEqual(association["SubnetId"], subnet["Subnet"]["SubnetId"])
                     self.assertEqual(association["AssociationState"]["State"], "associated")
 
     def test_create_vpc_end_point(self):

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -13,10 +13,10 @@ class TestEc2Integrations(unittest.TestCase):
         subnet = ec2.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.0.0/24")
 
         route_table = ec2.create_route_table(VpcId=vpc["Vpc"]["VpcId"])
-        ec2.associate_route_table(
+        association_id = ec2.associate_route_table(
             RouteTableId=route_table["RouteTable"]["RouteTableId"],
             SubnetId=subnet["Subnet"]["SubnetId"],
-        )
+        )['AssociationId']
 
         for route_tables in ec2.describe_route_tables()["RouteTables"]:
             for association in route_tables["Associations"]:
@@ -24,6 +24,10 @@ class TestEc2Integrations(unittest.TestCase):
                     self.assertEqual(association["VpcId"], vpc["Vpc"]["VpcId"])
                     self.assertEqual(association["SubnetId"], subnet["Subnet"]["SubnetId"])
                     self.assertEqual(association["AssociationState"]["State"], "associated")
+
+        ec2.disassociate_route_table(AssociationId=association_id)
+        for route_tables in ec2.describe_route_tables()["RouteTables"]:
+            self.assertEqual(route_tables['Associations'], [])
 
     def test_create_vpc_end_point(self):
         ec2 = self.ec2_client

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -27,7 +27,8 @@ class TestEc2Integrations(unittest.TestCase):
 
         ec2.disassociate_route_table(AssociationId=association_id)
         for route_tables in ec2.describe_route_tables()["RouteTables"]:
-            self.assertEqual(route_tables['Associations'], [])
+            for association in route_tables["Associations"]:
+                self.assertEqual(association, [])
 
     def test_create_vpc_end_point(self):
         ec2 = self.ec2_client

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -13,12 +13,15 @@ class TestEc2Integrations(unittest.TestCase):
         subnet = ec2.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.0.0/24")
 
         route_table = ec2.create_route_table(VpcId=vpc["Vpc"]["VpcId"])
-        ec2.associate_route_table(RouteTableId=route_table["RouteTable"]["RouteTableId"], SubnetId=subnet["Subnet"]["SubnetId"])
+        ec2.associate_route_table(
+            RouteTableId=route_table["RouteTable"]["RouteTableId"],
+            SubnetId=subnet["Subnet"]["SubnetId"],
+        )
 
-        for route_tables in ec2.describe_route_tables()['RouteTables']:
-            for association in route_tables['Associations']:
-                if association['RouteTableId'] == route_table["RouteTable"]["RouteTableId"]:
-                    self.assertEqual(association['AssociationState']['State'], 'associated')
+        for route_tables in ec2.describe_route_tables()["RouteTables"]:
+            for association in route_tables["Associations"]:
+                if association["RouteTableId"] == route_table["RouteTable"]["RouteTableId"]:
+                    self.assertEqual(association["AssociationState"]["State"], "associated")
 
     def test_create_vpc_end_point(self):
         ec2 = self.ec2_client

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -21,7 +21,6 @@ class TestEc2Integrations(unittest.TestCase):
         for route_tables in ec2.describe_route_tables()["RouteTables"]:
             for association in route_tables["Associations"]:
                 if association["RouteTableId"] == route_table["RouteTable"]["RouteTableId"]:
-                    self.assertEqual(association["VpcId"], vpc["Vpc"]["VpcId"])
                     self.assertEqual(association["SubnetId"], subnet["Subnet"]["SubnetId"])
                     self.assertEqual(association["AssociationState"]["State"], "associated")
 

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -7,6 +7,19 @@ class TestEc2Integrations(unittest.TestCase):
     def setUp(self):
         self.ec2_client = aws_stack.connect_to_service("ec2")
 
+    def test_create_route_table_association(self):
+        ec2 = self.ec2_client
+        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")
+        subnet = ec2.create_subnet(VpcId=vpc["Vpc"]["VpcId"], CidrBlock="10.0.0.0/24")
+
+        route_table = ec2.create_route_table(VpcId=vpc["Vpc"]["VpcId"])
+        ec2.associate_route_table(RouteTableId=route_table["RouteTable"]["RouteTableId"], SubnetId=subnet["Subnet"]["SubnetId"])
+
+        for route_tables in ec2.describe_route_tables()['RouteTables']:
+            for association in route_tables['Associations']:
+                if association['RouteTableId'] == route_table["RouteTable"]["RouteTableId"]:
+                    self.assertEqual(association['AssociationState']['State'], 'associated')
+
     def test_create_vpc_end_point(self):
         ec2 = self.ec2_client
         vpc = ec2.create_vpc(CidrBlock="10.0.0.0/16")

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -16,7 +16,7 @@ class TestEc2Integrations(unittest.TestCase):
         association_id = ec2.associate_route_table(
             RouteTableId=route_table["RouteTable"]["RouteTableId"],
             SubnetId=subnet["Subnet"]["SubnetId"],
-        )['AssociationId']
+        )["AssociationId"]
 
         for route_tables in ec2.describe_route_tables()["RouteTables"]:
             for association in route_tables["Associations"]:
@@ -27,8 +27,7 @@ class TestEc2Integrations(unittest.TestCase):
 
         ec2.disassociate_route_table(AssociationId=association_id)
         for route_tables in ec2.describe_route_tables()["RouteTables"]:
-            for association in route_tables["Associations"]:
-                self.assertEqual(association, [])
+            self.assertEqual(route_tables["Associations"], [])
 
     def test_create_vpc_end_point(self):
         ec2 = self.ec2_client


### PR DESCRIPTION
* Add tests for #4373 
* Tests won't pass until https://github.com/spulec/moto/pull/4096 is merged

Extending integration tests to match route table associations right state.