### PR TITLE
add .localstack config directory and config profiles

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -34,7 +34,11 @@ def _setup_cli_debug():
 @click.group(name="localstack", help="The LocalStack Command Line Interface (CLI)")
 @click.version_option(version=__version__, message="%(version)s")
 @click.option("--debug", is_flag=True, help="Enable CLI debugging mode")
-def localstack(debug):
+@click.option("--profile", type=str, help="Set the configuration profile")
+def localstack(debug, profile):
+    if profile:
+        os.environ["CONFIG_PROFILE"] = profile
+
     if debug:
         _setup_cli_debug()
 
@@ -224,6 +228,13 @@ def cmd_config_validate(file):
 @click.option("--format", type=click.Choice(["table", "plain", "dict", "json"]), default="table")
 def cmd_config_show(format):
     # TODO: parse values from potential docker-compose file?
+
+    from localstack_ext import config as ext_config
+
+    from localstack import config
+
+    assert config
+    assert ext_config
 
     if format == "table":
         print_config_table()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import platform
@@ -9,6 +8,7 @@ import tempfile
 import time
 from typing import Any, Dict, List, Mapping, Tuple
 
+import dotenv
 import six
 from boto3 import Session
 
@@ -95,7 +95,7 @@ class Directories:
             tmp=TMP_FOLDER,  # TODO: should inherit from root value for /var/lib/localstack (e.g., MOUNT_ROOT)
             functions=HOST_TMP_FOLDER,  # TODO: rename variable/consider a volume
             data=DATA_DIR,
-            config=None,  # TODO: will be introduced once .localstack config file has been refactored
+            config=CONFIG_DIR,
             init=None,  # TODO: introduce environment variable
             logs=TMP_FOLDER,  # TODO: add variable
         )
@@ -103,8 +103,8 @@ class Directories:
     @staticmethod
     def for_container() -> "Directories":
         """
-        /var/lib/localstack. Returns Localstack directory paths as they are defined within the container. Everything
-        shared and writable lives in /var/lib/localstack or /tmp/localstack.
+        Returns Localstack directory paths as they are defined within the container. Everything shared and writable
+        lives in /var/lib/localstack or /tmp/localstack.
 
         :returns: Directories object
         """
@@ -115,7 +115,7 @@ class Directories:
             tmp=TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
             functions=HOST_TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
             data=DATA_DIR,  # TODO: move to /var/lib/localstack/data
-            config="/etc/localstack",  # TODO: will be introduced once .localstack config file has been refactored
+            config=None,  # config directory is host-only
             logs="/var/lib/localstack/logs",
             init="/docker-entrypoint-initaws.d",
         )
@@ -159,6 +159,25 @@ def is_env_not_false(env_var_name):
     """Whether the given environment variable is empty or has a truthy value."""
     return os.environ.get(env_var_name, "").lower().strip() not in FALSE_STRINGS
 
+
+def load_environment(profile: str = None):
+    """Loads the environment variables from ~/.localstack/{profile}.env
+    :param profile: the profile to load (defaults to "default")
+    """
+    if not profile:
+        profile = "default"
+    path = os.path.join(CONFIG_DIR, f"{profile}.env")
+    dotenv.load_dotenv(path, override=False)
+
+
+# the configuration profile to load
+CONFIG_PROFILE = os.environ.get("CONFIG_PROFILE", "").strip()
+
+# host configuration directory
+CONFIG_DIR = os.environ.get("CONFIG_DIR", os.path.expanduser("~/.localstack"))
+
+# keep this on top to populate environment
+load_environment(CONFIG_PROFILE)
 
 # java options to Lambda
 LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
@@ -602,11 +621,6 @@ except socket.error:
 if is_in_docker and not os.environ.get("LAMBDA_REMOTE_DOCKER", "").strip():
     LAMBDA_REMOTE_DOCKER = True
 
-# local config file path in home directory
-CONFIG_FILE_PATH = os.path.join(TMP_FOLDER, ".localstack")
-if not is_in_docker:
-    CONFIG_FILE_PATH = os.path.join(os.path.expanduser("~"), ".localstack")
-
 # set variables no_proxy, i.e., run internal service calls directly
 no_proxy = ",".join(set((LOCALSTACK_HOSTNAME, LOCALHOST, LOCALHOST_IP, "[::1]")))
 if os.environ.get("no_proxy"):
@@ -732,25 +746,12 @@ if DEBUG:
     logging.getLogger("").setLevel(logging.DEBUG)
     logging.getLogger("localstack").setLevel(logging.DEBUG)
 
-
-def load_config_file(config_file=None):
-    from localstack.utils.common import get_or_create_file, to_str
-
-    config_file = config_file or CONFIG_FILE_PATH
-    content = get_or_create_file(config_file, permissions=0o600)
-    try:
-        configs = json.loads(to_str(content) or "{}")
-    except Exception as e:
-        print("Unable to load local config file %s as JSON: %s" % (config_file, e))
-        return {}
-    return configs
-
-
-def save_config_file(config, config_file=None):
-    from localstack.utils.common import save_file
-
-    config_file = config_file or CONFIG_FILE_PATH
-    save_file(config_file, json.dumps(config), permissions=0o600)
+if LS_LOG in TRACE_LOG_LEVELS:
+    load_end_time = time.time()
+    LOG = logging.getLogger(__name__)
+    LOG.debug(
+        "Initializing the configuration took %s ms" % int((load_end_time - load_start_time) * 1000)
+    )
 
 
 class ServiceProviderConfig(Mapping[str, str]):
@@ -793,13 +794,6 @@ SERVICE_PROVIDER_CONFIG = ServiceProviderConfig("default")
 for key, value in os.environ.items():
     if key.startswith("PROVIDER_OVERRIDE_"):
         SERVICE_PROVIDER_CONFIG.set_provider(key.lstrip("PROVIDER_OVERRIDE_").lower(), value)
-
-if LS_LOG in TRACE_LOG_LEVELS:
-    load_end_time = time.time()
-    LOG = logging.getLogger(__name__)
-    LOG.debug(
-        "Initializing the configuration took %s ms" % int((load_end_time - load_start_time) * 1000)
-    )
 
 # initialize directories
 if is_in_docker:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -163,11 +163,15 @@ def load_environment(profile: str = None):
     """Loads the environment variables from ~/.localstack/{profile}.env
     :param profile: the profile to load (defaults to "default")
     """
-    import dotenv
-
     if not profile:
         profile = "default"
+
     path = os.path.join(CONFIG_DIR, f"{profile}.env")
+    if not os.path.exists(path):
+        return
+
+    import dotenv
+
     dotenv.load_dotenv(path, override=False)
 
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -8,7 +8,6 @@ import tempfile
 import time
 from typing import Any, Dict, List, Mapping, Tuple
 
-import dotenv
 import six
 from boto3 import Session
 
@@ -164,6 +163,8 @@ def load_environment(profile: str = None):
     """Loads the environment variables from ~/.localstack/{profile}.env
     :param profile: the profile to load (defaults to "default")
     """
+    import dotenv
+
     if not profile:
         profile = "default"
     path = os.path.join(CONFIG_DIR, f"{profile}.env")
@@ -177,7 +178,11 @@ CONFIG_PROFILE = os.environ.get("CONFIG_PROFILE", "").strip()
 CONFIG_DIR = os.environ.get("CONFIG_DIR", os.path.expanduser("~/.localstack"))
 
 # keep this on top to populate environment
-load_environment(CONFIG_PROFILE)
+try:
+    load_environment(CONFIG_PROFILE)
+except ImportError:
+    # dotenv may not be available in lambdas or other environments where config is loaded
+    pass
 
 # java options to Lambda
 LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -811,3 +811,11 @@ else:
     dirs = Directories.from_config()
 
 dirs.mkdirs()
+
+# TODO: remove deprecation warning with next release
+for path in [dirs.config, os.path.join(dirs.tmp, ".localstack")]:
+    if path and os.path.isfile(path):
+        print(
+            f"warning: the config file .localstack is deprecated and no longer used, "
+            f"please remove it by running rm {path}"
+        )

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -28,17 +28,10 @@ from localstack.utils.serving import Server
 
 LOG = logging.getLogger(os.path.basename(__file__))
 
-# marker for extended/ignored libs in requirements.txt
-IGNORED_LIB_MARKER = "#extended-lib"
-BASIC_LIB_MARKER = "#basic-lib"
 
 # log format strings
 LOG_FORMAT = "%(asctime)s.%(msecs)03d:%(levelname)s:%(name)s: %(message)s"
 LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
-
-# plugin scopes
-PLUGIN_SCOPE_SERVICES = "services"
-PLUGIN_SCOPE_COMMANDS = "commands"
 
 # maps from API names to list of other API names that they depend on
 API_DEPENDENCIES = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ docker==5.0.0
 localstack-client>=1.24
 localstack-ext>=0.13.0.11
 localstack-plugin-loader>=0.1.0
+psutil>=5.4.8,<6.0.0
+python-dotenv>=0.19.1
 pyyaml>=5.1
 rich>=10.7.0
 requests>=2.20.0,<2.26
@@ -27,7 +29,6 @@ stevedore>=3.4.0
 # needed for python3.7 compat (TypedDict, Literal, type hints)
 typing-extensions; python_version < '3.8'
 tailer>=0.4.1
-psutil>=5.4.8,<6.0.0
 
 # extra=runtime
 airspeed>=0.5.14

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -69,39 +69,3 @@ class TestParseServicePorts:
         assert "foobar" in result
         # FOOBAR_PORT cannot be parsed
         assert result["foobar"] == 1235
-
-
-class TestLoadConfigFile:
-    def test_with_existing_file(self, tmp_path):
-        test_config = '{"foo": "bar", "why": 42}'
-
-        tmp_file = tmp_path / "config.json"
-        tmp_file.write_text(test_config)
-
-        cfg = config.load_config_file(str(tmp_file))
-
-        assert len(cfg) == 2
-        assert "foo" in cfg
-        assert "why" in cfg
-        assert cfg["foo"] == "bar"
-        assert cfg["why"] == 42
-
-    def test_illegal_config_content_fails_silently(self, tmp_path):
-        test_config = '{"foo: "bar"}'  # json syntax error
-
-        tmp_file = tmp_path / "config.json"
-        tmp_file.write_text(test_config)
-
-        cfg = config.load_config_file(str(tmp_file))
-
-        assert cfg is not None
-        assert len(cfg) == 0
-
-    def test_creates_file_if_not_exists(self, tmp_path):
-        tmp_file = tmp_path / "config.json"
-        assert not tmp_file.exists()
-
-        cfg = config.load_config_file(str(tmp_file))
-
-        assert tmp_file.exists()
-        assert len(cfg) == 0


### PR DESCRIPTION
This PR adds the `~/.localstack` config directory and introduces configuration profiles. A profile is a set of environment variables stored in an `.env` file in the localstack config directory.

```
 % tree ~/.localstack 
/home/thomas/.localstack
├── default.env
├── dev.env
└── pro.env
```

for example:
```
 % cat ~/.localstack/dev.env
DEBUG=1
DEVELOP=1
```

you can load a profile by either setting the env variable `CONFIG_PROFILE=<profile>` or the `--profile=<profile>` CLI flag when using the CLI.
For example `python -m localstack.cli.main --profile=dev start --host` will load the `dev.env` profile file if it exist.

behavior:
* if no profile is specified, the `default.env` is loaded (if it exists)
* explicitly defined environment variables will always overwrite the profile. 

you can use `python -m localstack.cli.main --profile=dev config show` to display the config environment variables

### Caveat:

once we release this, people who have the old `~/.localstack` file in their home directory may experience odd behavior.