### PR TITLE
Correcting typos in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can also use docker directly and use the following command to get started wi
 docker run --rm -it -p 4566:4566 -p 4571:4571 localstack/localstack
 ```
 
-Note that this will pull the current nighty build from the master branch and **not** the latest supported version.
+Note that this will pull the current nightly build from the master branch and **not** the latest supported version.
 
 to run a throw-away container without any external volumes. To start a subset of services use `-e "SERVICES=dynamodb,s3"`.
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Please be aware that the following configurations may have severe security impli
 * `DISABLE_CUSTOM_CORS_S3`: Whether to disable CORS override by S3 (default: 0).
 * `DISABLE_CUSTOM_CORS_APIGATEWAY`: Whether to disable CORS override by apigateway (default: 0).
 * `EXTRA_CORS_ALLOWED_ORIGINS`: Comma-separated list of origins that are allowed to communicate with localstack.
-* `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Allow-Headers` CORS header
-* `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be be added to `Access-Control-Expose-Headers` CORS header
+* `EXTRA_CORS_ALLOWED_HEADERS`: Comma-separated list of header names to be added to `Access-Control-Allow-Headers` CORS header
+* `EXTRA_CORS_EXPOSE_HEADERS`: Comma-separated list of header names to be added to `Access-Control-Expose-Headers` CORS header
 
 ### Providers Configurations
 


### PR DESCRIPTION
While reading documentation recently, I discovered a few typos in the README.md file. This PR corrects what I found.

Note: Given that this is only documentation edits, I didn't think it worthwhile to configure the dev environment for tests or linting, so those haven't been run.
