### PR TITLE
add plugin-based hooks for bootstrapping and infra startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,6 @@ clean-dist:				  ## Clean up python distribution directories
 
 # deprecated commands
 infra:             		  # legacy command used in the supervisord file to
-	($(VENV_RUN); exec bin/localstack start --host --no-banner)
+	($(VENV_RUN); LOCALSTACK_INFRA_PROCESS=1 exec bin/localstack start --host --no-banner)
 
 .PHONY: usage venv freeze install-basic install-runtime install-test install-dev install entrypoints init init-testlibs dist publish coveralls start docker-save-image docker-save-image-light docker-build docker-build-light docker-build-multi-platform docker-push-master docker-create-push-manifests docker-create-push-manifests-light docker-run-tests docker-run docker-mount-run docker-build-lambdas docker-cp-coverage test test-coverage test-docker test-docker-mount test-docker-mount-code ci-pro-smoke-tests lint lint-modified format format-modified init-precommit clean clean-dist vagrant-start vagrant-stop infra

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ clean-dist:				  ## Clean up python distribution directories
 	rm -rf *.egg-info
 
 # deprecated commands
-infra:             		  # legacy command used in the supervisord file to
-	($(VENV_RUN); LOCALSTACK_INFRA_PROCESS=1 exec bin/localstack start --host --no-banner)
+infra:             		  # legacy command used in the supervisord file to. Do not use subshell to allow proper signal handling.
+	$(VENV_RUN); LOCALSTACK_INFRA_PROCESS=1 exec bin/localstack start --host --no-banner
 
 .PHONY: usage venv freeze install-basic install-runtime install-test install-dev install entrypoints init init-testlibs dist publish coveralls start docker-save-image docker-save-image-light docker-build docker-build-light docker-build-multi-platform docker-push-master docker-create-push-manifests docker-create-push-manifests-light docker-run-tests docker-run docker-mount-run docker-build-lambdas docker-cp-coverage test test-coverage test-docker test-docker-mount test-docker-mount-code ci-pro-smoke-tests lint lint-modified format format-modified init-precommit clean clean-dist vagrant-start vagrant-stop infra

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -23,7 +23,7 @@ term_handler() {
     kill ${send_sig} "$suppid"
     wait "$suppid"
   fi
-  exit 143; # 128 + 15 -- SIGTERM
+  exit 0; # 128 + 15 = 143 -- SIGTERM, but 0 is expected if proper shutdown takes place
 }
 
 # Strip `LOCALSTACK_` prefix in environment variables name (except LOCALSTACK_HOSTNAME)

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -94,6 +94,8 @@ def cmd_status_services():
 def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
     if docker and host:
         raise click.ClickException("Please specify either --docker or --host")
+    if host and detached:
+        raise click.ClickException("Cannot start detached in host mode")
 
     if not no_banner:
         print_banner()
@@ -108,15 +110,12 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
         else:
             console.log("starting LocalStack in Docker mode :whale:")
 
-        if not detached:
-            console.rule(
-                "LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)"
-            )
+    bootstrap.prepare_host()
+
+    if not no_banner and not detached:
+        console.rule("LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)")
 
     if host:
-        if detached:
-            raise click.ClickException("cannot start detached in host mode")
-
         bootstrap.start_infra_locally()
     else:
         if detached:

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -1,16 +1,15 @@
+import logging
+
 from localstack import config
+from localstack.runtime import hooks
 
-# Note: make sure not to add any additional imports at the global scope here!
+LOG = logging.getLogger(__name__)
 
 
-def register_localstack_plugins():
-
-    docker_flags = []
-
-    # add Docker flags for edge ports
-    for port in [config.EDGE_PORT, config.EDGE_PORT_HTTP]:
+@hooks.configure_localstack_container()
+def configure_edge_port(container):
+    ports = [config.EDGE_PORT, config.EDGE_PORT_HTTP]
+    LOG.info("configuring container with edge ports: %s", ports)
+    for port in ports:
         if port:
-            docker_flags += ["-p {p}:{p}".format(p=port)]
-
-    result = {"docker": {"run_flags": " ".join(docker_flags)}}
-    return result
+            container.ports.add(port)

--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -1,0 +1,79 @@
+import functools
+
+from plugin import PluginManager, plugin
+
+# plugin namespace constants
+HOOKS_CONFIGURE_LOCALSTACK_CONTAINER = "localstack.hooks.configure_localstack_container"
+HOOKS_INSTALL = "localstack.hooks.install"
+HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
+HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
+HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
+
+
+def hook(namespace: str, priority: int = 0, **kwargs):
+    """
+    Decorator for creating functional plugins that have a hook_priority attribute.
+    """
+
+    def wrapper(fn):
+        fn.hook_priority = priority
+        return plugin(namespace=namespace, **kwargs)(fn)
+
+    return wrapper
+
+
+def hook_spec(namespace: str):
+    """
+    Creates a new hook decorator bound to a namespace.
+
+    on_infra_start = hook_spec("localstack.hooks.on_infra_start")
+
+    @on_infra_start()
+    def foo():
+        pass
+
+    # run all hooks in order
+    on_infra_start.run()
+    """
+    fn = functools.partial(hook, namespace=namespace)
+    # attach hook manager and run method to decorator for convenience calls
+    fn.manager = HookManager(namespace)
+    fn.run = fn.manager.run_in_order
+    return fn
+
+
+class HookManager(PluginManager):
+    def load_all_sorted(self, propagate_exceptions=False):
+        """
+        Loads all hook plugins and sorts them by their hook_priority attribute.
+        """
+        plugins = self.load_all(propagate_exceptions)
+        # the hook_priority attribute is part of the function wrapped in the FunctionPlugin
+        plugins.sort(
+            key=lambda _fn_plugin: getattr(_fn_plugin.fn, "hook_priority", 0), reverse=True
+        )
+        return plugins
+
+    def run_in_order(self, *args, **kwargs):
+        """
+        Loads and runs all plugins in order them with the given arguments.
+        """
+        for fn_plugin in self.load_all_sorted():
+            fn_plugin(*args, **kwargs)
+
+    def __str__(self):
+        return "HookManager(%s)" % self.namespace
+
+    def __repr__(self):
+        return self.__str__()
+
+
+# localstack container configuration (on the host)
+configure_localstack_container = hook_spec(HOOKS_CONFIGURE_LOCALSTACK_CONTAINER)
+# additional installers
+install = hook_spec(HOOKS_INSTALL)
+# prepare the host that's starting localstack
+prepare_host = hook_spec(HOOKS_PREPARE_HOST)
+# infra (runtime) lifecycle hooks
+on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
+on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -27,12 +27,11 @@ from localstack.constants import (
     ELASTICSEARCH_PLUGIN_LIST,
     INSTALL_DIR_INFRA,
     KMS_URL_PATTERN,
-    LOCALSTACK_INFRA_PROCESS,
     LOCALSTACK_MAVEN_VERSION,
     MODULE_MAIN_PATH,
     STS_JAR_URL,
 )
-from localstack.utils import bootstrap
+from localstack.runtime import hooks
 from localstack.utils.common import (
     chmod_r,
     download,
@@ -481,9 +480,7 @@ def install_components(names):
 
 
 def install_all_components():
-    # load plugins
-    os.environ[LOCALSTACK_INFRA_PROCESS] = "1"
-    bootstrap.load_plugins()
+    hooks.install.run_in_order()
     # install all components
     install_components(DEFAULT_SERVICE_PORTS.keys())
 
@@ -616,6 +613,7 @@ class InstallerManager:
 
 def main():
     if len(sys.argv) > 1:
+        # set API key so pro install hooks are called
         os.environ["LOCALSTACK_API_KEY"] = os.environ.get("LOCALSTACK_API_KEY") or "test"
         if sys.argv[1] == "libs":
             print("Initializing installation.")

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -480,7 +480,7 @@ def install_components(names):
 
 
 def install_all_components():
-    hooks.install.run_in_order()
+    hooks.install.run()
     # install all components
     install_components(DEFAULT_SERVICE_PORTS.keys())
 

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -1,18 +1,15 @@
 import functools
 import logging
 import os
-import pkgutil
 import re
 import shlex
-import sys
 import threading
 import warnings
 from functools import wraps
 from typing import Iterable, List, Optional, Set
 
-import six
-
 from localstack import config, constants
+from localstack.runtime import hooks
 from localstack.utils.common import FileListener, chmod_r, mkdir, poll_condition
 from localstack.utils.docker_utils import (
     DOCKER_CLIENT,
@@ -29,13 +26,6 @@ from localstack.utils.run import run, to_str
 from localstack.utils.serving import Server
 
 LOG = logging.getLogger(os.path.basename(__file__))
-
-# maps plugin scope ("services", "commands") to flags which indicate whether plugins have been loaded
-PLUGINS_LOADED = {}
-
-# predefined list of plugin modules, to speed up the plugin loading at startup
-# note: make sure to load localstack_ext before localstack
-PLUGIN_MODULES = ["localstack_ext", "localstack"]
 
 # marker for extended/ignored libs in requirements.txt
 IGNORED_LIB_MARKER = "#extended-lib"
@@ -102,89 +92,6 @@ def log_duration(name=None, min_ms=500):
         return wrapped
 
     return wrapper
-
-
-@log_duration()
-def load_plugin_from_path(file_path, scope=None):
-    if os.path.exists(file_path):
-        delimiters = r"[\\/]"
-        not_delimiters = r"[^\\/]"
-        regex = r"(^|.+{d})({n}+){d}plugins.py".format(d=delimiters, n=not_delimiters)
-        module = re.sub(regex, r"\2", file_path)
-        method_name = "register_localstack_plugins"
-        scope = scope or PLUGIN_SCOPE_SERVICES
-        if scope == PLUGIN_SCOPE_COMMANDS:
-            method_name = "register_localstack_commands"
-        try:
-            namespace = {}
-            exec("from %s.plugins import %s" % (module, method_name), namespace)
-            method_to_execute = namespace[method_name]
-        except Exception as e:
-            if not re.match(r".*cannot import name .*%s.*" % method_name, str(e)) and (
-                "No module named" not in str(e)
-            ):
-                LOG.debug("Unable to load plugins from module %s: %s" % (module, e))
-            return
-        try:
-            LOG.debug(
-                'Loading plugins - scope "%s", module "%s": %s' % (scope, module, method_to_execute)
-            )
-            return method_to_execute()
-        except Exception as e:
-            if not os.environ.get(ENV_SCRIPT_STARTING_DOCKER):
-                LOG.warning("Unable to load plugins from file %s: %s" % (file_path, e))
-
-
-def should_load_module(module, scope):
-    if module == "localstack_ext" and not os.environ.get("LOCALSTACK_API_KEY"):
-        return False
-    return True
-
-
-@log_duration()
-def load_plugins(scope=None):
-    scope = scope or PLUGIN_SCOPE_SERVICES
-    if PLUGINS_LOADED.get(scope):
-        return PLUGINS_LOADED[scope]
-
-    is_infra_process = (
-        os.environ.get(constants.LOCALSTACK_INFRA_PROCESS) in ["1", "true"] or "--host" in sys.argv
-    )
-    log_level = logging.WARNING if scope == PLUGIN_SCOPE_COMMANDS and not is_infra_process else None
-    setup_logging(log_level=log_level)
-
-    loaded_files = []
-    result = []
-
-    # Use a predefined list of plugin modules for now, to speed up the plugin loading at startup
-    # search_modules = pkgutil.iter_modules()
-    search_modules = PLUGIN_MODULES
-
-    for module in search_modules:
-        if not should_load_module(module, scope):
-            continue
-        file_path = None
-        if isinstance(module, six.string_types):
-            loader = pkgutil.get_loader(module)
-            if loader:
-                path = getattr(loader, "path", "") or getattr(loader, "filename", "")
-                if "__init__.py" in path:
-                    path = os.path.dirname(path)
-                file_path = os.path.join(path, "plugins.py")
-        elif six.PY3 and not isinstance(module, tuple):
-            file_path = os.path.join(module.module_finder.path, module.name, "plugins.py")
-        elif six.PY3 or isinstance(module[0], pkgutil.ImpImporter):
-            if hasattr(module[0], "path"):
-                file_path = os.path.join(module[0].path, module[1], "plugins.py")
-        if file_path and file_path not in loaded_files:
-            plugin_config = load_plugin_from_path(file_path, scope=scope)
-            if plugin_config:
-                result.append(plugin_config)
-            loaded_files.append(file_path)
-    # set global flag
-    PLUGINS_LOADED[scope] = result
-
-    return result
 
 
 def get_docker_image_details(image_name=None):
@@ -257,10 +164,6 @@ def get_server_version():
 
 def setup_logging(log_level=None):
     """Determine and set log level"""
-
-    if PLUGINS_LOADED.get("_logging_"):
-        return
-    PLUGINS_LOADED["_logging_"] = True
 
     # log level set by DEBUG env variable
     log_level = log_level or (logging.DEBUG if config.DEBUG else logging.INFO)
@@ -688,13 +591,7 @@ def configure_container(container: LocalstackContainer):
     container.additional_flags.extend(shlex.split(user_flags))
 
     # get additional parameters from plugins
-    # TODO: extract this into container config hooks and remove old plugin code
-    plugin_configs = load_plugins()
-    plugin_run_params = " ".join(
-        [entry.get("docker", {}).get("run_flags", "") for entry in plugin_configs]
-    )
-    plugin_run_params = extract_port_flags(plugin_run_params, container.ports)
-    container.additional_flags.extend(shlex.split(plugin_run_params))
+    hooks.configure_localstack_container.run()
 
     # construct default port mappings
     service_ports = config.SERVICE_PORTS
@@ -729,6 +626,17 @@ def configure_container(container: LocalstackContainer):
     bind_mounts.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
 
     container.additional_flags.append("--privileged")
+
+
+@log_duration()
+def prepare_host():
+    """
+    Prepare the host environment for running LocalStack, this should be called before start_infra_*.
+    """
+    if os.environ.get(constants.LOCALSTACK_INFRA_PROCESS) in constants.TRUE_STRINGS:
+        return
+
+    hooks.prepare_host.run()
 
 
 def start_infra_in_docker():

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -591,7 +591,7 @@ def configure_container(container: LocalstackContainer):
     container.additional_flags.extend(shlex.split(user_flags))
 
     # get additional parameters from plugins
-    hooks.configure_localstack_container.run()
+    hooks.configure_localstack_container.run(container)
 
     # construct default port mappings
     service_ports = config.SERVICE_PORTS

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -550,7 +550,9 @@ class LocalstackContainerServer(Server):
 
     def do_shutdown(self):
         try:
-            DOCKER_CLIENT.stop_container(self.container.name)
+            CmdDockerClient().stop_container(
+                self.container.name, timeout=10
+            )  # giving the container some time to stop
         except Exception as e:
             LOG.info("error cleaning up localstack container %s: %s", self.container.name, e)
 
@@ -612,6 +614,10 @@ def configure_container(container: LocalstackContainer):
             container.env_vars[env_var] = value
     container.env_vars["DOCKER_HOST"] = f"unix://{config.DOCKER_SOCK}"
     container.env_vars["HOST_TMP_FOLDER"] = config.HOST_TMP_FOLDER
+
+    # TODO discuss if this should be the default?
+    # to activate proper signal handling
+    container.env_vars["SET_TERM_HANDLER"] = "1"
 
     # data_dir mounting and environment variables
     bind_mounts = []

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -636,6 +636,7 @@ def prepare_host():
     if os.environ.get(constants.LOCALSTACK_INFRA_PROCESS) in constants.TRUE_STRINGS:
         return
 
+    setup_logging()
     hooks.prepare_host.run()
 
 


### PR DESCRIPTION
This PR replaces the old plugin loading mechanism methods `load_plugins` and `register_localstack_plugins`, with the new plugin-based hook system.

* Add the `hook_spec` and `HookManager` concepts built around [function plugins](https://github.com/localstack/localstack-plugin-loader/#functions-as-plugins) (into a new `runtime` module in preparation for more infra -> runtime refactoring)
* Add four types of hooks (can be extended in the future for more fine-grained control over the startup proceedure)
  * `configure_localstack_container` gets handed the `LocalstackContainer` object to add port mappings, volume binds, ... or anything else to the container that's about to run localstack
  * `install` called in `install.py::install_components` that is called when the infra is started, or `install.py` is run from the terminal
  * `prepare_host` called to prepare the host from which localstack is started, which shouldn't be called as part of the infra (e.g., creates the DNS server forward, the ec2 daemon, etc, ...)
  * `on_infra_start` called when `do_infra_start` is called, and currently used for most of the pro setup (patching, ...)
  * `on_infra_ready` called after the Ready marker has been printed

the companion PR in localstack-ext now uses these hooks to augment the localstack runtime.

