### PR TITLE
fix state checking for active service provider

### DIFF
--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -431,8 +431,10 @@ def do_start_infra(asynchronous, apis, is_in_docker):
         """
         Preload services if EAGER_SERVICE_LOADING is true.
         """
+        # TODO: lazy loading should become the default beginning 0.13.0
         if not config.EAGER_SERVICE_LOADING:
-            # TODO: lazy loading should become the default beginning 0.13.0
+            # listing the available service plugins will cause resolution of the entry points
+            SERVICE_PLUGINS.list_available()
             return
 
         apis = list()
@@ -448,7 +450,8 @@ def do_start_infra(asynchronous, apis, is_in_docker):
         if persistence.is_persistence_enabled():
             if not config.is_env_true(constants.ENV_PRO_ACTIVATED):
                 LOG.warning(
-                    "Persistence mechanism for community services (based on API calls record&replay) will be deprecated in 0.13.0"
+                    "Persistence mechanism for community services (based on API calls record&replay) will be "
+                    "deprecated in 0.13.0 "
                 )
 
             persistence.restore_persisted_data(apis)


### PR DESCRIPTION
previously, the error shown in the localstack service health check was not specific to a provider. meaning that if an entrypoint of a service provider failed to load, the service would show an error, even though that provider was not configured. this lead to services that have a pro provider always show an "error" state when lazy-initializing.

this PR makes that check explicit for the configured service provider.