### PR TITLE
Add simple UI for deploying CloudFormation stacks from public template URLs

### DIFF
--- a/localstack/services/cloudformation/deploy.html
+++ b/localstack/services/cloudformation/deploy.html
@@ -18,7 +18,8 @@
     <script type="text/babel">
       const REGIONS = <regions>;
       const DEFAULT_REGION = "us-east-1";
-      const LOCALSTACK_ENDPOINT = "http://localhost:4566";
+      const LOCALSTACK_ENDPOINT = `${window.location.protocol}//${window.location.host}`;
+      AWS.config.update({endpoint: LOCALSTACK_ENDPOINT, accessKeyId: "test", secretAccessKey: "test"});
 
       const templateBody = <templateBody>;
       const defaultStackName = "<stackName>";
@@ -45,7 +46,7 @@
         };
         const deployStack = async () => {
           setErrorMessage("");
-          AWS.config.update({endpoint: LOCALSTACK_ENDPOINT, region, accessKeyId: "test", secretAccessKey: "test"});
+          AWS.config.update({region});
           const client = new AWS.CloudFormation();
           const stackParameters = [];
           const params = {StackName: stackName, TemplateBody: templateBodyStr, Parameters: stackParameters};

--- a/localstack/services/cloudformation/deploy.html
+++ b/localstack/services/cloudformation/deploy.html
@@ -21,6 +21,7 @@
       const LOCALSTACK_ENDPOINT = `${window.location.protocol}//${window.location.host}`;
       AWS.config.update({endpoint: LOCALSTACK_ENDPOINT, accessKeyId: "test", secretAccessKey: "test"});
 
+      // parameter placeholders - filled in by the server when final HTML page gets rendered
       const templateBody = <templateBody>;
       const defaultStackName = "<stackName>";
       const initErrorMessage = <errorMessage>;
@@ -57,6 +58,7 @@
             setErrorMessage(`Error deploying CloudFormation stack: ${e}`);
           }
         };
+
         return (
           <table className="pure-table">
             <tbody>

--- a/localstack/services/cloudformation/deploy.html
+++ b/localstack/services/cloudformation/deploy.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>LocalStack - CloudFormation Deployment</title>
+    <script src="https://unpkg.com/react/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/aws-sdk/2.1015.0/aws-sdk.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css"></link>
+    <style type="text/css">
+      div { padding: 8px; }
+      .wrapper { width: 80%; margin-left: 10%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const REGIONS = <regions>;
+      const DEFAULT_REGION = "us-east-1";
+      const LOCALSTACK_ENDPOINT = "http://localhost:4566";
+
+      const templateBody = <templateBody>;
+      const defaultStackName = "<stackName>";
+      const initErrorMessage = "<errorMessage>";
+
+      const queryParams = new URLSearchParams(window.location.search);
+      const passedRegion = queryParams.get("region") || DEFAULT_REGION;
+      const templateURL = queryParams.get("templateURL");
+      // TODO: allow passing stack parameter values via queryParams as well!
+
+      function StackDetails (props) {
+        const templateBodyStr = JSON.stringify(templateBody);
+        const params = templateBody.Parameters || {};
+        const paramsMapped = Object.keys(params).map(p => ({ParameterKey: p, ParameterValue: params[p].Default || "", ... params[p]}));
+
+        const [region, setRegion] = React.useState(passedRegion);
+        const [stackName, setStackName] = React.useState(defaultStackName);
+        const [parameters, setParameters] = React.useState(paramsMapped);
+        const [errorMessage, setErrorMessage] = React.useState();
+
+        const handle = (handler) => (event) => handler(event.target.value);
+        const handleParam = (paramKey) => (event) => {
+          parameters.filter(p => p.ParameterKey === paramKey)[0].ParameterValue = event.target.value; setParameters([...parameters])
+        };
+        const deployStack = async () => {
+          setErrorMessage("");
+          AWS.config.update({endpoint: LOCALSTACK_ENDPOINT, region, accessKeyId: "test", secretAccessKey: "test"});
+          const client = new AWS.CloudFormation();
+          const stackParameters = [];
+          const params = {StackName: stackName, TemplateBody: templateBodyStr, Parameters: stackParameters};
+          try {
+            const result = await client.createStack(params).promise();
+            props.setResult(result);
+          } catch (e) {
+            setErrorMessage(`Error deploying CloudFormation stack: ${e}`);
+          }
+        };
+        return (
+          <table className="pure-table">
+            <tbody>
+              <tr>
+                <td>Template URL</td><td>{templateURL}</td>
+              </tr><tr>
+                <td>Template Body</td><td>
+                  <textarea rows="10" style={{width: "100%"}} disabled={true} defaultValue={templateBodyStr}></textarea>
+                </td>
+              </tr><tr>
+                <td>Stack Name</td><td><input name="stackName" value={stackName} onChange={handle(setStackName)}/></td>
+              </tr><tr>
+                <td>Stack Parameters</td><td>
+                  <table><tbody>
+                  {
+                    parameters.map(p => <tr key={p.ParameterKey}>
+                      <td>{p.ParameterKey} =</td><td><input type="text" value={p.ParameterValue} onChange={handleParam(p.ParameterKey)}/></td>
+                    </tr>)
+                  }
+                  </tbody></table>
+                </td>
+              </tr><tr>
+                <td>Target Region</td><td>
+                  <select name="region" value={region} onChange={handle(setRegion)}>
+                    {REGIONS.map(r => <option value={r} key={r}>{r}</option>)}
+                  </select>
+                </td>
+              </tr><tr>
+                <td></td><td><button onClick={deployStack}>Deploy Stack Locally</button><p>{errorMessage}</p></td>
+              </tr>
+            </tbody>
+          </table>
+        );
+      }
+
+      function RequestHandler (props) {
+        if (initErrorMessage) {
+          return <div>Error: {initErrorMessage}</div>
+        }
+        if (!templateURL) {
+          return (
+            <form method="GET">
+              <p>
+              Please specify stack template URL as <code>templateURL</code> query parameter, or in the field below:
+              </p>
+              <input type="text" name="templateURL" style={{width: "500px"}} />
+              <button type="submit">Continue</button>
+            </form>
+          );
+        }
+        const [deployResult, setDeployResult] = React.useState();
+        if (deployResult) {
+          return <>
+            <p>
+            Stack deployment successfully started - please check the logs in your LocalStack instance. Deployment response:
+            </p>
+            <textarea disabled={true} rows={4} style={{width: "500px"}}>{JSON.stringify(deployResult)}</textarea>
+            <p>
+            <b>Note:</b> To interactively browse the state of the locally deployed resources, you may want to check out our Web UI at { }
+            <a href="https://app.localstack.cloud">https://app.localstack.cloud</a> !
+            </p>
+          </>
+        }
+        return <StackDetails setResult={setDeployResult} />;
+      }
+
+      function App (props) {
+        return (
+          <div className="wrapper">
+            <div>
+              <img style={{float: "left", width: "60px", margin: "12px"}} src="https://app.localstack.cloud/images/logos/localstack.png" />
+              <h2 style={{float: "left"}}>LocalStack</h2>
+            </div>
+            <h3 style={{clear: "both"}}>Deploy CloudFormation Stack</h3>
+            <RequestHandler />
+          </div>
+        );
+      }
+
+      ReactDOM.render(React.createElement(App), document.getElementById('root'));
+    </script>
+  </body>
+</html>

--- a/localstack/services/cloudformation/deploy.html
+++ b/localstack/services/cloudformation/deploy.html
@@ -23,7 +23,7 @@
 
       const templateBody = <templateBody>;
       const defaultStackName = "<stackName>";
-      const initErrorMessage = "<errorMessage>";
+      const initErrorMessage = <errorMessage>;
 
       const queryParams = new URLSearchParams(window.location.search);
       const passedRegion = queryParams.get("region") || DEFAULT_REGION;

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -78,7 +78,7 @@ HEADER_SKIP_RESPONSE_ZIPPING = "_skip_response_gzipping_"
 SKIP_GZIP_APIS = [S3]
 
 # path prefix to indicate internal endpoints (e.g., resource graph, CFN deployment UI, etc)
-PATH_PREFIX_INTERNAL = "/_/"
+PATH_PREFIX_INTERNAL = "/_localstack/"
 
 
 class ProxyListenerEdge(ProxyListener):
@@ -486,7 +486,7 @@ def serve_internal_resource(method, path, data, headers):
     path = path if path.startswith("/") else f"/{path}"
     if method == "POST" and path == "/graph":
         return serve_resource_graph(data)
-    if path.startswith("/deploy"):
+    if path.startswith("/cloudformation/deploy"):
         return serve_cloudformation_ui(method, path)
     LOG.warning("Unable to find handler for internal endpoint: %s", path_orig)
     return 404

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import threading
 from collections import defaultdict
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from requests.models import Response
 
@@ -20,6 +20,7 @@ from localstack.constants import (
     LOCALHOST_IP,
     LOCALSTACK_ROOT_FOLDER,
     LS_LOG_TRACE_INTERNAL,
+    MODULE_MAIN_PATH,
     PATH_USER_REQUEST,
 )
 from localstack.dashboard import infra as dashboard_infra
@@ -31,6 +32,7 @@ from localstack.services.s3.s3_utils import uses_host_addressing
 from localstack.services.sqs.sqs_listener import is_sqs_queue_url
 from localstack.utils import persistence
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.aws.aws_stack import (
     Environment,
     is_internal_call_context,
@@ -43,7 +45,9 @@ from localstack.utils.common import (
     get_service_protocol,
     is_port_open,
     is_root,
+    load_file,
     merge_recursive,
+    parse_json_or_yaml,
     parse_request_data,
     run,
 )
@@ -73,6 +77,9 @@ API_UNKNOWN = "_unknown_"
 HEADER_SKIP_RESPONSE_ZIPPING = "_skip_response_gzipping_"
 SKIP_GZIP_APIS = [S3]
 
+# path prefix to indicate internal endpoints (e.g., resource graph, CFN deployment UI, etc)
+PATH_PREFIX_INTERNAL = "/_/"
+
 
 class ProxyListenerEdge(ProxyListener):
     def __init__(self, service_manager=None) -> None:
@@ -90,7 +97,10 @@ class ProxyListenerEdge(ProxyListener):
         if path.split("?")[0] == "/health":
             return self.health.handle(method, path, data)
         if method == "POST" and path == "/graph":
+            # TODO: leaving this here for backwards compatibility - should use internal path prefix below in the future
             return serve_resource_graph(data)
+        if path.startswith(PATH_PREFIX_INTERNAL):
+            return serve_internal_resource(method, path, data, headers)
 
         # kill the process if we receive this header
         headers.get(HEADER_KILL_SIGNAL) and sys.exit(0)
@@ -470,7 +480,19 @@ class HealthResource:
         return {"status": "OK"}
 
 
-def serve_resource_graph(data):
+def serve_internal_resource(method, path, data, headers):
+    path_orig = path
+    path = path[len(PATH_PREFIX_INTERNAL) :]
+    path = path if path.startswith("/") else f"/{path}"
+    if method == "POST" and path == "/graph":
+        return serve_resource_graph(data)
+    if path.startswith("/deploy"):
+        return serve_cloudformation_ui(method, path)
+    LOG.warning("Unable to find handler for internal endpoint: %s", path_orig)
+    return 404
+
+
+def serve_resource_graph(data: Dict[str, Any]) -> Dict[str, Any]:
     data = json.loads(to_str(data or "{}"))
 
     if not data.get("awsEnvironment"):
@@ -483,6 +505,34 @@ def serve_resource_graph(data):
         region=data.get("awsRegion"),
     )
     return graph
+
+
+def serve_cloudformation_ui(method, path):
+    deploy_html_file = os.path.join(MODULE_MAIN_PATH, "services", "cloudformation", "deploy.html")
+    deploy_html = load_file(deploy_html_file)
+    req_params = parse_request_data(method, path)
+    params = {
+        "stackName": "stack1",
+        "templateBody": "{}",
+        "errorMessage": "",
+        "regions": json.dumps(sorted(list(config.VALID_REGIONS))),
+    }
+
+    download_url = req_params.get("templateURL")
+    if download_url:
+        try:
+            LOG.debug("Attempting to download CloudFormation template URL: %s", download_url)
+            template_body = to_str(requests.get(download_url).content)
+            template_body = parse_json_or_yaml(template_body)
+            params["templateBody"] = json.dumps(template_body)
+        except Exception as e:
+            params["errorMessage"] = f"Unable to download CloudFormation template URL: {e}"
+
+    # using simple string replacement here, for simplicity (could be replaced with, e.g., jinja)
+    for key, value in params.items():
+        deploy_html = deploy_html.replace(f"<{key}>", value)
+    result = requests_response(deploy_html)
+    return result
 
 
 def get_api_from_custom_rules(method, path, data, headers):

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -514,7 +514,7 @@ def serve_cloudformation_ui(method, path):
     params = {
         "stackName": "stack1",
         "templateBody": "{}",
-        "errorMessage": "",
+        "errorMessage": "''",
         "regions": json.dumps(sorted(list(config.VALID_REGIONS))),
     }
 
@@ -526,7 +526,9 @@ def serve_cloudformation_ui(method, path):
             template_body = parse_json_or_yaml(template_body)
             params["templateBody"] = json.dumps(template_body)
         except Exception as e:
-            params["errorMessage"] = f"Unable to download CloudFormation template URL: {e}"
+            msg = f"Unable to download CloudFormation template URL: {e}"
+            LOG.info(msg)
+            params["errorMessage"] = json.dumps(msg.replace("\n", " - "))
 
     # using simple string replacement here, for simplicity (could be replaced with, e.g., jinja)
     for key, value in params.items():

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1137,20 +1137,26 @@ def download(url: str, path: str, verify_ssl=True):
         s.close()
 
 
-def parse_request_data(method, path, data=None, headers=None):
-    """Extract request data either from query string (for GET) or request body (for POST)."""
+def parse_request_data(method: str, path: str, data=None, headers=None):
+    """Extract request data either from query string as well as request body (e.g., for POST)."""
     result = {}
     headers = headers or {}
     content_type = headers.get("Content-Type", "")
+
+    # add query params to result
+    parsed_path = urlparse(path)
+    result.update(parse_qs(parsed_path.query))
+
+    # add params from url-encoded payload
     if method in ["POST", "PUT", "PATCH"] and (not content_type or "form-" in content_type):
         # content-type could be either "application/x-www-form-urlencoded" or "multipart/form-data"
         try:
-            result = parse_qs(to_str(data or ""))
+            params = parse_qs(to_str(data or ""))
+            result.update(params)
         except Exception:
             pass  # probably binary / JSON / non-URL encoded payload - ignore
-    if not result:
-        parsed_path = urlparse(path)
-        result = parse_qs(parsed_path.query)
+
+    # select first elements from result lists (this is assuming we are not using parameter lists!)
     result = dict([(k, v[0]) for k, v in result.items()])
     return result
 


### PR DESCRIPTION
Add simple UI for deploying CloudFormation stacks from public template URLs. Inspired from the "1-click deploy" feature in the AWS console that allows to point to an existing CFN template URL, fill out the required parameters, and trigger the deployment from the browser.

The app is implemented as a standalone React app, with embedded babel runtime compiler. (Deliberately kept simple, to avoid having a separate build step for this app).

The app is accessible under `http://localhost:4566/_/deploy`, and we can either pass in `templateURL` as a query parameter, or enter the template URL (e.g., https://s3.eu-central-1.amazonaws.com/cloudformation-templates-eu-central-1/DynamoDB_Secondary_Indexes.template) on the start page:

-----

<img width="669" alt="image" src="https://user-images.githubusercontent.com/2807888/140654127-f5cf4f31-b829-485f-8562-ccd03a374a1d.png">

-----

In the next step we download the template URL and extract the stack parameters (default values automatically applied):
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/2807888/140654160-fc982021-2651-47c5-b0f2-de28d2363423.png">

-----

Upon submit, the stack deployment is triggered, and we're displaying a result message (with a pointer to app.localstack.cloud, in case users are interested in browsing the deployed resources):

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/2807888/140654194-03559a86-51d9-4394-ac3e-b180e0d72bfc.png">

-----

/cc @dominikschubert @thrau 

@thrau - What are your thoughts on using a common path for all the internal, e.g., `/-/....`? Please review (see `PATH_PREFIX_INTERNAL` in the PR) - might affect the routing logic in other places.. Thanks

**Note:** The styling is very rudimentary at this point ;) - we can brush it up in a follow-up iteration...