### PR TITLE
fix single-space env default in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
       - "127.0.0.1:4566:4566"
       - "127.0.0.1:4571:4571"
     environment:
-      - SERVICES=${SERVICES- }
-      - DEBUG=${DEBUG- }
-      - DATA_DIR=${DATA_DIR- }
-      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
-      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }  # only required for Pro
+      - SERVICES=${SERVICES-}
+      - DEBUG=${DEBUG-}
+      - DATA_DIR=${DATA_DIR-}
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR-}
+      - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # only required for Pro
       - HOST_TMP_FOLDER=${TMPDIR:-/tmp/}localstack
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:


### PR DESCRIPTION
The example `docker-compose.yml` in the root dir of this repo uses the [env variable default syntax of Docker Compose](https://docs.docker.com/compose/environment-variables/#configure-compose-using-environment-variables).
However, a space is added before the closing bracket:
```
SERVICES=${SERVICES- }
```
This means that the default is not an empty string, but a string with a single white-space character.
This can cause issues in certain cases (`os.environ.get("<var>")` returns `True` for a single-whitespace string instead of `False` for an empty string).

This PR changes the default variables in the `docker-compose.yml` such that they are actually empty.