### PR TITLE
scheduler.py > Check delay_secs not none before making number operation

### DIFF
--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -26,7 +26,7 @@ class Job(object):
     def should_run_now(self):
         schedule = CronTab(self.schedule)
         delay_secs = schedule.next()
-        return delay_secs != None and delay_secs < 60
+        return delay_secs is not None and delay_secs < 60
 
     def do_run(self):
         FuncThread(self.job_func).start()


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
fix not supported netween instances of 'NoneType' and 'Int' in scheduler.py