### PR TITLE
Fix template deployer and tests to retrieve updated PhysicalResourceId for EC2::Instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN pip uninstall -y dataclasses
 RUN LAMBDA_EXECUTOR=local \
     PYTEST_LOGLEVEL=info \
     PYTEST_ARGS='--junitxml=target/test-report.xml' \
-    TEST_PATH=tests/integration/test_cloudformation.py::CloudFormationTest::test_cfn_update_ec2_instance_type \
+    TEST_PATH=tests/integration/test_cloudformation.py \
     make test-coverage
 
 # clean up temporary files created during test execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ RUN pip uninstall -y dataclasses
 RUN LAMBDA_EXECUTOR=local \
     PYTEST_LOGLEVEL=info \
     PYTEST_ARGS='--junitxml=target/test-report.xml' \
+    TEST_PATH=tests/integration/test_cloudformation.py::CloudFormationTest::test_cfn_update_ec2_instance_type \
     make test-coverage
 
 # clean up temporary files created during test execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,6 @@ RUN pip uninstall -y dataclasses
 RUN LAMBDA_EXECUTOR=local \
     PYTEST_LOGLEVEL=info \
     PYTEST_ARGS='--junitxml=target/test-report.xml' \
-    TEST_PATH=tests/integration/test_cloudformation.py \
     make test-coverage
 
 # clean up temporary files created during test execution

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN pip uninstall -y dataclasses
 RUN LAMBDA_EXECUTOR=local \
     PYTEST_LOGLEVEL=info \
     PYTEST_ARGS='--junitxml=target/test-report.xml' \
-    TEST_PATH=tests/integration/test_cloudformation.py \
+    TEST_PATH=tests/integration/test_cloudformation.py::CloudFormationTest::test_cfn_update_ec2_instance_type \
     make test-coverage
 
 # clean up temporary files created during test execution

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -167,13 +167,6 @@ class Stack(object):
         for res in [resource, state]:
             for attr, default in attr_defaults:
                 res[attr] = res.get(attr) or default
-        print("!set_resource_status", resource_id, res.get("PhysicalResourceId"), attr_defaults)
-        LOG.debug(
-            "!set_resource_status: %s %s %s",
-            resource_id,
-            res.get("PhysicalResourceId"),
-            attr_defaults,
-        )
         state["StackName"] = state.get("StackName") or self.stack_name
         state["StackId"] = state.get("StackId") or self.stack_id
         state["ResourceType"] = state.get("ResourceType") or self.resources[resource_id].get("Type")
@@ -680,7 +673,6 @@ def describe_stack_resources(req_params):
     stack = find_stack(stack_name)
     if not stack:
         return stack_not_found_error(stack_name)
-    LOG.debug("describe_stack_resources", stack.resource_states)  # TODO
     statuses = [
         res_status
         for res_id, res_status in stack.resource_states.items()

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -394,6 +394,7 @@ class EC2Instance(GenericBaseModel):
             InstanceType={"Value": props["InstanceType"]},
         )
         resp = client.describe_instances(InstanceIds=[instance_id])
+        print("tmp log (CI debug): update_resource2:", instance_id, resp)
         return resp["Reservations"][0]["Instances"][0]
 
     def get_physical_resource_id(self, attribute=None, **kwargs):

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -387,6 +387,7 @@ class EC2Instance(GenericBaseModel):
         groups = props.get("SecurityGroups", props.get("SecurityGroupIds"))
 
         client = aws_stack.connect_to_service("ec2")
+        print("tmp log (CI debug): update_resource:", groups, instance_id, props)
         client.modify_instance_attribute(
             Groups=groups,
             InstanceId=instance_id,

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -396,7 +396,6 @@ class EC2Instance(GenericBaseModel):
         instance_id = self.get_physical_resource_id()
         client = client or aws_stack.connect_to_service("ec2")
         resp = client.describe_instances(InstanceIds=[instance_id])
-        print("tmp log (CI debug): GET RES:", instance_id, resp)
         reservation = (resp.get("Reservations") or [{}])[0]
         return (reservation.get("Instances") or [None])[0]
 

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -384,7 +384,6 @@ class EC2Instance(GenericBaseModel):
         groups = props.get("SecurityGroups", props.get("SecurityGroupIds"))
 
         client = aws_stack.connect_to_service("ec2")
-        print("tmp log (CI debug): update_resource:", groups, instance_id, props)
         client.modify_instance_attribute(
             Groups=groups,
             InstanceId=instance_id,

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1309,11 +1309,9 @@ def update_resource_details(stack, resource_id, details, action=None):
         resource["PhysicalResourceId"] = details["KeyMetadata"]["KeyId"]
 
     if resource_type == "EC2::Instance":
-        print("UPDATE EC2::Instance PhysicalResourceId", details, resource)
         if details and isinstance(details, list) and hasattr(details[0], "id"):
             resource["PhysicalResourceId"] = details[0].id
         if isinstance(details, dict) and details.get("InstanceId"):
-            print("!!!SETTING TO INSTANCE ID", details.get("InstanceId"))
             resource["PhysicalResourceId"] = details["InstanceId"]
 
     if resource_type == "EC2::SecurityGroup":

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1310,8 +1310,10 @@ def update_resource_details(stack, resource_id, details, action=None):
         resource["PhysicalResourceId"] = details["KeyMetadata"]["KeyId"]
 
     if resource_type == "EC2::Instance":
-        if action == "CREATE":
-            print("!!CREATED EC2 instance", details[0].id)
+        print("!!!!UPDATE EC2 details", details, resource)
+        if details and isinstance(details, list) and hasattr(details[0], "id"):
+            # if action == "CREATE":
+            #     print("!!CREATED EC2 instance", details[0].id)
             resource["PhysicalResourceId"] = details[0].id
 
     if resource_type == "EC2::SecurityGroup":

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1310,11 +1310,8 @@ def update_resource_details(stack, resource_id, details, action=None):
         resource["PhysicalResourceId"] = details["KeyMetadata"]["KeyId"]
 
     if resource_type == "EC2::Instance":
-        print("!!!!UPDATE EC2 details", action, details, resource)
+        print("UPDATE EC2::Instance PhysicalResourceId", details, resource)
         if details and isinstance(details, list) and hasattr(details[0], "id"):
-            # if action == "CREATE":
-            #     print("!!CREATED EC2 instance", details[0].id)
-            print("!!!UPDATE PhysicalResourceId", details[0].id)
             resource["PhysicalResourceId"] = details[0].id
 
     if resource_type == "EC2::SecurityGroup":

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1310,10 +1310,11 @@ def update_resource_details(stack, resource_id, details, action=None):
         resource["PhysicalResourceId"] = details["KeyMetadata"]["KeyId"]
 
     if resource_type == "EC2::Instance":
-        print("!!!!UPDATE EC2 details", details, resource)
+        print("!!!!UPDATE EC2 details", action, details, resource)
         if details and isinstance(details, list) and hasattr(details[0], "id"):
             # if action == "CREATE":
             #     print("!!CREATED EC2 instance", details[0].id)
+            print("!!!UPDATE PhysicalResourceId", details[0].id)
             resource["PhysicalResourceId"] = details[0].id
 
     if resource_type == "EC2::SecurityGroup":

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1312,6 +1312,9 @@ def update_resource_details(stack, resource_id, details, action=None):
         print("UPDATE EC2::Instance PhysicalResourceId", details, resource)
         if details and isinstance(details, list) and hasattr(details[0], "id"):
             resource["PhysicalResourceId"] = details[0].id
+        if isinstance(details, dict) and details.get("InstanceId"):
+            print("!!!SETTING TO INSTANCE ID", details.get("InstanceId"))
+            resource["PhysicalResourceId"] = details["InstanceId"]
 
     if resource_type == "EC2::SecurityGroup":
         resource["PhysicalResourceId"] = details["GroupId"]

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1082,7 +1082,7 @@ def run_pre_create_actions(
             if "NoSuchBucket" not in str(e):
                 raise
         # hack: make sure the bucket actually exists, to prevent delete_bucket operation later on from failing
-        s3.create_bucket(Bucket=bucket_name)
+        aws_stack.get_or_create_bucket(bucket_name)
 
 
 # TODO: move as individual functions to RESOURCE_TO_FUNCTION

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1052,6 +1052,7 @@ def configure_resource_via_sdk(
     # run post-actions
     run_post_create_actions(action_name, resource_id, resources, resource_type, stack_name, result)
 
+    print("!!!result", action_name, resource_id, result)
     return result
 
 
@@ -1310,6 +1311,7 @@ def update_resource_details(stack, resource_id, details, action=None):
 
     if resource_type == "EC2::Instance":
         if action == "CREATE":
+            print("!!CREATED EC2 instance", details[0].id)
             resource["PhysicalResourceId"] = details[0].id
 
     if resource_type == "EC2::SecurityGroup":

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1052,7 +1052,6 @@ def configure_resource_via_sdk(
     # run post-actions
     run_post_create_actions(action_name, resource_id, resources, resource_type, stack_name, result)
 
-    print("!!!result", action_name, resource_id, result)
     return result
 
 

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2012,14 +2012,17 @@ class CloudFormationTest(unittest.TestCase):
         self.assertEqual(1, len(resp["Reservations"][0]["Instances"]))
         self.assertEqual("t2.nano", resp["Reservations"][0]["Instances"][0]["InstanceType"])
 
+        print("tmp log (CI debug): starting stack update")
         cfn.update_stack(
             StackName=stack_name,
             TemplateBody=template,
             Parameters=[{"ParameterKey": "InstanceType", "ParameterValue": "t2.medium"}],
         )
         await_stack_completion(stack_name, statuses="UPDATE_COMPLETE")
+        print("tmp log (CI debug): stack update completed")
 
         resp = ec2_client.describe_instances(InstanceIds=[instances[0]["PhysicalResourceId"]])
+        print("tmp log (CI debug): instance:", resp)
         self.assertEqual("t2.medium", resp["Reservations"][0]["Instances"][0]["InstanceType"])
 
         # clean up

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2008,6 +2008,7 @@ class CloudFormationTest(unittest.TestCase):
             return instances[0]["PhysicalResourceId"]
 
         instance_id = get_instance_id()
+        print("!!!!!instance_id1", instance_id)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
         self.assertEqual(1, len(resp["Reservations"][0]["Instances"]))
         self.assertEqual("t2.nano", resp["Reservations"][0]["Instances"][0]["InstanceType"])
@@ -2020,6 +2021,7 @@ class CloudFormationTest(unittest.TestCase):
         await_stack_completion(stack_name, statuses="UPDATE_COMPLETE")
 
         instance_id = get_instance_id()  # get ID of updated instance (may have changed!)
+        print("!!!!!instance_id2", instance_id)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
         reservations = resp["Reservations"]
         self.assertEqual(1, len(reservations))

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2010,8 +2010,10 @@ class CloudFormationTest(unittest.TestCase):
         instance_id = get_instance_id()
         print("!!!!!instance_id1", instance_id)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
+        print("!!!!!describe_instances1", ec2_client.describe_instances())
         self.assertEqual(1, len(resp["Reservations"][0]["Instances"]))
         self.assertEqual("t2.nano", resp["Reservations"][0]["Instances"][0]["InstanceType"])
+        print("!!!!!resp1", resp)
 
         cfn.update_stack(
             StackName=stack_name,
@@ -2023,6 +2025,8 @@ class CloudFormationTest(unittest.TestCase):
         instance_id = get_instance_id()  # get ID of updated instance (may have changed!)
         print("!!!!!instance_id2", instance_id)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
+        print("!!!!!resp2", resp)
+        print("!!!!!describe_instances2", ec2_client.describe_instances())
         reservations = resp["Reservations"]
         self.assertEqual(1, len(reservations))
         self.assertEqual("t2.medium", reservations[0]["Instances"][0]["InstanceType"])

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2002,18 +2002,14 @@ class CloudFormationTest(unittest.TestCase):
 
         def get_instance_id():
             resources = cfn.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
-            print("resources", resources)
             instances = [res for res in resources if res["ResourceType"] == "AWS::EC2::Instance"]
             self.assertEqual(1, len(instances))
             return instances[0]["PhysicalResourceId"]
 
         instance_id = get_instance_id()
-        print("!!!!!instance_id1", instance_id)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
-        print("!!!!!describe_instances1", ec2_client.describe_instances())
         self.assertEqual(1, len(resp["Reservations"][0]["Instances"]))
         self.assertEqual("t2.nano", resp["Reservations"][0]["Instances"][0]["InstanceType"])
-        print("!!!!!resp1", resp)
 
         cfn.update_stack(
             StackName=stack_name,
@@ -2023,10 +2019,7 @@ class CloudFormationTest(unittest.TestCase):
         await_stack_completion(stack_name, statuses="UPDATE_COMPLETE")
 
         instance_id = get_instance_id()  # get ID of updated instance (may have changed!)
-        print("!!!!!instance_id2", instance_id)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
-        print("!!!!!resp2", resp)
-        print("!!!!!describe_instances2", ec2_client.describe_instances())
         reservations = resp["Reservations"]
         self.assertEqual(1, len(reservations))
         self.assertEqual("t2.medium", reservations[0]["Instances"][0]["InstanceType"])

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1987,8 +1987,6 @@ class CloudFormationTest(unittest.TestCase):
         # clean up
         self.cleanup(stack_name)
 
-    # @pytest.mark.skip(reason="Temporarily disabled until test flakiness is fixed")
-    # TODO: re-enable this test once fixed!
     def test_cfn_update_ec2_instance_type(self):
         stack_name = "stack-%s" % short_uid()
         template = load_file(os.path.join(THIS_FOLDER, "templates", "template30.yaml"))
@@ -2007,7 +2005,9 @@ class CloudFormationTest(unittest.TestCase):
         instances = [res for res in resources if res["ResourceType"] == "AWS::EC2::Instance"]
         self.assertEqual(1, len(instances))
 
-        resp = ec2_client.describe_instances(InstanceIds=[instances[0]["PhysicalResourceId"]])
+        print(instances)
+        instance_id = instances[0]["PhysicalResourceId"]
+        resp = ec2_client.describe_instances(InstanceIds=[instance_id])
         self.assertEqual(1, len(resp["Reservations"][0]["Instances"]))
         self.assertEqual("t2.nano", resp["Reservations"][0]["Instances"][0]["InstanceType"])
 
@@ -2020,9 +2020,11 @@ class CloudFormationTest(unittest.TestCase):
         await_stack_completion(stack_name, statuses="UPDATE_COMPLETE")
         print("tmp log (CI debug): stack update completed")
 
-        resp = ec2_client.describe_instances(InstanceIds=[instances[0]["PhysicalResourceId"]])
+        resp = ec2_client.describe_instances(InstanceIds=[instance_id])
         print("tmp log (CI debug): instance:", resp)
-        self.assertEqual("t2.medium", resp["Reservations"][0]["Instances"][0]["InstanceType"])
+        reservations = resp["Reservations"]
+        self.assertEqual(1, len(reservations))
+        self.assertEqual("t2.medium", [0]["Instances"][0]["InstanceType"])
 
         # clean up
         self.cleanup(stack_name)

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2000,9 +2000,8 @@ class CloudFormationTest(unittest.TestCase):
             Parameters=[{"ParameterKey": "KeyName", "ParameterValue": "testkey"}],
         )
 
-        resources = cfn.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
-
         def get_instance_id():
+            resources = cfn.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
             instances = [res for res in resources if res["ResourceType"] == "AWS::EC2::Instance"]
             self.assertEqual(1, len(instances))
             return instances[0]["PhysicalResourceId"]

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2002,6 +2002,7 @@ class CloudFormationTest(unittest.TestCase):
 
         def get_instance_id():
             resources = cfn.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
+            print("resources", resources)
             instances = [res for res in resources if res["ResourceType"] == "AWS::EC2::Instance"]
             self.assertEqual(1, len(instances))
             return instances[0]["PhysicalResourceId"]
@@ -2011,18 +2012,15 @@ class CloudFormationTest(unittest.TestCase):
         self.assertEqual(1, len(resp["Reservations"][0]["Instances"]))
         self.assertEqual("t2.nano", resp["Reservations"][0]["Instances"][0]["InstanceType"])
 
-        print("tmp log (CI debug): starting stack update")
         cfn.update_stack(
             StackName=stack_name,
             TemplateBody=template,
             Parameters=[{"ParameterKey": "InstanceType", "ParameterValue": "t2.medium"}],
         )
         await_stack_completion(stack_name, statuses="UPDATE_COMPLETE")
-        print("tmp log (CI debug): stack update completed")
 
         instance_id = get_instance_id()  # get ID of updated instance (may have changed!)
         resp = ec2_client.describe_instances(InstanceIds=[instance_id])
-        print("tmp log (CI debug): instance:", resp)
         reservations = resp["Reservations"]
         self.assertEqual(1, len(reservations))
         self.assertEqual("t2.medium", reservations[0]["Instances"][0]["InstanceType"])

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -3,7 +3,6 @@ import os
 import time
 import unittest
 
-import pytest
 from botocore.exceptions import ClientError
 from botocore.parsers import ResponseParserError
 
@@ -1988,7 +1987,7 @@ class CloudFormationTest(unittest.TestCase):
         # clean up
         self.cleanup(stack_name)
 
-    @pytest.mark.skip(reason="Temporarily disabled until test flakiness is fixed")
+    # @pytest.mark.skip(reason="Temporarily disabled until test flakiness is fixed")
     # TODO: re-enable this test once fixed!
     def test_cfn_update_ec2_instance_type(self):
         stack_name = "stack-%s" % short_uid()


### PR DESCRIPTION
~Add temporary debug logs to investigate flaky EC2 CloudFormation test.~

Fix template deployer and tests to retrieve updated PhysicalResourceId for EC2::Instance