### PR TITLE
adjust renovatebot config to align PR/commit titles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,16 +1,25 @@
 {
   "extends": [
-    "schedule:earlyMondays"
+    "schedule:earlyMondays",
+    ":semanticCommitsDisabled"
   ],
   "enabledManagers": ["dockerfile"],
-  "dockerfile": {
+  "docker": {
     "pinDigests": true,
     "ignorePaths": ["bin/lambda/Dockerfile.nodejs14x"]
   },
   "packageRules": [
     {
+      "managers": ["dockerfile"],
+      "commitMessageAction": "update",
+      "commitMessageTopic": "Docker base image ({{{depName}}}) tag",
+      "digest": {
+        "commitMessageTopic": "Docker base image ({{{depName}}}{{#if currentValue}}:{{{currentValue}}}{{/if}}) digest"
+      }
+    },
+    {
       "matchDatasources": [
-        "docker"
+        "dockerfile"
       ],
       "matchPackageNames": ["python"],
       "matchUpdateTypes": [


### PR DESCRIPTION
This PR adjusts the config of RenovateBot such that the PR titles are more aligned with our usual structure.
A PR title (and also the commit) would afterwards look like this:
"update Docker base image (python:3.8.12-slim-buster) digest to 95db858"

This change was tested in a personal repo: https://github.com/alexrashed/renovate-tests/pull/2
After this PR is merged, the changes can be applied to the first PR created by RenovateBot (https://github.com/localstack/localstack/pull/5080) by checking the "retry" checkbox.