### PR TITLE
Correctly document and use TMPDIR and HOST_TMP_FOLDER in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ You can pass the following environment variables to LocalStack.
 * `<SERVICE>_PORT_EXTERNAL`: Port number to expose a specific service externally (defaults to service ports above). `SQS_PORT_EXTERNAL`, for example, is used when returning queue URLs from the SQS service to the client.
 * `IMAGE_NAME`: Specific name and tag of LocalStack Docker image to use, e.g., `localstack/localstack:0.11.0` (default: `localstack/localstack`).
 * `USE_LIGHT_IMAGE`: Whether to use the light-weight Docker image (default: `1`). Overwritten by `IMAGE_NAME`.
-* `TMPDIR`: Temporary folder inside the LocalStack container (default: `/tmp`).
+* `TMPDIR`: Temporary folder on the host running the CLI and inside the LocalStack container (default: `/tmp`).
 * `HOST_TMP_FOLDER`: Temporary folder on the host that gets mounted as `$TMPDIR/localstack` into the LocalStack container. Required only for Lambda volume mounts when using `LAMBDA_REMOTE_DOCKER=false`.
 * `DATA_DIR`: Local directory for saving persistent data (currently only supported for these services:
   Kinesis, DynamoDB, Elasticsearch, S3, Secretsmanager, SSM, SQS, SNS). Set it to `/tmp/localstack/data` to enable persistence

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER=${TMPDIR}
+      - HOST_TMP_FOLDER="${TMPDIR:-/tmp}/localstack"
     volumes:
-      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -500,7 +500,7 @@ def start_infra_in_docker():
 
     if DOCKER_CLIENT.is_container_running(container_name):
         raise Exception('LocalStack container named "%s" is already running' % container_name)
-    if config.TMP_FOLDER != config.HOST_TMP_FOLDER:
+    if config.TMP_FOLDER != config.HOST_TMP_FOLDER and config.LAMBDA_REMOTE_DOCKER:
         print(
             f"WARNING: The detected temp folder for localstack ({config.TMP_FOLDER}) is not equal to the "
             f"HOST_TMP_FOLDER environment variable set ({config.HOST_TMP_FOLDER})."

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -500,7 +500,7 @@ def start_infra_in_docker():
 
     if DOCKER_CLIENT.is_container_running(container_name):
         raise Exception('LocalStack container named "%s" is already running' % container_name)
-    if config.TMP_FOLDER != config.HOST_TMP_FOLDER and config.LAMBDA_REMOTE_DOCKER:
+    if config.TMP_FOLDER != config.HOST_TMP_FOLDER and not config.LAMBDA_REMOTE_DOCKER:
         print(
             f"WARNING: The detected temp folder for localstack ({config.TMP_FOLDER}) is not equal to the "
             f"HOST_TMP_FOLDER environment variable set ({config.HOST_TMP_FOLDER})."

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -500,6 +500,11 @@ def start_infra_in_docker():
 
     if DOCKER_CLIENT.is_container_running(container_name):
         raise Exception('LocalStack container named "%s" is already running' % container_name)
+    if config.TMP_FOLDER != config.HOST_TMP_FOLDER:
+        print(
+            f"WARNING: The detected temp folder for localstack ({config.TMP_FOLDER}) is not equal to the "
+            f"HOST_TMP_FOLDER environment variable set ({config.HOST_TMP_FOLDER})."
+        )  # Logger is not initialized at this point, so the warning is displayed via print
 
     os.environ[ENV_SCRIPT_STARTING_DOCKER] = "1"
 


### PR DESCRIPTION
Currently, the example docker-compose file uses TMPDIR incorrectly. If one would use this environment variable not to describe the actual TMPDIR (example /tmp), but the localstack-specific TMPDIR (most likely /tmp/localstack), it would produce inconsistent behavior.
The docker-compose.yml is updated to correctly use the TMPDIR value, and a warning is now displayed (should be discussed) if the HOST_TMP_FOLDER and the TMP_FOLDER of localstack (by default both /tmp/localstack) mismatch, to warn of possible configuration errors.