### PR TITLE
s3: handle OPTIONS request with "Access-Control-Request-Method" properly

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -466,6 +466,9 @@ def get_origin_host(headers):
 def append_cors_headers(bucket_name, request_method, request_headers, response):
     bucket_name = normalize_bucket_name(bucket_name)
 
+    # chrome sends OPTIONS request with "Access-Control-Request-Method" header first
+    request_method = request_headers.get("Access-Control-Request-Method") or request_method
+
     # Checking CORS is allowed or not
     cors = BUCKET_CORS.get(bucket_name)
     if not cors:
@@ -504,21 +507,21 @@ def append_cors_headers(bucket_name, request_method, request_headers, response):
                     response.headers["Access-Control-Allow-Origin"] = origin
                     if "AllowedMethod" in rule:
                         response.headers["Access-Control-Allow-Methods"] = (
-                            ",".join(allowed_methods)
+                            ", ".join(allowed_methods)
                             if isinstance(allowed_methods, list)
                             else allowed_methods
                         )
                     if "AllowedHeader" in rule:
                         allowed_headers = rule["AllowedHeader"]
                         response.headers["Access-Control-Allow-Headers"] = (
-                            ",".join(allowed_headers)
+                            ", ".join(allowed_headers)
                             if isinstance(allowed_headers, list)
                             else allowed_headers
                         )
                     if "ExposeHeader" in rule:
                         expose_headers = rule["ExposeHeader"]
                         response.headers["Access-Control-Expose-Headers"] = (
-                            ",".join(expose_headers)
+                            ", ".join(expose_headers)
                             if isinstance(expose_headers, list)
                             else expose_headers
                         )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -971,7 +971,9 @@ class TestS3(unittest.TestCase):
             "get_object", Params={"Bucket": bucket_name, "Key": object_key}
         )
         response = requests.get(url, verify=False)
-        self.assertEqual("ETag,x-amz-version-id", response.headers["Access-Control-Expose-Headers"])
+        self.assertEqual(
+            "ETag, x-amz-version-id", response.headers["Access-Control-Expose-Headers"]
+        )
         # clean up
         self._delete_bucket(bucket_name, [object_key])
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1525,105 +1525,6 @@ class TestS3(unittest.TestCase):
 
         self._delete_bucket(bucket_name, keys)
 
-    def test_cors_with_single_origin_error(self):
-        client = self._get_test_client()
-
-        bucket_cors_config = {
-            "CORSRules": [
-                {
-                    "AllowedOrigins": ["https://localhost:4200"],
-                    "AllowedMethods": ["GET", "PUT"],
-                    "MaxAgeSeconds": 3000,
-                    "AllowedHeaders": ["*"],
-                }
-            ]
-        }
-
-        bucket_name = "my-s3-bucket"
-        client.create_bucket(Bucket=bucket_name)
-        client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
-
-        # create signed url
-        url = client.generate_presigned_url(
-            ClientMethod="put_object",
-            Params={
-                "Bucket": bucket_name,
-                "Key": "424f6bae-c48f-42d8-9e25-52046aecc64d/document.pdf",
-                "ContentType": "application/pdf",
-                "ACL": "bucket-owner-full-control",
-            },
-            ExpiresIn=3600,
-        )
-        old_config = config.DISABLE_CUSTOM_CORS_S3
-        config.DISABLE_CUSTOM_CORS_S3 = False
-        result = requests.put(
-            url,
-            data="something",
-            verify=False,
-            headers={
-                "Origin": "https://localhost:4200",
-                "Content-Type": "application/pdf",
-            },
-        )
-        self.assertEqual(200, result.status_code)
-
-        bucket_cors_config = {
-            "CORSRules": [
-                {
-                    "AllowedOrigins": [
-                        "https://localhost:4200",
-                        "https://localhost:4201",
-                    ],
-                    "AllowedMethods": ["GET", "PUT"],
-                    "MaxAgeSeconds": 3000,
-                    "AllowedHeaders": ["*"],
-                }
-            ]
-        }
-
-        client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
-
-        # create signed url
-        url = client.generate_presigned_url(
-            ClientMethod="put_object",
-            Params={
-                "Bucket": bucket_name,
-                "Key": "424f6bae-c48f-42d8-9e25-52046aecc64d/document.pdf",
-                "ContentType": "application/pdf",
-                "ACL": "bucket-owner-full-control",
-            },
-            ExpiresIn=3600,
-        )
-
-        result = requests.put(
-            url,
-            data="something",
-            verify=False,
-            headers={
-                "Origin": "https://localhost:4200",
-                "Content-Type": "application/pdf",
-            },
-        )
-        self.assertEqual(200, result.status_code)
-
-        result = requests.put(
-            url,
-            data="something",
-            verify=False,
-            headers={
-                "Origin": "https://localhost:4201",
-                "Content-Type": "application/pdf",
-            },
-        )
-        self.assertEqual(200, result.status_code)
-
-        # cleanup
-        config.DISABLE_CUSTOM_CORS_S3 = old_config
-        client.delete_object(
-            Bucket=bucket_name, Key="424f6bae-c48f-42d8-9e25-52046aecc64d/document.pdf"
-        )
-        client.delete_bucket(Bucket=bucket_name)
-
     def test_s3_put_object_notification_with_lambda(self):
         bucket_name = "bucket-%s" % short_uid()
         function_name = "func-%s" % short_uid()
@@ -2692,3 +2593,112 @@ def test_replay_s3_call(api_version, bucket_name, payload):
 
     bucket_head = s3_client.head_bucket(Bucket=bucket_name)
     assert bucket_head["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+@patch.object(config, "DISABLE_CUSTOM_CORS_S3", False)
+def test_cors_with_single_origin_error(s3_client):
+    # works with TEST_TARGET=AWS_CLOUD
+    bucket_cors_config = {
+        "CORSRules": [
+            {
+                "AllowedOrigins": ["https://localhost:4200"],
+                "AllowedMethods": ["GET", "PUT"],
+                "MaxAgeSeconds": 3000,
+                "AllowedHeaders": ["*"],
+            }
+        ]
+    }
+
+    bucket_name = "bucket-%s" % short_uid()
+    object_key = "424f6bae-c48f-42d8-9e25-52046aecc64d/document.pdf"
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+    # create signed url
+    url = s3_client.generate_presigned_url(
+        ClientMethod="put_object",
+        Params={
+            "Bucket": bucket_name,
+            "Key": object_key,
+            "ContentType": "application/pdf",
+            "ACL": "bucket-owner-full-control",
+        },
+        ExpiresIn=3600,
+    )
+    result = requests.put(
+        url,
+        data="something",
+        verify=False,
+        headers={
+            "Origin": "https://localhost:4200",
+            "Content-Type": "application/pdf",
+        },
+    )
+    assert result.status_code == 200
+
+    bucket_cors_config = {
+        "CORSRules": [
+            {
+                "AllowedOrigins": [
+                    "https://localhost:4200",
+                    "https://localhost:4201",
+                ],
+                "AllowedMethods": ["GET", "PUT"],
+                "MaxAgeSeconds": 3000,
+                "AllowedHeaders": ["*"],
+            }
+        ]
+    }
+
+    s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+    # create signed url
+    url = s3_client.generate_presigned_url(
+        ClientMethod="put_object",
+        Params={
+            "Bucket": bucket_name,
+            "Key": object_key,
+            "ContentType": "application/pdf",
+            "ACL": "bucket-owner-full-control",
+        },
+        ExpiresIn=3600,
+    )
+
+    # mimic chrome behavior, sending OPTIONS request first for strict-origin-when-cross-origin
+    result = requests.options(
+        url,
+        headers={
+            "Origin": "https://localhost:4200",
+            "Access-Control-Request-Method": "PUT",
+        },
+    )
+    assert "Access-Control-Allow-Origin" in result.headers
+    assert result.headers["Access-Control-Allow-Origin"] == "https://localhost:4200"
+    assert "Access-Control-Allow-Methods" in result.headers
+    assert result.headers["Access-Control-Allow-Methods"] == "GET, PUT"
+
+    result = requests.put(
+        url,
+        data="something",
+        verify=False,
+        headers={
+            "Origin": "https://localhost:4200",
+            "Content-Type": "application/pdf",
+        },
+    )
+    assert result.status_code == 200
+
+    result = requests.put(
+        url,
+        data="something",
+        verify=False,
+        headers={
+            "Origin": "https://localhost:4201",
+            "Content-Type": "application/pdf",
+        },
+    )
+    assert result.status_code == 200
+
+    # cleanup
+    s3_client.delete_object(Bucket=bucket_name, Key=object_key)
+    s3_client.delete_bucket(Bucket=bucket_name)


### PR DESCRIPTION
Related issue: https://github.com/localstack/localstack/issues/4398

The `test_cors_with_single_origin_error` test against AWS:
```sh
$ TEST_TARGET=AWS_CLOUD pytest -vs -k test_cors_with_single_origin_error
============================================================================================================= test session starts ==============================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.4, py-1.11.0, pluggy-0.13.1 -- /opt/localstack/env/bin/python3
cachedir: .pytest_cache
rootdir: /opt/localstack/localstack
plugins: httpserver-1.0.2, rerunfailures-10.0
collected 1054 items / 1053 deselected / 1 selected

tests/integration/test_s3.py::test_cors_with_single_origin_error PASSED
```

Console log:
```sh
$ awslocal s3api create-bucket --bucket test
{
    "Location": "http://test.s3.localhost.localstack.cloud:4566/"
}

$ aws --endpoint-url=http://localhost:4566 s3api put-bucket-cors --bucket=test --cors-configuration '{
    "CORSRules": [
        {
            "AllowedHeaders": [
                "*"
            ],
            "AllowedMethods": [
                "GET",
                "PUT",
                "POST",
                "HEAD"
            ],
            "AllowedOrigins": [
                "*",
                "http://localhost:8000"
            ],
            "ExposeHeaders": [
                "ETag"
            ],
            "MaxAgeSeconds": 86400
        }
    ]
}'

$ aws --endpoint-url=http://localhost:4566 s3api get-bucket-cors --bucket=test
{
    "CORSRules": [
        {
            "AllowedHeaders": [
                "*"
            ],
            "AllowedMethods": [
                "GET",
                "PUT",
                "POST",
                "HEAD"
            ],
            "AllowedOrigins": [
                "*",
                "http://localhost:8000"
            ],
            "ExposeHeaders": [
                "ETag"
            ],
            "MaxAgeSeconds": 86400
        }
    ]
}

$ bucket=test; file=file2.doc; cat <<EOF | python | read upload_url
# generate presigned url for put_object (can't generate it by aws cli)
# instead of "awslocal s3 presign s3://evidence.api.lambda.s3.bucket/file.doc --region eu-west-1"

import os
import boto3

os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
os.environ['AWS_ACCESS_KEY_ID'] = 'test'
os.environ['AWS_SECRET_ACCESS_KEY'] = 'test'
url = boto3.client('s3', endpoint_url='http://localhost:4566').generate_presigned_url(
   ClientMethod='put_object',
   Params={'Bucket': '$bucket', 'Key': '$file'},
   ExpiresIn=3600
)
print(url)
EOF

$ echo $upload_url
http://localhost:4566/test/file2.doc?AWSAccessKeyId=test&Signature=8uA5%2BfbNKEdRo8mTzQfp6P2EQmE%3D&Expires=1637693398
```

![Screenshot_2021-11-23_19-53-15](https://user-images.githubusercontent.com/161289/143078202-b8f6cde0-f387-4ccd-b043-c6a8c77540a5.png)
