### PR TITLE
Document Custom Image support for Lambdas

### DIFF
--- a/doc/feature_coverage.md
+++ b/doc/feature_coverage.md
@@ -435,6 +435,7 @@ In the coverage tables below, the features are marked with their respective avai
   <tr><td colspan=4><b>Lambda</b></td></tr>
   <tr><td>Aliases</td><td>⭐⭐⭐⭐</td><td></td><td></td></tr>
   <tr><td>Code Signing Configs</td><td>⭐⭐</td><td></td><td></td></tr>
+  <tr><td>Custom Images (Pro)</td><td>⭐⭐⭐⭐</td><td></td><td></td></tr>
   <tr><td>Event Invoke Configs</td><td>⭐⭐⭐⭐</td><td></td><td></td></tr>
   <tr><td>Event Source Mappings</td><td>⭐⭐⭐⭐</td><td></td><td></td></tr>
   <tr><td>Function Concurrencies</td><td>⭐⭐⭐</td><td></td><td></td></tr>

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1215,6 +1215,10 @@ class Util:
     @classmethod
     def docker_image_for_lambda(cls, func_details):
         runtime = func_details.runtime or ""
+        if func_details.code.get("ImageUri"):
+            LOG.warning(
+                "ImageUri is set: Using Lambda container images is only supported in LocalStack Pro"
+            )
         docker_tag = runtime
         docker_image = config.LAMBDA_CONTAINER_REGISTRY
         # TODO: remove prefix once execution issues are fixed with dotnetcore/python lambdas


### PR DESCRIPTION
Currently the Feature Coverage misses this option.

Also, we should print some kind of warning if someone tries to use an ImageUri with LocalStack, and not fail only with an obscure error message.

Fixes #4452 