### PR TITLE
Fix: consider that there are no filters

### DIFF
--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -65,7 +65,9 @@ def publish_log_metrics_for_events(data):
     data = data if isinstance(data, dict) else json.loads(data)
     log_events = data.get("logEvents") or []
     logs_backend = logs_backends[aws_stack.get_region()]
-    metric_filters = logs_backend.filters.metric_filters
+    metric_filters = (
+        logs_backend.filters.metric_filters if hasattr(logs_backends, "filters") else []
+    )
     client = aws_stack.connect_to_service("cloudwatch")
     for metric_filter in metric_filters:
         pattern = metric_filter.get("filterPattern", "")


### PR DESCRIPTION
While triaging issue #4593 an error keep occurring to me about the LogsBackend object  not having and attribute. This PR makes a quick fix about that. 

```
File "/home/cristopher/Projects/localstack/localstack/services/logs/logs_listener.py", line 21, in forward_request
    publish_log_metrics_for_events(data)
  File "/home/cristopher/Projects/localstack/localstack/services/logs/logs_listener.py", line 68, in publish_log_metrics_for_events
    metric_filters = logs_backend.filters.metric_filters
AttributeError: 'LogsBackend' object has no attribute 'filters'
```

This is NOT a fix for the issue, due to being in reality an usage problem.
