### PR TITLE
Add integration request parameters for AWS::ApiGateway::Method

### DIFF
--- a/tests/integration/cloudformation/test_cloudformation_apigateway.py
+++ b/tests/integration/cloudformation/test_cloudformation_apigateway.py
@@ -1,0 +1,57 @@
+import jinja2
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+
+def test_cfn_apigateway_aws_integration(
+    cfn_client,
+    apigateway_client,
+    s3_client,
+    iam_client,
+    is_change_set_created_and_available,
+    is_stack_created,
+    cleanup_changesets,
+    cleanup_stacks,
+):
+    api_name = f"rest-api-{short_uid()}"
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    template_rendered = jinja2.Template(
+        load_template_raw("apigw-awsintegration-request-parameters.yaml")
+    ).render(api_name=api_name)
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+
+        apis = [
+            api for api in apigateway_client.get_rest_apis()["items"] if api["name"] == api_name
+        ]
+        assert len(apis) == 1
+        api_id = apis[0]["id"]
+
+        resources = apigateway_client.get_resources(restApiId=api_id)["items"]
+        assert (
+            resources[0]["resourceMethods"]["GET"]["requestParameters"]["method.request.path.id"]
+            is False
+        )
+        assert (
+            resources[0]["resourceMethods"]["GET"]["methodIntegration"]["requestParameters"][
+                "integration.request.path.object"
+            ]
+            == "method.request.path.id"
+        )
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -11,8 +11,10 @@ from localstack.utils.aws.aws_stack import create_dynamodb_table
 from localstack.utils.common import short_uid
 
 if TYPE_CHECKING:
+    from mypy_boto3_apigateway import APIGatewayClient
     from mypy_boto3_cloudformation import CloudFormationClient
     from mypy_boto3_dynamodb import DynamoDBClient
+    from mypy_boto3_iam import IAMClient
     from mypy_boto3_kinesis import KinesisClient
     from mypy_boto3_lambda import LambdaClient
     from mypy_boto3_logs import CloudWatchLogsClient
@@ -41,6 +43,16 @@ def _client(service):
 @pytest.fixture(scope="class")
 def dynamodb_client() -> "DynamoDBClient":
     return _client("dynamodb")
+
+
+@pytest.fixture(scope="class")
+def apigateway_client() -> "APIGatewayClient":
+    return _client("apigateway")
+
+
+@pytest.fixture(scope="class")
+def iam_client() -> "IAMClient":
+    return _client("iam")
 
 
 @pytest.fixture(scope="class")

--- a/tests/integration/templates/apigw-awsintegration-request-parameters.yaml
+++ b/tests/integration/templates/apigw-awsintegration-request-parameters.yaml
@@ -1,0 +1,132 @@
+Resources:
+  Bucket83908E77:
+    Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  MyRoleF48FFE04:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: "*"
+        Version: "2012-10-17"
+      RoleName: MyRole
+  MyRoleDefaultPolicyA36BE1DD:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject
+              - s3:Abort*
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - Bucket83908E77
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - Bucket83908E77
+                        - Arn
+                    - /*
+        Version: "2012-10-17"
+      PolicyName: MyRoleDefaultPolicyA36BE1DD
+      Roles:
+        - Ref: MyRoleF48FFE04
+  RestApi0C43BF4B:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: {{ api_name }}
+  RestApiCloudWatchRoleE3ED6605:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+  RestApiAccount7C83CF5A:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn:
+        Fn::GetAtt:
+          - RestApiCloudWatchRoleE3ED6605
+          - Arn
+    DependsOn:
+      - RestApi0C43BF4B
+  RestApiDeployment180EC50356429cbae887bcd485c89adef8803ba0:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: RestApi0C43BF4B
+      Description: Automatically created by the RestApi construct
+    DependsOn:
+      - RestApiGET0F59260B
+  RestApiDeploymentStageprod3855DE66:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: RestApi0C43BF4B
+      DeploymentId:
+        Ref: RestApiDeployment180EC50356429cbae887bcd485c89adef8803ba0
+      StageName: prod
+  RestApiGET0F59260B:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: GET
+      ResourceId:
+        Fn::GetAtt:
+          - RestApi0C43BF4B
+          - RootResourceId
+      RestApiId:
+        Ref: RestApi0C43BF4B
+      AuthorizationType: NONE
+      Integration:
+        Credentials:
+          Fn::GetAtt:
+            - MyRoleF48FFE04
+            - Arn
+        IntegrationHttpMethod: GET
+        RequestParameters:
+          integration.request.path.object: method.request.path.id
+        Type: AWS
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :apigateway:eu-west-1:s3:path/
+              - Ref: Bucket83908E77
+              - /{object}.json
+      RequestParameters:
+        method.request.path.id: false
+Outputs:
+  RestApiEndpoint0551178A:
+    Value:
+      Fn::Join:
+        - ""
+        - - https://
+          - Ref: RestApi0C43BF4B
+          - .execute-api.
+          - Ref: AWS::Region
+          - "."
+          - Ref: AWS::URLSuffix
+          - /
+          - Ref: RestApiDeploymentStageprod3855DE66
+          - /


### PR DESCRIPTION
Adds support for integration request parameters in AWS::ApiGateway::Method and moves the logic into service_models.

Closes #4203 