### PR TITLE
add patch utility

### DIFF
--- a/localstack/utils/patch.py
+++ b/localstack/utils/patch.py
@@ -7,14 +7,12 @@ def get_defining_object(method):
     """Returns either the class or the module that defines the given function/method."""
     # adapted from https://stackoverflow.com/a/25959545/804840
     if inspect.ismethod(method):
-        for cls in inspect.getmro(method.__self__.__class__):
-            if cls.__dict__.get(method.__name__) is method:
-                return cls
-        method = method.__func__  # fallback to __qualname__ parsing
+        return method.__self__
 
     if inspect.isfunction(method):
         class_name = method.__qualname__.split(".<locals>", 1)[0].rsplit(".", 1)[0]
         try:
+            # method is not bound but referenced by a class, like MyClass.mymethod
             cls = getattr(inspect.getmodule(method), class_name)
         except AttributeError:
             cls = method.__globals__.get(class_name)
@@ -22,6 +20,7 @@ def get_defining_object(method):
         if isinstance(cls, type):
             return cls
 
+    # method is a module-level function
     return inspect.getmodule(method)
 
 

--- a/localstack/utils/patch.py
+++ b/localstack/utils/patch.py
@@ -1,0 +1,112 @@
+import functools
+import inspect
+from typing import Any, Callable
+
+
+def get_defining_object(method):
+    """Returns either the class or the module that defines the given function/method."""
+    # adapted from https://stackoverflow.com/a/25959545/804840
+    if inspect.ismethod(method):
+        for cls in inspect.getmro(method.__self__.__class__):
+            if cls.__dict__.get(method.__name__) is method:
+                return cls
+        method = method.__func__  # fallback to __qualname__ parsing
+
+    if inspect.isfunction(method):
+        class_name = method.__qualname__.split(".<locals>", 1)[0].rsplit(".", 1)[0]
+        try:
+            cls = getattr(inspect.getmodule(method), class_name)
+        except AttributeError:
+            cls = method.__globals__.get(class_name)
+
+        if isinstance(cls, type):
+            return cls
+
+    return inspect.getmodule(method)
+
+
+def create_patch_proxy(target: Callable, new: Callable):
+    """
+    Creates a proxy that calls `new` but passes as first argument the target.
+    """
+
+    @functools.wraps(target)
+    def proxy(*args, **kwargs):
+        return new(target, *args, **kwargs)
+
+    return proxy
+
+
+class Patch:
+    obj: Any
+    name: str
+    new: Any
+
+    def __init__(self, obj: Any, name: str, new: Any) -> None:
+        super().__init__()
+        self.obj = obj
+        self.name = name
+        self.old = getattr(self.obj, name)
+        self.new = new
+        self.is_applied = False
+
+    def apply(self):
+        setattr(self.obj, self.name, self.new)
+        self.is_applied = True
+
+    def undo(self):
+        setattr(self.obj, self.name, self.old)
+        self.is_applied = False
+
+    def __enter__(self):
+        self.apply()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.undo()
+        return self
+
+    @staticmethod
+    def function(target: Callable, fn: Callable, pass_target: bool = True):
+        obj = get_defining_object(target)
+        name = target.__name__
+
+        if pass_target:
+            new = create_patch_proxy(target, fn)
+        else:
+            new = fn
+
+        return Patch(obj, name, new)
+
+
+def patch(target, pass_target=True):
+    """
+    Function decorator to create a patch via Patch.function and immediately apply it.
+
+    Example::
+
+        def echo(string):
+            return "echo " + string
+
+        @patch(target=echo)
+        def echo_uppercase(target, string):
+            return target(string).upper()
+
+        echo("foo")
+        # will print "ECHO FOO"
+
+        echo_uppercase.patch.undo()
+        echo("foo")
+        # will print "echo foo"
+
+    :param target: the function or method to patch
+    :param pass_target: whether to pass the target to the patching function as first parameter
+    :returns: the same function, but with a patch created
+    """
+
+    def wrapper(fn):
+        fn.patch = Patch.function(target, fn, pass_target=pass_target)
+        fn.patch.apply()
+        return fn
+
+    return wrapper

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -1,0 +1,89 @@
+from localstack.utils.patch import Patch, get_defining_object, patch
+
+
+def echo(arg):
+    return f"echo: {arg}"
+
+
+class MyEchoer:
+    def do_echo(self, arg):
+        return f"do_echo: {arg}"
+
+    @classmethod
+    def do_class_echo(cls, arg):
+        return f"do_class_echo: {arg}"
+
+
+def test_patch_context_manager():
+    assert echo("foo") == "echo: foo"
+
+    def monkey(arg):
+        return f"monkey: {arg}"
+
+    with Patch(get_defining_object(echo), "echo", monkey):
+        assert echo("foo") == "monkey: foo"
+
+    assert echo("foo") == "echo: foo"
+
+
+def test_patch_with_pass_target_context_manager():
+    assert echo("foo") == "echo: foo"
+
+    def uppercase(target, arg):
+        return target(arg).upper()
+
+    with Patch(get_defining_object(echo), "echo", uppercase):
+        assert echo("foo") == "ECHO: FOO"
+
+    assert echo("foo") == "echo: foo"
+
+
+def test_patch_decorator():
+    @patch(target=echo, pass_target=False)
+    def monkey(arg):
+        return f"monkey: {arg}"
+
+    assert echo("foo") == "monkey: foo"
+    monkey.patch.undo()
+    assert echo("foo") == "echo: foo"
+
+
+def test_patch_decorator_with_pass_target():
+    @patch(target=echo)
+    def uppercase(target, arg):
+        return target(arg).upper()
+
+    assert echo("foo") == "ECHO: FOO"
+    uppercase.patch.undo()
+    assert echo("foo") == "echo: foo"
+
+
+def test_patch_decorator_on_method():
+    @patch(target=MyEchoer.do_echo)
+    def uppercase(target, self, arg):
+        return target(self, arg).upper()
+
+    obj = MyEchoer()
+
+    assert obj.do_echo("foo") == "DO_ECHO: FOO"
+    uppercase.patch.undo()
+    assert obj.do_echo("foo") == "do_echo: foo"
+    assert MyEchoer().do_echo("foo") == "do_echo: foo"
+
+
+def test_patch_decorator_on_class_method():
+    @patch(target=MyEchoer.do_class_echo)
+    def uppercase(target, *args):
+        if len(args) > 1:
+            # this happens when the method is called on an object, the first arg will be the object
+            arg = args[1]
+        else:
+            arg = args[0]
+
+        return target(arg).upper()
+
+    assert MyEchoer.do_class_echo("foo") == "DO_CLASS_ECHO: FOO"
+    assert MyEchoer().do_class_echo("foo") == "DO_CLASS_ECHO: FOO"
+    uppercase.patch.undo()
+    assert MyEchoer.do_class_echo("foo") == "do_class_echo: foo"
+    assert MyEchoer().do_class_echo("foo") == "do_class_echo: foo"


### PR DESCRIPTION
This PR adds a patch utility module that could potentially clean up some code that does monkey patching.

The typical pattern is:

```python
def patch_dothings():
    # do things
    return orig()

orig = mymodule.dothings
mymodule.dothings = patch_dothings
```

this can now be replaced with
```python
@patch(mymodule.dothings)
def patch_dothings(orig):
    # do things
    return orig()
```

or 
```python
def patch_dothings(orig):
    # do things
    return orig()

Patch.function(mymodule.dothings, patch_dothings).apply()
```

class functions/methods can also be patched!

i also changed the `sqs_starter.py` to use the patch utility to try it out.