### PR TITLE
make can_use_sudo use non-interactive mode

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -537,7 +537,7 @@ def do_start_edge(bind_address, port, use_ssl, asynchronous=False):
 
 def can_use_sudo():
     try:
-        run("echo | sudo -S echo", print_error=False)
+        run("sudo -n -v", print_error=False)
         return True
     except Exception:
         return False


### PR DESCRIPTION
small change that avoids requiring stdin for can_use_sudo