### PR TITLE
Fixed/Improved Lambda Java runtimes tests

### DIFF
--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -46,7 +46,7 @@ from localstack.utils.common import (
 
 ARCHIVE_DIR_PREFIX = "lambda.archive."
 DEFAULT_GET_LOG_EVENTS_DELAY = 3
-LAMBDA_TIMEOUT_SEC = 8
+LAMBDA_TIMEOUT_SEC = 30
 LAMBDA_ASSETS_BUCKET_NAME = "ls-test-lambda-assets-bucket"
 MAX_LAMBDA_ARCHIVE_UPLOAD_SIZE = 50_000_000
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -1768,7 +1768,10 @@ class TestJavaRuntimes(LambdaTestBase):
     def test_java_runtime(self):
         self.assertIsNotNone(self.test_java_jar)
 
-        result = self.lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA, Payload=b"{}")
+        result = self.lambda_client.invoke(
+            FunctionName=TEST_LAMBDA_NAME_JAVA,
+            Payload=b'{"echo":"echo"}',
+        )
         result_data = result["Payload"].read()
 
         self.assertEqual(200, result["StatusCode"])
@@ -1851,7 +1854,12 @@ class TestJavaRuntimes(LambdaTestBase):
         self.assertEqual(202, result["StatusCode"])
 
     def test_kinesis_invocation(self):
-        payload = b'{"Records": [{"kinesis": {"data": "dGVzdA==", "partitionKey": "partition"}}]}'
+        payload = (
+            b'{"Records": [{'
+            b'"kinesis": {"data": "dGVzdA==", "partitionKey": "partition"},'
+            b'"eventID": "shardId-000000000001:12345678901234567890123456789012345678901234567890",'
+            b'"eventSourceARN": "arn:aws:kinesis:us-east-1:123456789012:stream/test"}]}'
+        )
         result = self.lambda_client.invoke(
             FunctionName=TEST_LAMBDA_NAME_JAVA_KINESIS, Payload=payload
         )
@@ -1861,10 +1869,16 @@ class TestJavaRuntimes(LambdaTestBase):
         self.assertEqual('"test "', to_str(result_data).strip())
 
     def test_kinesis_event(self):
+        payload = (
+            b'{"Records": [{'
+            b'"kinesis": {"data": "dGVzdA==", "partitionKey": "partition"},'
+            b'"eventID": "shardId-000000000001:12345678901234567890123456789012345678901234567890",'
+            b'"eventSourceARN": "arn:aws:kinesis:us-east-1:123456789012:stream/test"}]}'
+        )
         result = self.lambda_client.invoke(
             FunctionName=TEST_LAMBDA_NAME_JAVA,
             InvocationType="Event",
-            Payload=b'{"Records": [{"Kinesis": {"Data": "data", "PartitionKey": "partition"}}]}',
+            Payload=payload,
         )
         result_data = result["Payload"].read()
 
@@ -1872,7 +1886,10 @@ class TestJavaRuntimes(LambdaTestBase):
         self.assertEqual("", to_str(result_data).strip())
 
     def test_stream_handler(self):
-        result = self.lambda_client.invoke(FunctionName=TEST_LAMBDA_NAME_JAVA_STREAM, Payload=b"{}")
+        result = self.lambda_client.invoke(
+            FunctionName=TEST_LAMBDA_NAME_JAVA_STREAM,
+            Payload=b'{"echo":"echo"}',
+        )
         result_data = result["Payload"].read()
 
         self.assertEqual(200, result["StatusCode"])


### PR DESCRIPTION
Edit by @whummer : summary of this PR, for the record:

> updates Lambda Java runtimes tests to pass even with Thundra Java agent
> -  got rid of empty payloads as Thundra marks them as warmup requests by default
> -  added some of the missing properties into Kinesis event
> -  increased Lambda timeout because 8 seconds may not be enough for some of the tests with Java runtime when Thundra enabled