### PR TITLE
Fix deploying lambdas with similar names

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1491,8 +1491,6 @@ def get_function(function):
     for func in funcs:
         if function == func["FunctionName"]:
             return lookup_function(func, region, request.url)
-        elif function in func["FunctionArn"]:
-            return lookup_function(func, region, request.url)
     return not_found_error(func_arn(function))
 
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1489,7 +1489,7 @@ def get_function(function):
     region = LambdaRegion.get()
     funcs = do_list_functions()
     for func in funcs:
-        if function == func["FunctionName"]:
+        if function == func["FunctionName"] or function == func["FunctionArn"]:
             return lookup_function(func, region, request.url)
     return not_found_error(func_arn(function))
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1488,8 +1488,12 @@ def get_function(function):
     """
     region = LambdaRegion.get()
     funcs = do_list_functions()
+    arn_regex = r".*%s($|:.+)" % function
+    is_arn = ":" in function
     for func in funcs:
-        if function == func["FunctionName"] or function == func["FunctionArn"]:
+        if function == func["FunctionName"] or (
+            is_arn and re.match(arn_regex, func["FunctionArn"])
+        ):
             return lookup_function(func, region, request.url)
     return not_found_error(func_arn(function))
 

--- a/tests/integration/serverless/handler.js
+++ b/tests/integration/serverless/handler.js
@@ -2,6 +2,10 @@ module.exports.test = function(event) {
   console.log('!!!test', JSON.stringify(event));
 };
 
+module.exports.tests = function(event) {
+  console.log('!!!tests', JSON.stringify(event));
+};
+
 module.exports.processKinesis = function(event) {
   console.log('!!!processKinesis', JSON.stringify(event));
 };

--- a/tests/integration/serverless/serverless.yml
+++ b/tests/integration/serverless/serverless.yml
@@ -122,6 +122,10 @@ resources:
         QueueName: "${self:service}-${opt:stage}-CreateBackupQueue"
 
 functions:
+  tests:
+    handler: "handler.tests"
+    maximumEventAge: 7200
+    maximumRetryAttempts: 2
   test:
     handler: "handler.test"
     maximumEventAge: 7200

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -86,19 +86,24 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             self._create_function("myFunctions")
             self._create_function("myFunction")
-            result = json.loads(lambda_api.get_function("arn:aws:lambda:us-east-1:000000000000:function:myFunction")
-                                .get_data())
+            result = json.loads(
+                lambda_api.get_function(
+                    "arn:aws:lambda:us-east-1:000000000000:function:myFunction"
+                ).get_data()
+            )
             self.assertEquals(
                 result["Configuration"]["FunctionArn"],
                 "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
             )
-            result = json.loads(lambda_api.get_function("arn:aws:lambda:us-east-1:000000000000:function:myFunctions")
-                                .get_data())
+            result = json.loads(
+                lambda_api.get_function(
+                    "arn:aws:lambda:us-east-1:000000000000:function:myFunctions"
+                ).get_data()
+            )
             self.assertEquals(
                 result["Configuration"]["FunctionArn"],
                 "arn:aws:lambda:us-east-1:000000000000:function:myFunctions",
             )
-
 
     def test_get_event_source_mapping(self):
         region = lambda_api.LambdaRegion.get()

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -105,6 +105,25 @@ class TestLambdaAPI(unittest.TestCase):
                 "arn:aws:lambda:us-east-1:000000000000:function:myFunctions",
             )
 
+    def test_get_function_two_functions_with_similar_names_match_by_partial_arn(self):
+        with self.app.test_request_context():
+            self._create_function("myFunctions")
+            self._create_function("myFunction")
+            result = json.loads(
+                lambda_api.get_function("us-east-1:000000000000:function:myFunction").get_data()
+            )
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
+            )
+            result = json.loads(
+                lambda_api.get_function("us-east-1:000000000000:function:myFunctions").get_data()
+            )
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunctions",
+            )
+
     def test_get_event_source_mapping(self):
         region = lambda_api.LambdaRegion.get()
         with self.app.test_request_context():

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -67,7 +67,7 @@ class TestLambdaAPI(unittest.TestCase):
                 "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
             )
 
-    def test_get_function_two_functions_with_similar_names(self):
+    def test_get_function_two_functions_with_similar_names_match_by_name(self):
         with self.app.test_request_context():
             self._create_function("myFunctions")
             self._create_function("myFunction")
@@ -76,6 +76,29 @@ class TestLambdaAPI(unittest.TestCase):
                 result["Configuration"]["FunctionArn"],
                 "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
             )
+            result = json.loads(lambda_api.get_function("myFunctions").get_data())
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunctions",
+            )
+
+    def test_get_function_two_functions_with_similar_names_match_by_arn(self):
+        with self.app.test_request_context():
+            self._create_function("myFunctions")
+            self._create_function("myFunction")
+            result = json.loads(lambda_api.get_function("arn:aws:lambda:us-east-1:000000000000:function:myFunction")
+                                .get_data())
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
+            )
+            result = json.loads(lambda_api.get_function("arn:aws:lambda:us-east-1:000000000000:function:myFunctions")
+                                .get_data())
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunctions",
+            )
+
 
     def test_get_event_source_mapping(self):
         region = lambda_api.LambdaRegion.get()

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -58,6 +58,25 @@ class TestLambdaAPI(unittest.TestCase):
                 result["message"],
             )
 
+    def test_get_function_single_function_returns_correect_function(self):
+        with self.app.test_request_context():
+            self._create_function("myFunction")
+            result = json.loads(lambda_api.get_function("myFunction").get_data())
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
+            )
+
+    def test_get_function_two_functions_with_similar_names(self):
+        with self.app.test_request_context():
+            self._create_function("myFunctions")
+            self._create_function("myFunction")
+            result = json.loads(lambda_api.get_function("myFunction").get_data())
+            self.assertEquals(
+                result["Configuration"]["FunctionArn"],
+                "arn:aws:lambda:us-east-1:000000000000:function:myFunction",
+            )
+
     def test_get_event_source_mapping(self):
         region = lambda_api.LambdaRegion.get()
         with self.app.test_request_context():


### PR DESCRIPTION
Given situation we have for example two lambdas to deploy. One named getUsers and getUser. When e.g. serverless framework deploys those functions in that order, it fails to deploy getUser because getUsers's arn includes string "getUser".
I just removed the partial arn matching because it was the cause for the problem we faced. Not sure though if it's too naive assumption.