### PR TITLE
Fix HOST_REGEX_EXECUTE_API regex

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -58,7 +58,7 @@ from localstack.utils.common import to_bytes, to_str
 LOG = logging.getLogger(__name__)
 
 # regex path patterns
-HOST_REGEX_EXECUTE_API = r"(.*://)?([a-zA-Z0-9-]+)\.execute-api\..*"
+HOST_REGEX_EXECUTE_API = r"(?:.*://)?([a-zA-Z0-9-]+)\.execute-api\..*"
 TARGET_REGEX_S3_URI = (
     r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
 )


### PR DESCRIPTION
Minor change, the first group has to be non capturing, to work on line 256 correctly (and for pro).