### PR TITLE
Consolidate .coveragerc and .flake8 config int pyproject.toml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[run]
-relative_files = True
-source =
-    localstack/
-omit =
-    localstack/infra/
-    localstack/node_modules

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-ignore = E203, E266, E501, W503, F403
-max-line-length = 110
-select = B,C,E,F,I,W,T4,B9
-exclude = node_modules,.venv*,dist,fixes,localstack/infra,localstack/node_modules, venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+        entry: pflake8
+        additional_dependencies:
+          - pyproject-flake8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ RUN ES_BASE_DIR=localstack/infra/elasticsearch; \
 # run tests (to verify the build before pushing the image)
 ADD tests/ tests/
 # add configuration files
-ADD .coveragerc ./
+ADD pyproject.toml ./
 # fixes a dependency issue with pytest and python3.7 https://github.com/pytest-dev/pytest/issues/5594
 RUN pip uninstall -y argparse
 RUN pip uninstall -y dataclasses

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,7 @@ test:
 
 test-coverage:
 	($(VENV_RUN); python -m coverage --version; \
+		pip install "coverage[toml]>=5.5"; \
 		DEBUG=$(DEBUG) \
 		python -m coverage run $(COVERAGE_ARGS) -m \
 		pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))

--- a/Makefile
+++ b/Makefile
@@ -185,10 +185,10 @@ reinstall-p3:      ## Re-initialize the virtualenv with Python 3.x
 	PIP_CMD=pip3 VENV_OPTS="-p '`which python3`'" make install
 
 lint:              ## Run code linter to check code style
-	($(VENV_RUN); python -m flake8 --show-source --config .flake8 . )
+	($(VENV_RUN); python -m pflake8 --show-source)
 
 lint-modified:      ## Run code linter on modified files
-	($(VENV_RUN); python -m flake8 --show-source --config .flake8 `git ls-files -m | grep '\.py$$' | xargs` )
+	($(VENV_RUN); python -m pflake8 --show-source `git ls-files -m | grep '\.py$$' | xargs` )
 
 format:
 	($(VENV_RUN); python -m isort localstack tests; python -m black localstack tests )

--- a/bin/Dockerfile.base
+++ b/bin/Dockerfile.base
@@ -134,7 +134,7 @@ ADD localstack/dashboard/web/package.json localstack/dashboard/web/package.json
 RUN make install-web
 
 # install libs that require dependencies that are cleaned up below (e.g., gcc)
-RUN (virtualenv .venv && source .venv/bin/activate && pip install 'cryptography<3.4' 'uamqp>=1.2.14' 'coverage>=5.5')
+RUN (virtualenv .venv && source .venv/bin/activate && pip install 'cryptography<3.4' 'uamqp>=1.2.14' 'coverage[toml]>=5.5')
 
 # clean up (layers are later squashed into a single one)
 RUN rm -rf localstack/infra/elasticsearch/jdk/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,13 @@ max-line-length = 110
 ignore = 'E203,E266,E501,W503,F403'
 select = 'B,C,E,F,I,W,T4,B9'
 exclude = 'node_modules,.venv*,dist,fixes,localstack/infra,localstack/node_modules, venv'
+
+[tool.coverage.run]
+relative_files = true
+source = [
+    "localstack/"
+]
+omit = [
+    "localstack/infra/",
+    "localstack/node_modules"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,10 @@ extend_exclude = '(localstack/infra|localstack/node_modules)'
 profile = 'black'
 extend_skip = ['localstack/infra/', 'localstack/node_modules', 'bin']
 line_length = 100
+
+# call using pflake8
+[tool.flake8]
+max-line-length = 110
+ignore = 'E203,E266,E501,W503,F403'
+select = 'B,C,E,F,I,W,T4,B9'
+exclude = 'node_modules,.venv*,dist,fixes,localstack/infra,localstack/node_modules, venv'

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ black==21.6b0                  #extended-lib
 cachetools>=3.1.1,<4.0.0
 cbor2>=5.2.0
 # coverage version should be synced with bin/Dockerfile.base
-coverage>=5.5
+coverage[toml]>=5.5
 coveralls==3.1.0
 crontab>=0.22.6
 # pin version to avoid Rust build issues: https://github.com/pyca/cryptography/issues/5771

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,8 @@ flake8>=3.6.0                  #extended-lib
 flake8-black>=0.2.1            #extended-lib
 flake8-isort>=4.0.0            #extended-lib
 flake8-quotes>=0.11.0          #extended-lib
+# enables flake8 configuration through pyproject.toml
+pyproject-flake8               #extended-lib
 flask>=1.0.2
 flask-cors>=3.0.3,<3.1.0
 flask_swagger==0.2.12


### PR DESCRIPTION
This PR moves .flake8 and .coveragerc into pyproject.toml

* Use pflake8 wrapper
* Use coverage[toml] extra
* The makefile line "pip install coverage[toml]" can be removed once the docker base image has been deployed