### PR TITLE
Restructure python requirements and Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
             which python
             realpath $(which python)
             pip install --upgrade pip
-            pip install wheel setuptools pytest
-            pip install -r requirements.txt
+            pip install wheel setuptools
+            pip install -e ".[cli,runtime,test,dev]"
             python -m localstack.services.install libs
             python -m localstack.services.install testlibs
             mkdir -p target/reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,20 +23,20 @@ RUN curl https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt >> /etc/ss
 RUN pip install awscli awscli-local requests --upgrade
 RUN apk add iputils
 
-# add files required to install virtualenv dependencies
-ADD Makefile requirements.txt ./
-RUN make install-venv-docker
+# add configuration and source files
+ADD Makefile setup.py requirements.txt ./
+ADD localstack/ localstack/
+ADD bin/localstack bin/localstack
+# necessary for running pip install -e
+ADD bin/localstack.bat bin/localstack.bat
 
-# add files required to run "make init"
-RUN mkdir -p localstack/utils/kinesis/ && mkdir -p localstack/services/ && \
-  touch localstack/__init__.py localstack/utils/__init__.py localstack/services/__init__.py localstack/utils/kinesis/__init__.py
-ADD localstack/__init__.py localstack/constants.py localstack/config.py localstack/
-ADD localstack/services/awslambda localstack/services/awslambda
-ADD localstack/plugin/ localstack/plugin/
-ADD localstack/services/install.py localstack/services/generic_proxy.py localstack/services/__init__.py localstack/services/
-ADD localstack/services/cloudformation/deployment_utils.py localstack/services/cloudformation/deployment_utils.py
-ADD localstack/utils/ localstack/utils/
-ADD localstack/package.json localstack/package.json
+# install dependencies to run the localstack runtime and save which ones were installed
+RUN make install-runtime
+RUN make freeze > requirements-runtime.txt
+
+# install dependencies run localstack tests
+RUN make install-test
+RUN make freeze > requirements-test.txt
 
 # initialize installation (downloads remaining dependencies)
 RUN make init-testlibs
@@ -69,10 +69,6 @@ RUN if [ -e /usr/bin/aws ]; then mv /usr/bin/aws /usr/bin/aws.bk; fi; ln -s /opt
 ENV PYTHONPATH=/opt/code/localstack/.venv/lib/python3.8/site-packages:/opt/code/localstack/.venv/lib/python3.7/site-packages
 RUN which awslocal
 
-# add rest of the code
-ADD localstack/ localstack/
-ADD bin/localstack bin/localstack
-
 # fix some permissions and create local user
 RUN ES_BASE_DIR=localstack/infra/elasticsearch; \
     mkdir -p /.npm && \
@@ -94,14 +90,18 @@ ADD tests/ tests/
 # add configuration files
 ADD pyproject.toml ./
 # fixes a dependency issue with pytest and python3.7 https://github.com/pytest-dev/pytest/issues/5594
-RUN pip uninstall -y argparse
-RUN pip uninstall -y dataclasses
+RUN pip uninstall -y argparse dataclasses
 RUN LAMBDA_EXECUTOR=local \
     PYTEST_LOGLEVEL=info \
     PYTEST_ARGS='--junitxml=target/test-report.xml' \
     make test-coverage
 
+# clean up tests (created earlier via make freeze)
+RUN (. .venv/bin/activate; comm -3 requirements-runtime.txt requirements-test.txt | cut -d'=' -f1 | xargs pip uninstall -y )
+RUN rm -rf tests/ requirements-*.txt
+
 # clean up temporary files created during test execution
 RUN apk del --purge git cmake gcc musl-dev libc-dev; \
     rm -rf /tmp/localstack/*elasticsearch* /tmp/localstack.* tests/ /root/.npm/*cache /opt/terraform /root/.serverless; \
+    rm -rf .pytest_cache/; \
     mkdir /root/.serverless; chmod -R 777 /root/.serverless

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ venv:                  ## Create a new (empty) virtual environment
 	(test `which virtualenv` || $(PIP_CMD) install --user virtualenv) && \
 		(test -e $(VENV_DIR) || virtualenv $(VENV_OPTS) $(VENV_DIR))
 
+freeze:                   ## Run pip freeze -l in the virtual environment
+	@$(VENV_RUN); pip freeze -l
+
 install-basic: venv       ## Install basic dependencies for CLI usage into venv
 	$(VENV_RUN); $(PIP_CMD) install -e ".[cli]"
 

--- a/Makefile
+++ b/Makefile
@@ -16,45 +16,43 @@ else
 	VENV_RUN = . $(VENV_DIR)/bin/activate
 endif
 
-usage:             ## Show this help
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+usage:                 ## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/:.*##\s*/##/g' | awk -F'##' '{ printf "%-20s %s\n", $$1, $$2 }'
 
-setup-venv:
+venv:                  ## Create a new (empty) virtual environment
 	(test `which virtualenv` || $(PIP_CMD) install --user virtualenv) && \
 		(test -e $(VENV_DIR) || virtualenv $(VENV_OPTS) $(VENV_DIR))
 
-install-venv:
-	make setup-venv && \
-		test ! -e requirements.txt || ($(VENV_RUN); $(PIP_CMD) -q install -r requirements.txt)
+install-basic: venv       ## Install basic dependencies for CLI usage into venv
+	$(VENV_RUN); $(PIP_CMD) install -e ".[cli]"
 
-install-venv-docker: # make install-venv for the docker environment (hack to remove black and isort)
-	make setup-venv && \
-		test ! -e requirements.txt || \
-		($(VENV_RUN);  $(PIP_CMD) install `grep -v '^ *#\|^black\|^isort\|^flake8' requirements.txt | cut -d' ' -f1 | grep .`)
+install-runtime: venv     ## Install dependencies for the localstack runtime into venv
+	$(VENV_RUN); $(PIP_CMD) install -e ".[cli,runtime]"
 
-init:              ## Initialize the infrastructure, make sure all libs are downloaded
+install-test: venv        ## Install requirements to run tests into venv
+	$(VENV_RUN); $(PIP_CMD) install -e ".[cli,runtime,test]"
+
+install-dev: venv         ## Install developer requirements into venv
+	$(VENV_RUN); $(PIP_CMD) install -e ".[cli,runtime,test,dev]"
+
+install:                  ## Install full dependencies into venv, and download third-party services
+	(make install-dev && make init-testlibs) || exit 1
+
+init:                     ## Initialize the infrastructure, make sure all libs are downloaded
 	$(VENV_RUN); python -m localstack.services.install libs
 
 init-testlibs:
 	$(VENV_RUN); python -m localstack.services.install testlibs
 
-install:           ## Install full dependencies in virtualenv
-	(make install-venv && make init-testlibs) || exit 1
-
-install-basic:     ## Install basic dependencies for CLI usage in virtualenv
-	make setup-venv && \
-		($(VENV_RUN); cat requirements.txt | grep -ve '^#' | grep '#\(basic\|extended\)' | sed 's/ #.*//' \
-			| xargs $(PIP_CMD) install)
-
 publish:           ## Publish the library to the central PyPi repository
 	# build and upload archive
-	($(VENV_RUN) && ./setup.py sdist upload)
+	($(VENV_RUN) && python setup.py sdist upload)
 
 coveralls:         ## Publish coveralls metrics
 	($(VENV_RUN); coveralls)
 
-infra:             ## Manually start the local infrastructure for testing
-	($(VENV_RUN); exec bin/localstack start --host --no-banner)
+start:             ## Manually start the local infrastructure for testing
+	($(VENV_RUN); exec bin/localstack start --host)
 
 docker-build:      ## Build Docker image
 	# prepare
@@ -85,7 +83,7 @@ docker-push:       ## Push Docker image to registry
 	make docker-squash
 	docker push $(IMAGE_NAME):$(IMAGE_TAG)
 
-docker-push-master:## Push Docker image to registry IF we are currently on the master branch
+docker-push-master: ## Push Docker image to registry IF we are currently on the master branch
 	(CURRENT_BRANCH=`(git rev-parse --abbrev-ref HEAD | grep '^master$$' || ((git branch -a | grep 'HEAD detached at [0-9a-zA-Z]*)') && git branch -a)) | grep '^[* ]*master$$' | sed 's/[* ]//g' || true`; \
 		test "$$CURRENT_BRANCH" != 'master' && echo "Not on master branch.") || \
 	((test "$$DOCKER_USERNAME" = '' || test "$$DOCKER_PASSWORD" = '' ) && \
@@ -119,17 +117,6 @@ docker-mount-run:
 docker-build-lambdas:
 	docker build -t localstack/lambda-js:nodejs14.x -f bin/lambda/Dockerfile.nodejs14x .
 
-vagrant-start:
-	@vagrant up || EXIT_CODE=$$? ;\
- 	if [ "$EXIT_CODE" != "0" ]; then\
- 		echo "Predicted error. Ignoring...";\
-		vagrant ssh -c "sudo yum install -y epel-release && sudo yum update -y && sudo yum -y install wget perl gcc gcc-c++ dkms kernel-devel kernel-headers make bzip2";\
-		vagrant reload --provision;\
-	fi
-
-vagrant-stop:
-	vagrant halt
-
 docker-build-light:
 	@img_name=$(IMAGE_NAME_LIGHT); \
 		docker build -t $$img_name -f bin/Dockerfile.light .; \
@@ -142,13 +129,11 @@ docker-cp-coverage:
 		docker cp $$id:/opt/code/localstack/.coverage .coverage; \
 		docker rm -v $$id
 
-## Run automated tests
-test:
+test:              ## Run automated tests
 	($(VENV_RUN); DEBUG=$(DEBUG) pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))
 
-test-coverage:
+test-coverage:     ## Run automated tests and create coverage report
 	($(VENV_RUN); python -m coverage --version; \
-		pip install "coverage[toml]>=5.5"; \
 		DEBUG=$(DEBUG) \
 		python -m coverage run $(COVERAGE_ARGS) -m \
 		pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) -s $(PYTEST_ARGS) $(TEST_PATH))
@@ -188,16 +173,16 @@ reinstall-p3:      ## Re-initialize the virtualenv with Python 3.x
 lint:              ## Run code linter to check code style
 	($(VENV_RUN); python -m pflake8 --show-source)
 
-lint-modified:      ## Run code linter on modified files
+lint-modified:     ## Run code linter on modified files
 	($(VENV_RUN); python -m pflake8 --show-source `git ls-files -m | grep '\.py$$' | xargs` )
 
-format:
+format:            ## Run black and isort code formatter
 	($(VENV_RUN); python -m isort localstack tests; python -m black localstack tests )
 
-format-modified:
+format-modified:   ## Run black and isort code formatter on modified files
 	($(VENV_RUN); python -m isort `git ls-files -m | grep '\.py$$' | xargs`; python -m black `git ls-files -m | grep '\.py$$' | xargs` )
 
-init-precommit:
+init-precommit:    ## install te pre-commit hook into your local git repository
 	($(VENV_RUN); pre-commit install)
 
 clean:             ## Clean up (npm dependencies, downloaded infrastructure code, compiled Java classes)
@@ -213,4 +198,27 @@ clean:             ## Clean up (npm dependencies, downloaded infrastructure code
 	rm -rf $(VENV_DIR)
 	rm -f localstack/utils/kinesis/java/com/atlassian/*.class
 
-.PHONY: usage compile clean install infra test test-coverage install-venv-docker lint lint-modified format format-modified
+vagrant-start:
+	@vagrant up || EXIT_CODE=$$? ;\
+ 	if [ "$EXIT_CODE" != "0" ]; then\
+ 		echo "Predicted error. Ignoring...";\
+		vagrant ssh -c "sudo yum install -y epel-release && sudo yum update -y && sudo yum -y install wget perl gcc gcc-c++ dkms kernel-devel kernel-headers make bzip2";\
+		vagrant reload --provision;\
+	fi
+
+vagrant-stop:
+	vagrant halt
+
+# deprecated commands
+
+setup-venv: venv
+	@echo "this command is deprecated, use: make venv"
+
+install-venv: venv
+	@echo "this command is deprecated, use: make install-dev"
+	test ! -e requirements.txt || ($(VENV_RUN); $(PIP_CMD) -q install -r requirements.txt)
+
+infra:             # legacy command used in the supervisord file to
+	($(VENV_RUN); exec bin/localstack start --host --no-banner)
+
+.PHONY: usage compile clean install-basic install-runtime install-test install-dev infra run-dev test test-coverage install-venv-docker lint lint-modified format format-modified venv

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ additional native libs installed.
 The Makefile contains a target to conveniently run the local infrastructure for development:
 
 ```
-make infra
+make start
 ```
 
 #### Starting LocalStack using Vagrant (Centos 8)
@@ -679,13 +679,19 @@ target:
 make test
 ```
 
+to run a specific test, you can use the `TEST_PATH` variable, for example:
+
+```
+TEST_PATH='tests/unit/sns_test.py' make test
+```
+
 ## To check the Code Coverage
 
 Once the new feature / bug fix is done, run the unit testing and check for the coverage.
 
 ```
 # To run the particular test file (sample)
-pytest --cov=localstack tests/unit/test_common.py
+TEST_PATH='tests/unit/sns_test.py' make test-coverage
 
 # To check the coverage in the console
 coverage report

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import requests
 
 from localstack import config
-from localstack.config import KINESIS_PROVIDER, is_env_true
+from localstack.config import is_env_true
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS,
     DYNAMODB_JAR_URL,
@@ -31,11 +31,6 @@ from localstack.constants import (
     STS_JAR_URL,
 )
 from localstack.utils import bootstrap
-from localstack.utils.docker import DOCKER_CLIENT
-
-if __name__ == "__main__":
-    bootstrap.bootstrap_installation()
-# noqa: E402
 from localstack.utils.common import (
     chmod_r,
     download,
@@ -54,6 +49,7 @@ from localstack.utils.common import (
     untar,
     unzip,
 )
+from localstack.utils.docker import DOCKER_CLIENT
 
 LOG = logging.getLogger(__name__)
 
@@ -203,12 +199,12 @@ def install_elasticmq():
 
 
 def install_kinesis():
-    if KINESIS_PROVIDER == "kinesalite":
+    if config.KINESIS_PROVIDER == "kinesalite":
         return install_kinesalite()
-    elif KINESIS_PROVIDER == "kinesis-mock":
+    elif config.KINESIS_PROVIDER == "kinesis-mock":
         return install_kinesis_mock()
     else:
-        raise ValueError("unknown kinesis provider %s" % KINESIS_PROVIDER)
+        raise ValueError("unknown kinesis provider %s" % config.KINESIS_PROVIDER)
 
 
 def install_kinesalite():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,29 @@
-# (1) Lines annotated with "#extended-lib" are excluded
-# from the dependencies when we build the pip package
+# dependencies are grouped into blocks that define in which extra they belong to. for example, all requirements below
+#  the line `# extra=runtime`, can be installed with `pip install -e ".[runtime]"`
+#
+# install:  dependencies that are required for the cli (via pip install localstack)
+# runtime:  required to actually run localstack on the host
+# test:     for running tests and coverage analysis
+# dev:      for developing localstack
 
-# (2) Lines annotated with "#basic-lib" are included in the basic
-# version of the pip package (i.e., for "pip install localstack").
+# extra=install
+boto3>=1.14.33
+click>=7.0
+# dataclasses needed for python3.6 compat
+dataclasses; python_version < '3.7'
+#dnspython==1.16.0
+#docopt>=0.6.2
+docker==5.0.0
+localstack-ext>=0.12.16
+localstack-client>=1.24
+pyyaml>=5.1
+rich>=10.7.0
+requests>=2.20.0,<2.26
+# TODO: "six" dependency still needed?
+six>=1.12.0
+stevedore>=3.4.0
 
-# (3) The remaining dependencies (those without markers) are only included in
-# the "full" version of the pip package (i.e., "pip install localstack[full]").
-
+# extra=runtime
 airspeed>=0.5.14
 # Use our "ext" version until this bug is fixed: https://github.com/awslabs/amazon-kinesis-client-python/issues/99
 amazon_kclpy-ext==1.5.1
@@ -14,58 +31,48 @@ amazon_kclpy-ext==1.5.1
 aws-sam-translator>=1.15.1
 awscli>=1.14.18
 boto>=2.49.0
-boto3>=1.14.33                 #basic-lib
 botocore>=1.12.13
-black==21.6b0                  #extended-lib
 cachetools>=3.1.1,<4.0.0
 cbor2>=5.2.0
-click>=7.0                     #basic-lib
-# coverage version should be synced with bin/Dockerfile.base
-coverage[toml]>=5.5
-coveralls==3.1.0
 crontab>=0.22.6
 # pin version to avoid Rust build issues: https://github.com/pyca/cryptography/issues/5771
 cryptography<3.4
-Cython                         #extended-lib
-# dataclasses needed for python3.6 compat
-dataclasses; python_version < '3.7' #basic-lib
-dnspython==1.16.0              #basic-lib
-docopt>=0.6.2                  #basic-lib
-docker==5.0.0                  #basic-lib
 elasticsearch>=7.0.0,<8.0.0
-flake8>=3.6.0                  #extended-lib
-flake8-black>=0.2.1            #extended-lib
-flake8-isort>=4.0.0            #extended-lib
-flake8-quotes>=0.11.0          #extended-lib
-# enables flake8 configuration through pyproject.toml
-pyproject-flake8               #extended-lib
 flask>=1.0.2
 flask-cors>=3.0.3,<3.1.0
 flask_swagger==0.2.12
-forbiddenfruit==0.1.3
-isort==5.9.1                   #extended-lib
-jsondiff>=1.2.0
+#forbiddenfruit==0.1.3
+#jsondiff>=1.2.0
 jsonpatch>=1.24,<2.0
 jsonpath-rw>=1.4.0,<2.0.0
 localstack-ext[full]>=0.12.16
-localstack-ext>=0.12.16        #basic-lib
-localstack-client>=1.24        #basic-lib
 moto-ext[all]>=2.0.3.23
-pre-commit==2.13.0             #extended-lib
 psutil>=5.4.8,<6.0.0
-pympler>=0.6
+#pympler>=0.6
 pyopenssl==17.5.0
+Quart>=0.6.15
+readerwriterlock>=1.0.7
+requests-aws4auth==0.9
+#sasl>=0.2.1
+xmltodict>=0.11.0
+
+# extra=test
+# these requirements are used for testing, also during docker build
 pytest==6.2.4
 pytest-httpserver>=1.0.1
 pytest-rerunfailures==10.0
-pyyaml>=5.1                    #basic-lib
-Quart>=0.6.15
-rich>=10.7.0                   #basic-lib
-readerwriterlock>=1.0.7
-requests>=2.20.0,<2.26         #basic-lib
-requests-aws4auth==0.9
-sasl>=0.2.1
-# TODO: "six" dependency still needed?
-six>=1.12.0                    #basic-lib
-stevedore>=3.4.0               #basic-lib
-xmltodict>=0.11.0
+# coverage version should be synced with bin/Dockerfile.base
+coverage[toml]>=5.5
+
+# extra=dev
+black==21.6b0
+coveralls==3.1.0
+Cython
+flake8>=3.6.0
+flake8-black>=0.2.1
+flake8-isort>=4.0.0
+flake8-quotes>=0.11.0
+# enables flake8 configuration through pyproject.toml
+pre-commit==2.13.0
+pyproject-flake8
+isort==5.9.1

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,45 @@
 #!/usr/bin/env python
 
 import re
+from collections import defaultdict
 
 from setuptools import find_packages, setup
 
 import localstack
 
-# marker for extended/ignored and basic libs in requirements.txt
-IGNORED_LIB_MARKER = "#extended-lib"
-BASIC_LIB_MARKER = "#basic-lib"
 
-# parameter variables
-install_requires = []
-extra_requires = []
-dependency_links = []
-package_data = {}
+def parse_requirements(lines):
+    requirements = defaultdict(list)
+    extra = "install"
+
+    for line in lines:
+        line = line.strip()
+        if line.startswith("# extra="):
+            # all subsequent lines are associated with this extra, until a new extra appears
+            extra = line.split("=")[1]
+            continue
+
+        if line and line[0] == "#" and "#egg=" in line:
+            line = re.search(r"#\s*(.*)", line).group(1)
+
+        if line and line[0] != "#":
+            lib_stripped = line.split(" #")[0].strip()
+            requirements[extra].append(lib_stripped)
+
+    return requirements
 
 
 # determine version
 version = localstack.__version__
 
-
 # determine requirements
 with open("requirements.txt") as f:
-    requirements = f.read()
-for line in re.split("\n", requirements):
-    if line and line[0] == "#" and "#egg=" in line:
-        line = re.search(r"#\s*(.*)", line).group(1)
-    if line and line[0] != "#":
-        # include only basic requirements here
-        if IGNORED_LIB_MARKER not in line:
-            lib_stripped = line.split(" #")[0].strip()
-            if BASIC_LIB_MARKER in line:
-                install_requires.append(lib_stripped)
-            else:
-                extra_requires.append(lib_stripped)
+    req = parse_requirements(f.readlines())
 
 # copy requirements file, to make it available inside the package at runtime
 with open("localstack/requirements.copy.txt", "w") as f:
-    f.write(requirements)
-
+    with open("requirements.txt") as source:
+        f.write(source.read())
 
 package_data = {
     "": ["Makefile", "*.md"],
@@ -55,9 +55,17 @@ package_data = {
     ],
 }
 
+install_requires = req["install"]
+
+extras_require = {
+    "cli": req["install"],
+    "runtime": req["runtime"],
+    "test": req["test"],
+    "dev": req["dev"],
+}
+extras_require["full"] = extras_require["cli"] + extras_require["runtime"]  # deprecated
 
 if __name__ == "__main__":
-
     setup(
         name="localstack",
         version=version,
@@ -69,8 +77,7 @@ if __name__ == "__main__":
         packages=find_packages(exclude=("tests", "tests.*")),
         package_data=package_data,
         install_requires=install_requires,
-        extras_require={"full": extra_requires},
-        dependency_links=dependency_links,
+        extras_require=extras_require,
         test_suite="tests",
         license="Apache License 2.0",
         zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,6 @@ version = localstack.__version__
 with open("requirements.txt") as f:
     req = parse_requirements(f.readlines())
 
-# copy requirements file, to make it available inside the package at runtime
-with open("localstack/requirements.copy.txt", "w") as f:
-    with open("requirements.txt") as source:
-        f.write(source.read())
-
 package_data = {
     "": ["Makefile", "*.md"],
     "localstack": [


### PR DESCRIPTION
This PR prepares the build environment for the setuptools configuration we have introduced in other projects, where we group dependencies using setup.py extras.

* reorganize `requirements.txt` to group dependencies into "extra" blocks
* use `setup.py` to parse the requirements into extras
* refactor `Makefile` to install with `pip install -e .`
* refactor `Dockerfile` to use the new make commands and uninstall test dependencies
* disables several dependencies from requirements.txt
* makes the image smaller  (:pinching_hand:)

- [x] update documentation (make targets, developer guide)
- [x] remove code where pip is called in localstack to lazily install requirements
