### PR TITLE
Format JSON stack template for better readability in UI

### DIFF
--- a/localstack/services/cloudformation/deploy.html
+++ b/localstack/services/cloudformation/deploy.html
@@ -32,7 +32,7 @@
       // TODO: allow passing stack parameter values via queryParams as well!
 
       function StackDetails (props) {
-        const templateBodyStr = JSON.stringify(templateBody);
+        const templateBodyStr = JSON.stringify(templateBody, undefined, 2);
         const params = templateBody.Parameters || {};
         const paramsMapped = Object.keys(params).map(p => ({ParameterKey: p, ParameterValue: params[p].Default || "", ... params[p]}));
 


### PR DESCRIPTION
Adds basic formatting to the Cloudformation Stack deployment UI from #4868 

Just thought since the purpose is mostly to visualize the template, having proper formatting, makes it much easier to read for the user.

![image](https://user-images.githubusercontent.com/620817/140783737-15667b16-21ae-4f01-8dba-303db10d4a60.png)
