### PR TITLE
implement generic approach for routing internal REST resources

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -65,6 +65,9 @@ DOCKER_IMAGE_NAME_FULL = "localstack/localstack-full"
 # backdoor API path used to retrieve or update config variables
 CONFIG_UPDATE_PATH = "/?_config_"
 
+# API path for localstack internal resources
+INTERNAL_RESOURCE_PATH = "/_localstack"
+
 # environment variable name to tag local test runs
 ENV_INTERNAL_TEST_RUN = "LOCALSTACK_INTERNAL_TEST_RUN"
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -491,6 +491,10 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     @log_duration()
     def start_runtime_components():
         from localstack.services.edge import start_edge
+        from localstack.services.internal import LocalstackResourceHandler, get_internal_apis
+
+        # serve internal APIs through the generic proxy
+        ProxyListener.DEFAULT_LISTENERS.append(LocalstackResourceHandler(get_internal_apis()))
 
         # TODO: we want a composable LocalStack runtime (edge proxy, service manager, dns, ...)
         t = start_thread(start_edge, quiet=False)

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -1,0 +1,203 @@
+"""Module for localstack internal resources, such as health, graph, or _localstack/cloudformation/deploy. """
+import json
+import logging
+import os
+from collections import defaultdict
+from typing import Any, Dict, Optional
+
+import requests
+
+from localstack import config, constants
+from localstack.services.infra import terminate_all_processes_in_docker
+from localstack.services.routing import ResourceRouter, ResourceRouterProxyListener
+from localstack.utils.common import (
+    load_file,
+    merge_recursive,
+    parse_json_or_yaml,
+    parse_request_data,
+    to_str,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+class HealthResource:
+    """
+    Resource for the LocalStack /health endpoint. It provides access to the service states and other components of
+    localstack. We support arbitrary data to be put into the health state to support things like the
+    run_startup_scripts function in docker-entrypoint.sh which sets the status of the init scripts feature.
+    """
+
+    def __init__(self, service_manager) -> None:
+        super().__init__()
+        self.service_manager = service_manager
+        self.state = dict()
+
+    def on_post(self, request):
+        data = request.json()
+        # backdoor API to support restarting the instance
+        if data.get("action") in ["kill", "restart"]:
+            terminate_all_processes_in_docker()
+
+    def on_get(self, request):
+        path = request.path
+
+        reload = "reload" in path
+
+        # get service state
+        if reload:
+            self.service_manager.check_all()
+        services = {
+            service: state.value for service, state in self.service_manager.get_states().items()
+        }
+
+        # build state dict from internal state and merge into it the service states
+        result = dict(self.state)
+        result = merge_recursive({"services": services}, result)
+        return result
+
+    def on_put(self, request):
+        data = json.loads(to_str(request.data or "{}"))
+
+        # keys like "features:initScripts" should be interpreted as ['features']['initScripts']
+        state = defaultdict(dict)
+        for k, v in data.items():
+            if ":" in k:
+                path = k.split(":")
+            else:
+                path = [k]
+
+            d = state
+            for p in path[:-1]:
+                d = state[p]
+            d[path[-1]] = v
+
+        self.state = merge_recursive(state, self.state, overwrite=True)
+        return {"status": "OK"}
+
+
+class ResourceGraph:
+    """
+    Serves the resource graph for app.localstack.cloud.
+    """
+
+    def on_post(self, request):
+        return self.serve_resource_graph(request.json())
+
+    def serve_resource_graph(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        from localstack.dashboard import infra as dashboard_infra
+        from localstack.utils.aws.aws_stack import Environment
+
+        if not data.get("awsEnvironment"):
+            raise ValueError("cannot parse aws Environment from empty string")
+
+        env = Environment.from_string(data.get("awsEnvironment"))
+        graph = dashboard_infra.get_graph(
+            name_filter=data.get("nameFilter") or ".*",
+            env=env,
+            region=data.get("awsRegion"),
+        )
+        return graph
+
+
+class CloudFormationUi:
+    def on_get(self, request):
+        from localstack.utils.aws.aws_responses import requests_response
+
+        path = request.path
+        data = request.data
+        headers = request.headers
+
+        deploy_html_file = os.path.join(
+            constants.MODULE_MAIN_PATH, "services", "cloudformation", "deploy.html"
+        )
+        deploy_html = load_file(deploy_html_file)
+        req_params = parse_request_data("GET", path, data, headers)
+        params = {
+            "stackName": "stack1",
+            "templateBody": "{}",
+            "errorMessage": "''",
+            "regions": json.dumps(sorted(list(config.VALID_REGIONS))),
+        }
+
+        download_url = req_params.get("templateURL")
+        if download_url:
+            try:
+                LOG.debug("Attempting to download CloudFormation template URL: %s", download_url)
+                template_body = to_str(requests.get(download_url).content)
+                template_body = parse_json_or_yaml(template_body)
+                params["templateBody"] = json.dumps(template_body)
+            except Exception as e:
+                msg = f"Unable to download CloudFormation template URL: {e}"
+                LOG.info(msg)
+                params["errorMessage"] = json.dumps(msg.replace("\n", " - "))
+
+        # using simple string replacement here, for simplicity (could be replaced with, e.g., jinja)
+        for key, value in params.items():
+            deploy_html = deploy_html.replace(f"<{key}>", value)
+        result = requests_response(deploy_html)
+        return result
+
+
+class LocalstackResources(ResourceRouter):
+    """
+    Router for localstack-internal HTTP resources.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.add_default_routes()
+        # TODO: load routes as plugins
+
+    def add_default_routes(self):
+        from localstack.services.plugins import SERVICE_PLUGINS
+
+        health_resource = HealthResource(SERVICE_PLUGINS)
+        graph_resource = ResourceGraph()
+
+        # two special routes for legacy support (before `/_localstack` was introduced)
+        super().add_route("/health", health_resource)
+        super().add_route("/graph", graph_resource)
+
+        self.add_route("/health", health_resource)
+        self.add_route("/graph", graph_resource)
+        self.add_route("/cloudformation/deploy", CloudFormationUi())
+
+    def add_route(self, path: str, resource: Any, suffix: str = None):
+        super().add_route(f"{constants.INTERNAL_RESOURCE_PATH}{path}", resource, suffix)
+
+
+class LocalstackResourceHandler(ResourceRouterProxyListener):
+    """
+    Adapter to serve LocalstackResources through the edge proxy.
+    """
+
+    resources: LocalstackResources
+
+    def __init__(self, resources: LocalstackResources = None) -> None:
+        super().__init__(resources or LocalstackResources())
+
+    def forward_request(self, method, path, data, headers):
+        result = super().forward_request(method, path, data, headers)
+
+        if result == 404:
+            if not path.startswith(constants.INTERNAL_RESOURCE_PATH + "/"):
+                # only return 404 if we're accessing an internal resource, otherwise fall back to the other listeners
+                return True
+            else:
+                LOG.warning("Unable to find handler for path: %s", path)
+
+        return result
+
+
+INTERNAL_APIS: Optional[LocalstackResources] = None
+
+
+def get_internal_apis() -> LocalstackResources:
+    """
+    Get the LocalstackResources singleton.
+    """
+    global INTERNAL_APIS
+    if not INTERNAL_APIS:
+        INTERNAL_APIS = LocalstackResources()
+    return INTERNAL_APIS

--- a/localstack/services/routing.py
+++ b/localstack/services/routing.py
@@ -1,0 +1,175 @@
+import dataclasses
+import json
+from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import urlparse
+
+from localstack.services.generic_proxy import ProxyListener
+from localstack.utils.common import to_str
+
+
+@dataclasses.dataclass
+class Request:
+    method: str
+    path: str
+    data: Union[str, bytes]
+    headers: Dict
+
+    @property
+    def host(self) -> Optional[str]:
+        return self.headers.get("Host")
+
+    def json(self):
+        return json.loads(to_str(self.data or "{}"))
+
+
+@dataclasses.dataclass
+class RoutingRule:
+    uri_template: str
+    is_pattern: bool = False
+    method: str = None
+    match_host: bool = False
+
+    def url(self):
+        return urlparse(self.uri_template)
+
+    def matches(self, request: Request) -> bool:
+        if self.method and self.method != request.method:
+            return False
+
+        if self.is_pattern:
+            raise NotImplementedError
+
+        url = self.url()
+        host = request.host
+        path = urlparse(request.path).path if "?" in request.path else request.path
+
+        # TODO: consider matching default ports (80, 443 if scheme is https). Example: http://localhost:80 matches
+        #  http://localhost) check host rule
+        if self.match_host:
+            if not url.netloc:
+                raise ValueError("cannot match host without host pattern in URI template")
+
+            if not host:
+                return False
+            elif host != url.netloc:
+                return False
+
+        # check path components
+        if url.path == "/":
+            if path.startswith("/"):
+                return True
+
+        path = path.rstrip("/")  # ignore trailing slashes
+        base_path = url.path.rstrip("/")
+
+        path_parts = path.split("/")
+        base_path_parts = base_path.split("/")
+
+        if len(base_path_parts) != len(path_parts):
+            return False
+
+        for i, component in enumerate(base_path_parts):
+            if component != path_parts[i]:
+                return False
+
+        return True
+
+
+class Dispatcher:
+    """
+    Dispatches a request to a resource by resolving on_post, on_get, etc ... methods of the resource,
+    and then calling that method if it exists. Otherwise a ResourceRouter.NO_ROUTE is returned.
+    """
+
+    resource: Any
+    suffix: str
+
+    def __init__(self, resource: Any, suffix: str = None) -> None:
+        super().__init__()
+        self.resource = resource
+        self.suffix = suffix
+
+    def dispatch(self, request):
+        fn_name = self.get_method_name(request)
+        fn = getattr(self.resource, fn_name, None)
+        if fn:
+            return fn(request)
+        else:
+            return ResourceRouter.NO_ROUTE
+
+    def get_method_name(self, request):
+        if self.suffix:
+            return f"on_{request.method.lower()}_{self.suffix}"
+        else:
+            return f"on_{request.method.lower()}"
+
+
+class _NoRoute:
+    def __repr__(self):
+        return "no route"
+
+    def __str__(self):
+        return "no route"
+
+
+class ResourceRouter:
+    """
+    Matches requests to routing rules and calls the respective dispatchers.
+
+    """
+
+    NO_ROUTE = _NoRoute()  # sentinel object to indicate that there is no route available
+
+    routes: List[Tuple[RoutingRule, Dispatcher]]
+
+    def __init__(self):
+        self.routes = list()
+
+    def add_route(self, uri_template: str, resource: Any, suffix: str = None):
+        """
+        Adds a route to the given resource, where either on_<verb> or on_<verb>_<suffix> will be called.
+        """
+        # TODO: check if uri_template is a pattern and set is_pattern = True
+        rule = RoutingRule(uri_template, False)
+        self.add_routing_rule(rule, resource, suffix)
+
+    def add_routing_rule(self, rule: RoutingRule, resource: Any, suffix: str = None):
+        self.routes.append((rule, Dispatcher(resource, suffix)))
+
+    def dispatch(self, request: Request):
+        """
+        Dispatches the request to a resource, or returns ResourceRouter.NO_ROUTE.
+        """
+        dispatcher = self.get_matching_route(request)
+
+        if not dispatcher:
+            return ResourceRouter.NO_ROUTE
+
+        return dispatcher.dispatch(request)
+
+    def get_matching_route(self, request: Request) -> Optional[Dispatcher]:
+        for route, resource in self.routes:
+            if route.matches(request):
+                return resource
+
+        return None
+
+
+class ResourceRouterProxyListener(ProxyListener):
+    """
+    Adapter to serve a ResourceRouter through the generic proxy.
+    """
+
+    resources: ResourceRouter
+
+    def __init__(self, resources: ResourceRouter) -> None:
+        super().__init__()
+        self.resources = resources
+
+    def forward_request(self, method, path, data, headers):
+        result = self.resources.dispatch(Request(method, path, data, headers))
+
+        if result is ResourceRouter.NO_ROUTE:
+            return 404
+
+        return result

--- a/tests/integration/dashboard/test_graph.py
+++ b/tests/integration/dashboard/test_graph.py
@@ -6,15 +6,19 @@ from localstack.dashboard.infra import (
     find_node_by_attribute,
     find_node_by_id,
 )
-from localstack.services.edge import serve_resource_graph
+from localstack.services.internal import ResourceGraph
+
+
+def serve_resource_graph(data):
+    return ResourceGraph().serve_resource_graph(data)
 
 
 class TestResourceGraph:
-    request_data = '{"awsEnvironment": "%s:aws"}' % config.DEFAULT_REGION
+    request_data = {"awsEnvironment": "%s:aws" % config.DEFAULT_REGION}
 
     def test_empty_data_arg(self):
         with pytest.raises(ValueError):
-            serve_resource_graph("{}")
+            serve_resource_graph({})
 
     def test_basic_return_types(self):
         graph = serve_resource_graph(self.request_data)

--- a/tests/unit/services/test_internal.py
+++ b/tests/unit/services/test_internal.py
@@ -1,0 +1,99 @@
+from unittest import mock
+
+import requests
+
+from localstack.services.internal import HealthResource, LocalstackResourceHandler
+from localstack.services.plugins import ServiceManager, ServiceState
+from localstack.services.routing import Request
+from localstack.utils.testutil import proxy_server
+
+
+class TestHealthResource:
+    def test_put_and_get(self):
+        service_manager = ServiceManager()
+        service_manager.get_states = mock.MagicMock(return_value={"foo": ServiceState.AVAILABLE})
+
+        resource = HealthResource(service_manager)
+
+        resource.on_put(
+            Request(
+                "PUT",
+                "/",
+                b'{"features:initScripts": "initializing","features:persistence": "disabled"}',
+                {},
+            )
+        )
+
+        state = resource.on_get(Request("GET", "/", b"None", {}))
+
+        assert state == {
+            "features": {
+                "initScripts": "initializing",
+                "persistence": "disabled",
+            },
+            "services": {
+                "foo": "available",
+            },
+        }
+
+    def test_put_overwrite_and_get(self):
+        service_manager = ServiceManager()
+        service_manager.get_states = mock.MagicMock(return_value={"foo": ServiceState.AVAILABLE})
+
+        resource = HealthResource(service_manager)
+
+        resource.on_put(
+            Request(
+                "PUT",
+                "/",
+                b'{"features:initScripts": "initializing","features:persistence": "disabled"}',
+                {},
+            )
+        )
+
+        resource.on_put(Request("PUT", "/", b'{"features:initScripts": "initialized"}', {}))
+
+        state = resource.on_get(Request("GET", "/", b"None", {}))
+
+        assert state == {
+            "features": {
+                "initScripts": "initialized",
+                "persistence": "disabled",
+            },
+            "services": {
+                "foo": "available",
+            },
+        }
+
+
+class TestLocalstackResourceHandlerIntegration:
+    def test_health(self, monkeypatch):
+        with proxy_server(LocalstackResourceHandler()) as url:
+            # legacy endpoint
+            response = requests.get(f"{url}/health")
+            assert response.ok
+            assert "services" in response.json()
+
+            # new internal endpoint
+            response = requests.get(f"{url}/_localstack/health")
+            assert response.ok
+            assert "services" in response.json()
+
+    def test_cloudformation_ui(self):
+        with proxy_server(LocalstackResourceHandler()) as url:
+            # make sure it renders
+            response = requests.get(f"{url}/_localstack/cloudformation/deploy")
+            assert response.ok
+            assert "</html>" in response.text, "deploy UI did not render HTML"
+
+    def test_fallthrough(self):
+        with proxy_server(LocalstackResourceHandler()) as url:
+            # some other error is thrown by the proxy if there are no more listeners
+            response = requests.get(f"{url}/foobar")
+            assert not response.ok
+            assert not response.status_code == 404
+
+            # internal paths are 404ed
+            response = requests.get(f"{url}/_localstack/foobar")
+            assert not response.ok
+            assert response.status_code == 404

--- a/tests/unit/services/test_routing.py
+++ b/tests/unit/services/test_routing.py
@@ -1,0 +1,134 @@
+import pytest
+import requests
+
+from localstack.services.routing import (
+    Request,
+    ResourceRouter,
+    ResourceRouterProxyListener,
+    RoutingRule,
+)
+from localstack.utils.testutil import proxy_server
+
+
+class TestRoutingRule:
+    def test_matches_strict(self):
+        rule = RoutingRule("/foo/bar")
+
+        assert rule.matches(Request("GET", "/foo/bar", b"", {}))
+        assert rule.matches(Request("GET", "/foo/bar/", b"", {}))
+        assert rule.matches(Request("POST", "/foo/bar", b"", {}))
+
+        assert not rule.matches(Request("GET", "/foo/ba", b"", {}))
+        assert not rule.matches(Request("GET", "/foo/bare", b"", {}))
+        assert not rule.matches(Request("GET", "/foo/bar/ed", b"", {}))
+        assert not rule.matches(Request("GET", "/foo", b"", {}))
+
+    def test_matches_with_query(self):
+        rule = RoutingRule("/foo/bar")
+
+        assert rule.matches(Request("GET", "/foo/bar?", b"", {}))
+        assert rule.matches(Request("GET", "/foo/bar?help", b"", {}))
+        assert rule.matches(Request("GET", "/foo/bar?help=me&ok", b"", {}))
+
+    def test_matches_with_host(self):
+        rule = RoutingRule("http://localhost:4566/foo/bar", match_host=True)
+
+        assert rule.matches(Request("GET", "/foo/bar", b"", {"Host": "localhost:4566"}))
+        assert not rule.matches(Request("GET", "/foo/bar", b"", {"Host": "localhost"}))
+        assert not rule.matches(Request("GET", "/foo/bar", b"", {"Host": "example.com"}))
+        assert not rule.matches(Request("GET", "/foo/bar", b"", {}))
+
+    def test_matches_with_host_no_pattern_errors(self):
+        rule = RoutingRule("/foo/bar", match_host=True)
+
+        with pytest.raises(ValueError):
+            rule.matches(Request("GET", "/foo/bar", b"", {}))
+
+
+class TestResourceRouter:
+    def test_dispatch_returns_no_route(self):
+        router = ResourceRouter()
+        assert router.dispatch(Request("GET", "/health", b"", {})) == ResourceRouter.NO_ROUTE
+
+    def test_dispatch_to_correct_function(self):
+        requests = list()
+
+        class TestResource:
+            def on_get(self, req):
+                requests.append(req)
+                return "GET/OK"
+
+            def on_post(self, req):
+                requests.append(req)
+                return "POST/OK"
+
+        router = ResourceRouter()
+        router.add_route("/health", TestResource())
+
+        request = Request("GET", "/health", b"", {})
+        assert router.dispatch(request) == "GET/OK"
+        assert router.dispatch(request) == "GET/OK"
+        assert len(requests) == 2
+        assert requests[0] is request
+        assert requests[1] is request
+
+    def test_dispatch_with_suffix(self):
+        class TestResource:
+            def on_get_first(self, req):
+                return "GET/OK"
+
+            def on_post(self, req):
+                return "POST/NOK"
+
+            def on_post_second(self, req):
+                return "POST/OK"
+
+        router = ResourceRouter()
+        resource = TestResource()
+        router.add_route("/health/first", resource, suffix="first")
+        router.add_route("/health/second", resource, suffix="second")
+
+        assert router.dispatch(Request("GET", "/health/first", b"", {})) == "GET/OK"
+        assert router.dispatch(Request("POST", "/health/first", b"", {})) == ResourceRouter.NO_ROUTE
+
+        assert router.dispatch(Request("GET", "/health/second", b"", {})) == ResourceRouter.NO_ROUTE
+        assert router.dispatch(Request("POST", "/health/second", b"", {})) == "POST/OK"
+
+    def test_dispatch_to_non_existing_function_returns_no_route(self):
+        class TestResource:
+            def on_post(self, request):
+                return "POST/OK"
+
+        router = ResourceRouter()
+        router.add_route("/health", TestResource())
+
+        assert router.dispatch(Request("GET", "/health", b"", {})) == ResourceRouter.NO_ROUTE
+        assert router.dispatch(Request("POST", "/health", b"", {})) == "POST/OK"
+
+
+class TestResourceRouterProxyListener:
+    def test_with_server(self):
+        class TestResource:
+            def on_get(self, request):
+                return {"status": "ok"}
+
+        router = ResourceRouter()
+        router.add_route("/foo/bar", TestResource())
+
+        with proxy_server(ResourceRouterProxyListener(router)) as url:
+            response = requests.get(f"{url}/foo/bar")
+            assert response.ok
+            assert response.json() == {"status": "ok"}
+
+            # test with query
+            response = requests.get(f"{url}/foo/bar?hello=there")
+            assert response.ok
+            assert response.json() == {"status": "ok"}
+
+            response = requests.get(f"{url}/foo")
+            assert not response.ok
+            assert response.status_code == 404
+
+            response = requests.post(f"{url}/foo/bar")
+            assert not response.ok
+            assert response.status_code == 404

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -1,10 +1,8 @@
 import unittest
-from unittest import mock
 
 from werkzeug.datastructures import Headers
 
-from localstack.services.edge import HealthResource, get_auth_string, is_s3_form_data
-from localstack.services.plugins import ServiceManager, ServiceState
+from localstack.services.edge import get_auth_string, is_s3_form_data
 
 
 class EdgeServiceTest(unittest.TestCase):
@@ -103,51 +101,3 @@ class EdgeServiceTest(unittest.TestCase):
             headers_with_auth.get("authorization"),
             get_auth_string("POST", "/", Headers(), body_with_auth),
         )
-
-
-class TestHealthResource:
-    def test_put_and_get(self):
-        service_manager = ServiceManager()
-        service_manager.get_states = mock.MagicMock(return_value={"foo": ServiceState.AVAILABLE})
-
-        resource = HealthResource(service_manager)
-
-        resource.put(
-            "/", b'{"features:initScripts": "initializing","features:persistence": "disabled"}'
-        )
-
-        state = resource.get("/", None)
-
-        assert state == {
-            "features": {
-                "initScripts": "initializing",
-                "persistence": "disabled",
-            },
-            "services": {
-                "foo": "available",
-            },
-        }
-
-    def test_put_overwrite_and_get(self):
-        service_manager = ServiceManager()
-        service_manager.get_states = mock.MagicMock(return_value={"foo": ServiceState.AVAILABLE})
-
-        resource = HealthResource(service_manager)
-
-        resource.put(
-            "/", b'{"features:initScripts": "initializing","features:persistence": "disabled"}'
-        )
-
-        resource.put("/", b'{"features:initScripts": "initialized"}')
-
-        state = resource.get("/", None)
-
-        assert state == {
-            "features": {
-                "initScripts": "initialized",
-                "persistence": "disabled",
-            },
-            "services": {
-                "foo": "available",
-            },
-        }


### PR DESCRIPTION
This PR adds a tiny framework for routing REST calls to resource classes through the edge proxy, and uses that framework to route internal `/_localstack` calls. It's inspired by the Falcon framework that encapsulates request handlers into classes and `on_<verb>` methods.

Resources can be added with `get_internal_apis().add_route('/my/route', MyResource())` where `MyResource` is a class that  exposes optional `on_get(request: Request)`, `on_post`, `on_put`, ... methods.
We can now also think about adding internal routes through the plugin mechanism.
