### PR TITLE
Remove moto's CDATA wrapper from sqs message attr StringValue

### DIFF
--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -112,7 +112,7 @@ def patch_moto():
 
     # escape message responses to allow for special characters like "<"
     sqs_responses.RECEIVE_MESSAGE_RESPONSE = sqs_responses.RECEIVE_MESSAGE_RESPONSE.replace(
-        "<StringValue>{{ value.string_value }}</StringValue>",
+        "<StringValue><![CDATA[{{ value.string_value }}]]></StringValue>",
         "<StringValue>{{ _escape(value.string_value) }}</StringValue>",
     )
 


### PR DESCRIPTION
As indicated by the latest comment in #2626 message attribute bodies are now wrapped inside a CDATA tag (as of moto/moto#4337). This does not match the behaviour of AWS which uses html encoding. This behaviour is handled fine by some XML parsers (such as the one used by boto - hence the passing tests) but it causes issues for some SDKs, the .Net one in particular.

This PR removes the CDATA wrapper and relies on the existing escaping call to handle special characters (essentially reverting localstack behaviour back to before the moto change). 
I have not added any tests as I wasn't sure if they were possible when using the boto library, it only exposes the decoded attribute values.