### PR TITLE
Fix tests and remove obsolete patch for CloudWatch metrics filtering

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_starter.py
+++ b/localstack/services/cloudwatch/cloudwatch_starter.py
@@ -16,22 +16,6 @@ def apply_patches():
             )
         )
 
-    def get_all_metrics(self, *args, **kwargs):
-        # Filter results to return only unique combinations of (Namespace, MetricName, Dimensions)
-        # TODO: This is hugely inefficient (!), especially as the number of metric data is growing.
-        #       Should be fixed upstream, or we should roll our own implementation!
-        def comparator(i1, i2):
-            i1 = (i1.namespace, i1.name, set((d.name, d.value) for d in i1.dimensions))
-            i2 = (i2.namespace, i2.name, set((d.name, d.value) for d in i2.dimensions))
-            return i1 == i2
-
-        result = get_all_metrics_orig(self, *args, **kwargs)
-        result = to_unique_items_list(result, comparator=comparator)
-        return result
-
-    get_all_metrics_orig = cloudwatch_models.CloudWatchBackend.get_all_metrics
-    cloudwatch_models.CloudWatchBackend.get_all_metrics = get_all_metrics
-
     # add put_composite_alarm
 
     def put_composite_alarm(self):

--- a/localstack/services/cloudwatch/cloudwatch_starter.py
+++ b/localstack/services/cloudwatch/cloudwatch_starter.py
@@ -1,9 +1,7 @@
-import moto.cloudwatch.models as cloudwatch_models
 import moto.cloudwatch.responses as cloudwatch_responses
 
 from localstack import config
 from localstack.services.infra import start_moto_server
-from localstack.utils.common import to_unique_items_list
 
 
 def apply_patches():

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ flask_swagger==0.2.12
 jsonpatch>=1.24,<2.0
 jsonpath-rw>=1.4.0,<2.0.0
 localstack-ext[full]>=0.13.0
-moto-ext[all]>=2.2.6
+moto-ext[all]>=2.2.6.2
 pproxy>=2.7.0
 psutil>=5.4.8,<6.0.0
 #pympler>=0.6

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -64,7 +64,7 @@ class CloudWatchTest(unittest.TestCase):
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers("cloudwatch")
 
-        authorization = mock_aws_request_headers("monitoring")["Authorization"]
+        authorization = aws_stack.mock_aws_request_headers("monitoring")["Authorization"]
 
         headers.update(
             {

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -10,6 +10,7 @@ from six.moves.urllib.request import Request, urlopen
 from localstack import config
 from localstack.services.cloudwatch.cloudwatch_listener import PATH_GET_RAW_METRICS
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_stack import mock_aws_request_headers
 from localstack.utils.common import short_uid, to_str
 
 
@@ -63,14 +64,7 @@ class CloudWatchTest(unittest.TestCase):
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers("cloudwatch")
 
-        authorization = (
-            "AWS4-HMAC-SHA256 Credential=test/20201230/"
-            "us-east-1/monitoring/aws4_request, "
-            "SignedHeaders=content-encoding;host;"
-            "x-amz-content-sha256;x-amz-date, Signature="
-            "bb31fc5f4e58040ede9ed751133fe"
-            "839668b27290bc1406b6ffadc4945c705dc"
-        )
+        authorization = mock_aws_request_headers("monitoring")["Authorization"]
 
         headers.update(
             {
@@ -207,8 +201,7 @@ class CloudWatchTest(unittest.TestCase):
         rs = client.list_metrics()
         metrics = [m for m in rs["Metrics"] if m.get("Namespace") in namespaces]
         self.assertTrue(metrics)
-        # TODO: needs fixing in moto!
-        # self.assertEqual(len(metrics), len(namespaces) * num_dimensions)
+        self.assertEqual(len(metrics), len(namespaces) * num_dimensions)
 
     def test_store_tags(self):
         cloudwatch = aws_stack.connect_to_service("cloudwatch")

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -10,7 +10,6 @@ from six.moves.urllib.request import Request, urlopen
 from localstack import config
 from localstack.services.cloudwatch.cloudwatch_listener import PATH_GET_RAW_METRICS
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import mock_aws_request_headers
 from localstack.utils.common import short_uid, to_str
 
 
@@ -63,7 +62,6 @@ class CloudWatchTest(unittest.TestCase):
 
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers("cloudwatch")
-
         authorization = aws_stack.mock_aws_request_headers("monitoring")["Authorization"]
 
         headers.update(


### PR DESCRIPTION
* bump moto-ext to latest version
* remove obsolete patch for CloudWatch metrics filtering
* fix tests and re-enable commented out assertions