### PR TITLE
Rework docker usage in LocalStack to make use of the docker client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p localstack/utils/kinesis/ && mkdir -p localstack/services/ && \
 ADD localstack/constants.py localstack/config.py localstack/
 ADD localstack/services/install.py localstack/services/
 ADD localstack/services/cloudformation/deployment_utils.py localstack/services/cloudformation/deployment_utils.py
-ADD localstack/utils/common.py localstack/utils/bootstrap.py localstack/utils/docker.py localstack/utils/
+ADD localstack/utils/common.py localstack/utils/bootstrap.py localstack/utils/docker.py localstack/utils/run.py localstack/utils/
 ADD localstack/utils/aws/ localstack/utils/aws/
 ADD localstack/utils/kinesis/ localstack/utils/kinesis/
 ADD localstack/utils/analytics/ localstack/utils/analytics/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir -p localstack/utils/kinesis/ && mkdir -p localstack/services/ && \
 ADD localstack/constants.py localstack/config.py localstack/
 ADD localstack/services/install.py localstack/services/
 ADD localstack/services/cloudformation/deployment_utils.py localstack/services/cloudformation/deployment_utils.py
-ADD localstack/utils/common.py localstack/utils/bootstrap.py localstack/utils/
+ADD localstack/utils/common.py localstack/utils/bootstrap.py localstack/utils/docker.py localstack/utils/
 ADD localstack/utils/aws/ localstack/utils/aws/
 ADD localstack/utils/kinesis/ localstack/utils/kinesis/
 ADD localstack/utils/analytics/ localstack/utils/analytics/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
+      - HOST_TMP_FOLDER=${TMPDIR:-/tmp/localstack}
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,17 +11,15 @@ services:
       - "127.0.0.1:443:443"
       - "127.0.0.1:4566:4566"
       - "127.0.0.1:4571:4571"
-      - "127.0.0.1:${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
     environment:
       - SERVICES=${SERVICES- }
       - DEBUG=${DEBUG- }
       - DATA_DIR=${DATA_DIR- }
-      - PORT_WEB_UI=${PORT_WEB_UI- }
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR:-/tmp/localstack}
+      - HOST_TMP_FOLDER=${TMPDIR}
     volumes:
       - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -18,7 +18,6 @@ from localstack.constants import (
     DEFAULT_DEVELOP_PORT,
     DEFAULT_LAMBDA_CONTAINER_REGISTRY,
     DEFAULT_PORT_EDGE,
-    DEFAULT_PORT_WEB_UI,
     DEFAULT_SERVICE_PORTS,
     FALSE_STRINGS,
     LOCALHOST,
@@ -181,9 +180,6 @@ DOCKER_FLAGS = os.environ.get("DOCKER_FLAGS", "").strip()
 # command used to run Docker containers (e.g., set to "sudo docker" to run as sudo)
 DOCKER_CMD = os.environ.get("DOCKER_CMD", "").strip() or "docker"
 
-# whether to start the web API
-START_WEB = os.environ.get("START_WEB", "").strip() in TRUE_STRINGS
-
 # whether to forward edge requests in-memory (instead of via proxy servers listening on backend ports)
 # TODO: this will likely become the default and may get removed in the future
 FORWARD_EDGE_INMEM = True
@@ -193,10 +189,6 @@ EDGE_BIND_HOST = os.environ.get("EDGE_BIND_HOST", "").strip() or "127.0.0.1"
 EDGE_PORT = int(os.environ.get("EDGE_PORT") or 0) or DEFAULT_PORT_EDGE
 # fallback port for non-SSL HTTP edge service (in case HTTPS edge service cannot be used)
 EDGE_PORT_HTTP = int(os.environ.get("EDGE_PORT_HTTP") or 0)
-
-# port of Web UI
-PORT_WEB_UI = int(os.environ.get("PORT_WEB_UI", "").strip() or DEFAULT_PORT_WEB_UI)
-PORT_WEB_UI_SSL = PORT_WEB_UI + 1
 
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
@@ -296,10 +288,8 @@ CONFIG_ENV_VARS = [
     "DEBUG",
     "KINESIS_ERROR_PROBABILITY",
     "DYNAMODB_ERROR_PROBABILITY",
-    "PORT_WEB_UI",
     "DYNAMODB_READ_ERROR_PROBABILITY",
     "DYNAMODB_WRITE_ERROR_PROBABILITY",
-    "START_WEB",
     "DOCKER_BRIDGE_IP",
     "DEFAULT_REGION",
     "LAMBDA_JAVA_OPTS",

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -19,7 +19,6 @@ HEADER_AMZN_ERROR_TYPE = "X-Amzn-Errortype"
 
 # backend service ports, for services that are behind a proxy (counting down from 4566)
 DEFAULT_PORT_EDGE = 4566
-DEFAULT_PORT_WEB_UI = 8080
 
 # host name for localhost
 LOCALHOST = "localhost"

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -36,7 +36,6 @@ from localstack.utils.aws import aws_responses, aws_stack
 from localstack.utils.aws.aws_models import CodeSigningConfig, LambdaFunction
 from localstack.utils.common import (
     TMP_FILES,
-    FuncThread,
     ensure_readable,
     first_char_to_lower,
     is_zip_file,
@@ -62,6 +61,7 @@ from localstack.utils.common import (
 )
 from localstack.utils.docker import DOCKER_CLIENT
 from localstack.utils.http_utils import parse_chunked_data
+from localstack.utils.run import FuncThread
 
 # logger
 LOG = logging.getLogger(__name__)

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -13,7 +13,6 @@ import traceback
 from multiprocessing import Process, Queue
 from typing import Dict, Tuple, Union
 
-import localstack.utils.docker
 from localstack import config
 from localstack.constants import (
     THUNDRA_APIKEY,
@@ -49,7 +48,7 @@ from localstack.utils.common import (
     to_bytes,
     to_str,
 )
-from localstack.utils.docker import DOCKER_CLIENT, ContainerException
+from localstack.utils.docker import DOCKER_CLIENT, ContainerException, PortMappings
 from localstack.utils.run import FuncThread
 
 # constants
@@ -829,7 +828,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
 
         additional_flags = docker_flags or ""
         dns = config.LAMBDA_DOCKER_DNS
-        docker_java_ports = localstack.utils.docker.PortMappings()
+        docker_java_ports = PortMappings()
         if Util.debug_java_port:
             docker_java_ports.add(Util.debug_java_port)
         docker_image = Util.docker_image_for_lambda(func_details)

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -13,7 +13,6 @@ from localstack import config
 from localstack.constants import (
     HEADER_LOCALSTACK_EDGE_URL,
     HEADER_LOCALSTACK_REQUEST_URL,
-    HEADER_LOCALSTACK_TARGET,
     LOCALHOST,
     LOCALHOST_IP,
     LOCALSTACK_ROOT_FOLDER,
@@ -284,7 +283,6 @@ def get_api_from_headers(headers, method=None, path=None, data=None):
     if not auth_header and "." not in host:
         return result[0], result[1], path, host
 
-    ls_target = headers.get(HEADER_LOCALSTACK_TARGET, "")
     path = path or "/"
 
     # https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
@@ -324,8 +322,6 @@ def get_api_from_headers(headers, method=None, path=None, data=None):
     elif target.startswith("DynamoDBStreams") or host.startswith("streams.dynamodb."):
         # Note: DDB streams requests use ../dynamodb/.. auth header, hence we also need to update result_before
         result = result_before = "dynamodbstreams", config.PORT_DYNAMODBSTREAMS
-    elif ls_target == "web":
-        result = "web", config.PORT_WEB_UI
     elif result[0] == "EventBridge" or target.startswith("AWSEvents"):
         result = "events", config.PORT_EVENTS
     elif target.startswith("ResourceGroupsTaggingAPI_"):

--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -3,7 +3,8 @@ import time
 
 from crontab import CronTab
 
-from localstack.utils.common import FuncThread, short_uid
+from localstack.utils.common import short_uid
+from localstack.utils.run import FuncThread
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -79,10 +79,6 @@ ALLOWED_CORS_RESPONSE_HEADERS = [
 ALLOWED_CORS_ORIGINS = [
     "https://app.localstack.cloud",
     "http://app.localstack.cloud",
-    f"http://localhost:{config.PORT_WEB_UI}",
-    f"https://localhost:{config.PORT_WEB_UI_SSL}",
-    f"http://127.0.0.1:{config.PORT_WEB_UI}",
-    f"https://127.0.0.1:{config.PORT_WEB_UI_SSL}",
     f"https://localhost:{config.EDGE_PORT}",
     f"http://localhost:{config.EDGE_PORT}",
     f"https://localhost.localstack.cloud:{config.EDGE_PORT}",

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import tempfile
 import time
+from pathlib import Path
 
 import requests
 
@@ -33,6 +34,7 @@ from localstack.constants import (
     THUNDRA_JAVA_AGENT_VERSION,
 )
 from localstack.utils import bootstrap
+from localstack.utils.docker import DOCKER_CLIENT
 
 if __name__ == "__main__":
     bootstrap.bootstrap_installation()
@@ -296,20 +298,24 @@ def install_stepfunctions_local():
         # TODO: works only when running on the host, outside of Docker -> add a fallback if running in Docker?
         log_install_msg("Step Functions")
         mkdir(INSTALL_DIR_STEPFUNCTIONS)
-        run("{dc} pull {img}".format(dc=config.DOCKER_CMD, img=IMAGE_NAME_SFN_LOCAL))
+        DOCKER_CLIENT.pull_image(IMAGE_NAME_SFN_LOCAL)
         docker_name = "tmp-ls-sfn"
-        run(
-            ("{dc} run --name={dn} --entrypoint= -d --rm {img} sleep 15").format(
-                dc=config.DOCKER_CMD, dn=docker_name, img=IMAGE_NAME_SFN_LOCAL
-            )
+        DOCKER_CLIENT.run_container(
+            IMAGE_NAME_SFN_LOCAL,
+            remove=True,
+            entrypoint="",
+            name=docker_name,
+            detach=True,
+            command=["sleep", "15"],
         )
         time.sleep(5)
-        run(
-            "{dc} cp {dn}:/home/stepfunctionslocal/ {tgt}".format(
-                dc=config.DOCKER_CMD, dn=docker_name, tgt=INSTALL_DIR_INFRA
-            )
+        DOCKER_CLIENT.copy_from_container(
+            docker_name, local_path=INSTALL_DIR_INFRA, container_path="/home/stepfunctionslocal/"
         )
-        run("mv %s/stepfunctionslocal/*.jar %s" % (INSTALL_DIR_INFRA, INSTALL_DIR_STEPFUNCTIONS))
+
+        path = Path(f"{INSTALL_DIR_INFRA}/stepfunctionslocal/")
+        for file in path.glob("*.jar"):
+            file.rename(f"{INSTALL_DIR_STEPFUNCTIONS}/{file.name}")
         rm_rf("%s/stepfunctionslocal" % INSTALL_DIR_INFRA)
     # apply patches
     patch_class_file = os.path.join(INSTALL_DIR_STEPFUNCTIONS, SFN_PATCH_CLASS)

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -315,7 +315,7 @@ def install_stepfunctions_local():
 
         path = Path(f"{INSTALL_DIR_INFRA}/stepfunctionslocal/")
         for file in path.glob("*.jar"):
-            file.rename(f"{INSTALL_DIR_STEPFUNCTIONS}/{file.name}")
+            file.rename(Path(INSTALL_DIR_STEPFUNCTIONS) / file.name)
         rm_rf("%s/stepfunctionslocal" % INSTALL_DIR_INFRA)
     # apply patches
     patch_class_file = os.path.join(INSTALL_DIR_STEPFUNCTIONS, SFN_PATCH_CLASS)

--- a/localstack/utils/analytics/event_publisher.py
+++ b/localstack/utils/analytics/event_publisher.py
@@ -6,9 +6,10 @@ from six.moves import queue
 
 from localstack import config
 from localstack.constants import API_ENDPOINT
-from localstack.utils.common import FuncThread, JsonObject, get_or_create_file
+from localstack.utils.common import JsonObject, get_or_create_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import save_file, short_uid, timestamp
+from localstack.utils.run import FuncThread
 
 PROCESS_ID = short_uid()
 MACHINE_ID = None

--- a/localstack/utils/async_utils.py
+++ b/localstack/utils/async_utils.py
@@ -5,7 +5,8 @@ import time
 from contextvars import copy_context
 
 from localstack.utils import common
-from localstack.utils.common import TMP_THREADS, FuncThread, start_worker_thread
+from localstack.utils.common import TMP_THREADS, start_worker_thread
+from localstack.utils.run import FuncThread
 
 # reference to named event loop instances
 EVENT_LOOPS = {}

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -1,28 +1,25 @@
-import inspect
 import json
 import logging
 import os
 import pkgutil
 import re
-import select
 import shutil
-import subprocess
 import sys
 import threading
 import time
-import traceback
 import warnings
-from concurrent.futures._base import Future
 from datetime import datetime
-from typing import List, Union
 
 import pip as pip_mod
 import six
 
 from localstack import config, constants
 from localstack.utils.analytics.profiler import log_duration
+from localstack.utils.docker import DOCKER_CLIENT, PortMappings
 
 # set up logger
+from localstack.utils.run import run, to_str
+
 LOG = logging.getLogger(os.path.basename(__file__))
 
 # maps plugin scope ("services", "commands") to flags which indicate whether plugins have been loaded
@@ -212,11 +209,6 @@ def load_plugins(scope=None):
     return result
 
 
-def docker_container_running(container_name):
-    container_names = get_docker_container_names()
-    return container_name in container_names
-
-
 def get_docker_image_details(image_name=None):
     image_name = image_name or get_docker_image_to_start()
     try:
@@ -234,17 +226,6 @@ def get_docker_image_details(image_name=None):
         "created": result["Created"].split(".")[0],
     }
     return result
-
-
-def get_docker_container_names():
-    cmd = "%s ps --format '{{.Names}}'" % config.DOCKER_CMD
-    try:
-        output = to_str(run(cmd))
-        container_names = re.split(r"\s+", output.strip().replace("\n", " "))
-        return container_names
-    except Exception as e:
-        LOG.info('Unable to list Docker containers via "%s": %s' % (cmd, e))
-        return []
 
 
 def get_main_container_ip():
@@ -514,85 +495,6 @@ def validate_localstack_config(name):
     return False
 
 
-class PortMappings(object):
-    """Maps source to target port ranges for Docker port mappings."""
-
-    class HashableList(list):
-        def __hash__(self):
-            result = 0
-            for i in self:
-                result += hash(i)
-            return result
-
-    def __init__(self, bind_host=None):
-        self.bind_host = bind_host if bind_host else ""
-        self.mappings = {}
-
-    def add(self, port, mapped=None, protocol="tcp"):
-        mapped = mapped or port
-        if isinstance(port, list):
-            for i in range(port[1] - port[0] + 1):
-                self.add(port[0] + i, mapped[0] + i)
-            return
-        if port is None or int(port) <= 0:
-            raise Exception("Unable to add mapping for invalid port: %s" % port)
-        if self.contains(port):
-            return
-        for from_range, to_range in self.mappings.items():
-            if not self.in_expanded_range(port, from_range):
-                continue
-            if not self.in_expanded_range(mapped, to_range):
-                continue
-            self.expand_range(port, from_range)
-            self.expand_range(mapped, to_range)
-            return
-        protocol = str(protocol or "tcp").lower()
-        self.mappings[self.HashableList([port, port, protocol])] = [mapped, mapped]
-
-    def to_str(self) -> str:  # TODO test (and/or remove?)
-        bind_address = f"{self.bind_host}:" if self.bind_host else ""
-
-        def entry(k, v):
-            protocol = "/%s" % k[2] if k[2] != "tcp" else ""
-            if k[0] == k[1] and v[0] == v[1]:
-                return "-p %s%s:%s%s" % (bind_address, k[0], v[0], protocol)
-            return "-p %s%s-%s:%s-%s%s" % (bind_address, k[0], k[1], v[0], v[1], protocol)
-
-        return " ".join([entry(k, v) for k, v in self.mappings.items()])
-
-    def to_list(self) -> List[str]:  # TODO test
-        bind_address = f"{self.bind_host}:" if self.bind_host else ""
-
-        def entry(k, v):
-            protocol = "/%s" % k[2] if k[2] != "tcp" else ""
-            if k[0] == k[1] and v[0] == v[1]:
-                return ["-p", f"{bind_address}{k[0]}:{v[0]}{protocol}"]
-            return ["-p", f"{bind_address}{k[0]}-{k[1]}:{v[0]}-{v[1]}{protocol}"]
-
-        return [item for k, v in self.mappings.items() for item in entry(k, v)]
-
-    def contains(self, port):
-        for from_range, to_range in self.mappings.items():
-            if self.in_range(port, from_range):
-                return True
-
-    def in_range(self, port, range):
-        return port >= range[0] and port <= range[1]
-
-    def in_expanded_range(self, port, range):
-        return port >= range[0] - 1 and port <= range[1] + 1
-
-    def expand_range(self, port, range):
-        if self.in_range(port, range):
-            return
-        if port == range[0] - 1:
-            range[0] = port
-        elif port == range[1] + 1:
-            range[1] = port
-        else:
-            raise Exception("Unable to add port %s to existing range %s" % (port, range))
-
-
 def get_docker_image_to_start():
     image_name = os.environ.get("IMAGE_NAME")
     if not image_name:
@@ -621,7 +523,7 @@ def start_infra_in_docker():
 
     container_name = config.MAIN_CONTAINER_NAME
 
-    if docker_container_running(container_name):
+    if DOCKER_CLIENT.is_container_running(container_name):
         raise Exception('LocalStack container named "%s" is already running' % container_name)
 
     os.environ[ENV_SCRIPT_STARTING_DOCKER] = "1"
@@ -734,7 +636,7 @@ def start_infra_in_docker():
     if DO_CHMOD_DOCKER_SOCK:
         # fix permissions on /var/run/docker.sock
         for i in range(0, 100):
-            if docker_container_running(container_name):
+            if DOCKER_CLIENT.is_container_running(container_name):
                 break
             time.sleep(2)
         run(
@@ -756,157 +658,12 @@ def now_utc():
     return (datetime.utcnow() - epoch).total_seconds()
 
 
-def to_str(obj, errors="strict"):
-    return obj.decode("utf-8", errors) if isinstance(obj, six.binary_type) else obj
-
-
 def in_ci():
     """Whether or not we are running in a CI environment"""
     for key in ("CI", "TRAVIS"):
         if os.environ.get(key, "") not in [False, "", "0", "false"]:
             return True
     return False
-
-
-class FuncThread(threading.Thread):
-    """Helper class to run a Python function in a background thread."""
-
-    def __init__(self, func, params=None, quiet=False):
-        threading.Thread.__init__(self)
-        self.daemon = True
-        self.params = params
-        self.func = func
-        self.quiet = quiet
-        self.result_future = Future()
-        self._stop_event = threading.Event()
-
-    def run(self):
-        result = None
-        try:
-            kwargs = {}
-            argspec = inspect.getfullargspec(self.func)
-            if argspec.varkw or "_thread" in (argspec.args or []) + (argspec.kwonlyargs or []):
-                kwargs["_thread"] = self
-            result = self.func(self.params, **kwargs)
-        except Exception as e:
-            self.result_future.set_exception(e)
-            result = e
-            if not self.quiet:
-                LOG.info(
-                    "Thread run method %s(%s) failed: %s %s"
-                    % (self.func, self.params, e, traceback.format_exc())
-                )
-        finally:
-            try:
-                self.result_future.set_result(result)
-            except Exception:
-                # this can happen as InvalidStateError on shutdown, if the task is already canceled
-                pass
-
-    @property
-    def running(self):
-        return not self._stop_event.is_set()
-
-    def stop(self, quiet=False):
-        self._stop_event.set()
-
-
-def run(
-    cmd: Union[str, List[str]],
-    print_error=True,
-    asynchronous=False,
-    stdin=False,
-    stderr=subprocess.STDOUT,
-    outfile=None,
-    env_vars=None,
-    inherit_cwd=False,
-    inherit_env=True,
-    tty=False,
-    shell=True,
-):
-    LOG.debug("Executing command: %s", cmd)
-    env_dict = os.environ.copy() if inherit_env else {}
-    if env_vars:
-        env_dict.update(env_vars)
-    env_dict = dict([(k, to_str(str(v))) for k, v in env_dict.items()])
-
-    if tty:
-        asynchronous = True
-        stdin = True
-
-    try:
-        cwd = os.getcwd() if inherit_cwd else None
-        if not asynchronous:
-            if stdin:
-                return subprocess.check_output(
-                    cmd, shell=shell, stderr=stderr, env=env_dict, stdin=subprocess.PIPE, cwd=cwd
-                )
-            output = subprocess.check_output(cmd, shell=shell, stderr=stderr, env=env_dict, cwd=cwd)
-            return output.decode(config.DEFAULT_ENCODING)
-
-        stdin_arg = subprocess.PIPE if stdin else None
-        stdout_arg = open(outfile, "ab") if isinstance(outfile, six.string_types) else outfile
-        stderr_arg = stderr
-        if tty:
-            # Note: leave the "pty" import here (not supported in Windows)
-            import pty
-
-            master_fd, slave_fd = pty.openpty()
-            stdin_arg = slave_fd
-            stdout_arg = stderr_arg = None
-
-        # start the actual sub process
-        kwargs = {}
-        if is_linux() or is_mac_os():
-            kwargs["start_new_session"] = True
-        process = subprocess.Popen(
-            cmd,
-            shell=shell,
-            stdin=stdin_arg,
-            bufsize=-1,
-            stderr=stderr_arg,
-            stdout=stdout_arg,
-            env=env_dict,
-            cwd=cwd,
-            **kwargs,
-        )
-
-        if tty:
-            # based on: https://stackoverflow.com/questions/41542960
-            def pipe_streams(*args):
-                while process.poll() is None:
-                    r, w, e = select.select([sys.stdin, master_fd], [], [])
-                    if sys.stdin in r:
-                        d = os.read(sys.stdin.fileno(), 10240)
-                        os.write(master_fd, d)
-                    elif master_fd in r:
-                        o = os.read(master_fd, 10240)
-                        if o:
-                            os.write(sys.stdout.fileno(), o)
-
-            FuncThread(pipe_streams).start()
-
-        return process
-    except subprocess.CalledProcessError as e:
-        if print_error:
-            print("ERROR: '%s': exit code %s; output: %s" % (cmd, e.returncode, e.output))
-            sys.stdout.flush()
-        raise e
-
-
-def is_mac_os():
-    return "Darwin" in get_uname()
-
-
-def is_linux():
-    return "Linux" in get_uname()
-
-
-def get_uname():
-    try:
-        return to_str(subprocess.check_output("uname -a", shell=True))
-    except Exception:
-        return ""
 
 
 def mkdir(folder):

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -18,7 +18,7 @@ from localstack.utils.analytics.profiler import log_duration
 from localstack.utils.docker import DOCKER_CLIENT, ContainerException, PortMappings
 
 # set up logger
-from localstack.utils.run import run
+from localstack.utils.run import run, to_str
 
 LOG = logging.getLogger(os.path.basename(__file__))
 
@@ -257,7 +257,7 @@ def get_server_version():
         version, _ = DOCKER_CLIENT.exec_in_container(
             container_name, interactive=True, command=["bin/localstack", "--version"]
         )
-        version = version.decode(config.DEFAULT_ENCODING).strip().splitlines()[-1]
+        version = to_str(version).strip().splitlines()[-1]
         return version
     except ContainerException:
         try:
@@ -270,7 +270,7 @@ def get_server_version():
                 entrypoint="",
                 command=["bin/localstack", "--version"],
             )
-            version = version.decode(config.DEFAULT_ENCODING).strip().splitlines()[-1]
+            version = to_str(version).strip().splitlines()[-1]
             return version
         except ContainerException:
             # fall back to default constant

--- a/localstack/utils/cli.py
+++ b/localstack/utils/cli.py
@@ -25,18 +25,18 @@ from docopt import docopt
 from localstack import config, constants
 from localstack.utils import bootstrap
 from localstack.utils.bootstrap import (
-    docker_container_running,
     get_docker_image_details,
     get_main_container_id,
     get_main_container_ip,
     get_main_container_name,
     get_server_version,
-    run,
     setup_logging,
     start_infra_in_docker,
     start_infra_locally,
     validate_localstack_config,
 )
+from localstack.utils.docker import DOCKER_CLIENT
+from localstack.utils.run import run
 
 # Note: make sure we don't have other imports at the root level here
 
@@ -103,7 +103,7 @@ def cmd_ssh(argv, args):
     Options:
     """
     args.update(docopt(cmd_ssh.__doc__.strip(), argv=argv))
-    if not docker_container_running(config.MAIN_CONTAINER_NAME):
+    if not DOCKER_CLIENT.is_container_running(config.MAIN_CONTAINER_NAME):
         raise Exception(
             'Expected 1 running "%s" container, but found none' % config.MAIN_CONTAINER_NAME
         )
@@ -128,7 +128,7 @@ def print_status():
     img = get_docker_image_details()
     print("Docker image:\t\tTag %s, ID %s, Created %s" % (img["tag"], img["id"], img["created"]))
     cont_name = config.MAIN_CONTAINER_NAME
-    running = docker_container_running(cont_name)
+    running = DOCKER_CLIENT.is_container_running(cont_name)
     cont_status = "stopped"
     if running:
         cont_status = 'running (name: "%s", IP: %s)' % (

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -32,11 +32,11 @@ import dns.resolver
 import requests
 import six
 
+import localstack.utils.run
 from localstack import config
 from localstack.config import DEFAULT_ENCODING
 from localstack.constants import ENV_DEV
-from localstack.utils import bootstrap
-from localstack.utils.bootstrap import FuncThread
+from localstack.utils.run import FuncThread
 
 # arrays for temporary files and resources
 TMP_FILES = []
@@ -501,47 +501,6 @@ def is_list_or_tuple(obj):
 
 def in_docker():
     return config.in_docker()
-
-
-def has_docker():
-    try:
-        run("docker ps")
-        return True
-    except Exception:
-        return False
-
-
-def get_docker_container_names():
-    return bootstrap.get_docker_container_names()
-
-
-def get_docker_image_names(strip_latest=True):
-    cmd = "%s images --format '{{.Repository}}:{{.Tag}}'" % config.DOCKER_CMD
-    try:
-        output = to_str(run(cmd))
-        image_names = re.split(r"\s+", output.strip().replace("\n", " "))
-        if strip_latest:
-            suffix = ":latest"
-            for image in list(image_names):
-                if image.endswith(suffix):
-                    image_names.append(image[: -len(suffix)])
-        return image_names
-    except Exception as e:
-        LOG.info('Unable to list Docker images via "%s": %s' % (cmd, e))
-        return []
-
-
-def rm_docker_container(container_name_or_id, check_existence=False, safe=False):
-    if not container_name_or_id:
-        return
-    if check_existence and container_name_or_id not in get_docker_container_names():
-        # TODO: check names as well as container IDs!
-        return
-    try:
-        run("%s rm -f %s" % (config.DOCKER_CMD, container_name_or_id), print_error=False)
-    except Exception:
-        if not safe:
-            raise
 
 
 def path_from_url(url):
@@ -1017,11 +976,11 @@ def is_number(s):
 
 
 def is_mac_os():
-    return bootstrap.is_mac_os()
+    return localstack.utils.run.is_mac_os()
 
 
 def is_linux():
-    return bootstrap.is_linux()
+    return localstack.utils.run.is_linux()
 
 
 def is_windows():
@@ -1608,14 +1567,14 @@ def do_run(cmd: str, run_cmd: Callable, cache_duration_secs: int):
 
 def run(cmd, cache_duration_secs=0, **kwargs):
     def run_cmd():
-        return bootstrap.run(cmd, **kwargs)
+        return localstack.utils.run.run(cmd, **kwargs)
 
     return do_run(cmd, run_cmd, cache_duration_secs)
 
 
 def safe_run(cmd: List[str], cache_duration_secs=0, **kwargs) -> Union[str, subprocess.Popen]:
     def run_cmd():
-        return bootstrap.run(cmd, shell=False, **kwargs)
+        return localstack.utils.run.run(cmd, shell=False, **kwargs)
 
     return do_run(" ".join(cmd), run_cmd, cache_duration_secs)
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1287,7 +1287,7 @@ def cleanup_tmp_files():
     del TMP_FILES[:]
 
 
-def new_tmp_file():
+def new_tmp_file() -> str:
     """Return a path to a new temporary file."""
     tmp_file, tmp_path = tempfile.mkstemp()
     os.close(tmp_file)

--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -6,7 +6,6 @@ from enum import Enum, unique
 from typing import Dict, List, Optional, Tuple, Union
 
 from localstack import config
-from localstack.utils.bootstrap import PortMappings
 from localstack.utils.common import TMP_FILES, rm_rf, safe_run, save_file, short_uid
 
 LOG = logging.getLogger(__name__)
@@ -38,6 +37,85 @@ class NoSuchImage(ContainerException):
         message = message or f"Docker image {image_name} not found"
         super().__init__(message, stdout, stderr)
         self.image_name = image_name
+
+
+class PortMappings(object):
+    """Maps source to target port ranges for Docker port mappings."""
+
+    class HashableList(list):
+        def __hash__(self):
+            result = 0
+            for i in self:
+                result += hash(i)
+            return result
+
+    def __init__(self, bind_host=None):
+        self.bind_host = bind_host if bind_host else ""
+        self.mappings = {}
+
+    def add(self, port, mapped=None, protocol="tcp"):
+        mapped = mapped or port
+        if isinstance(port, list):
+            for i in range(port[1] - port[0] + 1):
+                self.add(port[0] + i, mapped[0] + i)
+            return
+        if port is None or int(port) <= 0:
+            raise Exception("Unable to add mapping for invalid port: %s" % port)
+        if self.contains(port):
+            return
+        for from_range, to_range in self.mappings.items():
+            if not self.in_expanded_range(port, from_range):
+                continue
+            if not self.in_expanded_range(mapped, to_range):
+                continue
+            self.expand_range(port, from_range)
+            self.expand_range(mapped, to_range)
+            return
+        protocol = str(protocol or "tcp").lower()
+        self.mappings[self.HashableList([port, port, protocol])] = [mapped, mapped]
+
+    def to_str(self) -> str:  # TODO test (and/or remove?)
+        bind_address = f"{self.bind_host}:" if self.bind_host else ""
+
+        def entry(k, v):
+            protocol = "/%s" % k[2] if k[2] != "tcp" else ""
+            if k[0] == k[1] and v[0] == v[1]:
+                return "-p %s%s:%s%s" % (bind_address, k[0], v[0], protocol)
+            return "-p %s%s-%s:%s-%s%s" % (bind_address, k[0], k[1], v[0], v[1], protocol)
+
+        return " ".join([entry(k, v) for k, v in self.mappings.items()])
+
+    def to_list(self) -> List[str]:  # TODO test
+        bind_address = f"{self.bind_host}:" if self.bind_host else ""
+
+        def entry(k, v):
+            protocol = "/%s" % k[2] if k[2] != "tcp" else ""
+            if k[0] == k[1] and v[0] == v[1]:
+                return ["-p", f"{bind_address}{k[0]}:{v[0]}{protocol}"]
+            return ["-p", f"{bind_address}{k[0]}-{k[1]}:{v[0]}-{v[1]}{protocol}"]
+
+        return [item for k, v in self.mappings.items() for item in entry(k, v)]
+
+    def contains(self, port):
+        for from_range, to_range in self.mappings.items():
+            if self.in_range(port, from_range):
+                return True
+
+    def in_range(self, port, range):
+        return port >= range[0] and port <= range[1]
+
+    def in_expanded_range(self, port, range):
+        return port >= range[0] - 1 and port <= range[1] + 1
+
+    def expand_range(self, port, range):
+        if self.in_range(port, range):
+            return
+        if port == range[0] - 1:
+            range[0] = port
+        elif port == range[1] + 1:
+            range[1] = port
+        else:
+            raise Exception("Unable to add port %s to existing range %s" % (port, range))
 
 
 class CmdDockerClient:
@@ -109,8 +187,10 @@ class CmdDockerClient:
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
                 )
 
-    def remove_container(self, container_name: str, force=True) -> None:
+    def remove_container(self, container_name: str, force=True, check_existence=False) -> None:
         """Removes container with given name"""
+        if check_existence and container_name not in self.get_running_container_names():
+            return
         cmd = self._docker_cmd() + ["rm"]
         if force:
             cmd.append("-f")
@@ -126,14 +206,16 @@ class CmdDockerClient:
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
                 )
 
-    def list_containers(self, filter: Union[List[str], str, None] = None) -> List[dict]:
+    def list_containers(self, filter: Union[List[str], str, None] = None, all=True) -> List[dict]:
         """List all containers matching the given filters
 
         Returns a list of dicts with keys id, image, name, labels, status
         """
         filter = [filter] if isinstance(filter, str) else filter
         cmd = self._docker_cmd()
-        cmd += ["ps", "-a"]
+        cmd.append("ps")
+        if all:
+            cmd.append("-a")
         options = []
         if filter:
             options += [y for filter_item in filter for y in ["--filter", filter_item]]
@@ -153,6 +235,16 @@ class CmdDockerClient:
         if cmd_result:
             container_list = [json.loads(line) for line in cmd_result.splitlines()]
         return container_list
+
+    def get_running_container_names(self):
+        """Returns a list of the names of all running containers"""
+        result = self.list_containers(all=False)
+        result = list(map(lambda container: container["name"], result))
+        return result
+
+    def is_container_running(self, container_name: str):
+        """Checks whether a container with a given name is currently running"""
+        return container_name in self.get_running_container_names()
 
     def copy_into_container(
         self, container_name: str, local_path: str, container_path: str
@@ -211,6 +303,7 @@ class CmdDockerClient:
         return entry_point
 
     def pull_image(self, docker_image: str) -> None:
+        """Pulls a image with a given name from a docker registry"""
         cmd = self._docker_cmd()
         cmd += ["pull", docker_image]
         LOG.debug("Pulling image with cmd: %s", cmd)
@@ -221,7 +314,25 @@ class CmdDockerClient:
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
             )
 
+    def get_docker_image_names(self, strip_latest=True):
+        cmd = self._docker_cmd()
+        cmd += ["images", "--format", "{{.Repository}}:{{.Tag}}"]
+        try:
+            output = safe_run(cmd)
+
+            image_names = output.splitlines()
+            if strip_latest:
+                suffix = ":latest"
+                for image in list(image_names):
+                    if image.endswith(suffix):
+                        image_names.append(image[: -len(suffix)])
+            return image_names
+        except Exception as e:
+            LOG.info('Unable to list Docker images via "%s": %s' % (cmd, e))
+            return []
+
     def get_container_logs(self, container_name_or_id: str, safe=False) -> str:
+        """Get all logs of a given container"""
         cmd = self._docker_cmd()
         cmd += ["logs", container_name_or_id]
         try:
@@ -261,7 +372,7 @@ class CmdDockerClient:
         finally:
             Util.rm_env_vars_file(env_file)
 
-    def run_container(self, image_name: str, stdin=None, **kwargs) -> Tuple[str, str]:
+    def run_container(self, image_name: str, stdin=None, **kwargs) -> Tuple[bytes, bytes]:
         cmd, env_file = self._build_run_create_cmd("run", image_name, **kwargs)
         LOG.debug("Run container with cmd: %s", cmd)
         result = self._run_async_cmd(cmd, stdin, kwargs.get("name") or "", image_name)
@@ -274,8 +385,8 @@ class CmdDockerClient:
         command: Union[List[str], str],
         interactive=False,
         detach=False,
-        env_vars: Optional[List[Tuple[str, str]]] = None,
-        stdin: Optional[str] = None,
+        env_vars: Optional[Dict[str, str]] = None,
+        stdin: Optional[bytes] = None,
     ) -> Tuple[bytes, bytes]:
         env_file = None
         cmd = self._docker_cmd()
@@ -409,9 +520,9 @@ class Util:
     MAX_ENV_ARGS_LENGTH = 20000
 
     @classmethod
-    def create_env_vars_file_flag(cls, env_vars: Dict) -> Tuple[List[str], str]:
+    def create_env_vars_file_flag(cls, env_vars: Dict) -> Tuple[List[str], Optional[str]]:
         if not env_vars:
-            return []
+            return [], None
         result = []
         env_vars = dict(env_vars)
         env_file = None

--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -282,9 +282,10 @@ class CmdDockerClient:
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
             )
 
-    def get_docker_image_names(self, strip_latest=True):
+    def get_docker_image_names(self, strip_latest=True, include_tags=True):
+        format_string = "{{.Repository}}:{{.Tag}}" if include_tags else "{{.Repository}}"
         cmd = self._docker_cmd()
-        cmd += ["images", "--format", "{{.Repository}}:{{.Tag}}"]
+        cmd += ["images", "--format", format_string]
         try:
             output = safe_run(cmd)
 

--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -308,7 +308,7 @@ class CmdDockerClient:
         try:
             return safe_run(cmd)
         except subprocess.CalledProcessError as e:
-            if not safe:
+            if safe:
                 return ""
             if "No such container" in e.stdout.decode(config.DEFAULT_ENCODING):
                 raise NoSuchContainer(container_name_or_id, stdout=e.stdout, stderr=e.stderr)

--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shlex
 import subprocess
 from enum import Enum, unique
 from typing import Dict, List, Optional, Tuple, Union
@@ -549,7 +550,7 @@ class CmdDockerClient:
         if dns:
             cmd += ["--dns", dns]
         if additional_flags:
-            cmd += additional_flags.split()
+            cmd += shlex.split(additional_flags)
         cmd.append(image_name)
         if command:
             cmd += command if isinstance(command, List) else [command]

--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -262,6 +262,14 @@ class CmdDockerClient:
         LOG.debug("Copying into container with cmd: %s", cmd)
         safe_run(cmd)
 
+    def copy_from_container(
+        self, container_name: str, local_path: str, container_path: str
+    ) -> None:
+        cmd = self._docker_cmd()
+        cmd += ["cp", f"{container_name}:{container_path}", local_path]
+        LOG.debug("Copying from container with cmd: %s", cmd)
+        safe_run(cmd)
+
     def pull_image(self, docker_image: str) -> None:
         """Pulls a image with a given name from a docker registry"""
         cmd = self._docker_cmd()
@@ -494,6 +502,7 @@ class CmdDockerClient:
         entrypoint: Optional[str] = None,
         remove: bool = False,
         interactive: bool = False,
+        tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
         mount_volumes: Optional[List[Tuple[str, str]]] = None,
@@ -521,6 +530,8 @@ class CmdDockerClient:
             ]
         if interactive:
             cmd.append("--interactive")
+        if tty:
+            cmd.append("--tty")
         if detach:
             cmd.append("--detach")
         if ports:

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -19,7 +19,6 @@ from localstack.utils.aws.aws_models import KinesisStream
 from localstack.utils.common import (
     TMP_FILES,
     TMP_THREADS,
-    FuncThread,
     ShellCommandThread,
     chmod_r,
     get_service_protocol,
@@ -33,6 +32,7 @@ from localstack.utils.common import (
 )
 from localstack.utils.kinesis import kclipy_helper
 from localstack.utils.kinesis.kinesis_util import EventFileReaderThread
+from localstack.utils.run import FuncThread
 
 EVENTS_FILE_PATTERN = os.path.join(tempfile.gettempdir(), "kclipy.*.fifo")
 LOG_FILE_PATTERN = os.path.join(tempfile.gettempdir(), "kclipy.*.log")

--- a/localstack/utils/kinesis/kinesis_util.py
+++ b/localstack/utils/kinesis/kinesis_util.py
@@ -4,7 +4,8 @@ import logging
 import socket
 import traceback
 
-from localstack.utils.common import FuncThread, truncate
+from localstack.utils.common import truncate
+from localstack.utils.run import FuncThread
 
 # set up local logger
 LOGGER = logging.getLogger(__name__)

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -1,0 +1,159 @@
+import inspect
+import logging
+import os
+import select
+import subprocess
+import sys
+import threading
+import traceback
+from concurrent.futures import Future
+from typing import List, Union
+
+from localstack import config
+
+LOG = logging.getLogger(__name__)
+
+
+def run(
+    cmd: Union[str, List[str]],
+    print_error=True,
+    asynchronous=False,
+    stdin=False,
+    stderr=subprocess.STDOUT,
+    outfile=None,
+    env_vars=None,
+    inherit_cwd=False,
+    inherit_env=True,
+    tty=False,
+    shell=True,
+):
+    LOG.debug("Executing command: %s", cmd)
+    env_dict = os.environ.copy() if inherit_env else {}
+    if env_vars:
+        env_dict.update(env_vars)
+    env_dict = dict([(k, to_str(str(v))) for k, v in env_dict.items()])
+
+    if tty:
+        asynchronous = True
+        stdin = True
+
+    try:
+        cwd = os.getcwd() if inherit_cwd else None
+        if not asynchronous:
+            if stdin:
+                return subprocess.check_output(
+                    cmd, shell=shell, stderr=stderr, env=env_dict, stdin=subprocess.PIPE, cwd=cwd
+                )
+            output = subprocess.check_output(cmd, shell=shell, stderr=stderr, env=env_dict, cwd=cwd)
+            return output.decode(config.DEFAULT_ENCODING)
+
+        stdin_arg = subprocess.PIPE if stdin else None
+        stdout_arg = open(outfile, "ab") if isinstance(outfile, str) else outfile
+        stderr_arg = stderr
+        if tty:
+            # Note: leave the "pty" import here (not supported in Windows)
+            import pty
+
+            master_fd, slave_fd = pty.openpty()
+            stdin_arg = slave_fd
+            stdout_arg = stderr_arg = None
+
+        # start the actual sub process
+        kwargs = {}
+        if is_linux() or is_mac_os():
+            kwargs["start_new_session"] = True
+        process = subprocess.Popen(
+            cmd,
+            shell=shell,
+            stdin=stdin_arg,
+            bufsize=-1,
+            stderr=stderr_arg,
+            stdout=stdout_arg,
+            env=env_dict,
+            cwd=cwd,
+            **kwargs,
+        )
+
+        if tty:
+            # based on: https://stackoverflow.com/questions/41542960
+            def pipe_streams(*args):
+                while process.poll() is None:
+                    r, w, e = select.select([sys.stdin, master_fd], [], [])
+                    if sys.stdin in r:
+                        d = os.read(sys.stdin.fileno(), 10240)
+                        os.write(master_fd, d)
+                    elif master_fd in r:
+                        o = os.read(master_fd, 10240)
+                        if o:
+                            os.write(sys.stdout.fileno(), o)
+
+            FuncThread(pipe_streams).start()
+
+        return process
+    except subprocess.CalledProcessError as e:
+        if print_error:
+            print("ERROR: '%s': exit code %s; output: %s" % (cmd, e.returncode, e.output))
+            sys.stdout.flush()
+        raise e
+
+
+def is_mac_os():
+    return "Darwin" in get_uname()
+
+
+def is_linux():
+    return "Linux" in get_uname()
+
+
+def get_uname():
+    try:
+        return to_str(subprocess.check_output("uname -a", shell=True))
+    except Exception:
+        return ""
+
+
+def to_str(obj, errors="strict"):
+    return obj.decode("utf-8", errors) if isinstance(obj, bytes) else obj
+
+
+class FuncThread(threading.Thread):
+    """Helper class to run a Python function in a background thread."""
+
+    def __init__(self, func, params=None, quiet=False):
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.params = params
+        self.func = func
+        self.quiet = quiet
+        self.result_future = Future()
+        self._stop_event = threading.Event()
+
+    def run(self):
+        result = None
+        try:
+            kwargs = {}
+            argspec = inspect.getfullargspec(self.func)
+            if argspec.varkw or "_thread" in (argspec.args or []) + (argspec.kwonlyargs or []):
+                kwargs["_thread"] = self
+            result = self.func(self.params, **kwargs)
+        except Exception as e:
+            self.result_future.set_exception(e)
+            result = e
+            if not self.quiet:
+                LOG.info(
+                    "Thread run method %s(%s) failed: %s %s"
+                    % (self.func, self.params, e, traceback.format_exc())
+                )
+        finally:
+            try:
+                self.result_future.set_result(result)
+            except Exception:
+                # this can happen as InvalidStateError on shutdown, if the task is already canceled
+                pass
+
+    @property
+    def running(self):
+        return not self._stop_event.is_set()
+
+    def stop(self, quiet=False):
+        self._stop_event.set()

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -113,7 +113,7 @@ def get_uname():
 
 
 def to_str(obj, errors="strict"):
-    return obj.decode("utf-8", errors) if isinstance(obj, bytes) else obj
+    return obj.decode(config.DEFAULT_ENCODING, errors) if isinstance(obj, bytes) else obj
 
 
 class FuncThread(threading.Thread):

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -17,8 +17,9 @@ from quart.app import _cancel_all_tasks
 
 from localstack import config
 from localstack.utils.async_utils import ensure_event_loop, run_coroutine, run_sync
-from localstack.utils.common import TMP_THREADS, FuncThread, load_file, retry
+from localstack.utils.common import TMP_THREADS, load_file, retry
 from localstack.utils.http_utils import uses_chunked_encoding
+from localstack.utils.run import FuncThread
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/server/multiserver.py
+++ b/localstack/utils/server/multiserver.py
@@ -14,7 +14,6 @@ from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.utils.bootstrap import setup_logging
 from localstack.utils.common import (
     TMP_THREADS,
-    FuncThread,
     ShellCommandThread,
     get_free_tcp_port,
     is_port_open,
@@ -22,6 +21,7 @@ from localstack.utils.common import (
     to_str,
     wait_for_port_open,
 )
+from localstack.utils.run import FuncThread
 
 LOG = logging.getLogger("localstack.multiserver")
 

--- a/tests/integration/docker/conftest.py
+++ b/tests/integration/docker/conftest.py
@@ -1,19 +1,19 @@
 import pytest
 
 from localstack.config import is_env_not_false
-from localstack.utils.docker import CmdDockerClient
+from localstack.utils.docker import DOCKER_CLIENT
 
 
 def _check_skip():
     if not is_env_not_false("SKIP_DOCKER_TESTS"):
         pytest.skip("SKIP_DOCKER_TESTS is set")
 
-    if not CmdDockerClient().has_docker():
+    if not DOCKER_CLIENT.has_docker():
         pytest.skip("Docker is not available")
 
 
 @pytest.fixture
 def docker_client():
     _check_skip()  # this is a hack to get a global skip for all tests that require the docker client
-    client = CmdDockerClient()
+    client = DOCKER_CLIENT
     yield client

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -438,3 +438,36 @@ class TestDockerClient:
         assert "alpine:latest" in docker_client.get_docker_image_names()
         assert "alpine" in docker_client.get_docker_image_names()
         assert "alpine" not in docker_client.get_docker_image_names(strip_latest=False)
+
+    def test_get_container_name(self, docker_client: DockerClient, dummy_container):
+        docker_client.start_container(dummy_container.container_id)
+        assert dummy_container.container_name == docker_client.get_container_name(
+            dummy_container.container_id
+        )
+
+    def test_get_container_name_not_existing(self, docker_client: DockerClient):
+        not_existent_container = "not_existing_container"
+        with pytest.raises(NoSuchContainer):
+            docker_client.get_container_name(not_existent_container)
+
+    def test_get_container_id(self, docker_client: DockerClient, dummy_container):
+        docker_client.start_container(dummy_container.container_id)
+        assert dummy_container.container_id == docker_client.get_container_id(
+            dummy_container.container_name
+        )
+
+    def test_get_container_id_not_existing(self, docker_client: DockerClient):
+        not_existent_container = "not_existing_container"
+        with pytest.raises(NoSuchContainer):
+            docker_client.get_container_id(not_existent_container)
+
+    def test_inspect_object(self, docker_client: DockerClient, dummy_container):
+        docker_client.start_container(dummy_container.container_id)
+        for identifier in [dummy_container.container_id, dummy_container.container_name]:
+            assert dummy_container.container_id == docker_client.inspect_object(identifier)["Id"]
+            assert (
+                f"/{dummy_container.container_name}"
+                == docker_client.inspect_object(identifier)["Name"]
+            )
+        docker_client.pull_image("alpine")
+        assert "alpine:latest" == docker_client.inspect_object("alpine")["RepoTags"][0]

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -436,6 +436,8 @@ class TestDockerClient:
         assert "alpine" not in docker_client.get_docker_image_names()
         docker_client.pull_image("alpine")
         assert "alpine:latest" in docker_client.get_docker_image_names()
+        assert "alpine:latest" not in docker_client.get_docker_image_names(include_tags=False)
+        assert "alpine" in docker_client.get_docker_image_names(include_tags=False)
         assert "alpine" in docker_client.get_docker_image_names()
         assert "alpine" not in docker_client.get_docker_image_names(strip_latest=False)
 

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -471,3 +471,14 @@ class TestDockerClient:
             )
         docker_client.pull_image("alpine")
         assert "alpine:latest" == docker_client.inspect_object("alpine")["RepoTags"][0]
+
+    def test_copy_from_container(self, tmpdir, docker_client: DockerClient, dummy_container):
+        docker_client.start_container(dummy_container.container_id)
+        docker_client.exec_in_container(
+            dummy_container.container_id, command=["sh", "-c", "echo TEST_CONTENT > test_file"]
+        )
+        local_path = tmpdir.join("test_file")
+        docker_client.copy_from_container(
+            dummy_container.container_id, local_path=str(local_path), container_path="test_file"
+        )
+        assert "TEST_CONTENT" == local_path.read().strip()

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -1900,7 +1900,7 @@ class TestDockerBehaviour(LambdaTestBase):
         if not isinstance(
             lambda_api.LAMBDA_EXECUTOR, lambda_executors.LambdaExecutorReuseContainers
         ):
-            pytest.skip("not testing docker reuse executor")
+            pytest.skip("only testing docker reuse executor")
 
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = "test_destroy_idle_containers"

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -9,7 +9,8 @@ import pytz
 import yaml
 
 from localstack.utils import common
-from localstack.utils.bootstrap import PortMappings, extract_port_flags
+from localstack.utils.bootstrap import extract_port_flags
+from localstack.utils.docker import PortMappings
 
 
 class TestCommon(unittest.TestCase):

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -12,8 +12,8 @@ from localstack.services import infra
 from localstack.services.generic_proxy import GenericProxy, ProxyListener
 from localstack.utils import async_utils, config_listener
 from localstack.utils.aws import aws_stack
-from localstack.utils.bootstrap import PortMappings
 from localstack.utils.common import TMP_FILES, download, json_safe, load_file, now_utc, parallelize
+from localstack.utils.docker import PortMappings
 from localstack.utils.http_utils import create_chunked_data, parse_chunked_data
 
 


### PR DESCRIPTION
This PR replaces run() calls throughout the code base with calls of the docker client, to reduce possible vulnerability to command injection.

To prevent issues with circular imports. the run() method and FuncThread() class had to be moved from bootstrap.py to a separate package.