### PR TITLE
Use VIRTUAL_ENV env var for LOCALSTACK_VENV_FOLDER constant

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -48,12 +48,15 @@ LOCALSTACK_ROOT_FOLDER = os.path.realpath(os.path.join(MODULE_MAIN_PATH, ".."))
 INSTALL_DIR_INFRA = os.path.join(MODULE_MAIN_PATH, "infra")
 
 # virtualenv folder
-LOCALSTACK_VENV_FOLDER = os.path.join(LOCALSTACK_ROOT_FOLDER, ".venv")
-if not os.path.isdir(LOCALSTACK_VENV_FOLDER):
-    # assuming this package lives here: <python>/lib/pythonX.X/site-packages/localstack/
-    LOCALSTACK_VENV_FOLDER = os.path.realpath(
-        os.path.join(LOCALSTACK_ROOT_FOLDER, "..", "..", "..")
-    )
+LOCALSTACK_VENV_FOLDER = os.environ.get("VIRTUAL_ENV")
+if not LOCALSTACK_VENV_FOLDER:
+    # fallback to the previous logic
+    LOCALSTACK_VENV_FOLDER = os.path.join(LOCALSTACK_ROOT_FOLDER, ".venv")
+    if not os.path.isdir(LOCALSTACK_VENV_FOLDER):
+        # assuming this package lives here: <python>/lib/pythonX.X/site-packages/localstack/
+        LOCALSTACK_VENV_FOLDER = os.path.realpath(
+            os.path.join(LOCALSTACK_ROOT_FOLDER, "..", "..", "..")
+        )
 
 # API Gateway path to indicate a user request sent to the gateway
 PATH_USER_REQUEST = "_user_request_"


### PR DESCRIPTION
https://docs.python.org/3/library/venv.html
> When a virtual environment is active, the VIRTUAL_ENV environment variable
> is set to the path of the virtual environment. This can be used to check
> if one is running inside a virtual environment.

I use a different directory for my virtual environment, and by coincidence, I use `.venv` file for project-based settings: https://github.com/naspeh/dotfiles/blob/eaf47f55f2e4b7f40e94f178fbe7a29f6c3b9421/env/zshrc#L77-L89

I set `export VENV_DIR=../env/` for `Makefile`, but we have this hardcoded `.venv` in `localstack.constants` that caused some issues while I was bootstrapping the project and running tests.  As you can see from docs, `VIRTUAL_ENV` is a good way to check the virtual environment. I keep existing logic as a fallback.

It is supposed to be my first PR in `localstack`, but I postponed it using `git stash`, and now I've prepared the fix.