### PR TITLE
Fix: DynamoDB output missing SSEDescription key and TableId

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -566,7 +566,7 @@ class ProxyListenerDynamoDB(ProxyListener):
             # Update only TableId and SSEDescription if present
             table_definitions = DynamoDBRegion.get().table_definitions.get(table_name)
             for key in ["TableId", "SSEDescription"]:
-                if table_definitions.get(key):
+                if table_definitions and table_definitions.get(key):
                     content = json.loads(to_str(response.content))
                     content.get("Table", {})[key] = table_definitions[key]
                     update_response_content(response, content)

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -493,7 +493,7 @@ class ProxyListenerDynamoDB(ProxyListener):
                     )
 
                 if data.get("Tags"):
-                    table_arn = content["TableArn"]
+                    table_arn = content["TableDescription"]["TableArn"]
                     DynamoDBRegion.TABLE_TAGS[table_arn] = {
                         tag["Key"]: tag["Value"] for tag in data["Tags"]
                     }

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -565,11 +565,12 @@ class ProxyListenerDynamoDB(ProxyListener):
 
             # Update only TableId and SSEDescription if present
             table_definitions = DynamoDBRegion.get().table_definitions.get(table_name)
-            for key in ["TableId", "SSEDescription"]:
-                if table_definitions and table_definitions.get(key):
-                    content = json.loads(to_str(response.content))
-                    content.get("Table", {})[key] = table_definitions[key]
-                    update_response_content(response, content)
+            if table_definitions:
+                for key in ["TableId", "SSEDescription"]:
+                    if table_definitions.get(key):
+                        content = json.loads(to_str(response.content))
+                        content.get("Table", {})[key] = table_definitions[key]
+                        update_response_content(response, content)
 
         elif action == "TagResource":
             table_arn = data["ResourceArn"]

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -831,7 +831,7 @@ class TestDynamoDB(unittest.TestCase):
         dynamodb = aws_stack.connect_to_service("dynamodb")
         table_name = "ddb-table-%s" % short_uid()
 
-        kms_master_key_id = long_uuid()
+        kms_master_key_id = long_uid()
         sse_specification = {"Enabled": True, "SSEType": "KMS", "KMSMasterKeyId": kms_master_key_id}
         kms_master_key_arn = "arn:aws:kms:%s:%s:key/%s" % (
             aws_stack.get_local_region(),

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -855,6 +855,8 @@ class TestDynamoDB(unittest.TestCase):
             result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"],
         )
 
+        delete_table(table_name)
+
 
 def delete_table(name):
     dynamodb_client = aws_stack.connect_to_service("dynamodb")

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -8,7 +8,6 @@ from time import sleep
 from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import STRING
 
-from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.utils import testutil
@@ -833,11 +832,7 @@ class TestDynamoDB(unittest.TestCase):
 
         kms_master_key_id = long_uid()
         sse_specification = {"Enabled": True, "SSEType": "KMS", "KMSMasterKeyId": kms_master_key_id}
-        kms_master_key_arn = "arn:aws:kms:%s:%s:key/%s" % (
-            aws_stack.get_local_region(),
-            TEST_AWS_ACCOUNT_ID,
-            kms_master_key_id,
-        )
+        kms_master_key_arn = aws_stack.kms_key_arn(kms_master_key_id)
 
         result = dynamodb.create_table(
             TableName=table_name,

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -15,7 +15,7 @@ from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import KinesisStream
 from localstack.utils.aws.aws_stack import get_environment
-from localstack.utils.common import json_safe, long_uuid, retry, short_uid
+from localstack.utils.common import json_safe, long_uid, retry, short_uid
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
 PARTITION_KEY = "id"


### PR DESCRIPTION
Fixes #4581.
* Fixing missing `SSEDescription` and `TableId` property on both `CreateTable` and `DescribeTable` output
* Adding tests to fit these requirements.
* Some minor fixes like redundant conditionals