### PR TITLE
Automatically pull images on image inspection

### DIFF
--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -395,9 +395,13 @@ class ContainerClient(metaclass=ABCMeta):
         """
         pass
 
-    def get_image_cmd(self, docker_image: str) -> str:
-        """Get the command for the given image"""
-        cmd_list = self.inspect_image(docker_image)["Config"]["Cmd"] or []
+    def get_image_cmd(self, docker_image: str, pull: bool = True) -> str:
+        """Get the command for the given image
+        :param docker_image: Docker image to inspect
+        :param pull: Whether to pull if image is not present
+        :return: Image command
+        """
+        cmd_list = self.inspect_image(docker_image, pull)["Config"]["Cmd"] or []
         return " ".join(cmd_list)
 
     def get_image_entrypoint(self, docker_image: str, pull: bool = True) -> str:
@@ -407,7 +411,7 @@ class ContainerClient(metaclass=ABCMeta):
         :return: Image entrypoint
         """
         LOG.debug("Getting the entrypoint for image: %s", docker_image)
-        entrypoint_list = self.inspect_image(docker_image)["Config"]["Entrypoint"] or []
+        entrypoint_list = self.inspect_image(docker_image, pull)["Config"]["Entrypoint"] or []
         return " ".join(entrypoint_list)
 
     @abstractmethod

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -362,9 +362,11 @@ class ContainerClient(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def inspect_image(self, image_name: str) -> Dict[str, Union[Dict, str]]:
+    def inspect_image(self, image_name: str, pull: bool = True) -> Dict[str, Union[Dict, str]]:
         """Get detailed attributes of an image.
 
+        :param image_name: Image name to inspect
+        :param pull: Whether to pull image if not existent
         :return: Dict containing docker attributes as returned by the daemon
         """
         pass
@@ -398,8 +400,12 @@ class ContainerClient(metaclass=ABCMeta):
         cmd_list = self.inspect_image(docker_image)["Config"]["Cmd"] or []
         return " ".join(cmd_list)
 
-    def get_image_entrypoint(self, docker_image: str) -> str:
-        """Get the entry point for the given image"""
+    def get_image_entrypoint(self, docker_image: str, pull: bool = True) -> str:
+        """Get the entry point for the given image
+        :param docker_image: Docker image to inspect
+        :param pull: Whether to pull if image is not present
+        :return: Image entrypoint
+        """
         LOG.debug("Getting the entrypoint for image: %s", docker_image)
         entrypoint_list = self.inspect_image(docker_image)["Config"]["Entrypoint"] or []
         return " ".join(entrypoint_list)
@@ -707,10 +713,13 @@ class CmdDockerClient(ContainerClient):
         except NoSuchObject as e:
             raise NoSuchContainer(container_name_or_id=e.object_id)
 
-    def inspect_image(self, image_name: str) -> Dict[str, Union[Dict, str]]:
+    def inspect_image(self, image_name: str, pull: bool = True) -> Dict[str, Union[Dict, str]]:
         try:
             return self._inspect_object(image_name)
         except NoSuchObject as e:
+            if pull:
+                self.pull_image(image_name)
+                return self.inspect_image(image_name, pull=False)
             raise NoSuchImage(image_name=e.object_id)
 
     def inspect_network(self, network_name: str) -> Dict[str, Union[Dict, str]]:
@@ -1312,10 +1321,13 @@ class SdkDockerClient(ContainerClient):
         except APIError:
             raise ContainerException()
 
-    def inspect_image(self, image_name: str) -> Dict[str, Union[Dict, str]]:
+    def inspect_image(self, image_name: str, pull: bool = True) -> Dict[str, Union[Dict, str]]:
         try:
             return self.client().images.get(image_name).attrs
         except NotFound:
+            if pull:
+                self.pull_image(image_name)
+                return self.inspect_image(image_name, pull=False)
             raise NoSuchImage(image_name)
         except APIError:
             raise ContainerException()

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -489,7 +489,25 @@ class TestDockerClient:
         with pytest.raises(NoSuchImage):
             docker_client.get_image_entrypoint("thisdoesnotexist")
 
+    def test_get_container_entrypoint_not_pulled_image(self, docker_client: ContainerClient):
+        try:
+            docker_client.get_image_cmd("alpine", pull=False)
+            safe_run([config.DOCKER_CMD, "rmi", "alpine"])
+        except ContainerException:
+            pass
+        entrypoint = docker_client.get_image_entrypoint("alpine")
+        assert "" == entrypoint
+
     def test_get_container_command(self, docker_client: ContainerClient):
+        command = docker_client.get_image_cmd("alpine")
+        assert "/bin/sh" == command
+
+    def test_get_container_command_not_pulled_image(self, docker_client: ContainerClient):
+        try:
+            docker_client.get_image_cmd("alpine", pull=False)
+            safe_run([config.DOCKER_CMD, "rmi", "alpine"])
+        except ContainerException:
+            pass
         command = docker_client.get_image_cmd("alpine")
         assert "/bin/sh" == command
 
@@ -611,14 +629,14 @@ class TestDockerClient:
     @pytest.mark.skip_offline
     def test_pull_docker_image(self, docker_client: ContainerClient):
         try:
-            docker_client.get_image_cmd("alpine")
+            docker_client.get_image_cmd("alpine", pull=False)
             safe_run([config.DOCKER_CMD, "rmi", "alpine"])
         except ContainerException:
             pass
         with pytest.raises(NoSuchImage):
-            docker_client.get_image_cmd("alpine")
+            docker_client.get_image_cmd("alpine", pull=False)
         docker_client.pull_image("alpine")
-        assert "/bin/sh" == docker_client.get_image_cmd("alpine").strip()
+        assert "/bin/sh" == docker_client.get_image_cmd("alpine", pull=False).strip()
 
     @pytest.mark.skip_offline
     def test_pull_non_existent_docker_image(self, docker_client: ContainerClient):
@@ -628,38 +646,40 @@ class TestDockerClient:
     @pytest.mark.skip_offline
     def test_pull_docker_image_with_tag(self, docker_client: ContainerClient):
         try:
-            docker_client.get_image_cmd("alpine")
+            docker_client.get_image_cmd("alpine", pull=False)
             safe_run([config.DOCKER_CMD, "rmi", "alpine"])
         except ContainerException:
             pass
         with pytest.raises(NoSuchImage):
-            docker_client.get_image_cmd("alpine")
+            docker_client.get_image_cmd("alpine", pull=False)
         docker_client.pull_image("alpine:3.13")
-        assert "/bin/sh" == docker_client.get_image_cmd("alpine:3.13").strip()
-        assert "alpine:3.13" in docker_client.inspect_image("alpine:3.13")["RepoTags"]
+        assert "/bin/sh" == docker_client.get_image_cmd("alpine:3.13", pull=False).strip()
+        assert "alpine:3.13" in docker_client.inspect_image("alpine:3.13", pull=False)["RepoTags"]
 
     @pytest.mark.skip_offline
     def test_pull_docker_image_with_hash(self, docker_client: ContainerClient):
         try:
-            docker_client.get_image_cmd("alpine")
+            docker_client.get_image_cmd("alpine", pull=False)
             safe_run([config.DOCKER_CMD, "rmi", "alpine"])
         except ContainerException:
             pass
         with pytest.raises(NoSuchImage):
-            docker_client.get_image_cmd("alpine")
+            docker_client.get_image_cmd("alpine", pull=False)
         docker_client.pull_image(
             "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"
         )
         assert (
             "/bin/sh"
             == docker_client.get_image_cmd(
-                "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"
+                "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
+                pull=False,
             ).strip()
         )
         assert (
             "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"
             in docker_client.inspect_image(
-                "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"
+                "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
+                pull=False,
             )["RepoDigests"]
         )
 
@@ -871,5 +891,5 @@ class TestDockerClient:
         assert "127.0.0.1" != ip
 
     def test_set_container_workdir(self, docker_client: ContainerClient):
-        result = docker_client.run_container("alpine", command=["pwd"], workdir="/tmp")
+        result = docker_client.run_container("alpine", command=["pwd"], workdir="/tmp", remove=True)
         assert "/tmp" == to_str(result[0]).strip()


### PR DESCRIPTION
When inspecting a not-pulled image (like a lambda image on first execution), we currently do not pull the image before inspecting it (for getting current entrypoint, etc.).

This PR adds a flag for this behavior. If `pull` is true, it will automatically pull before if necessary (default), otherwise it will not.
The image will only be pulled if not already existent.