### PR TITLE
RequestId attribute added to request_context

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -57,7 +57,7 @@ from localstack.utils.aws.aws_responses import (
     requests_response,
 )
 from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, THREAD_LOCAL
-from localstack.utils.common import camel_to_snake_case, json_safe, to_bytes, to_str
+from localstack.utils.common import camel_to_snake_case, json_safe, long_uid, to_bytes, to_str
 
 # set up logger
 LOG = logging.getLogger(__name__)
@@ -768,6 +768,7 @@ def get_lambda_event_request_context(
         "accountId": account_id,
         "resourceId": resource_id,
         "stage": stage,
+        "requestId": long_uid(),
         "identity": {
             "accountId": account_id,
             "sourceIp": source_ip,

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -431,6 +431,7 @@ class TestAPIGateway(unittest.TestCase):
         self.assertEqual("HTTP/1.1", request_context["protocol"])
         self.assertIn("requestTimeEpoch", request_context)
         self.assertIn("requestTime", request_context)
+        self.assertIn("requestId", request_context)
 
         # assert that header keys are lowercase (as in AWS)
         headers = parsed_body.get("headers") or {}


### PR DESCRIPTION
According to #4818, the object `request_context` inside the event parameter sent to a lambda triggered by a HTTP event should have a `requestId` attribute. 

Changes:
 - Add the requestId parameter to the object sent.
 - Add the assertion of the parameter in the corresponding test.
