### PR TITLE
fix: Respond to s3-website requests with the content-type of an object.

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1630,8 +1630,10 @@ def serve_static_website(headers, path, bucket_name):
     try:
         if path != "/":
             path = path.lstrip("/")
-            content = s3_client.get_object(Bucket=bucket_name, Key=path)["Body"].read()
-            return requests_response(status_code=200, content=content)
+            obj = s3_client.get_object(Bucket=bucket_name, Key=path)
+            content = obj["Body"].read()
+            headers = {"Content-Type": obj["ContentType"]} if obj.get("ContentType") else {}
+            return requests_response(status_code=200, content=content, headers=headers)
     except ClientError:
         LOGGER.debug("No such key found. %s" % path)
 


### PR DESCRIPTION
Closes #4487

This PR sets the content-type correctly on s3-website responses (that of the object requested). It does _not_ address other headers (notably `ETag`), though it can be extended to do so if desireable.