### PR TITLE
Consider alias in lambda_function_or_layer.

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -595,7 +595,15 @@ def lambda_function_or_layer_arn(
     if re.match(pattern, entity_name):
         return entity_name
     if ":" in entity_name:
-        raise Exception('Lambda %s name should not contain a colon ":": %s' % (type, entity_name))
+        client = connect_to_service("lambda")
+        entity_name, alias = entity_name.split(":")
+        try:
+            alias_response = client.get_alias(FunctionName=entity_name, Name=alias)
+            version = alias_response["FunctionVersion"]
+
+        except Exception:
+            raise Exception("Alias %s of %s not found" % (alias, entity_name))
+
     account_id = get_account_id(account_id)
     region_name = region_name or get_region()
     pattern = re.sub(r"\([^\|]+\|.+\)", type, pattern)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -596,7 +596,7 @@ def lambda_function_or_layer_arn(
         return entity_name
     if ":" in entity_name:
         client = connect_to_service("lambda")
-        entity_name, alias = entity_name.split(":")
+        entity_name, _, alias = entity_name.rpartition(":")
         try:
             alias_response = client.get_alias(FunctionName=entity_name, Name=alias)
             version = alias_response["FunctionVersion"]


### PR DESCRIPTION
This PR addresses issue #4158.

The problem derives from the function `lambda_function_or_layer(...)` considering the : (Colon) in the entity_name parameter as an error when in reality it can refer to an alias of the function.

With this PR, the function now also searches for a version of the function using the alias.
