### PR TITLE
Fix scaffolding for remaining AWS services

### DIFF
--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 from localstack.aws.scaffold import generate
 
 
-@pytest.mark.parametrize("service", ["apigateway", "cloudformation", "sqs"])
+@pytest.mark.parametrize("service", ["apigateway", "autoscaling", "cloudformation", "sqs"])
 def test_generated_code_compiles(service):
     runner = CliRunner()
     result = runner.invoke(generate, [service, "--no-doc", "--print"])

--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -4,7 +4,9 @@ from click.testing import CliRunner
 from localstack.aws.scaffold import generate
 
 
-@pytest.mark.parametrize("service", ["apigateway", "autoscaling", "cloudformation", "sqs"])
+@pytest.mark.parametrize(
+    "service", ["apigateway", "autoscaling", "cloudformation", "dynamodb", "sqs"]
+)
 def test_generated_code_compiles(service):
     runner = CliRunner()
     result = runner.invoke(generate, [service, "--no-doc", "--print"])

--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 from localstack.aws.scaffold import generate
 
 
-@pytest.mark.parametrize("service", ["cloudformation", "sqs"])
+@pytest.mark.parametrize("service", ["apigateway", "cloudformation", "sqs"])
 def test_generated_code_compiles(service):
     runner = CliRunner()
     result = runner.invoke(generate, [service, "--no-doc", "--print"])


### PR DESCRIPTION
There were a few corner cases in APIs that caused the scaffold script to generate invalid code for several services. This PR fixes those remaining issues, specifically surrounding:

* Illegal names (e.g., keywords, containing illegal characters, or starting with numeric characters)
* Circular type references

I added representative services to the `test_generated_code_compiles` as parameters instead of keep the list of all AWS services (which takes about 3 minutes to test through). For reference, this test will try to generate and compile all AWS services:

```python
import pytest
from click.testing import CliRunner

from localstack.aws.scaffold import generate
from localstack.aws.spec import list_services


@pytest.mark.parametrize("service", [service.service_name for service in list_services()])
def test_generated_code_compiles(service):
    runner = CliRunner()
    result = runner.invoke(generate, [service, "--no-doc", "--print"])
    assert result.exit_code == 0

    code = result.output
    compile(code, '<string>', 'exec')
```