### PR TITLE
Fix: SNS FIFO topic creation via cloudformation

### DIFF
--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -32,6 +32,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
     camel_to_snake_case,
     canonical_json,
+    canonicalize_bool_to_str,
     cp_r,
     is_base64,
     keys_to_lower,
@@ -1759,13 +1760,11 @@ class SNSTopic(GenericBaseModel):
             tags = params.get("Tags") or []
             topic_name = params.get("TopicName")
             if dedup is not None:
-                attributes["ContentBasedDeduplication"] = (
-                    "true" if str(dedup).lower() == "true" else "false"
-                )
+                attributes["ContentBasedDeduplication"] = canonicalize_bool_to_str(dedup)
             if display_name:
                 attributes["DisplayName"] = display_name
             if fifo_topic is not None:
-                attributes["FifoTopic"] = "true" if str(fifo_topic).lower() == "true" else "false"
+                attributes["FifoTopic"] = canonicalize_bool_to_str(fifo_topic)
             if kms_master_key:
                 attributes["KmsMasterKeyId"] = kms_master_key
             result = {"Name": topic_name, "Attributes": attributes, "Tags": tags}

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1759,11 +1759,13 @@ class SNSTopic(GenericBaseModel):
             tags = params.get("Tags") or []
             topic_name = params.get("TopicName")
             if dedup is not None:
-                attributes["ContentBasedDeduplication"] = dedup
+                attributes["ContentBasedDeduplication"] = (
+                    "true" if str(dedup).lower() == "true" else "false"
+                )
             if display_name:
                 attributes["DisplayName"] = display_name
             if fifo_topic is not None:
-                attributes["FifoTopic"] = fifo_topic
+                attributes["FifoTopic"] = "true" if str(fifo_topic).lower() == "true" else "false"
             if kms_master_key:
                 attributes["KmsMasterKeyId"] = kms_master_key
             result = {"Name": topic_name, "Attributes": attributes, "Tags": tags}

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1309,6 +1309,7 @@ def configure_resource_via_sdk(
         try:
             result = function(**params)
         except botocore.exceptions.ParamValidationError as e:
+            LOG.debug(f"Trying original parameters: {params_before_conversion}")
             if "type: <class 'bool'>" not in str(e):
                 raise
             result = function(**params_before_conversion)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1754,5 +1754,9 @@ def is_none_or_empty(obj: Union[Optional[str], Optional[list]]) -> bool:
     )
 
 
+def canonicalize_bool_to_str(val: bool) -> str:
+    return "true" if str(val).lower() == "true" else "false"
+
+
 # Code that requires util functions from above
 CACHE_FILE_PATTERN = CACHE_FILE_PATTERN.replace("_random_dir_", short_uid())

--- a/tests/integration/cloudformation/test_cloudformation_resource_sns.py
+++ b/tests/integration/cloudformation/test_cloudformation_resource_sns.py
@@ -1,0 +1,68 @@
+import jinja2
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+
+def test_sns_topic_fifo_with_deduplication(
+    cfn_client,
+    sns_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    topic_name = f"topic-{short_uid()}.fifo"
+    template_rendered = jinja2.Template(load_template_raw("sns_topic_fifo_dedup.yaml")).render(
+        sns_topic=topic_name
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    wait_until(is_change_set_created_and_available(change_set_id))
+    cfn_client.execute_change_set(ChangeSetName=change_set_id)
+    wait_until(is_stack_created(stack_id))
+
+    topics = sns_client.list_topics()["Topics"]
+    assert len([topic_name in t for t in topics]) == 1
+
+
+def test_sns_topic_fifo_without_suffix_fails(
+    cfn_client,
+    sns_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+):
+    """topic name needs .fifo suffix to be valid"""
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    topic_name = f"topic-{short_uid()}"
+    template_rendered = jinja2.Template(load_template_raw("sns_topic_fifo_dedup.yaml")).render(
+        sns_topic=topic_name
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+    wait_until(is_change_set_created_and_available(change_set_id))
+    cfn_client.execute_change_set(ChangeSetName=change_set_id)
+    wait_until(is_stack_created(stack_id))
+
+    stack = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+    assert stack.get("StackStatus") == "CREATE_FAILED"  # TODO: might be different on AWS, check

--- a/tests/integration/templates/sns_topic_fifo_dedup.yaml
+++ b/tests/integration/templates/sns_topic_fifo_dedup.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: {{ sns_topic }}
+      FifoTopic: true
+      ContentBasedDeduplication: true
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete


### PR DESCRIPTION
When creating a deduplicated FIFO SNS topic via cloudformation, the attributes were previously passed as booleans whereas it botocore expects strings here. They are now passed down as "true"/"false"