### PR TITLE
add support for more elasticsearch versions

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -91,14 +91,7 @@ LOG_LEVELS = ("trace-internal", "trace", "debug", "info", "warn", "error", "warn
 # Lambda defaults
 LAMBDA_TEST_ROLE = "arn:aws:iam::%s:role/lambda-test-role" % TEST_AWS_ACCOUNT_ID
 
-# installation constants
-ELASTICSEARCH_URLS = {
-    "7.10.0": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.10.0-linux-x86_64.tar.gz",
-    "7.7.0": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.7.0-linux-x86_64.tar.gz",
-    "7.4.0": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.4.0-linux-x86_64.tar.gz",
-    "7.1.0": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.1.0-linux-x86_64.tar.gz",
-    "6.7.0": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.0.zip",
-}
+# the version of elasticsearch that is pre-seeded into the base image (sync with Dockerfile.base)
 ELASTICSEARCH_DEFAULT_VERSION = "7.10.0"
 # See https://docs.aws.amazon.com/ja_jp/elasticsearch-service/latest/developerguide/aes-supported-plugins.html
 ELASTICSEARCH_PLUGIN_LIST = [

--- a/localstack/services/es/versions.py
+++ b/localstack/services/es/versions.py
@@ -1,0 +1,128 @@
+"""
+Functions for querying elasticsearch versions and getting download URLs. This script is also runnable to generate
+the latest install_versions from the github repository tags. Run::
+
+    python -m localstack.services.es.versions
+
+"""
+from typing import Dict
+
+import semver
+
+install_versions = {
+    "7.15": "7.15.1",
+    "7.14": "7.14.2",
+    "7.13": "7.13.4",
+    "7.12": "7.12.1",
+    "7.11": "7.11.2",
+    "7.10": "7.10.0",
+    "7.9": "7.9.3",
+    "7.8": "7.8.1",
+    "7.7": "7.7.1",
+    "7.6": "7.6.2",
+    "7.5": "7.5.2",
+    "7.4": "7.4.2",
+    "7.3": "7.3.2",
+    "7.2": "7.2.1",
+    "7.1": "7.1.1",
+    "7.0": "7.0.1",
+    "6.8": "6.8.20",
+    "6.7": "6.7.2",
+    "6.6": "6.6.2",
+    "6.5": "6.5.4",
+    "6.4": "6.4.3",
+    "6.3": "6.3.2",
+    "6.2": "6.2.4",
+    "6.1": "6.1.4",
+    "6.0": "6.0.1",
+    "5.6": "5.6.16",
+    "5.5": "5.5.3",
+    "5.4": "5.4.3",
+    "5.3": "5.3.3",
+    "5.2": "5.2.2",
+    "5.1": "5.1.2",
+    "5.0": "5.0.2",
+}
+
+
+def get_install_version(version: str) -> str:
+    try:
+        ver = semver.VersionInfo.parse(version)
+        k = f"{ver.major}.{ver.minor}"
+    except ValueError:
+        ver = version.split(".")
+        k = f"{ver[0]}.{ver[1]}"
+
+    if k not in install_versions:
+        raise ValueError("unknown version %s" % version)
+
+    return install_versions[k]
+
+
+def get_download_url(version: str) -> str:
+    ver = semver.VersionInfo.parse(get_install_version(version))
+    ver_str = str(ver)
+
+    repo = "https://artifacts.elastic.co/downloads/elasticsearch"
+
+    if ver.major <= 6:
+        return f"{repo}/elasticsearch-{ver_str}.tar.gz"
+
+    return f"{repo}/elasticsearch-{ver_str}-linux-x86_64.tar.gz"
+
+
+def fetch_latest_versions() -> Dict[str, str]:
+    """
+    Fetches from the elasticsearch git repository tags the latest patch versions for a minor version and returns a
+    dictionary where the key corresponds to the minor version, and the value to the patch version. Run this once in a
+    while and update the ``install_versions`` constant in this file. Make sure that the DEFAULT_ES_VERSION constants
+    however corresponds to the one pre-seeded in the Dockerfile.base.
+
+    Example::
+
+        {
+            # ... older version
+            '7.7': '7.7.1',
+            '7.8': '7.8.1',
+            '7.9': '7.9.3',
+            '8.0': '8.0.0-alpha2'
+        }
+
+    :returns: a version dictionary
+    """
+    from collections import defaultdict
+
+    import requests
+
+    versions = []
+
+    i = 0
+    while True:
+        tags = requests.get(
+            f"https://api.github.com/repos/elastic/elasticsearch/tags?per_page=100&page={i}"
+        ).json()
+        i += 1
+        if not tags:
+            break
+        versions.extend([tag["name"].lstrip("v") for tag in tags])
+
+    sem_version = []
+
+    for v in versions:
+        try:
+            sem_version.append(semver.VersionInfo.parse(v))
+        except ValueError:
+            pass
+
+    minor = defaultdict(list)
+
+    for ver in sem_version:
+        minor[f"{ver.major}.{ver.minor}"].append(ver)
+
+    return {k: str(max(versions)) for k, versions in minor.items()}
+
+
+if __name__ == "__main__":
+    from pprint import pprint
+
+    pprint(fetch_latest_versions())

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ localstack-plugin-loader>=0.1.0
 pyyaml>=5.1
 rich>=10.7.0
 requests>=2.20.0,<2.26
+semver>=2.10
 # TODO: "six" dependency still needed?
 six>=1.12.0
 stevedore>=3.4.0


### PR DESCRIPTION
This PR adds support for older (and generally more) elasticsearch versions. I've refactored a bit of the version and URL fetching logic to make it less static (removed the `ELASTICSEARCH_URL` constants and replaced it with a function).

I've tested the creation of a cluster with ES 5.5 locally, and at least starting/stopping and the health endpoints work. The default version is still respected (set to 7.10.0)
