### PR TITLE
add version to internal health http endpoint

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -54,6 +54,7 @@ class HealthResource:
         # build state dict from internal state and merge into it the service states
         result = dict(self.state)
         result = merge_recursive({"services": services}, result)
+        result["version"] = constants.VERSION
         return result
 
     def on_put(self, request):

--- a/tests/unit/services/test_internal.py
+++ b/tests/unit/services/test_internal.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import requests
 
+from localstack.constants import VERSION
 from localstack.services.internal import HealthResource, LocalstackResourceHandler
 from localstack.services.plugins import ServiceManager, ServiceState
 from localstack.services.routing import Request
@@ -34,6 +35,7 @@ class TestHealthResource:
             "services": {
                 "foo": "available",
             },
+            "version": VERSION,
         }
 
     def test_put_overwrite_and_get(self):
@@ -63,6 +65,7 @@ class TestHealthResource:
             "services": {
                 "foo": "available",
             },
+            "version": VERSION,
         }
 
 


### PR DESCRIPTION
Just adds the version of the running localstack instance to its /health endpoint

Response for `http://localhost:4566/health`

```json
{
    "services": {
        "acm": "available",
        "apigateway": "available",
        "cloudformation": "available",
        "cloudwatch": "available",
        "config": "available",
        "dynamodb": "available",
        "dynamodbstreams": "available",
        "ec2": "available",
        "es": "available",
        "events": "available",
        "firehose": "available",
        "iam": "available",
        "kinesis": "available",
        "kms": "available",
        "lambda": "available",
        "logs": "available",
        "redshift": "available",
        "resource-groups": "available",
        "resourcegroupstaggingapi": "available",
        "route53": "available",
        "route53resolver": "available",
        "s3": "available",
        "secretsmanager": "available",
        "ses": "available",
        "sns": "available",
        "sqs": "available",
        "ssm": "available",
        "stepfunctions": "available",
        "sts": "available",
        "support": "available",
        "swf": "available"
    },
    "version": "0.13.2"
}


```