### PR TITLE
Make some integration tests more lenient to environment changes

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -89,7 +89,6 @@ jobs:
       - name: Run community integration tests
         env:
           DEBUG: 0
-          PROXY_MAX_RETRIES: 0
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "local"
           LOCALSTACK_API_KEY: "test"
@@ -103,7 +102,6 @@ jobs:
       - name: Run Lambda Tests for lambda executor docker
         env:
           DEBUG: 0
-          PROXY_MAX_RETRIES: 0
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "docker"
           LOCALSTACK_API_KEY: "test"
@@ -114,7 +112,6 @@ jobs:
       - name: Run Lambda Tests for lambda executor docker-reuse
         env:
           DEBUG: 0
-          PROXY_MAX_RETRIES: 0
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "docker-reuse"
           LOCALSTACK_API_KEY: "test"

--- a/tests/integration/docker/test_docker.py
+++ b/tests/integration/docker/test_docker.py
@@ -676,7 +676,7 @@ class TestDockerClient:
 
     def test_inspect_image(self, docker_client: ContainerClient):
         docker_client.pull_image("alpine")
-        assert "alpine:latest" == docker_client.inspect_image("alpine")["RepoTags"][0]
+        assert "alpine" in docker_client.inspect_image("alpine")["RepoTags"][0]
 
     def test_copy_from_container(self, tmpdir, docker_client: ContainerClient, dummy_container):
         docker_client.start_container(dummy_container.container_id)

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1258,7 +1258,7 @@ class TestAPIGateway(unittest.TestCase):
             self.assertEqual(200, result.status_code)
             self.assertRegexpMatches(
                 content["headers"].get(HEADER_LOCALSTACK_REQUEST_URL),
-                f"http://.*localhost.*:{config.EDGE_PORT}/person/123",
+                "http://.*localhost.*/person/123",
             )
 
         for use_hostname in [True, False]:


### PR DESCRIPTION
Some tests make assumptions that no longer hold, depending on the environment and whether Pro is enabled or not, that is changed with this PR.
Also I remove the disabled retries, maybe that makes some tests more resilient.