### PR TITLE
add support for DefinitionSubstitutions in AWS::StepFunctions::StateMachine

### DIFF
--- a/localstack/utils/generic/wait_utils.py
+++ b/localstack/utils/generic/wait_utils.py
@@ -24,5 +24,5 @@ def wait_until(
         if strategy == "linear":
             next_wait = (wait / _retries) * (_retries + 1)
         elif strategy == "exponential":
-            next_wait = wait ** 2
+            next_wait = wait * 2
         wait_until(fn, next_wait, max_retries, strategy, _retries + 1, _max_wait)

--- a/tests/integration/cloudformation/test_cloudformation_stepfunctions.py
+++ b/tests/integration/cloudformation/test_cloudformation_stepfunctions.py
@@ -1,0 +1,69 @@
+import os
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_statemachine_definitionsubstitution(
+    cfn_client,
+    lambda_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+    stepfunctions_client,
+    s3_client,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=load_template_raw("stepfunctions_statemachine_substitutions.yaml"),
+        ChangeSetType="CREATE",
+        Capabilities=["CAPABILITY_IAM"],
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+
+        wait_until(is_stack_created(stack_id))
+
+        stack_result = cfn_client.describe_stacks(StackName=stack_id)
+        assert stack_result["Stacks"][0]["StackStatus"] == "CREATE_COMPLETE"
+
+        outputs = stack_result["Stacks"][0]["Outputs"]
+        assert len(outputs) == 1
+        statemachine_arn = outputs[0]["OutputValue"]
+
+        # execute statemachine
+        ex_result = stepfunctions_client.start_execution(stateMachineArn=statemachine_arn)
+
+        def _is_executed():
+            return (
+                stepfunctions_client.describe_execution(executionArn=ex_result["executionArn"])[
+                    "status"
+                ]
+                != "RUNNING"
+            )
+
+        wait_until(_is_executed)
+        execution_desc = stepfunctions_client.describe_execution(
+            executionArn=ex_result["executionArn"]
+        )
+        assert execution_desc["status"] == "SUCCEEDED"
+        # sync execution is currently not supported since botocore adds a "sync-" prefix
+        # ex_result = stepfunctions_client.start_sync_execution(stateMachineArn=statemachine_arn)
+
+        assert "hello from statemachine" in execution_desc["output"]
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from mypy_boto3_sns import SNSClient
     from mypy_boto3_sqs import SQSClient
     from mypy_boto3_ssm import SSMClient
+    from mypy_boto3_stepfunctions import SFNClient
 
 LOG = logging.getLogger(__name__)
 
@@ -99,6 +100,11 @@ def logs_client() -> "CloudWatchLogsClient":
 @pytest.fixture(scope="class")
 def secretsmanager_client() -> "SecretsManagerClient":
     return _client("secretsmanager")
+
+
+@pytest.fixture(scope="class")
+def stepfunctions_client() -> "SFNClient":
+    return _client("stepfunctions")
 
 
 @pytest.fixture

--- a/tests/integration/templates/stepfunctions_statemachine_substitutions.yaml
+++ b/tests/integration/templates/stepfunctions_statemachine_substitutions.yaml
@@ -1,0 +1,86 @@
+Resources:
+  mystaterole904FED2D:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: "*"
+        Version: "2012-10-17"
+  mystateroleDefaultPolicy4DD169B3:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: lambda:InvokeFunction
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - startFnB78B119D
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: mystateroleDefaultPolicy4DD169B3
+      Roles:
+        - Ref: mystaterole904FED2D
+  startFnServiceRoleB86C6980:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  startFnB78B119D:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: "
+
+          \                exports.handler = async function(event) {
+
+          \                    console.log(JSON.stringify({event}));
+
+          \                    return JSON.stringify({message: \"hello from statemachine lambda\"});
+
+          \                }
+
+          \            "
+      Role:
+        Fn::GetAtt:
+          - startFnServiceRoleB86C6980
+          - Arn
+      Handler: index.handler
+      Runtime: nodejs12.x
+    DependsOn:
+      - startFnServiceRoleB86C6980
+  stm:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineType: EXPRESS
+      RoleArn:
+        Fn::GetAtt:
+          - mystaterole904FED2D
+          - Arn
+      DefinitionString: '{"StartAt": "HelloWorld", "States": {"HelloWorld": {"Type": "Task", "Resource": "${StartFn}", "End": true}}}'
+      DefinitionSubstitutions:
+        StartFn:
+          Fn::GetAtt:
+            - startFnB78B119D
+            - Arn
+
+Outputs:
+  StateMachineArnOutput:
+    Value:
+      Fn::GetAtt:
+        - stm
+        - Arn

--- a/tests/unit/test_cloudformation.py
+++ b/tests/unit/test_cloudformation.py
@@ -1,49 +1,54 @@
 import re
-import unittest
 
+from localstack.services.cloudformation.models.stepfunctions import _apply_substitutions
 from localstack.utils.cloudformation import template_deployer, template_preparer
 
 
-class CloudFormationTest(unittest.TestCase):
-    def test_resolve_references(self):
-        ref = {
-            "Fn::Join": [
-                "",
-                [
-                    "arn:",
-                    {"Ref": "AWS::Partition"},
-                    ":apigateway:",
-                    {"Ref": "AWS::Region"},
-                    ":lambda:path/2015-03-31/functions/",
-                    "test:lambda:arn",
-                    "/invocations",
-                ],
-            ]
-        }
-        stack_name = "test"
-        resources = {}
-        result = template_deployer.resolve_refs_recursively(stack_name, ref, resources)
-        pattern = (
-            r"arn:aws:apigateway:.*:lambda:path/2015-03-31/functions/test:lambda:arn/invocations"
-        )
-        self.assertTrue(re.match(pattern, result))
+def test_resolve_references():
+    ref = {
+        "Fn::Join": [
+            "",
+            [
+                "arn:",
+                {"Ref": "AWS::Partition"},
+                ":apigateway:",
+                {"Ref": "AWS::Region"},
+                ":lambda:path/2015-03-31/functions/",
+                "test:lambda:arn",
+                "/invocations",
+            ],
+        ]
+    }
+    stack_name = "test"
+    resources = {}
+    result = template_deployer.resolve_refs_recursively(stack_name, ref, resources)
+    pattern = r"arn:aws:apigateway:.*:lambda:path/2015-03-31/functions/test:lambda:arn/invocations"
+    assert re.match(pattern, result)
 
-    def test_is_local_service_url(self):
-        local_urls = [
-            "http://localhost",
-            "https://localhost",
-            "http://localhost:4566",
-            "https://localhost:4566",
-            "http://localhost.localstack.cloud:4566",
-            "https://s3.localhost.localstack.cloud",
-            "http://mybucket.s3.localhost.localstack.cloud:4566",
-            "https://mybucket.s3.localhost",
-        ]
-        remote_urls = [
-            "https://mybucket.s3.amazonaws.com",
-            "http://mybucket.s3.us-east-1.amazonaws.com",
-        ]
-        for url in local_urls:
-            self.assertTrue(template_preparer.is_local_service_url(url))
-        for url in remote_urls:
-            self.assertFalse(template_preparer.is_local_service_url(url))
+
+def test_is_local_service_url():
+    local_urls = [
+        "http://localhost",
+        "https://localhost",
+        "http://localhost:4566",
+        "https://localhost:4566",
+        "http://localhost.localstack.cloud:4566",
+        "https://s3.localhost.localstack.cloud",
+        "http://mybucket.s3.localhost.localstack.cloud:4566",
+        "https://mybucket.s3.localhost",
+    ]
+    remote_urls = [
+        "https://mybucket.s3.amazonaws.com",
+        "http://mybucket.s3.us-east-1.amazonaws.com",
+    ]
+    for url in local_urls:
+        assert template_preparer.is_local_service_url(url)
+    for url in remote_urls:
+        assert not template_preparer.is_local_service_url(url)
+
+
+def test_apply_substitutions():
+    blubstr = "something ${foo} and ${test} + ${foo}"
+    subs = {"foo": "bar", "test": "resolved"}
+
+    assert _apply_substitutions(blubstr, subs) == "something bar and resolved + bar"


### PR DESCRIPTION
Adds support for  the "DefinitionSubstitutions" property in  for Cloudformation/SAM StateMachine resources. This property is used to inject dynamic values (e.g. ARNs resolved by cloudformation or other results from intrinsic functions) into the statemachine definition.

Context: 
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html
https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html

Closes #4533 