### PR TITLE
Add default for Name in AWS::SSM::Parameter

### DIFF
--- a/localstack/services/cloudformation/models/ssm.py
+++ b/localstack/services/cloudformation/models/ssm.py
@@ -5,6 +5,7 @@ from localstack.services.cloudformation.deployment_utils import (
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
+from localstack.utils.common import short_uid
 
 
 class SSMParameter(GenericBaseModel):
@@ -19,6 +20,12 @@ class SSMParameter(GenericBaseModel):
         param_name = self.props.get("Name") or self.resource_id
         param_name = self.resolve_refs_recursively(stack_name, param_name, resources)
         return aws_stack.connect_to_service("ssm").get_parameter(Name=param_name)["Parameter"]
+
+    @staticmethod
+    def add_defaults(resource, stack_name: str):
+        name = resource.get("Properties", {}).get("Name")
+        if not name:
+            resource["Properties"]["Name"] = f"CFN-{resource['LogicalResourceId']}-{short_uid()}"
 
     @staticmethod
     def get_deploy_templates():

--- a/tests/integration/cloudformation/test_cloudformation_ssm.py
+++ b/tests/integration/cloudformation/test_cloudformation_ssm.py
@@ -1,0 +1,46 @@
+import jinja2
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+
+def test_parameter_defaults(
+    cfn_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+    ssm_client,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    ssm_parameter_value = f"custom-{short_uid()}"
+    template_rendered = jinja2.Template(load_template_raw("ssm_parameter_defaultname.yaml")).render(
+        ssm_parameter_value=ssm_parameter_value
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+
+        stack = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+        parameter_name = stack["Outputs"][0]["OutputValue"]
+
+        assert "CustomParameter" in parameter_name
+        param = ssm_client.get_parameter(Name=parameter_name)
+        assert param["Parameter"]["Value"] == ssm_parameter_value
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/templates/ssm_parameter_defaultname.yaml
+++ b/tests/integration/templates/ssm_parameter_defaultname.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  CustomParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: {{ ssm_parameter_value }}
+
+Outputs:
+  CustomParameterOutput:
+    Value: !Ref CustomParameter


### PR DESCRIPTION
Minor fix for the AWS::SSM::Parameter cloudformation resource. Assigns a default name for parameters. Interestingly this generated name is a bit different from the usual AWS scheme of stack-logicalid-random in this case.