### PR TITLE
remove uname command for system check for windows compatibility

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -1328,7 +1328,7 @@ def is_linux() -> bool:
 
 
 def is_windows() -> bool:
-    return platform.system().lower() == "windows"
+    return localstack.utils.run.is_windows()
 
 
 def is_debian() -> bool:

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import os
+import platform
 import select
 import subprocess
 import sys
@@ -112,18 +113,15 @@ def run(
 
 
 def is_mac_os() -> bool:
-    return "Darwin" in get_uname()
+    return "darwin" == platform.system().lower()
 
 
 def is_linux() -> bool:
-    return "Linux" in get_uname()
+    return "linux" == platform.system().lower()
 
 
-def get_uname() -> str:
-    try:
-        return to_str(subprocess.check_output("uname -a", shell=True))
-    except Exception:
-        return ""
+def is_windows() -> bool:
+    return "windows" == platform.system().lower()
 
 
 def to_str(obj: Union[str, bytes], errors="strict"):


### PR DESCRIPTION
This PR removes the subprocess call to `uname` to find out the platform (which is unnecessary, since we have python `platform.system()`)
i also moved the `is_windows` logic to the run package with the others so it's consistent.