### PR TITLE
Fix AWS::SecretsManager::Secret ARN/Physical ID handling and tests

### DIFF
--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -15,7 +15,7 @@ from localstack import config
 from localstack.services.cloudformation import service_models
 from localstack.utils.aws import aws_stack
 
-from .models import elasticsearch, events, kinesisfirehose, logs, secretsmanager
+from .models import elasticsearch, events, kinesisfirehose, logs
 
 LOG = logging.getLogger(__name__)
 
@@ -76,19 +76,11 @@ def update_physical_resource_id(resource):
     elif isinstance(resource, kinesisfirehose.FirehoseDeliveryStream):
         resource.physical_resource_id = resource.params.get("DeliveryStreamName")
 
-    elif isinstance(resource, secretsmanager.SecretsManagerSecret):
-        resource.physical_resource_id = resource.params.get("Name")
-
     elif isinstance(resource, events.EventsRule):
         resource.physical_resource_id = resource.params.get("Name")
 
     elif isinstance(resource, elasticsearch.ElasticsearchDomain):
         resource.physical_resource_id = resource.params.get("DomainName")
-
-    elif isinstance(resource, secretsmanager.SecretsManagerSecret):
-        secret = secretsmanager.SecretsManagerSecret.fetch_details(resource.props["Name"])
-        if secret:
-            resource.props["ARN"] = resource.physical_resource_id = secret["ARN"]
 
     elif isinstance(resource, dynamodb_models.Table):
         resource.physical_resource_id = resource.name

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -21,9 +21,7 @@ class SecretsManagerSecret(GenericBaseModel):
         return "AWS::SecretsManager::Secret"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        props = self.props
-        result = props.get("ARN") or aws_stack.secretsmanager_secret_arn(props["Name"])
-        return result
+        return self.props.get("ARN")
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name in (REF_ARN_ATTRS + REF_ID_ATTRS):
@@ -77,8 +75,8 @@ class SecretsManagerSecret(GenericBaseModel):
 
     @staticmethod
     def add_defaults(resource, stack_name: str):
-        role_name = resource.get("Properties", {}).get("Name")
-        if not role_name:
+        name = resource.get("Properties", {}).get("Name")
+        if not name:
             resource["Properties"]["Name"] = generate_default_name(
                 stack_name, resource["LogicalResourceId"]
             )

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -535,6 +535,7 @@ def get_iam_role(resource, env=None):
     return "role-%s" % resource
 
 
+# TODO: remove this (can't statically define secret ARN because it includes a random suffix)
 def secretsmanager_secret_arn(secret_id, account_id=None, region_name=None):
     if ":" in (secret_id or ""):
         return secret_id

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -84,15 +84,6 @@ RESOURCE_TO_FUNCTION = {}
 # ----------------
 
 
-def get_secret_arn(secret_name, account_id=None):
-    # TODO: create logic to create static without lookup table!
-    from localstack.services.secretsmanager import secretsmanager_starter
-
-    storage = secretsmanager_starter.SECRET_ARN_STORAGE
-    key = "%s_%s" % (aws_stack.get_region(), secret_name)
-    return storage.get(key) or storage.get(secret_name)
-
-
 def find_stack(stack_name):
     from localstack.services.cloudformation.cloudformation_api import find_stack as api_find_stack
 
@@ -1024,11 +1015,6 @@ def determine_resource_physical_id(
         if attribute == "Arn":
             return aws_stack.role_arn(resource_props.get("RoleName"))
         return resource_props.get("RoleName")
-    elif resource_type == "SecretsManager::Secret":
-        arn = get_secret_arn(resource_props.get("Name")) or ""
-        if attribute == "Arn":
-            return arn
-        return arn.split(":")[-1]
     elif resource_type == "IAM::Policy":
         if attribute == "Arn":
             return aws_stack.policy_arn(resource_props.get("PolicyName"))


### PR DESCRIPTION
There were some issues with the AWS::SecretsManager::Secret  and the related cloudformation test. 

Removes the Username reference from the test template since this isn't actually defined and correctly fails when trying to deploy on AWS. The test now works both against AWS and LocalStack.

Also removes some presumably legacy code and unnecessary physical-id-generating fallbacks that led to some issues/race conditions when deploying the secret where the output resolved to the wrong ARN in up to 50% of test runs.