### PR TITLE
use werkzeug Response object in asf

### DIFF
--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -49,8 +49,7 @@ class AwsApiListener(ProxyListener):
         # TODO: creating response objects in this way (re-using the requests library instead of an HTTP server
         #  framework) is a bit ugly, but it's the way that the edge proxy expects them.
         resp = Response()
-        resp._content = response["body"]
-        resp.status_code = response["status_code"]
-        resp.headers.update(response["headers"])
-        resp.headers["Content-Length"] = str(len(response["body"]))
+        resp._content = response.get_data()
+        resp.status_code = response.status_code
+        resp.headers.update(response.headers)
         return resp

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -47,7 +47,8 @@ def _botocore_serializer_integration_test(
     # Use the parser from botocore to parse the serialized response
     response_parser = create_parser(service.protocol)
     parsed_response = response_parser.parse(
-        serialized_response, service.operation_model(action).output_shape
+        serialized_response.to_readonly_response_dict(),
+        service.operation_model(action).output_shape,
     )
 
     # Check if the result is equal to the initial response params
@@ -101,7 +102,8 @@ def _botocore_error_serializer_integration_test(
     # Use the parser from botocore to parse the serialized response
     response_parser: ResponseParser = create_parser(service.protocol)
     parsed_response = response_parser.parse(
-        serialized_response, service.operation_model(action).output_shape
+        serialized_response.to_readonly_response_dict(),
+        service.operation_model(action).output_shape,
     )
 
     # Check if the result is equal to the initial response params

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -162,7 +162,7 @@ def test_skeleton_e2e_sqs_send_message():
     # Use the parser from botocore to parse the serialized response
     response_parser = create_parser(sqs_service.protocol)
     parsed_response = response_parser.parse(
-        result, sqs_service.operation_model("SendMessage").output_shape
+        result.to_readonly_response_dict(), sqs_service.operation_model("SendMessage").output_shape
     )
 
     # Test the ResponseMetadata and delete it afterwards
@@ -201,7 +201,7 @@ def test_skeleton_e2e_sqs_send_message_not_implemented():
     # Use the parser from botocore to parse the serialized response
     response_parser = create_parser(sqs_service.protocol)
     parsed_response = response_parser.parse(
-        result, sqs_service.operation_model("SendMessage").output_shape
+        result.to_readonly_response_dict(), sqs_service.operation_model("SendMessage").output_shape
     )
 
     # Test the ResponseMetadata
@@ -244,7 +244,7 @@ def test_dispatch_common_service_exception():
     # Use the parser from botocore to parse the serialized response
     response_parser = create_parser(sqs_service.protocol)
     parsed_response = response_parser.parse(
-        result, sqs_service.operation_model("SendMessage").output_shape
+        result.to_readonly_response_dict(), sqs_service.operation_model("SendMessage").output_shape
     )
 
     assert "Error" in parsed_response
@@ -275,7 +275,7 @@ def test_dispatch_missing_method_returns_internal_failure():
     # Use the parser from botocore to parse the serialized response
     response_parser = create_parser(sqs_service.protocol)
     parsed_response = response_parser.parse(
-        result, sqs_service.operation_model("SendMessage").output_shape
+        result.to_readonly_response_dict(), sqs_service.operation_model("SendMessage").output_shape
     )
     assert "Error" in parsed_response
     assert parsed_response["Error"] == {


### PR DESCRIPTION
This PR changes the `HttpResponse` object in the ASF, which used to be a simple TypedDict, into a werkzeug Response object, which is convenient to use, and is also wsgi compliant.