### PR TITLE
Add timeout parameter to download(..) util function

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -728,7 +728,9 @@ def is_port_open(
                 result = sock.connect_ex((host, port))
                 if result != 0:
                     if not quiet:
-                        LOG.exception("Error connecting to TCP port %s:%s", host, port)
+                        LOG.warning(
+                            "Error connecting to TCP port %s:%s (result=%s)", host, port, result
+                        )
                     return False
     if "tcp" not in protocols or not http_path:
         return True
@@ -1213,7 +1215,7 @@ def download(url: str, path: str, verify_ssl: bool = True, timeout: float = None
     try:
         r = s.get(url, stream=True, verify=_verify, timeout=timeout)
         # check status code before attempting to read body
-        if r.status_code >= 400:
+        if not r.ok:
             raise Exception("Failed to download %s, response code %s" % (url, r.status_code))
 
         total = 0

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1196,23 +1196,27 @@ def get_proxies() -> Dict[str, str]:
     return proxy_map
 
 
-def download(url: str, path: str, verify_ssl=True):
-    """Downloads file at url to the given path"""
-    # make sure we're creating a new session here to
-    # enable parallel file downloads during installation!
+def download(url: str, path: str, verify_ssl: bool = True, timeout: float = None):
+    """Downloads file at url to the given path. Raises TimeoutError if the optional timeout (in secs) is reached."""
+
+    # make sure we're creating a new session here to enable parallel file downloads
     s = requests.Session()
     proxies = get_proxies()
     if proxies:
         s.proxies.update(proxies)
+
     # Use REQUESTS_CA_BUNDLE path. If it doesn't exist, use the method provided settings.
     # Note that a value that is not False, will result to True and will get the bundle file.
-    r = s.get(url, stream=True, verify=os.getenv("REQUESTS_CA_BUNDLE", verify_ssl))
-    # check status code before attempting to read body
-    if r.status_code >= 400:
-        raise Exception("Failed to download %s, response code %s" % (url, r.status_code))
+    _verify = os.getenv("REQUESTS_CA_BUNDLE", verify_ssl)
 
-    total = 0
+    r = None
     try:
+        r = s.get(url, stream=True, verify=_verify, timeout=timeout)
+        # check status code before attempting to read body
+        if r.status_code >= 400:
+            raise Exception("Failed to download %s, response code %s" % (url, r.status_code))
+
+        total = 0
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
         LOG.debug(
@@ -1241,8 +1245,11 @@ def download(url: str, path: str, verify_ssl=True):
         LOG.debug(
             "Done downloading %s, response code %s, total bytes %d" % (url, r.status_code, total)
         )
+    except requests.exceptions.ReadTimeout as e:
+        raise TimeoutError(f"Timeout ({timeout}) reached on download: {url} - {e}")
     finally:
-        r.close()
+        if r is not None:
+            r.close()
         s.close()
 
 

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -8,7 +8,7 @@ import yaml
 from requests.models import Response
 
 from localstack import config
-from localstack.services.generic_proxy import GenericProxy, ProxyListener
+from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.utils import async_utils, config_listener
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import TMP_FILES, download, json_safe, load_file, now_utc, parallelize
@@ -112,15 +112,14 @@ def run_parallel_download():
     test_port = 12124
     tmp_file_pattern = "/tmp/test.%s"
 
-    proxy = GenericProxy(port=test_port, update_listener=DownloadListener())
-    proxy.start()
+    proxy = start_proxy_server(test_port, update_listener=DownloadListener())
 
     def do_download(param):
         tmp_file = tmp_file_pattern % param
         TMP_FILES.append(tmp_file)
         download("http://localhost:%s/%s" % (test_port, param), tmp_file)
 
-    values = (1, 2, 3)
+    values = [1, 2, 3]
     parallelize(do_download, values)
     proxy.stop()
 

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -266,7 +266,7 @@ def test_download_with_timeout():
     class DownloadListener(ProxyListener):
         def forward_request(self, method, path, data, headers):
             if path == "/sleep":
-                time.sleep(5)
+                time.sleep(2)
             return {}
 
     port = get_free_tcp_port()

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -277,4 +277,7 @@ def test_download_with_timeout():
     assert load_file(tmp_file) == "{}"
     with pytest.raises(TimeoutError):
         download(f"http://localhost:{port}/sleep", tmp_file, timeout=1)
+
+    # clean up
+    proxy.stop()
     rm_rf(tmp_file)

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from localstack.services.generic_proxy import ProxyListener, start_proxy_server
 from localstack.utils.common import (
     PEM_CERT_END,
     PEM_CERT_START,
@@ -14,7 +15,9 @@ from localstack.utils.common import (
     PEM_KEY_START_REGEX,
     FileListener,
     FileMappedDocument,
+    download,
     generate_ssl_cert,
+    get_free_tcp_port,
     is_none_or_empty,
     load_file,
     new_tmp_file,
@@ -257,3 +260,21 @@ def test_generate_ssl_cert():
     # clean up
     rm_rf(cert_file_name)
     rm_rf(key_file_name)
+
+
+def test_download_with_timeout():
+    class DownloadListener(ProxyListener):
+        def forward_request(self, method, path, data, headers):
+            if path == "/sleep":
+                time.sleep(5)
+            return {}
+
+    port = get_free_tcp_port()
+    proxy = start_proxy_server(port, update_listener=DownloadListener())
+
+    tmp_file = new_tmp_file()
+    download(f"http://localhost:{port}/", tmp_file)
+    assert load_file(tmp_file) == "{}"
+    with pytest.raises(TimeoutError):
+        download(f"http://localhost:{port}/sleep", tmp_file, timeout=1)
+    rm_rf(tmp_file)


### PR DESCRIPTION
* Add timeout parameter to `download(..)` util function. Preparation to make the startup more resilient to timeouts (e.g., SSL cert).
* Also contains some minor refactoring/fixes for old tests