### PR TITLE
Distinguish polling and reactive mode in EventSourceListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ You can pass the following environment variables to LocalStack.
 * `DOCKER_CMD`: Shell command used to run Docker containers, e.g., set to `"sudo docker"` to run as sudo (default: `docker`).
 * `MAIN_CONTAINER_NAME`: Specify the main docker container name (default: `localstack_main`).
 * `INIT_SCRIPTS_PATH`: Specify the path to the initializing files with extensions .sh that are found default in `/docker-entrypoint-initaws.d`.
-* `LS_LOG`: Specify the log level('trace', 'debug', 'info', 'warn', 'error', 'warning') currently overrides the `DEBUG` configuration. Enable `LS_LOG=trace` to print detailed request/response messages.
+* `LS_LOG`: Specify the log level('trace', 'debug', 'info', 'warn', 'error', 'warning') currently overrides the `DEBUG` configuration. Enable `LS_LOG=trace` to print detailed request/response messages (or `LS_LOG=trace-internal` to include internal calls as well).
 
 An example passing the above environment variables to LocalStack to start Kinesis, Lambda, Dynamodb and SQS:
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -23,6 +23,7 @@ from localstack.constants import (
     LOCALHOST,
     LOCALHOST_IP,
     LOG_LEVELS,
+    TRACE_LOG_LEVELS,
     TRUE_STRINGS,
 )
 
@@ -150,7 +151,7 @@ HOST_TMP_FOLDER = os.environ.get("HOST_TMP_FOLDER", TMP_FOLDER)
 
 # whether to enable verbose debug logging
 LS_LOG = eval_log_type("LS_LOG")
-DEBUG = is_env_true("DEBUG") or LS_LOG == "trace"
+DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
 # whether to enable debugpy
 DEVELOP = is_env_true("DEVELOP")
@@ -585,7 +586,7 @@ def load_config_file(config_file=None):
     return configs
 
 
-if LS_LOG == "trace":
+if LS_LOG in TRACE_LOG_LEVELS:
     load_end_time = time.time()
     LOG = logging.getLogger(__name__)
     LOG.debug(

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -85,7 +85,8 @@ APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded"
 # strings to indicate truthy/falsy values
 TRUE_STRINGS = ("1", "true", "True")
 FALSE_STRINGS = ("0", "false", "False")
-LOG_LEVELS = ("trace", "debug", "info", "warn", "error", "warning")
+# strings with valid log levels for LS_LOG
+LOG_LEVELS = ("trace-internal", "trace", "debug", "info", "warn", "error", "warning")
 
 # Lambda defaults
 LAMBDA_TEST_ROLE = "arn:aws:iam::%s:role/lambda-test-role" % TEST_AWS_ACCOUNT_ID
@@ -163,6 +164,11 @@ TEST_AWS_SECRET_ACCESS_KEY = "test"
 # credentials being used for internal calls
 INTERNAL_AWS_ACCESS_KEY_ID = "__internal_call__"
 INTERNAL_AWS_SECRET_ACCESS_KEY = "__internal_call__"
+
+# trace log levels (excluding/including internal API calls), configurable via $LS_LOG
+LS_LOG_TRACE = "trace"
+LS_LOG_TRACE_INTERNAL = "trace-internal"
+TRACE_LOG_LEVELS = [LS_LOG_TRACE, LS_LOG_TRACE_INTERNAL]
 
 # list of official docker images
 OFFICIAL_IMAGES = [

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -14,7 +14,7 @@ import uuid
 from datetime import datetime
 from io import BytesIO
 from threading import BoundedSemaphore
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from flask import Flask, Response, jsonify, request
 from six.moves import cStringIO as StringIO
@@ -57,6 +57,7 @@ from localstack.utils.common import (
     safe_requests,
     save_file,
     short_uid,
+    start_worker_thread,
     synchronized,
     timestamp,
     timestamp_millis,
@@ -197,7 +198,11 @@ class EventSourceListener:
         raise NotImplementedError
 
     def start(self):
-        """Start listener in the background - to be implemented by subclasses."""
+        """Start listener in the background (for polling mode) - to be implemented by subclasses."""
+        pass
+
+    def process_event(self, event: Any):
+        """Process the given event (for reactive mode)"""
         pass
 
     @staticmethod
@@ -215,17 +220,34 @@ class EventSourceListener:
         if instance:
             instance.start()
 
+    @staticmethod
+    def process_event_via_listener(service_type: str, event: Any):
+        """Process event for the given service type (for reactive mode)"""
+        instance = EventSourceListener.get(service_type)
+        if not instance:
+            return
+
+        def _process(*args):
+            instance.process_event(event)
+
+        # start processing in background
+        start_worker_thread(_process)
+
 
 class EventSourceListenerSQS(EventSourceListener):
     # SQS listener thread settings
     SQS_LISTENER_THREAD: Dict = {}
     SQS_POLL_INTERVAL_SEC: float = 1
+    # whether to use polling via SQS API (or, alternatively, reactive mode with SQS updates received directly in-memory)
+    USE_POLLING = False
 
     @staticmethod
     def source_type():
         return "sqs"
 
     def start(self):
+        if not self.USE_POLLING:
+            return
         if self.SQS_LISTENER_THREAD:
             return
 
@@ -235,6 +257,30 @@ class EventSourceListenerSQS(EventSourceListener):
 
     def get_matching_event_sources(self) -> List[Dict]:
         return get_event_sources(source_arn=r".*:sqs:.*")
+
+    def process_event(self, event: Any):
+        if self.USE_POLLING:
+            return
+        # feed message into the first listening lambda (message should only get processed once)
+        queue_url = event["QueueUrl"]
+        try:
+            queue_name = queue_url.rpartition("/")[2]
+            queue_arn = aws_stack.sqs_queue_arn(queue_name)
+            sources = get_event_sources(source_arn=queue_arn)
+            arns = [s.get("FunctionArn") for s in sources]
+            source = (sources or [None])[0]
+            if not source:
+                return False
+
+            LOG.debug(
+                "Found %s source mappings for event from SQS queue %s: %s"
+                % (len(arns), queue_arn, arns)
+            )
+            # TODO: support message BatchSize here, same as for polling mode below
+            messages = event["Messages"]
+            self._process_messages_for_event_source(source, messages)
+        except Exception:
+            LOG.exception(f"Unable to run Lambda function on SQS messages from queue {queue_url}")
 
     def _listener_loop(self, *args):
         while True:
@@ -252,11 +298,9 @@ class EventSourceListenerSQS(EventSourceListener):
                 sqs_client = aws_stack.connect_to_service("sqs")
                 for source in sources:
                     queue_arn = source["EventSourceArn"]
-                    lambda_arn = source["FunctionArn"]
                     batch_size = max(min(source.get("BatchSize", 1), 10), 1)
 
                     try:
-                        region_name = queue_arn.split(":")[3]
                         queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
                         messages = unprocessed_messages.pop(queue_arn, None)
                         if not messages:
@@ -269,17 +313,7 @@ class EventSourceListenerSQS(EventSourceListener):
                             if not messages:
                                 continue
 
-                        LOG.debug(
-                            "Sending event from event source %s to Lambda %s"
-                            % (queue_arn, lambda_arn)
-                        )
-                        res = self._send_event_to_lambda(
-                            queue_arn,
-                            queue_url,
-                            lambda_arn,
-                            messages,
-                            region=region_name,
-                        )
+                        res = self._process_messages_for_event_source(source, messages)
                         if not res:
                             unprocessed_messages[queue_arn] = messages
 
@@ -290,6 +324,21 @@ class EventSourceListenerSQS(EventSourceListener):
                 pass
             finally:
                 time.sleep(self.SQS_POLL_INTERVAL_SEC)
+
+    def _process_messages_for_event_source(self, source, messages):
+        lambda_arn = source["FunctionArn"]
+        queue_arn = source["EventSourceArn"]
+        region_name = queue_arn.split(":")[3]
+        queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
+        LOG.debug("Sending event from event source %s to Lambda %s" % (queue_arn, lambda_arn))
+        res = self._send_event_to_lambda(
+            queue_arn,
+            queue_url,
+            lambda_arn,
+            messages,
+            region=region_name,
+        )
+        return res
 
     def _send_event_to_lambda(self, queue_arn, queue_url, lambda_arn, messages, region):
         def delete_messages(result, func_arn, event, error=None, dlq_sent=None, **kwargs):
@@ -316,9 +365,9 @@ class EventSourceListenerSQS(EventSourceListener):
             message_attrs = message_attributes_to_lower(msg.get("MessageAttributes"))
             records.append(
                 {
-                    "body": msg["Body"],
-                    "receiptHandle": msg["ReceiptHandle"],
-                    "md5OfBody": msg["MD5OfBody"],
+                    "body": msg.get("Body", "MessageBody"),
+                    "receiptHandle": msg.get("ReceiptHandle"),
+                    "md5OfBody": msg.get("MD5OfBody") or msg.get("MD5OfMessageBody"),
                     "eventSourceARN": queue_arn,
                     "eventSource": lambda_executors.EVENT_SOURCE_SQS,
                     "awsRegion": region,
@@ -662,35 +711,6 @@ def process_kinesis_records(records, stream_name):
     except Exception as e:
         LOG.warning(
             "Unable to run Lambda function on Kinesis records: %s %s" % (e, traceback.format_exc())
-        )
-
-
-def start_lambda_sqs_listener():
-    EventSourceListener.get("sqs").start()
-
-
-def process_sqs_message(queue_name, region_name=None):
-    # feed message into the first listening lambda (message should only get processed once)
-    # TODO: optimize the performance of this function - we should run start_lambda_sqs_listener() only if
-    #  event source mappings or queue configurations change, but not for every single incoming message!
-    try:
-        region_name = region_name or aws_stack.get_region()
-        queue_arn = aws_stack.sqs_queue_arn(queue_name, region_name=region_name)
-        sources = get_event_sources(source_arn=queue_arn)
-        arns = [s.get("FunctionArn") for s in sources]
-        source = (sources or [None])[0]
-        if not source:
-            return False
-
-        LOG.debug(
-            "Found %s source mappings for event from SQS queue %s: %s"
-            % (len(arns), queue_arn, arns)
-        )
-        start_lambda_sqs_listener()
-        return True
-    except Exception as e:
-        LOG.warning(
-            "Unable to run Lambda function on SQS messages: %s %s" % (e, traceback.format_exc())
         )
 
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -238,8 +238,9 @@ class EventSourceListenerSQS(EventSourceListener):
     # SQS listener thread settings
     SQS_LISTENER_THREAD: Dict = {}
     SQS_POLL_INTERVAL_SEC: float = 1
-    # whether to use polling via SQS API (or, alternatively, reactive mode with SQS updates received directly in-memory)
-    USE_POLLING = False
+    # Whether to use polling via SQS API (or, alternatively, reactive mode with SQS updates received directly in-memory)
+    # Advantage of polling is that we can delete messages directly from the queue (via 'ReceiptHandle') after processing
+    USE_POLLING = True
 
     @staticmethod
     def source_type():
@@ -295,7 +296,9 @@ class EventSourceListenerSQS(EventSourceListener):
 
                 unprocessed_messages = {}
 
-                sqs_client = aws_stack.connect_to_service("sqs")
+                sqs_client = aws_stack.connect_to_service(
+                    "sqs",
+                )
                 for source in sources:
                     queue_arn = source["EventSourceArn"]
                     batch_size = max(min(source.get("BatchSize", 1), 10), 1)

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -185,7 +185,8 @@ class LambdaExecutorPlugin:
         return cls.INSTANCES
 
 
-def get_from_event(event, key):
+def get_from_event(event: Dict, key: str):
+    """Retrieve a field with the given key from the list of Records within 'event'."""
     try:
         return event["Records"][0][key]
     except KeyError:

--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -1,15 +1,16 @@
 import json
 import re
+from typing import Dict
 
 import xmltodict
 from moto.sqs.models import TRANSPORT_TYPE_ENCODINGS, Message
 from moto.sqs.utils import parse_message_attributes
-from requests.models import Request
+from requests.models import Request, Response
 from six.moves.urllib.parse import urlencode
 
 from localstack import config, constants
 from localstack.config import SQS_PORT_EXTERNAL
-from localstack.services.awslambda import lambda_api
+from localstack.services.awslambda.lambda_api import EventSourceListener
 from localstack.services.install import SQS_BACKEND_IMPL
 from localstack.services.sns import sns_listener
 from localstack.utils.analytics import event_publisher
@@ -17,6 +18,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import (
     calculate_crc32,
     make_requests_error,
+    parse_urlencoded_data,
     requests_response,
 )
 from localstack.utils.common import (
@@ -202,10 +204,35 @@ def _list_dead_letter_source_queues(queues, queue_url):
     return format_list_dl_source_queues_response(dead_letter_source_queues)
 
 
-def _process_sent_message(path, req_data, headers):
-    queue_name = _queue_url(path, req_data, headers).rpartition("/")[2]
+def _process_sent_message(path: str, req_data: Dict[str, str], headers: Dict, response: Response):
+    """Extract one or multiple messages sent via SendMessage/SendMessageBatch from the given
+    request/response data and forward them to the Lambda EventSourceListener for further processing"""
 
-    lambda_api.process_sqs_message(queue_name)
+    queue_url = _queue_url(path, req_data, headers)
+    action = req_data.get("Action")
+
+    # extract data from XML response - assume data is wrapped in 2 parent elements
+    response_data = xmltodict.parse(response.content)
+    response_data = list(response_data.values())[0]
+    response_data = list(response_data.values())[0]
+
+    messages = []
+    if action == "SendMessage":
+        message = clone(req_data)
+        message.update(response_data)
+        messages.append(message)
+    elif action == "SendMessageBatch":
+        messages = parse_urlencoded_data(req_data, "SendMessageBatchRequestEntry")
+        # Note: only forwarding messages from 'Successful', not from 'Failed' list
+        for successful in response_data.get("SendMessageBatchResultEntry") or []:
+            msg = [m for m in messages if m["Id"] == successful["Id"]][0]
+            msg.update(successful)
+
+    event = {
+        "QueueUrl": queue_url,
+        "Messages": messages,
+    }
+    EventSourceListener.process_event_via_listener("sqs", event)
 
 
 def format_list_dl_source_queues_response(queues):
@@ -405,9 +432,8 @@ class ProxyListenerSQS(PersistingProxyListener):
             )
 
             if action == "CreateQueue":
-                queue_url = re.match(r".*<QueueUrl>(.*)</QueueUrl>", content_str, re.DOTALL).group(
-                    1
-                )
+                regex = r".*<QueueUrl>(.*)</QueueUrl>"
+                queue_url = re.match(regex, content_str, re.DOTALL).group(1)
                 if SQS_BACKEND_IMPL == "elasticmq":
                     _set_queue_attributes(queue_url, req_data)
 
@@ -416,9 +442,9 @@ class ProxyListenerSQS(PersistingProxyListener):
                 msg = "There should be at least one SendMessageBatchRequestEntry in the request."
                 return make_requests_error(code=404, code_string="EmptyBatchRequest", message=msg)
 
-        # instruct listeners to fetch new SQS message
+        # instruct listeners to process new SQS message
         if action in ("SendMessage", "SendMessageBatch"):
-            _process_sent_message(path, req_data, headers)
+            _process_sent_message(path, req_data, headers, response)
 
         if content_str_original != content_str:
             # if changes have been made, return patched response

--- a/localstack/services/sqs/sqs_listener.py
+++ b/localstack/services/sqs/sqs_listener.py
@@ -23,6 +23,7 @@ from localstack.utils.aws.aws_responses import (
 )
 from localstack.utils.common import (
     clone,
+    ensure_list,
     get_service_protocol,
     parse_request_data,
     path_from_url,
@@ -224,7 +225,9 @@ def _process_sent_message(path: str, req_data: Dict[str, str], headers: Dict, re
     elif action == "SendMessageBatch":
         messages = parse_urlencoded_data(req_data, "SendMessageBatchRequestEntry")
         # Note: only forwarding messages from 'Successful', not from 'Failed' list
-        for successful in response_data.get("SendMessageBatchResultEntry") or []:
+        entries = response_data.get("SendMessageBatchResultEntry") or []
+        entries = ensure_list(entries)
+        for successful in entries:
             msg = [m for m in messages if m["Id"] == successful["Id"]][0]
             msg.update(successful)
 

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 from binascii import crc32
 from struct import pack
 from typing import Optional
+from urllib.parse import parse_qs
 
 import xmltodict
 from flask import Response as FlaskResponse
@@ -330,6 +331,21 @@ def extract_url_encoded_param_list(req_data, pattern):
         if value is None:
             break
         result.append(value)
+    return result
+
+
+def parse_urlencoded_data(qs_data, top_level_attribute):
+    # TODO: potentially find a better way than calling moto here...
+    from moto.core.responses import BaseResponse
+
+    if qs_data and isinstance(qs_data, dict):
+        # make sure we're using the array form of query string dict here
+        qs_data = {k: v if isinstance(v, list) else [v] for k, v in qs_data.items()}
+    if isinstance(qs_data, (str, bytes)):
+        qs_data = parse_qs(qs_data)
+    response = BaseResponse()
+    response.querystring = qs_data
+    result = response._get_multi_param(top_level_attribute, skip_result_conversion=True)
     return result
 
 

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -13,7 +13,7 @@ from functools import wraps
 import six
 
 from localstack import config, constants
-from localstack.constants import TRACE_LOG_LEVELS
+from localstack.constants import LS_LOG_TRACE_INTERNAL, TRACE_LOG_LEVELS
 from localstack.utils.docker import DOCKER_CLIENT, ContainerException, PortMappings
 
 # set up logger
@@ -297,12 +297,16 @@ def setup_logging(log_level=None):
     logging.captureWarnings(True)
     logging.getLogger("asyncio").setLevel(logging.INFO)
     logging.getLogger("boto3").setLevel(logging.INFO)
-    logging.getLogger("s3transfer").setLevel(logging.INFO)
-    logging.getLogger("docker").setLevel(logging.WARNING)
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
-    logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("botocore").setLevel(logging.ERROR)
+    logging.getLogger("docker").setLevel(logging.WARNING)
     logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+    logging.getLogger("moto").setLevel(logging.WARNING)
+    logging.getLogger("requests").setLevel(logging.WARNING)
+    logging.getLogger("s3transfer").setLevel(logging.INFO)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+    if config.LS_LOG != LS_LOG_TRACE_INTERNAL:
+        # disable werkzeug API logs, unless detailed internal trace logging is enabled
+        logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
 
 # --------------

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -13,6 +13,7 @@ from functools import wraps
 import six
 
 from localstack import config, constants
+from localstack.constants import TRACE_LOG_LEVELS
 from localstack.utils.docker import DOCKER_CLIENT, ContainerException, PortMappings
 
 # set up logger
@@ -267,7 +268,7 @@ def setup_logging(log_level=None):
     # overriding the log level if LS_LOG has been set
     if config.LS_LOG:
         log_level = str(config.LS_LOG).upper()
-        if log_level == "TRACE":
+        if log_level.lower() in TRACE_LOG_LEVELS:
             log_level = "DEBUG"
         log_level = logging._nameToLevel[log_level]
         logging.getLogger("").setLevel(log_level)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -25,7 +25,7 @@ from contextlib import closing
 from datetime import date, datetime, timezone
 from multiprocessing.dummy import Pool
 from queue import Queue
-from typing import Callable, Dict, List, Optional, Sized, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sized, Type, Union
 from urllib.parse import parse_qs, urlparse
 
 import dns.resolver
@@ -520,6 +520,13 @@ def remove_attributes(obj: Dict, attributes: List[str], recursive: bool = False)
 
 def is_list_or_tuple(obj) -> bool:
     return isinstance(obj, (list, tuple))
+
+
+def ensure_list(obj: Any, wrap_none=False) -> List:
+    """Wrap the given object in a list, or return the object itself if it already is a list."""
+    if obj is None and not wrap_none:
+        return obj
+    return obj if isinstance(obj, list) else [obj]
 
 
 def in_docker() -> bool:

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -3,6 +3,8 @@ from urllib.parse import parse_qs
 
 from moto.core.responses import BaseResponse
 
+from localstack.utils.aws.aws_responses import parse_urlencoded_data
+
 
 class TestMoto(unittest.TestCase):
     def test_request_parsing(self):
@@ -43,5 +45,8 @@ class TestMoto(unittest.TestCase):
         response = BaseResponse()
         response.querystring = parse_qs(qs)
         result = response._get_multi_param("Metrics.member", skip_result_conversion=True)
+        self.assertEqual(result, expected)
 
+        # assert parsing via util
+        result = parse_urlencoded_data(parse_qs(qs), "Metrics.member")
         self.assertEqual(result, expected)


### PR DESCRIPTION
Distinguish polling and reactive mode in Lambda `EventSourceListener`. This can be used to enhance the performance of, e.g., the SQS event source listener. However, it is still required to delete messages from the queue after the listener has consumed them (hence polling is still enabled as default mode for SQS).

In the near future, we may enhance/replace this with a centralized event bus, allowing the event source listeners to subscribe to updates directly.