### PR TITLE
Pull out subtypes instance manager into separate util class for reusability

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -178,14 +178,14 @@ class EventSourceListener(SubtypesInstanceManager):
             )
             if self_managed_endpoints.get("KAFKA_BOOTSTRAP_SERVERS"):
                 service_type = "kafka"
-        instance = EventSourceListener.get(service_type)
+        instance = EventSourceListener.get(service_type, raise_if_missing=False)
         if instance:
             instance.start()
 
     @staticmethod
     def process_event_via_listener(service_type: str, event: Any):
         """Process event for the given service type (for reactive mode)"""
-        instance = EventSourceListener.get(service_type)
+        instance = EventSourceListener.get(service_type, raise_if_missing=False)
         if not instance:
             return
 

--- a/localstack/utils/generic/singleton_utils.py
+++ b/localstack/utils/generic/singleton_utils.py
@@ -1,0 +1,41 @@
+from typing import Dict, Type
+
+from localstack.utils.common import get_all_subclasses
+
+
+class SubtypesInstanceManager:
+    """Simple instance manager base class that scans the subclasses of a base type for concrete named
+    implementations, and lazily creates and returns (singleton) instances on demand."""
+
+    _instances: Dict[str, "SubtypesInstanceManager"]
+
+    @classmethod
+    def get(cls, subtype_name):
+        instances = cls.instances()
+        base_type = cls.get_base_type()
+        if not instances:
+            for clazz in get_all_subclasses(base_type):
+                instances[clazz.impl_name()] = clazz()
+        instance = instances.get(subtype_name)
+        if not instance:
+            raise NotImplementedError(
+                f"Unable to find implementation named '{subtype_name}' for base type {base_type}"
+            )
+        return instance
+
+    @classmethod
+    def instances(cls):
+        base_type = cls.get_base_type()
+        if not hasattr(base_type, "_instances"):
+            base_type._instances = {}
+        return base_type._instances
+
+    @staticmethod
+    def impl_name() -> str:
+        """Name of this concrete subtype - to be implemented by subclasses."""
+        raise NotImplementedError
+
+    @classmethod
+    def get_base_type(cls) -> Type:
+        """Get the base class for which instances are being managed - can be customized by subtypes."""
+        return cls

--- a/localstack/utils/generic/singleton_utils.py
+++ b/localstack/utils/generic/singleton_utils.py
@@ -10,21 +10,21 @@ class SubtypesInstanceManager:
     _instances: Dict[str, "SubtypesInstanceManager"]
 
     @classmethod
-    def get(cls, subtype_name):
+    def get(cls, subtype_name: str, raise_if_missing: bool = True):
         instances = cls.instances()
         base_type = cls.get_base_type()
         if not instances:
             for clazz in get_all_subclasses(base_type):
                 instances[clazz.impl_name()] = clazz()
         instance = instances.get(subtype_name)
-        if not instance:
+        if not instance and raise_if_missing:
             raise NotImplementedError(
                 f"Unable to find implementation named '{subtype_name}' for base type {base_type}"
             )
         return instance
 
     @classmethod
-    def instances(cls):
+    def instances(cls) -> Dict[str, "SubtypesInstanceManager"]:
         base_type = cls.get_base_type()
         if not hasattr(base_type, "_instances"):
             base_type._instances = {}


### PR DESCRIPTION
Minor refactoring: Pull out subtypes instance manager into separate `SubtypesInstanceManager` utility class for reusability. This class is now used as base class for `EventSourceListener`, and is also being used elsewhere (in -ext).