### PR TITLE
Fix cloudformation not creating multi route table associations

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -147,7 +147,7 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
         gw_id = self.resolve_refs_recursively(stack_name, props.get("GatewayId"), resources)
         route_tables = client.describe_route_tables()["RouteTables"]
         route_table = ([t for t in route_tables if t["RouteTableId"] == table_id] or [None])[0]
-        subnet_id = props.get("SubnetId")
+        subnet_id = self.resolve_refs_recursively(stack_name, props.get("SubnetId"), resources)
         if route_table:
             associations = route_table.get("Associations", [])
             association = [a for a in associations if a.get("GatewayId") == gw_id]
@@ -342,7 +342,7 @@ class EC2VPC(GenericBaseModel):
                     ]
                 )
                 for rt in resp["RouteTables"]:
-                    for assoc in rt["Associations"]:
+                    for assoc in rt.get("Associations", []):
                         ec2_client.disassociate_route_table(
                             AssociationId=assoc["RouteTableAssociationId"]
                         )

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -147,9 +147,16 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
         gw_id = self.resolve_refs_recursively(stack_name, props.get("GatewayId"), resources)
         route_tables = client.describe_route_tables()["RouteTables"]
         route_table = ([t for t in route_tables if t["RouteTableId"] == table_id] or [None])[0]
+        subnet_id = props.get("SubnetId")
         if route_table:
             associations = route_table.get("Associations", [])
             association = [a for a in associations if a.get("GatewayId") == gw_id]
+            if subnet_id:
+                association = [
+                    a
+                    for a in associations
+                    if a.get("GatewayId") == gw_id and a.get("SubnetId") == subnet_id
+                ]
             return (association or [None])[0]
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
@@ -165,7 +172,11 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
                     "RouteTableId": "RouteTableId",
                     "SubnetId": "SubnetId",
                 },
-            }
+            },
+            "delete": {
+                "function": "disassociate_route_table",
+                "parameters": {"AssociationId": "RouteTableAssociationId"},
+            },
         }
 
 
@@ -331,6 +342,10 @@ class EC2VPC(GenericBaseModel):
                     ]
                 )
                 for rt in resp["RouteTables"]:
+                    for assoc in rt["Associations"]:
+                        ec2_client.disassociate_route_table(
+                            AssociationId=assoc["RouteTableAssociationId"]
+                        )
                     ec2_client.delete_route_table(RouteTableId=rt["RouteTableId"])
 
         return {

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -155,7 +155,7 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
                 association = [
                     a
                     for a in associations
-                    if a.get("GatewayId") == gw_id and a.get("SubnetId") == subnet_id
+                    if a.get("SubnetId") == subnet_id
                 ]
             return (association or [None])[0]
 

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -152,11 +152,7 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
             associations = route_table.get("Associations", [])
             association = [a for a in associations if a.get("GatewayId") == gw_id]
             if subnet_id:
-                association = [
-                    a
-                    for a in associations
-                    if a.get("SubnetId") == subnet_id
-                ]
+                association = [a for a in associations if a.get("SubnetId") == subnet_id]
             return (association or [None])[0]
 
     def get_physical_resource_id(self, attribute=None, **kwargs):

--- a/tests/integration/templates/template37.yaml
+++ b/tests/integration/templates/template37.yaml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  Environment:
+    Type: String
+    Default: 'companyname-ci'
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      CidrBlock: "100.0.0.0/20"
+
+  RouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: VPC
+      Tags:
+      - Key: env
+        Value: production
+
+  SubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - 0
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock: "100.0.0.0/24"
+      VpcId:
+        Ref: VPC
+
+  SubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone:
+        Fn::Select:
+        - 0
+        - Fn::GetAZs:
+            Ref: AWS::Region
+      CidrBlock: "100.0.2.0/24"
+      VpcId:
+        Ref: VPC
+
+  RouteTableAssociationA:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: SubnetA
+      RouteTableId:
+        Ref: RouteTable
+      Main: false
+    DependsOn:
+      - SubnetA
+      - RouteTable
+
+  RouteTableAssociationB:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId:
+        Ref: SubnetB
+      RouteTableId:
+        Ref: RouteTable
+      Main: false
+    DependsOn:
+      - SubnetB
+      - RouteTable
+
+
+Outputs:
+  PublicRoute:
+    Value:
+      Ref: PublicRoute
+    Export:
+      Name: 'publicRoute-identify'

--- a/tests/integration/templates/template37.yaml
+++ b/tests/integration/templates/template37.yaml
@@ -1,8 +1,4 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Parameters:
-  Environment:
-    Type: String
-    Default: 'companyname-ci'
 
 Resources:
   VPC:
@@ -71,8 +67,6 @@ Resources:
 
 
 Outputs:
-  PublicRoute:
+  RouteTable:
     Value:
-      Ref: PublicRoute
-    Export:
-      Name: 'publicRoute-identify'
+      Ref: RouteTable

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2409,19 +2409,17 @@ class CloudFormationTest(unittest.TestCase):
     def test_cfn_with_multiple_route_table_associations(self):
         ec2_client = aws_stack.connect_to_service("ec2")
 
-        resp = ec2_client.describe_vpcs()
-        vpcs_before = [vpc["VpcId"] for vpc in resp["Vpcs"]]
-
         template = load_file(os.path.join(THIS_FOLDER, "templates", "template37.yaml"))
 
         stack_name = "stack-%s" % short_uid()
+
         details = create_and_await_stack(StackName=stack_name, TemplateBody=template)
-        route_table_id = [out["OutputValue"] for out in details['Outputs'] if out["OutputKey"] == "RouteTable"][0]
+        route_table_id = [
+            out["OutputValue"] for out in details["Outputs"] if out["OutputKey"] == "RouteTable"
+        ][0]
         route_table = ec2_client.describe_route_tables(
-                Filters=[
-                    {"Name": "route-table-id", "Values": [route_table_id]}
-                ]
-        )['RouteTables'][0]
+            Filters=[{"Name": "route-table-id", "Values": [route_table_id]}]
+        )["RouteTables"][0]
 
         # # Cloudformation Template will create more than one route table 2 in template + default
         self.assertEqual(2, len(route_table["Associations"]))

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2405,3 +2405,30 @@ class CloudFormationTest(unittest.TestCase):
 
         # Clean up
         self.cleanup(stack_name)
+
+    def test_cfn_with_multiple_route_table_associations(self):
+        ec2_client = aws_stack.connect_to_service("ec2")
+
+        resp = ec2_client.describe_vpcs()
+        vpcs_before = [vpc["VpcId"] for vpc in resp["Vpcs"]]
+
+        template = load_file(os.path.join(THIS_FOLDER, "templates", "template37.yaml"))
+
+        stack_name = "stack-%s" % short_uid()
+        create_and_await_stack(StackName=stack_name, TemplateBody=template)
+        resp = ec2_client.describe_vpcs()
+        vpcs = [vpc["VpcId"] for vpc in resp["Vpcs"] if vpc["VpcId"] not in vpcs_before]
+        self.assertEqual(1, len(vpcs))
+
+        resp = ec2_client.describe_route_tables(
+            Filters=[
+                {"Name": "vpc-id", "Values": [vpcs[0]]},
+                {"Name": "tag:env", "Values": ["production"]},
+            ]
+        )
+
+        # Cloudformation Template will create more than one route table 2 in template + default
+        self.assertEqual(2, len(resp["RouteTables"][0]["Associations"]))
+
+        # Clean up
+        self.cleanup(stack_name)


### PR DESCRIPTION
Subnet Route Table association were limited to one per route table, this will add a check for subnet id.

Similar fix as for route table.
