### PR TITLE
add "--offline" pytest flag, skip "online-only" tests, fix some tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,41 @@
 import os
 
+import pytest
+
 os.environ["LOCALSTACK_INTERNAL_TEST_RUN"] = "1"
 
 pytest_plugins = [
     "tests.integration.fixtures",
 ]
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--offline",
+        action="store_true",
+        default=False,
+        help="test run will not have an internet connection",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "skip_offline: mark the test to be skipped when the tests are run offline "
+        "(this test explicitly / semantically needs an internet connection)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--offline"):
+        # The tests are not executed offline, so we don't skip the tests marked to need an internet connection
+        return
+    skip_offline = pytest.mark.skip(
+        reason="Test cannot be executed offline / in a restricted network environment. "
+        "Add network connectivity and remove the --offline option when running "
+        "the test."
+    )
+
+    for item in items:
+        if "skip_offline" in item.keywords:
+            item.add_marker(skip_offline)

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -3,10 +3,9 @@ import json
 import logging
 import os
 from io import BytesIO
+from typing import Union
 
 import boto3.dynamodb.types
-
-from localstack.utils.common import to_bytes, to_str
 
 TEST_BUCKET_NAME = "test-bucket"
 KINESIS_STREAM_NAME = "test_stream_1"
@@ -21,6 +20,16 @@ ENDPOINT_URL = "http://%s:%s" % (
     os.environ["LOCALSTACK_HOSTNAME"],
     os.environ.get("EDGE_PORT", 4566),
 )
+
+
+# Do not import this function from localstack.utils.common (this is a standalone application / lambda).
+def to_str(obj: Union[str, bytes], encoding: str = "utf-8", errors="strict") -> str:
+    return obj.decode(encoding, errors) if isinstance(obj, bytes) else obj
+
+
+# Do not import this function from localstack.utils.common (this is a standalone application / lambda).
+def to_bytes(obj: Union[str, bytes], encoding: str = "utf-8", errors="strict") -> bytes:
+    return obj.encode(encoding, errors) if isinstance(obj, str) else obj
 
 
 # Subclass of boto's TypeDeserializer for DynamoDB

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -329,6 +329,7 @@ class TestEdgeProxiedElasticsearchCluster:
 
 
 class TestMultiClusterManager:
+    @pytest.mark.skip_offline
     def test_multi_cluster(self, monkeypatch):
         monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "domain")
         monkeypatch.setattr(config, "ES_MULTI_CLUSTER", True)
@@ -391,6 +392,7 @@ class TestElasticsearchApi:
 
 
 class TestMultiplexingClusterManager:
+    @pytest.mark.skip_offline
     def test_multiplexing_cluster(self, monkeypatch):
         monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "domain")
         monkeypatch.setattr(config, "ES_MULTI_CLUSTER", False)

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from time import sleep
 
 import cbor2
+import pytest
 import requests
 
 from localstack import config, constants
@@ -236,6 +237,7 @@ class TestKinesis(unittest.TestCase):
 
 
 class TestKinesisPythonClient(unittest.TestCase):
+    @pytest.mark.skip_offline
     def test_run_kcl(self):
         result = []
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -2351,6 +2351,7 @@ class TestS3(unittest.TestCase):
         # Cleanup
         self._delete_bucket(bucket, key_by_path)
 
+    @pytest.mark.skip_offline
     def test_s3_lambda_integration(self):
         if not use_docker():
             return

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -2,6 +2,8 @@ import json
 import os
 import unittest
 
+import pytest
+
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import retry, run
 from localstack.utils.testutil import get_lambda_log_events
@@ -32,6 +34,7 @@ class TestServerless(unittest.TestCase):
     def get_base_dir(cls):
         return os.path.join(os.path.dirname(__file__), "serverless")
 
+    @pytest.mark.skip_offline
     def test_event_rules_deployed(self):
         events = aws_stack.connect_to_service("events")
         rules = events.list_rules()["Rules"]
@@ -47,6 +50,7 @@ class TestServerless(unittest.TestCase):
         self.assertTrue(rule)
         self.assertEqual({"source": ["customSource"]}, json.loads(rule["EventPattern"]))
 
+    @pytest.mark.skip_offline
     def test_dynamodb_stream_handler_deployed(self):
         function_name = "sls-test-local-dynamodbStreamHandler"
         table_name = "Test"
@@ -66,6 +70,7 @@ class TestServerless(unittest.TestCase):
         resp = dynamodb_client.describe_table(TableName=table_name)
         self.assertEqual(event_source_arn, resp["Table"]["LatestStreamArn"])
 
+    @pytest.mark.skip_offline
     def test_kinesis_stream_handler_deployed(self):
         function_name = "sls-test-local-kinesisStreamHandler"
         function_name2 = "sls-test-local-kinesisConsumerHandler"
@@ -94,6 +99,7 @@ class TestServerless(unittest.TestCase):
         kinesis_client.put_record(StreamName=stream_name, Data=b"test123", PartitionKey="key1")
         retry(assert_invocations, sleep=1, retries=5)
 
+    @pytest.mark.skip_offline
     def test_queue_handler_deployed(self):
         function_name = "sls-test-local-queueHandler"
         queue_name = "sls-test-local-CreateQueue"
@@ -120,6 +126,7 @@ class TestServerless(unittest.TestCase):
         redrive_policy = json.loads(result["Attributes"]["RedrivePolicy"])
         self.assertEqual(3, redrive_policy["maxReceiveCount"])
 
+    @pytest.mark.skip_offline
     def test_lambda_with_configs_deployed(self):
         function_name = "sls-test-local-test"
 
@@ -136,6 +143,7 @@ class TestServerless(unittest.TestCase):
         self.assertEqual(2, resp.get("MaximumRetryAttempts"))
         self.assertEqual(7200, resp.get("MaximumEventAgeInSeconds"))
 
+    @pytest.mark.skip_offline
     def test_apigateway_deployed(self):
         function_name = "sls-test-local-router"
 

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -81,6 +81,7 @@ class TestTerraform(unittest.TestCase):
     def get_base_dir(cls):
         return os.path.join(os.path.dirname(__file__), "terraform")
 
+    @pytest.mark.skip_offline
     def test_bucket_exists(self):
         s3_client = aws_stack.connect_to_service("s3")
 
@@ -101,6 +102,7 @@ class TestTerraform(unittest.TestCase):
         response = s3_client.get_bucket_versioning(Bucket=BUCKET_NAME)
         self.assertEqual("Enabled", response["Status"])
 
+    @pytest.mark.skip_offline
     def test_sqs(self):
         sqs_client = aws_stack.connect_to_service("sqs")
         queue_url = sqs_client.get_queue_url(QueueName=QUEUE_NAME)["QueueUrl"]
@@ -111,6 +113,7 @@ class TestTerraform(unittest.TestCase):
         self.assertEqual("86400", response["Attributes"]["MessageRetentionPeriod"])
         self.assertEqual("10", response["Attributes"]["ReceiveMessageWaitTimeSeconds"])
 
+    @pytest.mark.skip_offline
     def test_lambda(self):
         lambda_client = aws_stack.connect_to_service("lambda")
         response = lambda_client.get_function(FunctionName=LAMBDA_NAME)
@@ -119,6 +122,7 @@ class TestTerraform(unittest.TestCase):
         self.assertEqual(LAMBDA_RUNTIME, response["Configuration"]["Runtime"])
         self.assertEqual(LAMBDA_ROLE, response["Configuration"]["Role"])
 
+    @pytest.mark.skip_offline
     def test_event_source_mapping(self):
         lambda_client = aws_stack.connect_to_service("lambda")
         all_mappings = lambda_client.list_event_source_mappings(
@@ -128,6 +132,7 @@ class TestTerraform(unittest.TestCase):
         assert function_mapping["FunctionArn"] == LAMBDA_ARN
         assert function_mapping["EventSourceArn"] == QUEUE_ARN
 
+    @pytest.mark.skip_offline
     def test_apigateway(self):
         apigateway_client = aws_stack.connect_to_service("apigateway")
         rest_apis = apigateway_client.get_rest_apis()
@@ -159,6 +164,7 @@ class TestTerraform(unittest.TestCase):
         )
         self.assertTrue(res2[0]["resourceMethods"]["GET"]["methodIntegration"]["uri"])
 
+    @pytest.mark.skip_offline
     def test_route53(self):
         route53 = aws_stack.connect_to_service("route53")
 
@@ -169,6 +175,7 @@ class TestTerraform(unittest.TestCase):
         response = route53.get_change(Id=change_id)
         self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
 
+    @pytest.mark.skip_offline
     def test_acm(self):
         acm = aws_stack.connect_to_service("acm")
 
@@ -176,6 +183,7 @@ class TestTerraform(unittest.TestCase):
         certs = [c for c in certs if c.get("DomainName") == "example.com"]
         self.assertEqual(1, len(certs))
 
+    @pytest.mark.skip_offline
     def test_apigateway_escaped_policy(self):
         apigateway_client = aws_stack.connect_to_service("apigateway")
         rest_apis = apigateway_client.get_rest_apis()
@@ -188,6 +196,7 @@ class TestTerraform(unittest.TestCase):
 
         self.assertEqual(1, len(service_apis))
 
+    @pytest.mark.skip_offline
     def test_dynamodb(self):
         def _table_exists(tablename, dynamotables):
             return any(name for name in dynamotables["TableNames"] if name == tablename)

--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 from localstack.aws.scaffold import generate
 
 
+@pytest.mark.skip_offline
 @pytest.mark.parametrize(
     "service", ["apigateway", "autoscaling", "cloudformation", "dynamodb", "sqs"]
 )

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -31,6 +31,7 @@ def test_version(runner):
     assert result.output.strip() == constants.VERSION
 
 
+@pytest.mark.skip_offline
 def test_status_services_error(runner):
     result = runner.invoke(cli, ["status", "services"])
     assert result.exit_code == 1

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -13,6 +13,7 @@ def runner():
     return CliRunner()
 
 
+@pytest.mark.skip_offline
 def test_list(runner, monkeypatch):
     monkeypatch.setattr(console, "no_color", True)
 
@@ -21,12 +22,14 @@ def test_list(runner, monkeypatch):
     assert "elasticmq/community" in result.output
 
 
+@pytest.mark.skip_offline
 def test_install_with_non_existing_package_fails(runner):
     result = runner.invoke(cli, ["install", "elasticmq", "funny"])
     assert result.exit_code == 1
     assert "unable to locate installer for package funny" in result.output
 
 
+@pytest.mark.skip_offline
 def test_install_failure_returns_non_zero_exit_code(runner, monkeypatch):
     def failing_installer():
         raise Exception("failing installer")
@@ -47,6 +50,7 @@ def test_install_failure_returns_non_zero_exit_code(runner, monkeypatch):
     assert "one or more package installations failed." in result.output
 
 
+@pytest.mark.skip_offline
 def test_install_with_package(runner):
     from localstack.services.install import INSTALL_PATH_ELASTICMQ_JAR
 

--- a/tests/unit/services/es/test_cluster_manager.py
+++ b/tests/unit/services/es/test_cluster_manager.py
@@ -11,6 +11,9 @@ class TestBuildClusterEndpoint:
         endpoint = build_cluster_endpoint(DomainKey("my-domain", "us-east-1", TEST_AWS_ACCOUNT_ID))
         assert endpoint == "localhost:4571"
 
+    @pytest.mark.skipif(
+        condition=config.in_docker(), reason="port mapping differs when being run in the container"
+    )
     def test_endpoint_strategy_path(self, monkeypatch):
         monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "path")
 
@@ -22,6 +25,9 @@ class TestBuildClusterEndpoint:
         )
         assert endpoint == "localhost:4566/es/eu-central-1/my-domain-1"
 
+    @pytest.mark.skipif(
+        condition=config.in_docker(), reason="port mapping differs when being run in the container"
+    )
     def test_endpoint_strategy_domain(self, monkeypatch):
         monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", "domain")
 

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -455,7 +455,8 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result["PackageType"] = None
             expected_result["ImageConfig"] = {}
             expected_result["Architectures"] = ["x86_64"]
-            self.assertDictEqual(expected_result, result)
+            # Check that the result contains the expected fields (some pro extensions could add additional fields)
+            self.assertDictContainsSubset(expected_result, result)
 
     def test_publish_update_version_increment(self):
         with self.app.test_request_context():
@@ -489,7 +490,8 @@ class TestLambdaAPI(unittest.TestCase):
             expected_result["PackageType"] = None
             expected_result["ImageConfig"] = {}
             expected_result["Architectures"] = ["x86_64"]
-            self.assertDictEqual(expected_result, result)
+            # Check that the result contains the expected fields (some pro extensions could add additional fields)
+            self.assertDictContainsSubset(expected_result, result)
 
     def test_publish_non_existant_function_version_returns_error(self):
         with self.app.test_request_context():
@@ -537,10 +539,17 @@ class TestLambdaAPI(unittest.TestCase):
             version1 = dict(latest_version)
             version1["FunctionArn"] = str(lambda_api.func_arn(self.FUNCTION_NAME)) + ":1"
             version1["Version"] = "1"
-            expected_result = {
-                "Versions": sorted([latest_version, version], key=lambda k: str(k.get("Version")))
-            }
-            self.assertDictEqual(expected_result, result)
+            expected_versions = sorted(
+                [latest_version, version], key=lambda k: str(k.get("Version"))
+            )
+
+            # Check if the result contains the same amount of versions and that they contain at least the defined fields
+            # (some pro extensions could add additional fields)
+            self.assertIn("Versions", result)
+            result_versions = result["Versions"]
+            self.assertEqual(len(result_versions), len(expected_versions))
+            for i in range(len(expected_versions)):
+                self.assertDictContainsSubset(expected_versions[i], result_versions[i])
 
     def test_list_non_existant_function_versions_returns_error(self):
         with self.app.test_request_context():


### PR DESCRIPTION
This PR adds a new pytest flag `--offline` ([according to the official pytest docs](https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option)). This flag indicates that the tests are executed in a network-restricted environment.
Since some of the tests explicitly download additional infrastructure, or communicate to external services via the host network, some tests have been marked with `@pytest.mark.skip_offline`. These tests are skipped in case the `--offline` option is set when executing the tests with pytest.