### PR TITLE
use werkzeug Request object in asf

### DIFF
--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -1,9 +1,8 @@
 import functools
 import json
 import sys
-from typing import Any, Callable, Dict, NamedTuple, Optional, Type
-
-from werkzeug.wrappers import Response
+from io import BytesIO
+from typing import IO, Any, Callable, Dict, NamedTuple, Optional, Type, Union
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -11,6 +10,10 @@ else:
     from typing_extensions import TypedDict
 
 from botocore.model import OperationModel, ServiceModel
+from werkzeug.datastructures import Headers
+from werkzeug.sansio.request import Request as _SansIORequest
+from werkzeug.utils import cached_property
+from werkzeug.wrappers import Response
 
 
 class ServiceRequest(TypedDict):
@@ -49,11 +52,121 @@ class CommonServiceException(ServiceException):
 Operation = Type[ServiceRequest]
 
 
-class HttpRequest(TypedDict):
-    path: str
-    method: str
-    headers: Dict[str, str]
-    body: bytes
+class HttpRequest(_SansIORequest):
+    """
+    A HttpRequest object. Creates basic compatibility with werkzeug's WSGI compliant Request objects, but also allows
+    simple requests without a web server environment.
+    """
+
+    def __init__(
+        self,
+        method: str = "GET",
+        path: str = "",
+        headers: Union[Dict, Headers] = None,
+        body: Union[bytes, str] = None,
+        scheme: str = "http",
+        root_path: str = "/",
+        query_string: bytes = b"",
+        remote_addr: str = None,
+    ):
+        if not headers:
+            self.headers = Headers()
+        elif isinstance(headers, Headers):
+            self.headers = headers
+        else:
+            self.headers = Headers(headers)
+
+        if not body:
+            self._body = b""
+        elif isinstance(body, str):
+            self._body = body.encode("utf-8")
+        else:
+            self._body = body
+
+        super(HttpRequest, self).__init__(
+            method=method,
+            scheme=scheme,
+            server=("127.0.0.1", None),
+            root_path=root_path,
+            path=path,
+            query_string=query_string,  # TODO: create query string from path
+            headers=headers,
+            remote_addr=remote_addr,
+        )
+
+    # properties for compatibility with werkzeug wsgi Request wrapper
+
+    @cached_property
+    def stream(self) -> IO[bytes]:
+        return BytesIO(self._body)
+
+    @cached_property
+    def data(self) -> bytes:
+        return self.get_data()
+
+    @cached_property
+    def json(self) -> Optional[Any]:
+        return self.get_json()
+
+    @property
+    def form(self):
+        raise NotImplementedError
+
+    @property
+    def values(self):
+        raise NotImplementedError
+
+    @property
+    def files(self):
+        raise NotImplementedError
+
+    @cached_property
+    def url_root(self) -> str:
+        return self.root_url
+
+    def get_data(
+        self, cache: bool = True, as_text: bool = False, parse_form_data: bool = False
+    ) -> Union[bytes, str]:
+        # copied from werkzeug.wrappers.Request
+        rv = getattr(self, "_cached_data", None)
+        if rv is None:
+            if parse_form_data:
+                self._load_form_data()
+            rv = self.stream.read()
+            if cache:
+                self._cached_data = rv
+        if as_text:
+            rv = rv.decode(self.charset, self.encoding_errors)
+
+        return rv  # type: ignore
+
+    _cached_json: Optional[None] = None
+
+    def get_json(
+        self, force: bool = False, silent: bool = False, cache: bool = True
+    ) -> Optional[Any]:
+
+        if cache and self._cached_json:
+            return self._cached_json
+
+        if not (force or self.is_json):
+            return None
+
+        try:
+            doc = json.loads(self.get_data(cache=cache))
+            if cache:
+                self._cached_json = doc
+            return doc
+        except ValueError:
+            if silent:
+                return None
+            raise
+
+    def _load_form_data(self):
+        pass
+
+    def close(self) -> None:
+        pass
 
 
 class HttpResponse(Response):

--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -10,7 +10,7 @@ from localstack.utils.aws.request_context import extract_region_from_headers
 
 
 def get_region(request: HttpRequest) -> str:
-    return extract_region_from_headers(request["headers"])
+    return extract_region_from_headers(request.headers)
 
 
 def get_account_id(_: HttpRequest) -> str:

--- a/tests/unit/aws/test_skeleton.py
+++ b/tests/unit/aws/test_skeleton.py
@@ -10,6 +10,7 @@ from botocore.parsers import create_parser
 
 from localstack.aws.api import (
     CommonServiceException,
+    HttpRequest,
     RequestContext,
     ServiceException,
     ServiceRequest,
@@ -151,12 +152,14 @@ def test_skeleton_e2e_sqs_send_message():
     context.account = "test"
     context.region = "us-west-1"
     context.service = sqs_service
-    context.request = {
-        "method": "POST",
-        "path": "/",
-        "body": "Action=SendMessage&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue&MessageBody=%7B%22foo%22%3A+%22bared%22%7D&DelaySeconds=2",
-        "headers": _get_sqs_request_headers(),
-    }
+    context.request = HttpRequest(
+        **{
+            "method": "POST",
+            "path": "/",
+            "body": "Action=SendMessage&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue&MessageBody=%7B%22foo%22%3A+%22bared%22%7D&DelaySeconds=2",
+            "headers": _get_sqs_request_headers(),
+        }
+    )
     result = skeleton.invoke(context)
 
     # Use the parser from botocore to parse the serialized response
@@ -190,12 +193,14 @@ def test_skeleton_e2e_sqs_send_message_not_implemented():
     context.account = "test"
     context.region = "us-west-1"
     context.service = sqs_service
-    context.request = {
-        "method": "POST",
-        "path": "/",
-        "body": "Action=SendMessage&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue&MessageBody=%7B%22foo%22%3A+%22bared%22%7D&DelaySeconds=2",
-        "headers": _get_sqs_request_headers(),
-    }
+    context.request = HttpRequest(
+        **{
+            "method": "POST",
+            "path": "/",
+            "body": "Action=SendMessage&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue&MessageBody=%7B%22foo%22%3A+%22bared%22%7D&DelaySeconds=2",
+            "headers": _get_sqs_request_headers(),
+        }
+    )
     result = skeleton.invoke(context)
 
     # Use the parser from botocore to parse the serialized response
@@ -233,12 +238,14 @@ def test_dispatch_common_service_exception():
     context.account = "test"
     context.region = "us-west-1"
     context.service = sqs_service
-    context.request = {
-        "method": "POST",
-        "path": "/",
-        "body": "Action=DeleteQueue&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue",
-        "headers": _get_sqs_request_headers(),
-    }
+    context.request = HttpRequest(
+        **{
+            "method": "POST",
+            "path": "/",
+            "body": "Action=DeleteQueue&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue",
+            "headers": _get_sqs_request_headers(),
+        }
+    )
     result = skeleton.invoke(context)
 
     # Use the parser from botocore to parse the serialized response
@@ -264,12 +271,14 @@ def test_dispatch_missing_method_returns_internal_failure():
     context.account = "test"
     context.region = "us-west-1"
     context.service = sqs_service
-    context.request = {
-        "method": "POST",
-        "path": "/",
-        "body": "Action=DeleteQueue&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue",
-        "headers": _get_sqs_request_headers(),
-    }
+    context.request = HttpRequest(
+        **{
+            "method": "POST",
+            "path": "/",
+            "body": "Action=DeleteQueue&Version=2012-11-05&QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue",
+            "headers": _get_sqs_request_headers(),
+        }
+    )
 
     result = skeleton.invoke(context)
     # Use the parser from botocore to parse the serialized response


### PR DESCRIPTION
This PR replaces the asf `HttpRequest` typed dict with  a modified version of `werkzeug.sansio.Request` that creates a good adapter between WSGI and localstack. Our `HttpRequest`is a drop-in replacement for werkzeug's WSGI request wrapper, so we can program against the same interface, but doesn't need the underlying WSGI IO (which is necessary when creating `HttpRequest` objects from within the edge proxy).
