### PR TITLE
refactor dynamodb to use serving.Server and additional parameters

### DIFF
--- a/localstack/services/dynamodb/dynamodb_starter.py
+++ b/localstack/services/dynamodb/dynamodb_starter.py
@@ -1,81 +1,56 @@
 import logging
-import os
+from typing import Optional
 
-from localstack import config
-from localstack.constants import MODULE_MAIN_PATH
-from localstack.services import install
 from localstack.services.dynamodb import dynamodb_listener
-from localstack.services.infra import do_run, log_startup_message, start_proxy_for_service
+from localstack.services.dynamodb.server import DynamodbServer, create_dynamodb_server
+from localstack.services.infra import log_startup_message, start_proxy_for_service
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import (
-    get_free_tcp_port,
-    mkdir,
-    wait_for_port_closed,
-    wait_for_port_open,
-)
 
-LOGGER = logging.getLogger(__name__)
+LOG = logging.getLogger(__name__)
 
-# backend service port (updated on startup)
-PORT_DYNAMODB_BACKEND = None
-
-# todo: will be replaced with plugin mechanism
-PROCESS_THREAD = None
+# server singleton
+_server: Optional[DynamodbServer] = None
 
 
 def check_dynamodb(expect_shutdown=False, print_error=False):
     out = None
+
+    if not expect_shutdown:
+        assert _server
+
     try:
-        # wait for backend port to be opened
-        wait_for_port_open(PORT_DYNAMODB_BACKEND, http_path="/", expect_success=False, sleep_time=1)
-        # check DynamoDB
-        endpoint_url = f"http://127.0.0.1:{PORT_DYNAMODB_BACKEND}"
-        out = aws_stack.connect_to_service("dynamodb", endpoint_url=endpoint_url).list_tables()
+        _server.wait_is_up()
+        out = aws_stack.connect_to_service("dynamodb", endpoint_url=_server.url).list_tables()
     except Exception:
         if print_error:
-            LOGGER.exception("DynamoDB health check failed")
+            LOG.exception("DynamoDB health check failed")
     if expect_shutdown:
         assert out is None
     else:
         assert isinstance(out["TableNames"], list)
 
 
-def start_dynamodb(port=None, asynchronous=False, update_listener=None):
-    global PROCESS_THREAD, PORT_DYNAMODB_BACKEND
-    PORT_DYNAMODB_BACKEND = get_free_tcp_port()
-    port = port or config.PORT_DYNAMODB
-    install.install_dynamodb_local()
-    ddb_data_dir_param = "-inMemory"
-    if config.DATA_DIR:
-        ddb_data_dir = "%s/dynamodb" % config.DATA_DIR
-        mkdir(ddb_data_dir)
-        # as the service command cds into a different directory, the absolute
-        # path of the DATA_DIR is needed as the -dbPath
-        absolute_path = os.path.abspath(ddb_data_dir)
-        ddb_data_dir_param = "-dbPath %s" % absolute_path
-    cmd = (
-        "cd %s/infra/dynamodb/; java -Djava.library.path=./DynamoDBLocal_lib "
-        + "-Xmx%s -jar DynamoDBLocal.jar -port %s %s"
-    ) % (
-        MODULE_MAIN_PATH,
-        config.DYNAMODB_HEAP_SIZE,
-        PORT_DYNAMODB_BACKEND,
-        ddb_data_dir_param,
-    )
+def start_dynamodb(port=None, asynchronous=True, update_listener=None):
+    global _server
+    if not _server:
+        _server = create_dynamodb_server()
+
+    _server.start()
+
     log_startup_message("DynamoDB")
     start_proxy_for_service(
         "dynamodb",
         port,
-        backend_port=PORT_DYNAMODB_BACKEND,
+        backend_port=_server.port,
         update_listener=update_listener,
     )
-    # todo: extract reference from do_run (should return pid)
-    PROCESS_THREAD = do_run(cmd, asynchronous, auto_restart=True)
-    return PROCESS_THREAD
+    return _server
 
 
 def restart_dynamodb():
-    LOGGER.debug("Restarting DynamoDB process ...")
-    PROCESS_THREAD.stop()
-    wait_for_port_closed(PORT_DYNAMODB_BACKEND)
+    if _server:
+        _server.shutdown()
+        _server.join(timeout=10)
+
+    LOG.debug("Restarting DynamoDB process ...")
     start_dynamodb(asynchronous=True, update_listener=dynamodb_listener.UPDATE_DYNAMODB)

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -1,0 +1,111 @@
+import logging
+import os
+from typing import List, Optional
+
+from localstack import config
+from localstack.config import is_env_true
+from localstack.constants import MODULE_MAIN_PATH
+from localstack.services import install
+from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
+from localstack.utils.run import FuncThread
+from localstack.utils.serving import Server
+
+LOG = logging.getLogger(__name__)
+
+
+class DynamodbServer(Server):
+    db_path: Optional[str]
+    heap_size: str
+
+    delay_transient_statuses: bool
+    optimize_db_before_startup: bool
+    share_db: bool
+    cors: Optional[str]
+
+    def __init__(self, port: int, host: str = "localhost") -> None:
+        super().__init__(port, host)
+
+        # set defaults
+        self.heap_size = config.DYNAMODB_HEAP_SIZE
+        self.delay_transient_statuses = False
+        self.optimize_db_before_startup = False
+        self.share_db = False
+        self.cors = None
+        self.db_path = None
+
+    @property
+    def in_memory(self):
+        return self.db_path is None
+
+    @property
+    def jar_path(self) -> str:
+        return f"{MODULE_MAIN_PATH}/infra/dynamodb/DynamoDBLocal.jar"
+
+    @property
+    def library_path(self) -> str:
+        return f"{MODULE_MAIN_PATH}/infra/dynamodb/DynamoDBLocal_lib"
+
+    def _create_shell_command(self) -> List[str]:
+        cmd = [
+            "java",
+            "-Xmx%s" % self.heap_size,
+            "-Djava.library.path=%s" % self.library_path,
+            "-jar",
+            self.jar_path,
+        ]
+        parameters = list()
+
+        parameters.extend(["-port", str(self.port)])
+        if self.in_memory:
+            parameters.append("-inMemory")
+        if self.db_path:
+            parameters.extend(["-dbPath", self.db_path])
+        if self.delay_transient_statuses:
+            parameters.extend(["-delayTransientStatuses"])
+        if self.optimize_db_before_startup:
+            parameters.extend(["-optimizeDbBeforeStartup"])
+        if self.share_db:
+            parameters.extend(["-sharedDb"])
+
+        return cmd + parameters
+
+    def do_start_thread(self) -> FuncThread:
+        install.install_dynamodb_local()
+
+        cmd = self._create_shell_command()
+        LOG.debug("starting dynamodb process %s", cmd)
+        t = ShellCommandThread(
+            cmd,
+            strip_color=True,
+            log_listener=self._log_listener,
+            auto_restart=True,
+        )
+        TMP_THREADS.append(t)
+        t.start()
+        return t
+
+    def _log_listener(self, line, **_kwargs):
+        LOG.info(line.rstrip())
+
+
+def create_dynamodb_server(port=None) -> DynamodbServer:
+    """
+    Creates a dynamodb server from the LocalStack configuration.
+    """
+    port = port or get_free_tcp_port()
+
+    server = DynamodbServer(port)
+
+    if config.DATA_DIR:
+        ddb_data_dir = "%s/dynamodb" % config.DATA_DIR
+        mkdir(ddb_data_dir)
+        absolute_path = os.path.abspath(ddb_data_dir)
+        server.db_path = absolute_path
+
+    server.heap_size = config.DYNAMODB_HEAP_SIZE
+    server.share_db = is_env_true("DYNAMODB_SHARE_DB")
+    server.optimize_db_before_startup = is_env_true("DYNAMODB_OPTIMIZE_DB_BEFORE_STARTUP")
+    server.delay_transient_statuses = is_env_true("DYNAMODB_DELAY_TRANSIENT_STATUSES")
+    server.cors = os.getenv("DYNAMODB_CORS", None)
+
+    return server

--- a/localstack/utils/serving.py
+++ b/localstack/utils/serving.py
@@ -178,7 +178,7 @@ class Server(abc.ABC):
 
         :raises StopServer: can be raised by the subclass to indicate the server should be stopped.
         """
-        raise NotImplementedError
+        pass
 
     def do_shutdown(self):
         """


### PR DESCRIPTION
This PR adds encapsulation for the dynamodb process into a `serving.Server` subclass, and adds a factory using environment variables to enable #4836
