### PR TITLE
Patch cfn stack outputs for apigateway for localstack compatibility

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -46,7 +46,7 @@ AWS_URL_SUFFIX = "localhost.localstack.cloud"  # value is "amazonaws.com" in rea
 IAM_POLICY_VERSION = "2012-10-17"
 
 REGEX_OUTPUT_APIGATEWAY = re.compile(
-    rf"^(https?://.+\.execute-api\.).+-.+-\d\.(amazonaws\.com|{AWS_URL_SUFFIX})/?(.*)$"
+    rf"^(https?://.+\.execute-api\.)(?:[^-]+-){{2,3}}\d\.(amazonaws\.com|{AWS_URL_SUFFIX})/?(.*)$"
 )
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/cloudformation/test_cloudformation_apigateway.py
+++ b/tests/integration/cloudformation/test_cloudformation_apigateway.py
@@ -1,5 +1,6 @@
 import jinja2
 
+from localstack import constants
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
 from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
@@ -112,13 +113,13 @@ def test_url_output(
         describe_response = cfn_client.describe_stacks(StackName=stack_id)
         outputs = describe_response["Stacks"][0]["Outputs"]
         assert len(outputs) == 2
-        api_id = [o["OutputValue"] for o in outputs if o["OutputKey"] == "ApiV2IdOutput"][0]
-        api_url = [o["OutputValue"] for o in outputs if o["OutputKey"] == "ApiV2UrlOutput"][0]
+        api_id = [o["OutputValue"] for o in outputs if o["OutputKey"] == "ApiV1IdOutput"][0]
+        api_url = [o["OutputValue"] for o in outputs if o["OutputKey"] == "ApiV1UrlOutput"][0]
         assert api_id
         assert api_url
         assert api_id in api_url
 
-        assert f"https://{api_id}.execute-api.localhost.localstack.cloud:4566" in api_url
+        assert f"https://{api_id}.execute-api.{constants.LOCALHOST_HOSTNAME}:4566" in api_url
 
     finally:
         cleanup_changesets([change_set_id])

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -370,3 +370,9 @@ def create_secret(secretsmanager_client):
 
     for item in items:
         secretsmanager_client.delete_secret(SecretId=item)
+
+
+only_localstack = pytest.mark.skipif(
+    os.environ.get("TEST_TARGET") == "AWS_CLOUD",
+    reason="test only applicable if run against localstack",
+)

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -10,6 +10,7 @@ from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import create_dynamodb_table
 from localstack.utils.common import short_uid
+from localstack.utils.testutil import start_http_server
 
 if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
@@ -376,3 +377,10 @@ only_localstack = pytest.mark.skipif(
     os.environ.get("TEST_TARGET") == "AWS_CLOUD",
     reason="test only applicable if run against localstack",
 )
+
+
+@pytest.fixture
+def tmp_http_server():
+    test_port, invocations, proxy = start_http_server()
+    yield test_port, invocations, proxy
+    proxy.stop()

--- a/tests/integration/templates/apigateway-url-output.yaml
+++ b/tests/integration/templates/apigateway-url-output.yaml
@@ -1,0 +1,49 @@
+Resources:
+  apigatewayE40D7439:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: {{ api_name }}
+      ProtocolType: HTTP
+  apigatewayDefaultStage039FEAD4:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId:
+        Ref: apigatewayE40D7439
+      StageName: $default
+      AutoDeploy: true
+  apigatewayGEThttpbinHttpIntegration1cd746b1d7348180429a2b4fcf7c1b7b024AD786:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId:
+        Ref: apigatewayE40D7439
+      IntegrationType: HTTP_PROXY
+      IntegrationMethod: GET
+      IntegrationUri: {{ integration_uri }}
+      PayloadFormatVersion: "1.0"
+  apigatewayGEThttpbinF0433EA1:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId:
+        Ref: apigatewayE40D7439
+      RouteKey: GET /test
+      AuthorizationType: NONE
+      Target:
+        Fn::Join:
+          - ""
+          - - integrations/
+            - Ref: apigatewayGEThttpbinHttpIntegration1cd746b1d7348180429a2b4fcf7c1b7b024AD786
+Outputs:
+  ApiV2IdOutput:
+    Value:
+      Ref: apigatewayE40D7439
+  ApiV2UrlOutput:
+    Value:
+      Fn::Join:
+        - ""
+        - - https://
+          - Ref: apigatewayE40D7439
+          - .execute-api.
+          - Ref: AWS::Region
+          - "."
+          - Ref: AWS::URLSuffix
+          - /

--- a/tests/integration/templates/apigateway-url-output.yaml
+++ b/tests/integration/templates/apigateway-url-output.yaml
@@ -1,49 +1,78 @@
 Resources:
-  apigatewayE40D7439:
-    Type: AWS::ApiGatewayV2::Api
+  apiC8550315:
+    Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: {{ api_name }}
-      ProtocolType: HTTP
-  apigatewayDefaultStage039FEAD4:
-    Type: AWS::ApiGatewayV2::Stage
+      Name:  {{ api_name }}
+  apiCloudWatchRoleAC81D93E:
+    Type: AWS::IAM::Role
     Properties:
-      ApiId:
-        Ref: apigatewayE40D7439
-      StageName: $default
-      AutoDeploy: true
-  apigatewayGEThttpbinHttpIntegration1cd746b1d7348180429a2b4fcf7c1b7b024AD786:
-    Type: AWS::ApiGatewayV2::Integration
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+  apiAccount57E28B43:
+    Type: AWS::ApiGateway::Account
     Properties:
-      ApiId:
-        Ref: apigatewayE40D7439
-      IntegrationType: HTTP_PROXY
-      IntegrationMethod: GET
-      IntegrationUri: {{ integration_uri }}
-      PayloadFormatVersion: "1.0"
-  apigatewayGEThttpbinF0433EA1:
-    Type: AWS::ApiGatewayV2::Route
+      CloudWatchRoleArn:
+        Fn::GetAtt:
+          - apiCloudWatchRoleAC81D93E
+          - Arn
+    DependsOn:
+      - apiC8550315
+  apiDeployment149F1294451e98552b666b9a7a9c18bdf7f51246:
+    Type: AWS::ApiGateway::Deployment
     Properties:
-      ApiId:
-        Ref: apigatewayE40D7439
-      RouteKey: GET /test
+      RestApiId:
+        Ref: apiC8550315
+      Description: Automatically created by the RestApi construct
+    DependsOn:
+      - apiGETECF0BD67
+  apiDeploymentStageprod896C8101:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: apiC8550315
+      DeploymentId:
+        Ref: apiDeployment149F1294451e98552b666b9a7a9c18bdf7f51246
+      StageName: prod
+  apiGETECF0BD67:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: GET
+      ResourceId:
+        Fn::GetAtt:
+          - apiC8550315
+          - RootResourceId
+      RestApiId:
+        Ref: apiC8550315
       AuthorizationType: NONE
-      Target:
-        Fn::Join:
-          - ""
-          - - integrations/
-            - Ref: apigatewayGEThttpbinHttpIntegration1cd746b1d7348180429a2b4fcf7c1b7b024AD786
+      Integration:
+        IntegrationHttpMethod: GET
+        Type: HTTP_PROXY
+        Uri: {{ integration_uri }}
 Outputs:
-  ApiV2IdOutput:
-    Value:
-      Ref: apigatewayE40D7439
-  ApiV2UrlOutput:
+  ApiV1UrlOutput:
     Value:
       Fn::Join:
         - ""
         - - https://
-          - Ref: apigatewayE40D7439
+          - Ref: apiC8550315
           - .execute-api.
           - Ref: AWS::Region
           - "."
           - Ref: AWS::URLSuffix
           - /
+          - Ref: apiDeploymentStageprod896C8101
+          - /
+  ApiV1IdOutput:
+    Value:
+      Ref: apiC8550315


### PR DESCRIPTION
API Gateway endpoints generated via CloudFormation are patched to return values compatible with localstack


Example of CDK-generated output for API Gateway v2 uri
```yaml
Outputs:
  ApiV2UrlOutput:
    Value:
      Fn::Join:
        - ""
        - - https://
          - Ref: apigatewayE40D7439
          - .execute-api.
          - Ref: AWS::Region
          - "."
          - Ref: AWS::URLSuffix
          - /
```

