### PR TITLE
Add support for states:::events:putEvents to publish events from StepFunction

### DIFF
--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -5,7 +5,7 @@ import re
 import time
 
 from localstack import config
-from localstack.constants import MOTO_ACCOUNT_ID, TEST_AWS_ACCOUNT_ID
+from localstack.constants import ENV_INTERNAL_TEST_RUN, MOTO_ACCOUNT_ID, TEST_AWS_ACCOUNT_ID
 from localstack.services.events.scheduler import JobScheduler
 from localstack.services.generic_proxy import ProxyListener, RegionBackend
 from localstack.utils.aws import aws_stack
@@ -21,9 +21,11 @@ from localstack.utils.tagging import TaggingService
 
 LOG = logging.getLogger(__name__)
 
-EVENTS_TMP_DIR = os.path.join(config.TMP_FOLDER, "cw_events")
-
+EVENTS_TMP_DIR = "cw_events"
 DEFAULT_EVENT_BUS_NAME = "default"
+
+# list of events used to run assertions during integration testing (not exposed to the user)
+TEST_EVENTS_CACHE = []
 
 
 class EventsBackend(RegionBackend):
@@ -48,9 +50,10 @@ def fix_date_format(response):
 
 
 def _create_and_register_temp_dir():
-    if EVENTS_TMP_DIR not in TMP_FILES:
-        mkdir(EVENTS_TMP_DIR)
-        TMP_FILES.append(EVENTS_TMP_DIR)
+    tmp_dir = _get_events_tmp_dir()
+    if tmp_dir not in TMP_FILES:
+        mkdir(tmp_dir)
+        TMP_FILES.append(tmp_dir)
 
 
 def _dump_events_to_files(events_with_added_uuid):
@@ -60,6 +63,10 @@ def _dump_events_to_files(events_with_added_uuid):
             os.path.join(EVENTS_TMP_DIR, "%s_%s" % (current_time_millis, event["uuid"])),
             json.dumps(event["event"]),
         )
+
+
+def _get_events_tmp_dir():
+    return os.path.join(config.TMP_FOLDER, EVENTS_TMP_DIR)
 
 
 def get_scheduled_rule_func(data):
@@ -146,18 +153,23 @@ class ProxyListenerEvents(ProxyListener):
         if method == "OPTIONS":
             return 200
 
-        action = headers.get("X-Amz-Target")
         if method == "POST" and path == "/":
+            action = headers.get("X-Amz-Target", "").split(".")[-1]
             parsed_data = json.loads(to_str(data))
 
-            if action == "AWSEvents.PutRule":
+            if action == "PutRule":
                 return handle_put_rule(parsed_data)
 
-            elif action == "AWSEvents.DeleteRule":
+            elif action == "DeleteRule":
                 handle_delete_rule(rule_name=parsed_data.get("Name", None))
 
-            elif action == "AWSEvents.DisableRule":
+            elif action == "DisableRule":
                 handle_disable_rule(rule_name=parsed_data.get("Name", None))
+
+            elif action == "PutEvents":
+                # keep track of events for local integration testing
+                if os.environ.get(ENV_INTERNAL_TEST_RUN):
+                    TEST_EVENTS_CACHE.extend(parsed_data.get("Entries", []))
 
         return True
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -77,12 +77,17 @@ URL_LOCALSTACK_FAT_JAR = (
 MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % INSTALL_DIR_INFRA
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
-SFN_PATCH_CLASS = (
+SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
+SFN_PATCH_CLASS2 = (
     "com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class"
 )
-SFN_PATCH_CLASS_URL = "%s/raw/master/stepfunctions-local-patch/%s" % (
+SFN_PATCH_CLASS_URL1 = "%s/raw/master/stepfunctions-local-patch/%s" % (
     ARTIFACTS_REPO,
-    SFN_PATCH_CLASS,
+    SFN_PATCH_CLASS1,
+)
+SFN_PATCH_CLASS_URL2 = "%s/raw/master/stepfunctions-local-patch/%s" % (
+    ARTIFACTS_REPO,
+    SFN_PATCH_CLASS2,
 )
 
 # kinesis-mock version
@@ -331,15 +336,19 @@ def install_stepfunctions_local():
             file.rename(Path(INSTALL_DIR_STEPFUNCTIONS) / file.name)
         rm_rf("%s/stepfunctionslocal" % INSTALL_DIR_INFRA)
     # apply patches
-    patch_class_file = os.path.join(INSTALL_DIR_STEPFUNCTIONS, SFN_PATCH_CLASS)
-    if not os.path.exists(patch_class_file):
-        download(SFN_PATCH_CLASS_URL, patch_class_file)
-        cmd = 'cd "%s"; zip %s %s' % (
-            INSTALL_DIR_STEPFUNCTIONS,
-            INSTALL_PATH_STEPFUNCTIONS_JAR,
-            SFN_PATCH_CLASS,
-        )
-        run(cmd)
+    for patch_class, patch_url in (
+        (SFN_PATCH_CLASS1, SFN_PATCH_CLASS_URL1),
+        (SFN_PATCH_CLASS2, SFN_PATCH_CLASS_URL2),
+    ):
+        patch_class_file = os.path.join(INSTALL_DIR_STEPFUNCTIONS, patch_class)
+        if not os.path.exists(patch_class_file):
+            download(patch_url, patch_class_file)
+            cmd = 'cd "%s"; zip %s %s' % (
+                INSTALL_DIR_STEPFUNCTIONS,
+                INSTALL_PATH_STEPFUNCTIONS_JAR,
+                patch_class,
+            )
+            run(cmd)
 
 
 def install_dynamodb_local():

--- a/localstack/services/stepfunctions/stepfunctions_listener.py
+++ b/localstack/services/stepfunctions/stepfunctions_listener.py
@@ -17,15 +17,15 @@ class ProxyListenerStepFunctions(ProxyListener):
     def return_response(self, method, path, data, headers, response):
         data = json.loads(to_str(data or "{}"))
         name = data.get("name") or (data.get("stateMachineArn") or "").split(":")[-1]
-        target = headers.get("X-Amz-Target")
+        target = headers.get("X-Amz-Target", "").split(".")[-1]
 
         # publish event
-        if target == "AWSStepFunctions.CreateStateMachine":
+        if target == "CreateStateMachine":
             event_publisher.fire_event(
                 event_publisher.EVENT_STEPFUNCTIONS_CREATE_SM,
                 payload={"m": event_publisher.get_hash(name)},
             )
-        elif target == "AWSStepFunctions.DeleteStateMachine":
+        elif target == "DeleteStateMachine":
             event_publisher.fire_event(
                 event_publisher.EVENT_STEPFUNCTIONS_DELETE_SM,
                 payload={"m": event_publisher.get_hash(name)},

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -39,6 +39,7 @@ def get_command(backend_port):
         "dynamodb",
         "ecs",
         "eks",
+        "events",
         "glue",
         "sagemaker",
         "sns",
@@ -49,6 +50,8 @@ def get_command(backend_port):
         flag = "--%s-endpoint" % service
         if service == "stepfunctions":
             flag = "--step-functions-endpoint"
+        elif service == "events":
+            flag = "--eventbridge-endpoint"
         elif service in ["athena", "eks"]:
             flag = "--step-functions-%s" % service
         endpoint = aws_stack.get_local_service_url(service)

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 from localstack.services.awslambda import lambda_api
+from localstack.services.events.events_listener import TEST_EVENTS_CACHE
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import clone, load_file, retry, short_uid
@@ -136,6 +137,26 @@ STATE_MACHINE_INTRINSIC_FUNCS = {
             "Resource": "__tbd__",
             "ResultSelector": {"payload.$": "$"},
             "ResultPath": "$.result_value",
+            "End": True,
+        },
+    },
+}
+STATE_MACHINE_EVENTS = {
+    "StartAt": "step1",
+    "States": {
+        "step1": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::events:putEvents",
+            "Parameters": {
+                "Entries": [
+                    {
+                        "DetailType": "TestMessage",
+                        "Source": "TestSource",
+                        "EventBusName": "__tbd__",
+                        "Detail": {"Message": "Hello from Step Functions!"},
+                    }
+                ]
+            },
             "End": True,
         },
     },
@@ -345,9 +366,7 @@ class TestStateMachine(unittest.TestCase):
             definition["States"]["state3"]["Resource"] = lambda_arn_2
         definition = json.dumps(definition)
         sm_name = "intrinsic-%s" % short_uid()
-        result = self.sfn_client.create_state_machine(
-            name=sm_name, definition=definition, roleArn=role_arn
-        )
+        self.sfn_client.create_state_machine(name=sm_name, definition=definition, roleArn=role_arn)
 
         # run state machine
         sm_arn = self.get_machine_arn(sm_name)
@@ -368,6 +387,50 @@ class TestStateMachine(unittest.TestCase):
 
         # clean up
         self.cleanup(sm_arn, state_machines_before)
+
+    def test_events_state_machine(self):
+        events = aws_stack.connect_to_service("events")
+        state_machines_before = self.sfn_client.list_state_machines()["stateMachines"]
+
+        # create event bus
+        bus_name = f"bus-{short_uid()}"
+        events.create_event_bus(Name=bus_name)
+
+        # create state machine
+        definition = clone(STATE_MACHINE_EVENTS)
+        definition["States"]["step1"]["Parameters"]["Entries"][0]["EventBusName"] = bus_name
+        definition = json.dumps(definition)
+        sm_name = "events-%s" % short_uid()
+        role_arn = aws_stack.role_arn("sfn_role")
+        self.sfn_client.create_state_machine(name=sm_name, definition=definition, roleArn=role_arn)
+
+        # run state machine
+        sm_arn = self.get_machine_arn(sm_name)
+        result = self.sfn_client.start_execution(stateMachineArn=sm_arn)
+        self.assertTrue(result.get("executionArn"))
+        events_before = len(TEST_EVENTS_CACHE)
+
+        def check_invocations():
+            # assert that the event is received
+            self.assertEqual(events_before + 1, len(TEST_EVENTS_CACHE))
+            last_event = TEST_EVENTS_CACHE[0]
+            self.assertEqual(bus_name, last_event["EventBusName"])
+            self.assertEqual("TestSource", last_event["Source"])
+            self.assertEqual("TestMessage", last_event["DetailType"])
+            self.assertEqual(
+                {"Message": "Hello from Step Functions!"}, json.loads(last_event["Detail"])
+            )
+
+        # assert that the event bus has received an event from the SM execution
+        retry(check_invocations, sleep=1, retries=10)
+
+        # clean up
+        self.cleanup(sm_arn, state_machines_before)
+        events.delete_event_bus(Name=bus_name)
+
+    # -----------------
+    # HELPER FUNCTIONS
+    # -----------------
 
     def get_machine_arn(self, sm_name):
         state_machines = self.sfn_client.list_state_machines()["stateMachines"]


### PR DESCRIPTION
Add support for `arn:aws:states:::events:putEvents` resource tyes to publish events directly from StepFunction. Goes hand in hand with a small patch here: https://github.com/localstack/localstack-artifacts/blob/005214d91fd2f1b68f49b77b383323462758a651/stepfunctions-local-patch/com/amazonaws/stepfunctions/local/runtime/Config.java#L156 (which we may be able to remove in the future).