### PR TITLE
Publish logs per metric and remove faulty metric filter behavior

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_starter.py
+++ b/localstack/services/cloudwatch/cloudwatch_starter.py
@@ -1,7 +1,9 @@
+import moto.cloudwatch.models as cloudwatch_models
 import moto.cloudwatch.responses as cloudwatch_responses
 
 from localstack import config
 from localstack.services.infra import start_moto_server
+from localstack.utils.common import to_unique_items_list
 
 
 def apply_patches():
@@ -13,6 +15,22 @@ def apply_patches():
                 "</AlarmName><TreatMissingData>{{ alarm.treat_missing_data }}</TreatMissingData>",
             )
         )
+
+    def list_metrics(self, *args, **kwargs):
+        # Filter results to return only unique combinations of (Namespace, MetricName, Dimensions)
+        # TODO: This is hugely inefficient (!), especially as the number of metric data is growing.
+        #       Should be fixed upstream, or we should roll our own implementation!
+        def comparator(i1, i2):
+            i1 = (i1.namespace, i1.name, set((d.name, d.value) for d in i1.dimensions))
+            i2 = (i2.namespace, i2.name, set((d.name, d.value) for d in i2.dimensions))
+            return i1 == i2
+
+        token, metric_list = list_metrics_orig(self, *args, **kwargs)
+        metric_list = to_unique_items_list(metric_list, comparator=comparator)
+        return token, metric_list
+
+    list_metrics_orig = cloudwatch_models.CloudWatchBackend.list_metrics
+    cloudwatch_models.CloudWatchBackend.list_metrics = list_metrics
 
     # add put_composite_alarm
 

--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -58,7 +58,6 @@ class ProxyListenerCloudWatchLogs(ProxyListener):
 
 def publish_log_metrics_for_events(data):
     """Filter and publish log metrics for matching events"""
-    # TODO: create separate RegionBackend class to store state
     from moto.logs.models import logs_backends
 
     data = data if isinstance(data, dict) else json.loads(data)
@@ -68,31 +67,28 @@ def publish_log_metrics_for_events(data):
     client = aws_stack.connect_to_service("cloudwatch")
     for metric_filter in metric_filters:
         pattern = metric_filter.get("filterPattern", "")
-        if log_events_match_filter_pattern(pattern, log_events):
-            for tf in metric_filter.get("metricTransformations", []):
-                value = tf.get("metricValue") or "1"
-                if "$size" in value:
-                    LOG.info("Expression not yet supported for log filter metricValue: %s" % value)
-                value = float(value) if is_number(value) else 1
-                data = [{"MetricName": tf["metricName"], "Value": value}]
-                try:
-                    client.put_metric_data(Namespace=tf["metricNamespace"], MetricData=data)
-                except Exception as e:
-                    LOG.info("Unable to put metric data for matching CloudWatch log events: %s" % e)
+        transformations = metric_filter.get("metricTransformations", [])
+        matches = get_pattern_matcher(pattern)
+        for log_event in log_events:
+            if matches(pattern, log_event):
+                for tf in transformations:
+                    value = tf.get("metricValue") or "1"
+                    if "$size" in value:
+                        LOG.info(
+                            "Expression not yet supported for log filter metricValue: %s" % value
+                        )
+                    value = float(value) if is_number(value) else 1
+                    data = [{"MetricName": tf["metricName"], "Value": value}]
+                    try:
+                        client.put_metric_data(Namespace=tf["metricNamespace"], MetricData=data)
+                    except Exception as e:
+                        LOG.info(
+                            "Unable to put metric data for matching CloudWatch log events: %s" % e
+                        )
 
 
-def log_events_match_filter_pattern(filter_pattern, log_events):
-    def matches(event):
-        # TODO: implement full support for filter pattern expressions:
-        # https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
-        return re.match(filter_pattern, event.get("message") or "")
-
-    filter_pattern = (filter_pattern or "").strip() or "*"
-    filter_pattern = filter_pattern.replace("*", ".*")
-    log_events = log_events if isinstance(log_events, list) else [log_events]
-    for event in log_events:
-        if matches(event):
-            return True
+def get_pattern_matcher(_):
+    return lambda pattern, log_event: True
 
 
 # instantiate listener

--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -74,17 +74,13 @@ def publish_log_metrics_for_events(data):
                 for tf in transformations:
                     value = tf.get("metricValue") or "1"
                     if "$size" in value:
-                        LOG.info(
-                            "Expression not yet supported for log filter metricValue: %s" % value
-                        )
+                        LOG.info("Expression not yet supported for log filter metricValue", value)
                     value = float(value) if is_number(value) else 1
                     data = [{"MetricName": tf["metricName"], "Value": value}]
                     try:
                         client.put_metric_data(Namespace=tf["metricNamespace"], MetricData=data)
                     except Exception as e:
-                        LOG.info(
-                            "Unable to put metric data for matching CloudWatch log events: %s" % e
-                        )
+                        LOG.info("Unable to put metric data for matching CloudWatch log events", e)
 
 
 def get_pattern_matcher(_):

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -15,9 +15,11 @@ from localstack.utils.testutil import start_http_server
 if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
     from mypy_boto3_cloudformation import CloudFormationClient
+    from mypy_boto3_cloudwatch import CloudWatchClient
     from mypy_boto3_dynamodb import DynamoDBClient
     from mypy_boto3_es import ElasticsearchServiceClient
     from mypy_boto3_events import EventBridgeClient
+    from mypy_boto3_firehose import FirehoseClient
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_kinesis import KinesisClient
     from mypy_boto3_kms import KMSClient
@@ -131,6 +133,16 @@ def ses_client() -> "SESClient":
 @pytest.fixture(scope="class")
 def es_client() -> "ElasticsearchServiceClient":
     return _client("es")
+
+
+@pytest.fixture(scope="class")
+def firehose_client() -> "FirehoseClient":
+    return _client("firehose")
+
+
+@pytest.fixture(scope="class")
+def cloudwatch_client() -> "CloudWatchClient":
+    return _client("cloudwatch")
 
 
 @pytest.fixture

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -29,19 +29,24 @@ class TestCloudWatchLogs:
     # TODO make creation and description atomic to avoid possible flake?
     def test_create_and_delete_log_group(self, logs_client):
         test_name = f"test-log-group-{short_uid()}"
-        log_groups_before = logs_client.describe_log_groups().get("logGroups", [])
+        log_groups_before = logs_client.describe_log_groups(
+            logGroupNamePrefix="test-log-group-"
+        ).get("logGroups", [])
 
         logs_client.create_log_group(logGroupName=test_name)
 
-        log_groups_between = logs_client.describe_log_groups().get("logGroups", [])
-        assert log_groups_between == []
+        log_groups_between = logs_client.describe_log_groups(
+            logGroupNamePrefix="test-log-group-"
+        ).get("logGroups", [])
         assert poll_condition(
             lambda: len(log_groups_before) + 1 == len(log_groups_between), timeout=5.0, interval=0.5
         )
 
         logs_client.delete_log_group(logGroupName=test_name)
 
-        log_groups_after = logs_client.describe_log_groups().get("logGroups", [])
+        log_groups_after = logs_client.describe_log_groups(
+            logGroupNamePrefix="test-log-group-"
+        ).get("logGroups", [])
         assert poll_condition(
             lambda: len(log_groups_between) - 1 == len(log_groups_after), timeout=5.0, interval=0.5
         )

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import logging
-
 import pytest
 
 from localstack.constants import APPLICATION_AMZ_JSON_1_1
@@ -9,8 +7,6 @@ from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.utils import testutil
 from localstack.utils.common import now_utc, poll_condition, retry, short_uid
 from tests.integration.test_lambda import TEST_LAMBDA_LIBS, TEST_LAMBDA_PYTHON3
-
-LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -38,7 +34,7 @@ class TestCloudWatchLogs:
         logs_client.create_log_group(logGroupName=test_name)
 
         log_groups_between = logs_client.describe_log_groups().get("logGroups", [])
-        LOG.info(f"{log_groups_between=}")
+        assert log_groups_between == []
         assert poll_condition(
             lambda: len(log_groups_before) + 1 == len(log_groups_between), timeout=5.0, interval=0.5
         )
@@ -46,7 +42,6 @@ class TestCloudWatchLogs:
         logs_client.delete_log_group(logGroupName=test_name)
 
         log_groups_after = logs_client.describe_log_groups().get("logGroups", [])
-        LOG.info(f"{log_groups_after=}")
         assert poll_condition(
             lambda: len(log_groups_between) - 1 == len(log_groups_after), timeout=5.0, interval=0.5
         )

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 
 import pytest
 
@@ -8,6 +9,8 @@ from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.utils import testutil
 from localstack.utils.common import now_utc, poll_condition, retry, short_uid
 from tests.integration.test_lambda import TEST_LAMBDA_LIBS, TEST_LAMBDA_PYTHON3
+
+LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -35,6 +38,7 @@ class TestCloudWatchLogs:
         logs_client.create_log_group(logGroupName=test_name)
 
         log_groups_between = logs_client.describe_log_groups().get("logGroups", [])
+        LOG.info(f"{log_groups_between=}")
         assert poll_condition(
             lambda: len(log_groups_before) + 1 == len(log_groups_between), timeout=5.0, interval=0.5
         )
@@ -42,6 +46,7 @@ class TestCloudWatchLogs:
         logs_client.delete_log_group(logGroupName=test_name)
 
         log_groups_after = logs_client.describe_log_groups().get("logGroups", [])
+        LOG.info(f"{log_groups_after=}")
         assert poll_condition(
             lambda: len(log_groups_between) - 1 == len(log_groups_after), timeout=5.0, interval=0.5
         )

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -1,15 +1,14 @@
-import unittest
-
-from localstack.services.logs.logs_listener import log_events_match_filter_pattern
+from localstack.services.logs.logs_listener import get_pattern_matcher
 
 
-class CloudWatchLogsTest(unittest.TestCase):
-    def test_filter_expressions(self):
-        def assert_match(pattern, log_events, expected):
-            result = log_events_match_filter_pattern(pattern, log_events)
-            self.assertTrue(result) if expected else self.assertFalse(result)
+class TestCloudWatchLogs:
+    def test_get_pattern_matcher(self):
+        def assert_match(filter_pattern, log_event, expected):
+            matches = get_pattern_matcher(filter_pattern)
+            assert matches(filter_pattern, log_event) == expected
 
-        log_events = [{"message": "test123"}, {"message": "foo bar 456"}]
-        assert_match("*", log_events, True)
-        assert_match("", log_events, True)
-        assert_match("INVALID", log_events, False)
+        # expect to always be True until proper filter methods are available
+        assert_match('{$.message = "Failed"}', {"message": '{"message":"Failed"}'}, True)
+        assert_match("ERROR", {"message": "Failed"}, True)
+        assert_match("", {"message": "FooBar"}, True)
+        assert_match("[w1=Failed]", {"message": "Failed"}, True)


### PR DESCRIPTION
Removes filter behavior which isn't in [documented in the official docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html). In the community edition the change in the PR amounts to filters selecting all logs all the time. Proper filtering for the JSON filters will be added to Pro. 

Loosely related to #4826 