### PR TITLE
Run golang local test only if executed in Alpine

### DIFF
--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -263,6 +263,6 @@ def is_change_set_finished(cfn_client):
 
 
 only_in_alpine = pytest.mark.skipif(
-    is_alpine(),
+    not is_alpine(),
     reason="test only applicable if run in alpine",
 )

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -8,7 +8,7 @@ import pytest
 
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import create_dynamodb_table
-from localstack.utils.common import short_uid
+from localstack.utils.common import is_alpine, short_uid
 
 if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
@@ -260,3 +260,9 @@ def is_change_set_finished(cfn_client):
         return _inner
 
     return _is_change_set_finished
+
+
+only_in_alpine = pytest.mark.skipif(
+    is_alpine(),
+    reason="test only applicable if run in alpine",
+)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -66,6 +66,7 @@ from localstack.utils.testutil import (
     get_lambda_log_events,
 )
 
+from .fixtures import only_in_alpine
 from .lambdas import lambda_integration
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
@@ -1605,6 +1606,7 @@ class TestGolangRuntimes(LambdaTestBase):
     def setUpClass(cls):
         cls.lambda_client = aws_stack.connect_to_service("lambda")
 
+    @only_in_alpine
     def test_golang_lambda_running_locally(self):
         if use_docker():
             return


### PR DESCRIPTION
This is a quick fix, as this test runs only if glibc >= 2.32 is present on the system, which might not be the case outside of the docker/alpine image.