### PR TITLE
Feature: SNS delivery logs

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -1004,5 +1004,4 @@ def store_delivery_log(
 
     log_output = json.dumps(delivery_log)
 
-    print(log_group_name)
     return store_cloudwatch_logs(log_group_name, log_stream_name, log_output, invocation_time)

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -1,8 +1,10 @@
 import ast
 import asyncio
 import base64
+import datetime
 import json
 import logging
+import time
 import traceback
 import uuid
 
@@ -24,7 +26,10 @@ from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import create_sqs_system_attributes, response_regex_replace
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
+from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.common import (
+    long_uid,
+    md5,
     parse_request_data,
     short_uid,
     start_thread,
@@ -410,6 +415,18 @@ async def message_to_subscriber(
             subscriber["Endpoint"],
             req_data["Message"][0],
         )
+
+        # MOCK DATA
+        delivery = {
+            "phoneCarrier": "Mock Carrier",
+            "mnc": 270,
+            "priceInUSD": 0.00645,
+            "smsType": "Transactional",
+            "mcc": 310,
+            "providerResponse": "Message has been accepted by phone carrier",
+            "dwellTimeMsUntilDeviceAck": 200,
+        }
+        store_delivery_log(subscriber, True, message, message_id, delivery)
         return
 
     elif subscriber["Protocol"] == "sqs":
@@ -442,8 +459,10 @@ async def message_to_subscriber(
                 MessageSystemAttributes=create_sqs_system_attributes(headers),
                 **kwargs,
             )
+            store_delivery_log(subscriber, True, message, message_id)
         except Exception as exc:
             LOG.info("Unable to forward SNS message to SQS: %s %s" % (exc, traceback.format_exc()))
+            store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
             if "NonExistentQueue" in str(exc):
                 LOG.info(
@@ -470,6 +489,13 @@ async def message_to_subscriber(
                 unsubscribe_url,
                 subject=req_data.get("Subject", [None])[0],
             )
+
+            delivery = {
+                "statusCode": response.status_code,
+                "providerResponse": response.get_data(),
+            }
+            store_delivery_log(subscriber, True, message, message_id)
+
             if isinstance(response, Response):
                 response.raise_for_status()
             elif isinstance(response, FlaskResponse):
@@ -482,6 +508,7 @@ async def message_to_subscriber(
                 "Unable to run Lambda function on SNS message: %s %s"
                 % (exc, traceback.format_exc())
             )
+            store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
         return
 
@@ -506,11 +533,19 @@ async def message_to_subscriber(
                 data=message_body,
                 verify=False,
             )
+
+            delivery = {
+                "statusCode": response.status_code,
+                "providerResponse": response.get_data(),
+            }
+            store_delivery_log(subscriber, True, message, message_id, delivery)
+
             response.raise_for_status()
         except Exception as exc:
             LOG.info(
                 "Received error on sending SNS message, putting to DLQ (if configured): %s" % exc
             )
+            store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
         return
 
@@ -518,11 +553,13 @@ async def message_to_subscriber(
         try:
             sns_client = aws_stack.connect_to_service("sns")
             sns_client.publish(TargetArn=subscriber["Endpoint"], Message=message)
+            store_delivery_log(subscriber, True, message, message_id)
         except Exception as exc:
             LOG.warning(
                 "Unable to forward SNS message to SNS platform app: %s %s"
                 % (exc, traceback.format_exc())
             )
+            store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
         return
 
@@ -540,6 +577,7 @@ async def message_to_subscriber(
                 },
                 Destination={"ToAddresses": [subscriber.get("Endpoint")]},
             )
+            store_delivery_log(subscriber, True, message, message_id)
     else:
         LOG.warning('Unexpected protocol "%s" for SNS subscription' % subscriber["Protocol"])
 
@@ -937,3 +975,34 @@ def check_filter_policy(filter_policy, message_attributes):
 
 def is_raw_message_delivery(susbcriber):
     return susbcriber.get("RawMessageDelivery") in ("true", True, "True")
+
+
+def store_delivery_log(
+    subscriber: dict, success: bool, message: str, message_id: str, delivery: dict = {}
+):
+
+    log_group_name = subscriber.get("TopicArn", "").replace("arn:aws:", "").replace(":", "/")
+    log_stream_name = long_uid()
+    invocation_time = int(time.time() * 1000)
+
+    delivery["deliveryId"] = (long_uid(),)
+    delivery["destination"] = (subscriber.get("Endpoint", ""),)
+    delivery["dwellTimeMs"] = 200
+    if not success:
+        delivery["attemps"] = 1
+
+    delivery_log = {
+        "notification": {
+            "messageMD5Sum": md5(message),
+            "messageId": message_id,
+            "topicArn": subscriber.get("TopicArn"),
+            "timestamp": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f%z"),
+        },
+        "delivery": delivery,
+        "status": "SUCCESS" if success else "FAILURE",
+    }
+
+    log_output = json.dumps(delivery_log)
+
+    print(log_group_name)
+    return store_cloudwatch_logs(log_group_name, log_stream_name, log_output, invocation_time)

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -30,6 +30,7 @@ from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.common import (
     long_uid,
     md5,
+    not_none_or,
     parse_request_data,
     short_uid,
     start_thread,
@@ -494,7 +495,7 @@ async def message_to_subscriber(
                 "statusCode": response.status_code,
                 "providerResponse": response.get_data(),
             }
-            store_delivery_log(subscriber, True, message, message_id)
+            store_delivery_log(subscriber, True, message, message_id, delivery)
 
             if isinstance(response, Response):
                 response.raise_for_status()
@@ -978,13 +979,14 @@ def is_raw_message_delivery(susbcriber):
 
 
 def store_delivery_log(
-    subscriber: dict, success: bool, message: str, message_id: str, delivery: dict = {}
+    subscriber: dict, success: bool, message: str, message_id: str, delivery: dict = None
 ):
 
     log_group_name = subscriber.get("TopicArn", "").replace("arn:aws:", "").replace(":", "/")
     log_stream_name = long_uid()
     invocation_time = int(time.time() * 1000)
 
+    delivery = not_none_or(delivery, {})
     delivery["deliveryId"] = (long_uid(),)
     delivery["destination"] = (subscriber.get("Endpoint", ""),)
     delivery["dwellTimeMs"] = 200

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import random
 import time
 import unittest
 
@@ -894,20 +895,31 @@ class SNSTest(unittest.TestCase):
         return queue_name, queue_arn, queue_url
 
     def test_publish_sms_endpoint(self):
-        # Clean posible previous sms messages
-        sns_backend = SNSBackend.get()
-        sns_backend.sms_messages = []
-
-        def check_messages():
-            self.assertEqual(len(list_of_contacts), len(sns_backend.sms_messages))
-
-        list_of_contacts = ["+10123456789", "+10000000000", "+19876543210"]
+        list_of_contacts = [
+            "+%d" % random.randint(100000000, 9999999999),
+            "+%d" % random.randint(100000000, 9999999999),
+            "+%d" % random.randint(100000000, 9999999999),
+        ]
         message = "Good news everyone!"
-        # Add SMS Subscribers
+
         for number in list_of_contacts:
             self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol="sms", Endpoint=number)
-        # Publish a message.
+
         self.sns_client.publish(Message=message, TopicArn=self.topic_arn)
+
+        sns_backend = SNSBackend.get()
+
+        def check_messages():
+            sms_messages = sns_backend.sms_messages
+            for contact in list_of_contacts:
+                sms_was_found = False
+                for message in sms_messages:
+                    if message["endpoint"] == contact:
+                        sms_was_found = True
+                        break
+
+                self.assertTrue(sms_was_found)
+
         retry(check_messages, sleep=0.5)
 
     def test_publish_sqs_from_sns(self):

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -905,7 +905,7 @@ class SNSTest(unittest.TestCase):
             self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol="sms", Endpoint=number)
         # Publish a message.
         self.sns_client.publish(Message=message, TopicArn=self.topic_arn)
-        retry(check_messages, retries=3, sleep=0.5)
+        retry(check_messages)
 
     def test_publish_sqs_from_sns(self):
         topic = self.sns_client.create_topic(Name="test_topic3")

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -894,8 +894,11 @@ class SNSTest(unittest.TestCase):
         return queue_name, queue_arn, queue_url
 
     def test_publish_sms_endpoint(self):
+        # Clean posible previous sms messages
+        sns_backend = SNSBackend.get()
+        sns_backend.sms_messages = []
+
         def check_messages():
-            sns_backend = SNSBackend.get()
             self.assertEqual(len(list_of_contacts), len(sns_backend.sms_messages))
 
         list_of_contacts = ["+10123456789", "+10000000000", "+19876543210"]
@@ -905,7 +908,7 @@ class SNSTest(unittest.TestCase):
             self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol="sms", Endpoint=number)
         # Publish a message.
         self.sns_client.publish(Message=message, TopicArn=self.topic_arn)
-        retry(check_messages)
+        retry(check_messages, sleep=0.5)
 
     def test_publish_sqs_from_sns(self):
         topic = self.sns_client.create_topic(Name="test_topic3")


### PR DESCRIPTION
Simple implementation of the [SNS delivery logs ](https://aws.amazon.com/premiumsupport/knowledge-center/monitor-sns-texts-cloudwatch/) requested in the issue #4036. 

Changes:
- Every time a message is being sent, a log in the CloudWatch service is created.
- Creation of a test for the creation of the LogGroup for the topic.

NOTES:
1.  The logs created are most approximate for the http/https and sms protocols.
2.  In contrary to AWS, the user doesn't need to create an IAM rol neither to set attributes for the topic for the logs to be created.
