### PR TITLE
Move rest of RESOURCE_TO_FUNCTION into service models

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -23,6 +23,21 @@ class GatewayResponse(GenericBaseModel):
         result = client.get_gateway_response(restApiId=api_id, responseType=props["ResponseType"])
         return result if "responseType" in result else None
 
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "put_gateway_response",
+                "parameters": {
+                    "restApiId": "RestApiId",
+                    "responseType": "ResponseType",
+                    "statusCode": "StatusCode",
+                    "responseParameters": "ResponseParameters",
+                    "responseTemplates": "ResponseTemplates",
+                },
+            }
+        }
+
 
 class GatewayRequestValidator(GenericBaseModel):
     @staticmethod
@@ -113,6 +128,20 @@ class GatewayDeployment(GenericBaseModel):
         # TODO possibly filter results by stage name or other criteria
 
         return result[0] if result else None
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_deployment",
+                "parameters": {
+                    "restApiId": "RestApiId",
+                    "stageName": "StageName",
+                    "stageDescription": "StageDescription",
+                    "description": "Description",
+                },
+            }
+        }
 
 
 class GatewayResource(GenericBaseModel):
@@ -496,6 +525,19 @@ class GatewayModel(GenericBaseModel):
             return models[0]
 
         return None
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_model",
+                "parameters": {
+                    "name": "Name",
+                    "restApiId": "RestApiId",
+                },
+                "defaults": {"contentType": "application/json"},
+            }
+        }
 
 
 class GatewayAccount(GenericBaseModel):

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -130,6 +130,15 @@ class LambdaFunctionVersion(GenericBaseModel):
         )
         return ([v for v in versions["Versions"] if v["Version"] == func_version] or [None])[0]
 
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "publish_version",
+                "parameters": select_parameters("FunctionName", "CodeSha256", "Description"),
+            }
+        }
+
 
 class LambdaEventSourceMapping(GenericBaseModel):
     @staticmethod
@@ -160,6 +169,22 @@ class LambdaEventSourceMapping(GenericBaseModel):
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
         return self.props.get("UUID")
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_event_source_mapping",
+                "parameters": select_parameters(
+                    "FunctionName",
+                    "EventSourceArn",
+                    "Enabled",
+                    "StartingPosition",
+                    "BatchSize",
+                    "StartingPositionTimestamp",
+                ),
+            }
+        }
 
 
 class LambdaPermission(GenericBaseModel):

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -1,5 +1,42 @@
+from localstack.services.cloudformation.deployment_utils import PLACEHOLDER_AWS_NO_VALUE
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
+from localstack.utils import common
 from localstack.utils.aws import aws_stack
+
+
+def get_ddb_provisioned_throughput(params, **kwargs):
+    args = params.get("ProvisionedThroughput")
+    if args == PLACEHOLDER_AWS_NO_VALUE:
+        return {}
+    if args:
+        if isinstance(args["ReadCapacityUnits"], str):
+            args["ReadCapacityUnits"] = int(args["ReadCapacityUnits"])
+        if isinstance(args["WriteCapacityUnits"], str):
+            args["WriteCapacityUnits"] = int(args["WriteCapacityUnits"])
+    return args
+
+
+def get_ddb_global_sec_indexes(params, **kwargs):
+    args = params.get("GlobalSecondaryIndexes")
+    if args:
+        for index in args:
+            provisoned_throughput = index["ProvisionedThroughput"]
+            if isinstance(provisoned_throughput["ReadCapacityUnits"], str):
+                provisoned_throughput["ReadCapacityUnits"] = int(
+                    provisoned_throughput["ReadCapacityUnits"]
+                )
+            if isinstance(provisoned_throughput["WriteCapacityUnits"], str):
+                provisoned_throughput["WriteCapacityUnits"] = int(
+                    provisoned_throughput["WriteCapacityUnits"]
+                )
+    return args
+
+
+def get_ddb_kinesis_stream_specification(params, **kwargs):
+    args = params.get("KinesisStreamSpecification")
+    if args:
+        args["TableName"] = params["TableName"]
+    return args
 
 
 class DynamoDBTable(GenericBaseModel):
@@ -17,3 +54,42 @@ class DynamoDBTable(GenericBaseModel):
         table_name = self.props.get("TableName") or self.resource_id
         table_name = self.resolve_refs_recursively(stack_name, table_name, resources)
         return aws_stack.connect_to_service("dynamodb").describe_table(TableName=table_name)
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": [
+                {
+                    "function": "create_table",
+                    "parameters": {
+                        "TableName": "TableName",
+                        "AttributeDefinitions": "AttributeDefinitions",
+                        "KeySchema": "KeySchema",
+                        "ProvisionedThroughput": get_ddb_provisioned_throughput,
+                        "LocalSecondaryIndexes": "LocalSecondaryIndexes",
+                        "GlobalSecondaryIndexes": get_ddb_global_sec_indexes,
+                        "StreamSpecification": lambda params, **kwargs: (
+                            common.merge_dicts(
+                                params.get("StreamSpecification"),
+                                {"StreamEnabled": True},
+                                default=None,
+                            )
+                        ),
+                    },
+                    "defaults": {
+                        "ProvisionedThroughput": {
+                            "ReadCapacityUnits": 5,
+                            "WriteCapacityUnits": 5,
+                        }
+                    },
+                },
+                {
+                    "function": "enable_kinesis_streaming_destination",
+                    "parameters": get_ddb_kinesis_stream_specification,
+                },
+            ],
+            "delete": {
+                "function": "delete_table",
+                "parameters": {"TableName": "TableName"},
+            },
+        }

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -1,3 +1,4 @@
+from localstack.services.cloudformation.deployment_utils import select_parameters
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -13,3 +14,21 @@ class FirehoseDeliveryStream(GenericBaseModel):
         return aws_stack.connect_to_service("firehose").describe_delivery_stream(
             DeliveryStreamName=stream_name
         )
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_delivery_stream",
+                "parameters": select_parameters(
+                    "DeliveryStreamName",
+                    "DeliveryStreamType",
+                    "S3DestinationConfiguration",
+                    "ElasticsearchDestinationConfiguration",
+                ),
+            },
+            "delete": {
+                "function": "delete_delivery_stream",
+                "parameters": {"DeliveryStreamName": "DeliveryStreamName"},
+            },
+        }

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -1,3 +1,4 @@
+from localstack.services.cloudformation.deployment_utils import PLACEHOLDER_RESOURCE_NAME
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -14,6 +15,19 @@ class SFNActivity(GenericBaseModel):
         client = aws_stack.connect_to_service("stepfunctions")
         result = client.describe_activity(activityArn=activity_arn)
         return result
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_activity",
+                "parameters": {"name": ["Name", PLACEHOLDER_RESOURCE_NAME], "tags": "Tags"},
+            },
+            "delete": {
+                "function": "delete_activity",
+                "parameters": {"activityArn": "PhysicalResourceId"},
+            },
+        }
 
 
 class SFNStateMachine(GenericBaseModel):
@@ -50,3 +64,20 @@ class SFNStateMachine(GenericBaseModel):
             "definition": props["DefinitionString"],
         }
         return client.update_state_machine(**kwargs)
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {
+                "function": "create_state_machine",
+                "parameters": {
+                    "name": ["StateMachineName", PLACEHOLDER_RESOURCE_NAME],
+                    "definition": "DefinitionString",
+                    "roleArn": "RoleArn",
+                },
+            },
+            "delete": {
+                "function": "delete_state_machine",
+                "parameters": {"stateMachineArn": "PhysicalResourceId"},
+            },
+        }

--- a/localstack/utils/cloudformation/cfn_utils.py
+++ b/localstack/utils/cloudformation/cfn_utils.py
@@ -1,0 +1,8 @@
+def rename_params(func, rename_map):
+    def do_rename(params, **kwargs):
+        values = func(params, **kwargs) if func else params
+        for old_param, new_param in rename_map.items():
+            values[new_param] = values.pop(old_param, None)
+        return values
+
+    return do_rename

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -126,21 +126,6 @@ def get_ddb_kinesis_stream_specification(params, **kwargs):
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
-    "KinesisFirehose::DeliveryStream": {
-        "create": {
-            "function": "create_delivery_stream",
-            "parameters": select_parameters(
-                "DeliveryStreamName",
-                "DeliveryStreamType",
-                "S3DestinationConfiguration",
-                "ElasticsearchDestinationConfiguration",
-            ),
-        },
-        "delete": {
-            "function": "delete_delivery_stream",
-            "parameters": {"DeliveryStreamName": "DeliveryStreamName"},
-        },
-    },
     "Elasticsearch::Domain": {
         "create": [
             {

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -120,25 +120,6 @@ def get_ddb_kinesis_stream_specification(params, **kwargs):
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
-    "Lambda::Version": {
-        "create": {
-            "function": "publish_version",
-            "parameters": select_parameters("FunctionName", "CodeSha256", "Description"),
-        }
-    },
-    "Lambda::EventSourceMapping": {
-        "create": {
-            "function": "create_event_source_mapping",
-            "parameters": select_parameters(
-                "FunctionName",
-                "EventSourceArn",
-                "Enabled",
-                "StartingPosition",
-                "BatchSize",
-                "StartingPositionTimestamp",
-            ),
-        }
-    },
     "DynamoDB::Table": {
         "create": [
             {

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -83,16 +83,6 @@ def lambda_get_params():
     return lambda params, **kwargs: params
 
 
-def rename_params(func, rename_map):
-    def do_rename(params, **kwargs):
-        values = func(params, **kwargs) if func else params
-        for old_param, new_param in rename_map.items():
-            values[new_param] = values.pop(old_param, None)
-        return values
-
-    return do_rename
-
-
 def es_add_tags_params(params, **kwargs):
     es_arn = aws_stack.es_domain_arn(params.get("DomainName"))
     tags = params.get("Tags", [])
@@ -136,14 +126,6 @@ def get_ddb_kinesis_stream_specification(params, **kwargs):
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
-    "S3::BucketPolicy": {
-        "create": {
-            "function": "put_bucket_policy",
-            "parameters": rename_params(
-                dump_json_params(None, "PolicyDocument"), {"PolicyDocument": "Policy"}
-            ),
-        }
-    },
     "KinesisFirehose::DeliveryStream": {
         "create": {
             "function": "create_delivery_stream",

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -18,10 +18,7 @@ from localstack.constants import FALSE_STRINGS, S3_STATIC_WEBSITE_HOSTNAME, TEST
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
     PLACEHOLDER_RESOURCE_NAME,
-    dump_json_params,
-    param_defaults,
     remove_none_values,
-    select_parameters,
 )
 from localstack.services.cloudformation.service_models import (
     KEY_RESOURCE_STATE,
@@ -85,27 +82,6 @@ def lambda_get_params():
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
-    "IAM::Role": {
-        "create": {
-            "function": "create_role",
-            "parameters": param_defaults(
-                dump_json_params(
-                    select_parameters(
-                        "Path",
-                        "RoleName",
-                        "AssumeRolePolicyDocument",
-                        "Description",
-                        "MaxSessionDuration",
-                        "PermissionsBoundary",
-                        "Tags",
-                    ),
-                    "AssumeRolePolicyDocument",
-                ),
-                {"RoleName": PLACEHOLDER_RESOURCE_NAME},
-            ),
-        },
-        "delete": {"function": "delete_role", "parameters": {"RoleName": "RoleName"}},
-    },
     "ApiGateway::Account": {},
     "ApiGateway::Model": {
         "create": {

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -83,12 +83,6 @@ def lambda_get_params():
     return lambda params, **kwargs: params
 
 
-def es_add_tags_params(params, **kwargs):
-    es_arn = aws_stack.es_domain_arn(params.get("DomainName"))
-    tags = params.get("Tags", [])
-    return {"ARN": es_arn, "TagList": tags}
-
-
 def get_ddb_provisioned_throughput(params, **kwargs):
     args = params.get("ProvisionedThroughput")
     if args == PLACEHOLDER_AWS_NO_VALUE:
@@ -126,32 +120,6 @@ def get_ddb_kinesis_stream_specification(params, **kwargs):
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
-    "Elasticsearch::Domain": {
-        "create": [
-            {
-                "function": "create_elasticsearch_domain",
-                "parameters": select_parameters(
-                    "AccessPolicies",
-                    "AdvancedOptions",
-                    "CognitoOptions",
-                    "DomainName",
-                    "EBSOptions",
-                    "ElasticsearchClusterConfig",
-                    "ElasticsearchVersion",
-                    "EncryptionAtRestOptions",
-                    "LogPublishingOptions",
-                    "NodeToNodeEncryptionOptions",
-                    "SnapshotOptions",
-                    "VPCOptions",
-                ),
-            },
-            {"function": "add_tags", "parameters": es_add_tags_params},
-        ],
-        "delete": {
-            "function": "delete_elasticsearch_domain",
-            "parameters": {"DomainName": "DomainName"},
-        },
-    },
     "Lambda::Version": {
         "create": {
             "function": "publish_version",

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -82,40 +82,6 @@ def lambda_get_params():
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {
-    "ApiGateway::Account": {},
-    "ApiGateway::Model": {
-        "create": {
-            "function": "create_model",
-            "parameters": {
-                "name": "Name",
-                "restApiId": "RestApiId",
-            },
-            "defaults": {"contentType": "application/json"},
-        }
-    },
-    "ApiGateway::Deployment": {
-        "create": {
-            "function": "create_deployment",
-            "parameters": {
-                "restApiId": "RestApiId",
-                "stageName": "StageName",
-                "stageDescription": "StageDescription",
-                "description": "Description",
-            },
-        }
-    },
-    "ApiGateway::GatewayResponse": {
-        "create": {
-            "function": "put_gateway_response",
-            "parameters": {
-                "restApiId": "RestApiId",
-                "responseType": "ResponseType",
-                "statusCode": "StatusCode",
-                "responseParameters": "ResponseParameters",
-                "responseTemplates": "ResponseTemplates",
-            },
-        }
-    },
     "StepFunctions::StateMachine": {
         "create": {
             "function": "create_state_machine",

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -81,32 +81,7 @@ def lambda_get_params():
 
 
 # maps resource types to functions and parameters for creation
-RESOURCE_TO_FUNCTION = {
-    "StepFunctions::StateMachine": {
-        "create": {
-            "function": "create_state_machine",
-            "parameters": {
-                "name": ["StateMachineName", PLACEHOLDER_RESOURCE_NAME],
-                "definition": "DefinitionString",
-                "roleArn": lambda params, **kwargs: get_role_arn(params.get("RoleArn"), **kwargs),
-            },
-        },
-        "delete": {
-            "function": "delete_state_machine",
-            "parameters": {"stateMachineArn": "PhysicalResourceId"},
-        },
-    },
-    "StepFunctions::Activity": {
-        "create": {
-            "function": "create_activity",
-            "parameters": {"name": ["Name", PLACEHOLDER_RESOURCE_NAME], "tags": "Tags"},
-        },
-        "delete": {
-            "function": "delete_activity",
-            "parameters": {"activityArn": "PhysicalResourceId"},
-        },
-    },
-}
+RESOURCE_TO_FUNCTION = {}
 
 
 # ----------------
@@ -127,11 +102,6 @@ def retrieve_topic_arn(topic_name):
     topics = aws_stack.connect_to_service("sns").list_topics()["Topics"]
     topic_arns = [t["TopicArn"] for t in topics if t["TopicArn"].endswith(":%s" % topic_name)]
     return topic_arns[0]
-
-
-def get_role_arn(role_arn, **kwargs):
-    role_arn = resolve_refs_recursively(kwargs.get("stack_name"), role_arn, kwargs.get("resources"))
-    return aws_stack.role_arn(role_arn)
 
 
 def find_stack(stack_name):


### PR DESCRIPTION
Part of the service model refactoring effort. Moves the rest of the RESOURCE_TO_FUNCTION in the template_deployer into the respective service models.

One part I'm not 100% certain about is the change in the last commit. I've dropped/removed the get_role_arn call which itself depends on resolve_refs_recursively. I would've assumed the parameters should already have gone through a resolve_refs_recursively call by this point? @whummer  Maybe you can provide a bit more insight here.  The original get_arn_role code was added in 3684fcfd66baa387e03f6b2d9d30585a4ab0130a