### PR TITLE
s3: explicitly handle OPTIONS request with "Access-Control-Request-Method" header 

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -467,8 +467,13 @@ def get_origin_host(headers):
 def append_cors_headers(bucket_name, request_method, request_headers, response):
     bucket_name = normalize_bucket_name(bucket_name)
 
-    # chrome sends OPTIONS request with "Access-Control-Request-Method" header first
-    request_method = request_headers.get("Access-Control-Request-Method") or request_method
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Method
+    # > The Access-Control-Request-Method request header is used by browsers when issuing a preflight request,
+    # > to let the server know which HTTP method will be used when the actual request is made.
+    # > This header is necessary as the preflight request is always an OPTIONS and doesn't use the same method
+    # > as the actual request.
+    if request_method == "OPTIONS" and "Access-Control-Request-Method" in request_headers:
+        request_method = request_headers["Access-Control-Request-Method"]
 
     # Checking CORS is allowed or not
     cors = BUCKET_CORS.get(bucket_name)

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -2659,7 +2659,7 @@ def test_replay_s3_call(api_version, bucket_name, payload):
 
 
 @patch.object(config, "DISABLE_CUSTOM_CORS_S3", False)
-def test_cors_with_single_origin_error(s3_client):
+def test_cors_with_allowed_origins(s3_client):
     # works with TEST_TARGET=AWS_CLOUD
     bucket_cors_config = {
         "CORSRules": [
@@ -2698,6 +2698,10 @@ def test_cors_with_single_origin_error(s3_client):
         },
     )
     assert result.status_code == 200
+    assert "Access-Control-Allow-Origin" in result.headers
+    assert result.headers["Access-Control-Allow-Origin"] == "https://localhost:4200"
+    assert "Access-Control-Allow-Methods" in result.headers
+    assert result.headers["Access-Control-Allow-Methods"] == "GET, PUT"
 
     bucket_cors_config = {
         "CORSRules": [
@@ -2750,6 +2754,10 @@ def test_cors_with_single_origin_error(s3_client):
         },
     )
     assert result.status_code == 200
+    assert "Access-Control-Allow-Origin" in result.headers
+    assert result.headers["Access-Control-Allow-Origin"] == "https://localhost:4200"
+    assert "Access-Control-Allow-Methods" in result.headers
+    assert result.headers["Access-Control-Allow-Methods"] == "GET, PUT"
 
     result = requests.put(
         url,
@@ -2761,6 +2769,10 @@ def test_cors_with_single_origin_error(s3_client):
         },
     )
     assert result.status_code == 200
+    assert "Access-Control-Allow-Origin" in result.headers
+    assert result.headers["Access-Control-Allow-Origin"] == "https://localhost:4201"
+    assert "Access-Control-Allow-Methods" in result.headers
+    assert result.headers["Access-Control-Allow-Methods"] == "GET, PUT"
 
     # cleanup
     s3_client.delete_object(Bucket=bucket_name, Key=object_key)


### PR DESCRIPTION
Followup for #4994

Also, add additional checks in the related test. I should add these checks in the original PR (related comment as well: https://github.com/localstack/localstack/pull/2565/files#r446286581)