### PR TITLE
Region for s3 notifications 

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1921,6 +1921,11 @@ def is_none_or_empty(obj: Union[Optional[str], Optional[list]]) -> bool:
     )
 
 
+def region_from_arn(arn_string):
+    result = re.search(r"arn:aws:\w+:([\w-]+):\d+", arn_string)
+    return result.groups(0)[0] if result else ""
+
+
 def canonicalize_bool_to_str(val: bool) -> str:
     return "true" if str(val).lower() == "true" else "false"
 


### PR DESCRIPTION
This PR addresses issue localstack/localstack#4763.

The changes are the next:
  1. Now the s3 notifications reach resources in different regions using the ARN
  2. Correction of the Event generated when a file is uploaded through a pre-signed post form.
