### PR TITLE
support ranges of host ports to be mapped to a container port

### DIFF
--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -24,7 +24,7 @@ from localstack.utils.common import (
     save_file,
     short_uid,
 )
-from localstack.utils.docker_utils import PortMappings
+from localstack.utils.common import is_empty_dir, mkdir, new_tmp_dir, rm_rf, save_file
 from localstack.utils.testutil import create_zip_file
 
 
@@ -391,56 +391,6 @@ class TestCommon(unittest.TestCase):
         assert {} == common.get_proxies()
         config.OUTBOUND_HTTP_PROXY = old_http_proxy
         config.OUTBOUND_HTTPS_PROXY = old_https_proxy
-
-
-class TestCommandLine(unittest.TestCase):
-    def test_extract_port_flags(self):
-        port_mappings = PortMappings()
-        flags = extract_port_flags("foo -p 1234:1234 bar", port_mappings=port_mappings)
-        self.assertEqual("foo  bar", flags)
-        mapping_str = port_mappings.to_str()
-        self.assertEqual("-p 1234:1234", mapping_str)
-
-        port_mappings = PortMappings()
-        flags = extract_port_flags(
-            "foo -p 1234:1234 bar -p 80-90:81-91 baz", port_mappings=port_mappings
-        )
-        self.assertEqual("foo  bar  baz", flags)
-        mapping_str = port_mappings.to_str()
-        self.assertIn("-p 1234:1234", mapping_str)
-        self.assertIn("-p 80-90:81-91", mapping_str)
-
-    def test_overlapping_port_ranges(self):
-        port_mappings = PortMappings()
-        port_mappings.add(4590)
-        port_mappings.add(4591)
-        port_mappings.add(4593)
-        port_mappings.add(4592)
-        port_mappings.add(4593)
-        result = port_mappings.to_str()
-        # assert that ranges are non-overlapping, i.e., no duplicate ports
-        self.assertEqual("-p 4590-4592:4590-4592 -p 4593:4593", result)
-
-    def test_port_ranges_with_bind_host(self):
-        port_mappings = PortMappings(bind_host="0.0.0.0")
-        port_mappings.add(5000)
-        port_mappings.add(5001)
-        port_mappings.add(5003)
-        result = port_mappings.to_str()
-        self.assertEqual("-p 0.0.0.0:5000-5001:5000-5001 -p 0.0.0.0:5003:5003", result)
-
-    def test_port_ranges_with_bind_host_to_dict(self):
-        port_mappings = PortMappings(bind_host="0.0.0.0")
-        port_mappings.add(5000, 6000)
-        port_mappings.add(5001, 7000)
-        port_mappings.add(5003, 8000)
-        result = port_mappings.to_dict()
-        expected_result = {
-            "6000/tcp": ("0.0.0.0", 5000),
-            "7000/tcp": ("0.0.0.0", 5001),
-            "8000/tcp": ("0.0.0.0", 5003),
-        }
-        self.assertEqual(expected_result, result)
 
 
 class TestCommonFileOperations:

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -14,7 +14,6 @@ import yaml
 
 from localstack import config
 from localstack.utils import common
-from localstack.utils.bootstrap import extract_port_flags
 from localstack.utils.common import (
     is_empty_dir,
     load_file,
@@ -24,7 +23,6 @@ from localstack.utils.common import (
     save_file,
     short_uid,
 )
-from localstack.utils.common import is_empty_dir, mkdir, new_tmp_dir, rm_rf, save_file
 from localstack.utils.testutil import create_zip_file
 
 

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -113,7 +113,7 @@ def list_in(a, b):
     )
 
 
-class TestCommandLine(unittest.TestCase):
+class TestPortMappings(unittest.TestCase):
     def test_extract_port_flags(self):
         port_mappings = PortMappings()
         flags = extract_port_flags("foo -p 1234:1234 bar", port_mappings=port_mappings)
@@ -167,10 +167,26 @@ class TestCommandLine(unittest.TestCase):
         }
         self.assertEqual(expected_result, result)
 
-    def test_adjacent_multi_to_one_mappings(self):
+    def test_many_to_one_adjacent_to_uniform(self):
         port_mappings = PortMappings()
+        port_mappings.add(5002)
         port_mappings.add(5003)
         port_mappings.add([5004, 5006], 5004)
-        expected_result = {"5003/tcp": 5003, "5004/tcp": [5004, 5005, 5006]}
+        expected_result = {
+            "5002/tcp": 5002,
+            "5003/tcp": 5003,
+            "5004/tcp": [5004, 5005, 5006],
+        }
+        result = port_mappings.to_dict()
+        self.assertEqual(expected_result, result)
+
+    def test_adjacent_port_to_many_to_one(self):
+        port_mappings = PortMappings()
+        port_mappings.add([7000, 7002], 7000)
+        port_mappings.add(6999)
+        expected_result = {
+            "6999/tcp": 6999,
+            "7000/tcp": [7000, 7001, 7002],
+        }
         result = port_mappings.to_dict()
         self.assertEqual(expected_result, result)

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -107,6 +107,12 @@ def test_argument_parsing():
     assert network == "mynet123"
 
 
+def list_in(a, b):
+    return len(a) <= len(b) and any(
+        map(lambda x: b[x : x + len(a)] == a, range(len(b) - len(a) + 1))
+    )
+
+
 class TestCommandLine(unittest.TestCase):
     def test_extract_port_flags(self):
         port_mappings = PortMappings()
@@ -161,8 +167,10 @@ class TestCommandLine(unittest.TestCase):
         }
         self.assertEqual(expected_result, result)
 
-
-def list_in(a, b):
-    return len(a) <= len(b) and any(
-        map(lambda x: b[x : x + len(a)] == a, range(len(b) - len(a) + 1))
-    )
+    def test_adjacent_multi_to_one_mappings(self):
+        port_mappings = PortMappings()
+        port_mappings.add(5003)
+        port_mappings.add([5004, 5006], 5004)
+        expected_result = {"5003/tcp": 5003, "5004/tcp": [5004, 5005, 5006]}
+        result = port_mappings.to_dict()
+        self.assertEqual(expected_result, result)

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from localstack import config
+from localstack.utils.bootstrap import extract_port_flags
 from localstack.utils.docker_utils import CmdDockerClient, DockerContainerStatus, PortMappings, Util
 
 LOG = logging.getLogger(__name__)
@@ -54,17 +55,16 @@ class TestDockerClient(unittest.TestCase):
 def test_argument_parsing():
     test_port_string = "-p 80:8080/udp"
     test_port_string_with_host = "-p 127.0.0.1:6000:7000/tcp"
+    test_port_string_many_to_one = "-p 9230-9231:9230"
     test_env_string = "-e TEST_ENV_VAR=test_string=123"
     test_mount_string = "-v /var/test:/opt/test"
-    argument_string = (
-        f"{test_port_string} {test_env_string} {test_mount_string} {test_port_string_with_host}"
-    )
+    argument_string = f"{test_port_string} {test_env_string} {test_mount_string} {test_port_string_with_host} {test_port_string_many_to_one}"
     env_vars = {}
     ports = PortMappings()
     mounts = []
     Util.parse_additional_flags(argument_string, env_vars, ports, mounts)
     assert env_vars == {"TEST_ENV_VAR": "test_string=123"}
-    assert ports.to_str() == "-p 80:8080/udp -p 6000:7000"
+    assert ports.to_str() == "-p 80:8080/udp -p 6000:7000 -p 9230-9231:9230"
     assert mounts == [("/var/test", "/opt/test")]
     argument_string = (
         "--add-host host.docker.internal:host-gateway --add-host arbitrary.host:127.0.0.1"
@@ -105,6 +105,61 @@ def test_argument_parsing():
     argument_string = r'-v "/tmp/test.jar:/tmp/foo bar/test.jar" --network mynet123'
     _, _, _, _, network = Util.parse_additional_flags(argument_string)
     assert network == "mynet123"
+
+
+class TestCommandLine(unittest.TestCase):
+    def test_extract_port_flags(self):
+        port_mappings = PortMappings()
+        flags = extract_port_flags("foo -p 1234:1234 bar", port_mappings=port_mappings)
+        self.assertEqual("foo  bar", flags)
+        mapping_str = port_mappings.to_str()
+        self.assertEqual("-p 1234:1234", mapping_str)
+
+        port_mappings = PortMappings()
+        flags = extract_port_flags(
+            "foo -p 1234:1234 bar -p 80-90:81-91 baz", port_mappings=port_mappings
+        )
+        self.assertEqual("foo  bar  baz", flags)
+        mapping_str = port_mappings.to_str()
+        self.assertIn("-p 1234:1234", mapping_str)
+        self.assertIn("-p 80-90:81-91", mapping_str)
+
+    def test_overlapping_port_ranges(self):
+        port_mappings = PortMappings()
+        port_mappings.add(4590)
+        port_mappings.add(4591)
+        port_mappings.add(4593)
+        port_mappings.add(4592)
+        port_mappings.add(4593)
+        result = port_mappings.to_str()
+        # assert that ranges are non-overlapping, i.e., no duplicate ports
+        self.assertEqual("-p 4590-4592:4590-4592 -p 4593:4593", result)
+
+    def test_port_ranges_with_bind_host(self):
+        port_mappings = PortMappings(bind_host="0.0.0.0")
+        port_mappings.add(5000)
+        port_mappings.add(5001)
+        port_mappings.add(5003)
+        port_mappings.add([5004, 5006], 9000)
+        result = port_mappings.to_str()
+        self.assertEqual(
+            "-p 0.0.0.0:5000-5001:5000-5001 -p 0.0.0.0:5003:5003 -p 0.0.0.0:5004-5006:9000", result
+        )
+
+    def test_port_ranges_with_bind_host_to_dict(self):
+        port_mappings = PortMappings(bind_host="0.0.0.0")
+        port_mappings.add(5000, 6000)
+        port_mappings.add(5001, 7000)
+        port_mappings.add(5003, 8000)
+        port_mappings.add([5004, 5006], 9000)
+        result = port_mappings.to_dict()
+        expected_result = {
+            "6000/tcp": ("0.0.0.0", 5000),
+            "7000/tcp": ("0.0.0.0", 5001),
+            "8000/tcp": ("0.0.0.0", 5003),
+            "9000/tcp": ("0.0.0.0", [5004, 5005, 5006]),
+        }
+        self.assertEqual(expected_result, result)
 
 
 def list_in(a, b):


### PR DESCRIPTION
this PR fixes a bug that causes starting localstack to fail to startup when specifying a port mapping from a range of host ports to a single container port EG `-p 9230-9231:9230`.  This turns out to be essential for being able to debug simultaneous nodejs lambda containers.  I am hoping to share the nodejs integration of localstack as described [here](https://github.com/localstack/localstack/issues/4443) but i discovered it was broken when trying to run on the newest version.

Specifying a host port range did work in version (0.12.16) but fails with the newest version of localstack.  To reproduce this you can pass a port range such as the example above into the `LAMBDA_DOCKER_FLAGS` variable of a localstack dockerfile.  

I have unit tested this (small) change but I was not able to build the docker image and confirm that the fix works because it looks like I encounter 4 failing integration tests when i try to build the docker container (before any of my changes are applied). I am happy to try to get this cleaned up and pushed through but will need guidance on how to build the container.

example error:
```
"errorMessage": "invalid literal for int() with base 10: '9230-9231'",
       "errorType": "ValueError",
       "stackTrace": Array [
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_api.py\", line 811, in run_lambda
         lock_discriminator=lock_discriminator,
",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 429, in execute
         return do_execute()
     ",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 419, in do_execute
         return _run(func_arn=func_arn)
     ",
         "  File \"/opt/code/localstack/localstack/utils/cloudwatch/cloudwatch_util.py\", line 157, in wrapped
         raise e
     ",
         "  File \"/opt/code/localstack/localstack/utils/cloudwatch/cloudwatch_util.py\", line 153, in wrapped
         result = func(*args, **kwargs)
     ",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 406, in _run
         raise e
     ",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 402, in _run
         result = self._execute(lambda_function, inv_context)
     ",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 710, in _execute
         result = self.run_lambda_executor(lambda_function=lambda_function, inv_context=inv_context)
     ",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 599, in run_lambda_executor
         stdin=event_stdin_bytes,
     ",
         "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 1119, in execute_in_container
         stdin=stdin,
     ",
         "  File \"/opt/code/localstack/localstack/utils/docker_utils.py\", line 1412, in run_container
         workdir=workdir,
     ",
         "  File \"/opt/code/localstack/localstack/utils/docker_utils.py\", line 1325, in create_container
         additional_flags, env_vars, ports, mount_volumes, network
     ",
         "  File \"/opt/code/localstack/localstack/utils/docker_utils.py\", line 953, in parse_additional_flags
         ports.add(int(host_port), int(container_port), protocol)
     ",
       ],
```