### PR TITLE
Fix statement handling for AWS::Events::EventBusPolicy

### DIFF
--- a/tests/integration/templates/eventbridge_policy_statement.yaml
+++ b/tests/integration/templates/eventbridge_policy_statement.yaml
@@ -1,0 +1,15 @@
+Resources:
+  LsEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+      Name: {{ event_bus_name }}
+  LsEventPolicy:
+    Type: AWS::Events::EventBusPolicy
+    Properties:
+      StatementId: {{ statement_id }}
+      Statement:
+        Effect: "Allow"
+        Principal: "*"
+        Action: "events:PutEvents"
+        Resource: !GetAtt LsEventBus.Arn
+      EventBusName: !Ref LsEventBus


### PR DESCRIPTION
When creating an event bus policy one can either specify a Policy Statement as Json or directly via Action,Resource,etc. fields. The statement handling here was broken because it didn't produce a valid policy statement format as expected by AWS.

Example of a valid resource policy for eventbridge:

```
{
  "Version": "2012-10-17",
  "Statement": [{
    "Sid": "statement-04b33061",
    "Effect": "Allow",
    "Principal": "*",
    "Action": "events:PutEvents",
    "Resource": "arn:aws:events:eu-central-1:000000000000:event-bus/event-bus-d20476ea"
  }]
}
```