### PR TITLE
fix arch check in install_go_lambda_runtime

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -414,7 +414,7 @@ def install_go_lambda_runtime():
 
     if system not in ["linux"]:
         raise ValueError("unsupported os %s for awslambda-go-runtime" % system)
-    if arch not in ["amd64", "arm32"]:
+    if arch not in ["amd64", "arm64"]:
         raise ValueError("unsupported arch %s for awslambda-go-runtime" % arch)
 
     url = GO_RUNTIME_DOWNLOAD_URL_TEMPLATE.format(


### PR DESCRIPTION
Addresses the comment in https://github.com/localstack/localstack/pull/4754#pullrequestreview-806142105

~~currently we have no way to test this though.~~

for full compatibility we also have to
- [x] compile the examples in https://github.com/localstack/awslamba-go-runtime for arm64
- [x] pick the right one in https://github.com/localstack/localstack/blob/10ce50ce2abe65973ed2d97233df5e1a717d26f1/tests/integration/test_lambda.py#L135-L137
- [x] re-enable https://github.com/localstack/localstack/blob/10ce50ce2abe65973ed2d97233df5e1a717d26f1/tests/integration/test_lambda.py#L1691-L1692