### PR TITLE
add Directories config object

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -5,6 +5,7 @@ shopt -s nullglob
 
 if [[ ! $INIT_SCRIPTS_PATH ]]
 then
+  # FIXME: move
   INIT_SCRIPTS_PATH=/docker-entrypoint-initaws.d
 fi
 if [[ ! $EDGE_PORT ]]

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -33,10 +33,25 @@ load_start_time = time.time()
 
 
 class Directories:
-    """Holds the different directories available to localstack"""
+    """
+    Holds the different directories available to localstack. Some directories are shared between the host and the
+    localstack container, some live only on the host and some only in the container.
+
+    Attributes:
+        infra:      container only; static infrastructure: binaries and libraries packaged with the image
+        var:        shared; variable data computed at runtime: lazy-loaded binaries, ssl cert, ...
+        cache:      shared; ephemeral data that has to persist across localstack runs and reboots
+        tmp:        individual; ephemeral data that does not have to persist across localstack runs but not reboots
+        shared_tmp: shared; ephemeral data used to communicate between container<->lambdas
+        data:       shared; holds localstack state, pods, ...
+        config:     host only; pre-defined configuration values, cached credentials, machine id, ...
+        init:       shared; user-defined provisioning scripts executed when in the container when it starts
+        logs:       shared; log files produced by localstack
+    """
 
     infra: str
     var: str
+    cache: str
     tmp: str
     shared_tmp: str
     data: str
@@ -48,6 +63,7 @@ class Directories:
         self,
         infra: str = None,
         var: str = None,
+        cache: str = None,
         tmp: str = None,
         shared_tmp: str = None,
         data: str = None,
@@ -58,6 +74,7 @@ class Directories:
         super().__init__()
         self.infra = infra
         self.var = var
+        self.cache = cache
         self.tmp = tmp
         self.shared_tmp = shared_tmp
         self.data = data
@@ -67,24 +84,49 @@ class Directories:
 
     @staticmethod
     def from_config():
+        """Returns Localstack directory paths from the config/environment variables defined by the config."""
         return Directories(
             infra=INSTALL_DIR_INFRA,
-            var=TMP_FOLDER,
-            tmp=TMP_FOLDER,
-            shared_tmp=HOST_TMP_FOLDER,
+            var=TMP_FOLDER,  # TODO: add variable
+            cache=TMP_FOLDER,  # TODO: add variable
+            tmp=TMP_FOLDER,  # TODO: move default value to /tmp/localstack/host
+            shared_tmp=HOST_TMP_FOLDER,  # TODO: move default value to /tmp/localstack/shared
             data=DATA_DIR,
-            config=None,  # FIXME: will be introduced once .localstack config file has been refactored
-            logs=TMP_FOLDER,
+            config=None,  # TODO: will be introduced once .localstack config file has been refactored
+            init=None,  # TODO: introduce environment variable
+            logs=TMP_FOLDER,  # TODO: move to /tmp/localstack/logs
+        )
+
+    @staticmethod
+    def for_container() -> "Directories":
+        """
+        /var/lib/localstack. Returns Localstack directory paths as they are defined within the container. Everything
+        shared and writable lives in /var/lib/localstack or /tmp/localstack.
+
+        :returns: Directories object
+        """
+        return Directories(
+            infra=INSTALL_DIR_INFRA,
+            var="/var/lib/localstack/libs",
+            cache="/var/lib/localstack/cache",
+            tmp=TMP_FOLDER,  # TODO: move to /tmp/localstack
+            shared_tmp=HOST_TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
+            data=DATA_DIR,  # TODO: move to /var/lib/localstack/data
+            config="/etc/localstack/",  # TODO: will be introduced once .localstack config file has been refactored
+            logs="/var/lib/localstack/logs",
+            init="/docker-entrypoint-initaws.d",
         )
 
     def mkdirs(self):
         for folder in [
             self.infra,
             self.var,
+            self.cache,
             self.tmp,
             self.shared_tmp,
             self.data,
             self.config,
+            self.init,
             self.logs,
         ]:
             if folder and not os.path.exists(folder):
@@ -732,5 +774,9 @@ if LS_LOG in TRACE_LOG_LEVELS:
     )
 
 # initialize directories
-dirs = Directories.from_config()
+if is_in_docker:
+    dirs = Directories.for_container()
+else:
+    dirs = Directories.from_config()
+
 dirs.mkdirs()

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -45,7 +45,9 @@ TEST_AWS_ACCOUNT_ID = os.environ["TEST_AWS_ACCOUNT_ID"]
 MODULE_MAIN_PATH = os.path.dirname(os.path.realpath(__file__))
 # TODO rename to "ROOT_FOLDER"!
 LOCALSTACK_ROOT_FOLDER = os.path.realpath(os.path.join(MODULE_MAIN_PATH, ".."))
-INSTALL_DIR_INFRA = os.path.join(MODULE_MAIN_PATH, "infra")
+INSTALL_DIR_INFRA = os.path.join(
+    MODULE_MAIN_PATH, "infra"
+)  # FIXME: deprecated, use config.dirs.infra
 
 # virtualenv folder
 LOCALSTACK_VENV_FOLDER = os.environ.get("VIRTUAL_ENV")

--- a/localstack/contrib/thundra.py
+++ b/localstack/contrib/thundra.py
@@ -115,7 +115,7 @@ def _init_java_agent_configs():
         "https://repo.thundra.io/service/local/artifact/maven/redirect?"
         + "r=thundra-releases&g=io.thundra.agent&a=thundra-agent-lambda-bootstrap&v={v}"
     ).format(v=version)
-    THUNDRA_JAVA_AGENT_LOCAL_PATH = "%s/%s" % (config.TMP_FOLDER, jar_name)
+    THUNDRA_JAVA_AGENT_LOCAL_PATH = "%s/%s" % (config.dirs.tmp, jar_name)
 
 
 def _install_java_agent():
@@ -217,11 +217,11 @@ def _init_node_agent_configs() -> bool:
 
     THUNDRA_NODE_AGENT_VERSION = version.strip()
     THUNDRA_NODE_AGENT_LOCAL_PATH = "%s/thundra/node/%s/" % (
-        config.TMP_FOLDER,
+        config.dirs.tmp,
         THUNDRA_NODE_AGENT_VERSION,
     )
     THUNDRA_NODE_AGENT_LOCAL_PATH_ON_HOST = "%s/thundra/node/%s/" % (
-        config.HOST_TMP_FOLDER,
+        config.dirs.shared_tmp,
         THUNDRA_NODE_AGENT_VERSION,
     )
 
@@ -327,11 +327,11 @@ def _init_python_agent_configs() -> bool:
 
     THUNDRA_PYTHON_AGENT_VERSION = version.strip()
     THUNDRA_PYTHON_AGENT_LOCAL_PATH = "%s/thundra/python/%s/" % (
-        config.TMP_FOLDER,
+        config.dirs.tmp,
         THUNDRA_PYTHON_AGENT_VERSION,
     )
     THUNDRA_PYTHON_AGENT_LOCAL_PATH_ON_HOST = "%s/thundra/python/%s/" % (
-        config.HOST_TMP_FOLDER,
+        config.dirs.shared_tmp,
         THUNDRA_PYTHON_AGENT_VERSION,
     )
 

--- a/localstack/contrib/thundra.py
+++ b/localstack/contrib/thundra.py
@@ -221,7 +221,7 @@ def _init_node_agent_configs() -> bool:
         THUNDRA_NODE_AGENT_VERSION,
     )
     THUNDRA_NODE_AGENT_LOCAL_PATH_ON_HOST = "%s/thundra/node/%s/" % (
-        config.dirs.shared_tmp,
+        config.dirs.functions,
         THUNDRA_NODE_AGENT_VERSION,
     )
 
@@ -331,7 +331,7 @@ def _init_python_agent_configs() -> bool:
         THUNDRA_PYTHON_AGENT_VERSION,
     )
     THUNDRA_PYTHON_AGENT_LOCAL_PATH_ON_HOST = "%s/thundra/python/%s/" % (
-        config.dirs.shared_tmp,
+        config.dirs.functions,
         THUNDRA_PYTHON_AGENT_VERSION,
     )
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -77,8 +77,8 @@ LOG = logging.getLogger(__name__)
 LAMBDA_POLICY_NAME_PATTERN = "lambda_policy_{name}_{qualifier}"
 # constants
 APP_NAME = "lambda_api"
-ARCHIVE_FILE_PATTERN = "%s/lambda.handler.*.jar" % config.TMP_FOLDER
-LAMBDA_SCRIPT_PATTERN = "%s/lambda_script_*.py" % config.TMP_FOLDER
+ARCHIVE_FILE_PATTERN = "%s/lambda.handler.*.jar" % config.dirs.tmp
+LAMBDA_SCRIPT_PATTERN = "%s/lambda_script_*.py" % config.dirs.tmp
 LAMBDA_ZIP_FILE_NAME = "original_lambda_archive.zip"
 LAMBDA_JAR_FILE_NAME = "original_lambda_archive.jar"
 
@@ -998,7 +998,7 @@ def set_archive_code(code, lambda_name, zip_file_content=None):
     latest_version = lambda_details.get_version(VERSION_LATEST)
     latest_version["CodeSize"] = len(zip_file_content)
     latest_version["CodeSha256"] = code_sha_256.decode("utf-8")
-    tmp_dir = "%s/zipfile.%s" % (config.TMP_FOLDER, short_uid())
+    tmp_dir = "%s/zipfile.%s" % (config.dirs.tmp, short_uid())
     mkdir(tmp_dir)
     tmp_file = "%s/%s" % (tmp_dir, LAMBDA_ZIP_FILE_NAME)
     save_file(tmp_file, zip_file_content)

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1484,7 +1484,7 @@ class Util:
 
     @classmethod
     def get_host_path_for_path_in_docker(cls, path):
-        return re.sub(r"^%s/(.*)$" % config.dirs.tmp, r"%s/\1" % config.dirs.shared_tmp, path)
+        return re.sub(r"^%s/(.*)$" % config.dirs.tmp, r"%s/\1" % config.dirs.functions, path)
 
     @classmethod
     def format_windows_path(cls, path):

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -69,7 +69,7 @@ from localstack.utils.run import FuncThread
 LAMBDA_EXECUTOR_JAR = INSTALL_PATH_LOCALSTACK_FAT_JAR
 LAMBDA_EXECUTOR_CLASS = "cloud.localstack.LambdaExecutor"
 LAMBDA_HANDLER_ENV_VAR_NAME = "_HANDLER"
-EVENT_FILE_PATTERN = "%s/lambda.event.*.json" % config.TMP_FOLDER
+EVENT_FILE_PATTERN = "%s/lambda.event.*.json" % config.dirs.tmp
 
 LAMBDA_SERVER_UNIQUE_PORTS = 500
 LAMBDA_SERVER_PORT_OFFSET = 5000
@@ -1484,7 +1484,7 @@ class Util:
 
     @classmethod
     def get_host_path_for_path_in_docker(cls, path):
-        return re.sub(r"^%s/(.*)$" % config.TMP_FOLDER, r"%s/\1" % config.HOST_TMP_FOLDER, path)
+        return re.sub(r"^%s/(.*)$" % config.dirs.tmp, r"%s/\1" % config.dirs.shared_tmp, path)
 
     @classmethod
     def format_windows_path(cls, path):
@@ -1540,7 +1540,7 @@ class Util:
 
     @staticmethod
     def mountable_tmp_file():
-        f = os.path.join(config.TMP_FOLDER, short_uid())
+        f = os.path.join(config.dirs.tmp, short_uid())
         TMP_FILES.append(f)
         return f
 

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Callable
 
-from localstack.constants import INSTALL_DIR_INFRA
+from localstack.config import dirs
 from localstack.utils import common
 
 # URL to "cfn-response" module which is required in some CF Lambdas
@@ -119,7 +119,7 @@ def param_json_to_str(name):
 
 
 def get_cfn_response_mod_file():
-    cfn_response_tmp_file = os.path.join(INSTALL_DIR_INFRA, "lambda.cfn-response.js")
+    cfn_response_tmp_file = os.path.join(dirs.infra, "lambda.cfn-response.js")
     if not os.path.exists(cfn_response_tmp_file):
         common.download(CFN_RESPONSE_MODULE_URL, cfn_response_tmp_file)
     return cfn_response_tmp_file

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -119,7 +119,7 @@ def param_json_to_str(name):
 
 
 def get_cfn_response_mod_file():
-    cfn_response_tmp_file = os.path.join(dirs.infra, "lambda.cfn-response.js")
+    cfn_response_tmp_file = os.path.join(dirs.static_libs, "lambda.cfn-response.js")
     if not os.path.exists(cfn_response_tmp_file):
         common.download(CFN_RESPONSE_MODULE_URL, cfn_response_tmp_file)
     return cfn_response_tmp_file

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -3,8 +3,7 @@ import os
 from typing import List, Optional
 
 from localstack import config
-from localstack.config import is_env_true
-from localstack.constants import MODULE_MAIN_PATH
+from localstack.config import dirs, is_env_true
 from localstack.services import install
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.run import FuncThread
@@ -39,11 +38,11 @@ class DynamodbServer(Server):
 
     @property
     def jar_path(self) -> str:
-        return f"{MODULE_MAIN_PATH}/infra/dynamodb/DynamoDBLocal.jar"
+        return f"{dirs.infra}/dynamodb/DynamoDBLocal.jar"
 
     @property
     def library_path(self) -> str:
-        return f"{MODULE_MAIN_PATH}/infra/dynamodb/DynamoDBLocal_lib"
+        return f"{dirs.infra}/dynamodb/DynamoDBLocal_lib"
 
     def _create_shell_command(self) -> List[str]:
         cmd = [
@@ -96,8 +95,8 @@ def create_dynamodb_server(port=None) -> DynamodbServer:
 
     server = DynamodbServer(port)
 
-    if config.DATA_DIR:
-        ddb_data_dir = "%s/dynamodb" % config.DATA_DIR
+    if config.dirs.data:
+        ddb_data_dir = "%s/dynamodb" % config.dirs.data
         mkdir(ddb_data_dir)
         absolute_path = os.path.abspath(ddb_data_dir)
         server.db_path = absolute_path

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -38,11 +38,11 @@ class DynamodbServer(Server):
 
     @property
     def jar_path(self) -> str:
-        return f"{dirs.infra}/dynamodb/DynamoDBLocal.jar"
+        return f"{dirs.static_libs}/dynamodb/DynamoDBLocal.jar"
 
     @property
     def library_path(self) -> str:
-        return f"{dirs.infra}/dynamodb/DynamoDBLocal_lib"
+        return f"{dirs.static_libs}/dynamodb/DynamoDBLocal_lib"
 
     def _create_shell_command(self) -> List[str]:
         cmd = [

--- a/localstack/services/es/cluster.py
+++ b/localstack/services/es/cluster.py
@@ -85,10 +85,10 @@ def resolve_directories(version: str, cluster_path: str, data_root: str = None) 
     modules_dir = os.path.join(install_dir, "modules")
 
     if data_root is None:
-        if config.DATA_DIR:
-            data_root = config.DATA_DIR
+        if config.dirs.data:
+            data_root = config.dirs.data
         else:
-            data_root = config.TMP_FOLDER
+            data_root = config.dirs.tmp
 
     data_path = os.path.join(data_root, "elasticsearch", cluster_path)
 
@@ -106,7 +106,7 @@ def init_directories(dirs: Directories):
     LOG.debug("initializing elasticsearch directories %s", dirs)
     chmod_r(dirs.install, 0o777)
 
-    if not dirs.data.startswith(config.DATA_DIR):
+    if not dirs.data.startswith(config.dirs.data):
         # only clear previous data if it's not in DATA_DIR
         rm_rf(dirs.data)
 

--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -67,7 +67,7 @@ def _dump_events_to_files(events_with_added_uuid):
 
 
 def _get_events_tmp_dir():
-    return os.path.join(config.TMP_FOLDER, EVENTS_TMP_DIR)
+    return os.path.join(config.dirs.tmp, EVENTS_TMP_DIR)
 
 
 def get_scheduled_rule_func(data):

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -641,7 +641,7 @@ if hasattr(BaseSelectorEventLoop, "_accept_connection2") and not hasattr(
 
 
 def get_cert_pem_file_path():
-    return os.path.join(config.TMP_FOLDER, SERVER_CERT_PEM_FILE)
+    return os.path.join(config.dirs.tmp, SERVER_CERT_PEM_FILE)
 
 
 def start_proxy_server(

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -378,11 +378,7 @@ def start_infra(asynchronous=False, apis=None):
                 % config.LAMBDA_EXECUTOR
             )
 
-        if (
-            is_in_docker
-            and not config.LAMBDA_REMOTE_DOCKER
-            and not os.environ.get("HOST_TMP_FOLDER")
-        ):
+        if is_in_docker and not config.LAMBDA_REMOTE_DOCKER and not config.dirs.shared_tmp:
             print(
                 "!WARNING! - Looks like you have configured $LAMBDA_REMOTE_DOCKER=0 - "
                 "please make sure to configure $HOST_TMP_FOLDER to point to your host's $TMPDIR"
@@ -513,7 +509,7 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     thread = start_runtime_components()
     preload_services()
 
-    if config.DATA_DIR:
+    if config.dirs.data:
         persistence.save_startup_info()
 
     print(READY_MARKER_OUTPUT)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -378,7 +378,7 @@ def start_infra(asynchronous=False, apis=None):
                 % config.LAMBDA_EXECUTOR
             )
 
-        if is_in_docker and not config.LAMBDA_REMOTE_DOCKER and not config.dirs.shared_tmp:
+        if is_in_docker and not config.LAMBDA_REMOTE_DOCKER and not config.dirs.functions:
             print(
                 "!WARNING! - Looks like you have configured $LAMBDA_REMOTE_DOCKER=0 - "
                 "please make sure to configure $HOST_TMP_FOLDER to point to your host's $TMPDIR"

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -54,25 +54,25 @@ from localstack.utils.docker_utils import DOCKER_CLIENT
 LOG = logging.getLogger(__name__)
 
 INSTALL_DIR_NPM = "%s/node_modules" % MODULE_MAIN_PATH  # FIXME: migrate to infra
-INSTALL_DIR_DDB = "%s/dynamodb" % dirs.infra
-INSTALL_DIR_KCL = "%s/amazon-kinesis-client" % dirs.infra
-INSTALL_DIR_STEPFUNCTIONS = "%s/stepfunctions" % dirs.infra
-INSTALL_DIR_KMS = "%s/kms" % dirs.infra
-INSTALL_DIR_ELASTICMQ = "%s/elasticmq" % dirs.infra
-INSTALL_PATH_LOCALSTACK_FAT_JAR = "%s/localstack-utils-fat.jar" % dirs.infra
+INSTALL_DIR_DDB = "%s/dynamodb" % dirs.static_libs
+INSTALL_DIR_KCL = "%s/amazon-kinesis-client" % dirs.static_libs
+INSTALL_DIR_STEPFUNCTIONS = "%s/stepfunctions" % dirs.static_libs
+INSTALL_DIR_KMS = "%s/kms" % dirs.static_libs
+INSTALL_DIR_ELASTICMQ = "%s/elasticmq" % dirs.static_libs
+INSTALL_PATH_LOCALSTACK_FAT_JAR = "%s/localstack-utils-fat.jar" % dirs.static_libs
 INSTALL_PATH_DDB_JAR = os.path.join(INSTALL_DIR_DDB, "DynamoDBLocal.jar")
 INSTALL_PATH_KCL_JAR = os.path.join(INSTALL_DIR_KCL, "aws-java-sdk-sts.jar")
 INSTALL_PATH_STEPFUNCTIONS_JAR = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "StepFunctionsLocal.jar")
 INSTALL_PATH_KMS_BINARY_PATTERN = os.path.join(INSTALL_DIR_KMS, "local-kms.<arch>.bin")
 INSTALL_PATH_ELASTICMQ_JAR = os.path.join(INSTALL_DIR_ELASTICMQ, "elasticmq-server.jar")
 INSTALL_PATH_KINESALITE_CLI = os.path.join(INSTALL_DIR_NPM, "kinesalite", "cli.js")
-INSTALL_PATH_KINESIS_MOCK = os.path.join(dirs.infra, "kinesis-mock")
+INSTALL_PATH_KINESIS_MOCK = os.path.join(dirs.static_libs, "kinesis-mock")
 URL_LOCALSTACK_FAT_JAR = (
     "https://repo1.maven.org/maven2/"
     + "cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar"
 ).format(v=LOCALSTACK_MAVEN_VERSION)
 
-MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.infra
+MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
@@ -116,7 +116,7 @@ TERRAFORM_VERSION = "0.13.7"
 TERRAFORM_URL_TEMPLATE = (
     "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip"
 )
-TERRAFORM_BIN = os.path.join(dirs.infra, f"terraform-{TERRAFORM_VERSION}", "terraform")
+TERRAFORM_BIN = os.path.join(dirs.static_libs, f"terraform-{TERRAFORM_VERSION}", "terraform")
 
 
 def get_elasticsearch_install_version(version: str) -> str:
@@ -133,7 +133,7 @@ def get_elasticsearch_install_dir(version: str) -> str:
 
     if version == ELASTICSEARCH_DEFAULT_VERSION and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
         # install the default version into a subfolder of the code base
-        install_dir = os.path.join(dirs.infra, "elasticsearch")
+        install_dir = os.path.join(dirs.static_libs, "elasticsearch")
     else:
         # put all other versions into the TMP_FOLDER
         install_dir = os.path.join(config.dirs.tmp, "elasticsearch", version)
@@ -330,13 +330,13 @@ def install_stepfunctions_local():
         )
         time.sleep(5)
         DOCKER_CLIENT.copy_from_container(
-            docker_name, local_path=dirs.infra, container_path="/home/stepfunctionslocal/"
+            docker_name, local_path=dirs.static_libs, container_path="/home/stepfunctionslocal/"
         )
 
-        path = Path(f"{dirs.infra}/stepfunctionslocal/")
+        path = Path(f"{dirs.static_libs}/stepfunctionslocal/")
         for file in path.glob("*.jar"):
             file.rename(Path(INSTALL_DIR_STEPFUNCTIONS) / file.name)
-        rm_rf("%s/stepfunctionslocal" % dirs.infra)
+        rm_rf("%s/stepfunctionslocal" % dirs.static_libs)
     # apply patches
     for patch_class, patch_url in (
         (SFN_PATCH_CLASS1, SFN_PATCH_CLASS_URL1),

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -17,7 +17,7 @@ import requests
 from plugin import Plugin, PluginManager
 
 from localstack import config
-from localstack.config import is_env_true
+from localstack.config import dirs, is_env_true
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS,
     DYNAMODB_JAR_URL,
@@ -25,7 +25,6 @@ from localstack.constants import (
     ELASTICSEARCH_DEFAULT_VERSION,
     ELASTICSEARCH_DELETE_MODULES,
     ELASTICSEARCH_PLUGIN_LIST,
-    INSTALL_DIR_INFRA,
     KMS_URL_PATTERN,
     LOCALSTACK_MAVEN_VERSION,
     MODULE_MAIN_PATH,
@@ -54,26 +53,26 @@ from localstack.utils.docker_utils import DOCKER_CLIENT
 
 LOG = logging.getLogger(__name__)
 
-INSTALL_DIR_NPM = "%s/node_modules" % MODULE_MAIN_PATH
-INSTALL_DIR_DDB = "%s/dynamodb" % INSTALL_DIR_INFRA
-INSTALL_DIR_KCL = "%s/amazon-kinesis-client" % INSTALL_DIR_INFRA
-INSTALL_DIR_STEPFUNCTIONS = "%s/stepfunctions" % INSTALL_DIR_INFRA
-INSTALL_DIR_KMS = "%s/kms" % INSTALL_DIR_INFRA
-INSTALL_DIR_ELASTICMQ = "%s/elasticmq" % INSTALL_DIR_INFRA
-INSTALL_PATH_LOCALSTACK_FAT_JAR = "%s/localstack-utils-fat.jar" % INSTALL_DIR_INFRA
+INSTALL_DIR_NPM = "%s/node_modules" % MODULE_MAIN_PATH  # FIXME: migrate to infra
+INSTALL_DIR_DDB = "%s/dynamodb" % dirs.infra
+INSTALL_DIR_KCL = "%s/amazon-kinesis-client" % dirs.infra
+INSTALL_DIR_STEPFUNCTIONS = "%s/stepfunctions" % dirs.infra
+INSTALL_DIR_KMS = "%s/kms" % dirs.infra
+INSTALL_DIR_ELASTICMQ = "%s/elasticmq" % dirs.infra
+INSTALL_PATH_LOCALSTACK_FAT_JAR = "%s/localstack-utils-fat.jar" % dirs.infra
 INSTALL_PATH_DDB_JAR = os.path.join(INSTALL_DIR_DDB, "DynamoDBLocal.jar")
 INSTALL_PATH_KCL_JAR = os.path.join(INSTALL_DIR_KCL, "aws-java-sdk-sts.jar")
 INSTALL_PATH_STEPFUNCTIONS_JAR = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "StepFunctionsLocal.jar")
 INSTALL_PATH_KMS_BINARY_PATTERN = os.path.join(INSTALL_DIR_KMS, "local-kms.<arch>.bin")
 INSTALL_PATH_ELASTICMQ_JAR = os.path.join(INSTALL_DIR_ELASTICMQ, "elasticmq-server.jar")
 INSTALL_PATH_KINESALITE_CLI = os.path.join(INSTALL_DIR_NPM, "kinesalite", "cli.js")
-INSTALL_PATH_KINESIS_MOCK = os.path.join(INSTALL_DIR_INFRA, "kinesis-mock")
+INSTALL_PATH_KINESIS_MOCK = os.path.join(dirs.infra, "kinesis-mock")
 URL_LOCALSTACK_FAT_JAR = (
     "https://repo1.maven.org/maven2/"
     + "cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar"
 ).format(v=LOCALSTACK_MAVEN_VERSION)
 
-MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % INSTALL_DIR_INFRA
+MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.infra
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
@@ -108,7 +107,7 @@ SQS_BACKEND_IMPL = os.environ.get("SQS_PROVIDER") or "moto"
 # GO Lambda runtime
 GO_RUNTIME_VERSION = "0.4.0"
 GO_RUNTIME_DOWNLOAD_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-runtime/releases/download/v{version}/awslamba-go-runtime-{version}-{os}-{arch}.tar.gz"
-GO_INSTALL_FOLDER = os.path.join(config.TMP_FOLDER, "awslamba-go-runtime")
+GO_INSTALL_FOLDER = os.path.join(config.dirs.tmp, "awslamba-go-runtime")
 GO_LAMBDA_RUNTIME = os.path.join(GO_INSTALL_FOLDER, "aws-lambda-mock")
 GO_LAMBDA_MOCKSERVER = os.path.join(GO_INSTALL_FOLDER, "mockserver")
 
@@ -117,7 +116,7 @@ TERRAFORM_VERSION = "0.13.7"
 TERRAFORM_URL_TEMPLATE = (
     "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip"
 )
-TERRAFORM_BIN = os.path.join(INSTALL_DIR_INFRA, f"terraform-{TERRAFORM_VERSION}", "terraform")
+TERRAFORM_BIN = os.path.join(dirs.infra, f"terraform-{TERRAFORM_VERSION}", "terraform")
 
 
 def get_elasticsearch_install_version(version: str) -> str:
@@ -134,10 +133,10 @@ def get_elasticsearch_install_dir(version: str) -> str:
 
     if version == ELASTICSEARCH_DEFAULT_VERSION and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
         # install the default version into a subfolder of the code base
-        install_dir = os.path.join(INSTALL_DIR_INFRA, "elasticsearch")
+        install_dir = os.path.join(dirs.infra, "elasticsearch")
     else:
         # put all other versions into the TMP_FOLDER
-        install_dir = os.path.join(config.TMP_FOLDER, "elasticsearch", version)
+        install_dir = os.path.join(config.dirs.tmp, "elasticsearch", version)
 
     return install_dir
 
@@ -157,7 +156,7 @@ def install_elasticsearch(version=None):
         install_dir_parent = os.path.dirname(install_dir)
         mkdir(install_dir_parent)
         # download and extract archive
-        tmp_archive = os.path.join(config.TMP_FOLDER, "localstack.%s" % os.path.basename(es_url))
+        tmp_archive = os.path.join(config.dirs.tmp, "localstack.%s" % os.path.basename(es_url))
         download_and_extract_with_retry(es_url, tmp_archive, install_dir_parent)
         elasticsearch_dir = glob.glob(os.path.join(install_dir_parent, "elasticsearch*"))
         if not elasticsearch_dir:
@@ -223,7 +222,7 @@ def install_elasticmq():
         log_install_msg("ElasticMQ")
         mkdir(INSTALL_DIR_ELASTICMQ)
         # download archive
-        tmp_archive = os.path.join(config.TMP_FOLDER, "elasticmq-server.jar")
+        tmp_archive = os.path.join(config.dirs.tmp, "elasticmq-server.jar")
         if not os.path.exists(tmp_archive):
             download(ELASTICMQ_JAR_URL, tmp_archive)
         shutil.copy(tmp_archive, INSTALL_DIR_ELASTICMQ)
@@ -331,13 +330,13 @@ def install_stepfunctions_local():
         )
         time.sleep(5)
         DOCKER_CLIENT.copy_from_container(
-            docker_name, local_path=INSTALL_DIR_INFRA, container_path="/home/stepfunctionslocal/"
+            docker_name, local_path=dirs.infra, container_path="/home/stepfunctionslocal/"
         )
 
-        path = Path(f"{INSTALL_DIR_INFRA}/stepfunctionslocal/")
+        path = Path(f"{dirs.infra}/stepfunctionslocal/")
         for file in path.glob("*.jar"):
             file.rename(Path(INSTALL_DIR_STEPFUNCTIONS) / file.name)
-        rm_rf("%s/stepfunctionslocal" % INSTALL_DIR_INFRA)
+        rm_rf("%s/stepfunctionslocal" % dirs.infra)
     # apply patches
     for patch_class, patch_url in (
         (SFN_PATCH_CLASS1, SFN_PATCH_CLASS_URL1),

--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -30,11 +30,11 @@ PORT_KINESIS_BACKEND = None
 
 def apply_patches_kinesalite():
     files = [
-        "%s/node_modules/kinesalite/validations/decreaseStreamRetentionPeriod.js",
-        "%s/node_modules/kinesalite/validations/increaseStreamRetentionPeriod.js",
+        "%s/kinesalite/validations/decreaseStreamRetentionPeriod.js",
+        "%s/kinesalite/validations/increaseStreamRetentionPeriod.js",
     ]
     for file_path in files:
-        file_path = file_path % MODULE_MAIN_PATH
+        file_path = file_path % install.INSTALL_DIR_NPM
         replace_in_file("lessThanOrEqual: 168", "lessThanOrEqual: 8760", file_path)
 
 
@@ -85,8 +85,8 @@ def start_kinesis_mock(port=None, asynchronous=False, update_listener=None):
     global PORT_KINESIS_BACKEND
     PORT_KINESIS_BACKEND = backend_port
     kinesis_data_dir_param = ""
-    if config.DATA_DIR:
-        kinesis_data_dir = "%s/kinesis" % config.DATA_DIR
+    if config.dirs.data:
+        kinesis_data_dir = "%s/kinesis" % config.dirs.data
         mkdir(kinesis_data_dir)
         kinesis_data_dir_param = "SHOULD_PERSIST_DATA=true PERSIST_PATH=%s" % kinesis_data_dir
     if not config.LS_LOG:
@@ -150,8 +150,8 @@ def start_kinesalite(port=None, asynchronous=False, update_listener=None):
     PORT_KINESIS_BACKEND = backend_port
     latency = config.KINESIS_LATENCY
     kinesis_data_dir_param = ""
-    if config.DATA_DIR:
-        kinesis_data_dir = "%s/kinesis" % config.DATA_DIR
+    if config.dirs.data:
+        kinesis_data_dir = "%s/kinesis" % config.dirs.data
         mkdir(kinesis_data_dir)
         kinesis_data_dir_param = "--path %s" % kinesis_data_dir
     cmd = (

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -31,8 +31,8 @@ def start_kms_local(port=None, backend_port=None, asynchronous=None, update_list
         "KMS_ACCOUNT_ID": TEST_AWS_ACCOUNT_ID,
         "ACCOUNT_ID": TEST_AWS_ACCOUNT_ID,
     }
-    if config.DATA_DIR:
-        env_vars["KMS_DATA_PATH"] = config.DATA_DIR
+    if config.dirs.data:
+        env_vars["KMS_DATA_PATH"] = config.dirs.data
     result = do_run(kms_binary, asynchronous, env_vars=env_vars)
     wait_for_port_open(backend_port)
     return result

--- a/localstack/services/ses/ses_starter.py
+++ b/localstack/services/ses/ses_starter.py
@@ -149,7 +149,7 @@ def apply_patches():
         return email
 
     def log_email_to_data_dir(id, email):
-        ses_dir = os.path.join(config.DATA_DIR or config.TMP_FOLDER, "ses")
+        ses_dir = os.path.join(config.dirs.data or config.dirs.tmp, "ses")
         mkdir(ses_dir)
 
         with open(os.path.join(ses_dir, id + ".json"), "w") as f:
@@ -188,7 +188,7 @@ def apply_patches():
             self, source, template, template_data, destinations, region
         )
 
-        ses_dir = os.path.join(config.DATA_DIR or config.TMP_FOLDER, "ses")
+        ses_dir = os.path.join(config.dirs.data or config.dirs.tmp, "ses")
         mkdir(ses_dir)
 
         with open(os.path.join(ses_dir, message.id + ".json"), "w") as f:

--- a/localstack/services/sqs/elasticmq.py
+++ b/localstack/services/sqs/elasticmq.py
@@ -52,7 +52,7 @@ class ElasticMQSerer(Server):
         )
 
         # create temporary config
-        config_file = os.path.join(config.TMP_FOLDER, "sqs.%s.conf" % short_uid())
+        config_file = os.path.join(config.dirs.tmp, "sqs.%s.conf" % short_uid())
         LOG.debug("saving config file to %s:\n%s", config_file, config_params)
         TMP_FILES.append(config_file)
         save_file(config_file, config_params)

--- a/localstack/utils/analytics/event_publisher.py
+++ b/localstack/utils/analytics/event_publisher.py
@@ -93,7 +93,7 @@ def get_config_file_homedir():
 
 
 def get_config_file_tempdir():
-    return _get_config_file(os.path.join(config.TMP_FOLDER, ".localstack"))
+    return _get_config_file(os.path.join(config.dirs.tmp, ".localstack"))
 
 
 def get_machine_id():

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -117,7 +117,7 @@ def get_config_file_homedir():
 
 
 def get_config_file_tempdir():
-    return _get_config_file(os.path.join(config.TMP_FOLDER, ".localstack"))
+    return _get_config_file(os.path.join(config.dirs.tmp, ".localstack"))
 
 
 def read_api_key_safe():

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -949,7 +949,7 @@ class Util:
 
     @staticmethod
     def mountable_tmp_file():
-        f = os.path.join(config.TMP_FOLDER, short_uid())
+        f = os.path.join(config.dirs.tmp, short_uid())
         TMP_FILES.append(f)
         return f
 

--- a/localstack/utils/persistence.py
+++ b/localstack/utils/persistence.py
@@ -12,7 +12,7 @@ import requests
 from six import add_metaclass
 
 from localstack import config, constants
-from localstack.config import DATA_DIR, is_env_not_false, is_env_true
+from localstack.config import is_env_not_false, is_env_true
 from localstack.services.generic_proxy import ProxyListener
 from localstack.utils.aws import aws_stack
 from localstack.utils.bootstrap import is_api_enabled
@@ -202,7 +202,7 @@ def restore_persisted_data(apis):
 
 
 def is_persistence_enabled():
-    return bool(config.DATA_DIR)
+    return bool(config.dirs.data)
 
 
 def is_persistence_restored():
@@ -219,7 +219,7 @@ class StartupInfo(NamedTuple):
 def save_startup_info():
     from localstack_ext.constants import VERSION as LOCALSTACK_EXT_VERSION
 
-    file_path = os.path.join(DATA_DIR, STARTUP_INFO_FILE)
+    file_path = os.path.join(config.dirs.data, STARTUP_INFO_FILE)
 
     info = StartupInfo(
         timestamp=datetime.datetime.now().isoformat(),
@@ -257,9 +257,9 @@ def _append_startup_info(file_path, startup_info: StartupInfo):
 def get_file_path(api, create=True):
     if api not in API_FILE_PATHS:
         API_FILE_PATHS[api] = False
-        if not DATA_DIR:
+        if not config.dirs.data:
             return False
-        file_path = API_FILE_PATTERN.format(data_dir=DATA_DIR, api=api)
+        file_path = API_FILE_PATTERN.format(data_dir=config.dirs.data, api=api)
         if create and not os.path.exists(file_path):
             with open(file_path, "a"):
                 os.utime(file_path, None)

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 from localstack import config, constants
 from localstack.cli.localstack import localstack as cli
-from localstack.config import get_edge_url, in_docker
+from localstack.config import DOCKER_SOCK, get_edge_url, in_docker
 from localstack.utils import docker_utils
 from localstack.utils.common import poll_condition
 
@@ -109,3 +109,25 @@ class TestCliContainerLifecycle:
         inspect = container_client.inspect_container(config.MAIN_CONTAINER_NAME)
         assert "42069/tcp" in inspect["HostConfig"]["PortBindings"]
         assert f"{volume}:{volume}" in inspect["HostConfig"]["Binds"]
+
+    def test_directories_mounted_correctly(self, runner, tmp_path, monkeypatch, container_client):
+        data_dir = tmp_path / "data_dir"
+        tmp_folder = tmp_path / "tmp"
+
+        # set different directories and make sure they are mounted correctly
+        monkeypatch.setenv("DATA_DIR", str(data_dir))
+        monkeypatch.setattr(config, "DATA_DIR", str(data_dir))
+        monkeypatch.setattr(config, "TMP_FOLDER", str(tmp_folder))
+        # reload directories from manipulated config
+        monkeypatch.setattr(config, "dirs", config.Directories.from_config())
+
+        runner.invoke(cli, ["start", "-d"])
+        runner.invoke(cli, ["wait", "-t", "60"])
+
+        # check that mounts were created correctly
+        inspect = container_client.inspect_container(config.MAIN_CONTAINER_NAME)
+        container_dirs = config.Directories.for_container()
+        binds = inspect["HostConfig"]["Binds"]
+        assert f"{tmp_folder}:{container_dirs.tmp}" in binds
+        assert f"{data_dir}:{container_dirs.data}" in binds
+        assert f"{DOCKER_SOCK}:{DOCKER_SOCK}" in binds

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -68,7 +68,7 @@ class TestSES:
         assert "VerificationToken" not in response[email]
 
     def test_send_email_save(self, ses_client):
-        data_dir = config.DATA_DIR or config.TMP_FOLDER
+        data_dir = config.dirs.data or config.dirs.tmp
         email = "user@example.com"
         ses_client.verify_email_address(EmailAddress=email)
         message = ses_client.send_email(
@@ -99,7 +99,7 @@ class TestSES:
         assert ["success@example.com"] == contents["Destinations"]["ToAddresses"]
 
     def test_send_templated_email_save(self, ses_client, create_template):
-        data_dir = config.DATA_DIR or config.TMP_FOLDER
+        data_dir = config.dirs.data or config.dirs.tmp
         email = "user@example.com"
         ses_client.verify_email_address(EmailAddress=email)
         ses_client.delete_template(TemplateName=TEST_TEMPLATE_ATTRIBUTES["TemplateName"])

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -3,7 +3,7 @@ import os.path
 import pytest
 from click.testing import CliRunner
 
-from localstack.cli.lpm import cli
+from localstack.cli.lpm import cli, console
 
 
 @pytest.fixture
@@ -12,7 +12,7 @@ def runner():
 
 
 def test_list(runner, monkeypatch):
-    monkeypatch.setenv("NO_COLOR", "1")
+    monkeypatch.setattr(console, "no_color", True)
 
     result = runner.invoke(cli, ["list"])
     assert result.exit_code == 0


### PR DESCRIPTION
this PR introduces a `Directories` object within the config that holds the localstack directories that we defined as follows:

* `infra`:  static infra (pre-seeded packages)
* `var`: variable data (shared between host and container that should persist between reboots, e.g., lazy-loaded packages, ssl cert, decryption key, ...) -> changes semantic to "static" in offline image
* `shared_tmp`: shared temp folder (shared between host and container, for things like temp lambda code files. needs to be available to e.g., lambda containers)
* `tmp`: temp folder (ephemeral data, can be mounted from the host, but doesn't have to be)
* `data`: data dir (has to be persistent on the host, shared with the container)
* `config`: ~/.localstack/ (host configuration directory with, for, e.g., pre-configured environment variables or credentials)
* `init`: user-defined container provisioning scripts
* `logs`: log files

currently, most of these directories map to TMP_DIR, but that should change in the future. I was thinking to have most directories in the container under /var/lib/localstack, that way we can stick to one additional mount from the host (in addition to tmp), which simplifies docker compose configs that would otherwise need very fine grained mount binds to enable all the different directories.

The semantic of the tmp/shared tmp folder is currently not the way I described it in the doc strings, but I think it should be. We can discuss and iterate :)

The PR also changes the references throughout the code from the config constants to the global `dirs` object 

## Update November 26

The revised layout is:

```
static_libs: container only; binaries and libraries statically packaged with the image
var_libs:    shared; binaries and libraries+data computed at runtime: lazy-loaded binaries, ssl cert, ...
cache:       shared; ephemeral data that has to persist across localstack runs and reboots
tmp:         shared; ephemeral data that has to persist across localstack runs but not reboots
functions:   shared; volume to communicate between host<->lambda containers
data:        shared; holds localstack state, pods, ...
config:      host only; pre-defined configuration values, cached credentials, machine id, ...
init:        shared; user-defined provisioning scripts executed in the container when it starts
logs:        shared; log files produced by localstack
```