### PR TITLE
Improve parsing logic for LAMBDA_DOCKER_FLAGS volumes

### DIFF
--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -79,6 +79,17 @@ def test_argument_parsing():
         argument_string = "--publish 80:80:80:80"
         Util.parse_additional_flags(argument_string, env_vars, ports, mounts)
 
+    # Test windows paths
+    argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task"'
+    env_vars, ports, mounts, extra_hosts = Util.parse_additional_flags(argument_string)
+    assert mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
+    argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task:ro"'
+    env_vars, ports, mounts, extra_hosts = Util.parse_additional_flags(argument_string)
+    assert mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
+    argument_string = r'-v "/var/test:/var/task:ro"'
+    env_vars, ports, mounts, extra_hosts = Util.parse_additional_flags(argument_string)
+    assert mounts == [("/var/test", "/var/task")]
+
 
 def list_in(a, b):
     return len(a) <= len(b) and any(


### PR DESCRIPTION
This PR improves the parsing of volume flags in LAMBDA_DOCKER_FLAGS and BATCH_DOCKER_FLAGS, so windows paths can be sent to the docker daemon (which should work with docker desktop for windows: https://docs.docker.com/desktop/windows/troubleshoot/#path-conversion-on-windows)

Prior logic just separates by colons `:`, which is inadequate for windows paths.