### PR TITLE
Support version qualifiers for managing Lambda policy statements

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -73,8 +73,8 @@ from localstack.utils.run import FuncThread
 # logger
 LOG = logging.getLogger(__name__)
 
-# name pattern of IAM policies associated with Lambda functions
-LAMBDA_POLICY_NAME_PATTERN = "lambda_policy_%s"
+# name pattern of IAM policies associated with Lambda functions (name/qualifier)
+LAMBDA_POLICY_NAME_PATTERN = "lambda_policy_{name}_{qualifier}"
 # constants
 APP_NAME = "lambda_api"
 ARCHIVE_FILE_PATTERN = "%s/lambda.handler.*.jar" % config.TMP_FOLDER
@@ -1272,11 +1272,24 @@ def get_lambda_policy(function, qualifier=None):
         for stmt in doc["Statement"]:
             stmt["Principal"] = stmt.get("Principal") or {"AWS": TEST_AWS_ACCOUNT_ID}
         doc["PolicyArn"] = p["Arn"]
+        doc["PolicyName"] = p["PolicyName"]
         doc["Id"] = "default"
         docs.append(doc)
+
+    # find policy by name
+    policy_name = _get_lambda_policy_name(aws_stack.lambda_function_name(function), qualifier=qualifier)
+    policy = [d for d in docs if d["PolicyName"] == policy_name]
+    if policy:
+        return policy[0]
+    # find policy by target Resource in statement (TODO: check if this heuristic holds in the general case)
     res_qualifier = func_qualifier(function, qualifier)
     policy = [d for d in docs if d["Statement"][0]["Resource"] == res_qualifier]
     return (policy or [None])[0]
+
+
+def _get_lambda_policy_name(resource_name: str, qualifier: str = None) -> str:
+    qualifier = qualifier or "latest"
+    return LAMBDA_POLICY_NAME_PATTERN.format(name=resource_name, qualifier=qualifier)
 
 
 def lookup_function(function, region, request_url):
@@ -1584,6 +1597,7 @@ def update_function_configuration(function):
 
 
 def generate_policy_statement(sid, action, arn, sourcearn, principal):
+
     statement = {
         "Sid": sid,
         "Effect": "Allow",
@@ -1620,11 +1634,13 @@ def add_permission(function):
     arn = func_arn(function)
     qualifier = request.args.get("Qualifier")
     q_arn = func_qualifier(function, qualifier)
-    result = add_permission_policy_statement(function, arn, q_arn)
+    result = add_permission_policy_statement(function, arn, q_arn, qualifier=qualifier)
     return result
 
 
-def add_permission_policy_statement(resource_name, resource_arn, resource_arn_qualified):
+def add_permission_policy_statement(
+    resource_name, resource_arn, resource_arn_qualified, qualifier=None
+):
     region = LambdaRegion.get()
     data = json.loads(to_str(request.data))
     iam_client = aws_stack.connect_to_service("iam")
@@ -1632,46 +1648,51 @@ def add_permission_policy_statement(resource_name, resource_arn, resource_arn_qu
     action = data.get("Action")
     principal = data.get("Principal")
     sourcearn = data.get("SourceArn")
-    previous_policy = get_lambda_policy(resource_name)
+    previous_policy = get_lambda_policy(resource_name, qualifier)
 
     if resource_arn not in region.lambdas:
         return not_found_error(resource_arn)
 
     if not re.match(r"lambda:[*]|lambda:[a-zA-Z]+|[*]", action):
-        return error_response(
-            '1 validation error detected: Value "%s" at "action" failed to satisfy '
+        msg = (
+            f'1 validation error detected: Value "{action}" at "action" failed to satisfy '
             "constraint: Member must satisfy regular expression pattern: "
-            "(lambda:[*]|lambda:[a-zA-Z]+|[*])" % action,
-            400,
-            error_type="ValidationException",
+            "(lambda:[*]|lambda:[a-zA-Z]+|[*])"
         )
+        return error_response(msg, 400, error_type="ValidationException")
 
     new_policy = generate_policy(sid, action, resource_arn_qualified, sourcearn, principal)
+    new_statement = new_policy["Statement"][0]
+    result = {"Statement": json.dumps(new_statement)}
 
     if previous_policy:
         statment_with_sid = next(
             (statement for statement in previous_policy["Statement"] if statement["Sid"] == sid),
             None,
         )
+        if statment_with_sid and statment_with_sid == new_statement:
+            LOG.debug(
+                f"Policy Statement SID '{sid}' for Lambda '{resource_arn_qualified}' already exists"
+            )
+            return result
         if statment_with_sid:
             msg = (
-                "The statement id (%s) provided already exists. Please provide a new statement id, "
-                "or remove the existing statement."
-            ) % sid
+                f"The statement id {sid} provided already exists. Please provide a new "
+                "statement id, or remove the existing statement."
+            )
             return error_response(msg, 400, error_type="ResourceConflictException")
 
         new_policy["Statement"].extend(previous_policy["Statement"])
         iam_client.delete_policy(PolicyArn=previous_policy["PolicyArn"])
 
-    policy_name = LAMBDA_POLICY_NAME_PATTERN % resource_name
-    LOG.debug('Creating IAM policy "%s" for Lambda resource %s' % (policy_name, resource_arn))
+    policy_name = _get_lambda_policy_name(resource_name, qualifier=qualifier)
+    LOG.debug('Creating IAM policy "%s" for Lambda resource %s', policy_name, resource_arn)
     iam_client.create_policy(
         PolicyName=policy_name,
         PolicyDocument=json.dumps(new_policy),
         Description='Policy for Lambda function "%s"' % resource_name,
     )
 
-    result = {"Statement": json.dumps(new_policy["Statement"][0])}
     return jsonify(result)
 
 
@@ -1679,7 +1700,7 @@ def add_permission_policy_statement(resource_name, resource_arn, resource_arn_qu
 def remove_permission(function, statement):
     qualifier = request.args.get("Qualifier")
     iam_client = aws_stack.connect_to_service("iam")
-    policy = get_lambda_policy(function)
+    policy = get_lambda_policy(function, qualifier=qualifier)
     if not policy:
         return not_found_error('Unable to find policy for Lambda function "%s"' % function)
     iam_client.delete_policy(PolicyArn=policy["PolicyArn"])

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1277,7 +1277,7 @@ def get_lambda_policy(function, qualifier=None):
         docs.append(doc)
 
     # find policy by name
-    policy_name = _get_lambda_policy_name(
+    policy_name = get_lambda_policy_name(
         aws_stack.lambda_function_name(function), qualifier=qualifier
     )
     policy = [d for d in docs if d["PolicyName"] == policy_name]
@@ -1289,7 +1289,7 @@ def get_lambda_policy(function, qualifier=None):
     return (policy or [None])[0]
 
 
-def _get_lambda_policy_name(resource_name: str, qualifier: str = None) -> str:
+def get_lambda_policy_name(resource_name: str, qualifier: str = None) -> str:
     qualifier = qualifier or "latest"
     return LAMBDA_POLICY_NAME_PATTERN.format(name=resource_name, qualifier=qualifier)
 
@@ -1687,7 +1687,7 @@ def add_permission_policy_statement(
         new_policy["Statement"].extend(previous_policy["Statement"])
         iam_client.delete_policy(PolicyArn=previous_policy["PolicyArn"])
 
-    policy_name = _get_lambda_policy_name(resource_name, qualifier=qualifier)
+    policy_name = get_lambda_policy_name(resource_name, qualifier=qualifier)
     LOG.debug('Creating IAM policy "%s" for Lambda resource %s', policy_name, resource_arn)
     iam_client.create_policy(
         PolicyName=policy_name,

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1277,7 +1277,9 @@ def get_lambda_policy(function, qualifier=None):
         docs.append(doc)
 
     # find policy by name
-    policy_name = _get_lambda_policy_name(aws_stack.lambda_function_name(function), qualifier=qualifier)
+    policy_name = _get_lambda_policy_name(
+        aws_stack.lambda_function_name(function), qualifier=qualifier
+    )
     policy = [d for d in docs if d["PolicyName"] == policy_name]
     if policy:
         return policy[0]

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -1,6 +1,6 @@
 import os
 
-from localstack.services.awslambda.lambda_api import LAMBDA_POLICY_NAME_PATTERN
+from localstack.services.awslambda.lambda_api import get_lambda_policy_name
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
@@ -222,7 +222,7 @@ class LambdaPermission(GenericBaseModel):
     def do_fetch_state(self, resource_name, resource_arn):
         iam = aws_stack.connect_to_service("iam")
         props = self.props
-        policy_name = LAMBDA_POLICY_NAME_PATTERN % resource_name
+        policy_name = get_lambda_policy_name(resource_name)
         policy_arn = aws_stack.policy_arn(policy_name)
         policy = iam.get_policy(PolicyArn=policy_arn)["Policy"]
         version = policy.get("DefaultVersionId")

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -25,6 +25,7 @@ from localstack.services.awslambda.lambda_api import (
     BATCH_SIZE_RANGES,
     INVALID_PARAMETER_VALUE_EXCEPTION,
     LAMBDA_DEFAULT_HANDLER,
+    _get_lambda_policy_name,
     use_docker,
 )
 from localstack.services.awslambda.lambda_utils import (
@@ -477,6 +478,7 @@ class TestLambdaBaseFeatures(unittest.TestCase):
             SourceArn=aws_stack.s3_bucket_arn("test-bucket"),
         )
         self.assertIn("Statement", resp)
+
         # fetch lambda policy
         policy = lambda_client.get_policy(FunctionName=function_name)["Policy"]
         self.assertIsInstance(policy, str)
@@ -489,9 +491,11 @@ class TestLambdaBaseFeatures(unittest.TestCase):
             aws_stack.s3_bucket_arn("test-bucket"),
             policy["Statement"][0]["Condition"]["ArnLike"]["AWS:SourceArn"],
         )
+
         # fetch IAM policy
         policies = iam_client.list_policies(Scope="Local", MaxItems=500)["Policies"]
-        matching = [p for p in policies if p["PolicyName"] == "lambda_policy_%s" % function_name]
+        policy_name = _get_lambda_policy_name(function_name)
+        matching = [p for p in policies if p["PolicyName"] == policy_name]
         self.assertEqual(len(matching), 1)
         self.assertIn(":policy/", matching[0]["Arn"])
 
@@ -577,7 +581,8 @@ class TestLambdaBaseFeatures(unittest.TestCase):
 
         # fetch IAM policy
         policies = iam_client.list_policies(Scope="Local", MaxItems=500)["Policies"]
-        matching = [p for p in policies if p["PolicyName"] == "lambda_policy_%s" % function_name]
+        policy_name = _get_lambda_policy_name(function_name)
+        matching = [p for p in policies if p["PolicyName"] == policy_name]
         self.assertEqual(1, len(matching))
         self.assertIn(":policy/", matching[0]["Arn"])
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -494,7 +494,7 @@ class TestLambdaBaseFeatures(unittest.TestCase):
 
         # fetch IAM policy
         policies = iam_client.list_policies(Scope="Local", MaxItems=500)["Policies"]
-        policy_name = _get_lambda_policy_name(function_name)
+        policy_name = get_lambda_policy_name(function_name)
         matching = [p for p in policies if p["PolicyName"] == policy_name]
         self.assertEqual(len(matching), 1)
         self.assertIn(":policy/", matching[0]["Arn"])

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -25,7 +25,7 @@ from localstack.services.awslambda.lambda_api import (
     BATCH_SIZE_RANGES,
     INVALID_PARAMETER_VALUE_EXCEPTION,
     LAMBDA_DEFAULT_HANDLER,
-    _get_lambda_policy_name,
+    get_lambda_policy_name,
     use_docker,
 )
 from localstack.services.awslambda.lambda_utils import (
@@ -581,7 +581,7 @@ class TestLambdaBaseFeatures(unittest.TestCase):
 
         # fetch IAM policy
         policies = iam_client.list_policies(Scope="Local", MaxItems=500)["Policies"]
-        policy_name = _get_lambda_policy_name(function_name)
+        policy_name = get_lambda_policy_name(function_name)
         matching = [p for p in policies if p["PolicyName"] == policy_name]
         self.assertEqual(1, len(matching))
         self.assertIn(":policy/", matching[0]["Arn"])


### PR DESCRIPTION
Support version qualifiers for managing Lambda policy statements.

This issue surfaced when replicating this Terraform user scenario which involves Lambda functions with multiple versions/qualifiers: https://github.com/lefnire/gnothi/tree/terraform/terraform