### PR TITLE
Disable shell mode in run(..) util if cmd is passed as a list

### DIFF
--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 import traceback
+from typing import Dict, List, Union
 
 import boto3
 from moto import core as moto_core
@@ -266,7 +267,13 @@ def register_signal_handlers():
     SIGNAL_HANDLERS_SETUP = True
 
 
-def do_run(cmd, asynchronous, print_output=None, env_vars={}, auto_restart=False):
+def do_run(
+    cmd: Union[str, List],
+    asynchronous: bool,
+    print_output: bool = None,
+    env_vars: Dict[str, str] = {},
+    auto_restart=False,
+):
     sys.stdout.flush()
     if asynchronous:
         if config.DEBUG and print_output is None:

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1648,7 +1648,8 @@ def do_run(cmd: str, run_cmd: Callable, cache_duration_secs: int):
     return result
 
 
-def run(cmd, cache_duration_secs=0, **kwargs):
+def run(cmd: Union[str, List[str]], cache_duration_secs=0, **kwargs):
+    # TODO: should be unified and replaced with safe_run(..) over time! (allowing only lists for cmd parameter)
     def run_cmd():
         return localstack.utils.run.run(cmd, **kwargs)
 

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -33,6 +33,18 @@ def run(
         env_dict.update(env_vars)
     env_dict = dict([(k, to_str(str(v))) for k, v in env_dict.items()])
 
+    if isinstance(cmd, list):
+        # See docs of subprocess.Popen(...):
+        #  "On POSIX with shell=True, the shell defaults to /bin/sh. If args is a string,
+        #   the string specifies the command to execute through the shell. [...] If args is
+        #   a sequence, the first item specifies the command string, and any additional
+        #   items will be treated as additional arguments to the shell itself."
+        # Hence, we should *disable* shell mode here to be on the safe side, to prevent
+        #  arguments in the cmd list from leaking into arguments to the shell itself. This will
+        #  effectively allow us to call run(..) with both - str and list - as cmd argument, although
+        #  over time we should move from "cmd: Union[str, List[str]]" to "cmd: List[str]" only.
+        shell = False
+
     if tty:
         asynchronous = True
         stdin = True

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from localstack.utils.common import is_none_or_empty, synchronized
+from localstack.utils.common import is_none_or_empty, synchronized, run
 
 
 class SynchronizedTest(unittest.TestCase):
@@ -46,3 +46,18 @@ def test_is_none_or_empty_strings(obj, result):
 )
 def test_is_none_or_empty_lists(obj, result):
     assert is_none_or_empty(obj) == result
+
+
+def test_run_cmd_as_str_or_list():
+    def _run(cmd):
+        return run(cmd).strip()
+
+    # Assert that commands can be specified as strings as well as lists.
+    # (shell=True|False flag for subprocess.Popen() is properly managed by run(..) function)
+    assert "foo bar 123" == _run("echo 'foo bar 123'")
+    assert "foo bar 123" == _run("echo foo bar 123")
+    assert "foo bar 123" == _run("  echo    foo    bar     123    ")
+    assert "foo bar 123" == _run(["echo", "foo bar 123"])
+    assert "foo bar 123" == _run(["echo", "foo", "bar", "123"])
+    with pytest.raises(FileNotFoundError):
+        _run(["echo 'foo bar 123'"])

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from localstack.utils.common import is_none_or_empty, synchronized, run
+from localstack.utils.common import is_none_or_empty, run, synchronized
 
 
 class SynchronizedTest(unittest.TestCase):


### PR DESCRIPTION
Disable shell mode in `run(..)` utility function if `cmd` is passed as a list - see description in the code comment.

/cc @thrau @dfangl 