### PR TITLE
implement one cluster per domain support for elasticsearch

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -293,6 +293,13 @@ LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
 # For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
 KINESIS_INITIALIZE_STREAMS = os.environ.get("KINESIS_INITIALIZE_STREAMS", "").strip()
 
+# Strategy used when creating elasticsearch domain endpoints routed through the edge proxy
+# valid values: domain | path | off
+ES_ENDPOINT_STRATEGY = os.environ.get("ES_ENDPOINT_STRATEGY", "").strip() or "domain"
+
+# Whether to start one cluster per domain (default), or multiplex domains to a single clusters
+ES_MULTI_CLUSTER = is_env_not_false("ES_MULTI_CLUSTER")
+
 # Equivalent to HTTP_PROXY, but only applicable for external connections
 OUTBOUND_HTTP_PROXY = os.environ.get("OUTBOUND_HTTP_PROXY", "")
 
@@ -319,6 +326,8 @@ CONFIG_ENV_VARS = [
     "DYNAMODB_ERROR_PROBABILITY",
     "DYNAMODB_READ_ERROR_PROBABILITY",
     "DYNAMODB_WRITE_ERROR_PROBABILITY",
+    "ES_ENDPOINT_STRATEGY",
+    "ES_MULTI_CLUSTER",
     "DOCKER_BRIDGE_IP",
     "DEFAULT_REGION",
     "LAMBDA_JAVA_OPTS",

--- a/localstack/services/es/cluster.py
+++ b/localstack/services/es/cluster.py
@@ -30,7 +30,7 @@ import requests
 
 from localstack import config, constants
 from localstack.services import install
-from localstack.services.generic_proxy import ProxyListener, UrlMatchingForwarder
+from localstack.services.generic_proxy import EndpointProxy
 from localstack.services.infra import DEFAULT_BACKEND_HOST, start_proxy_for_service
 from localstack.utils.common import (
     ShellCommandThread,
@@ -260,22 +260,6 @@ class CustomEndpoint:
             self.url = urlparse(endpoint)
         else:
             self.url = None
-
-
-class EndpointProxy(ProxyListener):
-    def __init__(self, base_url: str, cluster_url: str) -> None:
-        super().__init__()
-        self.forwarder = UrlMatchingForwarder(
-            base_url=base_url,
-            forward_url=cluster_url,
-        )
-        self.forward_request = self.forwarder.forward_request
-
-    def register(self):
-        ProxyListener.DEFAULT_LISTENERS.append(self)
-
-    def unregister(self):
-        ProxyListener.DEFAULT_LISTENERS.remove(self)
 
 
 class EdgeProxiedElasticsearchCluster(Server):

--- a/localstack/services/es/cluster.py
+++ b/localstack/services/es/cluster.py
@@ -49,25 +49,95 @@ CommandSettings = Dict[str, str]
 
 
 class Directories(NamedTuple):
-    base: str
+    install: str
     tmp: str
     mods: str
     data: str
     backup: str
 
 
-def _build_elasticsearch_run_command(es_bin: str, settings: CommandSettings) -> List[str]:
+def get_elasticsearch_health_status(url: str) -> Optional[str]:
+    """
+    Queries the health endpoint of elasticsearch and returns either the status ('green', 'yellow',
+    ...) or None if the response returned a non-200 response.
+    """
+    resp = requests.get(url + "/_cluster/health")
+
+    if resp and resp.ok:
+        es_status = resp.json()
+        es_status = es_status["status"]
+        return es_status
+
+    return None
+
+
+def resolve_directories(version: str, cluster_path: str, data_root: str = None) -> Directories:
+    """
+    Determines directories to find the elasticsearch binary as well as where to store the instance data.
+
+    :param version: the elasticsearch version (to resolve the install dir)
+    :param cluster_path: the path between data_root and the actual data directories
+    :param data_root: the root of the data dir (will be resolved to TMP_PATH or DATA_DIR by default)
+    :returns: a Directories data structure
+    """
+    # where to find elasticsearch binary and the modules
+    install_dir = install.get_elasticsearch_install_dir(version)
+    modules_dir = os.path.join(install_dir, "modules")
+
+    if data_root is None:
+        if config.DATA_DIR:
+            data_root = config.DATA_DIR
+        else:
+            data_root = config.TMP_FOLDER
+
+    data_path = os.path.join(data_root, "elasticsearch", cluster_path)
+
+    tmp_dir = os.path.join(data_path, "tmp")
+    data_dir = os.path.join(data_path, "data")
+    backup_dir = os.path.join(data_path, "backup")
+
+    return Directories(install_dir, tmp_dir, modules_dir, data_dir, backup_dir)
+
+
+def init_directories(dirs: Directories):
+    """
+    Makes sure the directories exist and have the necessary permissions.
+    """
+    LOG.debug("initializing elasticsearch directories %s", dirs)
+    chmod_r(dirs.install, 0o777)
+
+    if not dirs.data.startswith(config.DATA_DIR):
+        # only clear previous data if it's not in DATA_DIR
+        rm_rf(dirs.data)
+
+    mkdir(dirs.data)
+    chmod_r(dirs.data, 0o777)
+
+    rm_rf(dirs.tmp)
+    mkdir(dirs.tmp)
+    chmod_r(dirs.tmp, 0o777)
+
+    # clear potentially existing lock files (which cause problems since ES 7.10)
+    for d, dirs, files in os.walk(dirs.data, True):
+        for f in files:
+            if f.endswith(".lock"):
+                rm_rf(os.path.join(d, f))
+
+
+def build_elasticsearch_run_command(es_bin: str, settings: CommandSettings) -> List[str]:
     cmd_settings = [f"-E {k}={v}" for k, v, in settings.items()]
     return [es_bin] + cmd_settings
 
 
 class ElasticsearchCluster(Server):
-    def __init__(self, port=9200, host="localhost", version=None) -> None:
+    def __init__(
+        self, port=9200, host="localhost", version: str = None, directories: Directories = None
+    ) -> None:
         super().__init__(port, host)
         self._version = version or constants.ELASTICSEARCH_DEFAULT_VERSION
 
         self.command_settings = {}
-        self.directories = self._resolve_directories()
+        self.directories = directories or self._resolve_directories()
 
     @property
     def version(self):
@@ -112,7 +182,7 @@ class ElasticsearchCluster(Server):
         # delete Elasticsearch data that may be cached locally from a previous test run
         dirs = self.directories
 
-        bin_path = os.path.join(dirs.base, "bin/elasticsearch")
+        bin_path = os.path.join(dirs.install, "bin/elasticsearch")
 
         # build command settings for bin/elasticsearch
         settings = {
@@ -133,7 +203,7 @@ class ElasticsearchCluster(Server):
 
         self._settings_compatibility(settings)
 
-        cmd = _build_elasticsearch_run_command(bin_path, settings)
+        cmd = build_elasticsearch_run_command(bin_path, settings)
 
         return cmd
 
@@ -150,41 +220,11 @@ class ElasticsearchCluster(Server):
             del settings["transport.port"]
 
     def _resolve_directories(self) -> Directories:
-        # determine various directory paths
-        base_dir = install.get_elasticsearch_install_dir(self.version)
-
-        es_tmp_dir = os.path.join(base_dir, "tmp")
-        es_mods_dir = os.path.join(base_dir, "modules")
-        if config.DATA_DIR:
-            es_data_dir = os.path.join(config.DATA_DIR, "elasticsearch")
-        else:
-            es_data_dir = os.path.join(base_dir, "data")
-        backup_dir = os.path.join(config.TMP_FOLDER, "es_backup")
-
-        return Directories(base_dir, es_tmp_dir, es_mods_dir, es_data_dir, backup_dir)
+        # by default, the cluster data will be placed in <data_dir>/elasticsearch/<version>/
+        return resolve_directories(version=self.version, cluster_path=self.version)
 
     def _init_directories(self):
-        dirs = self.directories
-
-        LOG.debug("initializing elasticsearch directories %s", dirs)
-        chmod_r(dirs.base, 0o777)
-
-        if not dirs.data.startswith(config.DATA_DIR):
-            # only clear previous data if it's not in DATA_DIR
-            rm_rf(dirs.data)
-
-        mkdir(dirs.data)
-        chmod_r(dirs.data, 0o777)
-
-        rm_rf(dirs.tmp)
-        mkdir(dirs.tmp)
-        chmod_r(dirs.tmp, 0o777)
-
-        # clear potentially existing lock files (which cause problems since ES 7.10)
-        for d, dirs, files in os.walk(dirs.data, True):
-            for f in files:
-                if f.endswith(".lock"):
-                    rm_rf(os.path.join(d, f))
+        init_directories(self.directories)
 
 
 class ProxiedElasticsearchCluster(Server):
@@ -193,12 +233,15 @@ class ProxiedElasticsearchCluster(Server):
     backend will be assigned a random port.
     """
 
-    def __init__(self, port=9200, host="localhost", version=None) -> None:
+    def __init__(
+        self, port=9200, host="localhost", version=None, directories: Directories = None
+    ) -> None:
         super().__init__(port, host)
         self._version = version or constants.ELASTICSEARCH_DEFAULT_VERSION
 
         self.cluster = None
         self.cluster_port = None
+        self.directories = directories
 
     @property
     def version(self):
@@ -227,7 +270,10 @@ class ProxiedElasticsearchCluster(Server):
             self.cluster_port = get_free_tcp_port()
 
         self.cluster = ElasticsearchCluster(
-            port=self.cluster_port, host=DEFAULT_BACKEND_HOST, version=self.version
+            port=self.cluster_port,
+            host=DEFAULT_BACKEND_HOST,
+            version=self.version,
+            directories=self.directories,
         )
         self.cluster.start()
 
@@ -268,7 +314,7 @@ class EdgeProxiedElasticsearchCluster(Server):
     requests to the backend cluster.
     """
 
-    def __init__(self, url: str, version=None) -> None:
+    def __init__(self, url: str, version=None, directories: Directories = None) -> None:
         self._url = urlparse(url)
 
         super().__init__(
@@ -280,6 +326,7 @@ class EdgeProxiedElasticsearchCluster(Server):
         self.cluster = None
         self.cluster_port = None
         self.proxy = None
+        self.directories = directories
 
     @property
     def version(self):
@@ -309,7 +356,10 @@ class EdgeProxiedElasticsearchCluster(Server):
     def do_run(self):
         self.cluster_port = get_free_tcp_port()
         self.cluster = ElasticsearchCluster(
-            port=self.cluster_port, host=DEFAULT_BACKEND_HOST, version=self.version
+            port=self.cluster_port,
+            host=DEFAULT_BACKEND_HOST,
+            version=self.version,
+            directories=self.directories,
         )
         self.cluster.start()
 
@@ -327,18 +377,3 @@ class EdgeProxiedElasticsearchCluster(Server):
             self.proxy.unregister()
         if self.cluster:
             self.cluster.shutdown()
-
-
-def get_elasticsearch_health_status(url: str) -> Optional[str]:
-    """
-    Queries the health endpoint of elasticsearch and returns either the status ('green', 'yellow',
-    ...) or None if the response returned a non-200 response.
-    """
-    resp = requests.get(url + "/_cluster/health")
-
-    if resp and resp.ok:
-        es_status = resp.json()
-        es_status = es_status["status"]
-        return es_status
-
-    return None

--- a/localstack/services/es/cluster.py
+++ b/localstack/services/es/cluster.py
@@ -110,12 +110,15 @@ def init_directories(dirs: Directories):
         # only clear previous data if it's not in DATA_DIR
         rm_rf(dirs.data)
 
-    mkdir(dirs.data)
-    chmod_r(dirs.data, 0o777)
-
     rm_rf(dirs.tmp)
     mkdir(dirs.tmp)
     chmod_r(dirs.tmp, 0o777)
+
+    mkdir(dirs.data)
+    chmod_r(dirs.data, 0o777)
+
+    mkdir(dirs.backup)
+    chmod_r(dirs.backup, 0o777)
 
     # clear potentially existing lock files (which cause problems since ES 7.10)
     for d, dirs, files in os.walk(dirs.data, True):

--- a/localstack/services/es/cluster_manager.py
+++ b/localstack/services/es/cluster_manager.py
@@ -35,7 +35,7 @@ def create_cluster_manager() -> "ClusterManager":
             return MultiplexingClusterManager()
 
     raise ValueError(
-        "cannot manage clusters with ES_ENDPOINT_STRATEGY=off and ES_MULTI_CLUSTER=False"
+        "cannot manage clusters with ES_ENDPOINT_STRATEGY=off and ES_MULTI_CLUSTER=True"
     )
 
 

--- a/localstack/services/es/cluster_manager.py
+++ b/localstack/services/es/cluster_manager.py
@@ -1,0 +1,243 @@
+import logging
+import threading
+from typing import Dict, Optional
+
+from localstack import config, constants
+from localstack.constants import ELASTICSEARCH_DEFAULT_VERSION
+from localstack.services.es import versions
+from localstack.services.es.cluster import (
+    CustomEndpoint,
+    EdgeProxiedElasticsearchCluster,
+    ElasticsearchCluster,
+    ProxiedElasticsearchCluster,
+)
+from localstack.services.generic_proxy import EndpointProxy, FakeEndpointProxyServer
+from localstack.utils.common import get_free_tcp_port, start_thread
+from localstack.utils.serving import Server
+
+LOG = logging.getLogger(__name__)
+
+ES_BASE_DOMAIN = "es.localhost.localstack.cloud"
+
+
+def create_cluster_manager() -> "ClusterManager":
+    if config.ES_ENDPOINT_STRATEGY == "off" and not config.ES_MULTI_CLUSTER:
+        return SingletonClusterManager()
+
+    if config.ES_ENDPOINT_STRATEGY != "off":
+        if config.ES_MULTI_CLUSTER:
+            return MultiClusterManager()
+        else:
+            return MultiplexingClusterManager()
+
+    raise ValueError(
+        "cannot manage clusters with ES_ENDPOINT_STRATEGY=off and ES_MULTI_CLUSTER=False"
+    )
+
+
+def build_cluster_endpoint(
+    domain_name: str, custom_endpoint: Optional[CustomEndpoint] = None
+) -> str:
+    """
+    Builds the cluster endpoint from and optional custom_endpoint and the localstack elasticsearch config. Example
+    values:
+
+    - my-domain.es.localhost.localstack.cloud:4566 (endpoint strategy = domain (default))
+    - localhost:4566/my-domain (endpoint strategy = path)
+    - localhost:4751 (endpoint strategy = off)
+    - my.domain:443/foo (arbitrary endpoints (technically not allowed by AWS, but there are no rules in localstack))
+    """
+    if custom_endpoint and custom_endpoint.enabled:
+        return custom_endpoint.endpoint
+
+    if config.ES_ENDPOINT_STRATEGY == "off":
+        return "%s:%s" % (config.LOCALSTACK_HOSTNAME, config.PORT_ELASTICSEARCH)
+    if config.ES_ENDPOINT_STRATEGY == "path":
+        return "%s:%s/%s" % (config.LOCALSTACK_HOSTNAME, config.EDGE_PORT, domain_name)
+
+    return f"{domain_name}.{ES_BASE_DOMAIN}:{config.EDGE_PORT}"
+
+
+def determine_custom_endpoint(domain_endpoint_options: Dict) -> Optional[CustomEndpoint]:
+    if not domain_endpoint_options:
+        return
+
+    custom_endpoint = domain_endpoint_options.get("CustomEndpoint")
+    enabled = domain_endpoint_options.get("CustomEndpointEnabled", False)
+    # TODO: other attributes (are they relevant?)
+    #  - EnforceHTTPS: bool
+    #  - TLSSecurityPolicy: str
+    #  - CustomEndpointCertificateArn: str
+
+    if not custom_endpoint:
+        raise ValueError("Please provide the CustomEndpoint field to create a custom endpoint.")
+
+    # TODO: validate custom_endpoint
+
+    return CustomEndpoint(enabled, custom_endpoint)
+
+
+class ClusterManager:
+    clusters: Dict[str, Server]
+
+    def __init__(self) -> None:
+        self.clusters = dict()
+
+    def create(self, arn: str, create_domain_request: Dict) -> Server:
+        domain_name = create_domain_request.get("DomainName")
+        version = versions.get_install_version(
+            create_domain_request.get("ElasticsearchVersion") or ELASTICSEARCH_DEFAULT_VERSION
+        )
+
+        # determine custom domain endpoint
+        endpoint_options = create_domain_request.get("DomainEndpointOptions")
+        custom_endpoint = determine_custom_endpoint(endpoint_options)
+
+        # build final endpoint and cluster url
+        endpoint = build_cluster_endpoint(domain_name, custom_endpoint)
+        url = f"http://{endpoint}" if "://" not in endpoint else endpoint
+
+        # call abstract cluster factory
+        cluster = self._create_cluster(url, version, create_domain_request)
+        cluster.start()
+
+        # save cluster into registry and return
+        self.clusters[arn] = cluster
+        return cluster
+
+    def get(self, arn: str) -> Optional[Server]:
+        return self.clusters.get(arn)
+
+    def remove(self, arn: str):
+        if arn in self.clusters:
+            cluster = self.clusters.pop(arn)
+            if cluster:
+                LOG.debug("shutting down cluster arn %s (%s)", arn, cluster.url)
+                cluster.shutdown()
+
+    def is_up(self, arn: str) -> bool:
+        cluster = self.get(arn)
+        return cluster.is_up() if cluster else False
+
+    def _create_cluster(self, url, version, create_domain_request) -> Server:
+        """
+        Abstract cluster factory.
+        """
+        raise NotImplementedError
+
+
+class SingletonClusterManager(ClusterManager):
+    """
+    Manages a single cluster and always returns that cluster. Using this, we lie to the client about the the
+    elasticsearch domain version. The first call to create_domain with a specific version will create the cluster
+    with that version. Subsequent calls will believe they created a cluster with the version they specified. It keeps
+    the cluster running until the last domain was removed. It only works with a single endpoint.
+
+    Assumes the config:
+    - ES_ENDPOINT_STRATEGY == "off"
+    - ES_MULTI_CLUSTER == False
+    """
+
+    cluster: Optional[Server]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.server = None
+        self.mutex = threading.RLock()
+        self.cluster = None
+
+    def create(self, arn: str, create_domain_request: Dict) -> Server:
+        with self.mutex:
+            return super().create(arn, create_domain_request)
+
+    def _create_cluster(self, url, version, create_domain_request) -> Server:
+        if not self.cluster:
+            # FIXME: if remove() is called, then immediately after, create() (without letting time pass for the proxy to
+            #  shut down) there's a chance that there will be a bind exception when trying to start the proxy again
+            #  (which is currently always bound to PORT_ELASTICSEARCH)
+            self.cluster = ProxiedElasticsearchCluster(
+                port=config.PORT_ELASTICSEARCH, host=constants.LOCALHOST, version=version
+            )
+        return self.cluster
+
+    def remove(self, arn: str):
+
+        with self.mutex:
+            try:
+                cluster = self.clusters.pop(arn)
+            except KeyError:
+                return
+
+            LOG.debug("removing cluster for %s, %s remaining", arn, len(self.clusters))
+            if not self.clusters:
+                # shutdown the cluster if it is
+                cluster.shutdown()
+                self.cluster = None
+
+
+class EndpointCluster(FakeEndpointProxyServer):
+    """
+    An endpoint that points to a cluster, and behaves like a Server.
+    """
+
+    def __init__(self, cluster: Server, endpoint: EndpointProxy) -> None:
+        super().__init__(endpoint)
+        self.cluster = cluster
+
+    def health(self):
+        return super().health() and self.cluster.health()
+
+
+class MultiplexingClusterManager(ClusterManager):
+    """
+    Similar to SingletonClusterManager, but Multiplexes multiple endpoints to a single backend cluster.
+
+    Assumes the config:
+    - ES_ENDPOINT_STRATEGY != "off"
+    - ES_MULTI_CLUSTER = False
+    """
+
+    cluster: Optional[Server]
+    endpoints: Dict[str, EndpointCluster]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.cluster = None
+        self.endpoints = dict()
+        self.mutex = threading.RLock()
+
+    def _create_cluster(self, url, version, create_domain_request) -> Server:
+        with self.mutex:
+            if not self.cluster:
+                # startup routine for the singleton cluster instance
+                self.cluster = ElasticsearchCluster(port=get_free_tcp_port())
+
+                def _start_async(*_):
+                    LOG.info("starting %s on %s", type(self.cluster), self.cluster.url)
+                    self.cluster.start()  # start may block during install
+
+                start_thread(_start_async)
+
+        return EndpointCluster(self.cluster, EndpointProxy(url, self.cluster.url))
+
+    def remove(self, arn: str):
+        super().remove(arn)  # removes the fake server
+
+        if not self.endpoints:
+            # if there are no endpoints left, remove the cluster
+            with self.mutex:
+                if not self.cluster:
+                    return
+
+                LOG.debug("shutting down multiplexed cluster for %s: %s", arn, self.cluster.url)
+                self.cluster.shutdown()
+                self.cluster = None
+
+
+class MultiClusterManager(ClusterManager):
+    """
+    Manages one cluster and endpoint per domain.
+    """
+
+    def _create_cluster(self, url, version, create_domain_request) -> Server:
+        return EdgeProxiedElasticsearchCluster(url, version)

--- a/localstack/services/es/cluster_manager.py
+++ b/localstack/services/es/cluster_manager.py
@@ -16,7 +16,7 @@ from localstack.services.es.cluster import (
     resolve_directories,
 )
 from localstack.services.generic_proxy import EndpointProxy, FakeEndpointProxyServer
-from localstack.utils.common import get_free_tcp_port, start_thread
+from localstack.utils.common import call_safe, get_free_tcp_port, start_thread
 from localstack.utils.serving import Server
 
 LOG = logging.getLogger(__name__)
@@ -155,6 +155,11 @@ class ClusterManager:
         Abstract cluster factory.
         """
         raise NotImplementedError
+
+    def shutdown_all(self):
+        while self.clusters:
+            domain, cluster = self.clusters.popitem()
+            call_safe(cluster.shutdown)
 
 
 class SingletonClusterManager(ClusterManager):

--- a/localstack/services/es/cluster_manager.py
+++ b/localstack/services/es/cluster_manager.py
@@ -80,7 +80,7 @@ def build_cluster_endpoint(
     if config.ES_ENDPOINT_STRATEGY == "off":
         return "%s:%s" % (config.LOCALSTACK_HOSTNAME, config.PORT_ELASTICSEARCH)
     if config.ES_ENDPOINT_STRATEGY == "path":
-        return "%s:%s/%s/%s" % (
+        return "%s:%s/es/%s/%s" % (
             config.LOCALSTACK_HOSTNAME,
             config.EDGE_PORT,
             domain_key.region,

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -315,7 +315,10 @@ def create_domain():
     with _domain_mutex:
         if domain_name in region.es_domains:
             # domain already created
-            return error_response(error_type="ResourceAlreadyExistsException")
+            return error_response(
+                error_type="ResourceAlreadyExistsException",
+                message=f"domain {domain_name} already exists in region {region.name}",
+            )
 
         # "create" domain data
         region.es_domains[domain_name] = data

--- a/localstack/services/es/es_api.py
+++ b/localstack/services/es/es_api.py
@@ -134,9 +134,9 @@ def error_response(error_type, code=400, message="Unknown error."):
 
 
 def get_domain_arn(domain_name: str, region: str = None, account_id: str = None) -> str:
-    region = region or aws_stack.get_region()
-    account_id = account_id or TEST_AWS_ACCOUNT_ID
-    return "arn:aws:es:%s:%s:domain/%s" % (region, account_id, domain_name)
+    return aws_stack.elasticsearch_domain_arn(
+        domain_name=domain_name, account_id=account_id, region_name=region
+    )
 
 
 def parse_domain_arn(arn: str):

--- a/localstack/services/es/versions.py
+++ b/localstack/services/es/versions.py
@@ -71,7 +71,7 @@ def get_download_url(version: str) -> str:
     return f"{repo}/elasticsearch-{ver_str}-linux-x86_64.tar.gz"
 
 
-def fetch_latest_versions() -> Dict[str, str]:
+def fetch_latest_versions() -> Dict[str, str]:  # pragma: no cover
     """
     Fetches from the elasticsearch git repository tags the latest patch versions for a minor version and returns a
     dictionary where the key corresponds to the minor version, and the value to the patch version. Run this once in a
@@ -122,7 +122,7 @@ def fetch_latest_versions() -> Dict[str, str]:
     return {k: str(max(versions)) for k, versions in minor.items()}
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     from pprint import pprint
 
     pprint(fetch_latest_versions())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,6 +53,7 @@ def pytest_runtestloop(session):
             test_init_functions.add(TestTerraform.init_async)
             continue
         if ElasticsearchTest is test_class:
+            # FIXME: there are other elasticsearch test classes
             logger.info("will initialize ElasticsearchTest")
             test_init_functions.add(ElasticsearchTest.init_async)
             continue

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
     from mypy_boto3_cloudformation import CloudFormationClient
     from mypy_boto3_dynamodb import DynamoDBClient
+    from mypy_boto3_es import ElasticsearchServiceClient
     from mypy_boto3_events import EventBridgeClient
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_kinesis import KinesisClient
@@ -124,6 +125,11 @@ def stepfunctions_client() -> "SFNClient":
 @pytest.fixture(scope="class")
 def ses_client() -> "SESClient":
     return _client("ses")
+
+
+@pytest.fixture(scope="class")
+def es_client() -> "ElasticsearchServiceClient":
+    return _client("es")
 
 
 @pytest.fixture

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -7,8 +7,8 @@ import unittest
 from botocore.exceptions import ClientError
 
 from localstack import config
+from localstack.constants import ELASTICSEARCH_DEFAULT_VERSION
 from localstack.services.es.cluster import EdgeProxiedElasticsearchCluster
-from localstack.services.es.es_api import DEFAULT_ES_VERSION
 from localstack.services.install import install_elasticsearch
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import poll_condition, retry
@@ -96,7 +96,7 @@ class ElasticsearchTest(unittest.TestCase):
         status = es_client.describe_elasticsearch_domain(DomainName=TEST_DOMAIN_NAME)[
             "DomainStatus"
         ]
-        self.assertEqual(DEFAULT_ES_VERSION, status["ElasticsearchVersion"])
+        self.assertEqual(ELASTICSEARCH_DEFAULT_VERSION, status["ElasticsearchVersion"])
 
         domain_name = "es-%s" % short_uid()
         self._create_domain(name=domain_name, version="6.8", es_cluster_config=ES_CLUSTER_CONFIG)

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -139,7 +139,7 @@ class ElasticsearchTest(unittest.TestCase):
             d["DomainName"] for d in es_client.list_domain_names()["DomainNames"]
         ]
 
-        es_api.cluster_manager.shutdown_all()
+        es_api.cluster_manager().shutdown_all()
         es_api._cluster_manager = None
 
     def test_create_existing_domain_causes_exception(self):

--- a/tests/unit/services/es/test_cluster_manager.py
+++ b/tests/unit/services/es/test_cluster_manager.py
@@ -1,0 +1,56 @@
+import pytest
+
+from localstack import config
+from localstack.constants import TEST_AWS_ACCOUNT_ID
+from localstack.services.es.cluster_manager import DomainKey, build_cluster_endpoint
+
+
+class TestBuildClusterEndpoint:
+    def test_endpoint_strategy_off(self, monkeypatch):
+        monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "off")
+        endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
+        assert endpoint == "localhost:4571"
+
+    def test_endpoint_strategy_path(self, monkeypatch):
+        monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "path")
+
+        endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
+        assert endpoint == "localhost:4566/us-east-1/my-domain"
+
+        endpoint = build_cluster_endpoint(
+            DomainKey("my-domain-1", "eu-central-1", TEST_AWS_ACCOUNT_ID)
+        )
+        assert endpoint == "localhost:4566/eu-central-1/my-domain-1"
+
+    def test_endpoint_strategy_domain(self, monkeypatch):
+        monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "domain")
+
+        endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
+        assert endpoint == "my-domain.us-east-1.es.localhost.localstack.cloud:4566"
+
+        endpoint = build_cluster_endpoint(
+            DomainKey("my-domain-1", "eu-central-1", TEST_AWS_ACCOUNT_ID)
+        )
+        assert endpoint == "my-domain-1.eu-central-1.es.localhost.localstack.cloud:4566"
+
+
+class TestDomainKey:
+    def test_from_arn(self):
+        domain_key = DomainKey.from_arn("arn:aws:es:us-east-1:012345678901:domain/my-es-domain")
+
+        assert domain_key.domain_name == "my-es-domain"
+        assert domain_key.region == "us-east-1"
+        assert domain_key.account == "012345678901"
+
+    def test_arn(self):
+        domain_key = DomainKey(
+            domain_name="my-es-domain",
+            region="us-east-1",
+            account="012345678901",
+        )
+
+        assert domain_key.arn == "arn:aws:es:us-east-1:012345678901:domain/my-es-domain"
+
+    def test_from_arn_wrong_service(self):
+        with pytest.raises(ValueError):
+            DomainKey.from_arn("arn:aws:sqs:us-east-1:012345678901:my-queue")

--- a/tests/unit/services/es/test_cluster_manager.py
+++ b/tests/unit/services/es/test_cluster_manager.py
@@ -15,12 +15,12 @@ class TestBuildClusterEndpoint:
         monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "path")
 
         endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
-        assert endpoint == "localhost:4566/us-east-1/my-domain"
+        assert endpoint == "localhost:4566/es/us-east-1/my-domain"
 
         endpoint = build_cluster_endpoint(
             DomainKey("my-domain-1", "eu-central-1", TEST_AWS_ACCOUNT_ID)
         )
-        assert endpoint == "localhost:4566/eu-central-1/my-domain-1"
+        assert endpoint == "localhost:4566/es/eu-central-1/my-domain-1"
 
     def test_endpoint_strategy_domain(self, monkeypatch):
         monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "domain")


### PR DESCRIPTION
this PR adds one-cluster-per-domain support #4865 as well as the (necessary) domain and path-based endpoint creation.

## Endpoint strategies

the value of `ES_ENDPOINT_STRATEGY` governs how endpoints are created for a domain:

* `domain`: `<domain-name>.<region>.es.localhost.localstack.cloud:4566`
* `path`: `localhost:4566/es/<region>/<domain-name>`
* `off`: `localhost:4571` (only works with single cluster)

specifying a custom endpoint like `localhost:4566/foo/bar` will overwrite the behavior and simply make the elasticsearch cluster routable through that endpoint.

a major breaking change is that the localstack ES api now behaves like the AWS api, and does not send a fully-qualified URL in the `Endpoint` field of the `CreateElasticsearchDomain` request. (`localhost:4571` instead of `http://localhost:4571`)

## Multi-cluster

`ES_MULTI_CLUSTER`: a bolean flag indicating whether or not to spawn one cluster per domain, or to multiplex all domains to a single cluster.
There are three managers for the different config permutations:

| `ES_MULTI_CLUSTER` | `ES_ENDPOINT_STRATEGY` | Cluster manager |
|---------------------------------|------------------------------------------|------------------------|
| `True` | `path` or `domain` | `MultiClusterManager` creates one cluster per create domain request |
| `False` | `path` or `domain` | `MultiplexingClusterManager`, creates a single cluster for the first create domain request, then creates endpoints that point to that cluster |
| `False` | `off` | `SingletonClusterManager` creates a single cluster on `http://localhost:4571` and will return that endpoint for each subsequent create domain request | 
| `True` | `!= off` | Invalid configuration: cannot provide multiple clusters without an endpoint strategy |

## Storage Layout

The PR changes the way that cluster data is stored.
The elasticsearch installation directory is now untouched, all data comes into either the DATA_DIR or TMP_FOLDER, and will be organized as `<arn>/<domain>`.

```
thomas@om /tmp/localstack % tree -L 4
.
├── elasticsearch
│   └── arn:aws:es:us-east-1:000000000000:domain
│       ├── my-cluster-1
│       │   ├── backup
│       │   ├── data
│       │   └── tmp
│       ├── my-cluster-2
│       │   ├── backup
│       │   ├── data
│       │   └── tmp
```

## TODOs
- [x] endpoint strategies
- [x] multi-cluster management
- [x] update storage layout for elasticsearch instances (use domain names for es data dir)
- [x] write tests