### PR TITLE
s3: merge tests for presigned url signature authentication

### DIFF
--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -248,11 +248,10 @@ def authenticate_presign_url(method, path, headers, data=None):
     request_url = "{}://{}{}".format(parsed.scheme, parsed.netloc, parsed.path)
     # Fix https://github.com/localstack/localstack/issues/3912
     # urlencode method replaces white spaces with plus sign cause signature calculation to fail
-    request_url = (
-        "%s?%s" % (request_url, urlencode(query_string, quote_via=urlparse.quote, safe=" "))
-        if query_string
-        else request_url
+    query_string_encoded = (
+        urlencode(query_string, quote_via=urlparse.quote, safe=" ") if query_string else None
     )
+    request_url = "%s?%s" % (request_url, query_string_encoded) if query_string else request_url
     if forwarded_for:
         request_url = re.sub("://[^/]+", "://%s" % forwarded_for, request_url)
 
@@ -286,7 +285,7 @@ def authenticate_presign_url(method, path, headers, data=None):
             request_dict["url_path"],
         )
         request_dict["url"] = (
-            "%s?%s" % (request_dict["url"], urlencode(query_string))
+            "%s?%s" % (request_dict["url"], query_string_encoded)
             if query_string
             else request_dict["url"]
         )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -9,6 +9,7 @@ import time
 import unittest
 import uuid
 from io import BytesIO
+from unittest.mock import patch
 from urllib.parse import parse_qs, quote
 
 import boto3
@@ -1887,14 +1888,6 @@ class TestS3(unittest.TestCase):
         # clean up
         self._delete_bucket(bucket_name, [])
 
-    def test_presigned_url_signature_authentication(self):
-        old_config = config.S3_SKIP_SIGNATURE_VALIDATION
-        try:
-            config.S3_SKIP_SIGNATURE_VALIDATION = False
-            self.run_presigned_url_signature_authentication()
-        finally:
-            config.S3_SKIP_SIGNATURE_VALIDATION = old_config
-
     # Note: This test may have side effects (via `s3_client.meta.events.register(..)`) and
     # may not be suitable for parallel execution
     def test_presign_with_query_params(self):
@@ -1926,8 +1919,8 @@ class TestS3(unittest.TestCase):
         finally:
             s3_client.meta.events.unregister("before-sign.s3.GetObject", add_query_param)
 
-    def run_presigned_url_signature_authentication(self):
-
+    @patch.object(config, "S3_SKIP_SIGNATURE_VALIDATION", False)
+    def test_presigned_url_signature_authentication(self):
         client = boto3.client(
             "s3",
             endpoint_url=config.get_edge_url(),
@@ -1942,259 +1935,26 @@ class TestS3(unittest.TestCase):
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
         )
-
-        OBJECT_KEY = "temp 1.txt"
-        OBJECT_DATA = "this should be found in when you download {}.".format(OBJECT_KEY)
-        BUCKET = f"test-{short_uid()}"
-        EXPIRES = 4
-
-        def make_v2_url_invalid(url):
-            parsed = urlparse.urlparse(url)
-            query_params = parse_qs(parsed.query)
-            url = "{}/{}/{}?AWSAccessKeyId={}&Signature={}&Expires={}".format(
-                config.get_edge_url(),
-                BUCKET,
-                OBJECT_KEY,
-                "test",
-                query_params["Signature"][0],
-                query_params["Expires"][0],
-            )
-            return url
-
-        def make_v4_url_invalid(url):
-            parsed = urlparse.urlparse(url)
-            query_params = parse_qs(parsed.query)
-            url = (
-                "{}/{}/{}?X-Amz-Algorithm=AWS4-HMAC-SHA256&"
-                + "X-Amz-Credential={}&X-Amz-Date={}&"
-                + "X-Amz-Expires={}&X-Amz-SignedHeaders=host&"
-                + "X-Amz-Signature={}"
-            ).format(
-                config.get_edge_url(),
-                BUCKET,
-                OBJECT_KEY,
-                quote(query_params["X-Amz-Credential"][0]).replace("/", "%2F"),
-                query_params["X-Amz-Date"][0],
-                query_params["X-Amz-Expires"][0],
-                query_params["X-Amz-Signature"][0],
-            )
-            return url
-
-        client.create_bucket(Bucket=BUCKET)
-
-        client.put_object(Key=OBJECT_KEY, Bucket=BUCKET, Body="123")
-
-        # GET requests
-        presign_get_url = client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY},
-            ExpiresIn=EXPIRES,
+        bucket_name = "presign-%s" % short_uid()
+        url_prefix = "{}/{}".format(
+            config.get_edge_url(),
+            bucket_name,
         )
+        self.run_presigned_url_signature_authentication(client, client_v4, bucket_name, url_prefix)
 
-        presign_get_url_v4 = client_v4.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY},
-            ExpiresIn=EXPIRES,
-        )
-
-        # Valid request
-        response = requests.get(presign_get_url)
-        self.assertEqual(200, response.status_code)
-
-        response = requests.get(presign_get_url_v4)
-        self.assertEqual(200, response.status_code)
-
-        presign_get_url = client.generate_presigned_url(
-            "get_object",
-            Params={
-                "Bucket": BUCKET,
-                "Key": OBJECT_KEY,
-                "ResponseContentType": "text/plain",
-                "ResponseContentDisposition": "attachment;  filename=test.txt",
-            },
-            ExpiresIn=EXPIRES,
-        )
-
-        presign_get_url_v4 = client_v4.generate_presigned_url(
-            "get_object",
-            Params={
-                "Bucket": BUCKET,
-                "Key": OBJECT_KEY,
-                "ResponseContentType": "text/plain",
-            },
-            ExpiresIn=EXPIRES,
-        )
-
-        # Valid request
-        response = requests.get(presign_get_url)
-        self.assertEqual(200, response.status_code)
-
-        response = requests.get(presign_get_url_v4)
-        self.assertEqual(200, response.status_code)
-
-        # Invalid request
-        url = make_v2_url_invalid(presign_get_url)
-        response = requests.get(
-            url, data=OBJECT_DATA, headers={"Content-Type": "my-fake-content/type"}
-        )
-        self.assertEqual(403, response.status_code)
-
-        url = make_v4_url_invalid(presign_get_url_v4)
-        response = requests.get(url, headers={"Content-Type": "my-fake-content/type"})
-        self.assertEqual(403, response.status_code)
-
-        # PUT Requests
-        presign_put_url = client.generate_presigned_url(
-            "put_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY},
-            ExpiresIn=EXPIRES,
-        )
-
-        presign_put_url_v4 = client_v4.generate_presigned_url(
-            "put_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY},
-            ExpiresIn=EXPIRES,
-        )
-
-        # Valid request
-        response = requests.put(presign_put_url, data=OBJECT_DATA)
-        self.assertEqual(200, response.status_code)
-
-        response = requests.put(presign_put_url_v4, data=OBJECT_DATA)
-        self.assertEqual(200, response.status_code)
-
-        presign_put_url = client.generate_presigned_url(
-            "put_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY, "ContentType": "text/plain"},
-            ExpiresIn=EXPIRES,
-        )
-
-        presign_put_url_v4 = client_v4.generate_presigned_url(
-            "put_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY, "ContentType": "text/plain"},
-            ExpiresIn=EXPIRES,
-        )
-
-        # Valid request
-        response = requests.put(
-            presign_put_url, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
-        )
-        self.assertEqual(200, response.status_code)
-
-        response = requests.put(
-            presign_put_url_v4, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
-        )
-        self.assertEqual(200, response.status_code)
-
-        # Invalid request
-        url = make_v2_url_invalid(presign_put_url)
-        response = requests.put(
-            url, data=OBJECT_DATA, headers={"Content-Type": "my-fake-content/type"}
-        )
-        self.assertEqual(403, response.status_code)
-
-        url = make_v4_url_invalid(presign_put_url_v4)
-        response = requests.put(
-            url, data=OBJECT_DATA, headers={"Content-Type": "my-fake-content/type"}
-        )
-        self.assertEqual(403, response.status_code)
-
-        # DELETE Requests
-        presign_delete_url = client.generate_presigned_url(
-            "delete_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY},
-            ExpiresIn=EXPIRES,
-        )
-
-        presign_delete_url_v4 = client_v4.generate_presigned_url(
-            "delete_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY},
-            ExpiresIn=EXPIRES,
-        )
-
-        # Valid request
-
-        response = requests.delete(presign_delete_url)
-        self.assertEqual(204, response.status_code)
-
-        response = requests.delete(presign_delete_url_v4)
-        self.assertEqual(204, response.status_code)
-
-        presign_delete_url = client.generate_presigned_url(
-            "delete_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY, "VersionId": "1"},
-            ExpiresIn=EXPIRES,
-        )
-
-        presign_delete_url_v4 = client_v4.generate_presigned_url(
-            "delete_object",
-            Params={"Bucket": BUCKET, "Key": OBJECT_KEY, "VersionId": "1"},
-            ExpiresIn=EXPIRES,
-        )
-
-        # Valid request
-        response = requests.delete(presign_delete_url)
-        self.assertEqual(204, response.status_code)
-
-        response = requests.delete(presign_delete_url_v4)
-        self.assertEqual(204, response.status_code)
-
-        # Invalid request
-        url = make_v2_url_invalid(presign_delete_url)
-        response = requests.delete(url)
-        self.assertEqual(403, response.status_code)
-
-        url = make_v4_url_invalid(presign_delete_url_v4)
-        response = requests.delete(url)
-        self.assertEqual(403, response.status_code)
-
-        # Expired requests
-        time.sleep(4.5)
-
-        # GET
-        response = requests.get(presign_get_url)
-        self.assertEqual(403, response.status_code)
-        response = requests.get(presign_get_url_v4)
-        self.assertEqual(403, response.status_code)
-
-        # PUT
-        response = requests.put(
-            presign_put_url, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
-        )
-        self.assertEqual(403, response.status_code)
-        response = requests.put(
-            presign_put_url_v4, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
-        )
-        self.assertEqual(403, response.status_code)
-
-        # DELETE
-        response = requests.delete(presign_delete_url)
-        self.assertEqual(403, response.status_code)
-
-        response = requests.delete(presign_delete_url_v4)
-        self.assertEqual(403, response.status_code)
-
-        # Multipart uploading
-        response = self._perform_multipart_upload_with_presign(BUCKET, OBJECT_KEY, client)
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-        response = self._perform_multipart_upload_with_presign(BUCKET, OBJECT_KEY, client_v4)
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-
-        client.delete_object(Bucket=BUCKET, Key=OBJECT_KEY)
-        client.delete_bucket(Bucket=BUCKET)
-
+    @patch.object(config, "S3_SKIP_SIGNATURE_VALIDATION", False)
     def test_presigned_url_signature_authentication_virtual_host_addressing(self):
-        old_config = config.S3_SKIP_SIGNATURE_VALIDATION
-        try:
-            config.S3_SKIP_SIGNATURE_VALIDATION = False
-            self.run_presigned_url_signature_authentication_virtual_host_addressing()
-        finally:
-            config.S3_SKIP_SIGNATURE_VALIDATION = old_config
-
-    def run_presigned_url_signature_authentication_virtual_host_addressing(self):
-        # TODO: merge with run_presigned_url_signature_authentication() above!
         virtual_endpoint = "{}://{}:{}".format(
-            config.get_protocol(), S3_VIRTUAL_HOSTNAME, config.EDGE_PORT
+            config.get_protocol(),
+            S3_VIRTUAL_HOSTNAME,
+            config.EDGE_PORT,
+        )
+        bucket_name = "presign-%s" % short_uid()
+        url_prefix = "{}://{}.{}:{}".format(
+            config.get_protocol(),
+            bucket_name,
+            S3_VIRTUAL_HOSTNAME,
+            config.EDGE_PORT,
         )
         client = boto3.client(
             "s3",
@@ -2210,21 +1970,21 @@ class TestS3(unittest.TestCase):
             aws_access_key_id=TEST_AWS_ACCESS_KEY_ID,
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
         )
+        self.run_presigned_url_signature_authentication(client, client_v4, bucket_name, url_prefix)
 
-        OBJECT_KEY = "temp.txt"
-        OBJECT_DATA = "this should be found in when you download {}.".format(OBJECT_KEY)
-        bucket_name = "presign-%s" % short_uid()
+    def run_presigned_url_signature_authentication(
+        self, client, client_v4, bucket_name, url_prefix
+    ):
+        object_key = "temp.txt"
+        object_data = "this should be found in when you download {}.".format(object_key)
         expires = 4
 
         def make_v2_url_invalid(url):
             parsed = urlparse.urlparse(url)
             query_params = parse_qs(parsed.query)
-            url = "{}://{}.{}:{}/{}?AWSAccessKeyId={}&Signature={}&Expires={}".format(
-                config.get_protocol(),
-                bucket_name,
-                S3_VIRTUAL_HOSTNAME,
-                config.EDGE_PORT,
-                OBJECT_KEY,
+            url = "{}/{}?AWSAccessKeyId={}&Signature={}&Expires={}".format(
+                url_prefix,
+                object_key,
                 "test",
                 query_params["Signature"][0],
                 query_params["Expires"][0],
@@ -2235,16 +1995,13 @@ class TestS3(unittest.TestCase):
             parsed = urlparse.urlparse(url)
             query_params = parse_qs(parsed.query)
             url = (
-                "{}://{}.{}:{}/{}?X-Amz-Algorithm=AWS4-HMAC-SHA256&"
-                + "X-Amz-Credential={}&X-Amz-Date={}&"
-                + "X-Amz-Expires={}&X-Amz-SignedHeaders=host&"
-                + "X-Amz-Signature={}"
+                "{}/{}?X-Amz-Algorithm=AWS4-HMAC-SHA256&"
+                "X-Amz-Credential={}&X-Amz-Date={}&"
+                "X-Amz-Expires={}&X-Amz-SignedHeaders=host&"
+                "X-Amz-Signature={}"
             ).format(
-                config.get_protocol(),
-                bucket_name,
-                S3_VIRTUAL_HOSTNAME,
-                config.EDGE_PORT,
-                OBJECT_KEY,
+                url_prefix,
+                object_key,
                 quote(query_params["X-Amz-Credential"][0]).replace("/", "%2F"),
                 query_params["X-Amz-Date"][0],
                 query_params["X-Amz-Expires"][0],
@@ -2252,19 +2009,19 @@ class TestS3(unittest.TestCase):
             )
             return url
 
-        self.s3_client.create_bucket(Bucket=bucket_name)
-        self.s3_client.put_object(Key=OBJECT_KEY, Bucket=bucket_name, Body="123")
+        client.create_bucket(Bucket=bucket_name)
+        client.put_object(Key=object_key, Bucket=bucket_name, Body="123")
 
         # GET requests
         presign_get_url = client.generate_presigned_url(
             "get_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY},
+            Params={"Bucket": bucket_name, "Key": object_key},
             ExpiresIn=expires,
         )
 
         presign_get_url_v4 = client_v4.generate_presigned_url(
             "get_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY},
+            Params={"Bucket": bucket_name, "Key": object_key},
             ExpiresIn=expires,
         )
 
@@ -2279,8 +2036,9 @@ class TestS3(unittest.TestCase):
             "get_object",
             Params={
                 "Bucket": bucket_name,
-                "Key": OBJECT_KEY,
+                "Key": object_key,
                 "ResponseContentType": "text/plain",
+                "ResponseContentDisposition": "attachment;  filename=test.txt",
             },
             ExpiresIn=expires,
         )
@@ -2289,7 +2047,7 @@ class TestS3(unittest.TestCase):
             "get_object",
             Params={
                 "Bucket": bucket_name,
-                "Key": OBJECT_KEY,
+                "Key": object_key,
                 "ResponseContentType": "text/plain",
             },
             ExpiresIn=expires,
@@ -2305,7 +2063,7 @@ class TestS3(unittest.TestCase):
         # Invalid request
         url = make_v2_url_invalid(presign_get_url)
         response = requests.get(
-            url, data=OBJECT_DATA, headers={"Content-Type": "my-fake-content/type"}
+            url, data=object_data, headers={"Content-Type": "my-fake-content/type"}
         )
         self.assertEqual(403, response.status_code)
 
@@ -2316,28 +2074,28 @@ class TestS3(unittest.TestCase):
         # PUT Requests
         presign_put_url = client.generate_presigned_url(
             "put_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY},
+            Params={"Bucket": bucket_name, "Key": object_key},
             ExpiresIn=expires,
         )
 
         presign_put_url_v4 = client_v4.generate_presigned_url(
             "put_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY},
+            Params={"Bucket": bucket_name, "Key": object_key},
             ExpiresIn=expires,
         )
 
         # Valid request
-        response = requests.put(presign_put_url, data=OBJECT_DATA)
+        response = requests.put(presign_put_url, data=object_data)
         self.assertEqual(200, response.status_code)
 
-        response = requests.put(presign_put_url_v4, data=OBJECT_DATA)
+        response = requests.put(presign_put_url_v4, data=object_data)
         self.assertEqual(200, response.status_code)
 
         presign_put_url = client.generate_presigned_url(
             "put_object",
             Params={
                 "Bucket": bucket_name,
-                "Key": OBJECT_KEY,
+                "Key": object_key,
                 "ContentType": "text/plain",
             },
             ExpiresIn=expires,
@@ -2347,7 +2105,7 @@ class TestS3(unittest.TestCase):
             "put_object",
             Params={
                 "Bucket": bucket_name,
-                "Key": OBJECT_KEY,
+                "Key": object_key,
                 "ContentType": "text/plain",
             },
             ExpiresIn=expires,
@@ -2355,38 +2113,38 @@ class TestS3(unittest.TestCase):
 
         # Valid request
         response = requests.put(
-            presign_put_url, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
+            presign_put_url, data=object_data, headers={"Content-Type": "text/plain"}
         )
         self.assertEqual(200, response.status_code)
 
         response = requests.put(
-            presign_put_url_v4, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
+            presign_put_url_v4, data=object_data, headers={"Content-Type": "text/plain"}
         )
         self.assertEqual(200, response.status_code)
 
         # Invalid request
         url = make_v2_url_invalid(presign_put_url)
         response = requests.put(
-            url, data=OBJECT_DATA, headers={"Content-Type": "my-fake-content/type"}
+            url, data=object_data, headers={"Content-Type": "my-fake-content/type"}
         )
         self.assertEqual(403, response.status_code)
 
         url = make_v4_url_invalid(presign_put_url_v4)
         response = requests.put(
-            url, data=OBJECT_DATA, headers={"Content-Type": "my-fake-content/type"}
+            url, data=object_data, headers={"Content-Type": "my-fake-content/type"}
         )
         self.assertEqual(403, response.status_code)
 
         # DELETE Requests
         presign_delete_url = client.generate_presigned_url(
             "delete_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY},
+            Params={"Bucket": bucket_name, "Key": object_key},
             ExpiresIn=expires,
         )
 
         presign_delete_url_v4 = client_v4.generate_presigned_url(
             "delete_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY},
+            Params={"Bucket": bucket_name, "Key": object_key},
             ExpiresIn=expires,
         )
 
@@ -2400,13 +2158,13 @@ class TestS3(unittest.TestCase):
 
         presign_delete_url = client.generate_presigned_url(
             "delete_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY, "VersionId": "1"},
+            Params={"Bucket": bucket_name, "Key": object_key, "VersionId": "1"},
             ExpiresIn=expires,
         )
 
         presign_delete_url_v4 = client_v4.generate_presigned_url(
             "delete_object",
-            Params={"Bucket": bucket_name, "Key": OBJECT_KEY, "VersionId": "1"},
+            Params={"Bucket": bucket_name, "Key": object_key, "VersionId": "1"},
             ExpiresIn=expires,
         )
 
@@ -2437,11 +2195,11 @@ class TestS3(unittest.TestCase):
 
         # PUT
         response = requests.put(
-            presign_put_url, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
+            presign_put_url, data=object_data, headers={"Content-Type": "text/plain"}
         )
         self.assertEqual(403, response.status_code)
         response = requests.put(
-            presign_put_url_v4, data=OBJECT_DATA, headers={"Content-Type": "text/plain"}
+            presign_put_url_v4, data=object_data, headers={"Content-Type": "text/plain"}
         )
         self.assertEqual(403, response.status_code)
 
@@ -2452,12 +2210,12 @@ class TestS3(unittest.TestCase):
         self.assertEqual(403, response.status_code)
 
         # Multipart uploading
-        response = self._perform_multipart_upload_with_presign(bucket_name, OBJECT_KEY, client)
+        response = self._perform_multipart_upload_with_presign(bucket_name, object_key, client)
         self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-        response = self._perform_multipart_upload_with_presign(bucket_name, OBJECT_KEY, client_v4)
+        response = self._perform_multipart_upload_with_presign(bucket_name, object_key, client_v4)
         self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
 
-        client.delete_object(Bucket=bucket_name, Key=OBJECT_KEY)
+        client.delete_object(Bucket=bucket_name, Key=object_key)
         client.delete_bucket(Bucket=bucket_name)
 
     def test_presigned_url_with_session_token(self):


### PR DESCRIPTION
also, apply the fix from #3947 to virtual host addressing part

this is deduplication for
- `test_presigned_url_signature_authentication`
- `test_presigned_url_signature_authentication_virtual_host_addressing`

I will address this further with https://github.com/localstack/localstack/issues/4952.

----
Inspired by https://github.com/localstack/localstack/blob/62c495a41b04df323a69cdd7240cbd80df280b34/tests/integration/test_s3.py#L2195-L2195

How I made the comparison:
- unified some variables in both functions
- created two files with content from `run_presigned_url_signature_authentication` and `run_presigned_url_signature_authentication_virtual_host_addressing`
- compared files using `vimdiff`
- extracted common parts into one method

One difference I found: 
https://github.com/localstack/localstack/blob/62c495a41b04df323a69cdd7240cbd80df280b34/tests/integration/test_s3.py#L2013-L2013

From #3947

When I included it to common method `test_presigned_url_signature_authentication_virtual_host_addressing` started to fail
```
__________________________________________________________________________________ TestS3.test_presigned_url_signature_authentication_virtual_host_addressing __________________________________________________________________________________
....
tests/integration/test_s3.py:2054: in run_presigned_url_signature_authentication
    self.assertEqual(200, response.status_code)
E   AssertionError: 200 != 403
```
So I fixed this case in `localstack/services/s3/s3_utils.py` as well.