### PR TITLE
Strip extra xmlns attributes in PutBucketNotification requests

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -51,6 +51,7 @@ from localstack.utils.common import (
     md5,
     not_none_or,
     short_uid,
+    strip_xmlns,
     timestamp_millis,
     to_bytes,
     to_str,
@@ -1049,7 +1050,7 @@ def _sanitize_notification_filter_rules(filter_doc):
 
 
 def handle_put_bucket_notification(bucket, data):
-    parsed = xmltodict.parse(data)
+    parsed = strip_xmlns(xmltodict.parse(data))
     notif_config = parsed.get("NotificationConfiguration")
 
     notifications = []

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -921,6 +921,22 @@ def obj_to_xml(obj: SerializableObj) -> str:
     return str(obj)
 
 
+def strip_xmlns(obj: Any) -> Any:
+    """Strip xmlns attributes from a dict returned by xmltodict.parse."""
+    if isinstance(obj, list):
+        return [strip_xmlns(item) for item in obj]
+    if isinstance(obj, dict):
+        # Remove xmlns attribute.
+        obj.pop("@xmlns", None)
+        if len(obj) == 1 and "#text" in obj:
+            # If the only remaining key is the #text key, elide the dict
+            # entirely, to match the structure that xmltodict.parse would have
+            # returned if the xmlns namespace hadn't been present.
+            return obj["#text"]
+        return {k: strip_xmlns(v) for k, v in obj.items()}
+    return obj
+
+
 def now(millis: bool = False, tz: Optional[tzinfo] = None) -> int:
     return mktime(datetime.now(tz=tz), millis=millis)
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -190,6 +190,67 @@ class TestS3(unittest.TestCase):
         self.sqs_client.delete_queue(QueueUrl=queue_url)
         self._delete_bucket(bucket_name, [key_by_path, key_by_host])
 
+    def test_s3_put_object_notification_extra_xmlns(self):
+        """Test that request payloads with excessive xmlns attributes are
+        correctly handled.
+
+        This happens with the AWS Rust SDK.
+        See: https://github.com/awslabs/aws-sdk-rust/issues/301
+        """
+        bucket_name = "notif-%s" % short_uid()
+        s3_listener.handle_put_bucket_notification(
+            bucket_name,
+            """
+                <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <QueueConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id xmlns="http://s3.amazonaws.com/doc/2006-03-01/">queueid</Id>
+                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Put</Event>
+                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Post</Event>
+                        <Queue xmlns="http://s3.amazonaws.com/doc/2006-03-01/">queue</Queue>
+                        <Filter xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                            <S3Key xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                <FilterRule xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                    <Name xmlns="http://s3.amazonaws.com/doc/2006-03-01/">prefix</Name>
+                                    <Value xmlns="http://s3.amazonaws.com/doc/2006-03-01/">img/</Value>
+                                </FilterRule>
+                            </S3Key>
+                        </Filter>
+                    </QueueConfiguration>
+                    <TopicConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id xmlns="http://s3.amazonaws.com/doc/2006-03-01/">topicid</Id>
+                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Put</Event>
+                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Post</Event>
+                        <Topic xmlns="http://s3.amazonaws.com/doc/2006-03-01/">topic</Topic>
+                        <Filter xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                            <S3Key xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                <FilterRule xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                                    <Name xmlns="http://s3.amazonaws.com/doc/2006-03-01/">prefix</Name>
+                                    <Value xmlns="http://s3.amazonaws.com/doc/2006-03-01/">img/</Value>
+                                </FilterRule>
+                            </S3Key>
+                        </Filter>
+                    </TopicConfiguration>
+                </NotificationConfiguration>
+            """,
+        )
+        self.assertEqual(
+            s3_listener.S3_NOTIFICATIONS[bucket_name],
+            [
+                {
+                    "Id": "queueid",
+                    "Event": ["s3:ObjectCreated:Put", "s3:ObjectCreated:Post"],
+                    "Queue": "queue",
+                    "Filter": {"S3Key": {"FilterRule": [{"Name": "Prefix", "Value": "img/"}]}},
+                },
+                {
+                    "Id": "topicid",
+                    "Event": ["s3:ObjectCreated:Put", "s3:ObjectCreated:Post"],
+                    "Topic": "topic",
+                    "Filter": {"S3Key": {"FilterRule": [{"Name": "Prefix", "Value": "img/"}]}},
+                },
+            ],
+        )
+
     def test_s3_upload_fileobj_with_large_file_notification(self):
         bucket_name = "notif-large-%s" % short_uid()
         queue_url, queue_attributes = self._create_test_queue()


### PR DESCRIPTION
The Rust AWS SDK has extra xmlns attributes on child elements that cause localstack to misparse valid bucket notification configurations. I've described the issue more thoroughly here: https://github.com/awslabs/aws-sdk-rust/issues/301

I'm not really sure whose bug this is, to be honest. On the one hand localstack seems to choke on perfectly valid XML; on the other hand, sticking an `xmlns` attribute on every single element, like the Rust SDK does, is pretty weird. 

In any case, this PR fixes the issue on localstack's side, if that's deemed the right approach.