### PR TITLE
Fixed Lambda SNS event source as `aws:sns` ...

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -617,7 +617,7 @@ def process_sns_notification(
     event = {
         "Records": [
             {
-                "EventSource": "localstack:sns",
+                "EventSource": "aws:sns",
                 "EventVersion": "1.0",
                 "EventSubscriptionArn": subscription_arn,
                 "Sns": {


### PR DESCRIPTION
… (it was `localstack:sns` before)
