### PR TITLE
Fix STS response content type

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -39,7 +39,11 @@ from localstack.services.s3.s3_utils import (
 )
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_responses import create_sqs_system_attributes, requests_response
+from localstack.utils.aws.aws_responses import (
+    create_sqs_system_attributes,
+    is_html_response,
+    requests_response,
+)
 from localstack.utils.common import (
     clone,
     get_service_protocol,
@@ -1516,9 +1520,7 @@ class ProxyListenerS3(PersistingProxyListener):
                 # fix content-type: https://github.com/localstack/localstack/issues/618
                 #                   https://github.com/localstack/localstack/issues/549
                 #                   https://github.com/localstack/localstack/issues/854
-                if "text/html" in response.headers.get(
-                    "Content-Type", ""
-                ) and not response_content_str.lower().startswith("<!doctype html"):
+                if not is_html_response(response.headers, response_content_str):
                     response.headers["Content-Type"] = "application/xml; charset=utf-8"
 
                 reset_content_length = True

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -41,7 +41,7 @@ from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import (
     create_sqs_system_attributes,
-    is_html_response,
+    is_invalid_html_response,
     requests_response,
 )
 from localstack.utils.common import (
@@ -1520,7 +1520,8 @@ class ProxyListenerS3(PersistingProxyListener):
                 # fix content-type: https://github.com/localstack/localstack/issues/618
                 #                   https://github.com/localstack/localstack/issues/549
                 #                   https://github.com/localstack/localstack/issues/854
-                if not is_html_response(response.headers, response_content_str):
+
+                if is_invalid_html_response(response.headers, response_content_str):
                     response.headers["Content-Type"] = "application/xml; charset=utf-8"
 
                 reset_content_length = True

--- a/localstack/services/sts/sts_listener.py
+++ b/localstack/services/sts/sts_listener.py
@@ -1,7 +1,7 @@
 from requests.models import Request
 
 from localstack.services.generic_proxy import ProxyListener
-from localstack.utils.aws.aws_responses import MessageConversion
+from localstack.utils.aws.aws_responses import MessageConversion, is_html_response
 
 
 class ProxyListenerSTS(ProxyListener):
@@ -22,6 +22,9 @@ class ProxyListenerSTS(ProxyListener):
             MessageConversion.fix_error_codes(method, data, response)
             # fix content-length header
             response.headers["Content-Length"] = str(len(response._content))
+            # fix content-type header
+            if not is_html_response(response.headers, response._content):
+                response.headers["Content-Type"] = "text/xml"
 
 
 # instantiate listener

--- a/localstack/services/sts/sts_listener.py
+++ b/localstack/services/sts/sts_listener.py
@@ -1,7 +1,7 @@
 from requests.models import Request
 
 from localstack.services.generic_proxy import ProxyListener
-from localstack.utils.aws.aws_responses import MessageConversion, is_html_response
+from localstack.utils.aws.aws_responses import MessageConversion, is_invalid_html_response
 
 
 class ProxyListenerSTS(ProxyListener):
@@ -23,7 +23,7 @@ class ProxyListenerSTS(ProxyListener):
             # fix content-length header
             response.headers["Content-Length"] = str(len(response._content))
             # fix content-type header
-            if not is_html_response(response.headers, response._content):
+            if is_invalid_html_response(response.headers, response._content):
                 response.headers["Content-Type"] = "text/xml"
 
 

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -226,9 +226,9 @@ def is_json_request(req_headers: Dict) -> bool:
     return "json" in ctype or "json" in accept
 
 
-def is_html_response(headers, content) -> bool:
+def is_invalid_html_response(headers, content) -> bool:
     content_type = headers.get("Content-Type", "")
-    return "text/html" in content_type and str_startswith_ignore_case(content, "<!doctype html")
+    return "text/html" in content_type and not str_startswith_ignore_case(content, "<!doctype html")
 
 
 def raise_exception_if_error_response(response):

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -26,6 +26,7 @@ from localstack.utils.common import (
     json_safe,
     replace_response_content,
     short_uid,
+    str_startswith_ignore_case,
     to_bytes,
     to_str,
     truncate,
@@ -223,6 +224,11 @@ def is_json_request(req_headers: Dict) -> bool:
     ctype = req_headers.get("Content-Type", "")
     accept = req_headers.get("Accept", "")
     return "json" in ctype or "json" in accept
+
+
+def is_html_response(headers, content) -> bool:
+    content_type = headers.get("Content-Type", "")
+    return "text/html" in content_type and str_startswith_ignore_case(content, "<!doctype html")
 
 
 def raise_exception_if_error_response(response):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1442,6 +1442,10 @@ def str_remove(string, index, end_index=None):
     return "%s%s" % (string[:index], string[end_index:])
 
 
+def str_startswith_ignore_case(value: str, prefix: str) -> bool:
+    return value[: len(prefix)].lower() == prefix.lower()
+
+
 def last_index_of(array, value):
     """Return the last index of `value` in the given list, or -1 if it does not exist."""
     result = -1


### PR DESCRIPTION
STS responses contain `Content-Type: text/html` header, but AWS returns `text/xml`. 
Some applications (e.g. Hashicorp Vault) rely on `text/xml` and don't work properly. 