### PR TITLE
Apply convertion for all clients

### DIFF
--- a/localstack/services/iam/iam_listener.py
+++ b/localstack/services/iam/iam_listener.py
@@ -12,8 +12,6 @@ BOOL_ATTRS = [
     "IsTruncated",
 ]
 
-AWS_SDK_JS = "aws-sdk-js"
-
 
 class ProxyListenerIAM(ProxyListener):
     def forward_request(self, method, path, data, headers):
@@ -31,9 +29,7 @@ class ProxyListenerIAM(ProxyListener):
             MessageConversion.fix_date_format(response)
             MessageConversion.fix_error_codes(method, data, response)
             MessageConversion.fix_xml_empty_boolean(response, BOOL_ATTRS)
-
-            if AWS_SDK_JS in headers.get("User-Agent", ""):
-                MessageConversion.booleans_to_lowercase(response, BOOL_ATTRS)
+            MessageConversion.booleans_to_lowercase(response, BOOL_ATTRS)
 
             # fix content-length header
             response.headers["Content-Length"] = str(len(response._content))


### PR DESCRIPTION
Continuation of #4887. 

Changes:
 - The conversion of booleans from the IAM service responses to lowercase is done for all clients now.
