### PR TITLE
refactor elasticsearch cluster to use serving.Server

### DIFF
--- a/localstack/services/es/cluster.py
+++ b/localstack/services/es/cluster.py
@@ -28,9 +28,8 @@ Here's how you can use it:
         print('ok, bye')
 """
 import logging
-import multiprocessing
 import os
-import time
+import threading
 from typing import Dict, List, NamedTuple, Optional
 
 import requests
@@ -38,15 +37,8 @@ import requests
 from localstack import config, constants
 from localstack.services import install
 from localstack.services.infra import DEFAULT_BACKEND_HOST, do_run, start_proxy_for_service
-from localstack.utils.common import (
-    chmod_r,
-    get_free_tcp_port,
-    get_service_protocol,
-    is_root,
-    mkdir,
-    rm_rf,
-    start_thread,
-)
+from localstack.utils.common import chmod_r, get_free_tcp_port, is_root, mkdir, rm_rf
+from localstack.utils.serving import Server
 
 LOG = logging.getLogger(__name__)
 
@@ -62,117 +54,41 @@ def _build_elasticsearch_run_command(es_bin: str, settings: CommandSettings) -> 
     return [es_bin] + cmd_settings
 
 
-class ElasticsearchCluster:
-    # TODO: inherit from localstack.utils.serving.Server
-
+class ElasticsearchCluster(Server):
     def __init__(self, port=9200, host="localhost", version=None) -> None:
-        super().__init__()
-        self._port = port
-        self._host = host
+        super().__init__(port, host)
         self._version = version or constants.ELASTICSEARCH_DEFAULT_VERSION
 
         self.command_settings = {}
-
         self.directories = self._resolve_directories()
-
-        self._elasticsearch_thread = None
-
-        self._lifecycle_lock = multiprocessing.RLock()
-        self._started = False
-        self._stopped = multiprocessing.Event()
-        self._starting = multiprocessing.Event()
-
-    @property
-    def host(self):
-        return self._host
-
-    @property
-    def port(self):
-        return self._port
 
     @property
     def version(self):
         return self._version
 
-    @property
-    def url(self):
-        return "%s://%s:%s" % (get_service_protocol(), self.host, self.port)
-
-    def is_up(self):
-        if not self._started:
-            return False
-        if not self._starting.is_set():
-            return False
-
-        try:
-            return self.health() is not None
-        except Exception:
-            return False
-
     def health(self):
         return get_elasticsearch_health_status(self.url)
 
-    def shutdown(self):
-        with self._lifecycle_lock:
-            if not self._started:
-                return
+    def do_run(self):
+        # FIXME: if this fails the cluster could be left in a wonky state
+        # FIXME: this is not a good place to run install, and it only works because we're
+        #  assuming that there will only ever be one running Elasticsearch cluster
+        install.install_elasticsearch(self.version)
+        self._init_directories()
 
-            if not self._elasticsearch_thread:
-                return
+        cmd = self._create_run_command(additional_settings=self.command_settings)
+        cmd = " ".join(cmd)
 
-            self._elasticsearch_thread.stop()
+        user = constants.OS_USER_ELASTICSEARCH
+        if is_root() and user:
+            # run the elasticsearch process as a non-root user (when running in docker)
+            cmd = f"su {user} -c '{cmd}'"
 
-    def start(self):
-        with self._lifecycle_lock:
-            if self._started:
-                return
-            self._started = True
+        env_vars = self._create_env_vars()
 
-        start_thread(self._run_elasticsearch)
-
-    def join(self, timeout=None):
-        with self._lifecycle_lock:
-            if not self._started:
-                return
-
-        if not self._elasticsearch_thread:
-            self._starting.wait()
-
-        return self._elasticsearch_thread.join(timeout=timeout)
-
-    def _run_elasticsearch(self, *args):
-        # *args is necessary for start_thread to work
-        with self._lifecycle_lock:
-            if self._elasticsearch_thread:
-                return
-
-            # FIXME: if this fails the cluster could be left in a wonky state
-            # FIXME: this is not a good place to run install, and it only works because we're
-            #  assuming that there will only ever be one running Elasticsearch cluster
-            install.install_elasticsearch(self.version)
-            self._init_directories()
-
-            cmd = self._create_run_command(additional_settings=self.command_settings)
-            cmd = " ".join(cmd)
-
-            user = constants.OS_USER_ELASTICSEARCH
-            if is_root() and user:
-                # run the elasticsearch process as a non-root user (when running in docker)
-                cmd = f"su {user} -c '{cmd}'"
-
-            env_vars = self._create_env_vars()
-
-            LOG.info("starting elasticsearch: %s with env %s", cmd, env_vars)
-            # use asynchronous=True to get a ShellCommandThread
-            self._elasticsearch_thread = do_run(cmd, asynchronous=True, env_vars=env_vars)
-            self._starting.set()
-
-        # block until the thread running the command is done
-        try:
-            self._elasticsearch_thread.join()
-        finally:
-            LOG.info("elasticsearch process ended")
-            self._stopped.set()
+        LOG.info("starting elasticsearch: %s with env %s", cmd, env_vars)
+        # use asynchronous=True to get a ShellCommandThread
+        return do_run(cmd, asynchronous=False, env_vars=env_vars)
 
     def _create_run_command(
         self, additional_settings: Optional[CommandSettings] = None
@@ -240,68 +156,34 @@ class ElasticsearchCluster:
         chmod_r(dirs.tmp, 0o777)
 
 
-class ProxiedElasticsearchCluster:
+class ProxiedElasticsearchCluster(Server):
     """
     Starts an ElasticsearchCluster behind a localstack service proxy. The ElasticsearchCluster
     backend will be assigned a random port.
-
-    TODO: inherit from localstack.utils.serving.Server
     """
 
     def __init__(self, port=9200, host="localhost", version=None) -> None:
-        super().__init__()
-        self._port = port
-        self._host = host
+        super().__init__(port, host)
         self._version = version or constants.ELASTICSEARCH_DEFAULT_VERSION
 
         self._cluster = None
-        self._backend_port = None
+        self._cluster_port = None
         self._proxy_thread = None
-
-        self._lifecycle_lock = multiprocessing.RLock()
-        self._started = False
-        self._stopped = multiprocessing.Event()
-        self._starting = multiprocessing.Event()
-
-    @property
-    def host(self):
-        return self._host
-
-    @property
-    def port(self):
-        return self._port
+        self._running = threading.Event()
 
     @property
     def version(self):
         return self._version
 
-    @property
-    def url(self):
-        return "%s://%s:%s" % (get_service_protocol(), self.host, self.port)
-
     def is_up(self):
         # check service lifecycle
-        if not self._started:
-            return False
-        if not self._starting.is_set():
-            return False
         if not self._cluster or not self._proxy_thread:
-            return False
-
-        # check that proxy is running
-        if not self._proxy_thread.running:
             return False
 
         if not self._cluster.is_up():
             return False
 
-        try:
-            # calls health through the proxy to elasticsearch, making sure implicitly that both are
-            # running
-            LOG.info("calling health endpoint %s", self.url)
-            return self.health() is not None
-        except Exception:
-            return False
+        return super().is_up()
 
     def health(self):
         """
@@ -310,56 +192,35 @@ class ProxiedElasticsearchCluster:
         """
         return get_elasticsearch_health_status(self.url)
 
-    def shutdown(self):
-        with self._lifecycle_lock:
-            if not self._started:
-                return
-
-            if self._proxy_thread:
-                self._proxy_thread.stop()
-            if self._cluster:
-                self._cluster.shutdown()
-
-    def start(self):
-        with self._lifecycle_lock:
-            if self._started:
-                return
-            self._started = True
-
+    def do_run(self):
         # start elasticsearch backend
-        self._backend_port = get_free_tcp_port()
-        self._cluster = ElasticsearchCluster(port=self._backend_port, host=DEFAULT_BACKEND_HOST)
+        self._cluster_port = get_free_tcp_port()
+        self._cluster = ElasticsearchCluster(port=self._cluster_port, host=DEFAULT_BACKEND_HOST)
         self._cluster.start()
+
+        self._cluster.wait_is_up()
+        LOG.info("elasticsearch cluster on %s is ready", self._cluster.url)
 
         # start front-facing proxy
         self._proxy_thread = start_proxy_for_service(
             "elasticsearch",
             self.port,
-            self._backend_port,
+            self._cluster_port,
             update_listener=None,
             quiet=True,
             params={"protocol_version": "HTTP/1.0"},
         )
 
-        self._starting.set()
+        self._running.set()
 
-    def join(self, timeout=None):
-        with self._lifecycle_lock:
-            if not self._started:
-                return
+        return self._proxy_thread.join()
 
+    def do_shutdown(self):
         if not self._proxy_thread:
-            self._starting.wait()
+            self._running.wait()
 
-        then = time.time()
-
-        if self._proxy_thread:
-            self._proxy_thread.join(timeout=timeout)
-
-        # subtract time already spent waiting, but wait at least another 100 ms
-        timeout = max(0.1, (timeout - (time.time() - then)))
-
-        self._cluster.join(timeout=timeout)
+        self._cluster.shutdown()
+        self._proxy_thread.stop()
 
 
 def get_elasticsearch_health_status(url: str) -> Optional[str]:


### PR DESCRIPTION
`serving.Server` was inspired by the `ElasticsearchCluster` implementation, and pulled up as part of #4793. this PR uses the new abstract for the `ElasticsearchCluster` implementation.