### PR TITLE
Fix: IAM User with custom username isn't created with property

### DIFF
--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1034,6 +1034,31 @@ class IAMManagedPolicy(GenericBaseModel):
         return {"create": {"function": _create}}
 
 
+class IAMUser(GenericBaseModel):
+    @staticmethod
+    def cloudformation_type():
+        return "AWS::IAM::User"
+
+    def get_physical_resource_id(self, attribute=None, **kwargs):
+        return self.props.get("UserName")
+
+    def get_resource_name(self):
+        return self.props.get("UserName")
+
+    def fetch_state(self, stack_name, resources):
+        user_name = self.resolve_refs_recursively(stack_name, self.props.get("UserName"), resources)
+        return aws_stack.connect_to_service("iam").get_user(UserName=user_name)["User"]
+
+    def update_resource(self, new_resource, stack_name, resources):
+        props = new_resource["Properties"]
+        client = aws_stack.connect_to_service("iam")
+        return client.update_user(
+            UserName=props.get("UserName"),
+            NewPath=props.get("NewPath") or "",
+            NewUserName=props.get("NewUserName") or "",
+        )
+
+
 class GatewayResponse(GenericBaseModel):
     @staticmethod
     def cloudformation_type():

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1058,6 +1058,19 @@ class IAMUser(GenericBaseModel):
             NewUserName=props.get("NewUserName") or "",
         )
 
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_user",
+                "parameters": ["Path", "UserName", "PermissionsBoundary", "Tags"],
+            },
+            "delete": {
+                "function": "delete_user",
+                "parameters": ["UserName"],
+            },
+        }
+
 
 class GatewayResponse(GenericBaseModel):
     @staticmethod


### PR DESCRIPTION
When you're deploying an `AWS::IAM::User` with the UserName property defined isn't taken, uses the physical resource id instead of.

Also, the console it's printing: `localstack_1  | 2021-08-12T02:15:09:WARNING:localstack.utils.cloudformation.template_deployer: Unexpected resource type IAM::User when resolving references of resource HeveaUser: {'Type': 'AWS::IAM::User', 'LogicalResourceId': 'CustomUsername', 'Properties': {'UserName': 'custom_username'}}`


The current result it's:
```console
> aws iam list-users
{
    "Users": [
        {
            "Path": "/",
            "UserName": "CustomUsername",
            "UserId": "ohy0nq0xlr17v8i72b1e",
            "Arn": "arn:aws:iam::000000000000:user/CustomUsername",
            "CreateDate": "2021-08-12T02:15:08.897Z"
        }
    ]
}
```