### PR TITLE
restructure localstack container bootstrapping and add CLI commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,32 @@ jobs:
       - store_test_results:
           path: target/reports/
 
+  itest-bootstrap:
+    machine:
+      image: ubuntu-2004:202107-02
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Run bootstrap tests
+          environment:
+            DEBUG: 1
+            TEST_PATH: "tests/bootstrap"
+            PYTEST_ARGS: "--junitxml=target/reports/bootstrap.xml -o junit_suite_name='bootstrap'"
+            COVERAGE_ARGS: "-p"
+          command: make test-coverage
+      - run:
+          name: Store coverage results
+          command: mv .coverage.* target/coverage/
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/coverage/
+      - store_test_results:
+          path: target/reports/
+
   docker-build:
     parameters:
       platform:
@@ -289,6 +315,9 @@ workflows:
       - itest-elasticmq:
           requires:
             - preflight
+      - itest-bootstrap:
+          requires:
+            - preflight
       - docker-build:
           name: docker-build-amd64
           platform: amd64
@@ -309,6 +338,7 @@ workflows:
           requires:
             - itest-lambda-docker
             - itest-elasticmq
+            - itest-bootstrap
             - docker-build-amd64
             - docker-build-arm64
       - docker-push:
@@ -318,5 +348,6 @@ workflows:
           requires:
             - itest-lambda-docker
             - itest-elasticmq
+            - itest-bootstrap
             - docker-build-amd64
             - docker-build-arm64

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -8,18 +8,25 @@ import sys
 import threading
 import warnings
 from functools import wraps
-from typing import Iterable, List, Set
+from typing import Iterable, List, Optional, Set
 
 import six
 
 from localstack import config, constants
-from localstack.config import parse_service_ports
-from localstack.constants import LS_LOG_TRACE_INTERNAL, TRACE_LOG_LEVELS
-from localstack.utils.common import chmod_r, mkdir
-from localstack.utils.docker_utils import DOCKER_CLIENT, ContainerException, PortMappings
+from localstack.utils.common import FileListener, chmod_r, mkdir, poll_condition
+from localstack.utils.docker_utils import (
+    DOCKER_CLIENT,
+    CmdDockerClient,
+    ContainerException,
+    PortMappings,
+    SimpleVolumeBind,
+    VolumeBind,
+    VolumeMappings,
+)
 
 # set up logger
 from localstack.utils.run import run, to_str
+from localstack.utils.serving import Server
 
 LOG = logging.getLogger(os.path.basename(__file__))
 
@@ -261,7 +268,7 @@ def setup_logging(log_level=None):
     # overriding the log level if LS_LOG has been set
     if config.LS_LOG:
         log_level = str(config.LS_LOG).upper()
-        if log_level.lower() in TRACE_LOG_LEVELS:
+        if log_level.lower() in constants.TRACE_LOG_LEVELS:
             log_level = "DEBUG"
         log_level = logging._nameToLevel[log_level]
         logging.getLogger("").setLevel(log_level)
@@ -297,7 +304,7 @@ def setup_logging(log_level=None):
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("s3transfer").setLevel(logging.INFO)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
-    if config.LS_LOG != LS_LOG_TRACE_INTERNAL:
+    if config.LS_LOG != constants.LS_LOG_TRACE_INTERNAL:
         # disable werkzeug API logs, unless detailed internal trace logging is enabled
         logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
@@ -356,7 +363,7 @@ def get_enabled_apis() -> Set[str]:
 
     The result is cached, so it's safe to call. Clear the cache with get_enabled_apis.cache_clear().
     """
-    return resolve_apis(parse_service_ports().keys())
+    return resolve_apis(config.parse_service_ports().keys())
 
 
 def canonicalize_api_names(apis: Iterable[str] = None) -> List[str]:
@@ -510,7 +517,7 @@ def get_docker_image_to_start():
     return image_name
 
 
-def extract_port_flags(user_flags, port_mappings):
+def extract_port_flags(user_flags, port_mappings: PortMappings):
     regex = r"-p\s+([0-9]+)(\-([0-9]+))?:([0-9]+)(\-([0-9]+))?"
     matches = re.match(".*%s" % regex, user_flags)
     if matches:
@@ -524,11 +531,112 @@ def extract_port_flags(user_flags, port_mappings):
     return user_flags
 
 
-def start_infra_in_docker():
+class LocalstackContainer:
+    name: str
+    image_name: str
+    volumes: VolumeMappings
+    ports: PortMappings
+    entrypoint: str
+    additional_flags: List[str]
+    command: List[str]
+
+    privileged: bool = True
+    remove: bool = True
+    interactive: bool = False
+    tty: bool = False
+    detach: bool = False
+    inherit_env: bool = True
+
+    logfile: Optional[str] = None
+    stdin: Optional[str] = None
+    user: Optional[str] = None
+    cap_add: Optional[str] = None
+    network: Optional[str] = None
+    dns: Optional[str] = None
+    workdir: Optional[str] = None
+
+    def __init__(self, name: str = None):
+        self.name = name or config.MAIN_CONTAINER_NAME
+        self.entrypoint = os.environ.get("ENTRYPOINT", "")
+        self.command = shlex.split(os.environ.get("CMD", ""))
+        self.image_name = get_docker_image_to_start()
+        self.ports = PortMappings(bind_host=config.EDGE_BIND_HOST)
+        self.volumes = VolumeMappings()
+        self.env_vars = dict()
+        self.additional_flags = list()
+
+        self.logfile = os.path.join(config.TMP_FOLDER, f"{self.name}_container.log")
+
+    def _get_mount_volumes(self) -> List[SimpleVolumeBind]:
+        # FIXME: VolumeMappings should be supported by the docker client
+        mount_volumes = list()
+        for volume in self.volumes:
+            if isinstance(volume, tuple):
+                mount_volumes.append(volume)
+            elif isinstance(volume, VolumeBind):
+                mount_volumes.append((volume.host_dir, volume.container_dir))
+            else:
+                raise NotImplementedError("no support for volume type %s" % type(volume))
+            mount_volumes.append(volume)
+        return mount_volumes
+
+    def run(self):
+        client = CmdDockerClient()
+        client.default_run_outfile = self.logfile
+
+        return client.run_container(
+            image_name=self.image_name,
+            stdin=self.stdin,
+            name=self.name,
+            entrypoint=self.entrypoint or None,
+            remove=self.remove,
+            interactive=self.interactive,
+            tty=self.tty,
+            detach=self.detach,
+            command=self.command or None,
+            mount_volumes=self._get_mount_volumes(),
+            ports=self.ports,
+            env_vars=self.env_vars,
+            user=self.user,
+            cap_add=self.cap_add,
+            network=self.network,
+            dns=self.dns,
+            additional_flags=" ".join(self.additional_flags),
+            workdir=self.workdir,
+        )
+
+    def truncate_log(self):
+        with open(self.logfile, "wb") as fd:
+            fd.write(b"")
+
+
+class LocalstackContainerServer(Server):
+    container: LocalstackContainer
+
+    def __init__(self, container) -> None:
+        super().__init__(config.EDGE_PORT, config.EDGE_BIND_HOST)
+        self.container = container
+
+    def do_run(self):
+        return self.container.run()
+
+    def do_shutdown(self):
+        try:
+            CmdDockerClient().stop_container(self.container.name)
+        except Exception as e:
+            LOG.info("error cleaning up localstack container %s: %s", self.container.name, e)
+
+
+class ContainerExists(Exception):
+    pass
+
+
+def prepare_docker_start():
+    # prepare environment for docker start
     container_name = config.MAIN_CONTAINER_NAME
 
     if DOCKER_CLIENT.is_container_running(container_name):
-        raise Exception('LocalStack container named "%s" is already running' % container_name)
+        raise ContainerExists('LocalStack container named "%s" is already running' % container_name)
     if config.TMP_FOLDER != config.HOST_TMP_FOLDER and not config.LAMBDA_REMOTE_DOCKER:
         print(
             f"WARNING: The detected temp folder for localstack ({config.TMP_FOLDER}) is not equal to the "
@@ -537,105 +645,153 @@ def start_infra_in_docker():
 
     os.environ[ENV_SCRIPT_STARTING_DOCKER] = "1"
 
-    # load plugins before starting the docker container
-    plugin_configs = load_plugins()
-
-    # prepare APIs
-    canonicalize_api_names()
-
-    entrypoint = os.environ.get("ENTRYPOINT", "")
-    cmd = os.environ.get("CMD", "")
-    user_flags = config.DOCKER_FLAGS
-    image_name = get_docker_image_to_start()
-    service_ports = config.SERVICE_PORTS
-    force_noninteractive = os.environ.get("FORCE_NONINTERACTIVE", "")
-
-    # get run params
-    plugin_run_params = " ".join(
-        [entry.get("docker", {}).get("run_flags", "") for entry in plugin_configs]
-    )
-
-    # container for port mappings
-    port_mappings = PortMappings(bind_host=config.EDGE_BIND_HOST)
-
-    # get port ranges defined via DOCKER_FLAGS (if any)
-    user_flags = extract_port_flags(user_flags, port_mappings)
-    plugin_run_params = extract_port_flags(plugin_run_params, port_mappings)
-
-    # construct default port mappings
-    if service_ports.get("edge") == 0:
-        service_ports.pop("edge")
-    for port in service_ports.values():
-        if port:
-            port_mappings.add(port)
-
-    env_vars = {}
-    for env_var in config.CONFIG_ENV_VARS:
-        value = os.environ.get(env_var, None)
-        if value is not None:
-            env_vars[env_var] = value
-
-    bind_mounts = []
-    data_dir = os.environ.get("DATA_DIR", None)
-    if data_dir is not None:
-        container_data_dir = "/tmp/localstack_data"
-        bind_mounts.append((data_dir, container_data_dir))
-        env_vars["DATA_DIR"] = container_data_dir
-    bind_mounts.append((config.TMP_FOLDER, "/tmp/localstack"))
-    bind_mounts.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
-    env_vars["DOCKER_HOST"] = f"unix://{config.DOCKER_SOCK}"
-    env_vars["HOST_TMP_FOLDER"] = config.HOST_TMP_FOLDER
-
-    if config.DEVELOP:
-        port_mappings.add(config.DEVELOP_PORT)
-
-    docker_cmd = [config.DOCKER_CMD, "run"]
-    if not force_noninteractive and not in_ci():
-        docker_cmd.append("-it")
-    if entrypoint:
-        docker_cmd += shlex.split(entrypoint)
-    if env_vars:
-        docker_cmd += [item for k, v in env_vars.items() for item in ["-e", "{}={}".format(k, v)]]
-    if user_flags:
-        docker_cmd += shlex.split(user_flags)
-    if plugin_run_params:
-        docker_cmd += shlex.split(plugin_run_params)
-    docker_cmd += ["--rm", "--privileged"]
-    docker_cmd += ["--name", container_name]
-    docker_cmd += port_mappings.to_list()
-    docker_cmd += [
-        volume
-        for host_path, docker_path in bind_mounts
-        for volume in ["-v", f"{host_path}:{docker_path}"]
-    ]
-    docker_cmd.append(image_name)
-    docker_cmd += shlex.split(cmd)
-
+    # make sure temp folder exists
     mkdir(config.TMP_FOLDER)
     try:
         chmod_r(config.TMP_FOLDER, 0o777)
     except Exception:
         pass
 
-    class ShellRunnerThread(threading.Thread):
-        def __init__(self, cmd):
-            threading.Thread.__init__(self)
-            self.daemon = True
-            self.cmd = cmd
-            self.started = threading.Event()
-            self.process = None
 
-        def run(self):
-            self.process = run(self.cmd, asynchronous=True, shell=False)
-            self.started.set()
+def configure_container(container: LocalstackContainer):
+    """
+    Configuration routine for the LocalstackContainer.
+    """
+    # get additional configured flags
+    user_flags = config.DOCKER_FLAGS
+    user_flags = extract_port_flags(user_flags, container.ports)
+    container.additional_flags.extend(user_flags)
 
-    # keep this print output here for debugging purposes
-    print(docker_cmd)
-    t = ShellRunnerThread(docker_cmd)
-    t.start()
-    t.started.wait()
-    t.process.wait()
-    sys.exit(t.process.returncode)
+    # get additional parameters from plugins
+    # TODO: extract this into container config hooks and remove old plugin code
+    plugin_configs = load_plugins()
+    plugin_run_params = " ".join(
+        [entry.get("docker", {}).get("run_flags", "") for entry in plugin_configs]
+    )
+    plugin_run_params = extract_port_flags(plugin_run_params, container.ports)
+    container.additional_flags.extend(plugin_run_params)
+
+    # construct default port mappings
+    service_ports = config.SERVICE_PORTS
+    if service_ports.get("edge") == 0:
+        service_ports.pop("edge")
+    for port in service_ports.values():
+        if port:
+            container.ports.add(port)
+
+    if config.DEVELOP:
+        container.ports.add(config.DEVELOP_PORT)
+
+    # environment variables
+    # pass through environment variables defined in config
+    for env_var in config.CONFIG_ENV_VARS:
+        value = os.environ.get(env_var, None)
+        if value is not None:
+            container.env_vars[env_var] = value
+    container.env_vars["DOCKER_HOST"] = f"unix://{config.DOCKER_SOCK}"
+    container.env_vars["HOST_TMP_FOLDER"] = config.HOST_TMP_FOLDER
+
+    # data_dir mounting and environment variables
+    bind_mounts = []
+    data_dir = os.environ.get("DATA_DIR", None)
+    if data_dir is not None:
+        container_data_dir = "/tmp/localstack_data"
+        container.volumes.add((data_dir, container_data_dir))
+        container.env_vars["DATA_DIR"] = container_data_dir
+
+    # default bind mounts
+    container.volumes.add((config.TMP_FOLDER, "/tmp/localstack"))
+    bind_mounts.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
+
+    container.additional_flags.append("--privileged")
+
+
+def start_infra_in_docker():
+    prepare_docker_start()
+
+    container = LocalstackContainer()
+
+    # create and prepare container
+    configure_container(container)
+
+    container.truncate_log()
+
+    # printing the container log is the current way we're occupying the terminal
+    log_printer = FileListener(container.logfile, print)
+    log_printer.start()
+
+    # start the Localstack container as a Server
+    server = LocalstackContainerServer(container)
+    try:
+        server.start()
+        server.join()
+    except KeyboardInterrupt:
+        print("ok, bye!")
+    finally:
+        server.shutdown()
+        log_printer.close()
+
+
+def start_infra_in_docker_detached(console):
+    """
+    An alternative to start_infra_in_docker where the terminal is not blocked by the follow on the logfile.
+    """
+    console.log("preparing environment")
+    try:
+        prepare_docker_start()
+    except ContainerExists as e:
+        console.print(str(e))
+        return
+
+    # create and prepare container
+    console.log("configuring container")
+    container = LocalstackContainer()
+    configure_container(container)
+    container.truncate_log()
+
+    # start the Localstack container as a Server
+    console.log("starting container")
+    server = LocalstackContainerServer(container)
+    server.start()
+    server.wait_is_up()
+    console.log("detaching")
+
+
+def wait_container_is_ready(timeout: Optional[float] = None):
+    """Blocks until the localstack main container is running and the ready marker has been printed."""
+    from localstack.services.infra import READY_MARKER_OUTPUT
+
+    container_name = config.MAIN_CONTAINER_NAME
+
+    def is_container_running():
+        return DOCKER_CLIENT.is_container_running(container_name)
+
+    if not poll_condition(is_container_running, timeout=timeout):
+        return False
+
+    logfile = LocalstackContainer(container_name).logfile
+
+    ready = threading.Event()
+
+    def set_ready_if_marker_found(_line: str):
+        if _line == READY_MARKER_OUTPUT:
+            ready.set()
+
+    # start a tail on the logfile
+    listener = FileListener(logfile, set_ready_if_marker_found)
+    listener.start()
+
+    try:
+        # but also check the existing log in case the container has been running longer
+        with open(logfile, "r") as fd:
+            for line in fd:
+                if READY_MARKER_OUTPUT == line.strip():
+                    return True
+
+        # TODO: calculate remaining timeout
+        return ready.wait(timeout)
+    finally:
+        listener.close()
 
 
 # ---------------

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -577,7 +577,7 @@ class LocalstackContainer:
                 mount_volumes.append((volume.host_dir, volume.container_dir))
             else:
                 raise NotImplementedError("no support for volume type %s" % type(volume))
-            mount_volumes.append(volume)
+
         return mount_volumes
 
     def run(self):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1966,7 +1966,7 @@ class FileListener:
 
     def _do_start_thread(self) -> FuncThread:
         if self.use_tail_command:
-            thread = self._create_tail_command_thread()  # FIXME run shell command thread
+            thread = self._create_tail_command_thread()
             thread.start()
             thread.started.wait(5)
             self.started.set()

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -164,6 +164,7 @@ class ShellCommandThread(FuncThread):
         self.log_listener = log_listener
         self.stop_listener = stop_listener
         self.strip_color = strip_color
+        self.started = threading.Event()
         FuncThread.__init__(self, self.run_cmd, params, quiet=quiet)
 
     def run_cmd(self, params):
@@ -206,6 +207,7 @@ class ShellCommandThread(FuncThread):
                 inherit_cwd=self.inherit_cwd,
                 inherit_env=self.inherit_env,
             )
+            self.started.set()
             if outfile:
                 if outfile == subprocess.PIPE:
                     # get stdout/stderr from child process and write to parent output
@@ -1925,6 +1927,86 @@ class _RequestsSafe(type):
             return method(*args, **kwargs)
 
         return _wrapper
+
+
+class FileListener:
+    """
+    Platform independent `tail -f` command that calls a callback every time a new line is received on the file. If
+    use_tail_command is set (which is the default if we're not on windows and the tail command is available),
+    then a `tail -f` subprocess will be started. Otherwise the tailer library is used that uses polling with retry.
+    """
+
+    def __init__(self, file_path: str, callback: Callable[[str], None]):
+        self.file_path = file_path
+        self.callback = callback
+
+        self.thread: Optional[FuncThread] = None
+        self.started = threading.Event()
+
+        self.use_tail_command = not is_windows() and is_command_available("tail")
+
+    def start(self):
+        self.thread = self._do_start_thread()
+        self.started.wait()
+
+        if self.thread.result_future.done():
+            # this will re-raise exceptions from the run command that occurred before started was set
+            self.thread.result_future.result()
+
+    def join(self, timeout=None):
+        if self.thread:
+            self.thread.join(timeout=timeout)
+
+    def close(self):
+        if self.thread and self.thread.running:
+            self.thread.stop()
+
+        self.started.clear()
+        self.thread = None
+
+    def _do_start_thread(self) -> FuncThread:
+        if self.use_tail_command:
+            thread = self._create_tail_command_thread()  # FIXME run shell command thread
+            thread.start()
+            thread.started.wait(5)
+            self.started.set()
+        else:
+            thread = self._create_tailer_thread()
+            thread.start()
+
+        return thread
+
+    def _create_tail_command_thread(self) -> ShellCommandThread:
+        def _log_listener(line, *args, **kwargs):
+            try:
+                self.callback(line.rstrip("\r\n"))
+            except Exception:
+                pass
+
+        if not os.path.isfile(self.file_path):
+            raise FileNotFoundError
+
+        return ShellCommandThread(
+            cmd=["tail", "-f", self.file_path], quiet=False, log_listener=_log_listener
+        )
+
+    def _create_tailer_thread(self) -> FuncThread:
+        from tailer import Tailer
+
+        tailer = Tailer(open(self.file_path), end=True)
+
+        def _run_follow(*_):
+            try:
+                self.started.set()
+                for line in tailer.follow(delay=0.25):
+                    try:
+                        self.callback(line)
+                    except Exception:
+                        pass
+            finally:
+                tailer.close()
+
+        return FuncThread(func=_run_follow, on_stop=tailer.close)
 
 
 # create class-of-a-class

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -504,7 +504,7 @@ class ContainerClient(metaclass=ABCMeta):
 class CmdDockerClient(ContainerClient):
     """Class for managing docker containers using the command line executable"""
 
-    default_run_outfile: Optional[str]
+    default_run_outfile: Optional[str] = None
 
     def _docker_cmd(self) -> List[str]:
         """Return the string to be used for running Docker commands."""

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -82,14 +82,6 @@ class NoSuchNetwork(ContainerException):
         self.network_name = network_name
 
 
-class HashableList(list):
-    def __hash__(self):
-        result = 0
-        for i in self:
-            result += hash(i)
-        return result
-
-
 class PortMappings(object):
     """Maps source to target port ranges for Docker port mappings."""
 

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import io
 import json
 import logging
@@ -79,6 +80,14 @@ class NoSuchNetwork(ContainerException):
         message = message or f"Docker network {network_name} not found"
         super().__init__(message, stdout, stderr)
         self.network_name = network_name
+
+
+class HashableList(list):
+    def __hash__(self):
+        result = 0
+        for i in self:
+            result += hash(i)
+        return result
 
 
 class PortMappings(object):
@@ -218,6 +227,59 @@ class PortMappings(object):
             range[0] = port + 1
         else:
             range[1] = port - 1
+
+
+SimpleVolumeBind = Tuple[str, str]
+"""Type alias for a simple version of VolumeBind"""
+
+
+@dataclasses.dataclass
+class VolumeBind:
+    """Represents a --volume argument run/create command. When using VolumeBind to bind-mount a file or directory
+    that does not yet exist on the Docker host, -v creates the endpoint for you. It is always created as a directory.
+    """
+
+    host_dir: str
+    container_dir: str
+    options: Optional[List[str]] = None
+
+    def to_str(self) -> str:
+        args = list()
+
+        if self.host_dir:
+            args.append(self.host_dir)
+
+        if not self.container_dir:
+            raise ValueError("no container dir specified")
+
+        args.append(self.container_dir)
+
+        if self.options:
+            args.append(self.options)
+
+        return ":".join(args)
+
+
+class VolumeMappings:
+    mappings: List[Union[SimpleVolumeBind, VolumeBind]]
+
+    def __init__(self, mappings: List[Union[SimpleVolumeBind, VolumeBind]] = None):
+        self.mappings = mappings if mappings is not None else list()
+
+    def add(self, mapping: Union[SimpleVolumeBind, VolumeBind]):
+        self.append(mapping)
+
+    def append(
+        self,
+        mapping: Union[
+            SimpleVolumeBind,
+            VolumeBind,
+        ],
+    ):
+        self.mappings.append(mapping)
+
+    def __iter__(self):
+        return self.mappings.__iter__()
 
 
 class ContainerClient(metaclass=ABCMeta):
@@ -361,7 +423,7 @@ class ContainerClient(metaclass=ABCMeta):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[Tuple[str, str]]] = None,
+        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         env_vars: Optional[Dict[str, str]] = None,
         user: Optional[str] = None,
@@ -390,7 +452,7 @@ class ContainerClient(metaclass=ABCMeta):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[Tuple[str, str]]] = None,
+        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         env_vars: Optional[Dict[str, str]] = None,
         user: Optional[str] = None,
@@ -441,6 +503,8 @@ class ContainerClient(metaclass=ABCMeta):
 
 class CmdDockerClient(ContainerClient):
     """Class for managing docker containers using the command line executable"""
+
+    default_run_outfile: Optional[str]
 
     def _docker_cmd(self) -> List[str]:
         """Return the string to be used for running Docker commands."""
@@ -759,7 +823,7 @@ class CmdDockerClient(ContainerClient):
             "inherit_env": True,
             "asynchronous": True,
             "stderr": subprocess.PIPE,
-            "outfile": subprocess.PIPE,
+            "outfile": self.default_run_outfile or subprocess.PIPE,
         }
         if stdin:
             kwargs["stdin"] = True
@@ -797,7 +861,7 @@ class CmdDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[Tuple[str, str]]] = None,
+        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         env_vars: Optional[Dict[str, str]] = None,
         user: Optional[str] = None,
@@ -930,10 +994,14 @@ class Util:
         additional_flags: str,
         env_vars: Dict[str, str] = None,
         ports: PortMappings = None,
-        mounts: List[Tuple[str, str]] = None,
+        mounts: List[SimpleVolumeBind] = None,
         network: Optional[str] = None,
     ) -> Tuple[
-        Dict[str, str], PortMappings, List[Tuple[str, str]], Optional[Dict[str, str]], Optional[str]
+        Dict[str, str],
+        PortMappings,
+        List[SimpleVolumeBind],
+        Optional[Dict[str, str]],
+        Optional[str],
     ]:
         """Parses environment, volume and port flags passed as string
         :param additional_flags: String which contains the flag definitions
@@ -1025,7 +1093,7 @@ class Util:
 
     @staticmethod
     def convert_mount_list_to_dict(
-        mount_volumes: List[Tuple[str, str]]
+        mount_volumes: List[SimpleVolumeBind],
     ) -> Dict[str, Dict[str, str]]:
         """Converts a List of (host_path, container_path) tuples to a Dict suitable as volume argument for docker sdk"""
         return dict(
@@ -1350,7 +1418,7 @@ class SdkDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[Tuple[str, str]]] = None,
+        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         env_vars: Optional[Dict[str, str]] = None,
         user: Optional[str] = None,
@@ -1427,7 +1495,7 @@ class SdkDockerClient(ContainerClient):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[Tuple[str, str]]] = None,
+        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
         ports: Optional[PortMappings] = None,
         env_vars: Optional[Dict[str, str]] = None,
         user: Optional[str] = None,

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -204,6 +204,8 @@ class OutputReaderThread(FuncThread):
                 LOGGER.warning("Unable to notify log subscriber: %s" % e)
 
     def start_reading(self, params):
+        # FIXME: consider using common.FileListener
+
         for line in self._tail(params["file"]):
             # notify subscribers
             self.notify_subscribers(line)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ six>=1.12.0
 stevedore>=3.4.0
 # needed for python3.7 compat (TypedDict, Literal, type hints)
 typing-extensions; python_version < '3.8'
+tailer>=0.4.1
 
 # extra=runtime
 airspeed>=0.5.14

--- a/tests/bootstrap/__init__.py
+++ b/tests/bootstrap/__init__.py
@@ -1,0 +1,2 @@
+"""Bootstrapping is the process of starting localstack. This is not always testable in the regular integration test
+environment. This is what this module is for. """

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -1,0 +1,100 @@
+import pytest
+import requests
+from click.testing import CliRunner
+
+from localstack import config
+from localstack.cli.localstack import localstack as cli
+from localstack.config import get_edge_url, in_docker
+from localstack.services.infra import READY_MARKER_OUTPUT
+from localstack.utils import docker_utils
+from localstack.utils.common import poll_condition
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def container_exists(client, container_name):
+    try:
+        container_id = client.get_container_id(container_name)
+        return True if container_id else False
+    except Exception:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def container_client():
+    client = docker_utils.SdkDockerClient()
+
+    yield client
+
+    try:
+        client.stop_container(config.MAIN_CONTAINER_NAME)
+    except Exception:
+        pass
+
+    # wait until container has been removed
+    assert poll_condition(
+        lambda: not container_exists(client, config.MAIN_CONTAINER_NAME), timeout=20
+    )
+
+
+@pytest.mark.skipif(condition=in_docker(), reason="cannot run CLI tests in docker")
+class TestCliContainerLifecycle:
+    def test_start_wait_stop(self, runner, container_client):
+        result = runner.invoke(cli, ["start", "-d"])
+        assert result.exit_code == 0
+        assert "starting LocalStack" in result.output
+
+        result = runner.invoke(cli, ["wait", "-t", "60"])
+        assert result.exit_code == 0
+
+        assert container_client.is_container_running(
+            config.MAIN_CONTAINER_NAME
+        ), "container name was not running after wait"
+
+        health = requests.get(get_edge_url() + "/health")
+        assert health.ok, "health request did not return OK: %s" % health.text
+
+        result = runner.invoke(cli, ["stop"])
+        assert result.exit_code == 0
+
+        with pytest.raises(requests.ConnectionError):
+            requests.get(get_edge_url() + "/health")
+
+    def test_wait_timeout_raises_exception(self, runner, container_client):
+        result = runner.invoke(cli, ["start", "-d"])
+        assert result.exit_code == 0
+        assert "starting LocalStack" in result.output
+
+        result = runner.invoke(
+            cli, ["wait", "-t", "0.5"]
+        )  # on day this test will hopefully fail ;-)
+        assert result.exit_code != 0
+
+    def test_logs(self, runner, container_client):
+        result = runner.invoke(cli, ["logs"])
+        assert result.exit_code != 0
+
+        runner.invoke(cli, ["start", "-d"])
+        runner.invoke(cli, ["wait", "-t", "60"])
+
+        result = runner.invoke(cli, ["logs"])
+        assert READY_MARKER_OUTPUT in result.output
+
+    def test_status_services(self, runner):
+        result = runner.invoke(cli, ["status", "services"])
+        assert result.exit_code != 0
+        assert "could not connect to LocalStack health endpoint" in result.output
+
+        runner.invoke(cli, ["start", "-d"])
+        runner.invoke(cli, ["wait", "-t", "60"])
+
+        result = runner.invoke(cli, ["status", "services"])
+
+        # just a smoke test
+        assert "dynamodb" in result.output
+        for line in result.output.splitlines():
+            if "dynamodb" in line:
+                assert "available" in line

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -68,9 +68,8 @@ class TestCliContainerLifecycle:
         assert result.exit_code == 0
         assert "starting LocalStack" in result.output
 
-        result = runner.invoke(
-            cli, ["wait", "-t", "0.5"]
-        )  # on day this test will hopefully fail ;-)
+        result = runner.invoke(cli, ["wait", "-t", "0.5"])
+        # one day this test will surely fail ;-)
         assert result.exit_code != 0
 
     def test_logs(self, runner, container_client):

--- a/tests/bootstrap/test_localstack_container.py
+++ b/tests/bootstrap/test_localstack_container.py
@@ -1,0 +1,27 @@
+import pytest
+import requests
+
+from localstack import config
+from localstack.config import in_docker
+from localstack.utils.bootstrap import LocalstackContainerServer
+
+
+@pytest.mark.skipif(condition=in_docker(), reason="cannot run bootstrap tests in docker")
+class TestLocalstackContainerServer:
+    def test_lifecycle(self):
+
+        server = LocalstackContainerServer()
+        server.container.ports.add(config.EDGE_PORT)
+
+        assert not server.is_up()
+        try:
+            server.start()
+            assert server.wait_is_up(60)
+
+            response = requests.get("http://localhost:4566/health")
+            assert response.ok, "expected health check to return OK: %s" % response.text
+        finally:
+            server.shutdown()
+
+        server.join(30)
+        assert not server.is_up()

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -1,14 +1,21 @@
+import os.path
 import threading
+import time
 import unittest
 from unittest.mock import MagicMock
 
 import pytest
 
-from localstack.utils.common import is_none_or_empty, run, synchronized
+from localstack.utils.common import (
+    FileListener,
+    is_none_or_empty,
+    poll_condition,
+    run,
+    synchronized,
+)
 
 
 class SynchronizedTest(unittest.TestCase):
-
     reallock = threading.RLock()
     mocklock = MagicMock(wraps=reallock)
 
@@ -61,3 +68,81 @@ def test_run_cmd_as_str_or_list():
     assert "foo bar 123" == _run(["echo", "foo", "bar", "123"])
     with pytest.raises(FileNotFoundError):
         _run(["echo 'foo bar 123'"])
+
+
+@pytest.mark.parametrize("tail_engine", ["command", "tailer"])
+class TestFileListener:
+    def test_basic_usage(self, tail_engine, tmp_path):
+        lines = list()
+
+        file = tmp_path / "log.txt"
+        file.touch()
+        fd = open(file, "a")
+        listener = FileListener(str(file), lines.append)
+        listener.use_tail_command = tail_engine != "tailer"
+
+        try:
+            listener.start()
+            assert listener.started.is_set()
+            fd.write("hello" + os.linesep)
+            fd.write("pytest" + os.linesep)
+            fd.flush()
+
+            assert poll_condition(lambda: len(lines) == 2, timeout=3), (
+                "expected two lines to appear. %s" % lines
+            )
+
+            assert lines[0] == "hello"
+            assert lines[1] == "pytest"
+        finally:
+            listener.close()
+
+        try:
+            fd.write("foobar" + os.linesep)
+            time.sleep(0.5)
+            assert len(lines) == 2, "expected listener.stop() to stop listening on new "
+        finally:
+            fd.close()
+
+    def test_callback_exception_ignored(self, tail_engine, tmp_path):
+        lines = list()
+
+        def callback(line):
+            if "throw" in line:
+                raise ValueError("oh noes")
+
+            lines.append(line)
+
+        file = tmp_path / "log.txt"
+        file.touch()
+        fd = open(file, "a")
+        listener = FileListener(str(file), callback)
+        listener.use_tail_command = tail_engine != "tailer"
+
+        try:
+            listener.start()
+            assert listener.started.is_set()
+            fd.write("hello" + os.linesep)
+            fd.flush()
+            fd.write("throw" + os.linesep)
+            fd.write("pytest" + os.linesep)
+            fd.flush()
+
+            assert poll_condition(lambda: len(lines) == 2, timeout=3), (
+                "expected two lines to appear. %s" % lines
+            )
+
+            assert lines[0] == "hello"
+            assert lines[1] == "pytest"
+        finally:
+            fd.close()
+            listener.close()
+
+    def test_open_missing_file(self, tail_engine):
+        lines = list()
+
+        listener = FileListener("/tmp/does/not/exist", lines.append)
+        listener.use_tail_command = tail_engine != "tailer"
+
+        with pytest.raises(FileNotFoundError):
+            listener.start()


### PR DESCRIPTION
This PR adds the following CLI commands and the necessary restructuring to make them possible:

*  `localstack start --detached`: starts the localstack container in the background
* `localstack wait` blocks until localstack is running (the ready marker has been printed)
* `localstack logs --follow` tails the log output of localstack

The most noteworthy changes and improvements:

* The most fundamental change is that, in the `start_infra_in_docker` routine, the terminal output no longer comes directly from the `docker run` command itself, but is forwarded to a logfile in the TMP folder that is then tailed using a new uiltity called `FileListener` (that is platform independent, but needs to be tested on Windows). that log is then printed to stdout asynchronously, while waiting on the docker run command to stop (via the `Server` abstraction)
* added the CLI commands
* The part of `start_infra_in_docker` that was building the command is now separated into a holder object (`LocalstackContainer`) and a configuration routine (`configure_container`)
* adds a dedicated test step for bootstrapping (which involves starting up and tearing down the container).
* `FORCE_NONINTERACTIVE` is not used anymore (there's no obvious reason to have an interactive tty docker session when only logs are printed to stdout)

Some things that I hope will be useful in the future:
* with the `LocalstackContainerServer`, you can now treat localstack as you would any `Server` implementation. this can be used in tests to start up and tear down localstack without mucking about with low-level docker commands.
* the `LocalstackContainer` object can be passed to configuration hooks that modify the startup behavior, without being part of the actual startup routine
* being able to start localstack in detached mode via the CLI paves the way for a new type of UX

Things that need improving:
* more bootstrap tests! especially for testing custom docker flags and volume mounts
* The way the logfile is resolved for the `LocalstackContainer` is sort of hacky
* The CmdDockerClient is used to allow the `--privileged` flag for the container startup
* extend the item types `VolumeMappings` and use that throughout the `ContainerClient` abstraction (some ideas in this gist: https://gist.github.com/thrau/b450e79c6a08d965ca2731b26065b67c)
* the ContainerClient abstraction does not provide any way of capturing or streaming the output of commands to something outside of the abstraction. i added `default_out_file` as a workaround, which is handed down as `outfile` parameter to the underlying subprocess to be able to capture the output of a `run_container` execution
* the CI build step starts up localstack containers with the latest image, not the one built in the pipeline. this is only an issue when there is new interaction between the cli and the container runtime.