### PR TITLE
Add flag to check port availability in start_proxy_server(..) to avoid test flakes

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -529,6 +529,7 @@ def do_start_edge(bind_address, port, use_ssl, asynchronous=False):
         bind_address=bind_address,
         use_ssl=True,
         update_listener=PROXY_LISTENER_EDGE,
+        check_port=False,
     )
     if not asynchronous:
         proxy.join()

--- a/localstack/services/es/cluster.py
+++ b/localstack/services/es/cluster.py
@@ -290,6 +290,7 @@ class ProxiedElasticsearchCluster(Server):
             self.cluster_port,
             update_listener=None,
             quiet=True,
+            # TODO: check if protocol_version still needed - doesn't seem to be used in start_proxy_server(..)
             params={"protocol_version": "HTTP/1.0"},
         )
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -201,8 +201,16 @@ def start_proxy_for_service(
     )
 
 
-def start_proxy(port, backend_url=None, update_listener=None, quiet=False, params={}, use_ssl=None):
+def start_proxy(
+    port: int,
+    backend_url: str = None,
+    update_listener=None,
+    quiet: bool = False,
+    params: Dict = None,
+    use_ssl: bool = None,
+):
     use_ssl = config.USE_SSL if use_ssl is None else use_ssl
+    params = {} if params is None else params
     proxy_thread = start_proxy_server(
         port=port,
         forward_url=backend_url,
@@ -210,6 +218,7 @@ def start_proxy(port, backend_url=None, update_listener=None, quiet=False, param
         update_listener=update_listener,
         quiet=quiet,
         params=params,
+        check_port=False,
     )
     return proxy_thread
 


### PR DESCRIPTION
Add flag to check port availability in `start_proxy_server(..)` to avoid test flakes.

Attempt to fix `test_download_with_timeout()` which recently started flaking. The test starts up a proxy server with a download listener, and we need to wait for the port to be available before making HTTP requests. This should also be useful for other tests that are using `start_proxy_server()` to start up a temporary server.

Using the default value `check_port=True` primarily for use in our tests. Explicitly setting `check_port=False` in `edge.py`/`infra.py` to preserve the existing logic of health/port checks in the service startups (and avoid introducing additional startup delay).