### PR TITLE
Filter warnings about tail unrecognized file system from test logs

### DIFF
--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -607,7 +607,7 @@ def get_lambda_log_events(
             or "REPORT" in raw_message
             # necessary until tail is updated in docker images. See this PR:
             # http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commitdiff;h=v8.24-111-g1118f32
-            or "tail: unrecognized file system type 0x794c7630" in raw_message
+            or "tail: unrecognized file system type" in raw_message
             or regex_filter
             and not re.search(regex_filter, raw_message)
         ):

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -605,6 +605,9 @@ def get_lambda_log_events(
             or "START" in raw_message
             or "END" in raw_message
             or "REPORT" in raw_message
+            # necessary until tail is updated in docker images. See this PR:
+            # http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commitdiff;h=v8.24-111-g1118f32
+            or "tail: unrecognized file system type 0x794c7630" in raw_message
             or regex_filter
             and not re.search(regex_filter, raw_message)
         ):


### PR DESCRIPTION
Due to the bug fixed by this PR http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commitdiff;h=v8.24-111-g1118f32

this log message can appear if tail is executed in the context of lambda execution.

This PR filters that message, until we can update the tail command in the lambda docker images.