### PR TITLE
Reject empty SNS messages

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -165,6 +165,12 @@ class ProxyListenerSNS(PersistingProxyListener):
             elif req_action == "Publish":
                 if req_data.get("Subject") == [""]:
                     return make_error(code=400, code_string="InvalidParameter", message="Subject")
+                if not req_data.get("Message") or all(
+                    not message for message in req_data.get("Message")
+                ):
+                    return make_error(
+                        code=400, code_string="InvalidParameter", message="Empty message"
+                    )
                 sns_backend = SNSBackend.get()
                 # No need to create a topic to send SMS or single push notifications with SNS
                 # but we can't mock a sending so we only return that it went well

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, List
 import boto3
 import botocore.config
 import pytest
-from mypy_boto3_sns.type_defs import GetTopicAttributesResponseTypeDef
 
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -30,6 +29,7 @@ if TYPE_CHECKING:
     from mypy_boto3_secretsmanager import SecretsManagerClient
     from mypy_boto3_ses import SESClient
     from mypy_boto3_sns import SNSClient
+    from mypy_boto3_sns.type_defs import GetTopicAttributesResponseTypeDef
     from mypy_boto3_sqs import SQSClient
     from mypy_boto3_ssm import SSMClient
     from mypy_boto3_stepfunctions import SFNClient

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List
 import boto3
 import botocore.config
 import pytest
+from mypy_boto3_sns.type_defs import GetTopicAttributesResponseTypeDef
 
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -229,13 +230,29 @@ def sqs_queue(sqs_create_queue):
 
 
 @pytest.fixture
-def sns_topic(sns_client):
-    # TODO: add fixture factories
-    topic_name = "test-topic-%s" % short_uid()
-    response = sns_client.create_topic(Name=topic_name)
-    topic_arn = response["TopicArn"]
-    yield sns_client.get_topic_attributes(TopicArn=topic_arn)
-    sns_client.delete_topic(TopicArn=topic_arn)
+def sns_create_topic(sns_client):
+    topic_arns = []
+
+    def _create_topic(**kwargs):
+        if "Name" not in kwargs:
+            kwargs["Name"] = "test-topic-%s" % short_uid()
+        response = sns_client.create_topic(**kwargs)
+        topic_arns.append(response["TopicArn"])
+        return response
+
+    yield _create_topic
+
+    for topic_arn in topic_arns:
+        try:
+            sns_client.delete_topic(TopicArn=topic_arn)
+        except Exception as e:
+            LOG.debug("error cleaning up topic %s: %s", topic_arn, e)
+
+
+@pytest.fixture
+def sns_topic(sns_client, sns_create_topic) -> "GetTopicAttributesResponseTypeDef":
+    topic_arn = sns_create_topic()["TopicArn"]
+    return sns_client.get_topic_attributes(TopicArn=topic_arn)
 
 
 @pytest.fixture


### PR DESCRIPTION
Currently, empty SNS messages are permitted, this diverges from AWS behavior.

This PR introduces a check if the message is empty, and adds a test to check if an empty message is successfully rejected.
Also a TODO was acted upon to add a sns_create_topic fixture to create multiple topics if necessary.

Test also passes against AWS.

Fixes #5096 