### PR TITLE
Fix getting IP addresses of docker containers with non-default networks

### DIFF
--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -1119,7 +1119,6 @@ class SdkDockerClient(ContainerClient):
             raise ContainerException()
 
     def get_container_ip(self, container_name_or_id: str) -> str:
-        LOG.debug("Getting container IP of %s", container_name_or_id)
         networks = self.inspect_container(container_name_or_id)["NetworkSettings"]["Networks"]
         network_names = list(networks)
         if len(network_names) > 1:

--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -256,7 +256,10 @@ class ContainerClient(metaclass=ABCMeta):
 
     @abstractmethod
     def get_container_ip(self, container_name_or_id: str) -> str:
-        """Get the IP address of a given container"""
+        """Get the IP address of a given container
+
+        If container has multiple networks, it will return the IP of the first
+        """
         pass
 
     def get_image_cmd(self, docker_image: str) -> str:
@@ -1116,7 +1119,12 @@ class SdkDockerClient(ContainerClient):
             raise ContainerException()
 
     def get_container_ip(self, container_name_or_id: str) -> str:
-        return self.inspect_container(container_name_or_id)["NetworkSettings"]["IPAddress"]
+        LOG.debug("Getting container IP of %s", container_name_or_id)
+        networks = self.inspect_container(container_name_or_id)["NetworkSettings"]["Networks"]
+        network_names = list(networks)
+        if len(network_names) > 1:
+            LOG.info("Container has more than one assigned network. Picking the first one...")
+        return networks[network_names[0]]["IPAddress"]
 
     def has_docker(self) -> bool:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ Cython                         #extended-lib
 dataclasses; python_version < '3.7' #basic-lib
 dnspython==1.16.0              #basic-lib
 docopt>=0.6.2                  #basic-lib
-docker>=3.7.2                  #basic-lib
+docker==5.0.0                  #basic-lib
 elasticsearch>=7.0.0,<8.0.0
 flake8>=3.6.0                  #extended-lib
 flake8-black>=0.2.1            #extended-lib

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -42,10 +42,12 @@ def dummy_container(create_container):
 
 
 @pytest.fixture
-def create_container(docker_client: ContainerClient):
+def create_container(docker_client: ContainerClient, create_network):
     """
     Uses the factory as fixture pattern to wrap ContainerClient.create_container as a factory that
     removes the containers after the fixture is cleaned up.
+
+    Depends on create network for correct cleanup order
     """
     containers = list()
 
@@ -63,6 +65,29 @@ def create_container(docker_client: ContainerClient):
             docker_client.remove_container(c)
         except Exception:
             LOG.warning("failed to remove test container %s", c)
+
+
+@pytest.fixture
+def create_network():
+    """
+    Uses the factory as fixture pattern to wrap the creation of networks as a factory that
+    removes the networks after the fixture is cleaned up.
+    """
+    networks = list()
+
+    def _create_network(network_name: str):
+        network_id = safe_run([config.DOCKER_CMD, "network", "create", network_name]).strip()
+        networks.append(network_id)
+        return network_id
+
+    yield _create_network
+
+    for network in networks:
+        try:
+            LOG.debug("Removing network %s", network)
+            safe_run([config.DOCKER_CMD, "network", "remove", network])
+        except CalledProcessError:
+            pass
 
 
 class TestDockerClient:
@@ -741,6 +766,22 @@ class TestDockerClient:
     def test_get_container_ip(self, docker_client: ContainerClient, dummy_container):
         docker_client.start_container(dummy_container.container_id)
         ip = docker_client.get_container_ip(dummy_container.container_id)
+        assert re.match(
+            r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
+            ip,
+        )
+        assert "127.0.0.1" != ip
+
+    def test_get_container_ip_with_network(
+        self, docker_client: ContainerClient, create_container, create_network
+    ):
+        network_name = "ls_test_network_%s" % short_uid()
+        create_network(network_name)
+        container = create_container(
+            "alpine", network=network_name, command=["sh", "-c", "while true; do sleep 1; done"]
+        )
+        docker_client.start_container(container.container_id)
+        ip = docker_client.get_container_ip(container.container_id)
         assert re.match(
             r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$",
             ip,


### PR DESCRIPTION
Fixes #4515 

If a non-default network is assigned to the container queried, it will return an empty string instead of a correct IP.
This PR fixes this behaviour by returning the IP of the first assigned network (can lead to problems if LocalStack is assigned multiple networks for different purposes, but the fix provides a similar behavior to the command line client)