### PR TITLE
add initial support for region-based in-place partition rewriting

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -453,6 +453,9 @@ OUTBOUND_HTTP_PROXY = os.environ.get("OUTBOUND_HTTP_PROXY", "")
 # Equivalent to HTTPS_PROXY, but only applicable for external connections
 OUTBOUND_HTTPS_PROXY = os.environ.get("OUTBOUND_HTTPS_PROXY", "")
 
+# Whether to enable the partition adjustment listener (in order to support other partitions that the default)
+PARTITION_ADJUSTMENT = is_env_true("PARTITION_ADJUSTMENT")
+
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -454,7 +454,7 @@ OUTBOUND_HTTP_PROXY = os.environ.get("OUTBOUND_HTTP_PROXY", "")
 OUTBOUND_HTTPS_PROXY = os.environ.get("OUTBOUND_HTTPS_PROXY", "")
 
 # Whether to enable the partition adjustment listener (in order to support other partitions that the default)
-PARTITION_ADJUSTMENT = is_env_true("PARTITION_ADJUSTMENT")
+ARN_PARTITION_REWRITING = is_env_true("ARN_PARTITION_REWRITING")
 
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -13,3 +13,14 @@ def configure_edge_port(container):
     for port in ports:
         if port:
             container.ports.add(port)
+
+
+# Register the PartitionAdjustingProxyListener only if the default region is a region in the AWS GovCloud partition
+@hooks.on_infra_start(should_load=lambda: config.DEFAULT_REGION.startswith("us-gov-"))
+def register_partition_adjusting_proxy_listener():
+    LOG.info(
+        "Registering PartitionAdjustingProxyListener to dynamically replace partitions in requests and responses."
+    )
+    from localstack.services.generic_proxy import PartitionAdjustingProxyListener, ProxyListener
+
+    ProxyListener.DEFAULT_LISTENERS.append(PartitionAdjustingProxyListener())

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -15,8 +15,8 @@ def configure_edge_port(container):
             container.ports.add(port)
 
 
-# Register the PartitionAdjustingProxyListener only if the default region is a region in the AWS GovCloud partition
-@hooks.on_infra_start(should_load=lambda: config.DEFAULT_REGION.startswith("us-gov-"))
+# Register the PartitionAdjustingProxyListener only if the feature flag is enabled
+@hooks.on_infra_start(should_load=lambda: config.PARTITION_ADJUSTMENT)
 def register_partition_adjusting_proxy_listener():
     LOG.info(
         "Registering PartitionAdjustingProxyListener to dynamically replace partitions in requests and responses."

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -15,12 +15,12 @@ def configure_edge_port(container):
             container.ports.add(port)
 
 
-# Register the ArnPartitionRewritingListener only if the feature flag is enabled
+# Register the ArnPartitionRewriteListener only if the feature flag is enabled
 @hooks.on_infra_start(should_load=lambda: config.ARN_PARTITION_REWRITING)
 def register_partition_adjusting_proxy_listener():
     LOG.info(
-        "Registering ArnPartitionRewritingListener to dynamically replace partitions in requests and responses."
+        "Registering ArnPartitionRewriteListener to dynamically replace partitions in requests and responses."
     )
-    from localstack.services.generic_proxy import ArnPartitionRewritingListener, ProxyListener
+    from localstack.services.generic_proxy import ArnPartitionRewriteListener, ProxyListener
 
-    ProxyListener.DEFAULT_LISTENERS.append(ArnPartitionRewritingListener())
+    ProxyListener.DEFAULT_LISTENERS.append(ArnPartitionRewriteListener())

--- a/localstack/plugins.py
+++ b/localstack/plugins.py
@@ -15,12 +15,12 @@ def configure_edge_port(container):
             container.ports.add(port)
 
 
-# Register the PartitionAdjustingProxyListener only if the feature flag is enabled
-@hooks.on_infra_start(should_load=lambda: config.PARTITION_ADJUSTMENT)
+# Register the ArnPartitionRewritingListener only if the feature flag is enabled
+@hooks.on_infra_start(should_load=lambda: config.ARN_PARTITION_REWRITING)
 def register_partition_adjusting_proxy_listener():
     LOG.info(
-        "Registering PartitionAdjustingProxyListener to dynamically replace partitions in requests and responses."
+        "Registering ArnPartitionRewritingListener to dynamically replace partitions in requests and responses."
     )
-    from localstack.services.generic_proxy import PartitionAdjustingProxyListener, ProxyListener
+    from localstack.services.generic_proxy import ArnPartitionRewritingListener, ProxyListener
 
-    ProxyListener.DEFAULT_LISTENERS.append(PartitionAdjustingProxyListener())
+    ProxyListener.DEFAULT_LISTENERS.append(ArnPartitionRewritingListener())

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -2124,6 +2124,9 @@ def delete_function_event_invoke_config(function):
     region = LambdaRegion.get()
     try:
         function_arn = func_arn(function)
+        if function_arn not in region.lambdas:
+            msg = f"Function not found: {function_arn}"
+            return not_found_error(msg)
         lambda_obj = region.lambdas[function_arn]
     except Exception as e:
         return error_response(str(e), 400)

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -1,6 +1,5 @@
 import json
 
-import mypy_boto3_sns
 from botocore.exceptions import ClientError
 
 from localstack.services.cloudformation.deployment_utils import (
@@ -176,7 +175,7 @@ class SNSTopicPolicy(GenericBaseModel):
     @classmethod
     def get_deploy_templates(cls):
         def _create(resource_id, resources, resource_type, func, stack_name):
-            sns_client: mypy_boto3_sns.SNSClient = aws_stack.connect_to_service("sns")
+            sns_client = aws_stack.connect_to_service("sns")
             resource = cls(resources[resource_id])
             props = resource.props
 

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -1,5 +1,8 @@
 import json
 
+import mypy_boto3_sns
+from botocore.exceptions import ClientError
+
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     is_none_or_empty_value,
@@ -161,5 +164,49 @@ class SNSSubscription(GenericBaseModel):
             "delete": {
                 "function": "unsubscribe",
                 "parameters": {"SubscriptionArn": sns_subscription_arn},
+            },
+        }
+
+
+class SNSTopicPolicy(GenericBaseModel):
+    @classmethod
+    def cloudformation_type(cls):
+        return "AWS::SNS::TopicPolicy"
+
+    @classmethod
+    def get_deploy_templates(cls):
+        def _create(resource_id, resources, resource_type, func, stack_name):
+            sns_client: mypy_boto3_sns.SNSClient = aws_stack.connect_to_service("sns")
+            resource = cls(resources[resource_id])
+            props = resource.props
+
+            resources[resource_id]["PhysicalResourceId"] = generate_default_name(
+                stack_name, resource_id
+            )
+
+            policy = json.dumps(props["PolicyDocument"])
+            for topic_arn in props["Topics"]:
+                sns_client.set_topic_attributes(
+                    TopicArn=topic_arn, AttributeName="Policy", AttributeValue=policy
+                )
+
+        def _delete(resource_id, resources, *args, **kwargs):
+            sns_client = aws_stack.connect_to_service("sns")
+            resource = cls(resources[resource_id])
+            props = resource.props
+
+            for topic_arn in props["Topics"]:
+                try:
+                    sns_client.set_topic_attributes(
+                        TopicArn=topic_arn, AttributeName="Policy", AttributeValue=""
+                    )
+                except ClientError as err:
+                    if "NotFound" not in err.response["Error"]["Code"]:
+                        raise
+
+        return {
+            "create": {"function": _create},
+            "delete": {
+                "function": _delete,
             },
         }

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -616,7 +616,7 @@ class ProxyListenerDynamoDB(ProxyListener):
 
         # Note: We need to ensure that the same access key is used here for all requests,
         # otherwise DynamoDBLocal stores tables/items in separate namespaces
-        _replace(r"Credential=[^/]+/", r"Credential=%s/" % constants.TEST_AWS_ACCESS_KEY_ID)
+        _replace(r"Credential=[^/]+/", r"Credential=%s/" % constants.INTERNAL_AWS_ACCESS_KEY_ID)
         # Note: The NoSQL Workbench sends "localhost" as the region name, which we need to correct here
         _replace(
             r"Credential=([^/]+/[^/]+)/localhost",

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -18,7 +18,7 @@ from flask_cors.core import (
     ACL_REQUEST_HEADERS,
 )
 from requests.models import Request, Response
-from six.moves.urllib.parse import parse_qs, urlencode, urlparse
+from six.moves.urllib.parse import parse_qs, unquote, urlencode, urlparse
 from werkzeug.exceptions import HTTPException
 
 from localstack import config
@@ -270,7 +270,7 @@ class PartitionAdjustingProxyListener(MessageModifyingProxyListener):
             return result
         elif isinstance(source, bytes):
             try:
-                decoded = to_str(source)
+                decoded = unquote(to_str(source))
                 adjusted = self._adjust_partition(decoded, static_partition)
                 return to_bytes(adjusted)
             except UnicodeDecodeError:

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -269,9 +269,13 @@ class PartitionAdjustingProxyListener(MessageModifyingProxyListener):
                 result.append(self._adjust_partition(v, static_partition))
             return result
         elif isinstance(source, bytes):
-            decoded = to_str(source)
-            adjusted = self._adjust_partition(decoded, static_partition)
-            return to_bytes(adjusted)
+            try:
+                decoded = to_str(source)
+                adjusted = self._adjust_partition(decoded, static_partition)
+                return to_bytes(adjusted)
+            except UnicodeDecodeError:
+                # If the body can't be decoded to a string, we return the initial source
+                return source
         elif not isinstance(source, str):
             # Ignore any other types
             return source

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -39,6 +39,7 @@ from localstack.services.messages import Request as RoutingRequest
 from localstack.services.messages import Response as RoutingResponse
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import LambdaResponse
+from localstack.utils.aws.aws_stack import is_internal_call_context
 from localstack.utils.common import (
     generate_ssl_cert,
     json_safe,
@@ -241,6 +242,9 @@ class PartitionAdjustingProxyListener(MessageModifyingProxyListener):
         headers: Headers,
         response: Response,
     ) -> Optional[RoutingResponse]:
+        # Only handle responses for calls from external clients
+        if is_internal_call_context(headers):
+            return None
         return RoutingResponse(
             status_code=response.status_code,
             content=self._adjust_partition(response.content),

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -603,6 +603,9 @@ def modify_and_forward(
             return response
 
     # perform the actual invocation of the backend service
+    headers_to_send = None
+    data_to_send = None
+    method_to_send = None
     if response is None:
         headers_to_send = handler_chain_request.headers
         headers_to_send["Connection"] = headers_to_send.get("Connection") or "close"
@@ -641,10 +644,10 @@ def modify_and_forward(
     # run outbound handlers (post-invocation)
     for listener in listeners_outbound:
         updated_response = listener.return_response(
-            method=original_request.method,
-            path=original_request.path,
-            data=original_request.data,
-            headers=original_request.headers,
+            method=method_to_send or handler_chain_request.method,
+            path=handler_chain_request.path,
+            data=data_to_send or handler_chain_request.data,
+            headers=headers_to_send or handler_chain_request.headers,
             response=response,
         )
         message_modifier = isinstance(listener, MessageModifyingProxyListener)

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -194,7 +194,7 @@ class MessageModifyingProxyListener(ProxyListener):
         return None
 
 
-class ArnPartitionRewritingListener(MessageModifyingProxyListener):
+class ArnPartitionRewriteListener(MessageModifyingProxyListener):
     """
     Intercepts requests and responses and tries to adjust the partitions in ARNs within the intercepted requests.
     For incoming requests, the default partition is set ("aws").
@@ -304,7 +304,7 @@ class ArnPartitionRewritingListener(MessageModifyingProxyListener):
     def _partition_lookup(self, region: str):
         try:
             partition = self._get_partition_for_region(region)
-        except ArnPartitionRewritingListener.InvalidRegionException:
+        except ArnPartitionRewriteListener.InvalidRegionException:
             try:
                 # If the region is not properly set (f.e. because it is set to a wildcard),
                 # the partition is determined based on the default region.
@@ -328,7 +328,7 @@ class ArnPartitionRewritingListener(MessageModifyingProxyListener):
         elif re.match(r"^(us|eu|ap|sa|ca|me|af)-\w+-\d+$", region):
             return "aws"
         else:
-            raise ArnPartitionRewritingListener.InvalidRegionException(
+            raise ArnPartitionRewriteListener.InvalidRegionException(
                 f"Region ({region}) could not be matched to a partition."
             )
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -209,6 +209,10 @@ def get_region():
     return get_local_region()
 
 
+def get_partition():
+    return boto3.session.Session().get_partition_for_region(get_region())
+
+
 def get_local_region():
     global LOCAL_REGION
     if LOCAL_REGION is None:
@@ -839,7 +843,6 @@ def inject_region_into_auth_headers(region, headers):
         regex = r"Credential=([^/]+)/([^/]+)/([^/]+)/"
         auth_header = re.sub(regex, r"Credential=\1/\2/%s/" % region, auth_header)
         headers["Authorization"] = auth_header
-    return headers
 
 
 def dynamodb_get_item_raw(request):

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -209,8 +209,9 @@ def get_region():
     return get_local_region()
 
 
-def get_partition():
-    return boto3.session.Session().get_partition_for_region(get_region())
+def get_partition(region_name: str = None):
+    region_name = region_name or get_region()
+    return boto3.session.Session().get_partition_for_region(region_name)
 
 
 def get_local_region():

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -349,6 +349,34 @@ def connect_to_service(
         return new_client
 
 
+def create_external_boto_client(
+    service_name,
+    client=True,
+    env=None,
+    region_name=None,
+    endpoint_url=None,
+    config: botocore.config.Config = None,
+    verify=False,
+    cache=True,
+    *args,
+    **kwargs,
+):
+    return connect_to_service(
+        service_name,
+        client,
+        env,
+        region_name,
+        endpoint_url,
+        config,
+        verify,
+        cache,
+        aws_access_key_id="__test_call__",
+        aws_secret_access_key="__test_key__",
+        *args,
+        **kwargs,
+    )
+
+
 def get_s3_hostname():
     global CACHE_S3_HOSTNAME_DNS_STATUS
     if CACHE_S3_HOSTNAME_DNS_STATUS is None:

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -11,6 +11,7 @@ import zipfile
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import boto3
 import requests
 from six import iteritems
 
@@ -734,3 +735,12 @@ def list_all_resources(
         collected_items += result.get(list_attr_name, [])
 
     return collected_items
+
+
+def response_arn_matches_partition(client, response_arn: str) -> bool:
+    parsed_arn = aws_stack.parse_arn(response_arn)
+    return (
+        client.meta.partition
+        == boto3.session.Session().get_partition_for_region(parsed_arn["region"])
+        and client.meta.partition == parsed_arn["partition"]
+    )

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -48,7 +48,7 @@ def _client(service):
         if os.environ.get("TEST_DISABLE_RETRIES_AND_TIMEOUTS")
         else None
     )
-    return aws_stack.connect_to_service(service, config=config)
+    return aws_stack.create_external_boto_client(service, config=config)
 
 
 @pytest.fixture(scope="class")

--- a/tests/integration/lambdas/lambda_integration.py
+++ b/tests/integration/lambdas/lambda_integration.py
@@ -123,7 +123,7 @@ def handler(event, context):
                 kinesis_record["Data"] = json.dumps(ddb_new_image["data"])
                 forward_event_to_target_stream(kinesis_record, target_name)
             elif forwarding_target.startswith("s3:"):
-                s3_client = connect_to_service("s3")
+                s3_client = create_external_boto_client("s3")
                 test_data = to_bytes(json.dumps({"test_data": ddb_new_image["data"]["test_data"]}))
                 s3_client.upload_fileobj(BytesIO(test_data), TEST_BUCKET_NAME, target_name)
         else:
@@ -166,16 +166,16 @@ def deserialize_event(event):
 def forward_events(records):
     if not records:
         return
-    kinesis = connect_to_service("kinesis")
+    kinesis = create_external_boto_client("kinesis")
     kinesis.put_records(StreamName=KINESIS_STREAM_NAME, Records=records)
 
 
 def forward_event_to_target_stream(record, stream_name):
-    kinesis = connect_to_service("kinesis")
+    kinesis = create_external_boto_client("kinesis")
     kinesis.put_record(
         StreamName=stream_name, Data=record["Data"], PartitionKey=record["PartitionKey"]
     )
 
 
-def connect_to_service(service):
+def create_external_boto_client(service):
     return boto3.client(service, endpoint_url=ENDPOINT_URL)

--- a/tests/integration/test_acm.py
+++ b/tests/integration/test_acm.py
@@ -27,7 +27,7 @@ JjZ91eQ0hjkCMHw2U/Aw5WJjOpnitqM7mzT6HtoQknFekROn3aRukswy1vUhZscv
 
 class TestACM(unittest.TestCase):
     def test_import_certificate(self):
-        acm = aws_stack.connect_to_service("acm")
+        acm = aws_stack.create_external_boto_client("acm")
 
         certs_before = acm.list_certificates().get("CertificateSummaryList", [])
 
@@ -49,7 +49,7 @@ class TestACM(unittest.TestCase):
         self.assertEqual(len(certs_before) + 1, len(certs_after))
 
     def test_domain_validation(self):
-        acm = aws_stack.connect_to_service("acm")
+        acm = aws_stack.create_external_boto_client("acm")
 
         domain_name = "example-%s.com" % short_uid()
         options = [{"DomainName": domain_name, "ValidationDomain": domain_name}]

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -122,7 +122,7 @@ class TestAPIGateway(unittest.TestCase):
     TEST_API_GATEWAY_AUTHORIZER_OPS = [{"op": "replace", "path": "/name", "value": "test1"}]
 
     def test_create_rest_api_with_custom_id(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         apigw_name = "gw-%s" % short_uid()
         test_id = "testId123"
         result = client.create_rest_api(name=apigw_name, tags={TAG_KEY_CUSTOM_ID: test_id})
@@ -169,7 +169,7 @@ class TestAPIGateway(unittest.TestCase):
         self.assertEqual(len(test_data["records"]), len(result["Records"]))
 
         # clean up
-        kinesis = aws_stack.connect_to_service("kinesis")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
         kinesis.delete_stream(StreamName=self.TEST_STREAM_KINESIS_API_GW)
 
     def test_api_gateway_sqs_integration_with_event_source(self):
@@ -213,10 +213,10 @@ class TestAPIGateway(unittest.TestCase):
         self.assertEqual("b639f52308afd65866c86f274c59033f", body_md5)
 
         # clean up
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         sqs_client.delete_queue(QueueUrl=queue_url)
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.delete_function(FunctionName=self.TEST_LAMBDA_SQS_HANDLER_NAME)
 
     def test_api_gateway_sqs_integration(self):
@@ -463,7 +463,7 @@ class TestAPIGateway(unittest.TestCase):
         )
 
     def test_api_gateway_authorizer_crud(self):
-        apig = aws_stack.connect_to_service("apigateway")
+        apig = aws_stack.create_external_boto_client("apigateway")
 
         authorizer = apig.create_authorizer(
             restApiId=self.TEST_API_GATEWAY_ID, **self.TEST_API_GATEWAY_AUTHORIZER
@@ -505,7 +505,7 @@ class TestAPIGateway(unittest.TestCase):
         self.assertRaises(Exception, apig.get_authorizer, self.TEST_API_GATEWAY_ID, authorizer_id)
 
     def test_apigateway_with_lambda_integration(self):
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
 
         # create Lambda function
         lambda_name = "apigw-lambda-%s" % short_uid()
@@ -610,13 +610,13 @@ class TestAPIGateway(unittest.TestCase):
         self.assertEqual(ctx.exception.response["Error"]["Code"], "NotFoundException")
 
         # clean up
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.delete_function(FunctionName=lambda_name)
         apigw_client.delete_rest_api(restApiId=api_id)
 
     def test_api_gateway_handle_domain_name(self):
         domain_name = "%s.example.com" % short_uid()
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
 
         rs = apigw_client.create_domain_name(domainName=domain_name)
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
@@ -659,7 +659,7 @@ class TestAPIGateway(unittest.TestCase):
                 self.assertEqual(204, result.status_code)
 
     def test_apigateway_with_custom_authorization_method(self):
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
 
         # create Lambda function
         lambda_name = "apigw-lambda-%s" % short_uid()
@@ -697,12 +697,12 @@ class TestAPIGateway(unittest.TestCase):
         self.assertEqual(authorizer["id"], method_response["authorizerId"])
 
         # clean up
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.delete_function(FunctionName=lambda_name)
         apigw_client.delete_rest_api(restApiId=api_id)
 
     def test_create_model(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="this is my api")
         rest_api_id = response["id"]
         dummy_rest_api_id = "_non_existing_"
@@ -746,7 +746,7 @@ class TestAPIGateway(unittest.TestCase):
         client.delete_rest_api(restApiId=rest_api_id)
 
     def test_get_api_models(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="this is my api")
         rest_api_id = response["id"]
         model_name = "testModel"
@@ -772,7 +772,7 @@ class TestAPIGateway(unittest.TestCase):
         client.delete_rest_api(restApiId=rest_api_id)
 
     def test_request_validator(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="this is my api")
         rest_api_id = response["id"]
         # CREATE
@@ -808,7 +808,7 @@ class TestAPIGateway(unittest.TestCase):
         client.delete_rest_api(restApiId=rest_api_id)
 
     def test_base_path_mapping(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="this is my api")
         rest_api_id = response["id"]
 
@@ -861,7 +861,7 @@ class TestAPIGateway(unittest.TestCase):
             client.delete_base_path_mapping(domainName=domain_name, basePath=base_path)
 
     def test_base_path_mapping_root(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api2", description="this is my api")
         rest_api_id = response["id"]
 
@@ -914,7 +914,7 @@ class TestAPIGateway(unittest.TestCase):
             client.delete_base_path_mapping(domainName=domain_name, basePath=base_path)
 
     def test_api_account(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="test 123")
         rest_api_id = response["id"]
 
@@ -929,7 +929,7 @@ class TestAPIGateway(unittest.TestCase):
         client.delete_rest_api(restApiId=rest_api_id)
 
     def test_get_model_by_name(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="this is my api")
         rest_api_id = response["id"]
         dummy_rest_api_id = "_non_existing_"
@@ -958,7 +958,7 @@ class TestAPIGateway(unittest.TestCase):
             self.assertEqual("Invalid Rest API Id specified", e.response["Error"]["Message"])
 
     def test_get_model_with_invalid_name(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         response = client.create_rest_api(name="my_api", description="this is my api")
         rest_api_id = response["id"]
 
@@ -1029,7 +1029,7 @@ class TestAPIGateway(unittest.TestCase):
             "tags": {"tag_key": "tag_value"},
         }
 
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         usage_plan_id = client.create_usage_plan(**payload)["id"]
 
         key_name = "testApiKey"
@@ -1071,7 +1071,7 @@ class TestAPIGateway(unittest.TestCase):
         api_id = self.create_api_gateway_and_deploy(response_templates, True)
         url = gateway_request_url(api_id=api_id, stage_name="staging", path="/")
 
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
 
         # Create multiple usage plans
         usage_plan_ids = []
@@ -1120,7 +1120,7 @@ class TestAPIGateway(unittest.TestCase):
     def test_import_rest_api(self):
         rest_api_name = "restapi-%s" % short_uid()
 
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         rest_api_id = client.create_rest_api(name=rest_api_name)["id"]
 
         spec_file = load_file(TEST_SWAGGER_FILE)
@@ -1157,9 +1157,9 @@ class TestAPIGateway(unittest.TestCase):
         client.delete_rest_api(restApiId=rest_api_id)
 
     def test_step_function_integrations(self):
-        client = aws_stack.connect_to_service("apigateway")
-        sfn_client = aws_stack.connect_to_service("stepfunctions")
-        lambda_client = aws_stack.connect_to_service("lambda")
+        client = aws_stack.create_external_boto_client("apigateway")
+        sfn_client = aws_stack.create_external_boto_client("stepfunctions")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
 
         state_machine_name = "test"
         state_machine_def = {
@@ -1306,7 +1306,7 @@ class TestAPIGateway(unittest.TestCase):
         client.delete_rest_api(restApiId=rest_api["id"])
 
     def test_api_gateway_http_integration_with_path_request_parameter(self):
-        client = aws_stack.connect_to_service("apigateway")
+        client = aws_stack.create_external_boto_client("apigateway")
         test_port = get_free_tcp_port()
         backend_url = "http://localhost:%s/person/{id}" % (test_port)
 
@@ -1382,8 +1382,8 @@ class TestAPIGateway(unittest.TestCase):
         )
 
     def test_api_gateway_s3_get_integration(self):
-        apigw_client = aws_stack.connect_to_service("apigateway")
-        s3_client = aws_stack.connect_to_service("s3")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
+        s3_client = aws_stack.create_external_boto_client("s3")
 
         bucket_name = "test-bucket"
         object_name = "test.json"
@@ -1415,7 +1415,7 @@ class TestAPIGateway(unittest.TestCase):
         s3_client.delete_bucket(Bucket=bucket_name)
 
     def test_api_mock_integration_response_params(self):
-        # apigw_client = aws_stack.connect_to_service('apigateway')
+        # apigw_client = aws_stack.create_external_boto_client('apigateway')
 
         resps = [
             {
@@ -1443,7 +1443,7 @@ class TestAPIGateway(unittest.TestCase):
 
     def connect_api_gateway_to_s3(self, bucket_name, file_name, api_id, method):
         """Connects the root resource of an api gateway to the given object of an s3 bucket."""
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
         s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{}".format(
             aws_stack.get_region(), bucket_name, file_name
         )
@@ -1543,8 +1543,8 @@ class TestAPIGateway(unittest.TestCase):
         )
 
     def test_apigw_test_invoke_method_api(self):
-        client = aws_stack.connect_to_service("apigateway")
-        lambda_client = aws_stack.connect_to_service("lambda")
+        client = aws_stack.create_external_boto_client("apigateway")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
 
         # create test Lambda
         fn_name = f"test-{short_uid()}"
@@ -1633,7 +1633,7 @@ class TestAPIGateway(unittest.TestCase):
     ):
         response_templates = response_templates or {}
         integration_type = integration_type or "AWS_PROXY"
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
         response = apigw_client.create_rest_api(name="my_api", description="this is my api")
         api_id = response["id"]
         resources = apigw_client.get_resources(restApiId=api_id)

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -18,7 +18,7 @@ class CloudWatchTest(unittest.TestCase):
         metric_name = "metric-%s" % short_uid()
         namespace = "namespace-%s" % short_uid()
 
-        client = aws_stack.connect_to_service("cloudwatch")
+        client = aws_stack.create_external_boto_client("cloudwatch")
 
         # Put metric data without value
         data = [
@@ -76,14 +76,14 @@ class CloudWatchTest(unittest.TestCase):
         request = Request(url, encoded_data, headers, method="POST")
         urlopen(request)
 
-        client = aws_stack.connect_to_service("cloudwatch")
+        client = aws_stack.create_external_boto_client("cloudwatch")
         rs = client.list_metrics(Namespace=namespace, MetricName=metric_name)
         self.assertEqual(1, len(rs["Metrics"]))
         self.assertEqual(namespace, rs["Metrics"][0]["Namespace"])
 
     def test_get_metric_data(self):
 
-        conn = aws_stack.connect_to_service("cloudwatch")
+        conn = aws_stack.create_external_boto_client("cloudwatch")
 
         conn.put_metric_data(
             Namespace="some/thing", MetricData=[dict(MetricName="someMetric", Value=23)]
@@ -169,7 +169,7 @@ class CloudWatchTest(unittest.TestCase):
         self.assertGreaterEqual(len(result["metrics"]), 3)
 
     def test_multiple_dimensions(self):
-        client = aws_stack.connect_to_service("cloudwatch")
+        client = aws_stack.create_external_boto_client("cloudwatch")
 
         namespaces = [
             "ns1-%s" % short_uid(),
@@ -202,7 +202,7 @@ class CloudWatchTest(unittest.TestCase):
         self.assertEqual(len(metrics), len(namespaces) * num_dimensions)
 
     def test_store_tags(self):
-        cloudwatch = aws_stack.connect_to_service("cloudwatch")
+        cloudwatch = aws_stack.create_external_boto_client("cloudwatch")
 
         alarm_name = "a-%s" % short_uid()
         response = cloudwatch.put_metric_alarm(

--- a/tests/integration/test_config_service.py
+++ b/tests/integration/test_config_service.py
@@ -10,10 +10,10 @@ TEST_RESOURCE_TYPES = "AWS::EC2::Instance"
 
 class TestConfigService(unittest.TestCase):
     def setUp(self):
-        self.config_service_client = aws_stack.connect_to_service("config")
+        self.config_service_client = aws_stack.create_external_boto_client("config")
 
     def create_iam_role(self, iam_role_name):
-        self.iam_client = aws_stack.connect_to_service("iam")
+        self.iam_client = aws_stack.create_external_boto_client("iam")
         assume_policy_document = {
             "Version": "2012-10-17",
             "Statement": [
@@ -67,11 +67,11 @@ class TestConfigService(unittest.TestCase):
 
         self.create_configuration_recorder(iam_role_arn)
 
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
         test_bucket_name = "test-bucket"
         s3_client.create_bucket(Bucket=test_bucket_name)
 
-        sns_client = aws_stack.connect_to_service("sns")
+        sns_client = aws_stack.create_external_boto_client("sns")
         sns_topic_arn = sns_client.create_topic(Name="test-sns-topic")["TopicArn"]
 
         delivery_channel_name = "test-delivery-channel"

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -143,7 +143,7 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_list_tags_of_resource(self):
         table_name = "ddb-table-%s" % short_uid()
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         rs = dynamodb.create_table(
             TableName=table_name,
@@ -178,8 +178,8 @@ class TestDynamoDB(unittest.TestCase):
         delete_table(table_name)
 
     def test_stream_spec_and_region_replacement(self):
-        ddbstreams = aws_stack.connect_to_service("dynamodbstreams")
-        kinesis = aws_stack.connect_to_service("kinesis")
+        ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
         table_name = "ddb-%s" % short_uid()
         aws_stack.create_dynamodb_table(
             table_name,
@@ -214,7 +214,7 @@ class TestDynamoDB(unittest.TestCase):
         self.assertNotIn(stream_name, kinesis.list_streams()["StreamNames"])
 
     def test_multiple_update_expressions(self):
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         table = self.dynamodb.Table(TEST_DDB_TABLE_NAME)
 
@@ -310,12 +310,12 @@ class TestDynamoDB(unittest.TestCase):
         def wait_for_stream_created(table_name):
             stream_name = get_kinesis_stream_name(table_name)
             stream = KinesisStream(id=stream_name, num_shards=1)
-            kinesis = aws_stack.connect_to_service("kinesis", env=get_environment(None))
+            kinesis = aws_stack.create_external_boto_client("kinesis", env=get_environment(None))
             stream.connect(kinesis)
             stream.wait_for()
 
-        dynamodb = aws_stack.connect_to_service("dynamodb")
-        ddbstreams = aws_stack.connect_to_service("dynamodbstreams")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
+        ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
 
         table_name = "table_with_stream-%s" % short_uid()
         table = dynamodb.create_table(
@@ -351,8 +351,8 @@ class TestDynamoDB(unittest.TestCase):
         self.assertIn("ShardIterator", response)
 
     def test_dynamodb_stream_stream_view_type(self):
-        dynamodb = aws_stack.connect_to_service("dynamodb")
-        ddbstreams = aws_stack.connect_to_service("dynamodbstreams")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
+        ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
         table_name = "table_with_stream-%s" % short_uid()
         # create table
         table = dynamodb.create_table(
@@ -418,8 +418,8 @@ class TestDynamoDB(unittest.TestCase):
         delete_table(table_name)
 
     def test_dynamodb_with_kinesis_stream(self):
-        dynamodb = aws_stack.connect_to_service("dynamodb")
-        kinesis = aws_stack.connect_to_service("kinesis")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
 
         # create kinesis datastream
         kinesis.create_stream(StreamName="kinesis_dest_stream", ShardCount=1)
@@ -509,7 +509,7 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_global_tables(self):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         # create global table
         regions = [
@@ -554,7 +554,7 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_create_duplicate_table(self):
         table_name = "duplicateTable"
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         dynamodb.create_table(
             TableName=table_name,
@@ -579,7 +579,7 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_delete_table(self):
         table_name = "test-ddb-table-%s" % short_uid()
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         tables_before = len(dynamodb.list_tables()["TableNames"])
 
@@ -605,7 +605,7 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_transaction_write_items(self):
         table_name = "test-ddb-table-%s" % short_uid()
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         dynamodb.create_table(
             TableName=table_name,
@@ -647,7 +647,7 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_batch_write_items(self):
         table_name = "test-ddb-table-%s" % short_uid()
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         dynamodb.create_table(
             TableName=table_name,
             KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
@@ -671,8 +671,8 @@ class TestDynamoDB(unittest.TestCase):
 
     def test_dynamodb_stream_records_with_update_item(self):
         table_name = "test-ddb-table-%s" % short_uid()
-        dynamodb = aws_stack.connect_to_service("dynamodb")
-        ddbstreams = aws_stack.connect_to_service("dynamodbstreams")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
+        ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
 
         aws_stack.create_dynamodb_table(
             table_name,
@@ -750,7 +750,7 @@ class TestDynamoDB(unittest.TestCase):
         table_name = "ddb-table-%s" % short_uid()
         partition_key = "username"
 
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         aws_stack.create_dynamodb_table(table_name, partition_key)
 
         rs = dynamodb.query(
@@ -790,7 +790,7 @@ class TestDynamoDB(unittest.TestCase):
             runtime=LAMBDA_RUNTIME_PYTHON36,
         )
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.create_event_source_mapping(
             EventSourceArn=latest_stream_arn, FunctionName=function_name
         )
@@ -816,11 +816,11 @@ class TestDynamoDB(unittest.TestCase):
         self.assertEqual({"SK": {"S": item["SK"]}}, dynamodb_event["Keys"])
         self.assertEqual({"S": item["Name"]}, dynamodb_event["NewImage"]["Name"])
 
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         dynamodb.delete_table(TableName=table_name)
 
     def test_dynamodb_batch_write_item(self):
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         table_name = "ddb-table-%s" % short_uid()
 
         dynamodb.create_table(
@@ -844,7 +844,7 @@ class TestDynamoDB(unittest.TestCase):
         self.assertEqual({}, result.get("UnprocessedItems"))
 
     def test_dynamodb_create_table_with_sse_specification(self):
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         table_name = "ddb-table-%s" % short_uid()
 
         kms_master_key_id = long_uid()
@@ -870,7 +870,7 @@ class TestDynamoDB(unittest.TestCase):
         delete_table(table_name)
 
     def test_dynamodb_create_table_with_partial_sse_specification(self):
-        dynamodb = aws_stack.connect_to_service("dynamodb")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
         table_name = "ddb-table-%s" % short_uid()
 
         sse_specification = {"Enabled": True}
@@ -889,7 +889,7 @@ class TestDynamoDB(unittest.TestCase):
         self.assertEqual("KMS", result["TableDescription"]["SSEDescription"]["SSEType"])
         self.assertIn("KMSMasterKeyArn", result["TableDescription"]["SSEDescription"])
         kms_master_key_arn = result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"]
-        kms_client = aws_stack.connect_to_service("kms")
+        kms_client = aws_stack.create_external_boto_client("kms")
         result = kms_client.describe_key(KeyId=kms_master_key_arn)
         self.assertEqual("AWS", result["KeyMetadata"]["KeyManager"])
 
@@ -897,5 +897,5 @@ class TestDynamoDB(unittest.TestCase):
 
 
 def delete_table(name):
-    dynamodb_client = aws_stack.connect_to_service("dynamodb")
+    dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
     dynamodb_client.delete_table(TableName=name)

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -5,7 +5,7 @@ from localstack.utils.aws import aws_stack
 
 class TestEc2Integrations(unittest.TestCase):
     def setUp(self):
-        self.ec2_client = aws_stack.connect_to_service("ec2")
+        self.ec2_client = aws_stack.create_external_boto_client("ec2")
 
     def test_create_route_table_association(self):
         ec2 = self.ec2_client
@@ -112,8 +112,8 @@ class TestEc2Integrations(unittest.TestCase):
     def test_vcp_peering_difference_regions(self):
         # Note: different regions currently not supported due to set_default_region_in_headers(..) in edge.py
         region1 = region2 = aws_stack.get_region()
-        ec2_client1 = aws_stack.connect_to_service(service_name="ec2", region_name=region1)
-        ec2_client2 = aws_stack.connect_to_service(service_name="ec2", region_name=region2)
+        ec2_client1 = aws_stack.create_external_boto_client(service_name="ec2", region_name=region1)
+        ec2_client2 = aws_stack.create_external_boto_client(service_name="ec2", region_name=region2)
 
         cidr_block1 = "192.168.1.2/24"
         cidr_block2 = "192.168.1.2/24"

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -39,27 +39,27 @@ class TestEdgeAPI:
             self._invoke_stepfunctions_via_edge(edge_url)
 
     def _invoke_kinesis_via_edge(self, edge_url):
-        client = aws_stack.connect_to_service("kinesis", endpoint_url=edge_url)
+        client = aws_stack.create_external_boto_client("kinesis", endpoint_url=edge_url)
         result = client.list_streams()
         assert "StreamNames" in result
 
     def _invoke_dynamodbstreams_via_edge(self, edge_url):
-        client = aws_stack.connect_to_service("dynamodbstreams", endpoint_url=edge_url)
+        client = aws_stack.create_external_boto_client("dynamodbstreams", endpoint_url=edge_url)
         result = client.list_streams()
         assert "Streams" in result
 
     def _invoke_firehose_via_edge(self, edge_url):
-        client = aws_stack.connect_to_service("firehose", endpoint_url=edge_url)
+        client = aws_stack.create_external_boto_client("firehose", endpoint_url=edge_url)
         result = client.list_delivery_streams()
         assert "DeliveryStreamNames" in result
 
     def _invoke_stepfunctions_via_edge(self, edge_url):
-        client = aws_stack.connect_to_service("stepfunctions", endpoint_url=edge_url)
+        client = aws_stack.create_external_boto_client("stepfunctions", endpoint_url=edge_url)
         result = client.list_state_machines()
         assert "stateMachines" in result
 
     def _invoke_dynamodb_via_edge_go_sdk(self, edge_url):
-        client = aws_stack.connect_to_service("dynamodb")
+        client = aws_stack.create_external_boto_client("dynamodb")
         table_name = f"t-{short_uid()}"
         aws_stack.create_dynamodb_table(table_name, "id")
 
@@ -83,7 +83,7 @@ class TestEdgeAPI:
         client.delete_table(TableName=table_name)
 
     def _invoke_s3_via_edge(self, edge_url):
-        client = aws_stack.connect_to_service("s3", endpoint_url=edge_url)
+        client = aws_stack.create_external_boto_client("s3", endpoint_url=edge_url)
         bucket_name = "edge-%s" % short_uid()
 
         client.create_bucket(Bucket=bucket_name)
@@ -116,7 +116,7 @@ class TestEdgeAPI:
         assert to_str(result.getvalue()) == "file_content_123"
 
     def _invoke_s3_via_edge_multipart_form(self, edge_url):
-        client = aws_stack.connect_to_service("s3", endpoint_url=edge_url)
+        client = aws_stack.create_external_boto_client("s3", endpoint_url=edge_url)
         bucket_name = "edge-%s" % short_uid()
         object_name = "testobject"
         object_data = b"testdata"
@@ -162,8 +162,8 @@ class TestEdgeAPI:
         region_original = os.environ.get("DEFAULT_REGION")
         os.environ["DEFAULT_REGION"] = "us-southeast-2"
         edge_url = "%s://localhost:%s" % (get_service_protocol(), edge_port)
-        sns_client = aws_stack.connect_to_service("sns", endpoint_url=edge_url)
-        sqs_client = aws_stack.connect_to_service("sqs", endpoint_url=edge_url)
+        sns_client = aws_stack.create_external_boto_client("sns", endpoint_url=edge_url)
+        sqs_client = aws_stack.create_external_boto_client("sqs", endpoint_url=edge_url)
 
         topic = sns_client.create_topic(Name="test_topic3")
         topic_arn = topic["TopicArn"]

--- a/tests/integration/test_elasticsearch.py
+++ b/tests/integration/test_elasticsearch.py
@@ -135,7 +135,7 @@ class ElasticsearchTest(unittest.TestCase):
         cls._delete_document(TEST_DOC_ID)
 
         # make sure domain deletion works
-        es_client = aws_stack.connect_to_service("es")
+        es_client = aws_stack.create_external_boto_client("es")
         es_client.delete_elasticsearch_domain(DomainName=cls.domain_name)
         assert cls.domain_name not in [
             d["DomainName"] for d in es_client.list_domain_names()["DomainNames"]
@@ -150,14 +150,14 @@ class ElasticsearchTest(unittest.TestCase):
             self._create_domain(name=self.domain_name, es_cluster_config=ES_CLUSTER_CONFIG)
 
     def test_describe_elasticsearch_domains(self):
-        es_client = aws_stack.connect_to_service("es")
+        es_client = aws_stack.create_external_boto_client("es")
 
         result = es_client.describe_elasticsearch_domains(DomainNames=[self.domain_name])
         self.assertEqual(1, len(result["DomainStatusList"]))
         self.assertEqual(result["DomainStatusList"][0]["DomainName"], self.domain_name)
 
     def test_domain_es_version(self):
-        es_client = aws_stack.connect_to_service("es")
+        es_client = aws_stack.create_external_boto_client("es")
 
         status = es_client.describe_elasticsearch_domain(DomainName=self.domain_name)[
             "DomainStatus"
@@ -182,7 +182,7 @@ class ElasticsearchTest(unittest.TestCase):
             self.assertIn(req_result[0]["health"], ["green", "yellow"])
             self.assertIn(req_result[0]["index"], indexes)
 
-        es_client = aws_stack.connect_to_service("es")
+        es_client = aws_stack.create_external_boto_client("es")
         test_domain_name_1 = "test1-%s" % short_uid()
         test_domain_name_2 = "test2-%s" % short_uid()
         self._create_domain(name=test_domain_name_1, version="6.8")
@@ -197,7 +197,7 @@ class ElasticsearchTest(unittest.TestCase):
         self.assertFalse(status_test_domain_name_2["DomainStatus"]["Processing"])
 
     def test_domain_creation(self):
-        es_client = aws_stack.connect_to_service("es")
+        es_client = aws_stack.create_external_boto_client("es")
 
         # make sure we cannot re-create same domain name
         self.assertRaises(
@@ -269,7 +269,7 @@ class ElasticsearchTest(unittest.TestCase):
 
     @classmethod
     def _create_domain(cls, name=None, version=None, es_cluster_config=None):
-        es_client = aws_stack.connect_to_service("es")
+        es_client = aws_stack.create_external_boto_client("es")
         name = name or cls.domain_name
         kwargs = {}
         if version:

--- a/tests/integration/test_error_injection.py
+++ b/tests/integration/test_error_injection.py
@@ -24,7 +24,7 @@ class TestErrorInjection(unittest.TestCase):
             pytest.skip("skipping TestErrorInjection (TEST_ERROR_INJECTION not set or false)")
 
     def test_kinesis_error_injection(self):
-        kinesis = aws_stack.connect_to_service("kinesis")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
         aws_stack.create_kinesis_stream(TEST_STREAM_NAME)
 
         records = [{"Data": "0", "ExplicitHashKey": "0", "PartitionKey": "0"}]

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -37,11 +37,11 @@ TEST_EVENT_PATTERN = {
 
 class EventsTest(unittest.TestCase):
     def setUp(self):
-        self.events_client = aws_stack.connect_to_service("events")
-        self.iam_client = aws_stack.connect_to_service("iam")
-        self.sns_client = aws_stack.connect_to_service("sns")
-        self.sfn_client = aws_stack.connect_to_service("stepfunctions")
-        self.sqs_client = aws_stack.connect_to_service("sqs")
+        self.events_client = aws_stack.create_external_boto_client("events")
+        self.iam_client = aws_stack.create_external_boto_client("iam")
+        self.sns_client = aws_stack.create_external_boto_client("sns")
+        self.sfn_client = aws_stack.create_external_boto_client("stepfunctions")
+        self.sqs_client = aws_stack.create_external_boto_client("sqs")
 
     def assertIsValidEvent(self, event):
         expected_fields = (
@@ -137,7 +137,7 @@ class EventsTest(unittest.TestCase):
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -189,7 +189,7 @@ class EventsTest(unittest.TestCase):
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -260,8 +260,8 @@ class EventsTest(unittest.TestCase):
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
 
-        sns_client = aws_stack.connect_to_service("sns")
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sns_client = aws_stack.create_external_boto_client("sns")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         topic_name = "topic-{}".format(short_uid())
         topic_arn = sns_client.create_topic(Name=topic_name)["TopicArn"]
 
@@ -320,7 +320,7 @@ class EventsTest(unittest.TestCase):
         bus_name_1 = "bus1-{}".format(short_uid())
         bus_name_2 = "bus2-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -581,7 +581,7 @@ class EventsTest(unittest.TestCase):
         proxy = start_proxy(local_port, update_listener=HttpEndpointListener())
         wait_for_port_open(local_port)
 
-        events_client = aws_stack.connect_to_service("events")
+        events_client = aws_stack.create_external_boto_client("events")
         connection_arn = events_client.create_connection(
             Name="TestConnection",
             AuthorizationType="BASIC",
@@ -638,11 +638,11 @@ class EventsTest(unittest.TestCase):
         bus_name = "bus-{}".format(short_uid())
 
         # create firehose target bucket
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
         s3_client.create_bucket(Bucket=s3_bucket)
 
         # create firehose delivery stream to s3
-        firehose_client = aws_stack.connect_to_service("firehose")
+        firehose_client = aws_stack.create_external_boto_client("firehose")
         stream = firehose_client.create_delivery_stream(
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
@@ -698,13 +698,15 @@ class EventsTest(unittest.TestCase):
         self.cleanup(bus_name, rule_name, target_id)
 
     def test_put_events_with_target_sqs_new_region(self):
-        self.events_client = aws_stack.connect_to_service("events", region_name="eu-west-1")
+        self.events_client = aws_stack.create_external_boto_client(
+            "events", region_name="eu-west-1"
+        )
         queue_name = "queue-{}".format(short_uid())
         rule_name = "rule-{}".format(short_uid())
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs", region_name="eu-west-1")
+        sqs_client = aws_stack.create_external_boto_client("sqs", region_name="eu-west-1")
         sqs_client.create_queue(QueueName=queue_name)
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -743,7 +745,7 @@ class EventsTest(unittest.TestCase):
         stream_name = "stream-{}".format(short_uid())
         stream_arn = aws_stack.kinesis_stream_arn(stream_name)
 
-        kinesis_client = aws_stack.connect_to_service("kinesis")
+        kinesis_client = aws_stack.create_external_boto_client("kinesis")
         kinesis_client.create_stream(StreamName=stream_name, ShardCount=1)
 
         self.events_client.create_event_bus(Name=bus_name)
@@ -813,7 +815,7 @@ class EventsTest(unittest.TestCase):
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -873,7 +875,7 @@ class EventsTest(unittest.TestCase):
         target_id_1 = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -941,13 +943,17 @@ class EventsTest(unittest.TestCase):
         self.cleanup(bus_name, rule_name, target_id, queue_url=queue_url)
 
     def test_put_event_without_source(self):
-        self.events_client = aws_stack.connect_to_service("events", region_name="eu-west-1")
+        self.events_client = aws_stack.create_external_boto_client(
+            "events", region_name="eu-west-1"
+        )
 
         response = self.events_client.put_events(Entries=[{"DetailType": "Test", "Detail": "{}"}])
         self.assertIn("Entries", response)
 
     def test_put_event_without_detail(self):
-        self.events_client = aws_stack.connect_to_service("events", region_name="eu-west-1")
+        self.events_client = aws_stack.create_external_boto_client(
+            "events", region_name="eu-west-1"
+        )
 
         response = self.events_client.put_events(
             Entries=[
@@ -959,8 +965,8 @@ class EventsTest(unittest.TestCase):
         self.assertIn("Entries", response)
 
     def test_trigger_event_on_ssm_change(self):
-        sqs = aws_stack.connect_to_service("sqs")
-        ssm = aws_stack.connect_to_service("ssm")
+        sqs = aws_stack.create_external_boto_client("sqs")
+        ssm = aws_stack.create_external_boto_client("ssm")
         rule_name = "rule-{}".format(short_uid())
         target_id = "target-{}".format(short_uid())
 
@@ -1014,7 +1020,7 @@ class EventsTest(unittest.TestCase):
         rule_name = "rule-{}".format(short_uid())
         target_id = "target-{}".format(short_uid())
 
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
         queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
@@ -1114,5 +1120,5 @@ class EventsTest(unittest.TestCase):
         if bus_name:
             self.events_client.delete_event_bus(Name=bus_name)
         if queue_url:
-            sqs_client = aws_stack.connect_to_service("sqs")
+            sqs_client = aws_stack.create_external_boto_client("sqs")
             sqs_client.delete_queue(QueueUrl=queue_url)

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -84,7 +84,7 @@ def test_firehose_http():
     wait_for_port_open(local_port)
 
     # create firehose stream with http destination
-    firehose = aws_stack.connect_to_service("firehose")
+    firehose = aws_stack.create_external_boto_client("firehose")
     stream_name = "firehose_" + short_uid()
     stream = firehose.create_delivery_stream(
         DeliveryStreamName=stream_name,

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -14,7 +14,7 @@ from localstack.utils.kinesis import kinesis_connector
 
 class TestIAMIntegrations(unittest.TestCase):
     def setUp(self):
-        self.iam_client = aws_stack.connect_to_service("iam")
+        self.iam_client = aws_stack.create_external_boto_client("iam")
 
     def test_run_kcl_with_iam_assume_role(self):
         env_vars = {}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -73,7 +73,7 @@ class IntegrationTest(unittest.TestCase):
 
         # create scheduled Lambda function
         rule_name = "rule-%s" % short_uid()
-        events = aws_stack.connect_to_service("events")
+        events = aws_stack.create_external_boto_client("events")
         events.put_rule(Name=rule_name, ScheduleExpression="rate(1 minutes)")
         events.put_targets(
             Rule=rule_name, Targets=[{"Id": "target-%s" % short_uid(), "Arn": func_arn}]
@@ -85,7 +85,7 @@ class IntegrationTest(unittest.TestCase):
 
     def test_firehose_s3(self):
         s3_resource = aws_stack.connect_to_resource("s3")
-        firehose = aws_stack.connect_to_service("firehose")
+        firehose = aws_stack.create_external_boto_client("firehose")
 
         s3_prefix = "/testdata"
         test_data = '{"test": "firehose_data_%s"}' % short_uid()
@@ -119,9 +119,9 @@ class IntegrationTest(unittest.TestCase):
             self.assertRegex(key, r".*/\d{4}/\d{2}/\d{2}/\d{2}/.*\-\d{4}\-\d{2}\-\d{2}\-\d{2}.*")
 
     def test_firehose_kinesis_to_s3(self):
-        kinesis = aws_stack.connect_to_service("kinesis")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
         s3_resource = aws_stack.connect_to_resource("s3")
-        firehose = aws_stack.connect_to_service("firehose")
+        firehose = aws_stack.create_external_boto_client("firehose")
 
         aws_stack.create_kinesis_stream(TEST_STREAM_NAME, delete=True)
 
@@ -173,11 +173,11 @@ class IntegrationTest(unittest.TestCase):
         lambda_ddb_name = "lambda-ddb-%s" % short_uid()
         queue_name = "queue-%s" % short_uid()
         dynamodb = aws_stack.connect_to_resource("dynamodb")
-        dynamodb_service = aws_stack.connect_to_service("dynamodb")
-        dynamodbstreams = aws_stack.connect_to_service("dynamodbstreams")
-        kinesis = aws_stack.connect_to_service("kinesis")
-        sns = aws_stack.connect_to_service("sns")
-        sqs = aws_stack.connect_to_service("sqs")
+        dynamodb_service = aws_stack.create_external_boto_client("dynamodb")
+        dynamodbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
+        sns = aws_stack.create_external_boto_client("sns")
+        sqs = aws_stack.create_external_boto_client("sqs")
 
         LOGGER.info("Creating test streams...")
         run_safe(
@@ -386,9 +386,9 @@ class IntegrationTest(unittest.TestCase):
         table_name = TEST_TABLE_NAME + "lsbat" + ddb_lease_table_suffix
         stream_name = TEST_STREAM_NAME
         lambda_ddb_name = "lambda-ddb-%s" % short_uid()
-        dynamodb = aws_stack.connect_to_service("dynamodb", client=True)
-        dynamodb_service = aws_stack.connect_to_service("dynamodb")
-        dynamodbstreams = aws_stack.connect_to_service("dynamodbstreams")
+        dynamodb = aws_stack.create_external_boto_client("dynamodb", client=True)
+        dynamodb_service = aws_stack.create_external_boto_client("dynamodb")
+        dynamodbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
 
         LOGGER.info("Creating test streams...")
         run_safe(
@@ -845,7 +845,7 @@ def test_kinesis_lambda_forward_chain(kinesis_client, s3_client, create_lambda_f
 
 
 def get_event_source_arn(stream_name):
-    kinesis = aws_stack.connect_to_service("kinesis")
+    kinesis = aws_stack.create_external_boto_client("kinesis")
     return kinesis.describe_stream(StreamName=stream_name)["StreamDescription"]["StreamARN"]
 
 
@@ -860,7 +860,7 @@ def get_lambda_invocations_count(
 
 def get_lambda_metrics(func_name, metric=None, period=None, start_time=None, end_time=None):
     metric = metric or "Invocations"
-    cloudwatch = aws_stack.connect_to_service("cloudwatch")
+    cloudwatch = aws_stack.create_external_boto_client("cloudwatch")
     period = period or 600
     end_time = end_time or datetime.now()
     if start_time is None:

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -17,7 +17,7 @@ from localstack.utils.kinesis import kinesis_connector
 
 class TestKinesis(unittest.TestCase):
     def test_stream_consumers(self):
-        client = aws_stack.connect_to_service("kinesis")
+        client = aws_stack.create_external_boto_client("kinesis")
         stream_name = "test-%s" % short_uid()
         stream_arn = aws_stack.kinesis_stream_arn(stream_name)
 
@@ -69,7 +69,7 @@ class TestKinesis(unittest.TestCase):
         client.delete_stream(StreamName=stream_name)
 
     def test_subscribe_to_shard(self):
-        client = aws_stack.connect_to_service("kinesis")
+        client = aws_stack.create_external_boto_client("kinesis")
         stream_name = "test-%s" % short_uid()
         stream_arn = aws_stack.kinesis_stream_arn(stream_name)
 
@@ -125,7 +125,7 @@ class TestKinesis(unittest.TestCase):
         client.delete_stream(StreamName=stream_name, EnforceConsumerDeletion=True)
 
     def test_subscribe_to_shard_with_sequence_number_as_iterator(self):
-        client = aws_stack.connect_to_service("kinesis")
+        client = aws_stack.create_external_boto_client("kinesis")
         stream_name = "test-%s" % short_uid()
         stream_arn = aws_stack.kinesis_stream_arn(stream_name)
 
@@ -181,7 +181,7 @@ class TestKinesis(unittest.TestCase):
         client.delete_stream(StreamName=stream_name, EnforceConsumerDeletion=True)
 
     def test_get_records(self):
-        client = aws_stack.connect_to_service("kinesis")
+        client = aws_stack.create_external_boto_client("kinesis")
         stream_name = "test-%s" % short_uid()
 
         client.create_stream(StreamName=stream_name, ShardCount=1)
@@ -218,7 +218,7 @@ class TestKinesis(unittest.TestCase):
         client.delete_stream(StreamName=stream_name)
 
     def _get_shard_iterator(self, stream_name):
-        client = aws_stack.connect_to_service("kinesis")
+        client = aws_stack.create_external_boto_client("kinesis")
         response = client.describe_stream(StreamName=stream_name)
         sequence_number = (
             response.get("StreamDescription")
@@ -254,7 +254,7 @@ class TestKinesisPythonClient(unittest.TestCase):
             wait_until_started=True,
         )
 
-        kinesis = aws_stack.connect_to_service("kinesis")
+        kinesis = aws_stack.create_external_boto_client("kinesis")
 
         stream_summary = kinesis.describe_stream_summary(StreamName=stream_name)
         self.assertEqual(1, stream_summary["StreamDescriptionSummary"]["OpenShardCount"])

--- a/tests/integration/test_multiregion.py
+++ b/tests/integration/test_multiregion.py
@@ -18,8 +18,8 @@ REGION4 = "eu-central-1"
 
 class TestMultiRegion(unittest.TestCase):
     def test_multi_region_sns(self):
-        sns_1 = aws_stack.connect_to_service("sns", region_name=REGION1)
-        sns_2 = aws_stack.connect_to_service("sns", region_name=REGION2)
+        sns_1 = aws_stack.create_external_boto_client("sns", region_name=REGION1)
+        sns_2 = aws_stack.create_external_boto_client("sns", region_name=REGION2)
         len_1 = len(sns_1.list_topics()["Topics"])
         len_2 = len(sns_2.list_topics()["Topics"])
 
@@ -38,8 +38,8 @@ class TestMultiRegion(unittest.TestCase):
         self.assertIn(REGION2, result2[0]["TopicArn"])
 
     def test_multi_region_sqs(self):
-        sqs_1 = aws_stack.connect_to_service("sqs", region_name=REGION1)
-        sqs_2 = aws_stack.connect_to_service("sqs", region_name=REGION2)
+        sqs_1 = aws_stack.create_external_boto_client("sqs", region_name=REGION1)
+        sqs_2 = aws_stack.create_external_boto_client("sqs", region_name=REGION2)
         len_1 = len(sqs_1.list_queues().get("QueueUrls", []))
         len_2 = len(sqs_2.list_queues().get("QueueUrls", []))
 
@@ -58,10 +58,10 @@ class TestMultiRegion(unittest.TestCase):
         self.assertNotIn(REGION2, result2[0])
 
     def test_multi_region_api_gateway(self):
-        gw_1 = aws_stack.connect_to_service("apigateway", region_name=REGION1)
-        gw_2 = aws_stack.connect_to_service("apigateway", region_name=REGION2)
-        gw_3 = aws_stack.connect_to_service("apigateway", region_name=REGION3)
-        sqs_1 = aws_stack.connect_to_service("sqs", region_name=REGION1)
+        gw_1 = aws_stack.create_external_boto_client("apigateway", region_name=REGION1)
+        gw_2 = aws_stack.create_external_boto_client("apigateway", region_name=REGION2)
+        gw_3 = aws_stack.create_external_boto_client("apigateway", region_name=REGION3)
+        sqs_1 = aws_stack.create_external_boto_client("sqs", region_name=REGION1)
         len_1 = len(gw_1.get_rest_apis()["items"])
         len_2 = len(gw_2.get_rest_apis()["items"])
 

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -19,9 +19,9 @@ PUBLICATION_RETRIES = 4
 
 class TestNotifications(unittest.TestCase):
     def setUp(self):
-        self.s3_client = aws_stack.connect_to_service("s3")
-        self.sqs_client = aws_stack.connect_to_service("sqs")
-        self.sns_client = aws_stack.connect_to_service("sns")
+        self.s3_client = aws_stack.create_external_boto_client("s3")
+        self.sqs_client = aws_stack.create_external_boto_client("sqs")
+        self.sns_client = aws_stack.create_external_boto_client("sns")
 
     def test_sqs_queue_names(self):
         sqs_client = self.sqs_client
@@ -262,7 +262,7 @@ class TestNotifications(unittest.TestCase):
         #
         # Tests s3->sns->sqs notifications
         #
-        sns_client = aws_stack.connect_to_service("sns")
+        sns_client = aws_stack.create_external_boto_client("sns")
         topic_info = sns_client.create_topic(Name=TEST_S3_TOPIC_NAME)
 
         s3_client.put_bucket_notification_configuration(
@@ -307,7 +307,7 @@ class TestNotifications(unittest.TestCase):
         self._delete_notification_config()
 
     def _delete_notification_config(self):
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
         s3_client.put_bucket_notification_configuration(
             Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS, NotificationConfiguration={}
         )
@@ -319,7 +319,7 @@ class TestNotifications(unittest.TestCase):
 
     def _receive_assert_delete(self, queue_url, assertions, sqs_client=None, required_subject=None):
         if not sqs_client:
-            sqs_client = aws_stack.connect_to_service("sqs")
+            sqs_client = aws_stack.create_external_boto_client("sqs")
 
         response = sqs_client.receive_message(QueueUrl=queue_url)
 

--- a/tests/integration/test_resourcegroups.py
+++ b/tests/integration/test_resourcegroups.py
@@ -7,7 +7,7 @@ from localstack.utils.common import short_uid
 
 class TestResourceGroups(unittest.TestCase):
     def setUp(self):
-        self.resource_group_client = aws_stack.connect_to_service("resource-groups")
+        self.resource_group_client = aws_stack.create_external_boto_client("resource-groups")
 
     def test_create_group(self):
         name = "resource_group-{}".format(short_uid())

--- a/tests/integration/test_rgsa.py
+++ b/tests/integration/test_rgsa.py
@@ -5,8 +5,8 @@ from localstack.utils.aws import aws_stack
 
 class TestRGSAIntegrations(unittest.TestCase):
     def setUp(self):
-        self.rgsa_client = aws_stack.connect_to_service("resourcegroupstaggingapi")
-        self.ec2_client = aws_stack.connect_to_service("ec2")
+        self.rgsa_client = aws_stack.create_external_boto_client("resourcegroupstaggingapi")
+        self.ec2_client = aws_stack.create_external_boto_client("ec2")
 
     def test_get_resources(self):
         vpc = self.ec2_client.create_vpc(CidrBlock="10.0.0.0/16")

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -9,7 +9,7 @@ from localstack.utils.common import short_uid
 
 class TestRoute53:
     def test_create_hosted_zone(self):
-        route53 = aws_stack.connect_to_service("route53")
+        route53 = aws_stack.create_external_boto_client("route53")
 
         response = route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 201
@@ -18,8 +18,8 @@ class TestRoute53:
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     def test_associate_vpc_with_hosted_zone(self):
-        ec2 = aws_stack.connect_to_service("ec2")
-        route53 = aws_stack.connect_to_service("route53")
+        ec2 = aws_stack.create_external_boto_client("ec2")
+        route53 = aws_stack.create_external_boto_client("route53")
 
         name = "zone123"
         response = route53.create_hosted_zone(Name=name, CallerReference="ref123")
@@ -73,7 +73,7 @@ class TestRoute53:
             )
 
     def test_reusable_delegation_sets(self):
-        client = aws_stack.connect_to_service("route53")
+        client = aws_stack.create_external_boto_client("route53")
 
         sets_before = client.list_reusable_delegation_sets().get("DelegationSets", [])
 
@@ -111,8 +111,8 @@ class TestRoute53:
 
 class TestRoute53Resolver:
     def test_create_resolver_endpoint(self):
-        ec2 = aws_stack.connect_to_service("ec2")
-        resolver = aws_stack.connect_to_service("route53resolver")
+        ec2 = aws_stack.create_external_boto_client("ec2")
+        resolver = aws_stack.create_external_boto_client("route53resolver")
 
         # getting list of existing (default) subnets
         subnets = ec2.describe_subnets()["Subnets"]

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -97,10 +97,10 @@ class PutRequest(Request):
 #     def wrapper(self):
 #         try:
 #             # test via path based addressing
-#             TestS3.OVERWRITTEN_CLIENT = aws_stack.connect_to_service('s3', config={'addressing_style': 'virtual'})
+#             TestS3.OVERWRITTEN_CLIENT = aws_stack.create_external_boto_client('s3', config={'addressing_style': 'virtual'})
 #             wrapped()
 #             # test via host based addressing
-#             TestS3.OVERWRITTEN_CLIENT = aws_stack.connect_to_service('s3', config={'addressing_style': 'path'})
+#             TestS3.OVERWRITTEN_CLIENT = aws_stack.create_external_boto_client('s3', config={'addressing_style': 'path'})
 #             wrapped()
 #         finally:
 #             # reset client
@@ -112,8 +112,8 @@ class TestS3(unittest.TestCase):
     OVERWRITTEN_CLIENT = None
 
     def setUp(self):
-        self._s3_client = aws_stack.connect_to_service("s3")
-        self.sqs_client = aws_stack.connect_to_service("sqs")
+        self._s3_client = aws_stack.create_external_boto_client("s3")
+        self.sqs_client = aws_stack.create_external_boto_client("sqs")
 
     @property
     def s3_client(self):
@@ -970,7 +970,7 @@ class TestS3(unittest.TestCase):
         # Test setup
         bucket = "test-bucket-%s" % short_uid()
 
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
         s3_client.create_bucket(Bucket=bucket)
         s3_client.put_bucket_cors(
             Bucket=bucket,
@@ -1643,10 +1643,10 @@ class TestS3(unittest.TestCase):
         # clean up
         self._delete_bucket(bucket_name, [table_name])
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.delete_function(FunctionName=function_name)
 
-        dynamodb_client = aws_stack.connect_to_service("dynamodb")
+        dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
         dynamodb_client.delete_table(TableName=table_name)
 
     def test_s3_put_object_notification_with_sns_topic(self):
@@ -1655,7 +1655,7 @@ class TestS3(unittest.TestCase):
         queue_name = "queue-%s" % short_uid()
         key_name = "bucket-key-%s" % short_uid()
 
-        sns_client = aws_stack.connect_to_service("sns")
+        sns_client = aws_stack.create_external_boto_client("sns")
 
         self.s3_client.create_bucket(Bucket=bucket_name)
         queue_url = self.sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
@@ -1876,7 +1876,7 @@ class TestS3(unittest.TestCase):
             request.url += "requestedBy=abcDEF123"
 
         bucket_name = short_uid()
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
         s3_presign = boto3.client(
             "s3",
             endpoint_url=config.get_edge_url(),
@@ -2325,7 +2325,7 @@ class TestS3(unittest.TestCase):
             ),
         )
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.invoke(FunctionName=function_name, InvocationType="Event")
 
         retry(
@@ -2361,8 +2361,8 @@ class TestS3(unittest.TestCase):
         run("cd %s; npm i @aws-sdk/client-s3; npm i @aws-sdk/s3-request-presigner" % temp_folder)
 
         function_name = "func-integration-%s" % short_uid()
-        lambda_client = aws_stack.connect_to_service("lambda")
-        s3_client = aws_stack.connect_to_service("s3")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
+        s3_client = aws_stack.create_external_boto_client("s3")
 
         testutil.create_lambda_function(
             func_name=function_name,
@@ -2387,7 +2387,7 @@ class TestS3(unittest.TestCase):
         bucket_name = short_uid()
         port1 = 443
         port2 = 4566
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
 
         s3_presign = boto3.client(
             "s3",
@@ -2651,7 +2651,7 @@ class TestS3New:
 )
 @pytest.mark.skipif(os.environ.get("LOCALSTACK_API_KEY", "") != "", reason="replay skipped in pro")
 def test_replay_s3_call(api_version, bucket_name, payload):
-    s3_client = aws_stack.connect_to_service("s3")
+    s3_client = aws_stack.create_external_boto_client("s3")
 
     with pytest.raises(ClientError) as error:
         s3_client.head_bucket(Bucket=bucket_name)

--- a/tests/integration/test_secretsmanager.py
+++ b/tests/integration/test_secretsmanager.py
@@ -21,7 +21,7 @@ RESOURCE_POLICY = {
 
 class SecretsManagerTest(unittest.TestCase):
     def setUp(self):
-        self.secretsmanager_client = aws_stack.connect_to_service("secretsmanager")
+        self.secretsmanager_client = aws_stack.create_external_boto_client("secretsmanager")
 
     def test_create_and_update_secret(self):
         secret_name = "s-%s" % short_uid()

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -39,7 +39,7 @@ class TestCSRF(unittest.TestCase):
 
     @patch.object(config, "DISABLE_CUSTOM_CORS_S3", True)
     def test_cors_s3_override(self):
-        client = aws_stack.connect_to_service("s3")
+        client = aws_stack.create_external_boto_client("s3")
 
         BUCKET_CORS_CONFIG = {
             "CORSRules": [

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -17,7 +17,7 @@ class TestServerless(unittest.TestCase):
             # install dependencies
             run("cd %s; npm install" % base_dir)
         # list apigateway before sls deployment
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
         apis = apigw_client.get_rest_apis()["items"]
         cls.api_ids = [api["id"] for api in apis]
 
@@ -36,7 +36,7 @@ class TestServerless(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_event_rules_deployed(self):
-        events = aws_stack.connect_to_service("events")
+        events = aws_stack.create_external_boto_client("events")
         rules = events.list_rules()["Rules"]
 
         rule = ([r for r in rules if r["Name"] == "sls-test-cf-event"] or [None])[0]
@@ -55,8 +55,8 @@ class TestServerless(unittest.TestCase):
         function_name = "sls-test-local-dynamodbStreamHandler"
         table_name = "Test"
 
-        lambda_client = aws_stack.connect_to_service("lambda")
-        dynamodb_client = aws_stack.connect_to_service("dynamodb")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
+        dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
 
         resp = lambda_client.list_functions()
         function = [fn for fn in resp["Functions"] if fn["FunctionName"] == function_name][0]
@@ -76,8 +76,8 @@ class TestServerless(unittest.TestCase):
         function_name2 = "sls-test-local-kinesisConsumerHandler"
         stream_name = "KinesisTestStream"
 
-        lambda_client = aws_stack.connect_to_service("lambda")
-        kinesis_client = aws_stack.connect_to_service("kinesis")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
+        kinesis_client = aws_stack.create_external_boto_client("kinesis")
 
         resp = lambda_client.list_functions()
         function = [fn for fn in resp["Functions"] if fn["FunctionName"] == function_name][0]
@@ -104,8 +104,8 @@ class TestServerless(unittest.TestCase):
         function_name = "sls-test-local-queueHandler"
         queue_name = "sls-test-local-CreateQueue"
 
-        lambda_client = aws_stack.connect_to_service("lambda")
-        sqs_client = aws_stack.connect_to_service("sqs")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
 
         resp = lambda_client.list_functions()
         function = [fn for fn in resp["Functions"] if fn["FunctionName"] == function_name][0]
@@ -130,7 +130,7 @@ class TestServerless(unittest.TestCase):
     def test_lambda_with_configs_deployed(self):
         function_name = "sls-test-local-test"
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
 
         resp = lambda_client.list_functions()
         function = [fn for fn in resp["Functions"] if fn["FunctionName"] == function_name][0]
@@ -147,13 +147,13 @@ class TestServerless(unittest.TestCase):
     def test_apigateway_deployed(self):
         function_name = "sls-test-local-router"
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
 
         resp = lambda_client.list_functions()
         function = [fn for fn in resp["Functions"] if fn["FunctionName"] == function_name][0]
         self.assertEqual("handler.createHttpRouter", function["Handler"])
 
-        apigw_client = aws_stack.connect_to_service("apigateway")
+        apigw_client = aws_stack.create_external_boto_client("apigateway")
         apis = apigw_client.get_rest_apis()["items"]
         api_ids = [api["id"] for api in apis if api["id"] not in self.api_ids]
         self.assertEqual(1, len(api_ids))

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -47,8 +47,8 @@ TEST_LAMBDA_ECHO_FILE = os.path.join(THIS_FOLDER, "lambdas", "lambda_echo.py")
 class SNSTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.sqs_client = aws_stack.connect_to_service("sqs")
-        cls.sns_client = aws_stack.connect_to_service("sns")
+        cls.sqs_client = aws_stack.create_external_boto_client("sqs")
+        cls.sns_client = aws_stack.create_external_boto_client("sns")
         cls.topic_arn = cls.sns_client.create_topic(Name=TEST_TOPIC_NAME)["TopicArn"]
         cls.queue_url = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_NAME)["QueueUrl"]
         cls.dlq_url = cls.sqs_client.create_queue(QueueName=TEST_QUEUE_DLQ_NAME)["QueueUrl"]
@@ -712,7 +712,7 @@ class SNSTest(unittest.TestCase):
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.delete_function(FunctionName=func_name)
 
     def test_publish_message_after_subscribe_topic(self):

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -654,6 +654,7 @@ class SNSTest(unittest.TestCase):
     def test_create_topic_test_arn(self):
         response = self.sns_client.create_topic(Name=TEST_TOPIC_NAME)
         topic_arn_params = response["TopicArn"].split(":")
+        testutil.response_arn_matches_partition(self.sns_client, response["TopicArn"])
         self.assertEqual(topic_arn_params[4], TEST_AWS_ACCOUNT_ID)
         self.assertEqual(topic_arn_params[5], TEST_TOPIC_NAME)
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1149,6 +1149,7 @@ class TestSqsProvider:
         attrs = result["Attributes"]
         assert len(attrs) == 3
         assert "test-queue-" in attrs["QueueArn"]
+        assert testutil.response_arn_matches_partition(sqs_client, attrs["QueueArn"])
         assert int(float(attrs["CreatedTimestamp"])) == pytest.approx(int(time.time()), 30)
         assert int(attrs["VisibilityTimeout"]) == 30, "visibility timeout is not the default value"
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -75,7 +75,7 @@ TEST_REGION = "us-east-1"
 class SQSTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.client = aws_stack.connect_to_service("sqs")
+        cls.client = aws_stack.create_external_boto_client("sqs")
 
     def test_list_queue_tags(self):
         queue_info = self.client.create_queue(QueueName=TEST_QUEUE_NAME)
@@ -394,7 +394,7 @@ class SQSTest(unittest.TestCase):
         self.client.delete_queue(QueueUrl=dlq_info["QueueUrl"])
 
     def test_dead_letter_queue_execution(self):
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
 
         # create SQS queue with DLQ redrive policy
         queue_name1 = "dlq-%s" % short_uid()
@@ -581,7 +581,7 @@ class SQSTest(unittest.TestCase):
             runtime=LAMBDA_RUNTIME_PYTHON36,
         )
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.create_event_source_mapping(
             EventSourceArn=aws_stack.sqs_queue_arn(queue_name),
             FunctionName=function_name,
@@ -685,7 +685,7 @@ class SQSTest(unittest.TestCase):
             runtime=LAMBDA_RUNTIME_PYTHON36,
         )
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.create_event_source_mapping(
             EventSourceArn=queue_arn, FunctionName=function_name
         )
@@ -779,7 +779,7 @@ class SQSTest(unittest.TestCase):
             func_name=func_name, zip_file=zip_file, handler=handler, runtime=runtime
         )
 
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_client.create_event_source_mapping(EventSourceArn=queue_arn, FunctionName=func_name)
 
         self.client.send_message(

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -168,9 +168,9 @@ STATE_MACHINE_EVENTS = {
 class TestStateMachine(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.lambda_client = aws_stack.connect_to_service("lambda")
-        cls.s3_client = aws_stack.connect_to_service("s3")
-        cls.sfn_client = aws_stack.connect_to_service("stepfunctions")
+        cls.lambda_client = aws_stack.create_external_boto_client("lambda")
+        cls.s3_client = aws_stack.create_external_boto_client("s3")
+        cls.sfn_client = aws_stack.create_external_boto_client("stepfunctions")
 
         zip_file = testutil.create_lambda_archive(load_file(TEST_LAMBDA_PYTHON), get_content=True)
         zip_file2 = testutil.create_lambda_archive(load_file(TEST_LAMBDA_ECHO), get_content=True)
@@ -391,7 +391,7 @@ class TestStateMachine(unittest.TestCase):
         self.cleanup(sm_arn, state_machines_before)
 
     def test_events_state_machine(self):
-        events = aws_stack.connect_to_service("events")
+        events = aws_stack.create_external_boto_client("events")
         state_machines_before = self.sfn_client.list_state_machines()["stateMachines"]
 
         # create event bus
@@ -476,8 +476,8 @@ TEST_STATE_MACHINE = {
 def test_multiregion(region_name):
     other_region = "us-east-1" if region_name != "us-east-1" else "us-east-2"
     # TODO: create client factory fixture
-    client1 = aws_stack.connect_to_service("stepfunctions", region_name=region_name)
-    client2 = aws_stack.connect_to_service("stepfunctions", region_name=other_region)
+    client1 = aws_stack.create_external_boto_client("stepfunctions", region_name=region_name)
+    client2 = aws_stack.create_external_boto_client("stepfunctions", region_name=other_region)
 
     # create state machine
     name = "sf-%s" % short_uid()

--- a/tests/integration/test_sts.py
+++ b/tests/integration/test_sts.py
@@ -6,7 +6,7 @@ from localstack.utils.aws import aws_stack
 
 class TestSTSIntegrations(unittest.TestCase):
     def setUp(self):
-        self.sts_client = aws_stack.connect_to_service("sts")
+        self.sts_client = aws_stack.create_external_boto_client("sts")
 
     def test_assume_role(self):
         test_role_session_name = "s3-access-example"

--- a/tests/integration/test_support.py
+++ b/tests/integration/test_support.py
@@ -13,7 +13,10 @@ TEST_SUPPORT_CASE = {
 
 class TestConfigService(unittest.TestCase):
     def setUp(self):
-        self.support_client = aws_stack.connect_to_service("support")
+        # support is only available in us-east-1
+        self.support_client = aws_stack.create_external_boto_client(
+            "support", region_name="us-east-1"
+        )
 
     def create_case(self):
         response = self.support_client.create_case(

--- a/tests/integration/test_swf.py
+++ b/tests/integration/test_swf.py
@@ -8,7 +8,7 @@ DEFAULT_TASK_LIST = {"name": "default"}
 
 class TestSwf(unittest.TestCase):
     def setUp(self):
-        self.swf_client = aws_stack.connect_to_service("swf")
+        self.swf_client = aws_stack.create_external_boto_client("swf")
 
         self.swf_unique_id = datetime.datetime.now().isoformat()
         self.swf_version = "1.0"

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -83,7 +83,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_bucket_exists(self):
-        s3_client = aws_stack.connect_to_service("s3")
+        s3_client = aws_stack.create_external_boto_client("s3")
 
         response = s3_client.head_bucket(Bucket=BUCKET_NAME)
         self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
@@ -104,7 +104,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_sqs(self):
-        sqs_client = aws_stack.connect_to_service("sqs")
+        sqs_client = aws_stack.create_external_boto_client("sqs")
         queue_url = sqs_client.get_queue_url(QueueName=QUEUE_NAME)["QueueUrl"]
         response = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["All"])
 
@@ -115,7 +115,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_lambda(self):
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         response = lambda_client.get_function(FunctionName=LAMBDA_NAME)
         self.assertEqual(LAMBDA_NAME, response["Configuration"]["FunctionName"])
         self.assertEqual(LAMBDA_HANDLER, response["Configuration"]["Handler"])
@@ -124,7 +124,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_event_source_mapping(self):
-        lambda_client = aws_stack.connect_to_service("lambda")
+        lambda_client = aws_stack.create_external_boto_client("lambda")
         all_mappings = lambda_client.list_event_source_mappings(
             EventSourceArn=QUEUE_ARN, FunctionName=LAMBDA_NAME
         )
@@ -134,7 +134,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_apigateway(self):
-        apigateway_client = aws_stack.connect_to_service("apigateway")
+        apigateway_client = aws_stack.create_external_boto_client("apigateway")
         rest_apis = apigateway_client.get_rest_apis()
 
         rest_id = None
@@ -166,7 +166,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_route53(self):
-        route53 = aws_stack.connect_to_service("route53")
+        route53 = aws_stack.create_external_boto_client("route53")
 
         response = route53.create_hosted_zone(Name="zone123", CallerReference="ref123")
         self.assertEqual(201, response["ResponseMetadata"]["HTTPStatusCode"])
@@ -177,7 +177,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_acm(self):
-        acm = aws_stack.connect_to_service("acm")
+        acm = aws_stack.create_external_boto_client("acm")
 
         certs = acm.list_certificates()["CertificateSummaryList"]
         certs = [c for c in certs if c.get("DomainName") == "example.com"]
@@ -185,7 +185,7 @@ class TestTerraform(unittest.TestCase):
 
     @pytest.mark.skip_offline
     def test_apigateway_escaped_policy(self):
-        apigateway_client = aws_stack.connect_to_service("apigateway")
+        apigateway_client = aws_stack.create_external_boto_client("apigateway")
         rest_apis = apigateway_client.get_rest_apis()
 
         service_apis = []
@@ -201,7 +201,7 @@ class TestTerraform(unittest.TestCase):
         def _table_exists(tablename, dynamotables):
             return any(name for name in dynamotables["TableNames"] if name == tablename)
 
-        dynamo_client = aws_stack.connect_to_service("dynamodb")
+        dynamo_client = aws_stack.create_external_boto_client("dynamodb")
         tables = dynamo_client.list_tables()
         self.assertTrue(_table_exists("tf_dynamotable1", tables))
         self.assertTrue(_table_exists("tf_dynamotable2", tables))

--- a/tests/performance/test_sqs_performance.py
+++ b/tests/performance/test_sqs_performance.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from localstack.utils.aws.aws_stack import connect_to_service, get_sqs_queue_url
+from localstack.utils.aws.aws_stack import create_external_boto_client, get_sqs_queue_url
 
 QUEUE_NAME = "test-perf-3610"
 NUM_MESSAGES = 300
@@ -16,7 +16,7 @@ def print_duration(start, num_msgs, action):
 
 
 def send_messages():
-    sqs = connect_to_service("sqs")
+    sqs = create_external_boto_client("sqs")
     queue_url = sqs.create_queue(QueueName=QUEUE_NAME)["QueueUrl"]
 
     print("Starting to send %s messages" % NUM_MESSAGES)
@@ -27,7 +27,7 @@ def send_messages():
 
 
 def receive_messages():
-    sqs = connect_to_service("sqs")
+    sqs = create_external_boto_client("sqs")
     queue_url = get_sqs_queue_url(QUEUE_NAME)
     messages = []
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,21 @@
+from contextlib import contextmanager
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def switch_region():
+    """A fixture which allows to easily switch the region in the config within a `with` context."""
+
+    @contextmanager
+    def _switch_region(region: str):
+        from localstack import config
+
+        previous_region = config.DEFAULT_REGION
+        try:
+            config.DEFAULT_REGION = region
+            yield
+        finally:
+            config.DEFAULT_REGION = previous_region
+
+    return _switch_region

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -1,78 +1,109 @@
 import json
 
+import pytest
 from requests.models import Response
 
 from localstack.services.generic_proxy import PartitionAdjustingProxyListener
+from localstack.utils.common import to_bytes, to_str
+
+# Define the callables used to convert the payload to the appropriate encoding for the tests
+byte_encoding = to_bytes
+string_encoding = to_str
 
 
-def test_partition_adjustment_in_request():
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_partition_adjustment_in_request(encoding):
     listener = PartitionAdjustingProxyListener()
-    data = json.dumps(
-        {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    data = encoding(
+        json.dumps(
+            {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+        )
     )
     headers = {
         "some-header-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
     }
     result = listener.forward_request(
         method="POST",
-        # TODO check if this is url encoded at this time
-        path="/?arn=arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-path/*",
-        # TODO check if this is binary encoded at this time
+        path="/?arn=arn%3Aaws%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path%2F%2A&"
+        "arn2=arn%3Aaws%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path2%2F%2A",
         data=data,
         headers=headers,
     )
     assert result.method == "POST"
-    assert result.path == "/?arn=arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-path/*"
-    assert result.data == json.dumps(
-        {"some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    assert (
+        result.path
+        == "/?arn=arn%3Aaws-us-gov%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path%2F%2A&"
+        "arn2=arn%3Aaws-us-gov%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path2%2F%2A"
+    )
+    assert result.data == encoding(
+        json.dumps(
+            {
+                "some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"
+            }
+        )
     )
     assert result.headers == {
         "some-header-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
     }
 
 
-def test_partition_adjustment_in_request_without_region_and_without_default_partition():
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_partition_adjustment_in_request_without_region_and_without_default_partition(encoding):
     listener = PartitionAdjustingProxyListener()
-    data = json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
+    data = encoding(
+        json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
+    )
     headers = {"some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"}
     result = listener.forward_request(
         method="POST",
-        path="/?arn=arn:aws-us-gov:iam::123456789012:ArnInPath",
+        path="/?arn=arn%3Aaws%3Aiam%3A%3A123456789012%3AArnInPath&"
+        "arn2=arn%3Aaws%3Aiam%3A%3A123456789012%3AArnInPath2",
         data=data,
         headers=headers,
     )
     assert result.method == "POST"
-    assert result.path == "/?arn=arn:aws:iam::123456789012:ArnInPath"
-    assert result.data == json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
+    assert (
+        result.path == "/?arn=arn%3Aaws%3Aiam%3A%3A123456789012%3AArnInPath&"
+        "arn2=arn%3Aaws%3Aiam%3A%3A123456789012%3AArnInPath2"
+    )
+    assert result.data == encoding(
+        json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
+    )
     assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
 
 
-def test_partition_adjustment_in_request_without_region_and_with_default_region(switch_region):
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_partition_adjustment_in_request_without_region_and_with_default_region(
+    encoding, switch_region
+):
     with switch_region("us-gov-east-1"):
         listener = PartitionAdjustingProxyListener()
-        data = json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
+        data = encoding(json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"}))
         headers = {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
         result = listener.forward_request(
             method="POST",
-            path="/?arn=arn:aws:iam::123456789012:ArnInPath",
+            path="/?arn=arn%3Aaws%3Aiam%3A%3A123456789012%3AArnInPath",
             data=data,
             headers=headers,
         )
         assert result.method == "POST"
-        assert result.path == "/?arn=arn:aws-us-gov:iam::123456789012:ArnInPath"
-        assert result.data == json.dumps(
-            {"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"}
+        assert result.path == "/?arn=arn%3Aaws-us-gov%3Aiam%3A%3A123456789012%3AArnInPath"
+        assert result.data == encoding(
+            json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
         )
         assert result.headers == {
             "some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"
         }
 
 
-def test_partition_adjustment_in_response():
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_partition_adjustment_in_response(encoding):
     listener = PartitionAdjustingProxyListener()
     response = Response()
-    response._content = json.dumps(
-        {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    response._content = encoding(
+        json.dumps(
+            {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+        )
     )
     response._status_code = 200
     response.headers = {
@@ -87,16 +118,21 @@ def test_partition_adjustment_in_response():
     assert result.headers == {
         "some-header-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
     }
-    assert result.content == json.dumps(
-        {"some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    assert result.content == encoding(
+        json.dumps(
+            {
+                "some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"
+            }
+        )
     )
 
 
-def test_partition_adjustment_in_response_without_region_and_without_default_region():
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_partition_adjustment_in_response_without_region_and_without_default_region(encoding):
     listener = PartitionAdjustingProxyListener()
     response = Response()
-    response._content = json.dumps(
-        {"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"}
+    response._content = encoding(
+        json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
     )
     response._status_code = 200
     response.headers = {"some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"}
@@ -107,17 +143,20 @@ def test_partition_adjustment_in_response_without_region_and_without_default_reg
 
     assert result.status_code == response.status_code
     assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
-    assert result.content == json.dumps(
-        {"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"}
+    assert result.content == encoding(
+        json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
     )
 
 
-def test_partition_adjustment_in_response_without_region_and_with_default_region(switch_region):
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_partition_adjustment_in_response_without_region_and_with_default_region(
+    encoding, switch_region
+):
     with switch_region("us-gov-east-1"):
         listener = PartitionAdjustingProxyListener()
         response = Response()
-        response._content = json.dumps(
-            {"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"}
+        response._content = encoding(
+            json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
         )
         response._status_code = 200
         response.headers = {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
@@ -130,6 +169,6 @@ def test_partition_adjustment_in_response_without_region_and_with_default_region
         assert result.headers == {
             "some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"
         }
-        assert result.content == json.dumps(
-            {"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"}
+        assert result.content == encoding(
+            json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
         )

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -77,33 +77,6 @@ def test_partition_adjustment_in_request_without_region_and_without_default_part
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
-@pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
-def test_partition_adjustment_in_request_without_region_and_with_default_region(
-    encoding, switch_region, origin_partition
-):
-    with switch_region("us-gov-east-1"):
-        listener = PartitionAdjustingProxyListener()
-        data = encoding(
-            json.dumps(
-                {"some-data-with-arn": f"arn:{origin_partition}:iam::123456789012:ArnInData"}
-            )
-        )
-        headers = {"some-header-with-arn": f"arn:{origin_partition}:iam::123456789012:ArnInHeader"}
-        result = listener.forward_request(
-            method="POST",
-            path=f"/?arn=arn%3A{origin_partition}%3Aiam%3A%3A123456789012%3AArnInPath",
-            data=data,
-            headers=headers,
-        )
-        assert result.method == "POST"
-        assert result.path == "/?arn=arn%3Aaws%3Aiam%3A%3A123456789012%3AArnInPath"
-        assert result.data == encoding(
-            json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
-        )
-        assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
-
-
-@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 def test_partition_adjustment_in_response(encoding):
     listener = PartitionAdjustingProxyListener()
     response = Response()

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -1,0 +1,135 @@
+import json
+
+from requests.models import Response
+
+from localstack.services.generic_proxy import PartitionAdjustingProxyListener
+
+
+def test_partition_adjustment_in_request():
+    listener = PartitionAdjustingProxyListener()
+    data = json.dumps(
+        {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    )
+    headers = {
+        "some-header-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    }
+    result = listener.forward_request(
+        method="POST",
+        # TODO check if this is url encoded at this time
+        path="/?arn=arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-path/*",
+        # TODO check if this is binary encoded at this time
+        data=data,
+        headers=headers,
+    )
+    assert result.method == "POST"
+    assert result.path == "/?arn=arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-path/*"
+    assert result.data == json.dumps(
+        {"some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    )
+    assert result.headers == {
+        "some-header-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    }
+
+
+def test_partition_adjustment_in_request_without_region_and_without_default_partition():
+    listener = PartitionAdjustingProxyListener()
+    data = json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
+    headers = {"some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"}
+    result = listener.forward_request(
+        method="POST",
+        path="/?arn=arn:aws-us-gov:iam::123456789012:ArnInPath",
+        data=data,
+        headers=headers,
+    )
+    assert result.method == "POST"
+    assert result.path == "/?arn=arn:aws:iam::123456789012:ArnInPath"
+    assert result.data == json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
+    assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
+
+
+def test_partition_adjustment_in_request_without_region_and_with_default_region(switch_region):
+    with switch_region("us-gov-east-1"):
+        listener = PartitionAdjustingProxyListener()
+        data = json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
+        headers = {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
+        result = listener.forward_request(
+            method="POST",
+            path="/?arn=arn:aws:iam::123456789012:ArnInPath",
+            data=data,
+            headers=headers,
+        )
+        assert result.method == "POST"
+        assert result.path == "/?arn=arn:aws-us-gov:iam::123456789012:ArnInPath"
+        assert result.data == json.dumps(
+            {"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"}
+        )
+        assert result.headers == {
+            "some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"
+        }
+
+
+def test_partition_adjustment_in_response():
+    listener = PartitionAdjustingProxyListener()
+    response = Response()
+    response._content = json.dumps(
+        {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    )
+    response._status_code = 200
+    response.headers = {
+        "some-header-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    }
+
+    result = listener.return_response(
+        method="POST", path="/", data="ignored", headers={}, response=response
+    )
+
+    assert result.status_code == response.status_code
+    assert result.headers == {
+        "some-header-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    }
+    assert result.content == json.dumps(
+        {"some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    )
+
+
+def test_partition_adjustment_in_response_without_region_and_without_default_region():
+    listener = PartitionAdjustingProxyListener()
+    response = Response()
+    response._content = json.dumps(
+        {"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"}
+    )
+    response._status_code = 200
+    response.headers = {"some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"}
+
+    result = listener.return_response(
+        method="POST", path="/", data="ignored", headers={}, response=response
+    )
+
+    assert result.status_code == response.status_code
+    assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
+    assert result.content == json.dumps(
+        {"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"}
+    )
+
+
+def test_partition_adjustment_in_response_without_region_and_with_default_region(switch_region):
+    with switch_region("us-gov-east-1"):
+        listener = PartitionAdjustingProxyListener()
+        response = Response()
+        response._content = json.dumps(
+            {"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"}
+        )
+        response._status_code = 200
+        response.headers = {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
+
+        result = listener.return_response(
+            method="POST", path="/", data="ignored", headers={}, response=response
+        )
+
+        assert result.status_code == response.status_code
+        assert result.headers == {
+            "some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"
+        }
+        assert result.content == json.dumps(
+            {"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"}
+        )

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -12,6 +12,23 @@ string_encoding = to_str
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+def test_no_partition_adjustment_in_request(encoding):
+    listener = PartitionAdjustingProxyListener()
+    data = encoding(json.dumps({"some-data-without-arn": "nothing to see here"}))
+    headers = {"some-header-without-arn": "nothing to see here"}
+    result = listener.forward_request(
+        method="POST",
+        path="/?nothingtoseehere",
+        data=data,
+        headers=headers,
+    )
+    assert result.method == "POST"
+    assert result.path == "/?nothingtoseehere"
+    assert result.data == encoding(json.dumps({"some-data-without-arn": "nothing to see here"}))
+    assert result.headers == {"some-header-without-arn": "nothing to see here"}
+
+
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 @pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
 def test_partition_adjustment_in_request(encoding, origin_partition):
     listener = PartitionAdjustingProxyListener()

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from requests.models import Response
 
-from localstack.services.generic_proxy import ArnPartitionRewritingListener
+from localstack.services.generic_proxy import ArnPartitionRewriteListener
 from localstack.utils.common import to_bytes, to_str
 
 # Define the callables used to convert the payload to the appropriate encoding for the tests
@@ -13,7 +13,7 @@ string_encoding = to_str
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 def test_no_arn_partition_rewriting_in_request(encoding):
-    listener = ArnPartitionRewritingListener()
+    listener = ArnPartitionRewriteListener()
     data = encoding(json.dumps({"some-data-without-arn": "nothing to see here"}))
     headers = {"some-header-without-arn": "nothing to see here"}
     result = listener.forward_request(
@@ -31,7 +31,7 @@ def test_no_arn_partition_rewriting_in_request(encoding):
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 @pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
 def test_arn_partition_rewriting_in_request(encoding, origin_partition):
-    listener = ArnPartitionRewritingListener()
+    listener = ArnPartitionRewriteListener()
     data = encoding(
         json.dumps(
             {
@@ -70,7 +70,7 @@ def test_arn_partition_rewriting_in_request(encoding, origin_partition):
 def test_arn_partition_rewriting_in_request_without_region_and_without_default_partition(
     encoding, origin_partition
 ):
-    listener = ArnPartitionRewritingListener()
+    listener = ArnPartitionRewriteListener()
     data = encoding(
         json.dumps({"some-data-with-arn": f"arn:{origin_partition}:iam::123456789012:ArnInData"})
     )
@@ -95,7 +95,7 @@ def test_arn_partition_rewriting_in_request_without_region_and_without_default_p
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 def test_arn_partition_rewriting_in_response(encoding):
-    listener = ArnPartitionRewritingListener()
+    listener = ArnPartitionRewriteListener()
     response = Response()
     response._content = encoding(
         json.dumps(
@@ -126,7 +126,7 @@ def test_arn_partition_rewriting_in_response(encoding):
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 def test_arn_partition_rewriting_in_response_without_region_and_without_default_region(encoding):
-    listener = ArnPartitionRewritingListener()
+    listener = ArnPartitionRewriteListener()
     response = Response()
     response._content = encoding(
         json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
@@ -150,7 +150,7 @@ def test_arn_partition_rewriting_in_response_without_region_and_with_default_reg
     encoding, switch_region
 ):
     with switch_region("us-gov-east-1"):
-        listener = ArnPartitionRewritingListener()
+        listener = ArnPartitionRewriteListener()
         response = Response()
         response._content = encoding(
             json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from requests.models import Response
 
-from localstack.services.generic_proxy import PartitionAdjustingProxyListener
+from localstack.services.generic_proxy import ArnPartitionRewritingListener
 from localstack.utils.common import to_bytes, to_str
 
 # Define the callables used to convert the payload to the appropriate encoding for the tests
@@ -12,8 +12,8 @@ string_encoding = to_str
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
-def test_no_partition_adjustment_in_request(encoding):
-    listener = PartitionAdjustingProxyListener()
+def test_no_arn_partition_rewriting_in_request(encoding):
+    listener = ArnPartitionRewritingListener()
     data = encoding(json.dumps({"some-data-without-arn": "nothing to see here"}))
     headers = {"some-header-without-arn": "nothing to see here"}
     result = listener.forward_request(
@@ -30,8 +30,8 @@ def test_no_partition_adjustment_in_request(encoding):
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 @pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
-def test_partition_adjustment_in_request(encoding, origin_partition):
-    listener = PartitionAdjustingProxyListener()
+def test_arn_partition_rewriting_in_request(encoding, origin_partition):
+    listener = ArnPartitionRewritingListener()
     data = encoding(
         json.dumps(
             {
@@ -67,10 +67,10 @@ def test_partition_adjustment_in_request(encoding, origin_partition):
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 @pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
-def test_partition_adjustment_in_request_without_region_and_without_default_partition(
+def test_arn_partition_rewriting_in_request_without_region_and_without_default_partition(
     encoding, origin_partition
 ):
-    listener = PartitionAdjustingProxyListener()
+    listener = ArnPartitionRewritingListener()
     data = encoding(
         json.dumps({"some-data-with-arn": f"arn:{origin_partition}:iam::123456789012:ArnInData"})
     )
@@ -94,8 +94,8 @@ def test_partition_adjustment_in_request_without_region_and_without_default_part
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
-def test_partition_adjustment_in_response(encoding):
-    listener = PartitionAdjustingProxyListener()
+def test_arn_partition_rewriting_in_response(encoding):
+    listener = ArnPartitionRewritingListener()
     response = Response()
     response._content = encoding(
         json.dumps(
@@ -125,8 +125,8 @@ def test_partition_adjustment_in_response(encoding):
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
-def test_partition_adjustment_in_response_without_region_and_without_default_region(encoding):
-    listener = PartitionAdjustingProxyListener()
+def test_arn_partition_rewriting_in_response_without_region_and_without_default_region(encoding):
+    listener = ArnPartitionRewritingListener()
     response = Response()
     response._content = encoding(
         json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
@@ -146,11 +146,11 @@ def test_partition_adjustment_in_response_without_region_and_without_default_reg
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
-def test_partition_adjustment_in_response_without_region_and_with_default_region(
+def test_arn_partition_rewriting_in_response_without_region_and_with_default_region(
     encoding, switch_region
 ):
     with switch_region("us-gov-east-1"):
-        listener = PartitionAdjustingProxyListener()
+        listener = ArnPartitionRewritingListener()
         response = Response()
         response._content = encoding(
             json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})


### PR DESCRIPTION
This PR adds initial support for in-place rewriting of ARN partitions.
Currently, we cannot really support other regions due to the assumption of the default partition ("aws") in LocalStack as well as in moto.
In order to support other partitions without rewriting all this code, this PR introduces the `PartitionAdjustingProxyListener`.
This listener replaces the partition in ARNs in requests as well as in responses based on:
- The region in the ARN.
- If the region is not specific for a partition (f.e. `*`) it defaults to the partition of the `DEFAULT_REGION`.

This PR is still a work in progress.