### PR TITLE
Support resovling SSM parameter values in CloudFormation

### DIFF
--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -21,6 +21,7 @@ from localstack.utils.cloudformation.template_preparer import prepare_template_b
 from localstack.utils.common import (
     clone,
     clone_safe,
+    is_none_or_empty,
     long_uid,
     parse_request_data,
     recurse_object,
@@ -689,12 +690,12 @@ def create_change_set(req_params: Dict[str, Any]):
     template_body: Optional[str] = req_params.get("TemplateBody")
     template_url: Optional[str] = req_params.get("TemplateUrl")  # s3 or secretsmanager url
 
-    if change_set_name is None or change_set_name.strip() == "":
+    if is_none_or_empty(change_set_name):
         return error_response(
             "ChangeSetName required", 400, "ValidationError"
         )  # TODO: check proper message
 
-    if stack_name is None or stack_name.strip() == "":
+    if is_none_or_empty(stack_name):
         return error_response(
             "StackName required", 400, "ValidationError"
         )  # TODO: check proper message
@@ -726,7 +727,6 @@ def create_change_set(req_params: Dict[str, Any]):
             return error_response(
                 f"Stack '{stack_name}' does not exist.", 400, "ValidationError"
             )  # stack should exist already
-        pass
     elif change_set_type == "CREATE":
         # create new (empty) stack
         if stack is not None:

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -1,11 +1,12 @@
 import json
 import logging
 import traceback
-from typing import Any, Dict, List, Literal, Optional, overload
+from typing import Any, Dict, List, Optional, overload
 
 import xmltodict
 from flask import Flask, request
 from requests.models import Response
+from typing_extensions import Literal
 
 from localstack.services.generic_proxy import RegionBackend
 from localstack.utils.aws import aws_responses, aws_stack

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -665,7 +665,7 @@ def create_change_set(req_params):
         req_params_copy = clone_stack_params(req_params)
         stack = Stack(req_params_copy, empty_stack_template)
         state.stacks[stack.stack_id] = stack
-        stack.set_stack_status("CREATE_COMPLETE")
+        stack.set_stack_status("REVIEW_IN_PROGRESS")
     change_set = StackChangeSet(req_params, template)
     deployer = template_deployer.TemplateDeployer(stack)
     deployer.construct_changes(

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -316,12 +316,21 @@ class Stack(object):
                 }
                 # TODO: extract dynamic parameter resolving
                 # TODO: support different types and refactor logic to use metadata (here not yet populated properly)
-                if value.get("Type", "") == "AWS::SSM::Parameter::Value<String>":
-                    ssm_client = aws_stack.connect_to_service("ssm")
-                    resolved_value = ssm_client.get_parameter(Name=param_value)["Parameter"][
-                        "Value"
-                    ]
-                    result[key]["ResolvedValue"] = resolved_value
+                param_type = value.get("Type", "")
+                if not is_none_or_empty(param_type):
+                    if param_type == "AWS::SSM::Parameter::Value<String>":
+                        ssm_client = aws_stack.connect_to_service("ssm")
+                        resolved_value = ssm_client.get_parameter(Name=param_value)["Parameter"][
+                            "Value"
+                        ]
+                        result[key]["ResolvedValue"] = resolved_value
+                    elif param_type.startswith("AWS::"):
+                        LOG.info(
+                            f"Parameter Type '{param_type}' is currently not supported. Coming soon, stay tuned!"
+                        )
+                    else:
+                        # lets assume we support the normal CFn parameters
+                        pass
 
         # add stack parameters
         result.update({p["ParameterKey"]: p for p in self.metadata["Parameters"]})

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -5,6 +5,7 @@ import re
 import xml.etree.ElementTree as ET
 from binascii import crc32
 from struct import pack
+from typing import Optional
 
 import xmltodict
 from flask import Response as FlaskResponse
@@ -33,7 +34,9 @@ class ErrorResponse(Exception):
         self.response = response
 
 
-def flask_error_response_json(msg, code=500, error_type="InternalFailure"):
+def flask_error_response_json(
+    msg: str, code: Optional[int] = 500, error_type: Optional[str] = "InternalFailure"
+):
     result = {
         "Type": "User" if code < 500 else "Server",
         "message": msg,
@@ -51,7 +54,11 @@ def requests_error_response_json(message, code=500, error_type="InternalFailure"
 
 
 def requests_error_response_xml(
-    message, code=400, code_string="InvalidParameter", service=None, xmlns=None
+    message: str,
+    code: Optional[int] = 400,
+    code_string: Optional[str] = "InvalidParameter",
+    service: Optional[str] = None,
+    xmlns: Optional[str] = None,
 ):
     response = RequestsResponse()
     xmlns = xmlns or "http://%s.amazonaws.com/doc/2010-03-31/" % service
@@ -167,7 +174,11 @@ def requests_error_response_xml_signature_calculation(
 
 
 def flask_error_response_xml(
-    message, code=500, code_string="InternalFailure", service=None, xmlns=None
+    message: str,
+    code: Optional[int] = 500,
+    code_string: Optional[str] = "InternalFailure",
+    service: Optional[str] = None,
+    xmlns: Optional[str] = None,
 ):
     response = requests_error_response_xml(
         message, code=code, code_string=code_string, service=service, xmlns=xmlns

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -276,7 +276,7 @@ def connect_to_service(
     env=None,
     region_name=None,
     endpoint_url=None,
-    config=None,
+    config: botocore.config.Config = None,
     verify=False,
     cache=True,
     *args,
@@ -302,20 +302,20 @@ def connect_to_service(
             backend_url = os.environ.get(backend_env_name, "").strip()
             if backend_url:
                 endpoint_url = backend_url
-        config = config or botocore.client.Config()
+        boto_config = config or botocore.client.Config()
         # configure S3 path/host style addressing
         if service_name == "s3":
             if re.match(r"https?://localhost(:[0-9]+)?", endpoint_url):
                 endpoint_url = endpoint_url.replace("://localhost", "://%s" % get_s3_hostname())
         # To, prevent error "Connection pool is full, discarding connection ...",
         # set the environment variable MAX_POOL_CONNECTIONS. Default is 150.
-        config.max_pool_connections = MAX_POOL_CONNECTIONS
+        boto_config.max_pool_connections = MAX_POOL_CONNECTIONS
         result = method(
             service_name,
             region_name=region,
             endpoint_url=endpoint_url,
             verify=verify,
-            config=config,
+            config=boto_config,
             **kwargs,
         )
         if not cache:

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -2032,7 +2032,7 @@ class TemplateDeployer(object):
                 "ParameterKey": logical_id,
                 "ParameterValue": provided_param_value if default is None else default,
             }
-            if default is None:
+            if default is not None:
                 resolved_value = self.resolve_param(logical_id, value.get("Type"), default)
                 if resolved_value is not None:
                     param["ResolvedValue"] = resolved_value

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 import traceback
+from typing import Optional
 from urllib.parse import urlparse
 
 from moto.cloudformation import parsing
@@ -1515,6 +1516,7 @@ def is_none_or_empty_value(value):
     return not value or value == PLACEHOLDER_AWS_NO_VALUE
 
 
+# TODO: this shouldn't be called for stack parameters
 def determine_resource_physical_id(
     resource_id, resources=None, stack=None, attribute=None, stack_name=None
 ):
@@ -2008,25 +2010,45 @@ class TemplateDeployer(object):
             "Resources"
         ][resource_id]
 
-    def apply_parameter_changes(self, old_stack, new_stack):
+    def resolve_param(
+        self, logical_id: str, param_type: str, default_value: Optional[str] = None
+    ) -> Optional[str]:
+        if param_type == "AWS::SSM::Parameter::Value<String>":
+            ssm_client = aws_stack.connect_to_service("ssm")
+            param = ssm_client.get_parameter(Name=default_value)
+            return param["Parameter"]["Value"]
+        return None
+
+    def apply_parameter_changes(self, old_stack, new_stack) -> None:
         parameters = {
-            p["ParameterKey"]: p["ParameterValue"] for p in old_stack.metadata["Parameters"]
+            p["ParameterKey"]: p
+            for p in old_stack.metadata["Parameters"]  # go through current parameter values
         }
 
-        for key, value in new_stack.template["Parameters"].items():
-            parameters[key] = value.get("Default", parameters.get(key))
+        for logical_id, value in new_stack.template["Parameters"].items():
+            default = value.get("Default")
+            param_type = value.get("Type")
+            provided_param_value = parameters.get(logical_id)
+            resolved_value = self.resolve_param(logical_id, param_type, default)
+            parameter_value = provided_param_value if default is None else default
+            param = {
+                "ParameterKey": logical_id,
+                "ParameterValue": parameter_value,
+            }
+            if resolved_value is not None:
+                param["ResolvedValue"] = resolved_value
 
-        parameters.update(
-            {p["ParameterKey"]: p["ParameterValue"] for p in new_stack.metadata["Parameters"]}
-        )
+            parameters[logical_id] = param
+
+        parameters.update({p["ParameterKey"]: p for p in new_stack.metadata["Parameters"]})
 
         for change_set in new_stack.change_sets:
             parameters.update({p["ParameterKey"]: p for p in change_set.metadata["Parameters"]})
 
-        old_stack.metadata["Parameters"] = [
-            {"ParameterKey": k, "ParameterValue": v} for k, v in parameters.items() if v
-        ]
+        # TODO: unclear/undocumented behavior in implicitly updating old_stack parameter here
+        old_stack.metadata["Parameters"] = [v for v in parameters.values() if v]
 
+    # TODO: fix circular import with cloudformation_api.py when importing Stack here
     def construct_changes(
         self,
         existing_stack,

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -2027,16 +2027,15 @@ class TemplateDeployer(object):
 
         for logical_id, value in new_stack.template["Parameters"].items():
             default = value.get("Default")
-            param_type = value.get("Type")
             provided_param_value = parameters.get(logical_id)
-            resolved_value = self.resolve_param(logical_id, param_type, default)
-            parameter_value = provided_param_value if default is None else default
             param = {
                 "ParameterKey": logical_id,
-                "ParameterValue": parameter_value,
+                "ParameterValue": provided_param_value if default is None else default,
             }
-            if resolved_value is not None:
-                param["ResolvedValue"] = resolved_value
+            if default is None:
+                resolved_value = self.resolve_param(logical_id, value.get("Type"), default)
+                if resolved_value is not None:
+                    param["ResolvedValue"] = resolved_value
 
             parameters[logical_id] = param
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -25,7 +25,7 @@ from contextlib import closing
 from datetime import date, datetime, timezone
 from multiprocessing.dummy import Pool
 from queue import Queue
-from typing import Callable, List, Union
+from typing import Callable, List, Optional, Sized, Union
 from urllib.parse import parse_qs, urlparse
 
 import dns.resolver
@@ -1727,6 +1727,14 @@ def isoformat_milliseconds(t):
 def replace_response_content(response, pattern, replacement):
     content = to_str(response.content or "")
     response._content = re.sub(pattern, replacement, content)
+
+
+def is_none_or_empty(obj: Union[Optional[str], Optional[list]]) -> bool:
+    return (
+        obj is None
+        or (isinstance(obj, str) and obj.strip() == "")
+        or (isinstance(obj, Sized) and len(obj) == 0)
+    )
 
 
 # Code that requires util functions from above

--- a/localstack/utils/generic/wait_utils.py
+++ b/localstack/utils/generic/wait_utils.py
@@ -1,5 +1,7 @@
 import time
-from typing import Callable, Literal
+from typing import Callable
+
+from typing_extensions import Literal
 
 
 def wait_until(

--- a/localstack/utils/generic/wait_utils.py
+++ b/localstack/utils/generic/wait_utils.py
@@ -1,0 +1,26 @@
+import time
+from typing import Callable, Literal
+
+
+def wait_until(
+    fn: Callable[[], bool],
+    wait: float = 1.0,
+    max_retries: int = 10,
+    strategy: Literal["exponential", "static", "linear"] = "exponential",
+    _retries: int = 0,
+    _max_wait: float = 120,
+) -> None:
+    """waits until a given condition is true, rechecking it periodically"""
+    if max_retries < _retries:
+        raise Exception("Too many retries!")
+    completed = fn()
+    if not completed:
+        if wait > _max_wait:
+            raise Exception("Maximum wait time reached")
+        time.sleep(wait)
+        next_wait = wait  # static
+        if strategy == "linear":
+            next_wait = (wait / _retries) * (_retries + 1)
+        elif strategy == "exponential":
+            next_wait = wait ** 2
+        wait_until(fn, next_wait, max_retries, strategy, _retries + 1)

--- a/localstack/utils/generic/wait_utils.py
+++ b/localstack/utils/generic/wait_utils.py
@@ -8,19 +8,19 @@ def wait_until(
     max_retries: int = 10,
     strategy: Literal["exponential", "static", "linear"] = "exponential",
     _retries: int = 0,
-    _max_wait: float = 120,
+    _max_wait: float = 240,
 ) -> None:
     """waits until a given condition is true, rechecking it periodically"""
     if max_retries < _retries:
-        raise Exception("Too many retries!")
+        return
     completed = fn()
     if not completed:
         if wait > _max_wait:
-            raise Exception("Maximum wait time reached")
+            return
         time.sleep(wait)
-        next_wait = wait  # static
+        next_wait = wait  # default: static
         if strategy == "linear":
             next_wait = (wait / _retries) * (_retries + 1)
         elif strategy == "exponential":
             next_wait = wait ** 2
-        wait_until(fn, next_wait, max_retries, strategy, _retries + 1)
+        wait_until(fn, next_wait, max_retries, strategy, _retries + 1, _max_wait)

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -1,31 +1,47 @@
 import os
 
-from localstack.utils.cloudformation.template_preparer import template_to_json
+import jinja2
+import pytest
+from botocore.exceptions import ClientError
+
 from localstack.utils.common import load_file, short_uid
+from localstack.utils.generic.wait_utils import wait_until
+
+# TODO: refactor fixtures to automatically cleanup resources
+# TODO: use factory fixtures for common resources
 
 
 def load_template(tmpl_path: str) -> str:
     template = load_file(
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "templates", tmpl_path)
     )
-    return template_to_json(template)
+    return template
+    # return template_to_json(template)
 
 
 def test_create_change_set_without_parameters(cfn_client, sns_client):
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"change-set-{short_uid()}"
+
     response = cfn_client.create_change_set(
         StackName=stack_name,
         ChangeSetName=change_set_name,
         TemplateBody=load_template("sns_topic_simple.yaml"),
         ChangeSetType="CREATE",
     )
-    try:
-        change_set_id = response["Id"]
-        stack_id = response["StackId"]
-        assert change_set_id
-        assert stack_id
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    assert change_set_id
+    assert stack_id
 
+    def is_change_set_created_and_available():
+        check_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+        return (
+            check_set.get("Status") == "CREATE_COMPLETE"
+            and check_set.get("ExecutionStatus") == "AVAILABLE"
+        )
+
+    try:
         # make sure the change set wasn't executed (which would create a topic)
         list_topics_response = sns_client.list_topics()
         assert len(list_topics_response["Topics"]) == 0
@@ -34,6 +50,8 @@ def test_create_change_set_without_parameters(cfn_client, sns_client):
         stack_response = cfn_client.describe_stacks(StackName=stack_id)
         assert stack_response["Stacks"][0]["StackStatus"] == "REVIEW_IN_PROGRESS"
 
+        # Change set can now either be already created/available or it is pending/unavailable
+        wait_until(is_change_set_created_and_available, 2, 10, strategy="exponential")
         describe_response = cfn_client.describe_change_set(ChangeSetName=change_set_id)
 
         assert describe_response["ChangeSetName"] == change_set_name
@@ -49,4 +67,296 @@ def test_create_change_set_without_parameters(cfn_client, sns_client):
         assert changes[0]["ResourceChange"]["ResourceType"] == "AWS::SNS::Topic"
         assert changes[0]["ResourceChange"]["LogicalResourceId"] == "topic123"
     finally:
-        cfn_client.delete_change_set(ChangeSetName=change_set_name)
+        wait_until(is_change_set_created_and_available, 2, 10, strategy="exponential")
+        cfn_client.delete_change_set(ChangeSetName=change_set_name, StackName=stack_name)
+        cfn_client.delete_stack(StackName=stack_id)
+
+
+def is_aws_cloud() -> bool:
+    return os.environ.get("TEST_TARGET", "") == "AWS_CLOUD"
+
+
+# TODO: implement
+@pytest.mark.xfail(condition=not is_aws_cloud(), reason="Not properly implemented")
+def test_create_change_set_update_without_parameters(cfn_client, sns_client):
+    """after creating a stack via a CREATE change set we send an UPDATE change set changing the SNS topic name"""
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    change_set_name2 = f"change-set-{short_uid()}"
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=load_template("sns_topic_simple.yaml"),
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    assert change_set_id
+    assert stack_id
+
+    def is_change_set_created_and_available(id: str):
+        def _inner():
+            check_set = cfn_client.describe_change_set(ChangeSetName=id)
+            return (
+                check_set.get("Status") == "CREATE_COMPLETE"
+                and check_set.get("ExecutionStatus") == "AVAILABLE"
+            )
+
+        return _inner
+
+    def wait_for_finished(id: str):
+        def _wait_for_finished():
+            check_set = cfn_client.describe_change_set(ChangeSetName=id)
+            return check_set["ExecutionStatus"] == "EXECUTE_COMPLETE"
+
+        return _wait_for_finished
+
+    try:
+        # Change set can now either be already created/available or it is pending/unavailable
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(wait_for_finished(change_set_id), 2, 10, strategy="exponential", _max_wait=300)
+        template = load_template("sns_topic_simple.yaml")
+
+        update_response = cfn_client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name2,
+            TemplateBody=template.replace("sns-topic-simple", "sns-topic-simple-2"),
+            ChangeSetType="UPDATE",
+        )
+        wait_until(is_change_set_created_and_available(update_response["Id"]))
+        describe_response = cfn_client.describe_change_set(ChangeSetName=update_response["Id"])
+        changes = describe_response["Changes"]
+        assert len(changes) == 1
+        assert changes[0]["Type"] == "Resource"
+        change = changes[0]["ResourceChange"]
+        assert change["Action"] == "Modify"
+        assert change["ResourceType"] == "AWS::SNS::Topic"
+        assert change["LogicalResourceId"] == "topic123"
+        assert "sns-topic-simple" in change["PhysicalResourceId"]
+        assert change["Replacement"] == "True"
+        assert "Properties" in change["Scope"]
+        assert len(change["Details"]) == 1
+        assert change["Details"][0]["Target"]["Name"] == "TopicName"
+        assert change["Details"][0]["Target"]["RequiresRecreation"] == "Always"
+    finally:
+        cfn_client.delete_change_set(ChangeSetName=change_set_name, StackName=stack_name)
+        cfn_client.delete_change_set(ChangeSetName=change_set_name2, StackName=stack_name)
+        cfn_client.delete_stack(StackName=stack_id)
+
+
+@pytest.mark.skip(reason="TODO")
+def test_create_change_set_with_template_url(cfn_client):
+    pass
+
+
+@pytest.mark.xfail(reason="change set type not implemented")
+def test_create_change_set_create_existing(cfn_client):
+    """tries to create an already existing stack"""
+
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=load_template("sns_topic_simple.yaml"),
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    assert change_set_id
+    assert stack_id
+
+    cfn_client.execute_change_set(ChangeSetName=change_set_id)
+
+    def wait_for_finished():
+        check_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+        return check_set["ExecutionStatus"] == "EXECUTE_COMPLETE"
+
+    wait_until(wait_for_finished)
+
+    with pytest.raises(Exception) as ex:
+        change_set_name2 = f"change-set-{short_uid()}"
+        response = cfn_client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name2,
+            TemplateBody=load_template("sns_topic_simple.yaml"),
+            ChangeSetType="CREATE",
+        )
+    assert ex is not None
+
+
+def test_create_change_set_update_nonexisting(cfn_client):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+
+    with pytest.raises(Exception) as ex:
+        response = cfn_client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name,
+            TemplateBody=load_template("sns_topic_simple.yaml"),
+            ChangeSetType="UPDATE",
+        )
+        change_set_id = response["Id"]
+        stack_id = response["StackId"]
+        assert change_set_id
+        assert stack_id
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+    assert "does not exist" in err["Message"]
+
+
+@pytest.mark.skip(reason="TODO")
+def test_create_change_set_import(cfn_client):
+    """test importing existing resources into a stack via the change set"""
+    pass  # TODO
+
+
+def test_create_change_set_invalid_params(cfn_client):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    with pytest.raises(ClientError) as ex:
+        cfn_client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name,
+            TemplateBody=load_template("sns_topic_simple.yaml"),
+            ChangeSetType="INVALID",
+        )
+    err = ex.value.response["Error"]
+    assert err["Code"] == "ValidationError"
+
+
+def test_create_change_set_missing_stackname(cfn_client):
+    """in this case boto doesn't even let us send the request"""
+    change_set_name = f"change-set-{short_uid()}"
+    with pytest.raises(Exception):
+        cfn_client.create_change_set(
+            StackName="",
+            ChangeSetName=change_set_name,
+            TemplateBody=load_template("sns_topic_simple.yaml"),
+            ChangeSetType="CREATE",
+        )
+
+
+@pytest.mark.xfail(
+    reason="ssm parameter resolution not implemented",
+    condition=(os.environ.get("TEST_TARGET") != "AWS_CLOUD"),
+)
+def test_create_change_set_with_ssm_parameter(cfn_client, sns_client, ssm_client):
+    """References a simple stack parameter"""
+
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    parameter_name = f"ls-param-{short_uid()}"
+    parameter_value = f"ls-param-value-{short_uid()}"
+    sns_topic_logical_id = "topic123"
+    parameter_logical_id = "parameter123"
+
+    ssm_client.put_parameter(Name=parameter_name, Value=parameter_value, Type="String")
+    template = load_template("dynamicparameter_ssm_string.yaml")
+    template_rendered = jinja2.Template(template).render(parameter_name=parameter_name)
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    assert change_set_id
+    assert stack_id
+
+    def is_change_set_created_and_available():
+        check_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+        return (
+            check_set.get("Status") == "CREATE_COMPLETE"
+            and check_set.get("ExecutionStatus") == "AVAILABLE"
+        )
+
+    try:
+        # make sure the change set wasn't executed (which would create a new topic)
+        list_topics_response = sns_client.list_topics()
+        matching_topics = [
+            t for t in list_topics_response["Topics"] if parameter_value in t["TopicArn"]
+        ]
+        assert matching_topics == []
+
+        # stack is initially in REVIEW_IN_PROGRESS state. only after executing the change_set will it change its status
+        stack_response = cfn_client.describe_stacks(StackName=stack_id)
+        assert stack_response["Stacks"][0]["StackStatus"] == "REVIEW_IN_PROGRESS"
+
+        # Change set can now either be already created/available or it is pending/unavailable
+        wait_until(is_change_set_created_and_available, 2, 10, strategy="exponential")
+        describe_response = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+
+        assert describe_response["ChangeSetName"] == change_set_name
+        assert describe_response["ChangeSetId"] == change_set_id
+        assert describe_response["StackId"] == stack_id
+        assert describe_response["StackName"] == stack_name
+        assert describe_response["ExecutionStatus"] == "AVAILABLE"
+        assert describe_response["Status"] == "CREATE_COMPLETE"
+        changes = describe_response["Changes"]
+        assert len(changes) == 1
+        assert changes[0]["Type"] == "Resource"
+        assert changes[0]["ResourceChange"]["Action"] == "Add"
+        assert changes[0]["ResourceChange"]["ResourceType"] == "AWS::SNS::Topic"
+        assert changes[0]["ResourceChange"]["LogicalResourceId"] == sns_topic_logical_id
+
+        parameters = describe_response["Parameters"]
+        assert len(parameters) == 1
+        assert parameters[0]["ParameterKey"] == parameter_logical_id
+        assert parameters[0]["ParameterValue"] == parameter_name
+        assert parameters[0]["ResolvedValue"] == parameter_value  # the important part
+
+    finally:  # TODO: make part of fixture
+        wait_until(is_change_set_created_and_available, 2, 10, strategy="exponential")
+        cfn_client.delete_change_set(ChangeSetName=change_set_name, StackName=stack_name)
+        cfn_client.delete_stack(StackName=stack_id)
+        ssm_client.delete_parameter(Name=parameter_name)
+
+
+def test_describe_change_set_nonexisting(cfn_client):
+    with pytest.raises(Exception) as ex:
+        cfn_client.describe_change_set(ChangeSetName="DoesNotExist")
+
+    assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_execute_change_set(cfn_client, sns_client):
+    """check if executing a change set succeeds in creating/modifying the resources in changed"""
+
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=load_template("sns_topic_simple.yaml"),
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    assert change_set_id
+    assert stack_id
+
+    cfn_client.execute_change_set(ChangeSetName=change_set_id)
+
+    def wait_for_finished():
+        check_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+        return check_set["ExecutionStatus"] == "EXECUTE_COMPLETE"
+
+    wait_until(wait_for_finished)
+    # check if stack resource was created
+    topics = sns_client.list_topics()
+    topic_arns = [t for t in map(lambda x: x["TopicArn"], topics["Topics"])]
+    assert any([("sns-topic-simple" in t) for t in topic_arns])
+    # TODO: cleanup creates resources
+
+
+def test_delete_change_set_nonexisting(cfn_client):
+    with pytest.raises(Exception) as ex:
+        cfn_client.delete_change_set(ChangeSetName="DoesNotExist")
+
+    assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -1,0 +1,47 @@
+import os
+
+from localstack.utils.cloudformation.template_preparer import template_to_json
+from localstack.utils.common import load_file, short_uid
+
+
+def load_template(tmpl_path: str) -> str:
+    template = load_file(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "templates", tmpl_path)
+    )
+    return template_to_json(template)
+
+
+def test_create_change_set_without_parameters(cfn_client):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=load_template("sns_topic_simple.yaml"),
+        ChangeSetType="CREATE",
+    )
+    try:
+        change_set_id = response["Id"]
+        stack_id = response["StackId"]
+        assert change_set_id
+        assert stack_id
+
+        stack_response = cfn_client.describe_stacks(StackName=stack_id)
+        assert stack_response["Stacks"][0]["StackStatus"] == "REVIEW_IN_PROGRESS"
+
+        describe_response = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+
+        assert describe_response["ChangeSetName"] == change_set_name
+        assert describe_response["ChangeSetId"] == change_set_id
+        assert describe_response["StackId"] == stack_id
+        assert describe_response["StackName"] == stack_name
+        assert describe_response["ExecutionStatus"] == "AVAILABLE"
+        assert describe_response["Status"] == "CREATE_COMPLETE"
+        changes = describe_response["Changes"]
+        assert len(changes) == 1
+        assert changes[0]["Type"] == "Resource"
+        assert changes[0]["ResourceChange"]["Action"] == "Add"
+        assert changes[0]["ResourceChange"]["ResourceType"] == "AWS::SNS::Topic"
+        assert changes[0]["ResourceChange"]["LogicalResourceId"] == "topic123"
+    finally:
+        cfn_client.delete_change_set(ChangeSetName=change_set_name)

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -34,9 +34,9 @@ def test_create_change_set_without_parameters(
 
     try:
         # make sure the change set wasn't executed (which would create a topic)
-        list_topics_response = sns_client.list_topics()
-        assert len(list_topics_response["Topics"]) == 0
-
+        topics = sns_client.list_topics()
+        topic_arns = [t for t in map(lambda x: x["TopicArn"], topics["Topics"])]
+        assert not any(["sns-topic-simple" in arn for arn in topic_arns])
         # stack is initially in REVIEW_IN_PROGRESS state. only after executing the change_set will it change its status
         stack_response = cfn_client.describe_stacks(StackName=stack_id)
         assert stack_response["Stacks"][0]["StackStatus"] == "REVIEW_IN_PROGRESS"

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 
 from localstack.utils.common import load_file, short_uid
 from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.util import is_aws_cloud
 
 
 def load_template_raw(tmpl_path: str) -> str:
@@ -13,6 +14,9 @@ def load_template_raw(tmpl_path: str) -> str:
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "templates", tmpl_path)
     )
     return template
+
+
+# TODO: create util function for asserting some common stack/change set verification patterns here
 
 
 def test_create_change_set_without_parameters(
@@ -62,10 +66,6 @@ def test_create_change_set_without_parameters(
     finally:
         cleanup_stacks([stack_id])
         cleanup_changesets([change_set_id])
-
-
-def is_aws_cloud() -> bool:
-    return os.environ.get("TEST_TARGET", "") == "AWS_CLOUD"
 
 
 # TODO: implement

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -2,7 +2,7 @@ import jinja2
 
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
-from tests.integration.cloudformation.test_cloudformation_changesets import load_template
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
 
 
 def test_create_stack_with_ssm_parameters(
@@ -14,7 +14,7 @@ def test_create_stack_with_ssm_parameters(
     parameter_logical_id = "parameter123"
     try:
         ssm_client.put_parameter(Name=parameter_name, Value=parameter_value, Type="String")
-        template = load_template("dynamicparameter_ssm_string.yaml")
+        template = load_template_raw("dynamicparameter_ssm_string.yaml")
         template_rendered = jinja2.Template(template).render(parameter_name=parameter_name)
         response = cfn_client.create_stack(
             StackName=stack_name,

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -12,17 +12,17 @@ def test_create_stack_with_ssm_parameters(
     parameter_name = f"ls-param-{short_uid()}"
     parameter_value = f"ls-param-value-{short_uid()}"
     parameter_logical_id = "parameter123"
-    try:
-        ssm_client.put_parameter(Name=parameter_name, Value=parameter_value, Type="String")
-        template = load_template_raw("dynamicparameter_ssm_string.yaml")
-        template_rendered = jinja2.Template(template).render(parameter_name=parameter_name)
-        response = cfn_client.create_stack(
-            StackName=stack_name,
-            TemplateBody=template_rendered,
-        )
-        stack_id = response["StackId"]
-        assert stack_id
+    ssm_client.put_parameter(Name=parameter_name, Value=parameter_value, Type="String")
+    template = load_template_raw("dynamicparameter_ssm_string.yaml")
+    template_rendered = jinja2.Template(template).render(parameter_name=parameter_name)
+    response = cfn_client.create_stack(
+        StackName=stack_name,
+        TemplateBody=template_rendered,
+    )
+    stack_id = response["StackId"]
+    assert stack_id
 
+    try:
         wait_until(is_stack_created(stack_id))
 
         created_stack = cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -1,0 +1,42 @@
+import jinja2
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template
+
+
+def test_create_stack_with_ssm_parameters(
+    cfn_client, ssm_client, sns_client, cleanup_stacks, is_stack_created
+):
+    stack_name = f"stack-{short_uid()}"
+    parameter_name = f"ls-param-{short_uid()}"
+    parameter_value = f"ls-param-value-{short_uid()}"
+    parameter_logical_id = "parameter123"
+    try:
+        ssm_client.put_parameter(Name=parameter_name, Value=parameter_value, Type="String")
+        template = load_template("dynamicparameter_ssm_string.yaml")
+        template_rendered = jinja2.Template(template).render(parameter_name=parameter_name)
+        response = cfn_client.create_stack(
+            StackName=stack_name,
+            TemplateBody=template_rendered,
+        )
+        stack_id = response["StackId"]
+        assert stack_id
+
+        wait_until(is_stack_created(stack_id))
+
+        created_stack = cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]
+        assert created_stack is not None
+        assert created_stack["Parameters"][0]["ParameterKey"] == parameter_logical_id
+        assert created_stack["Parameters"][0]["ParameterValue"] == parameter_name
+        assert created_stack["Parameters"][0]["ResolvedValue"] == parameter_value
+
+        topics = sns_client.list_topics()
+        topic_arns = [t["TopicArn"] for t in topics["Topics"]]
+        assert any([parameter_value in t for t in topic_arns])
+    finally:
+        cleanup_stacks([stack_id])
+        # TODO: cleanup parameter
+
+
+# TODO: more tests

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient
     from mypy_boto3_kinesis import KinesisClient
     from mypy_boto3_lambda import LambdaClient
+    from mypy_boto3_logs import CloudWatchLogsClient
     from mypy_boto3_s3 import S3Client
     from mypy_boto3_sns import SNSClient
     from mypy_boto3_sqs import SQSClient
@@ -26,8 +27,11 @@ LOG = logging.getLogger(__name__)
 def _client(service):
     if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
         return boto3.client(service)
+    # can't set the timeouts to 0 like in the AWS CLI because the underlying http client requires values > 0
     config = (
-        botocore.config.Config(connect_timeout=0, read_timeout=0, retries={"total_max_attempts": 1})
+        botocore.config.Config(
+            connect_timeout=1_000, read_timeout=1_000, retries={"total_max_attempts": 1}
+        )
         if os.environ.get("TEST_DISABLE_RETRIES_AND_TIMEOUTS")
         else None
     )
@@ -72,6 +76,11 @@ def lambda_client() -> "LambdaClient":
 @pytest.fixture(scope="class")
 def kinesis_client() -> "KinesisClient":
     return _client("kinesis")
+
+
+@pytest.fixture(scope="class")
+def logs_client() -> "CloudWatchLogsClient":
+    return _client("logs")
 
 
 @pytest.fixture

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -225,7 +225,7 @@ def is_stack_created(cfn_client):
         def _inner():
             resp = cfn_client.describe_stacks(StackName=stack_id)
             s = resp["Stacks"][0]  # since the lookup  uses the id we can only get a single response
-            return s.get("StackStatus", "") == "CREATE_COMPLETE"
+            return s.get("StackStatus") == "CREATE_COMPLETE"
 
         return _inner
 
@@ -237,7 +237,7 @@ def is_change_set_finished(cfn_client):
     def _is_change_set_finished(change_set_id: str):
         def _inner():
             check_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
-            return check_set["ExecutionStatus"] == "EXECUTE_COMPLETE"
+            return check_set.get("ExecutionStatus") == "EXECUTE_COMPLETE"
 
         return _inner
 

--- a/tests/integration/templates/dynamicparameter_ssm_string.yaml
+++ b/tests/integration/templates/dynamicparameter_ssm_string.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  parameter123:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: {{ parameter_name }}
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName:
+        Ref: parameter123
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete

--- a/tests/integration/templates/sns_topic_simple.yaml
+++ b/tests/integration/templates/sns_topic_simple.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: sns-topic-simple
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete

--- a/tests/integration/templates/ssm_parameter_def.yaml
+++ b/tests/integration/templates/ssm_parameter_def.yaml
@@ -1,0 +1,11 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  TestParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: ls-ssm-parameter-01
+      Description: test param 1
+      Type: String
+      Value: value123
+      Tags:
+        tag1: value1

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -3,7 +3,6 @@ import os
 import time
 import unittest
 
-import pytest
 from botocore.exceptions import ClientError
 from botocore.parsers import ResponseParserError
 
@@ -1141,7 +1140,7 @@ class CloudFormationTest(unittest.TestCase):
         # clean up
         self.cleanup(stack_name)
 
-    @pytest.mark.xfail
+    # @pytest.mark.xfail
     def test_cfn_handle_log_group_resource(self):
         stack_name = "stack-%s" % short_uid()
         log_group_prefix = "/aws/lambda/AWS_DUB_LAM_10000000"

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1140,7 +1140,6 @@ class CloudFormationTest(unittest.TestCase):
         # clean up
         self.cleanup(stack_name)
 
-    # @pytest.mark.xfail
     def test_cfn_handle_log_group_resource(self):
         stack_name = "stack-%s" % short_uid()
         log_group_prefix = "/aws/lambda/AWS_DUB_LAM_10000000"

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -3,6 +3,7 @@ import os
 import time
 import unittest
 
+import pytest
 from botocore.exceptions import ClientError
 from botocore.parsers import ResponseParserError
 
@@ -73,10 +74,6 @@ TEST_TEMPLATE_8 = {
 TEST_TEMPLATE_9 = (
     """
 Parameters:
-  FeatureBranch:
-    Type: String
-    Default: false
-    AllowedValues: ["true", "false"]
   gitBranch:
     Type: String
     Default: dev
@@ -888,6 +885,7 @@ class CloudFormationTest(unittest.TestCase):
             TemplateBody=TEST_CHANGE_SET_BODY % bucket_name,
             Parameters=[{"ParameterKey": "EnvironmentType", "ParameterValue": "stage"}],
             Capabilities=["CAPABILITY_IAM"],
+            ChangeSetType="CREATE",
         )
 
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
@@ -935,6 +933,7 @@ class CloudFormationTest(unittest.TestCase):
             StackName=stack_name,
             ChangeSetName=change_set_name,
             TemplateBody=load_file(TEST_DEPLOY_BODY_1) % role_name,
+            ChangeSetType="CREATE",
         )
 
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
@@ -981,6 +980,7 @@ class CloudFormationTest(unittest.TestCase):
                 {"ParameterKey": "CompanyName", "ParameterValue": "MyCompany"},
                 {"ParameterKey": "MyEmail1", "ParameterValue": "my@email.com"},
             ],
+            ChangeSetType="CREATE",
         )
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
 
@@ -1031,6 +1031,7 @@ class CloudFormationTest(unittest.TestCase):
                 {"ParameterKey": "tableName", "ParameterValue": ddb_table_name_prefix},
                 {"ParameterKey": "env", "ParameterValue": env},
             ],
+            ChangeSetType="CREATE",
         )
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
         change_set_id = rs["Id"]
@@ -1077,6 +1078,7 @@ class CloudFormationTest(unittest.TestCase):
             StackName=stack_name,
             ChangeSetName=change_set_name,
             TemplateBody=load_file(TEST_DEPLOY_BODY_4),
+            ChangeSetType="CREATE",
         )
 
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
@@ -1139,6 +1141,7 @@ class CloudFormationTest(unittest.TestCase):
         # clean up
         self.cleanup(stack_name)
 
+    @pytest.mark.xfail
     def test_cfn_handle_log_group_resource(self):
         stack_name = "stack-%s" % short_uid()
         log_group_prefix = "/aws/lambda/AWS_DUB_LAM_10000000"

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -1,0 +1,5 @@
+import os
+
+
+def is_aws_cloud() -> bool:
+    return os.environ.get("TEST_TARGET", "") == "AWS_CLOUD"

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -2,7 +2,9 @@ import threading
 import unittest
 from unittest.mock import MagicMock
 
-from localstack.utils.common import synchronized
+import pytest
+
+from localstack.utils.common import is_none_or_empty, synchronized
 
 
 class SynchronizedTest(unittest.TestCase):
@@ -18,3 +20,29 @@ class SynchronizedTest(unittest.TestCase):
         self.locked()
         self.mocklock.__enter__.assert_called_with()
         self.mocklock.__exit__.assert_called_with(None, None, None)
+
+
+@pytest.mark.parametrize(
+    ["obj", "result"],
+    [
+        ("nonempty", False),
+        ("", True),
+        (None, True),
+        ("   ", True),
+    ],
+)
+def test_is_none_or_empty_strings(obj, result):
+    assert is_none_or_empty(obj) == result
+
+
+@pytest.mark.parametrize(
+    ["obj", "result"],
+    [
+        ([], True),
+        (None, True),
+        ([1], False),
+        (["1", "2"], False),
+    ],
+)
+def test_is_none_or_empty_lists(obj, result):
+    assert is_none_or_empty(obj) == result


### PR DESCRIPTION
Adds support for SSM parameter resolution for CloudFormation. 

There are still some issues with the flow for parameter initialization which will need a bit more refactoring in the future but for now it adds the SSM string parameter support without rewriting too much of the core CFn logic.

Some other changes:

- Started adding new tests in a new cloudformation test subdir for integration tests since we'll have to add more CFn tests here in the near future. The exiting Unittest tests will be moved there in the near future as well and split up where necessary.
- Added new fixtures for cleanup (might make sense to encapsulate them in a utils fixture to avoid too many parameters in the unit tests)
- Minor type hint additions
- Support for change set types ("CREATE"/"UPDATE") and corresponding errors. "IMPORT" is not yet supported, but a corresponding TODO was added.