### PR TITLE
fix issues in aws service framework dispatching

### DIFF
--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -1,6 +1,6 @@
 import functools
 import sys
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, NamedTuple, Optional, Type
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -59,12 +59,31 @@ class HttpResponse(TypedDict):
     status_code: int
 
 
+class ServiceOperation(NamedTuple):
+    service: str
+    operation: str
+
+
 class RequestContext:
     service: ServiceModel
     operation: OperationModel
     region: str
     account_id: str
     request: HttpRequest
+    service_request: ServiceRequest
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.service = None
+        self.operation = None
+        self.region = None
+        self.account_id = None
+        self.request = None
+        self.service_request = None
+
+    @property
+    def service_operation(self) -> ServiceOperation:
+        return ServiceOperation(self.service.service_name, self.operation.name)
 
 
 ServiceRequestHandler = Callable[[RequestContext, ServiceRequest], Optional[ServiceResponse]]

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Callable, Dict, NamedTuple, Optional, Union
 
 from botocore import xform_name
-from botocore.model import ListShape, MapShape, ServiceModel, StructureShape
+from botocore.model import ServiceModel
 
 from localstack.aws.api import (
     CommonServiceException,
@@ -103,9 +103,6 @@ class ServiceRequestDispatcher:
         args = []
         kwargs = {}
 
-        if context.operation:
-            self._init_required_members(context.operation, request)
-
         if not self.expand_parameters:
             if self.pass_context:
                 args.append(context)
@@ -118,25 +115,6 @@ class ServiceRequestDispatcher:
             kwargs["context"] = context
 
         return self.fn(*args, **kwargs)
-
-    def _init_required_members(self, operation, request):
-        """
-        Sets required members of the request to empty structures if they are not already in the request.
-        """
-        input_shape = operation.input_shape
-
-        if not input_shape:
-            return
-        if not isinstance(input_shape, StructureShape):
-            return
-
-        for required_member in input_shape.required_members:
-            if required_member not in request:
-                shape = input_shape.members[required_member]
-                if isinstance(shape, ListShape):
-                    request[required_member] = []
-                elif isinstance(shape, (StructureShape, MapShape)):
-                    request[required_member] = {}
 
 
 class Skeleton:

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -197,6 +197,7 @@ def _botocore_parser_integration_test(
     method: str = None,
     request_uri: str = None,
     headers: dict = None,
+    expected: dict = None,
     **kwargs
 ):
     # Load the appropriate service
@@ -216,8 +217,8 @@ def _botocore_parser_integration_test(
     parser = create_parser(service)
     operation_model, parsed_request = parser.parse(serialized_request)
 
-    # Check if the result is equal to the initial params
-    assert parsed_request == kwargs
+    # Check if the result is equal to the given "expected" dict or the kwargs (if "expected" has not been set)
+    assert parsed_request == (expected or kwargs)
 
 
 def test_query_parser_sqs_with_botocore():
@@ -255,6 +256,16 @@ def test_query_parser_sqs_with_botocore():
         },
         MessageDeduplicationId="string",
         MessageGroupId="string",
+    )
+
+
+def test_query_parser_empty_required_members_sqs_with_botocore():
+    _botocore_parser_integration_test(
+        service="sqs",
+        action="SendMessageBatch",
+        QueueUrl="string",
+        Entries=[],
+        expected={"QueueUrl": "string", "Entries": None},
     )
 
 


### PR DESCRIPTION
This PR fixes a few issues blocking the pilot SQS implementation that are mostly related to dispatching requests.

* sets the attributes of `RequestContext` to None (to avoid attribute errors at runtime)
* skeleton re-uses the parsed operation/request from the RequestContext if it exists (in preparation for new handler framework)
* adds a `ServiceOperation` that encapsulates the unique identifier of an operation `service_name, operation_name` (in preparation for service request routing)
* `ServiceRequestDispatcher` initializes the required default values (boto clients may remove empty lists or dict from the request entirely, but the APIs expect a value)