### PR TITLE
Add SIGINT signal handler to enable clean shutdown across different operating systems

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -552,6 +552,7 @@ def download_and_extract_with_retry(archive_url, tmp_archive, target_dir):
         download_and_extract(archive_url, target_dir, tmp_archive=tmp_archive)
 
 
+# kept here for backwards compatibility (installed on "make init" - TODO should be removed)
 installers = {
     "cloudformation": install_cloudformation_libs,
     "dynamodb": install_dynamodb_local,
@@ -617,7 +618,7 @@ class InstallerManager:
 
 def main():
     if len(sys.argv) > 1:
-        # set API key so pro install hooks are called
+        # set test API key so pro install hooks are called
         os.environ["LOCALSTACK_API_KEY"] = os.environ.get("LOCALSTACK_API_KEY") or "test"
         if sys.argv[1] == "libs":
             print("Initializing installation.")


### PR DESCRIPTION
Add SIGINT signal handler to enable clean shutdown across MacOS/Linux. (See details in the code comment.)

Addresses #5069

Tested under MacOS using:
* `localstack start` -> `kill -INT <pid>`
* `localstack start` -> CTRL-C
* `npm run localstack` -> `kill -INT <pid>`
* `npm run localstack` -> CTRL-C