### PR TITLE
Allow redirection of var libs to static libs inside the container / move dependencies to correct folders

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -107,9 +107,14 @@ class Directories:
 
         :returns: Directories object
         """
+        # only set CONTAINER_VAR_LIBS inside the container to redirect var_libs to static_libs
+        # to avoid override by host mount
+        var_libs = (
+            os.environ.get("CONTAINER_VAR_LIBS", "").strip() or "/var/lib/localstack/var_libs"
+        )
         return Directories(
             static_libs=INSTALL_DIR_INFRA,
-            var_libs="/var/lib/localstack/var_libs",
+            var_libs=var_libs,
             cache="/var/lib/localstack/cache",
             tmp=TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
             functions=HOST_TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -107,15 +107,17 @@ class Directories:
 
         :returns: Directories object
         """
-        # only set CONTAINER_VAR_LIBS inside the container to redirect var_libs to static_libs
-        # to avoid override by host mount
+        # only set CONTAINER_VAR_LIBS_FOLDER/CONTAINER_CACHE_FOLDER inside the container to redirect var_libs/cache to
+        # another directory to avoid override by host mount
         var_libs = (
-            os.environ.get("CONTAINER_VAR_LIBS", "").strip() or "/var/lib/localstack/var_libs"
+            os.environ.get("CONTAINER_VAR_LIBS_FOLDER", "").strip()
+            or "/var/lib/localstack/var_libs"
         )
+        cache = os.environ.get("CONTAINER_CACHE_FOLDER", "").strip() or "/var/lib/localstack/cache"
         return Directories(
             static_libs=INSTALL_DIR_INFRA,
             var_libs=var_libs,
-            cache="/var/lib/localstack/cache",
+            cache=cache,
             tmp=TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
             functions=HOST_TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
             data=DATA_DIR,  # TODO: move to /var/lib/localstack/data

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -641,7 +641,7 @@ if hasattr(BaseSelectorEventLoop, "_accept_connection2") and not hasattr(
 
 
 def get_cert_pem_file_path():
-    return os.path.join(config.dirs.tmp, SERVER_CERT_PEM_FILE)
+    return os.path.join(config.dirs.cache, SERVER_CERT_PEM_FILE)
 
 
 def start_proxy_server(

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -107,7 +107,7 @@ SQS_BACKEND_IMPL = os.environ.get("SQS_PROVIDER") or "moto"
 # GO Lambda runtime
 GO_RUNTIME_VERSION = "0.4.0"
 GO_RUNTIME_DOWNLOAD_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-runtime/releases/download/v{version}/awslamba-go-runtime-{version}-{os}-{arch}.tar.gz"
-GO_INSTALL_FOLDER = os.path.join(config.dirs.tmp, "awslamba-go-runtime")
+GO_INSTALL_FOLDER = os.path.join(config.dirs.var_libs, "awslamba-go-runtime")
 GO_LAMBDA_RUNTIME = os.path.join(GO_INSTALL_FOLDER, "aws-lambda-mock")
 GO_LAMBDA_MOCKSERVER = os.path.join(GO_INSTALL_FOLDER, "mockserver")
 


### PR DESCRIPTION
This allows us to redirect the var libs folder to static libs if we want to prevent an override by a host mount.

Therefore, this variable should ONLY be set inside the container and only be referenced in this context.