### PR TITLE
WIP: dirty fixes for podman

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -616,9 +616,8 @@ def configure_container(container: LocalstackContainer):
 
     configure_volume_mounts(container)
 
-    # TODO: no need in podman container (docker runs inside podman without this)
     # mount docker socket
-    # container.volumes.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
+    container.volumes.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
 
     container.additional_flags.append("--privileged")
 

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -616,8 +616,9 @@ def configure_container(container: LocalstackContainer):
 
     configure_volume_mounts(container)
 
+    # TODO: no need in podman container (docker runs inside podman without this)
     # mount docker socket
-    container.volumes.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
+    # container.volumes.append((config.DOCKER_SOCK, config.DOCKER_SOCK))
 
     container.additional_flags.append("--privileged")
 

--- a/podman.md
+++ b/podman.md
@@ -1,31 +1,60 @@
-## Rootfull Podman
+To use `podman` to run `localstack`, just alias `alias docker=podman` is not enough, `localstack` is using [docker-py](https://pypi.org/project/docker/) which requires connection to `/var/run/docker.sock`.
 
-### With podman-docker
+## podman-docker
+
+There is package `podman-docker` that emulates Docker CLI using podman, it creates links
+- `/usr/bin/docker ->  /usr/bin/podman`
+- `/var/run/docker.sock -> /run/podman/podman.sock`
+
+This package is available for some distros:
 - https://archlinux.org/packages/community/x86_64/podman-docker/
+- https://packages.ubuntu.com/impish/podman-docker
 - https://packages.debian.org/sid/podman-docker
 
-```
-systemctl start podman.service
-DEBUG=1 localstack start
+## Rootfull Podman with podman-docker
+
+The simplest option is to run `localstack` using `podman` by having `podman-docker` and running `localstack start` as root
+```sh
+# you have to start podman socket first
+sudo systemctl start podman
+
+# then
+sudo sh -c 'DEBUG=1 localstack start'
 ```
 
-### Without podman-docker
-```
-systemctl start podman.service
-DEBUG=1 DOCKER_CMD=podman DOCKER_HOST=unix://run/podman/podman.sock DOCKER_SOCK=/run/podman/podman.sock localstack start
+## Rootfull Podman without podman-docker
+```sh
+# you still have to start podman socket first
+sudo systemctl start podman
+
+# you have to pass a bunch of env variables
+sudo sh -c 'DEBUG=1 DOCKER_CMD=podman DOCKER_HOST=unix://run/podman/podman.sock DOCKER_SOCK=/run/podman/podman.sock localstack start'
 ```
 
 ## Rootless Podman
+You have to prepare your environment first:
 - https://wiki.archlinux.org/title/Podman#Rootless_Podman
 - https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
-- https://www.redhat.com/sysadmin/controlling-access-rootless-podman-users ignore_chown_errors=true
 - https://www.redhat.com/sysadmin/rootless-podman
-- https://github.com/containers/podman/issues/7704
 
-```
+```sh
+# again you have to start podman socket first
 systemctl --user start podman.service
-DEBUG=1 DOCKER_CMD="podman --log-level=debug --storage-opt overlay.ignore_chown_errors=true" DOCKER_SOCK=$XDG_RUNTIME_DIR/podman/podman.sock DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock localstack start
+
+# and then localstack
+DEBUG=1 DOCKER_CMD="podman" DOCKER_SOCK=$XDG_RUNTIME_DIR/podman/podman.sock DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock localstack start
 ```
 
-## Other
-- https://www.redhat.com/sysadmin/podman-inside-container
+If you have problems with [subuid and subgid](https://wiki.archlinux.org/title/Podman#Set_subuid_and_subgid) you could try use [overlay.ignore_chown_errors option](https://www.redhat.com/sysadmin/controlling-access-rootless-podman-users)
+```sh
+DEBUG=1 DOCKER_CMD="podman --storage-opt overlay.ignore_chown_errors=true" DOCKER_SOCK=$XDG_RUNTIME_DIR/podman/podman.sock DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock localstack start
+```
+
+## Skip /var/run/docker.sock socket
+
+There is another option with `LEGACY_DOCKER_CLIENT=1`, but its legacy
+
+```sh
+DEBUG=1 DOCKER_CMD="sudo docker" LEGACY_DOCKER_CLIENT=1 localstack start
+```
+

--- a/podman.md
+++ b/podman.md
@@ -1,0 +1,31 @@
+## Rootfull Podman
+
+### With podman-docker
+- https://archlinux.org/packages/community/x86_64/podman-docker/
+- https://packages.debian.org/sid/podman-docker
+
+```
+systemctl start podman.service
+DEBUG=1 localstack start
+```
+
+### Without podman-docker
+```
+systemctl start podman.service
+DEBUG=1 DOCKER_CMD=podman DOCKER_HOST=unix://run/podman/podman.sock DOCKER_SOCK=/run/podman/podman.sock localstack start
+```
+
+## Rootless Podman
+- https://wiki.archlinux.org/title/Podman#Rootless_Podman
+- https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
+- https://www.redhat.com/sysadmin/controlling-access-rootless-podman-users ignore_chown_errors=true
+- https://www.redhat.com/sysadmin/rootless-podman
+- https://github.com/containers/podman/issues/7704
+
+```
+systemctl --user start podman.service
+DEBUG=1 DOCKER_CMD="podman --log-level=debug --storage-opt overlay.ignore_chown_errors=true" DOCKER_SOCK=$XDG_RUNTIME_DIR/podman/podman.sock DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock localstack start
+```
+
+## Other
+- https://www.redhat.com/sysadmin/podman-inside-container


### PR DESCRIPTION
*This PR is probably will be closed anyway, this is just for historical purposes.*

I will use these changes for HackDays demo. 

With this set of dirty fixes, I was able to run `localstack` with `podman`, so it works almost out of the box :D with the simplest option (running `podman` as root with `podman-docker`).

There are many ways to run `podman` including **rootless** and **rootfull** modes

With rootless `podman`, you have two options:
* [Set subuid and subgid](https://wiki.archlinux.org/title/Podman#Set_subuid_and_subgid)
* use `podman --storage-opt overlay.ignore_chown_errors=true`

The main questions would be:
- which option do we want to support from CLI?
- should we just create a doc page for all possible options?

P.S. I added `podman.md` file mainly for my notes
