### PR TITLE
Fix: ApiKeyRequired in API Gateway not working from cloud formation

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -354,6 +354,7 @@ class GatewayMethod(GenericBaseModel):
                         "restApiId": "RestApiId",
                         "resourceId": "ResourceId",
                         "httpMethod": "HttpMethod",
+                        "apiKeyRequired": "ApiKeyRequired",
                         "authorizationType": "AuthorizationType",
                         "authorizerId": "AuthorizerId",
                         "requestParameters": "RequestParameters",


### PR DESCRIPTION
Fixing #4529  -   ApiKeyRequired value was not getting passed to API gateway.

https://github.com/localstack/localstack/issues/4529
