### PR TITLE
add cli command to show current config

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -220,6 +220,59 @@ def cmd_config_validate(file):
         sys.exit(1)
 
 
+@localstack_config.command(name="show", help="Print the current LocalStack config values")
+@click.option("--format", type=click.Choice(["table", "plain", "dict", "json"]), default="table")
+def cmd_config_show(format):
+    # TODO: parse values from potential docker-compose file?
+
+    if format == "table":
+        print_config_table()
+    elif format == "plain":
+        print_config_pairs()
+    elif format == "dict":
+        print_config_dict()
+    elif format == "json":
+        print_config_json()
+    else:
+        print_config_pairs()  # fall back to plain
+
+
+def print_config_json():
+    import json
+
+    from localstack import config
+
+    console.print(json.dumps(dict(config.collect_config_items())))
+
+
+def print_config_pairs():
+    from localstack import config
+
+    for key, value in config.collect_config_items():
+        console.print(f"{key}={value}")
+
+
+def print_config_dict():
+    from localstack import config
+
+    console.print(dict(config.collect_config_items()))
+
+
+def print_config_table():
+    from rich.table import Table
+
+    from localstack import config
+
+    grid = Table(show_header=True)
+    grid.add_column("Key")
+    grid.add_column("Value")
+
+    for key, value in config.collect_config_items():
+        grid.add_row(key, str(value))
+
+    console.print(grid)
+
+
 @localstack.command(name="ssh", help="Obtain a shell in the running LocalStack container")
 def cmd_ssh():
     from localstack import config

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -7,7 +7,7 @@ import socket
 import subprocess
 import tempfile
 import time
-from typing import Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Tuple
 
 import six
 from boto3 import Session
@@ -490,6 +490,28 @@ for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
         clean_key + "_PORT",
         clean_key + "_PORT_EXTERNAL",
     ]
+
+
+def collect_config_items() -> List[Tuple[str, Any]]:
+    """Returns a list of key-value tuples of LocalStack configuration values."""
+    none = object()  # sentinel object
+
+    # collect which keys to print
+    keys = list()
+    keys.extend(CONFIG_ENV_VARS)
+    keys.append("DATA_DIR")
+    keys.sort()
+
+    values = globals()
+
+    result = list()
+    for k in keys:
+        v = values.get(k, none)
+        if v is none:
+            continue
+        result.append((k, v))
+    result.sort()
+    return result
 
 
 def ping(host):

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import threading
 
 import click
@@ -139,3 +140,42 @@ def test_validate_config_syntax_error(runner, monkeypatch, tmp_path):
 
     assert result.exit_code == 1
     assert "error" in result.output
+
+
+def test_config_show_table(runner):
+    result = runner.invoke(cli, ["config", "show"])
+    assert result.exit_code == 0
+    assert "DATA_DIR" in result.output
+    assert "DEBUG" in result.output
+
+
+def test_config_show_json(runner):
+    result = runner.invoke(cli, ["config", "show", "--format=json"])
+    assert result.exit_code == 0
+
+    doc = json.loads(result.output)
+    assert "DATA_DIR" in doc
+    assert "DEBUG" in doc
+    assert type(doc["DEBUG"]) == bool
+
+
+def test_config_show_plain(runner, monkeypatch):
+    monkeypatch.setenv("DEBUG", "1")
+    monkeypatch.setattr(config, "DEBUG", True)
+
+    result = runner.invoke(cli, ["config", "show", "--format=plain"])
+    assert result.exit_code == 0
+
+    assert "DATA_DIR=" in result.output
+    assert "DEBUG=True" in result.output
+
+
+def test_config_show_dict(runner, monkeypatch):
+    monkeypatch.setenv("DEBUG", "1")
+    monkeypatch.setattr(config, "DEBUG", True)
+
+    result = runner.invoke(cli, ["config", "show", "--format=dict"])
+    assert result.exit_code == 0
+
+    assert "'DATA_DIR':" in result.output
+    assert "'DEBUG': True" in result.output


### PR DESCRIPTION
Adds a CLI command that lets you output the configuration variables given the current environment. this will be useful to debug custom configurations lying around in `~/.localstack/config.env`. part of #5014

supports different output formats (table (left), plain (right), dict, json)

![localstack-cli-show](https://user-images.githubusercontent.com/3996682/143617852-45917be7-299d-477a-a726-1122ff82ca14.png)
