### PR TITLE
iam response booleans to lowercase

### DIFF
--- a/localstack/services/iam/iam_listener.py
+++ b/localstack/services/iam/iam_listener.py
@@ -9,7 +9,10 @@ BOOL_ATTRS = [
     "HardExpiry",
     "RequireSymbols",
     "ExpirePasswords",
+    "IsTruncated",
 ]
+
+AWS_SDK_JS = "aws-sdk-js"
 
 
 class ProxyListenerIAM(ProxyListener):
@@ -28,6 +31,10 @@ class ProxyListenerIAM(ProxyListener):
             MessageConversion.fix_date_format(response)
             MessageConversion.fix_error_codes(method, data, response)
             MessageConversion.fix_xml_empty_boolean(response, BOOL_ATTRS)
+
+            if AWS_SDK_JS in headers.get("User-Agent", ""):
+                MessageConversion.booleans_to_lowercase(response, BOOL_ATTRS)
+
             # fix content-length header
             response.headers["Content-Length"] = str(len(response._content))
 

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -453,6 +453,21 @@ class MessageConversion(object):
             response._content = re.sub(regex, replace, to_str(response.content), flags=REGEX_FLAGS)
 
     @staticmethod
+    def booleans_to_lowercase(response, tag_names):
+        for tag_name in tag_names:
+            regex_true = r"<{tag}>\s*True\s*</{tag}>".format(tag=tag_name)
+            replace_true = r"<{tag}>true</{tag}>".format(tag=tag_name)
+            response._content = re.sub(
+                regex_true, replace_true, to_str(response.content), flags=REGEX_FLAGS
+            )
+
+            regex_false = r"<{tag}>\s*False\s*</{tag}>".format(tag=tag_name)
+            replace_false = r"<{tag}>false</{tag}>".format(tag=tag_name)
+            response._content = re.sub(
+                regex_false, replace_false, to_str(response.content), flags=REGEX_FLAGS
+            )
+
+    @staticmethod
     def _reset_account_id(data):
         """Fix account ID in request payload. All external-facing responses contain our
         predefined account ID (defaults to 000000000000), whereas the backend endpoint


### PR DESCRIPTION
After testing #4831, it's shown that the iam client of the AWS SDK for NodeJs needs the boolean values to be in lowercase not truncated like many other SDKs.

Changes:
 - Transform to lowercase the boolean values of the xml content when User-Agent is `aws-sdk-js`
