### PR TITLE
Allow credentials (enabled `Access-Control-Allow-Credentials` header) …

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -244,6 +244,8 @@ def apply_template(integration, req_res_type, data, path_params={}, query_params
 
 
 def apply_response_parameters(response, integration, api_id=None):
+    if response.headers.get("Access-Control-Allow-Origin") != "*":
+        response.headers["Access-Control-Allow-Credentials"] = "true"
     int_responses = integration.get("integrationResponses") or {}
     if not int_responses:
         return response


### PR DESCRIPTION
... for API-Gateway integrations if CORS is not enabled for all domains

**P.S.** I have inspired from `s3_listener.append_cors_headers`

This is required if the request's credentials mode is `include`.

For example, if I enable credentials for Axios requests (`withCredentials: true` option), without this change, request fails with the following error:
```
The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```