### PR TITLE
Fix cloudformation not creating multi route tables

### DIFF
--- a/tests/integration/templates/template36.yaml
+++ b/tests/integration/templates/template36.yaml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  Environment:
+    Type: String
+    Default: 'companyname-ci'
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock: "100.0.0.0/20"
+
+  RouteTableProduction:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: env
+        Value: production
+
+  RouteTableQa:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: env
+        Value: qa
+
+  RouteTableQa2:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: env
+        Value: qa
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      RouteTableId:
+        Ref: RouteTableProduction
+
+Outputs:
+  PublicRoute:
+    Value:
+      Ref: PublicRoute
+    Export:
+      Name: 'publicRoute-identify'


### PR DESCRIPTION
The check against current stack was breaking multi route tables creation from the cloudformation template.
