### PR TITLE
chore(compose): update sample compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }
       - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
       - DOCKER_HOST=unix:///var/run/docker.sock
-      - HOST_TMP_FOLDER="${TMPDIR:-/tmp}/localstack"
+      - HOST_TMP_FOLDER=${TMPDIR:-/tmp/}localstack
     volumes:
       - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION
## Summary

* Update `HOST_TMP_FOLDER` to avoid slash duplications (`$TMPDIR` already comes with a trailing slash)
* Remove surrounding quotes since they are getting passed (at least on Mac) as part of the `$HOST_TMP_FOLDER` var, resulting in paths like `"a/b/c"/d` which leads to mounting errors

Please let me know if these changes may lead to any negative side effects on platforms other than Mac.