### PR TITLE
pin docker base images, enable dependabot to update once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_TYPE=full
 
 # java-builder: Stage to build a custom JRE (with jlink)
-FROM python:3.8-slim-buster as java-builder
+FROM python:3.8.12-slim-buster@sha256:d328c165606db4773f8242972ae82c2f7312478a5071090a768d0e9fc63fab51 as java-builder
 ARG TARGETARCH
 
 # install OpenJDK 11
@@ -32,7 +32,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java, maven,...)
-FROM python:3.8-slim-buster as base
+FROM python:3.8.12-slim-buster@sha256:d328c165606db4773f8242972ae82c2f7312478a5071090a768d0e9fc63fab51 as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies


### PR DESCRIPTION
With the recent refactoring of how we build the docker images (https://github.com/localstack/localstack/pull/4754), we do not squash the image anymore.
However, the base image (`python:3.8-slim-buster`) is updated quite frequently. Therefore, we don't really benefit from the layer caching (both the local cache when pulling as well as the remote cache when building), since the whole cache is invalidated with an update of the base image.

This commit explicitly pins the docker base images by referencing them by their manifest-list digest:
```
$ docker buildx imagetools inspect docker.io/library/python:3.8.12-slim-buster
Name:      docker.io/library/python:3.8.12-slim-buster
...
Digest:    sha256:d328c165606db4773f8242972ae82c2f7312478a5071090a768d0e9fc63fab51
...
```
(It needs to be the manifest-list's digest, otherwise a specific platform image would be referenced leading in build failures on other platforms.)

The downside of pinning the digest is that the base image is not updated anymore (updates to the - mutable - tags are ignored).
Therefore this PR also enables GitHub's dependabot with the following config:
- It only updates the root Dockerfile.
- The Docker/Python dependency updates are limited to patch updates.
- The updates are scheduled to be executed every Monday morning at 9:00 UTC.
- The resulting PRs need to be manually approved and merged. (We could think about configuring some kind of auto-merge in the future, [but we would need to enable the automerge GitHub feature](https://github.com/marketplace/actions/fetch-metadata-from-dependabot-prs#enabling-auto-merge).)