### PR TITLE
Add basic interface for StateSerializer to be used in persistence mechanism

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -1,9 +1,13 @@
+import abc
 import json
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Collection, Dict, Optional
 
 import requests
+from flask import Request
+from readerwriterlock import rwlock
 
 from localstack import config
 from localstack.utils.bootstrap import canonicalize_api_names
@@ -12,11 +16,91 @@ from localstack.utils.common import clone
 # set up logger
 LOG = logging.getLogger(__name__)
 
-# map of service plugins, mapping from service name to plugin details
-SERVICE_PLUGINS = {}
+# TODO: Define interfaces for ServiceLifecycle, SchemaValidation, SecurityEnforcement, etc.
+#       to achieve composable ServicePlugins.
+#  Ultimately, the plugin metamodel will allow to easily add new ServicePlugins that consist of:
+#     - optional initializer (e.g., download dependencies, apply patches)
+#     - service lifecycle (start, stop, pause)
+#     - health check
+#     - state manager for persistent state (potentially composite)
+#     - request/schema validator (future work)
+#     - security interceptor (future work)
+#     ...
 
 # maps service names to health status
-STATUSES = {}
+STATUSES: Dict[str, Dict] = {}
+
+
+# ---------------------------
+# STATE SERIALIZER INTERFACE
+# ---------------------------
+
+
+class PersistenceContext:
+    def __init__(self, state_dir: str = None, lock: rwlock.RWLockable = None):
+        # state dir (within DATA_DIR) of currently processed API in local file system
+        self.state_dir: str = state_dir
+        # read-write lock for concurrency control of incoming requests
+        self.lock: rwlock.RWLockable = lock
+
+
+class StateSerializer(abc.ABC):
+    """A state serializer encapsulates the logic of persisting and loading service state to/from disk."""
+
+    @abc.abstractmethod
+    def restore_state(self, context: PersistenceContext):
+        """Restore state from the underlying persistence file"""
+        pass
+
+    @abc.abstractmethod
+    def update_state(self, context: PersistenceContext, request: Request):
+        """Update persistence state based on the incoming request"""
+        pass
+
+    @abc.abstractmethod
+    def is_write_request(self, request: Request) -> bool:
+        """Returns whether the given request is a write request that should trigger serialization"""
+        return False
+
+    def get_lock_for_request(self, request: Request) -> Optional[rwlock.Lockable]:
+        """Returns a lock (or None) that should be used to guard the given request, for concurrency control"""
+        return None
+
+    def get_context(self) -> PersistenceContext:
+        """Returns the current persistence context"""
+        return None
+
+
+class StateSerializerComposite(StateSerializer):
+    """Composite state serializer that delegates the requests to a collection of underlying concrete serializers"""
+
+    def __init__(self, serializers: Collection[StateSerializer] = None):
+        self.serializers: Collection[StateSerializer] = serializers or []
+
+    def restore_state(self, context: PersistenceContext):
+        for serializer in self.serializers:
+            serializer.restore_state(context)
+
+    def update_state(self, context: PersistenceContext, request: Request):
+        for serializer in self.serializers:
+            serializer.update_state(context, request)
+
+    def is_write_request(self, request: Request) -> bool:
+        return any(ser.is_write_request(request) for ser in self.serializers)
+
+    def get_lock_for_request(self, request: Request) -> Optional[rwlock.Lockable]:
+        if self.serializers:
+            return self.serializers[0].get_lock_for_request(
+                request
+            )  # return lock from first serializer
+
+    def get_context(self) -> PersistenceContext:
+        if self.serializers:
+            return self.serializers[0].get_context()  # return context from first serializer
+
+
+# maps service names to serializers (TODO: to be encapsulated in ServicePlugin instances)
+SERIALIZERS: Dict[str, StateSerializer] = {}
 
 
 # -----------------
@@ -61,6 +145,10 @@ def register_plugin(plugin):
         if existing.priority > plugin.priority:
             return
     SERVICE_PLUGINS[plugin.name()] = plugin
+
+
+# map of service plugins, mapping from service name to plugin details
+SERVICE_PLUGINS: Dict[str, Plugin] = {}
 
 
 # -------------------------

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -6,8 +6,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Collection, Dict, Optional
 
 import requests
-from flask import Request
 from readerwriterlock import rwlock
+from requests.models import Request
 
 from localstack import config
 from localstack.utils.bootstrap import canonicalize_api_names
@@ -37,11 +37,14 @@ STATUSES: Dict[str, Dict] = {}
 
 
 class PersistenceContext:
+    state_dir: str
+    lock: rwlock.RWLockable
+
     def __init__(self, state_dir: str = None, lock: rwlock.RWLockable = None):
         # state dir (within DATA_DIR) of currently processed API in local file system
-        self.state_dir: str = state_dir
+        self.state_dir = state_dir
         # read-write lock for concurrency control of incoming requests
-        self.lock: rwlock.RWLockable = lock
+        self.lock = lock
 
 
 class StateSerializer(abc.ABC):

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ pytest==6.2.4
 pytest-rerunfailures==10.0
 pyyaml>=5.1                    #basic-lib
 Quart>=0.6.15
+readerwriterlock>=1.0.7
 requests>=2.20.0,<2.26         #basic-lib
 requests-aws4auth==0.9
 sasl>=0.2.1


### PR DESCRIPTION
Add basic interface for `StateSerializer` to be used in persistence mechanism.

This is the first PR in a series of changes aiming to establish a flexible, composable `ServicePlugin` component model that will allow us to encapsulate the entire lifecycle of service plugins in a more clean way.

Currently, the changes in this PR are mostly related to the interface of `StateSerializer` - implementations are added elsewhere, and more details will follow soon.