### PR TITLE
remove fix_resource_props_for_sdk_deployment

### DIFF
--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -100,6 +100,13 @@ class LambdaFunction(GenericBaseModel):
         def get_delete_params(params, **kwargs):
             return {"FunctionName": params.get("FunctionName")}
 
+        def get_environment_params(params, **kwargs):
+            # botocore/data/lambda/2015-03-31/service-2.json:1161 (EnvironmentVariableValue)
+            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-environment.html
+            if "Environment" in params:
+                environment_variables = params["Environment"].get("Variables", {})
+                return {"Variables": {k: str(v) for k, v in environment_variables.items()}}
+
         return {
             "create": {
                 "function": "create_function",
@@ -110,7 +117,7 @@ class LambdaFunction(GenericBaseModel):
                     "Handler": "Handler",
                     "Code": get_lambda_code_param,
                     "Description": "Description",
-                    "Environment": "Environment",
+                    "Environment": get_environment_params,
                     "Timeout": "Timeout",
                     "MemorySize": "MemorySize",
                     "Layers": "Layers"

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -1,7 +1,5 @@
 import json
 
-import mypy_boto3_kms
-
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
@@ -55,7 +53,7 @@ class KMSKey(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def _create(resource_id, resources, resource_type, func, stack_name):
-            kms_client: mypy_boto3_kms.KMSClient = aws_stack.connect_to_service("kms")
+            kms_client = aws_stack.connect_to_service("kms")
             resource = cls(resources[resource_id])
             props = resource.props
             params = {}

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -1,3 +1,7 @@
+import json
+
+import mypy_boto3_kms
+
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
@@ -48,19 +52,47 @@ class KMSKey(GenericBaseModel):
             # append tags, to allow us to determine in fetch_state whether this key is already deployed
             tags.append({"Key": "localstack-key-id", "Value": short_uid()})
 
-    @staticmethod
-    def get_deploy_templates():
-        def create_params(params, **kwargs):
-            return {
-                "Policy": params.get("KeyPolicy"),
-                "Tags": [
+    @classmethod
+    def get_deploy_templates(cls):
+        def _create(resource_id, resources, resource_type, func, stack_name):
+            kms_client: mypy_boto3_kms.KMSClient = aws_stack.connect_to_service("kms")
+            resource = cls(resources[resource_id])
+            props = resource.props
+            params = {}
+            if props.get("KeyPolicy"):
+                params["Policy"] = json.dumps(props["KeyPolicy"])
+
+            if props.get("Tags"):
+                params["Tags"] = [
                     {"TagKey": tag["Key"], "TagValue": tag["Value"]}
-                    for tag in params.get("Tags", [])
-                ],
-            }
+                    for tag in props.get("Tags", [])
+                ]
+
+            if props.get("Description"):
+                params["Description"] = props["Description"]
+
+            if props.get("KeySpec"):
+                params["KeySpec"] = props["KeySpec"]
+
+            new_key = kms_client.create_key(**params)
+            key_id = new_key["KeyMetadata"]["KeyId"]
+            resource.resource_json["PhysicalResourceId"] = key_id
+
+            # key is created but some fields map to separate api calls
+            if props.get("EnableKeyRotation", False):
+                kms_client.enable_key_rotation(KeyId=key_id)
+            else:
+                kms_client.disable_key_rotation(KeyId=key_id)
+
+            if props.get("Enabled", True):
+                kms_client.enable_key(KeyId=key_id)
+            else:
+                kms_client.disable_key(KeyId=key_id)
 
         return {
-            "create": {"function": "create_key", "parameters": create_params},
+            "create": [
+                {"function": _create},
+            ],
             "delete": {
                 # TODO Key needs to be deleted in KMS backend
                 "function": "schedule_key_deletion",

--- a/tests/integration/cloudformation/test_cloudformation_kms.py
+++ b/tests/integration/cloudformation/test_cloudformation_kms.py
@@ -1,0 +1,41 @@
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+
+def test_kms_key_disabled(
+    cfn_client,
+    sqs_client,
+    kms_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+
+    template_rendered = load_template_raw("kms_key_disabled.yaml")
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["Outputs"]
+        assert len(outputs) == 1
+        key_id = outputs[0]["OutputValue"]
+        assert key_id
+        my_key = kms_client.describe_key(KeyId=key_id)
+        assert not my_key["KeyMetadata"]["Enabled"]
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/templates/kms_key_disabled.yaml
+++ b/tests/integration/templates/kms_key_disabled.yaml
@@ -1,0 +1,26 @@
+Resources:
+  TestKey4CACAF33:
+    Type: AWS::KMS::Key
+    Properties:
+      KeyPolicy:
+        Statement:
+          - Action: kms:*
+            Effect: Allow
+            Principal:
+              AWS:
+                Fn::Join:
+                  - ""
+                  - - "arn:"
+                    - Ref: AWS::Partition
+                    - ":iam::"
+                    - Ref: AWS::AccountId
+                    - :root
+            Resource: "*"
+        Version: "2012-10-17"
+      Enabled: false
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+Outputs:
+  KeyIdOutput:
+    Value:
+      Ref: TestKey4CACAF33


### PR DESCRIPTION
Removes the `fix_resource_props_for_sdk_deployment` from the template deployer and moves the code into the corresponding service models.

Also adds support for the `EnableKeyRotation` and `Enabled` Properties on `AWS::KMS::Key`.