### PR TITLE
Add CloudFormation support for AWS::Events::EventBusPolicy

### DIFF
--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -11,6 +11,7 @@ from localstack.services.cloudformation.service_models import (
 )
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
+from localstack.utils.common import short_uid
 
 
 class EventConnection(GenericBaseModel):
@@ -130,3 +131,69 @@ class EventsRule(GenericBaseModel):
                 "parameters": {"Name": "PhysicalResourceId"},
             },
         }
+
+
+class EventBusPolicy(GenericBaseModel):
+    def get_physical_resource_id(self, attribute=None, **kwargs):
+        return f"EventBusPolicy-{short_uid()}"
+
+    @classmethod
+    def cloudformation_type(cls):
+        return "AWS::Events::EventBusPolicy"
+
+    @classmethod
+    def get_deploy_templates(cls):
+        def _create(resource_id, resources, resource_type, func, stack_name):
+            events = aws_stack.connect_to_service("events")
+            resource = resources[resource_id]
+            props = resource["Properties"]
+
+            event_bus_name = props.get("EventBusName")
+            policy = props.get("Statement")  # either this field  is set or all other fields
+            statement_id = props.get("StatementId")
+            if policy is not None:
+                events.put_permission(EventBusName=event_bus_name, Policy=json.dumps(policy))
+            else:
+                condition = props.get("Condition")
+                if condition is not None:
+                    events.put_permission(
+                        EventBusName=event_bus_name,
+                        StatementId=statement_id,
+                        Action=props["Action"],
+                        Principal=props["Principal"],
+                        Condition=condition,
+                    )
+                else:
+                    # note: setting condition to None here is *NOT* equivalent to not specifying it and will throw
+                    events.put_permission(
+                        EventBusName=event_bus_name,
+                        StatementId=statement_id,
+                        Action=props["Action"],
+                        Principal=props["Principal"],
+                    )
+
+        def _delete(resource_id, resources, resource_type, func, stack_name):
+            events = aws_stack.connect_to_service("events")
+            resource = resources[resource_id]
+            props = resource["Properties"]
+            event_bus_name = props.get("EventBusName")
+            statement_id = props.get("StatementId")
+            try:
+                events.remove_permission(
+                    EventBusName=event_bus_name,
+                    StatementId=statement_id,
+                    RemoveAllPermissions=False,
+                )
+            except Exception as err:
+                if err.response["Error"]["Code"] == "ResourceNotFoundException":
+                    pass  # expected behavior ("parent" resource event bus already deleted)
+                else:
+                    raise err
+
+        return {
+            "create": {"function": _create},
+            "delete": {"function": _delete},
+        }
+
+
+# TODO: AWS::Events::Archive

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -134,9 +134,6 @@ class EventsRule(GenericBaseModel):
 
 
 class EventBusPolicy(GenericBaseModel):
-    def get_physical_resource_id(self, attribute=None, **kwargs):
-        return f"EventBusPolicy-{short_uid()}"
-
     @classmethod
     def cloudformation_type(cls):
         return "AWS::Events::EventBusPolicy"
@@ -147,6 +144,8 @@ class EventBusPolicy(GenericBaseModel):
             events = aws_stack.connect_to_service("events")
             resource = resources[resource_id]
             props = resource["Properties"]
+
+            resource["PhysicalResourceId"] = f"EventBusPolicy-{short_uid()}"
 
             event_bus_name = props.get("EventBusName")
             policy = props.get("Statement")  # either this field  is set or all other fields

--- a/tests/integration/cloudformation/test_cloudformation_events.py
+++ b/tests/integration/cloudformation/test_cloudformation_events.py
@@ -1,0 +1,87 @@
+import json
+import logging
+
+import jinja2
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+LOG = logging.getLogger(__name__)
+
+
+def test_eventbus_policies(
+    cfn_client,
+    events_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    event_bus_name = f"event-bus-{short_uid()}"
+    template_rendered = jinja2.Template(load_template_raw("eventbridge_policy.yaml")).render(
+        event_bus_name=event_bus_name
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        assert (
+            cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["StackStatus"]
+            == "CREATE_COMPLETE"
+        )
+
+        # check that both statements were added
+        describe_response = events_client.describe_event_bus(Name=event_bus_name)
+        policy = json.loads(describe_response["Policy"])
+        assert len(policy["Statement"]) == 2
+
+        # verify physical resource ID creation
+        pol1_description = cfn_client.describe_stack_resource(
+            StackName=stack_id, LogicalResourceId="eventPolicy"
+        )
+        pol2_description = cfn_client.describe_stack_resource(
+            StackName=stack_id, LogicalResourceId="eventPolicy2"
+        )
+        assert (
+            pol1_description["StackResourceDetail"]["PhysicalResourceId"]
+            != pol2_description["StackResourceDetail"]["PhysicalResourceId"]
+        )
+
+        # TODO: Fix cloudformation change set update status
+        # TODO: Fix second changeset execution (should delete resource in stack's _resource_states)
+        # delete one of the 2 statements and check if the other still exists
+        # template_rendered_single_policy = jinja2.Template(load_template_raw("eventbridge_policy_singlepolicy.yaml")).render(
+        #     event_bus_name=event_bus_name
+        # )
+        # change_set_name = f"change-set-update-{short_uid()}"
+        # response = cfn_client.create_change_set(
+        #     StackName=stack_name,
+        #     ChangeSetName=change_set_name,
+        #     TemplateBody=template_rendered_single_policy,
+        # )
+        # change_set_id = response["Id"]
+        # wait_until(is_change_set_created_and_available(change_set_id))
+        # cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        # cfn_client.get_waiter("stack_create_complete").wait(StackName=stack_id, WaiterConfig={'Delay': 5, 'MaxAttempts': 10})  # TODO: should be get_waiter("stack_update_complete")
+        #
+        # describe_response = events_client.describe_event_bus(Name=event_bus_name)
+        # policy = json.loads(describe_response['Policy'])
+        # assert len(policy['Statement']) == 1
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
     from mypy_boto3_cloudformation import CloudFormationClient
     from mypy_boto3_dynamodb import DynamoDBClient
+    from mypy_boto3_events import EventBridgeClient
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_kinesis import KinesisClient
     from mypy_boto3_lambda import LambdaClient
@@ -95,6 +96,11 @@ def kinesis_client() -> "KinesisClient":
 @pytest.fixture(scope="class")
 def logs_client() -> "CloudWatchLogsClient":
     return _client("logs")
+
+
+@pytest.fixture(scope="class")
+def events_client() -> "EventBridgeClient":
+    return _client("events")
 
 
 @pytest.fixture(scope="class")

--- a/tests/integration/templates/eventbridge_policy.yaml
+++ b/tests/integration/templates/eventbridge_policy.yaml
@@ -1,0 +1,21 @@
+Resources:
+  bus707364D1:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: {{ event_bus_name }}
+  eventPolicy:
+    Type: AWS::Events::EventBusPolicy
+    Properties:
+      StatementId: pol1
+      Action: events:PutEvents
+      EventBusName:
+        Ref: bus707364D1
+      Principal: "111122223333"
+  eventPolicy2:
+    Type: AWS::Events::EventBusPolicy
+    Properties:
+      StatementId: pol2
+      Action: events:PutEvents
+      EventBusName:
+        Ref: bus707364D1
+      Principal: "*"

--- a/tests/integration/templates/eventbridge_policy_singlepolicy.yaml
+++ b/tests/integration/templates/eventbridge_policy_singlepolicy.yaml
@@ -1,0 +1,13 @@
+Resources:
+  bus707364D1:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: {{ event_bus_name }}
+  eventPolicy:
+    Type: AWS::Events::EventBusPolicy
+    Properties:
+      StatementId: pol1
+      Action: events:PutEvents
+      EventBusName:
+        Ref: bus707364D1
+      Principal: "111122223333"


### PR DESCRIPTION
Adds support for the [AWS::Events::EventBusPolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbuspolicy.html) resource.

Second part of the test is commented out for now since this is a general issue of our cloudformation engine right now that will be handled separately.