### PR TITLE
Add support for s3:ObjectCreated:Copy event

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -226,7 +226,9 @@ def send_notifications(method, bucket_name, object_path, version_id, headers):
             }[method]
             # TODO: support more detailed methods, e.g., DeleteMarkerCreated
             # http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html
-            if action == "ObjectCreated" and method == "POST":
+            if action == "ObjectCreated" and method == "PUT" and "x-amz-copy-source" in headers:
+                api_method = "Copy"
+            elif action == "ObjectCreated" and method == "POST":
                 api_method = "CompleteMultipartUpload"
             else:
                 api_method = {"PUT": "Put", "POST": "Post", "DELETE": "Delete"}[method]


### PR DESCRIPTION
Hi.

When we execute `aws s3api copy-object` command, AWS publishes `ObjectCreated:Copy` event.
Currently, localstack publishes `ObjectCreated:Put`.

This PR fixes it.

Regards.