### PR TITLE
s3: fix replay tests for CI

### DIFF
--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -2679,7 +2679,7 @@ class TestS3New:
         ),
     ],
 )
-@pytest.mark.xfail
+@pytest.mark.skipif(os.environ.get("LOCALSTACK_API_KEY", "") != "", reason="replay skipped in pro")
 def test_replay_s3_call(api_version, bucket_name, payload):
     s3_client = aws_stack.connect_to_service("s3")
 


### PR DESCRIPTION
Skip replay tests introduced by #4985 for `Pro` integration tests, as we skip `replay` in `Pro` because of the different implementation of persistency.

Because of these lines in `localstack-ext`: https://github.com/localstack/localstack-ext/blob/833b345a9ecbd0f84bcbba6199d21be0cc34e7c6/localstack_ext/utils/persistence.py#L146-L148

We get this error
```
        resp = persistence.replay_command(payload)
>       assert resp.status_code == 200
E       AttributeError: 'NoneType' object has no attribute 'status_code'
```


Failed runs:
- https://github.com/localstack/localstack/runs/4290802930?check_suite_focus=true

