### PR TITLE
Add support for multi-region request handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,15 +31,10 @@ RUN make install-venv-docker
 RUN mkdir -p localstack/utils/kinesis/ && mkdir -p localstack/services/ && \
   touch localstack/__init__.py localstack/utils/__init__.py localstack/services/__init__.py localstack/utils/kinesis/__init__.py
 ADD localstack/constants.py localstack/config.py localstack/
-ADD localstack/services/install.py localstack/services/
+ADD localstack/services/install.py localstack/services/generic_proxy.py localstack/services/__init__.py localstack/services/
 ADD localstack/services/cloudformation/deployment_utils.py localstack/services/cloudformation/deployment_utils.py
-ADD localstack/utils/common.py localstack/utils/bootstrap.py localstack/utils/docker.py localstack/utils/run.py localstack/utils/
-ADD localstack/utils/aws/ localstack/utils/aws/
-ADD localstack/utils/kinesis/ localstack/utils/kinesis/
-ADD localstack/utils/analytics/ localstack/utils/analytics/
-ADD localstack/utils/generic/ localstack/utils/generic/
+ADD localstack/utils/ localstack/utils/
 ADD localstack/package.json localstack/package.json
-ADD localstack/services/__init__.py localstack/services/install.py localstack/services/
 
 # initialize installation (downloads remaining dependencies)
 RUN make init-testlibs

--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ You can pass the following environment variables to LocalStack.
   Example value: `kinesis,lambda,sqs` to start Kinesis, Lambda, and SQS.
   In addition, the following shorthand values can be specified to run a predefined ensemble of services:
   - `serverless`: run services often used for Serverless apps (`iam`, `lambda`, `dynamodb`, `apigateway`, `s3`, `sns`)
-* `DEFAULT_REGION`: AWS region to use when talking to the API (default: `us-east-1`).
 * `EDGE_BIND_HOST`: Address the edge service binds to. (default: `127.0.0.1`, in docker containers `0.0.0.0`)
 * `EDGE_PORT`: Port number for the edge service, the main entry point for all API invocations (default: `4566`).
 * `HOSTNAME`: Name of the host to expose the services internally (default: `localhost`).
@@ -283,11 +282,13 @@ Please be aware that the following configurations may have severe security impli
 
 The following environment configurations can be useful for debugging:
 * `DEVELOP`: Starts a debugpy server before starting LocalStack services
-* `DEVELOP_PORT`:  Port number for debugpy server
-* `WAIT_FOR_DEBUGGER`:  Forces LocalStack to wait for a debugger to start the services
+* `DEVELOP_PORT`: Port number for debugpy server
+* `WAIT_FOR_DEBUGGER`: Forces LocalStack to wait for a debugger to start the services
 
 The following environment configurations are *deprecated*:
 * `USE_SSL`: Whether to use `https://...` URLs with SSL encryption (default: `false`). Deprecated as of version 0.11.3 - each service endpoint now supports multiplexing HTTP/HTTPS traffic over the same port.
+* `DEFAULT_REGION`: AWS region to use when talking to the API (needs to be activated via `USE_SINGLE_REGION=1`). Deprecated and inactive as of version 0.12.17 - LocalStack now has full multi-region support.
+* `USE_SINGLE_REGION`: Whether to use the legacy single-region mode, defined via `DEFAULT_REGION`.
 
 Additionally, the following *read-only* environment variables are available:
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -162,7 +162,11 @@ DEVELOP_PORT = int(os.environ.get("DEVELOP_PORT", "").strip() or DEFAULT_DEVELOP
 WAIT_FOR_DEBUGGER = is_env_true("WAIT_FOR_DEBUGGER")
 
 # whether to use SSL encryption for the services
+# TODO: this is deprecated and should be removed (edge port supports HTTP/HTTPS multiplexing)
 USE_SSL = is_env_true("USE_SSL")
+
+# whether to use the legacy single-region mode, defined via DEFAULT_REGION
+USE_SINGLE_REGION = is_env_true("USE_SINGLE_REGION")
 
 # whether to run in TF compatibility mode for TF integration tests
 # (e.g., returning verbatim ports for ELB resources, rather than edge port 4566, etc.)
@@ -286,6 +290,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_DOCKER_NETWORK",
     "LAMBDA_REMOVE_CONTAINERS",
     "USE_SSL",
+    "USE_SINGLE_REGION",
     "DEBUG",
     "KINESIS_ERROR_PROBABILITY",
     "DYNAMODB_ERROR_PROBABILITY",

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -3,6 +3,7 @@ import sys
 
 from localstack import config
 from localstack.constants import TRUE_STRINGS
+from localstack.utils.aws.request_context import patch_request_handling
 from localstack.utils.bootstrap import ENV_SCRIPT_STARTING_DOCKER
 
 # Note: make sure not to add any additional imports at the global scope here!
@@ -229,6 +230,9 @@ def do_register_localstack_plugins():
         )
 
         register_plugin(Plugin("support", start=support_starter.start_support))
+
+        # apply patches
+        patch_request_handling()
 
     except Exception as e:
         if not os.environ.get(ENV_SCRIPT_STARTING_DOCKER):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -41,6 +41,9 @@ APIGATEWAY_SQS_DATA_INBOUND_TEMPLATE = (
 # special tag name to allow specifying a custom ID for new REST APIs
 TAG_KEY_CUSTOM_ID = "_custom_id_"
 
+# map API IDs to region names
+API_REGIONS = {}
+
 # TODO: make the CRUD operations in this file generic for the different model types (authorizes, validators, ...)
 
 

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -1,0 +1,126 @@
+import logging
+import re
+import threading
+
+from flask import request
+from requests.models import Request
+from requests.structures import CaseInsensitiveDict
+
+from localstack.services import generic_proxy
+from localstack.utils.common import empty_context_manager
+from localstack.utils.run import FuncThread
+
+LOG = logging.getLogger(__name__)
+
+THREAD_LOCAL = threading.local()
+
+MARKER_APIGW_REQUEST_REGION = "__apigw_request_region__"
+
+
+def get_proxy_request_for_thread():
+    try:
+        return THREAD_LOCAL.request_context
+    except Exception:
+        return None
+
+
+def get_flask_request_for_thread():
+    try:
+        return Request(
+            url=request.path,
+            data=request.data,
+            headers=CaseInsensitiveDict(request.headers),
+            method=request.method,
+        )
+    except Exception as e:
+        # swallow error: "Working outside of request context."
+        if "Working outside" in str(e):
+            return None
+        raise
+
+
+def extract_region_from_auth_header(headers):
+    from localstack.utils.aws import aws_stack
+
+    # TODO: use method from aws_stack, which currently causes stack overflow due to call to get_region()!
+    auth = headers.get("Authorization") or ""
+    region = re.sub(r".*Credential=[^/]+/[^/]+/([^/]+)/.*", r"\1", auth)
+    if region == auth:
+        return None
+    region = region or aws_stack.get_local_region()
+    return region
+
+
+def get_request_context():
+    candidates = [get_proxy_request_for_thread(), get_flask_request_for_thread()]
+    for req in candidates:
+        if req is not None:
+            return req
+
+
+class RequestContextManager(object):
+    """Context manager which sets the given request context (i.e., region) for the scope of the block."""
+
+    def __init__(self, request_context):
+        self.request_context = request_context
+
+    def __enter__(self):
+        THREAD_LOCAL.request_context = self.request_context
+
+    def __exit__(self, type, value, traceback):
+        THREAD_LOCAL.request_context = None
+
+
+def get_region_from_request_context():
+    """look up region from request context"""
+    request_context = get_request_context()
+    if not request_context:
+        return
+    region = extract_region_from_auth_header(request_context.headers)
+
+    # Fix region lookup for certain requests, e.g., API gateway invocations
+    #  that do not contain region details in the Authorization header.
+    region = request_context.headers.get(MARKER_APIGW_REQUEST_REGION) or region
+
+    return region
+
+
+def patch_request_handling():
+
+    # TODO: move into generic_proxy.py, instead of patching here
+
+    def modify_and_forward(method=None, path=None, data_bytes=None, headers=None, *args, **kwargs):
+        """Patch proxy forward method and store request in thread local."""
+        request_context = get_proxy_request_for_thread()
+        context_manager = empty_context_manager()
+        if not request_context:
+            request_context = Request(url=path, data=data_bytes, headers=headers, method=method)
+            context_manager = RequestContextManager(request_context)
+        with context_manager:
+            result = modify_and_forward_orig(
+                method, path, data_bytes=data_bytes, headers=headers, *args, **kwargs
+            )
+        return result
+
+    modify_and_forward_orig = generic_proxy.modify_and_forward
+    generic_proxy.modify_and_forward = modify_and_forward
+
+    # make sure that we inherit THREAD_LOCAL request contexts to spawned sub-threads
+
+    def thread_init(self, *args, **kwargs):
+        self._req_context = get_request_context()
+        return thread_init_orig(self, *args, **kwargs)
+
+    def thread_run(self, *args, **kwargs):
+        if self._req_context:
+            THREAD_LOCAL.request_context = self._req_context
+        return thread_run_orig(self, *args, **kwargs)
+
+    thread_run_orig = FuncThread.run
+    FuncThread.run = thread_run
+    thread_init_orig = FuncThread.__init__
+    FuncThread.__init__ = thread_init
+
+
+# apply patches
+patch_request_handling()

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -2,7 +2,6 @@ import logging
 import re
 import threading
 
-from flask import request
 from requests.models import Request
 from requests.structures import CaseInsensitiveDict
 
@@ -25,6 +24,9 @@ def get_proxy_request_for_thread():
 
 
 def get_flask_request_for_thread():
+    # importing here to avoid import errors from test Lambdas
+    from flask import request
+
     try:
         return Request(
             url=request.path,

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -2,6 +2,7 @@ import logging
 import re
 import threading
 
+from flask import request
 from requests.models import Request
 from requests.structures import CaseInsensitiveDict
 
@@ -24,9 +25,6 @@ def get_proxy_request_for_thread():
 
 def get_flask_request_for_thread():
     try:
-        # importing here to avoid import errors from test Lambdas
-        from flask import request
-
         return Request(
             url=request.path,
             data=request.data,

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -23,10 +23,10 @@ def get_proxy_request_for_thread():
 
 
 def get_flask_request_for_thread():
-    # importing here to avoid import errors from test Lambdas
-    from flask import request
-
     try:
+        # importing here to avoid import errors from test Lambdas
+        from flask import request
+
         return Request(
             url=request.path,
             data=request.data,
@@ -123,7 +123,3 @@ def patch_request_handling():
     FuncThread.run = thread_run
     thread_init_orig = FuncThread.__init__
     FuncThread.__init__ = thread_init
-
-
-# apply patches
-patch_request_handling()

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -5,7 +5,6 @@ import threading
 from requests.models import Request
 from requests.structures import CaseInsensitiveDict
 
-from localstack.services import generic_proxy
 from localstack.utils.common import empty_context_manager
 from localstack.utils.run import FuncThread
 
@@ -88,6 +87,8 @@ def get_region_from_request_context():
 
 
 def patch_request_handling():
+    # importing here to avoid import errors from test Lambdas
+    from localstack.services import generic_proxy
 
     # TODO: move into generic_proxy.py, instead of patching here
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -195,7 +195,8 @@ class ShellCommandThread(FuncThread):
                             if self.outfile not in [None, os.devnull]:
                                 outstream.write(line)
                                 outstream.flush()
-                self.process.wait()
+                if self.process:
+                    self.process.wait()
             else:
                 self.process.communicate()
         except Exception as e:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -158,7 +158,6 @@ class IntegrationTest(unittest.TestCase):
         testutil.assert_objects(json.loads(to_str(test_data)), all_objects)
 
     # TODO fix duplication with test_lambda_streams_batch_and_transactions(..)!
-    # @profiled()
     def test_kinesis_lambda_sns_ddb_sqs_streams(self):
         def create_kinesis_stream(name, delete=False):
             stream = aws_stack.create_kinesis_stream(name, delete=delete)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -39,6 +39,7 @@ from localstack.services.infra import start_proxy
 from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_stack import lambda_function_arn
 from localstack.utils.common import (
     cp_r,
     download,
@@ -203,7 +204,7 @@ class LambdaTestBase(unittest.TestCase):
     # TODO: the test below is being executed for all subclasses - should be refactored!
     def test_create_lambda_function(self):
         func_name = "lambda_func-{}".format(short_uid())
-        kms_key_arn = "arn:aws:kms:us-east-1:000000000000:key11"
+        kms_key_arn = "arn:aws:kms:%s:000000000000:key11" % aws_stack.get_region()
         vpc_config = {
             "SubnetIds": ["subnet-123456789"],
             "SecurityGroupIds": ["sg-123456789"],
@@ -230,7 +231,7 @@ class LambdaTestBase(unittest.TestCase):
         client = aws_stack.connect_to_service("lambda")
         client.create_function(**kwargs)
 
-        function_arn = "arn:aws:lambda:us-east-1:000000000000:function:" + func_name
+        function_arn = lambda_function_arn(func_name)
         partial_function_arn = ":".join(function_arn.split(":")[3:])
 
         # Get function by Name, ARN and partial ARN
@@ -856,7 +857,8 @@ class TestLambdaBaseFeatures(unittest.TestCase):
             Description="Testing CodeSigning Config",
             AllowedPublishers={
                 "SigningProfileVersionArns": [
-                    "arn:aws:signer:us-east-1:000000000000:/signing-profiles/test",
+                    "arn:aws:signer:%s:000000000000:/signing-profiles/test"
+                    % aws_stack.get_region(),
                 ]
             },
             CodeSigningPolicies={"UntrustedArtifactOnDeployment": "Enforce"},

--- a/tests/integration/test_multiregion.py
+++ b/tests/integration/test_multiregion.py
@@ -1,0 +1,107 @@
+import base64
+import json
+import unittest
+
+import requests
+
+from localstack import config
+from localstack.constants import PATH_USER_REQUEST
+from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs
+from localstack.utils.aws import aws_stack
+from localstack.utils.common import short_uid, to_str
+
+REGION1 = "us-east-1"
+REGION2 = "us-east-2"
+REGION3 = "us-west-1"
+REGION4 = "eu-central-1"
+
+
+class TestMultiRegion(unittest.TestCase):
+    def test_multi_region_sns(self):
+        sns_1 = aws_stack.connect_to_service("sns", region_name=REGION1)
+        sns_2 = aws_stack.connect_to_service("sns", region_name=REGION2)
+        len_1 = len(sns_1.list_topics()["Topics"])
+        len_2 = len(sns_2.list_topics()["Topics"])
+
+        topic_name1 = "t-%s" % short_uid()
+        sns_1.create_topic(Name=topic_name1)
+        result1 = sns_1.list_topics()["Topics"]
+        result2 = sns_2.list_topics()["Topics"]
+        self.assertEqual(len(result1), len_1 + 1)
+        self.assertEqual(len(result2), len_2)
+        self.assertIn(REGION1, result1[0]["TopicArn"])
+
+        topic_name2 = "t-%s" % short_uid()
+        sns_2.create_topic(Name=topic_name2)
+        result2 = sns_2.list_topics()["Topics"]
+        self.assertEqual(len(result2), len_2 + 1)
+        self.assertIn(REGION2, result2[0]["TopicArn"])
+
+    def test_multi_region_sqs(self):
+        sqs_1 = aws_stack.connect_to_service("sqs", region_name=REGION1)
+        sqs_2 = aws_stack.connect_to_service("sqs", region_name=REGION2)
+        len_1 = len(sqs_1.list_queues().get("QueueUrls", []))
+        len_2 = len(sqs_2.list_queues().get("QueueUrls", []))
+
+        queue_name1 = "q-%s" % short_uid()
+        sqs_1.create_queue(QueueName=queue_name1)
+        result1 = sqs_1.list_queues().get("QueueUrls", [])
+        self.assertEqual(len(result1), len_1 + 1)
+        self.assertEqual(len(sqs_2.list_queues().get("QueueUrls", [])), len_2)
+        self.assertNotIn(REGION1, result1[0])
+
+        queue_name2 = "q-%s" % short_uid()
+        sqs_2.create_queue(QueueName=queue_name2)
+        result2 = sqs_2.list_queues().get("QueueUrls", [])
+        self.assertEqual(len(result2), len_2 + 1)
+        self.assertEqual(len(sqs_1.list_queues().get("QueueUrls", [])), len_1 + 1)
+        self.assertNotIn(REGION2, result2[0])
+
+    def test_multi_region_api_gateway(self):
+        gw_1 = aws_stack.connect_to_service("apigateway", region_name=REGION1)
+        gw_2 = aws_stack.connect_to_service("apigateway", region_name=REGION2)
+        gw_3 = aws_stack.connect_to_service("apigateway", region_name=REGION3)
+        sqs_1 = aws_stack.connect_to_service("sqs", region_name=REGION1)
+        len_1 = len(gw_1.get_rest_apis()["items"])
+        len_2 = len(gw_2.get_rest_apis()["items"])
+
+        api_name1 = "a-%s" % short_uid()
+        gw_1.create_rest_api(name=api_name1)
+        result1 = gw_1.get_rest_apis()["items"]
+        self.assertEqual(len(result1), len_1 + 1)
+        self.assertEqual(len(gw_2.get_rest_apis()["items"]), len_2)
+
+        api_name2 = "a-%s" % short_uid()
+        gw_2.create_rest_api(name=api_name2)
+        result2 = gw_2.get_rest_apis()["items"]
+        self.assertEqual(len(gw_1.get_rest_apis()["items"]), len_1 + 1)
+        self.assertEqual(len(result2), len_2 + 1)
+
+        api_name3 = "a-%s" % short_uid()
+        queue_name1 = "q-%s" % short_uid()
+        result = sqs_1.create_queue(QueueName=queue_name1)
+        queue_arn = aws_stack.sqs_queue_arn(queue_name1, region_name=REGION1)
+        result = connect_api_gateway_to_sqs(
+            api_name3, stage_name="test", queue_arn=queue_arn, path="/data", region_name=REGION3
+        )
+        api_id = result["id"]
+        result = gw_3.get_rest_apis()["items"]
+        self.assertEqual(result[-1]["name"], api_name3)
+
+        # post message and receive from SQS
+        url = self._gateway_request_url(api_id=api_id, stage_name="test", path="/data")
+        test_data = {"foo": "bar"}
+        result = requests.post(url, data=json.dumps(test_data))
+        self.assertEqual(result.status_code, 200)
+        messages = aws_stack.sqs_receive_message(queue_arn)["Messages"]
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            json.loads(to_str(base64.b64decode(to_str(messages[0]["Body"])))), test_data
+        )
+
+    def _gateway_request_url(self, api_id, stage_name, path):
+        pattern = "%s/restapis/{api_id}/{stage_name}/%s{path}" % (
+            config.TEST_APIGATEWAY_URL,
+            PATH_USER_REQUEST,
+        )
+        return pattern.format(api_id=api_id, stage_name=stage_name, path=path)


### PR DESCRIPTION
This PR adds support for multi-region request handling.

Note: This may be a potentially breaking change for some users - however, controlling the request region from the client is more in line with the behavior in real AWS.

The current request region is tracked in a thread-local variable (`THREAD_LOCAL`), so that invocation chains are automatically using the correct region in the `Authorization` header (e.g., if the client is calling an API method which then calls another API as part of handling the request).

TODOs:

- [x] make sure all tests are passing
- [x] add config option `USE_SINGLE_REGION` to enable the legacy single-region mode
