### PR TITLE
[wip] Return container ID in Docker SDK client for interactive=True,attach=False

### DIFF
--- a/localstack/utils/docker.py
+++ b/localstack/utils/docker.py
@@ -1172,6 +1172,8 @@ class SdkDockerClient(ContainerClient):
                         if stdin:
                             sock.sendall(to_bytes(stdin))
                             sock.shutdown(socket.SHUT_WR)
+                        if not attach:
+                            return to_bytes(container.id), b""
                         stdout, stderr = self._read_from_sock(sock, False)
                     except socket.timeout:
                         LOG.debug(

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -557,6 +557,12 @@ class TestDockerClient:
         assert "stderrtest" == stderr.decode(config.DEFAULT_ENCODING).strip()
 
     def test_run_detached_with_logs(self, docker_client: ContainerClient):
+        self._run_detached_with_logs(docker_client)
+
+    def test_run_detached_with_logs_interactive(self, docker_client: ContainerClient):
+        self._run_detached_with_logs(docker_client, True)
+
+    def _run_detached_with_logs(self, docker_client: ContainerClient, interactive: bool = False):
         container_name = _random_container_name()
         message = "test_message"
         try:
@@ -565,6 +571,7 @@ class TestDockerClient:
                 name=container_name,
                 detach=True,
                 command=["echo", message],
+                interactive=interactive,
             )
             container_id = output.decode(config.DEFAULT_ENCODING).strip()
             logs = docker_client.get_container_logs(container_id)

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -482,7 +482,10 @@ class TestDockerClient:
             )
 
             output, _ = docker_client.start_container(
-                container_name, interactive=True, stdin=message.encode(config.DEFAULT_ENCODING)
+                container_name,
+                interactive=True,
+                attach=True,
+                stdin=message.encode(config.DEFAULT_ENCODING),
             )
 
             assert message == output.decode(config.DEFAULT_ENCODING).strip()


### PR DESCRIPTION
Return container ID in Docker SDK client for interactive=True, attach=False . This is required in a few places where we're launching Lambda containers with `interactive=True` (to pass in events via `stdin`), yet the containers should be detached and started up non-blockingly in the background (returning the container ID via `stdout`).