### PR TITLE
Fix raw message delivery attribute for sns/sqs subscriptions

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -775,9 +775,8 @@ def create_sns_message_body(subscriber, req_data, message_id=None):
 
 
 def create_sqs_message_attributes(subscriber, attributes):
-    # Message attributes are going empty because of this hence removing this check.
-    # if not is_raw_message_delivery(subscriber):
-    #     return {}
+    if not is_raw_message_delivery(subscriber):
+        return {}
 
     message_attributes = {}
     for key, value in attributes.items():


### PR DESCRIPTION
AWS behavior is to only pass sns message attributes as sqs message attributes if `raw_message_delivery` is enabled.
PR #3887 introduces this behavior, which is not identical to AWS.

Demo SQS Message if raw_message_delivery is not enabled on AWS:
```
{
    "Messages": [
        {
            "MessageId": "cb98bce2-f11f-4bac-8870-0605ada8cb91",
            "ReceiptHandle": "AQEBSvvZb/WZACLr3onUPhHEyGLrtmmzA8e8wK0w8A+UykenUK7v2rxk6qy4MAfVKfr6ywmxjuKNuaLmjDtjt1f7xUR6llpad6Iy8dpShvooPsszYvGYzYFjp3f61oF8VZfMmzklM5Z6CtQN6Vr5NmG+/FZn2hRVo4s54Oy00GvVcj1bm8tOt/am4CwLKTzsD2hXa/lXIQ9Sl+QPGSM2rOBmqKqUQ9bET8vPsx1xdt9Ag7nSGlCBkW1/AUrlkZPPGb+/YtoqbU7St0iKbKLNv1WZt7JxSrAq0VNEAFOzF8sbweyHpe/NIpn4BELwLDFNB4T8ahw8mmoBr2WVJhbvDz7imiXA8uri4fsqGuJPHzIugKO+GhlZ3GSPpExpsyZF4+lGcv/oVgaiKi7NuV6Ord6yGA==",
            "MD5OfBody": "868db474dc18d3764a4939a02abce3cd",
            "Body": "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"26a7b12d-bf26-5110-9400-e89722adc1b7\",\n  \"TopicArn\" : \"arn:aws:sns:eu-central-1:869636330914:ls-test-topic\",\n  \"Message\" : \"{\\\"operatorId\\\":3375003,\\\"eventTypeId\\\":1,\\\"eventLevelId\\\":1,\\\"validFrom\\\":\\\"2018-03-10T09:00:00Z\\\",\\\"validTo\\\":\\\"2018-03-11T09:00:00Z\\\"}\",\n  \"Timestamp\" : \"2021-09-14T12:53:31.210Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"VXouhlNJNsqi5a9m+tuCSACvtfQ+lID84S1pioo11DblGvvKZfKPAcx+WmVsFicXCgRn9VvNok3Vz7zY89OTHx6UkJOq/2GbWUr2o/KG1LzASNO8x/Y3P9pQggVrRVXDZTjcFMqbKNYgEROwUuDFO7q8E28JNiq7qYlvt4kPOUj5CFerpT0S9/8P+Ut6fWiK5+PIL/azhkd+P5OypHUFCbl+MedL1nonRebp/OcXYHD7U9D/EIuIz+NmaNCCuiFAECP5D6WG33jxYs4P75qX4XusynmN2UdxySljv+olIvPaUOMVduM+52/fxu81r4gDEA0BFOR/4CgiKxwY6G2Vsg==\",\n  \"SigningCertURL\" : \"https://sns.eu-central-1.amazonaws.com/SimpleNotificationService-010a507c1833636cd94bdb98bd93083a.pem\",\n  \"UnsubscribeURL\" : \"https://sns.eu-central-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-central-1:869636330914:ls-test-topic:86ecdc89-a3b9-4041-a186-21153c509f10\",\n  \"MessageAttributes\" : {\n    \"SomeNameType\" : {\"Type\":\"String\",\"Value\":\"Orchestration.Services.Model.Pollution.PollutionMessage\"}\n  }\n}"
        }
    ]
}
``` 
If it is enabled:
```
{
    "Messages": [
        {
            "MessageId": "4a4c61e2-dc0b-4cf2-b2b3-370329323289",
            "ReceiptHandle": "AQEBl3vzFIWBncmzcdmAUk7KPxJ7LrZI/zWjlJsWUxTpBnrVSmkSDwbLl9Hrogbgpp6qsZEdijwiYvid1z4xafqUVFxYmStyj4+tWn6jH8syJZwajhUKd/IXSrDZQPtaL2rEHEoIpyQQIvRq6IiSdqTQVzEKQJYGLG7Elftu9MW5sD1XIpsPBreWywzpdt/lWN4b7cbSPxRqwC6T1EDlcaoXDzw+uRkNG8CMl/MqT6cVS79DhEvDb/CmZS3So86qf6S/yvxEdRH4obGKeg5RlFWNADH7Hxxft9W8E223h6xnU7D9DLfy/vDMDN6oNAcTadPrsyVL6Wruj8+dNpRurDphhK7/vEeGkspg2TIw0jgYSzMJDh5d/XA0VZqZF0l2/gBjhdsXM3xethfStjLRorcfMQ==",
            "MD5OfBody": "53810f00d136168d96a1d9b6ca3cc0ee",
            "Body": "{\"operatorId\":3375003,\"eventTypeId\":1,\"eventLevelId\":1,\"validFrom\":\"2018-03-10T09:00:00Z\",\"validTo\":\"2018-03-11T09:00:00Z\"}",
            "MD5OfMessageAttributes": "d8851d45ac6319acafe674825cc7825b",
            "MessageAttributes": {
                "SomeNameType": {
                    "StringValue": "Orchestration.Services.Model.Pollution.PollutionMessage",
                    "DataType": "String"
                }
            }
        }
    ]
}
```

(Example taken from https://stackoverflow.com/questions/44238656/how-to-add-sqs-message-attributes-in-sns-subscription)

Fixes #4458 .

Maybe @usmangani1 can chime in here.