### PR TITLE
download test-jar for Lambda integration tests with `make init-testlibs`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,9 @@ jobs:
             docker pull -q lambci/lambda:java8
             docker pull -q lambci/lambda:python3.8
       - run:
+          name: Initialize Test Libraries
+          command: make init-testlibs
+      - run:
           name: Test docker client
           environment:
             DEBUG: 1

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -118,6 +118,13 @@ TERRAFORM_URL_TEMPLATE = (
 )
 TERRAFORM_BIN = os.path.join(dirs.static_libs, f"terraform-{TERRAFORM_VERSION}", "terraform")
 
+# Java Test Jar Download (used for tests)
+TEST_LAMBDA_JAVA = os.path.join(config.dirs.var_libs, "localstack-utils-tests.jar")
+MAVEN_BASE_URL = "https://repo.maven.apache.org/maven2"
+TEST_LAMBDA_JAR_URL = "{url}/cloud/localstack/{name}/{version}/{name}-{version}-tests.jar".format(
+    version=LOCALSTACK_MAVEN_VERSION, url=MAVEN_BASE_URL, name="localstack-utils"
+)
+
 
 def get_elasticsearch_install_version(version: str) -> str:
     from localstack.services.es import versions
@@ -407,6 +414,13 @@ def install_lambda_java_libs():
         download(URL_LOCALSTACK_FAT_JAR, INSTALL_PATH_LOCALSTACK_FAT_JAR)
 
 
+def install_lambda_java_testlibs():
+    # Download the LocalStack Utils Test jar file from the maven repo
+    if not os.path.exists(TEST_LAMBDA_JAVA):
+        mkdir(os.path.dirname(TEST_LAMBDA_JAVA))
+        download(TEST_LAMBDA_JAR_URL, TEST_LAMBDA_JAVA)
+
+
 def install_go_lambda_runtime():
     if os.path.isfile(GO_LAMBDA_RUNTIME):
         return
@@ -622,6 +636,7 @@ def main():
         if sys.argv[1] in ("libs", "testlibs"):
             # Install additional libraries for testing
             install_amazon_kinesis_client_libs()
+            install_lambda_java_testlibs()
         print("Done.")
 
 

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -12,12 +12,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from localstack import config
-from localstack.constants import (
-    LAMBDA_TEST_ROLE,
-    LOCALSTACK_MAVEN_VERSION,
-    LOCALSTACK_ROOT_FOLDER,
-    TEST_AWS_ACCOUNT_ID,
-)
+from localstack.constants import LAMBDA_TEST_ROLE, TEST_AWS_ACCOUNT_ID
 from localstack.services.apigateway.helpers import gateway_request_url
 from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.services.awslambda.lambda_api import (
@@ -45,6 +40,7 @@ from localstack.services.infra import start_proxy
 from localstack.services.install import (
     GO_RUNTIME_VERSION,
     INSTALL_PATH_LOCALSTACK_FAT_JAR,
+    TEST_LAMBDA_JAVA,
     download_and_extract,
 )
 from localstack.utils import testutil
@@ -52,7 +48,6 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import lambda_function_arn
 from localstack.utils.common import (
     cp_r,
-    download,
     get_arch,
     get_free_tcp_port,
     get_os,
@@ -88,9 +83,6 @@ TEST_LAMBDA_RUBY = os.path.join(THIS_FOLDER, "lambdas", "lambda_integration.rb")
 TEST_LAMBDA_DOTNETCORE2 = os.path.join(THIS_FOLDER, "lambdas", "dotnetcore2", "dotnetcore2.zip")
 TEST_LAMBDA_DOTNETCORE31 = os.path.join(THIS_FOLDER, "lambdas", "dotnetcore31", "dotnetcore31.zip")
 TEST_LAMBDA_CUSTOM_RUNTIME = os.path.join(THIS_FOLDER, "lambdas", "custom-runtime")
-TEST_LAMBDA_JAVA = os.path.join(
-    LOCALSTACK_ROOT_FOLDER, "localstack", "infra", "localstack-utils-tests.jar"
-)
 TEST_LAMBDA_JAVA_WITH_LIB = os.path.join(
     THIS_FOLDER, "lambdas", "java", "lambda_echo", "lambda-function-with-lib-0.0.1.jar"
 )
@@ -134,12 +126,7 @@ TEST_LAMBDA_FUNCTION_PREFIX = "lambda-function"
 TEST_SNS_TOPIC_NAME = "sns-topic-1"
 TEST_STAGE_NAME = "testing"
 
-MAVEN_BASE_URL = "https://repo.maven.apache.org/maven2"
-
 TEST_GOLANG_LAMBDA_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-runtime/releases/download/v{version}/example-handler-{os}-{arch}.tar.gz"
-TEST_LAMBDA_JAR_URL = "{url}/cloud/localstack/{name}/{version}/{name}-{version}-tests.jar".format(
-    version=LOCALSTACK_MAVEN_VERSION, url=MAVEN_BASE_URL, name="localstack-utils"
-)
 
 TEST_LAMBDA_LIBS = [
     "localstack",
@@ -1725,12 +1712,8 @@ class TestJavaRuntimes(LambdaTestBase):
     def setUpClass(cls):
         cls.lambda_client = aws_stack.connect_to_service("lambda")
 
-        # deploy lambda - Java
-        if not os.path.exists(TEST_LAMBDA_JAVA):
-            mkdir(os.path.dirname(TEST_LAMBDA_JAVA))
-            download(TEST_LAMBDA_JAR_URL, TEST_LAMBDA_JAVA)
-
         # deploy Lambda - default handler
+        # The TEST_LAMBDA_JAVA jar file is downloaded with `make init-testlibs`.
         cls.test_java_jar = load_file(TEST_LAMBDA_JAVA, mode="rb")
         zip_dir = new_tmp_dir()
         zip_lib_dir = os.path.join(zip_dir, "lib")


### PR DESCRIPTION
Currently, the Java Lambda integration tests download an external jar file which is then used to run tests within the Java lambda runtime. Previously, the jar file was downloaded on demand in the setup class of the test. This causes problems when you want to run the tests in a network restricted environment.
This PR moves the installation of the test-jar to the `install.py` where it is installed with the `make init-testlibs` call (just like the kinesis client).