### PR TITLE
add unit tests for file operations

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -926,6 +926,12 @@ def cp_r(src, dst, rm_dest_on_conflict=False, ignore_copystat_errors=False, **kw
 
 
 def disk_usage(path):
+    if not os.path.exists(path):
+        return 0
+
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+
     total_size = 0
     for dirpath, dirnames, filenames in os.walk(path):
         for f in filenames:


### PR DESCRIPTION
This PR adds a test class with example tests for basic file operations implemented in `common.py`