### PR TITLE
implement check before restarting kinesis and stepfunction

### DIFF
--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -199,11 +199,16 @@ def check_kinesis(expect_shutdown=False, print_error=False):
         assert out and isinstance(out.get("StreamNames"), list)
 
 
+def kinesis_running():
+    return PROCESS_THREAD is not None
+
+
 def restart_kinesis():
-    LOGGER.debug("Restarting Kinesis process ...")
-    PROCESS_THREAD.stop()
-    kinesis_stopped.wait()
-    kinesis_stopped.clear()
-    start_kinesis(asynchronous=True, update_listener=kinesis_listener.UPDATE_KINESIS)
-    # giving the process some time to startup; TODO: to be replaced with service lifecycle plugin
-    time.sleep(1)
+    if PROCESS_THREAD:
+        LOGGER.debug("Restarting Kinesis process ...")
+        PROCESS_THREAD.stop()
+        kinesis_stopped.wait()
+        kinesis_stopped.clear()
+        start_kinesis(asynchronous=True, update_listener=kinesis_listener.UPDATE_KINESIS)
+        # giving the process some time to startup; TODO: to be replaced with service lifecycle plugin
+        time.sleep(1)

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -95,6 +95,8 @@ def check_stepfunctions(expect_shutdown=False, print_error=False):
 
 
 def restart_stepfunctions():
+    if not PROCESS_THREAD:
+        return
     LOG.debug("Restarting StepFunctions process ...")
     PROCESS_THREAD.stop()
     start_stepfunctions(


### PR DESCRIPTION
Restarting 

This PR prevents kinesis or stepfunctions from throwing an exception on restart when not eagerly loaded.



