### PR TITLE
Move delete patches in template deployer to service models

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -1,11 +1,7 @@
 from moto.ec2.utils import generate_route_id
 
 from localstack.services.cloudformation.deployment_utils import generate_default_name
-from localstack.services.cloudformation.service_models import (
-    KEY_RESOURCE_STATE,
-    REF_ID_ATTRS,
-    GenericBaseModel,
-)
+from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
 
 
@@ -317,21 +313,16 @@ class EC2VPC(GenericBaseModel):
         resp = client.describe_vpcs(Filters=[{"Name": "cidr", "Values": [self.props["CidrBlock"]]}])
         return (resp["Vpcs"] or [None])[0]
 
-    @staticmethod
-    def get_deploy_templates():
+    @classmethod
+    def get_deploy_templates(cls):
         def _pre_delete(resource_id, resources, resource_type, func, stack_name):
-            res = resources[resource_id]
-            state = res[
-                KEY_RESOURCE_STATE
-            ]  # TODO: there is probably a better way to get the state here
-            physical_resource_id = res["PhysicalResourceId"] or state.get("VpcId")
-            res["PhysicalResourceId"] = physical_resource_id
-
-            if state.get("VpcId"):
+            res = cls(resources[resource_id])
+            vpc_id = res.state.get("VpcId")
+            if vpc_id:
                 ec2_client = aws_stack.connect_to_service("ec2")
                 resp = ec2_client.describe_route_tables(
                     Filters=[
-                        {"Name": "vpc-id", "Values": [state.get("VpcId")]},
+                        {"Name": "vpc-id", "Values": [vpc_id]},
                         {"Name": "association.main", "Values": ["false"]},
                     ]
                 )

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -125,6 +125,7 @@ class S3Bucket(GenericBaseModel, FakeBucket):
                 s3.delete_bucket_policy(Bucket=bucket_name)
             except Exception:
                 pass
+            s3_listener.remove_bucket_notification(resource["PhysicalResourceId"])
             # TODO: divergence from how AWS deals with bucket deletes (should throw an error)
             try:
                 delete_all_s3_objects(bucket_name)

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -785,28 +785,6 @@ def delete_resource(resource_id, resources, stack_name):
     if res_type == "AWS::S3::Bucket":
         s3_listener.remove_bucket_notification(res["PhysicalResourceId"])
 
-    if res_type == "AWS::IAM::Role":
-        role_name = res.get("PhysicalResourceId") or res.get("Properties", {}).get("RoleName")
-        try:
-            iam_client = aws_stack.connect_to_service("iam")
-            rs = iam_client.list_role_policies(RoleName=role_name)
-            for policy in rs["PolicyNames"]:
-                iam_client.delete_role_policy(RoleName=role_name, PolicyName=policy)
-
-            rs = iam_client.list_instance_profiles_for_role(RoleName=role_name)
-            for instance_profile in rs["InstanceProfiles"]:
-                ip_name = instance_profile["InstanceProfileName"]
-                iam_client.remove_role_from_instance_profile(
-                    InstanceProfileName=ip_name, RoleName=role_name
-                )
-                # iam_client.delete_instance_profile(
-                #     InstanceProfileName=ip_name
-                # )
-
-        except Exception as e:
-            if "NoSuchEntity" not in str(e):
-                raise
-
     if res_type == "AWS::EC2::VPC":
         state = res[KEY_RESOURCE_STATE]
         physical_resource_id = res["PhysicalResourceId"] or state.get("VpcId")


### PR DESCRIPTION
Moves some delete patching from the `template_deployer.py` to the respective service models.

The patches for `AWS::EC2::Subnet` and `AWS::EC2::RouteTable` were removed since they didn't seem to affect any tests and either didn't make sense in the context or should be handled differently (**if** these issues resurface)