### PR TITLE
Get hostname by using gethostname() method instead of reading /etc/hostname

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -590,9 +590,9 @@ def in_docker():
     except Exception:
         pass
     with open("/proc/1/cgroup", "rt") as ifh:
-        os_hostname = open("/etc/hostname", "rt").read().strip()
+        os_hostname = socket.gethostname()
         content = ifh.read()
-        if os_hostname in content or "docker" in content:
+        if (os_hostname and os_hostname in content) or "docker" in content:
             return True
     return False
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -590,9 +590,11 @@ def in_docker():
     except Exception:
         pass
     with open("/proc/1/cgroup", "rt") as ifh:
-        os_hostname = socket.gethostname()
         content = ifh.read()
-        if (os_hostname and os_hostname in content) or "docker" in content:
+        if "docker" in content:
+            return True
+        os_hostname = socket.gethostname()
+        if os_hostname and os_hostname in content:
             return True
     return False
 


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
This PR replaces the lookup of /etc/hostname with the `socket.gethostname()` method.
Also, a check is introduced if a hostname is detected (in case it might be empty).

One could argue for `platform.node()` instead of `socket.gethostname()` since it caches its value, but the safer option in my opinion is `socker.gethostname()` if, for some reason, the hostname would change (also it is not called that often so performance is critical).

Fixes #5028