### PR TITLE
fix health endpoint to support feature states

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -56,6 +56,7 @@ function run_startup_scripts {
     sleep 7
   done
 
+  curl -XPUT -s -d '{"features:initScripts":"initializing"}' "http://localhost:$EDGE_PORT/health" > /dev/null
   for f in $INIT_SCRIPTS_PATH/*; do
     case "$f" in
       *.sh)     echo "$0: running $f"; . "$f" ;;
@@ -63,6 +64,7 @@ function run_startup_scripts {
     esac
     echo
   done
+  curl -XPUT -s -d '{"features:initScripts":"initialized"}' "http://localhost:$EDGE_PORT/health" > /dev/null
 }
 
 run_startup_scripts &

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -565,23 +565,6 @@ class ServicePluginManager(ServiceManager):
 SERVICE_PLUGINS: ServicePluginManager = ServicePluginManager()
 
 
-# -------------------------
-# HEALTH CHECK API METHODS
-# -------------------------
-
-
-def get_services_health(reload=False):
-    if reload:
-        SERVICE_PLUGINS.check_all()
-
-    result = {
-        "services": {
-            service: state.value for service, state in SERVICE_PLUGINS.get_states().items()
-        }
-    }
-    return result
-
-
 # -----------------------------
 # INFRASTRUCTURE HEALTH CHECKS
 # -----------------------------


### PR DESCRIPTION
We removed the ability to put arbitrary state into the health resource, which broke user code. This PR re-introduces this functionality in an encapsulation called `HealthResource` which is served via the edge proxy.

* Fixes #4769