### PR TITLE
Fix: solve issue with wrong arn generation in managedpolicy

### DIFF
--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1006,7 +1006,7 @@ class IAMManagedPolicy(GenericBaseModel):
         return "AWS::IAM::ManagedPolicy"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return aws_stack.role_arn(self.props["ManagedPolicyName"])
+        return aws_stack.policy_arn(self.props["ManagedPolicyName"])
 
     def fetch_state(self, stack_name, resources):
         return IAMPolicy.get_policy_state(self, stack_name, resources, managed_policy=True)


### PR DESCRIPTION
For some reason, the managed policies were returning role RNAs, instead of policy, this PR corrects that small error