### PR TITLE
fix RenovateBot config by globally disabling minor and major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,12 @@
     "pinDigests": true,
     "ignorePaths": ["bin/lambda/Dockerfile.nodejs14x"]
   },
+  "major": {
+    "enabled": false
+  },
+  "minor": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "managers": ["dockerfile"],
@@ -16,17 +22,6 @@
       "digest": {
         "commitMessageTopic": "Docker base image ({{{depName}}}{{#if currentValue}}:{{{currentValue}}}{{/if}}) digest"
       }
-    },
-    {
-      "matchDatasources": [
-        "dockerfile"
-      ],
-      "matchPackageNames": ["python"],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Unfortunately, the (previously working) configuration which limits the python docker base image (digest) updates to patch versions does not seem to work anymore.
This fix disables minor and major updates globally and removes the python-package specific configuration.