### PR TITLE
add missing cloudformation properties for sns

### DIFF
--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1708,6 +1708,30 @@ class SNSTopic(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _create_params(params, *args, **kwargs):
+            attributes = {}
+            dedup = params.get("ContentBasedDeduplication")
+            display_name = params.get("DisplayName")
+            fifo_topic = params.get("FifoTopic")
+            kms_master_key = params.get("KmsMasterKeyId")
+            # todo subscription
+            tags = params.get("Tags") or {}
+            topic_name = params.get("TopicName")
+            if dedup is not None:
+                attributes["ContentBasedDeduplication"] = dedup
+            if display_name:
+                attributes["DisplayName"] = display_name
+            if fifo_topic is not None:
+                attributes["FifoTopic"] = fifo_topic
+            if kms_master_key:
+                attributes["KmsMasterKeyId"] = kms_master_key
+            result = {
+                "Name": topic_name,
+                "Attributes": attributes,
+                "Tags": tags
+            }
+            return result
+
         def _topic_arn(params, resources, resource_id, **kwargs):
             resource = SNSTopic(resources[resource_id])
             return resource.physical_resource_id or resource.get_physical_resource_id()
@@ -1715,7 +1739,7 @@ class SNSTopic(GenericBaseModel):
         return {
             "create": {
                 "function": "create_topic",
-                "parameters": {"Name": "TopicName", "Tags": "Tags"},
+                "parameters": _create_params,
             },
             "delete": {
                 "function": "delete_topic",

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -785,7 +785,7 @@ def create_sqs_message_attributes(subscriber, attributes):
         if value["Type"] == "Binary":
             attribute["BinaryValue"] = base64.decodebytes(to_bytes(value["Value"]))
         else:
-            attribute["StringValue"] = str(value["Value"])
+            attribute["StringValue"] = str(value.get("Value", ""))
 
         message_attributes[key] = attribute
 


### PR DESCRIPTION
Currently, SNS topics do not have their properties set using cloud formation. This commit should (hopefully) fix that issue
