### PR TITLE
move normalize_bucket_name to s3_utils

### DIFF
--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -9,6 +9,7 @@ from localstack.services.cloudformation.deployment_utils import (
     dump_json_params,
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
+from localstack.services.s3 import s3_utils
 from localstack.utils.aws import aws_stack
 from localstack.utils.cloudformation.cfn_utils import rename_params
 from localstack.utils.common import canonical_json, md5
@@ -49,10 +50,7 @@ class S3Bucket(GenericBaseModel, FakeBucket):
 
     @staticmethod
     def normalize_bucket_name(bucket_name):
-        bucket_name = bucket_name or ""
-        # AWS automatically converts upper to lower case chars in bucket names
-        bucket_name = bucket_name.lower()
-        return bucket_name
+        return s3_utils.normalize_bucket_name(bucket_name)
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -22,7 +22,6 @@ from requests.models import Request, Response
 from six.moves.urllib import parse as urlparse
 
 from localstack import config, constants
-from localstack.services.cloudformation.models.s3 import S3Bucket
 from localstack.services.s3 import multipart_content
 from localstack.services.s3.s3_utils import (
     ALLOWED_HEADER_OVERRIDES,
@@ -34,6 +33,7 @@ from localstack.services.s3.s3_utils import (
     get_forwarded_for_host,
     is_expired,
     is_static_website,
+    normalize_bucket_name,
     uses_host_addressing,
     validate_bucket_name,
 )
@@ -1028,11 +1028,6 @@ def is_object_specific_request(path, headers):
     bucket_in_domain = is_bucket_specified_in_domain_name(path, headers)
     parts = len(path.split("/"))
     return parts > (1 if bucket_in_domain else 2)
-
-
-# TODO: remove dependency on cloudformation resource class here (extract as utility fn)
-def normalize_bucket_name(bucket_name):
-    return S3Bucket.normalize_bucket_name(bucket_name)
 
 
 def empty_response():

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -138,6 +138,12 @@ def extract_bucket_and_key_name(headers, path):
     return extract_bucket_name(headers, path), extract_key_name(headers, path)
 
 
+def normalize_bucket_name(bucket_name):
+    bucket_name = bucket_name or ""
+    bucket_name = bucket_name.lower()
+    return bucket_name
+
+
 def validate_bucket_name(bucket_name):
     """
     Validate s3 bucket name based on the documentation


### PR DESCRIPTION
This PR fixes an issue, where this line: https://github.com/localstack/localstack/blob/5ed4699e4803b111ac62ab986513d0ea40ea7d81/localstack/services/generic_proxy.py#L385-L386

 would lead to a complete import of the cloudformation API.

This lead to the first HTTP request to the edge server taking over 3 seconds.

Related to this todo: https://github.com/localstack/localstack/blob/5ed4699e4803b111ac62ab986513d0ea40ea7d81/localstack/services/s3/s3_listener.py#L1033-L1035

Generally I think it's better the cloudformation service depends on other services (like in this instance, now the `s3_utils` provided by `services.s3`) rather than the other way around.