### PR TITLE
Extend escapeJavaScript(..) velocity template function and add more tests for it

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -193,6 +193,14 @@ class ApiInvocationContext:
                 self.auth_info["identity"] = {}
             return self.auth_info["identity"]
 
+    def is_websocket_request(self):
+        upgrade_header = str(self.headers.get("upgrade") or "")
+        return upgrade_header.lower() == "websocket"
+
+    def is_v1(self):
+        """Whether this is an API Gateway v1 request"""
+        return self.apigw_version == ApiGatewayVersion.V1
+
 
 class ProxyListenerApiGateway(ProxyListener):
     def forward_request(self, method, path, data, headers):
@@ -423,6 +431,10 @@ def set_api_id_stage_invocation_path(
     if all(values):
         return invocation_context
 
+    # skip if this is a websocket request
+    if invocation_context.is_websocket_request():
+        return invocation_context
+
     path = invocation_context.path
     headers = invocation_context.headers
 
@@ -600,7 +612,7 @@ def invoke_rest_api_integration_backend(
 
             # Sample request context:
             # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-as-simple-proxy-for-lambda.html#api-gateway-create-api-as-simple-proxy-for-lambda-test
-            request_context = get_lambda_event_request_context(invocation_context)
+            request_context = get_event_request_context(invocation_context)
             stage_variables = (
                 get_stage_variables(api_id, stage)
                 if not is_test_invoke_method(method, path)
@@ -903,7 +915,7 @@ def get_stage_variables(api_id: str, stage: str) -> Dict[str, str]:
     return response.get("variables")
 
 
-def get_lambda_event_request_context(invocation_context: ApiInvocationContext):
+def get_event_request_context(invocation_context: ApiInvocationContext):
     method = invocation_context.method
     path = invocation_context.path
     headers = invocation_context.headers

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -5,7 +5,14 @@ import re
 from six.moves.urllib.parse import quote_plus, unquote_plus
 
 from localstack import config
-from localstack.utils.common import extract_jsonpath, recurse_object, short_uid
+from localstack.utils.common import (
+    extract_jsonpath,
+    is_number,
+    json_safe,
+    recurse_object,
+    short_uid,
+    to_number,
+)
 
 
 class VelocityInput(object):
@@ -22,7 +29,11 @@ class VelocityInput(object):
         return extract_jsonpath(value, path)
 
     def json(self, path):
-        return json.dumps(self.path(path))
+        path = path or "$"
+        matching = self.path(path)
+        if isinstance(matching, (list, dict)):
+            matching = json_safe(matching)
+        return json.dumps(matching)
 
     def __getattr__(self, name):
         return self.value.get(name)
@@ -57,7 +68,16 @@ class VelocityUtil(object):
         return unquote_plus(s)
 
     def escapeJavaScript(self, s):
-        return str(str(s).replace('"', r"\"")).replace("'", r"\'")
+        try:
+            return json.dumps(json.loads(s))
+        except Exception:
+            primitive_types = (str, int, bool, float, type(None))
+            s = s if isinstance(s, primitive_types) else str(s)
+        if str(s).strip() in ["true", "false"]:
+            s = bool(s)
+        elif s not in [True, False] and is_number(s):
+            s = to_number(s)
+        return json.dumps(s)
 
 
 def render_velocity_template(template, context, variables={}, as_json=False):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1189,6 +1189,14 @@ def is_number(s: Any) -> bool:
         return False
 
 
+def to_number(s: Any) -> Union[int, float]:
+    """Cast the string representation of the given object to a number (int or float), or raise ValueError."""
+    try:
+        return int(str(s))
+    except ValueError:
+        return float(str(s))
+
+
 def is_mac_os() -> bool:
     return localstack.utils.run.is_mac_os()
 

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1220,7 +1220,7 @@ class TestAPIGateway(unittest.TestCase):
                 "requestTemplates": {
                     "application/json": """
                     #set($data = $util.escapeJavaScript($input.json('$')))
-                    {"input": "$data","stateMachineArn": "%s"}
+                    {"input": $data, "stateMachineArn": "%s"}
                     """
                     % sm_arn
                 }

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from localstack.services.apigateway import apigateway_listener
@@ -76,18 +77,34 @@ class ApiGatewayPathsTest(unittest.TestCase):
         self.assertEqual(None, result)
 
 
-class TestVelocityUtil(unittest.TestCase):
-    def test_render_template_values(self):
-        util = templating.VelocityUtil()
+def test_render_template_values():
+    util = templating.VelocityUtil()
 
-        encoded = util.urlEncode("x=a+b")
-        self.assertEqual("x%3Da%2Bb", encoded)
+    encoded = util.urlEncode("x=a+b")
+    assert encoded == "x%3Da%2Bb"
 
-        decoded = util.urlDecode("x=a+b")
-        self.assertEqual("x=a b", decoded)
+    decoded = util.urlDecode("x=a+b")
+    assert decoded == "x=a b"
 
-        escaped = util.escapeJavaScript("it's")
-        self.assertEqual(r"it\'s", escaped)
+    escape_tests = (
+        ("it's", '"it\'s"'),
+        ("0010", "10"),
+        ("true", "true"),
+        ("True", '"True"'),
+        ("1.021", "1.021"),
+        ("'''", "\"'''\""),
+        ('""', '""'),
+        ('"""', '"\\"\\"\\""'),
+        ('{"foo": 123}', '{"foo": 123}'),
+        ('{"foo"": 123}', '"{\\"foo\\"\\": 123}"'),
+        (1, "1"),
+        (True, "true"),
+    )
+    for string, expected in escape_tests:
+        escaped = util.escapeJavaScript(string)
+        assert escaped == expected
+        # we should be able to json.loads in all of the cases!
+        json.loads(escaped)
 
 
 class TestJSONPatch(unittest.TestCase):


### PR DESCRIPTION
Extend `escapeJavaScript(..)` velocity template function and add more tests for it. This function is required for API GW request/response mapping templates.

Partial fix for #4719