### PR TITLE
fix overwrite behavior for PUT requests to the health endpoint

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -457,7 +457,7 @@ class HealthResource:
                 d = state[p]
             d[path[-1]] = v
 
-        self.state = merge_recursive(state, self.state)
+        self.state = merge_recursive(state, self.state, overwrite=True)
         return {"status": "OK"}
 
 

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -113,8 +113,32 @@ class TestHealthResource:
         resource = HealthResource(service_manager)
 
         resource.put(
-            "/", b'{"features:initScripts": "initialized","features:persistence": "disabled"}'
+            "/", b'{"features:initScripts": "initializing","features:persistence": "disabled"}'
         )
+
+        state = resource.get("/", None)
+
+        assert state == {
+            "features": {
+                "initScripts": "initializing",
+                "persistence": "disabled",
+            },
+            "services": {
+                "foo": "available",
+            },
+        }
+
+    def test_put_overwrite_and_get(self):
+        service_manager = ServiceManager()
+        service_manager.get_states = mock.MagicMock(return_value={"foo": ServiceState.AVAILABLE})
+
+        resource = HealthResource(service_manager)
+
+        resource.put(
+            "/", b'{"features:initScripts": "initializing","features:persistence": "disabled"}'
+        )
+
+        resource.put("/", b'{"features:initScripts": "initialized"}')
 
         state = resource.get("/", None)
 


### PR DESCRIPTION
The health endpoint PUT didn't overwrite the state dict correctly, which was blocking #4769
