### PR TITLE
Support <apiId>.execute-api.* hostnames for API Gateway invocation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,12 +468,15 @@ $ ▶ laws lambda list-functions
 
 ### Invoking API Gateway
 
-While API Gateway endpoints on AWS use a custom DNS name to identify the API ID (e.g., `https://nmafetnwf6.execute-api.us-east-1.amazonaws.com/prod/my/path`), LocalStack uses the special URL path indicator `.../_user_request_/...` to indicate the execution of a REST API method.
-
-The URL pattern for API Gateway executions is `http://localhost:4566/restapis/<apiId>/<stage>/_user_request_/<methodPath>`. The example URL above would map to the following `localhost` URL:
+To invoke the path `/my/path` of an API Gateway with ID `id123` in stage `prod`, you can use the special hostname/URL syntax below:
 
 ```
-$ curl http://localhost:4566/restapis/nmafetnwf6/prod/_user_request_/my/path
+$ curl http://id123.execute-api.localhost.localstack.cloud:4566/prod/my/path
+```
+
+Alternatively, if your system is facing issues resolving the custom DNS name, you can use this URL pattern instead:
+```
+$ curl http://localhost:4566/restapis/id123/prod/_user_request_/my/path
 ```
 
 ## Testing Backdoors and Special Features


### PR DESCRIPTION
Support `<apiId>.execute-api.*` hostnames for API Gateway invocation URLs. 

This allows users to use the more convenient format:
```
http://<APIGATEWAY_ID>.execute-api.localhost.localstack.cloud:4566/<stage>/<path>
```
... in addition to:
```
http://localhost:4566/restapis/<APIGATEWAY_ID>/<stage>/_user_request_/<path>
```