### PR TITLE
Add initial integration of Route53Resolver API

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,3 @@ recursive-include localstack/ext *.java
 recursive-include localstack/ext pom.xml
 recursive-include localstack/utils/kinesis *.java
 recursive-include localstack/utils/kinesis *.py
-recursive-include localstack/dashboard/web *
-prune localstack/dashboard/web/node_modules

--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -53,16 +53,23 @@ def fix_date_format(response):
 
 def _create_and_register_temp_dir():
     tmp_dir = _get_events_tmp_dir()
-    if tmp_dir not in TMP_FILES:
+    if not os.path.exists(tmp_dir):
         mkdir(tmp_dir)
         TMP_FILES.append(tmp_dir)
+    return tmp_dir
 
 
 def _dump_events_to_files(events_with_added_uuid):
-    current_time_millis = int(round(time.time() * 1000))
-    for event in events_with_added_uuid:
-        target = os.path.join(_get_events_tmp_dir(), "%s_%s" % (current_time_millis, event["uuid"]))
-        save_file(target, json.dumps(event["event"]))
+    try:
+        _create_and_register_temp_dir()
+        current_time_millis = int(round(time.time() * 1000))
+        for event in events_with_added_uuid:
+            target = os.path.join(
+                _get_events_tmp_dir(), "%s_%s" % (current_time_millis, event["uuid"])
+            )
+            save_file(target, json.dumps(event["event"]))
+    except Exception as e:
+        LOG.info("Unable to dump events to tmp dir %s: %s", _get_events_tmp_dir(), e)
 
 
 def _get_events_tmp_dir():

--- a/localstack/services/events/events_starter.py
+++ b/localstack/services/events/events_starter.py
@@ -11,11 +11,7 @@ from moto.events.responses import EventsHandler as events_handler
 
 from localstack import config
 from localstack.constants import APPLICATION_AMZ_JSON_1_1, TEST_AWS_ACCOUNT_ID
-from localstack.services.events.events_listener import (
-    DEFAULT_EVENT_BUS_NAME,
-    _create_and_register_temp_dir,
-    _dump_events_to_files,
-)
+from localstack.services.events.events_listener import DEFAULT_EVENT_BUS_NAME, _dump_events_to_files
 from localstack.services.events.scheduler import JobScheduler
 from localstack.services.infra import start_moto_server
 from localstack.utils.aws import aws_stack
@@ -148,7 +144,6 @@ def apply_patches():
         entries = self._get_param("Entries")
         events = list(map(lambda event: {"event": event, "uuid": str(uuid.uuid4())}, entries))
 
-        _create_and_register_temp_dir()
         _dump_events_to_files(events)
         event_rules = self.events_backend.rules
 

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -155,6 +155,13 @@ def route53():
 
 
 @aws_provider()
+def route53resolver():
+    from localstack.services.route53 import route53_starter
+
+    return Service("route53resolver", start=route53_starter.start_route53_resolver)
+
+
+@aws_provider()
 def s3():
     from localstack.services.s3 import s3_listener, s3_starter
 

--- a/localstack/services/route53/route53_starter.py
+++ b/localstack/services/route53/route53_starter.py
@@ -65,3 +65,14 @@ def start_route53(port=None, asynchronous=False, update_listener=None):
         asynchronous=asynchronous,
         update_listener=update_listener,
     )
+
+
+def start_route53_resolver(port=None, asynchronous=False, update_listener=None):
+    port = port or config.PORT_ROUTE53RESOLVER
+    return start_moto_server(
+        "route53resolver",
+        port,
+        name="Route53 Resolver",
+        asynchronous=asynchronous,
+        update_listener=update_listener,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ dataclasses; python_version < '3.7'
 #dnspython==1.16.0
 #docopt>=0.6.2
 docker==5.0.0
-localstack-client>=1.24
+localstack-client>=1.28
 localstack-ext>=0.13.0.11
 localstack-plugin-loader>=0.1.0
 psutil>=5.4.8,<6.0.0

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -1,19 +1,21 @@
-import unittest
+import re
+
+import pytest
 
 from localstack import constants
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 
 
-class TestRoute53(unittest.TestCase):
+class TestRoute53:
     def test_create_hosted_zone(self):
         route53 = aws_stack.connect_to_service("route53")
 
         response = route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
-        self.assertEqual(201, response["ResponseMetadata"]["HTTPStatusCode"])
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 201
 
         response = route53.get_change(Id="string")
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     def test_associate_vpc_with_hosted_zone(self):
         ec2 = aws_stack.connect_to_service("ec2")
@@ -33,7 +35,7 @@ class TestRoute53(unittest.TestCase):
             VPC={"VPCRegion": vpc_region, "VPCId": vpc_id},
             Comment="test 123",
         )
-        self.assertTrue(result["ChangeInfo"].get("Id"))
+        assert result["ChangeInfo"].get("Id")
 
         # list zones by VPC
         result = route53.list_hosted_zones_by_vpc(VPCId=vpc_id, VPCRegion=vpc_region)[
@@ -44,22 +46,22 @@ class TestRoute53(unittest.TestCase):
             "Name": "%s." % name,
             "Owner": {"OwningAccount": constants.TEST_AWS_ACCOUNT_ID},
         }
-        self.assertIn(expected, result)
+        assert expected in result
 
         # list zones by name
         result = route53.list_hosted_zones_by_name(DNSName=name).get("HostedZones")
-        self.assertEqual("zone123.", result[0]["Name"])
+        assert result[0]["Name"] == "zone123."
         result = route53.list_hosted_zones_by_name(DNSName="%s." % name).get("HostedZones")
-        self.assertEqual("zone123.", result[0]["Name"])
+        assert result[0]["Name"] == "zone123."
 
-        result = route53.disassociate_vpc_from_hosted_zone(
+        route53.disassociate_vpc_from_hosted_zone(
             HostedZoneId=zone_id,
             VPC={"VPCRegion": aws_stack.get_region(), "VPCId": vpc_id},
             Comment="test2",
         )
-        self.assertIn(response["ResponseMetadata"]["HTTPStatusCode"], [200, 201])
+        assert response["ResponseMetadata"]["HTTPStatusCode"] in [200, 201]
         # subsequent call (after disassociation) should fail with 404 error
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             route53.disassociate_vpc_from_hosted_zone(
                 HostedZoneId=zone_id,
                 VPC={"VPCRegion": aws_stack.get_region(), "VPCId": vpc_id},
@@ -83,19 +85,49 @@ class TestRoute53(unittest.TestCase):
         set_id_2 = result_2["Id"]
 
         result_1 = client.get_reusable_delegation_set(Id=set_id_1)
-        self.assertEqual(200, result_1["ResponseMetadata"]["HTTPStatusCode"])
-        self.assertEqual(set_id_1, result_1["DelegationSet"]["Id"])
+        assert result_1["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert result_1["DelegationSet"]["Id"] == set_id_1
 
         result_1 = client.list_reusable_delegation_sets()
-        self.assertEqual(200, result_1["ResponseMetadata"]["HTTPStatusCode"])
-        self.assertEqual(len(sets_before) + 2, len(result_1["DelegationSets"]))
+        assert result_1["ResponseMetadata"]["HTTPStatusCode"] == 200
+        # TODO: assertion should be updated, to allow for parallel tests
+        assert len(result_1["DelegationSets"]) == len(sets_before) + 2
 
         result_1 = client.delete_reusable_delegation_set(Id=set_id_1)
-        self.assertEqual(200, result_1["ResponseMetadata"]["HTTPStatusCode"])
+        assert result_1["ResponseMetadata"]["HTTPStatusCode"] == 200
 
         result_2 = client.delete_reusable_delegation_set(Id=set_id_2)
-        self.assertEqual(200, result_2["ResponseMetadata"]["HTTPStatusCode"])
+        assert result_2["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-        with self.assertRaises(Exception) as ctx:
+        with pytest.raises(Exception) as ctx:
             client.get_reusable_delegation_set(Id=set_id_1)
-        self.assertEqual(404, ctx.exception.response["ResponseMetadata"]["HTTPStatusCode"])
+        assert ctx.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+
+
+class TestRoute53Resolver:
+    def test_reusable_delegation_sets(self):
+        ec2 = aws_stack.connect_to_service("ec2")
+        resolver = aws_stack.connect_to_service("route53resolver")
+
+        # getting list of existing (default) subnets
+        subnets = ec2.describe_subnets()["Subnets"]
+        subnet_ids = [s["SubnetId"] for s in subnets]
+        # construct IPs within CIDR range
+        ips = [re.sub(r"(.*)\.[0-9]+/.+", r"\1.5", s["CidrBlock"]) for s in subnets]
+
+        groups = []
+        addresses = [
+            {"SubnetId": subnet_ids[0], "Ip": ips[0]},
+            {"SubnetId": subnet_ids[1], "Ip": ips[1]},
+        ]
+
+        result = resolver.create_resolver_endpoint(
+            CreatorRequestId="req123",
+            SecurityGroupIds=groups,
+            Direction="INBOUND",
+            IpAddresses=addresses,
+        )
+        result = result.get("ResolverEndpoint")
+        assert result
+        assert result.get("CreatorRequestId") == "req123"
+        assert result.get("Direction") == "INBOUND"

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -105,7 +105,7 @@ class TestRoute53:
 
 
 class TestRoute53Resolver:
-    def test_reusable_delegation_sets(self):
+    def test_create_resolver_endpoint(self):
         ec2 = aws_stack.connect_to_service("ec2")
         resolver = aws_stack.connect_to_service("route53resolver")
 


### PR DESCRIPTION
* add initial integration of Route53Resolver API and simple smoke test. Partially addresses #5048 . More features will follow soon. /cc @macnev2013 
* add minor fix and error handling in `_dump_events_to_files()` util function
* cleanup obsolete/unused MANIFEST entries
* migrate Route53 tests from `unittest`->`pytest`