### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1256,7 +1256,7 @@ class TestAPIGateway(unittest.TestCase):
             result = requests.get(url)
             content = json.loads(result._content)
             self.assertEqual(200, result.status_code)
-            self.assertRegexpMatches(
+            self.assertRegex(
                 content["headers"].get(HEADER_LOCALSTACK_REQUEST_URL),
                 "http://.*localhost.*/person/123",
             )

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -64,7 +64,7 @@ class TestLambdaAPI(unittest.TestCase):
         with self.app.test_request_context():
             self._create_function("myFunction")
             result = json.loads(lambda_api.get_function("myFunction").get_data())
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"],
                 aws_stack.lambda_function_arn("myFunction"),
             )
@@ -74,12 +74,12 @@ class TestLambdaAPI(unittest.TestCase):
             self._create_function("myFunctions")
             self._create_function("myFunction")
             result = json.loads(lambda_api.get_function("myFunction").get_data())
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"],
                 aws_stack.lambda_function_arn("myFunction"),
             )
             result = json.loads(lambda_api.get_function("myFunctions").get_data())
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunctions")
             )
 
@@ -90,13 +90,13 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(
                 lambda_api.get_function(aws_stack.lambda_function_arn("myFunction")).get_data()
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunction")
             )
             result = json.loads(
                 lambda_api.get_function(aws_stack.lambda_function_arn("myFunctions")).get_data()
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunctions")
             )
 
@@ -109,7 +109,7 @@ class TestLambdaAPI(unittest.TestCase):
                     f"{aws_stack.get_region()}:000000000000:function:myFunction"
                 ).get_data()
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunction")
             )
             result = json.loads(
@@ -117,7 +117,7 @@ class TestLambdaAPI(unittest.TestCase):
                     f"{aws_stack.get_region()}:000000000000:function:myFunctions"
                 ).get_data()
             )
-            self.assertEquals(
+            self.assertEqual(
                 result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunctions")
             )
 


### PR DESCRIPTION
Similar to https://github.com/localstack/localstack/pull/4213 . The aliases have been removed in Python 3.11 https://docs.python.org/3/library/unittest.html#deprecated-aliases . Regex to check the cases.

```
rg -t py 'assertEquals|assertNotEquals|assertAlmostEquals|assertNotAlmostEquals|assertRegexpMatches|assertNotRegexpMatches|assertRaisesRegexp|failUnlessEqual|failIfEqual|failUnlessAlmostEqual|failUnless|failUnlessRaises|failIf'
```
