### PR TITLE
Add ability to specify custom IDs for API GW REST APIs via tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ awslocal kinesis list-streams
 **UPDATE**: Use the environment variable `$LOCALSTACK_HOSTNAME` to determine the target host
 inside your Lambda function. See [Configurations](#Configurations) section for more details.
 
-## Using the official AWS CLI version 2 Docker image with Localstack Docker container
+### Using the official AWS CLI version 2 Docker image with Localstack Docker container
 
 By default the container running [amazon/aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-docker.html) is isolated from `0.0.0.0:4566` on the host machine, that means that aws-cli cannot reach localstack through your shell.
 
@@ -457,6 +457,12 @@ The URL pattern for API Gateway executions is `http://localhost:4566/restapis/<a
 ```
 $ curl http://localhost:4566/restapis/nmafetnwf6/prod/_user_request_/my/path
 ```
+
+## Testing Backdoors and Special Features
+
+LocalStack provides a number of small backdoors and utility features that are designed to make local testing even easier and more efficient.
+
+* **Providing custom IDs for API Gateway REST APIs**: You can specify `tags={"_custom_id_":"myid123"}` on creation of an API Gateway REST API, to assign it the custom ID `"myid123"` (can be useful to have a static API GW endpoint URL for testing).
 
 ## Integrations
 

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -11,7 +11,7 @@ from moto.core.utils import camelcase_to_underscores
 from localstack import config
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import (
-    TAG_KEY_STATIC_ID,
+    TAG_KEY_CUSTOM_ID,
     apply_json_patch_safe,
     import_api_from_openapi_spec,
 )
@@ -477,11 +477,11 @@ def apply_patches():
     def create_rest_api(self, *args, tags={}, **kwargs):
         result = create_rest_api_orig(self, *args, tags=tags, **kwargs)
         tags = tags or {}
-        static_id = tags.get(TAG_KEY_STATIC_ID)
-        if static_id:
+        custom_id = tags.get(TAG_KEY_CUSTOM_ID)
+        if custom_id:
             self.apis.pop(result.id)
-            result.id = static_id
-            self.apis[static_id] = result
+            result.id = custom_id
+            self.apis[custom_id] = result
         return result
 
     create_rest_api_orig = apigateway_models.APIGatewayBackend.create_rest_api

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -11,6 +11,7 @@ from moto.core.utils import camelcase_to_underscores
 from localstack import config
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import (
+    TAG_KEY_STATIC_ID,
     apply_json_patch_safe,
     import_api_from_openapi_spec,
 )
@@ -471,6 +472,20 @@ def apply_patches():
             return 200, {}, json.dumps(deployment)
         return result
 
+    # patch create_rest_api to allow using static API IDs defined via tags
+
+    def create_rest_api(self, *args, tags={}, **kwargs):
+        result = create_rest_api_orig(self, *args, tags=tags, **kwargs)
+        tags = tags or {}
+        static_id = tags.get(TAG_KEY_STATIC_ID)
+        if static_id:
+            self.apis.pop(result.id)
+            result.id = static_id
+            self.apis[static_id] = result
+        return result
+
+    create_rest_api_orig = apigateway_models.APIGatewayBackend.create_rest_api
+    apigateway_models.APIGatewayBackend.create_rest_api = create_rest_api
     apigateway_models.Resource.get_integration = apigateway_models_resource_get_integration
     apigateway_models.Resource.delete_integration = apigateway_models_resource_delete_integration
     apigateway_response_resource_methods_orig = APIGatewayResponse.resource_methods

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import Dict
+from typing import Any, Dict, List
 
 from jsonpatch import apply_patch
 from jsonpointer import JsonPointerException
@@ -38,32 +38,36 @@ APIGATEWAY_SQS_DATA_INBOUND_TEMPLATE = (
     "Action=SendMessage&MessageBody=$util.base64Encode($input.json('$'))"
 )
 
+# special tag name to allow specifying a static ID for new REST APIs
+TAG_KEY_STATIC_ID = "_static_id_"
+
 # TODO: make the CRUD operations in this file generic for the different model types (authorizes, validators, ...)
 
 
 class APIGatewayRegion(RegionBackend):
     def __init__(self):
+        # TODO: introduce a RestAPI class to encapsulate the variables below
         # maps (API id) -> [authorizers]
-        self.authorizers = {}
+        self.authorizers: Dict[str, List[Dict]] = {}
         # maps (API id) -> [validators]
-        self.validators = {}
+        self.validators: Dict[str, List[Dict]] = {}
         # maps (API id) -> [documentation_parts]
-        self.documentation_parts = {}
+        self.documentation_parts: Dict[str, List[Dict]] = {}
         # maps (API id) -> [gateway_responses]
-        self.gateway_responses = {}
+        self.gateway_responses: Dict[str, List[Dict]] = {}
         # account details
-        self.account = {
+        self.account: Dict[str, Any] = {
             "cloudwatchRoleArn": aws_stack.role_arn("api-gw-cw-role"),
             "throttleSettings": {"burstLimit": 1000, "rateLimit": 500},
             "features": ["UsagePlans"],
             "apiKeyVersion": "1",
         }
         # maps (domain_name) -> [path_mappings]
-        self.base_path_mappings = {}
+        self.base_path_mappings: Dict[str, List[Dict]] = {}
         # maps ID to VPC link details
-        self.vpc_links = {}
+        self.vpc_links: Dict[str, Dict] = {}
         # maps cert ID to client certificate details
-        self.client_certificates = {}
+        self.client_certificates: Dict[str, Dict] = {}
 
 
 def make_json_response(message):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -38,8 +38,8 @@ APIGATEWAY_SQS_DATA_INBOUND_TEMPLATE = (
     "Action=SendMessage&MessageBody=$util.base64Encode($input.json('$'))"
 )
 
-# special tag name to allow specifying a static ID for new REST APIs
-TAG_KEY_STATIC_ID = "_static_id_"
+# special tag name to allow specifying a custom ID for new REST APIs
+TAG_KEY_CUSTOM_ID = "_custom_id_"
 
 # TODO: make the CRUD operations in this file generic for the different model types (authorizes, validators, ...)
 

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -16,6 +16,7 @@ from requests.structures import CaseInsensitiveDict
 from localstack import config
 from localstack.constants import HEADER_LOCALSTACK_REQUEST_URL, TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import (
+    TAG_KEY_STATIC_ID,
     connect_api_gateway_to_sqs,
     gateway_request_url,
     get_resource_for_path,
@@ -110,6 +111,17 @@ class TestAPIGateway(unittest.TestCase):
         "authorizerResultTtlInSeconds": 300,
     }
     TEST_API_GATEWAY_AUTHORIZER_OPS = [{"op": "replace", "path": "/name", "value": "test1"}]
+
+    def test_create_rest_api_with_static_id(self):
+        client = aws_stack.connect_to_service("apigateway")
+        apigw_name = "gw-%s" % short_uid()
+        test_id = "testId123"
+        result = client.create_rest_api(name=apigw_name, tags={TAG_KEY_STATIC_ID: test_id})
+        self.assertEqual(test_id, result["id"])
+        self.assertEqual(apigw_name, result["name"])
+        result = client.get_rest_api(restApiId=test_id)
+        self.assertEqual(test_id, result["id"])
+        self.assertEqual(apigw_name, result["name"])
 
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -16,7 +16,7 @@ from requests.structures import CaseInsensitiveDict
 from localstack import config
 from localstack.constants import HEADER_LOCALSTACK_REQUEST_URL, TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import (
-    TAG_KEY_STATIC_ID,
+    TAG_KEY_CUSTOM_ID,
     connect_api_gateway_to_sqs,
     gateway_request_url,
     get_resource_for_path,
@@ -112,11 +112,11 @@ class TestAPIGateway(unittest.TestCase):
     }
     TEST_API_GATEWAY_AUTHORIZER_OPS = [{"op": "replace", "path": "/name", "value": "test1"}]
 
-    def test_create_rest_api_with_static_id(self):
+    def test_create_rest_api_with_custom_id(self):
         client = aws_stack.connect_to_service("apigateway")
         apigw_name = "gw-%s" % short_uid()
         test_id = "testId123"
-        result = client.create_rest_api(name=apigw_name, tags={TAG_KEY_STATIC_ID: test_id})
+        result = client.create_rest_api(name=apigw_name, tags={TAG_KEY_CUSTOM_ID: test_id})
         self.assertEqual(test_id, result["id"])
         self.assertEqual(apigw_name, result["name"])
         result = client.get_rest_api(restApiId=test_id)


### PR DESCRIPTION
Add ability to specify custom IDs for API GW REST APIs via tags. This has been requested by some of our users, to simplify the dev&test loop if the API resources are frequently re-deployed.