### PR TITLE
s3: fix deleting objects from non-existing bucket

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -660,7 +660,12 @@ def fix_delete_objects_response(bucket_name, method, parsed_path, data, headers,
     content = to_str(response._content)
     if "<Error>" not in content:
         return
+
     result = xmltodict.parse(content).get("DeleteResult")
+    # can be NoSuchBucket error
+    if not result:
+        return
+
     errors = result.get("Error")
     errors = errors if isinstance(errors, list) else [errors]
     deleted = result.get("Deleted")

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -864,6 +864,14 @@ class TestS3(unittest.TestCase):
         # clean up
         self._delete_bucket(bucket_name)
 
+    def test_delete_non_existing_keys_in_non_existing_bucket(self):
+        with self.assertRaises(ClientError) as ctx:
+            self.s3_client.delete_objects(
+                Bucket="non-existent-bucket",
+                Delete={"Objects": [{"Key": "dummy1"}, {"Key": "dummy2"}]},
+            )
+        self.assertEqual("NoSuchBucket", ctx.exception.response["Error"]["Code"])
+
     def test_s3_request_payer(self):
         bucket_name = "test-%s" % short_uid()
         self.s3_client.create_bucket(Bucket=bucket_name)
@@ -877,7 +885,7 @@ class TestS3(unittest.TestCase):
         self.assertEqual("Requester", response["Payer"])
         self._delete_bucket(bucket_name)
 
-    def delete_non_existing_bucket(self):
+    def test_delete_non_existing_bucket(self):
         bucket_name = "test-%s" % short_uid()
         with self.assertRaises(ClientError) as ctx:
             self.s3_client.delete_bucket(Bucket=bucket_name)


### PR DESCRIPTION
While investigating https://github.com/localstack/localstack/issues/4639 found this.


```sh
# while deleting objects from the non-existing bucket
awslocal s3api delete-objects --bucket test-non-existing --delete '{"Objects":[{"Key":"test.txt"}]}' 

# server throws error
2021-11-18T07:51:59.155:WARNING:localstack.utils.server.http2_server: Error in proxy handler for request POST http://localhost:4566/test-non-existing?delete: 'NoneType' object has no attribute 'get' Traceback (most recent call last):
  File "/opt/localstack/localstack/localstack/utils/server/http2_server.py", line 159, in index
    result = await run_sync(handler, request, data)
  File "/opt/localstack/localstack/localstack/utils/async_utils.py", line 86, in run_sync
    return await loop.run_in_executor(thread_pool, copy_context().run, func_wrapped)
  File "/opt/localstack/localstack/localstack/utils/run.py", line 150, in run
    result = self.func(self.params, **kwargs)
  File "/opt/localstack/localstack/localstack/utils/async_utils.py", line 31, in _run
    return fn(*args, **kwargs)
  File "/opt/localstack/localstack/localstack/services/generic_proxy.py", line 669, in handler
    response = modify_and_forward(
  File "/opt/localstack/localstack/localstack/utils/aws/request_context.py", line 205, in modify_and_forward
    result = modify_and_forward_orig(
  File "/opt/localstack/localstack/localstack/services/generic_proxy.py", line 338, in modify_and_forward
    listener_result = listener.forward_request(
  File "/opt/localstack/localstack/localstack/services/edge.py", line 172, in forward_request
    result = do_forward_request(api, method, path, data, headers, port=port)
  File "/opt/localstack/localstack/localstack/services/edge.py", line 227, in do_forward_request
    result = do_forward_request_inmem(api, method, path, data, headers, port=port)
  File "/opt/localstack/localstack/localstack/services/edge.py", line 250, in do_forward_request_inmem
    response = modify_and_forward(
  File "/opt/localstack/localstack/localstack/services/generic_proxy.py", line 414, in modify_and_forward
    updated_response = update_listener.return_response(**kwargs)
  File "/opt/localstack/localstack/localstack/services/s3/s3_listener.py", line 1446, in return_response
    fix_delete_objects_response(bucket_name, method, parsed, data, headers, response)
  File "/opt/localstack/localstack/localstack/services/s3/s3_listener.py", line 664, in fix_delete_objects_response
    errors = result.get("Error")
AttributeError: 'NoneType' object has no attribute 'get'
```