### PR TITLE
Add CloudFormation support for AWS::SQS::QueuePolicy

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1398,9 +1398,6 @@ def add_default_resource_props(
     elif res_type == "AWS::SQS::Queue" and not props.get("QueueName"):
         props["QueueName"] = "queue-%s" % short_uid()
 
-    elif res_type == "AWS::SQS::QueuePolicy" and not resource.get("PhysicalResourceId"):
-        resource["PhysicalResourceId"] = _generate_res_name()
-
     elif res_type == "AWS::IAM::ManagedPolicy" and not resource.get("ManagedPolicyName"):
         resource["ManagedPolicyName"] = _generate_res_name()
 

--- a/tests/integration/cloudformation/test_cloudformation_sqs.py
+++ b/tests/integration/cloudformation/test_cloudformation_sqs.py
@@ -1,0 +1,41 @@
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+
+def test_sqs_queue_policy(
+    cfn_client,
+    sqs_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+
+    template_rendered = load_template_raw("sqs_with_queuepolicy.yaml")
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["Outputs"]
+        assert len(outputs) == 1
+        queue_url = outputs[0]["OutputValue"]
+        resp = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["Policy"])
+        assert (
+            "Statement" in resp["Attributes"]["Policy"]
+        )  # just kind of a smoke test to see if its set
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/templates/sqs_with_queuepolicy.yaml
+++ b/tests/integration/templates/sqs_with_queuepolicy.yaml
@@ -1,0 +1,27 @@
+Resources:
+  Queue4A7E3555:
+    Type: AWS::SQS::Queue
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  QueuePolicy25439813:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - sqs:SendMessage
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+            Effect: Allow
+            Principal: "*"
+            Resource:
+              Fn::GetAtt:
+                - Queue4A7E3555
+                - Arn
+        Version: "2012-10-17"
+      Queues:
+        - Ref: Queue4A7E3555
+Outputs:
+  QueueUrlOutput:
+    Value:
+      Ref: Queue4A7E3555


### PR DESCRIPTION
Adds support for the [AWS::SQS::QueuePolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-policy.html) resource. 