### PR TITLE
Add option to add permissions for file

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -608,6 +608,13 @@ def load_config_file(config_file=None):
     return configs
 
 
+def save_config_file(config, config_file=None):
+    from localstack.utils.common import save_file
+
+    config_file = config_file or CONFIG_FILE_PATH
+    save_file(config_file, json.dumps(config), permissions=0o600)
+
+
 class ServiceProviderConfig(Mapping[str, str]):
     _provider_config: Dict[str, str]
     default_value: str

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -599,7 +599,7 @@ def load_config_file(config_file=None):
     from localstack.utils.common import get_or_create_file, to_str
 
     config_file = config_file or CONFIG_FILE_PATH
-    content = get_or_create_file(config_file)
+    content = get_or_create_file(config_file, permissions=0o600)
     try:
         configs = json.loads(to_str(content) or "{}")
     except Exception as e:

--- a/localstack/utils/analytics/event_publisher.py
+++ b/localstack/utils/analytics/event_publisher.py
@@ -84,7 +84,7 @@ def read_api_key_safe():
 
 
 def _get_config_file(path):
-    get_or_create_file(path)
+    get_or_create_file(path, permissions=0o600)
     return path
 
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1322,14 +1322,18 @@ def extract_from_jsonpointer_path(target, path: str, delimiter: str = "/", auto_
     return target
 
 
-def save_file(file, content, append=False):
+def save_file(file, content, append=False, permissions=None):
     mode = "a" if append else "w+"
     if not isinstance(content, six.string_types):
         mode = mode + "b"
+
+    def _opener(path, flags):
+        return os.open(path, flags, permissions)
+
     # make sure that the parent dir exsits
     mkdir(os.path.dirname(file))
     # store file contents
-    with open(file, mode) as f:
+    with open(file, mode, opener=_opener if permissions else None) as f:
         f.write(content)
         f.flush()
 
@@ -1344,12 +1348,12 @@ def load_file(file_path, default=None, mode=None):
     return result
 
 
-def get_or_create_file(file_path, content=None):
+def get_or_create_file(file_path, content=None, permissions=None):
     if os.path.exists(file_path):
         return load_file(file_path)
     content = "{}" if content is None else content
     try:
-        save_file(file_path, content)
+        save_file(file_path, content, permissions=permissions)
         return content
     except Exception:
         pass


### PR DESCRIPTION
This PR introduces the option to add permissions when saving files, especially important for config files.

Also an experiment to make a flaky test more stable (and in the same time mark as xfail, to evaluate during some time in the CI).
