### PR TITLE
Return `InvocationResult` with the response content of forwarded request …

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1201,8 +1201,7 @@ def forward_to_external_url(func_details, event, context, invocation_type):
         "Received result from external Lambda endpoint (status %s): %s"
         % (result.status_code, content)
     )
-    result = aws_responses.requests_to_flask_response(result)
-    result = lambda_executors.InvocationResult(result)
+    result = lambda_executors.InvocationResult(content)
     return result
 
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1197,7 +1197,9 @@ def forward_to_external_url(func_details, event, context, invocation_type):
     LOG.debug("Forwarding Lambda invocation to LAMBDA_FORWARD_URL: %s" % config.LAMBDA_FORWARD_URL)
     result = safe_requests.post(url, data, headers=headers)
     if result.status_code >= 400:
-        raise Exception("Received error status code %s from external Lambda invocation" % result.status_code)
+        raise Exception(
+            "Received error status code %s from external Lambda invocation" % result.status_code
+        )
     content = run_safe(lambda: to_str(result.content)) or result.content
     LOG.debug(
         "Received result from external Lambda endpoint (status %s): %s"

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1196,6 +1196,8 @@ def forward_to_external_url(func_details, event, context, invocation_type):
     data = json.dumps(json_safe(event)) if isinstance(event, dict) else str(event)
     LOG.debug("Forwarding Lambda invocation to LAMBDA_FORWARD_URL: %s" % config.LAMBDA_FORWARD_URL)
     result = safe_requests.post(url, data, headers=headers)
+    if result.status_code >= 400:
+        raise Exception("Received error status code %s from external Lambda invocation" % result.status_code)
     content = run_safe(lambda: to_str(result.content)) or result.content
     LOG.debug(
         "Received result from external Lambda endpoint (status %s): %s"


### PR DESCRIPTION
… instead of wrapping as Flask response in "LAMBDA_FORWARD_URL" mode

