### PR TITLE
Move defaults from template_deployer to service models

### DIFF
--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Callable
 
 from localstack.constants import INSTALL_DIR_INFRA
 from localstack.utils import common
@@ -144,8 +145,10 @@ def generate_default_name(stack_name: str, logical_resource_id: str):
     return f"{stack_name_part}-{resource_id_part}-{random_id_part}"
 
 
-def pre_create_default_name(key: str):
-    def _pre_create_default_name(resource_id, resources, resource_type, func, stack_name):
+def pre_create_default_name(key: str) -> Callable[[str, dict, str, dict, str], None]:
+    def _pre_create_default_name(
+        resource_id: str, resources: dict, resource_type: str, func: dict, stack_name: str
+    ):
         resource = resources[resource_id]
         props = resource["Properties"]
         if not props.get(key):

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -60,7 +60,7 @@ class GatewayRequestValidator(GenericBaseModel):
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
-        role_name = resource.get("Properties", {}).get("Name")
+        role_name = resource["properties"].get("Name")
         if not role_name:
             resource["Properties"]["Name"] = generate_default_name(
                 stack_name, resource["LogicalResourceId"]

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -2,6 +2,7 @@ import json
 from urllib.parse import urlparse
 
 from localstack.services.cloudformation.deployment_utils import (
+    generate_default_name,
     lambda_keys_to_lower,
     params_list_to_dict,
 )
@@ -58,6 +59,14 @@ class GatewayRequestValidator(GenericBaseModel):
         return result[0] if result else None
 
     @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("Name")
+        if not role_name:
+            resource["Properties"]["Name"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
+
+    @staticmethod
     def get_deploy_templates():
         return {
             "create": {
@@ -90,6 +99,14 @@ class GatewayRestAPI(GenericBaseModel):
         api_name = self.resolve_refs_recursively(stack_name, api_name, resources)
         result = list(filter(lambda api: api["name"] == api_name, apis))
         return result[0] if result else None
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("Name")
+        if not role_name:
+            resource["Properties"]["Name"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):
@@ -440,6 +457,14 @@ class GatewayUsagePlan(GenericBaseModel):
         return (result or [None])[0]
 
     @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("UsagePlanName")
+        if not role_name:
+            resource["Properties"]["UsagePlanName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
+
+    @staticmethod
     def get_deploy_templates():
         return {
             "create": {
@@ -475,6 +500,14 @@ class GatewayApiKey(GenericBaseModel):
             if r.get("name") == key_name and cust_id in (None, r.get("customerId"))
         ]
         return (result or [None])[0]
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("Name")
+        if not role_name:
+            resource["Properties"]["Name"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():
@@ -610,6 +643,14 @@ class GatewayModel(GenericBaseModel):
             return models[0]
 
         return None
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("Name")
+        if not role_name:
+            resource["Properties"]["Name"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -398,11 +398,12 @@ class GatewayStage(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def get_params(params, **kwargs):
-            result = keys_to_lower(params)
+        def get_params(resource_props, stack_name, resources, resource_id):
+            stage_name = resource_props.get("StageName", "default")
+            resources[resource_id]["Properties"]["StageName"] = stage_name
+            result = keys_to_lower(resource_props)
             param_names = [
                 "restApiId",
-                "stageName",
                 "deploymentId",
                 "description",
                 "cacheClusterEnabled",
@@ -415,9 +416,15 @@ class GatewayStage(GenericBaseModel):
             ]
             result = select_attributes(result, param_names)
             result["tags"] = {t["key"]: t["value"] for t in result.get("tags", [])}
+            result["stageName"] = stage_name
             return result
 
-        return {"create": {"function": "create_stage", "parameters": get_params}}
+        return {
+            "create": {
+                "function": "create_stage",
+                "parameters": get_params,
+            }
+        }
 
 
 class GatewayUsagePlan(GenericBaseModel):

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -3,6 +3,7 @@ import os
 from localstack.services.awslambda.lambda_api import LAMBDA_POLICY_NAME_PATTERN
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
 from localstack.services.cloudformation.deployment_utils import (
+    generate_default_name,
     get_cfn_response_mod_file,
     select_parameters,
 )
@@ -58,6 +59,14 @@ class LambdaFunction(GenericBaseModel):
                 k: str(v) for k, v in environment_variables.items()
             }
         return client.update_function_configuration(**update_props)
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("FunctionName")
+        if not role_name:
+            resource["Properties"]["FunctionName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -1,3 +1,4 @@
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -17,6 +18,14 @@ class CloudFormationStack(GenericBaseModel):
         result = client.describe_stacks(StackName=child_stack_name)
         result = (result.get("Stacks") or [None])[0]
         return result
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("StackName")
+        if not role_name:
+            resource["Properties"]["StackName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/cloudwatch.py
+++ b/localstack/services/cloudformation/models/cloudwatch.py
@@ -1,3 +1,4 @@
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -22,6 +23,14 @@ class CloudWatchAlarm(GenericBaseModel):
         alarm_name = self.resolve_refs_recursively(stack_name, self.props["AlarmName"], resources)
         result = client.describe_alarms(AlarmNames=[alarm_name]).get(self._response_name(), [])
         return (result or [None])[0]
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("AlarmName")
+        if not role_name:
+            resource["Properties"]["AlarmName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -2,6 +2,7 @@ from localstack.services.cloudformation.deployment_utils import PLACEHOLDER_AWS_
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
+from localstack.utils.common import short_uid
 
 
 def get_ddb_provisioned_throughput(params, **kwargs):
@@ -18,17 +19,25 @@ def get_ddb_provisioned_throughput(params, **kwargs):
 
 def get_ddb_global_sec_indexes(params, **kwargs):
     args = params.get("GlobalSecondaryIndexes")
+    is_ondemand = params.get("BillingMode") == "PAY_PER_REQUEST"
     if args:
         for index in args:
-            provisoned_throughput = index["ProvisionedThroughput"]
-            if isinstance(provisoned_throughput["ReadCapacityUnits"], str):
-                provisoned_throughput["ReadCapacityUnits"] = int(
-                    provisoned_throughput["ReadCapacityUnits"]
-                )
-            if isinstance(provisoned_throughput["WriteCapacityUnits"], str):
-                provisoned_throughput["WriteCapacityUnits"] = int(
-                    provisoned_throughput["WriteCapacityUnits"]
-                )
+            provisioned_throughput = index.get("ProvisionedThroughput")
+            if is_ondemand and provisioned_throughput is None:
+                pass  # optional for API calls
+            elif provisioned_throughput is not None:
+                # convert types
+                if isinstance(provisioned_throughput["ReadCapacityUnits"], str):
+                    provisioned_throughput["ReadCapacityUnits"] = int(
+                        provisioned_throughput["ReadCapacityUnits"]
+                    )
+                if isinstance(provisioned_throughput["WriteCapacityUnits"], str):
+                    provisioned_throughput["WriteCapacityUnits"] = int(
+                        provisioned_throughput["WriteCapacityUnits"]
+                    )
+            else:
+                raise Exception("Can't specify ProvisionedThroughput with PAY_PER_REQUEST")
+
     return args
 
 
@@ -55,16 +64,27 @@ class DynamoDBTable(GenericBaseModel):
         table_name = self.resolve_refs_recursively(stack_name, table_name, resources)
         return aws_stack.connect_to_service("dynamodb").describe_table(TableName=table_name)
 
-    @staticmethod
-    def get_deploy_templates():
+    @classmethod
+    def get_deploy_templates(cls):
+        def _pre_create(resource_id, resources, resource_type, func, stack_name):
+            resource = resources[resource_id]
+            props = resource["Properties"]
+
+            def _generate_res_name():  # TODO: generalize
+                return "%s-%s-%s" % (stack_name, resource_id, short_uid())
+
+            props["TableName"] = props.get("TableName") or _generate_res_name()
+
         return {
             "create": [
+                {"function": _pre_create},
                 {
                     "function": "create_table",
                     "parameters": {
                         "TableName": "TableName",
                         "AttributeDefinitions": "AttributeDefinitions",
                         "KeySchema": "KeySchema",
+                        "BillingMode": "BillingMode",
                         "ProvisionedThroughput": get_ddb_provisioned_throughput,
                         "LocalSecondaryIndexes": "LocalSecondaryIndexes",
                         "GlobalSecondaryIndexes": get_ddb_global_sec_indexes,

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -1,5 +1,6 @@
 from moto.ec2.utils import generate_route_id
 
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -236,6 +237,14 @@ class SecurityGroup(GenericBaseModel):
         if attribute in REF_ID_ATTRS:
             props = self.props
             return props.get("GroupId") or props.get("GroupName")
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("GroupName")
+        if not role_name:
+            resource["Properties"]["GroupName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -2,6 +2,7 @@ import json
 
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
+    pre_create_default_name,
     select_parameters,
 )
 from localstack.services.cloudformation.service_models import (
@@ -99,7 +100,7 @@ class EventsRule(GenericBaseModel):
                 "EventBusName",
             ]
             result = select_parameters(*attrs)(params, **kwargs)
-            result["Name"] = result.get("Name") or PLACEHOLDER_RESOURCE_NAME
+            # result["Name"] = result.get("Name") or PLACEHOLDER_RESOURCE_NAME
 
             def wrap_in_lists(o, **kwargs):
                 if isinstance(o, dict):
@@ -116,6 +117,7 @@ class EventsRule(GenericBaseModel):
 
         return {
             "create": [
+                {"function": pre_create_default_name("Name")},
                 {"function": "put_rule", "parameters": events_put_rule_params},
                 {
                     "function": "put_targets",

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -100,7 +100,6 @@ class EventsRule(GenericBaseModel):
                 "EventBusName",
             ]
             result = select_parameters(*attrs)(params, **kwargs)
-            # result["Name"] = result.get("Name") or PLACEHOLDER_RESOURCE_NAME
 
             def wrap_in_lists(o, **kwargs):
                 if isinstance(o, dict):

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -31,6 +31,14 @@ class IAMManagedPolicy(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         return IAMPolicy.get_policy_state(self, stack_name, resources, managed_policy=True)
 
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("ManagedPolicyName")
+        if not role_name:
+            resource["Properties"]["ManagedPolicyName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
+
     @classmethod
     def get_deploy_templates(cls):
         def _create(resource_id, resources, resource_type, func, stack_name, *args, **kwargs):
@@ -354,6 +362,14 @@ class InstanceProfile(GenericBaseModel):
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
         return self.physical_resource_id or self.props.get("InstanceProfileName")
+
+    @staticmethod
+    def add_defaults(resource, stack_name):
+        role_name = resource.get("Properties", {}).get("InstanceProfileName")
+        if not role_name:
+            resource["Properties"]["InstanceProfileName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -8,6 +8,7 @@ from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
     PLACEHOLDER_RESOURCE_NAME,
     dump_json_params,
+    generate_default_name,
     param_defaults,
     remove_none_values,
     select_parameters,
@@ -165,6 +166,14 @@ class IAMRole(GenericBaseModel, MotoRole):
         return client.update_role(
             RoleName=props.get("RoleName"), Description=props.get("Description") or ""
         )
+
+    @staticmethod
+    def add_defaults(resource, stack_name):
+        role_name = resource.get("Properties", {}).get("RoleName")
+        if not role_name:
+            resource["Properties"]["RoleName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -1,3 +1,4 @@
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -24,6 +25,14 @@ class LogsLogGroup(GenericBaseModel):
         logs = aws_stack.connect_to_service("logs")
         groups = logs.describe_log_groups(logGroupNamePrefix=group_name)["logGroups"]
         return ([g for g in groups if g["logGroupName"] == group_name] or [None])[0]
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("LogGroupName")
+        if not role_name:
+            resource["Properties"]["LogGroupName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/redshift.py
+++ b/localstack/services/cloudformation/models/redshift.py
@@ -1,3 +1,4 @@
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -17,6 +18,14 @@ class RedshiftCluster(GenericBaseModel):
         )
         result = client.describe_clusters(ClusterIdentifier=cluster_id)["Clusters"]
         return (result or [None])[0]
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("ClusterIdentifier")
+        if not role_name:
+            resource["Properties"]["ClusterIdentifier"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -7,9 +7,10 @@ from localstack.constants import AWS_REGION_US_EAST_1, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
     dump_json_params,
+    generate_default_name,
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.services.s3 import s3_utils
+from localstack.services.s3 import s3_listener, s3_utils
 from localstack.utils.aws import aws_stack
 from localstack.utils.cloudformation.cfn_utils import rename_params
 from localstack.utils.common import canonical_json, md5
@@ -51,6 +52,14 @@ class S3Bucket(GenericBaseModel, FakeBucket):
     @staticmethod
     def normalize_bucket_name(bucket_name):
         return s3_utils.normalize_bucket_name(bucket_name)
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("BucketName")
+        if not role_name:
+            resource["Properties"]["BucketName"] = s3_listener.normalize_bucket_name(
+                generate_default_name(stack_name, resource["LogicalResourceId"])
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -3,6 +3,7 @@ import logging
 import random
 import string
 
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import (
     REF_ARN_ATTRS,
     REF_ID_ATTRS,
@@ -73,6 +74,14 @@ class SecretsManagerSecret(GenericBaseModel):
         result = [alphabet[random.randrange(len(alphabet))] for _ in range(length)]
         result = "".join(result)
         return result
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("Name")
+        if not role_name:
+            resource["Properties"]["Name"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -1,6 +1,9 @@
 import json
 
-from localstack.services.cloudformation.deployment_utils import is_none_or_empty_value
+from localstack.services.cloudformation.deployment_utils import (
+    generate_default_name,
+    is_none_or_empty_value,
+)
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import canonicalize_bool_to_str
@@ -30,6 +33,14 @@ class SNSTopic(GenericBaseModel):
             )
         )
         return result[0] if result else None
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("TopicName")
+        if not role_name:
+            resource["Properties"]["TopicName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -6,6 +6,7 @@ from moto.sqs.models import Queue as MotoQueue
 
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
+    generate_default_name,
     params_list_to_dict,
     params_select_attributes,
 )
@@ -103,6 +104,14 @@ class SQSQueue(GenericBaseModel, MotoQueue):
         ]
         result["Arn"] = result["QueueArn"]
         return result
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("QueueName")
+        if not role_name:
+            resource["Properties"]["QueueName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -1,7 +1,10 @@
 import re
 from typing import Dict
 
-from localstack.services.cloudformation.deployment_utils import PLACEHOLDER_RESOURCE_NAME
+from localstack.services.cloudformation.deployment_utils import (
+    PLACEHOLDER_RESOURCE_NAME,
+    generate_default_name,
+)
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 
@@ -67,6 +70,14 @@ class SFNStateMachine(GenericBaseModel):
             "definition": props["DefinitionString"],
         }
         return client.update_state_machine(**kwargs)
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        role_name = resource.get("Properties", {}).get("StateMachineName")
+        if not role_name:
+            resource["Properties"]["StateMachineName"] = generate_default_name(
+                stack_name, resource["LogicalResourceId"]
+            )
 
     @classmethod
     def get_deploy_templates(cls):

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -39,6 +39,7 @@ class GenericBaseModel(CloudFormationModel):
     """
 
     def __init__(self, resource_json, region_name=None, **params):
+        # self.stack_name = stack_name # TODO: add stack name to params
         self.region_name = region_name or aws_stack.get_region()
         self.resource_json = resource_json
         self.resource_type = resource_json["Type"]
@@ -81,6 +82,12 @@ class GenericBaseModel(CloudFormationModel):
     @staticmethod
     def get_deploy_templates():
         """Return template configurations used to create the final API requests (implemented by subclasses)."""
+        pass
+
+    # TODO: rework to normal instance method when resources aren't mutated in different place anymore
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        """Set any defaults required, including auto-generating names. Must be called before deploying the resource"""
         pass
 
     # ----------------------

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1222,11 +1222,7 @@ def add_default_resource_props(
         return "%s-%s-%s" % (stack_name, resource_name or resource_id, short_uid())
 
     # TODO: move logic below into resource classes!
-
-    if res_type == "AWS::Lambda::EventSourceMapping" and not props.get("StartingPosition"):
-        props["StartingPosition"] = "LATEST"
-
-    elif res_type == "AWS::Logs::LogGroup" and not props.get("LogGroupName") and resource_name:
+    if res_type == "AWS::Logs::LogGroup" and not props.get("LogGroupName") and resource_name:
         props["LogGroupName"] = resource_name
 
     elif res_type == "AWS::Lambda::Function" and not props.get("FunctionName"):
@@ -1249,7 +1245,7 @@ def add_default_resource_props(
         props["Name"] = _generate_res_name()
 
     elif res_type == "AWS::ApiGateway::Stage" and not props.get("StageName"):
-        props["StageName"] = "default"
+        props["StageName"] = "default"  # TODO
 
     elif res_type == "AWS::ApiGateway::ApiKey" and not props.get("Name"):
         props["Name"] = _generate_res_name()

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1215,9 +1215,10 @@ def add_default_resource_props(
     props = resource["Properties"] = resource.get("Properties", {})
     existing_resources = existing_resources or {}
 
-    my_instance = get_resource_model_instance(resource_id, existing_resources)
-    if my_instance is not None:
-        my_instance.add_defaults(resource, stack_name)
+    canonical_type = canonical_resource_type(res_type)
+    resource_class = RESOURCE_MODELS.get(canonical_type)
+    if resource_class is not None:
+        resource_class.add_defaults(resource, stack_name)
 
     def _generate_res_name():
         return "%s-%s-%s" % (stack_name, resource_name or resource_id, short_uid())

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -33,7 +33,6 @@ from localstack.utils.cloudformation import template_preparer
 from localstack.utils.common import (
     get_all_subclasses,
     prevent_stack_overflow,
-    short_uid,
     start_worker_thread,
     to_bytes,
     to_str,
@@ -1212,23 +1211,10 @@ def add_default_resource_props(
     """Apply some fixes to resource props which otherwise cause deployments to fail"""
 
     res_type = resource["Type"]
-    props = resource["Properties"] = resource.get("Properties", {})
-
     canonical_type = canonical_resource_type(res_type)
     resource_class = RESOURCE_MODELS.get(canonical_type)
     if resource_class is not None:
         resource_class.add_defaults(resource, stack_name)
-
-    # TODO: move logic below into resource classes!
-    if res_type == "AWS::Logs::LogGroup" and not props.get("LogGroupName") and resource_name:
-        props["LogGroupName"] = resource_name
-
-    elif res_type == "AWS::KMS::Key":
-        tags = props["Tags"] = props.get("Tags", [])
-        existing = [t for t in tags if t["Key"] == "localstack-key-id"]
-        if not existing:
-            # append tags, to allow us to determine in service_models.py whether this key is already deployed
-            tags.append({"Key": "localstack-key-id", "Value": short_uid()})
 
 
 # -----------------------

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1241,9 +1241,6 @@ def add_default_resource_props(
     elif res_type == "AWS::SQS::Queue" and not props.get("QueueName"):
         props["QueueName"] = "queue-%s" % short_uid()
 
-    elif res_type == "AWS::IAM::ManagedPolicy" and not resource.get("ManagedPolicyName"):
-        resource["ManagedPolicyName"] = _generate_res_name()
-
     elif res_type == "AWS::ApiGateway::RestApi" and not props.get("Name"):
         props["Name"] = _generate_res_name()
 
@@ -1284,9 +1281,6 @@ def add_default_resource_props(
     elif res_type == "AWS::Redshift::Cluster":
         props["ClusterIdentifier"] = props.get("ClusterIdentifier") or _generate_res_name()
 
-    elif res_type == "AWS::IAM::InstanceProfile":
-        props["InstanceProfileName"] = props.get("InstanceProfileName") or _generate_res_name()
-
     elif res_type == "AWS::Logs::LogGroup":
         props["LogGroupName"] = props.get("LogGroupName") or _generate_res_name()
 
@@ -1297,9 +1291,6 @@ def add_default_resource_props(
         if not existing:
             # append tags, to allow us to determine in service_models.py whether this key is already deployed
             tags.append({"Key": "localstack-key-id", "Value": short_uid()})
-
-    elif res_type == "AWS::IAM::ManagedPolicy":
-        props["ManagedPolicyName"] = props.get("ManagedPolicyName") or _generate_res_name()
 
 
 # -----------------------

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1226,6 +1226,7 @@ def add_default_resource_props(
         props["LogGroupName"] = resource_name
 
     elif res_type == "AWS::Lambda::Function" and not props.get("FunctionName"):
+        # TODO: generalize this for all auto-name generations
         # FunctionName is up to 64 characters long
         random_id_part = short_uid()
         resource_id_part = resource_id[:24]
@@ -1243,9 +1244,6 @@ def add_default_resource_props(
 
     elif res_type == "AWS::ApiGateway::RestApi" and not props.get("Name"):
         props["Name"] = _generate_res_name()
-
-    elif res_type == "AWS::ApiGateway::Stage" and not props.get("StageName"):
-        props["StageName"] = "default"  # TODO
 
     elif res_type == "AWS::ApiGateway::ApiKey" and not props.get("Name"):
         props["Name"] = _generate_res_name()
@@ -1291,6 +1289,7 @@ def add_default_resource_props(
         props["LogGroupName"] = props.get("LogGroupName") or _generate_res_name()
 
     elif res_type == "AWS::KMS::Key":
+        # TODO: inspect
         tags = props["Tags"] = props.get("Tags", [])
         existing = [t for t in tags if t["Key"] == "localstack-key-id"]
         if not existing:
@@ -1307,7 +1306,7 @@ def add_default_resource_props(
             if not resource_id:
                 resource_id = canonical_json(json_safe(props))
                 resource_id = md5(resource_id)
-            props[entry[1]] = "cf-%s-%s" % (stack_name, resource_id)
+            props[entry[1]] = "cf-%s-%s" % (stack_name, resource_id)  # TODO: not valid AWS behavior
 
 
 # -----------------------

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1263,10 +1263,6 @@ def add_default_resource_props(
     elif res_type == "AWS::ApiGateway::RequestValidator" and not props.get("Name"):
         props["Name"] = _generate_res_name()
 
-    elif res_type == "AWS::DynamoDB::Table":
-        update_dynamodb_index_resource(resource)
-        props["TableName"] = props.get("TableName") or _generate_res_name()
-
     elif res_type == "AWS::CloudWatch::Alarm":
         props["AlarmName"] = props.get("AlarmName") or _generate_res_name()
 
@@ -1316,16 +1312,6 @@ def add_default_resource_props(
                 resource_id = canonical_json(json_safe(props))
                 resource_id = md5(resource_id)
             props[entry[1]] = "cf-%s-%s" % (stack_name, resource_id)
-
-
-def update_dynamodb_index_resource(resource):
-    if resource.get("Properties").get("BillingMode") == "PAY_PER_REQUEST":
-        for glob_index in resource.get("Properties", {}).get("GlobalSecondaryIndexes", []):
-            if not glob_index.get("ProvisionedThroughput"):
-                glob_index["ProvisionedThroughput"] = {
-                    "ReadCapacityUnits": 99,
-                    "WriteCapacityUnits": 99,
-                }
 
 
 # -----------------------

--- a/tests/integration/templates/s3_bucket_autoname.yaml
+++ b/tests/integration/templates/s3_bucket_autoname.yaml
@@ -1,0 +1,9 @@
+Resources:
+  myb3B4550BC:
+    Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+Outputs:
+  BucketNameOutput:
+    Value:
+      Ref: myb3B4550BC

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1778,15 +1778,7 @@ class CloudFormationTest(unittest.TestCase):
 
         # 2 roles created successfully
         rs = iam_client.list_roles()
-        roles = [
-            role
-            for role in rs["Roles"]
-            if role["RoleName"]
-            in [
-                "cf-{}-Role".format(stack_name),
-                "cf-{}-StateMachineExecutionRole".format(stack_name),
-            ]
-        ]
+        roles = [role for role in rs["Roles"] if stack_name in role["RoleName"]]
 
         self.assertEqual(2, len(roles))
 


### PR DESCRIPTION
Moves the default values (mostly name generation) to the service models and adjusts/extends the tests where necessary.

The only thing that should be changed on the user's side should be some of the auto-generated Names that now conform more to what CloudFormation would produce.