### PR TITLE
Rework sfn region patching

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -77,7 +77,7 @@ MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/ae7dbdfced9fb3cc06289c4b370d451bc3dc3250/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/047cc6dcd2e31f5ff3ec52d293c61b875f606958/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -76,7 +76,9 @@ URL_LOCALSTACK_FAT_JAR = (
 MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
-SFN_PATCH_URL_PREFIX = f"{ARTIFACTS_REPO}/raw/sfn-multiregion/stepfunctions-local-patch"
+SFN_PATCH_URL_PREFIX = (
+    f"{ARTIFACTS_REPO}/raw/ae7dbdfced9fb3cc06289c4b370d451bc3dc3250/stepfunctions-local-patch"
+)
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (
     "com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class"

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -34,6 +34,7 @@ from localstack.runtime import hooks
 from localstack.utils.common import (
     chmod_r,
     download,
+    file_exists_not_empty,
     get_arch,
     get_os,
     is_windows,
@@ -75,11 +76,24 @@ URL_LOCALSTACK_FAT_JAR = (
 MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
+SFN_PATCH_URL_PREFIX = f"{ARTIFACTS_REPO}/raw/sfn-multiregion/stepfunctions-local-patch"
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (
     "com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class"
 )
-SFN_PATCH_URL_PREFIX = f"{ARTIFACTS_REPO}/raw/master/stepfunctions-local-patch"
+SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
+SFN_PATCH_CLASS_REGION = "cloud/localstack/StepFunctionsStarter$RegionAspect.class"
+SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
+
+# additional JAR libs required for multi-region and persistence (PRO only) support
+MAVEN_REPO = "https://repo1.maven.org/maven2"
+URL_ASPECTJRT = f"{MAVEN_REPO}/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar"
+URL_ASPECTJWEAVER = f"{MAVEN_REPO}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7.jar"
+URL_KRYO = f"{MAVEN_REPO}/com/esotericsoftware/kryo/5.2.0/kryo-5.2.0.jar"
+URL_OBJENESIS = f"{MAVEN_REPO}/org/objenesis/objenesis/3.2/objenesis-3.2.jar"
+URL_MINLOG = f"{MAVEN_REPO}/com/esotericsoftware/minlog/1.3.1/minlog-1.3.1.jar"
+URL_REFLECTASM = f"{MAVEN_REPO}/com/esotericsoftware/reflectasm/1.11.9/reflectasm-1.11.9.jar"
+JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER, URL_KRYO, URL_OBJENESIS, URL_MINLOG, URL_REFLECTASM]
 
 # kinesis-mock version
 KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.0"
@@ -337,10 +351,38 @@ def install_stepfunctions_local():
         for file in path.glob("*.jar"):
             file.rename(Path(INSTALL_DIR_STEPFUNCTIONS) / file.name)
         rm_rf("%s/stepfunctionslocal" % dirs.static_libs)
-    # apply patches
-    for patch_class in (SFN_PATCH_CLASS1, SFN_PATCH_CLASS2):
+
+    classes = [
+        SFN_PATCH_CLASS1,
+        SFN_PATCH_CLASS2,
+        SFN_PATCH_CLASS_REGION,
+        SFN_PATCH_CLASS_STARTER,
+        SFN_PATCH_FILE_METAINF,
+    ]
+    for patch_class in classes:
         patch_url = f"{SFN_PATCH_URL_PREFIX}/{patch_class}"
         add_file_to_jar(patch_class, patch_url, target_jar=INSTALL_PATH_STEPFUNCTIONS_JAR)
+
+    # special case for Manifest file - extract first, replace content, then update in JAR file
+    manifest_file = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "META-INF", "MANIFEST.MF")
+    if not os.path.exists(manifest_file):
+        content = run(["unzip", "-p", INSTALL_PATH_STEPFUNCTIONS_JAR, "META-INF/MANIFEST.MF"])
+        content = re.sub(
+            "Main-Class: .+", "Main-Class: cloud.localstack.StepFunctionsStarter", content
+        )
+        classpath = " ".join([os.path.basename(jar) for jar in JAR_URLS])
+        content = re.sub(r"Class-Path: \. ", f"Class-Path: {classpath} . ", content)
+        save_file(manifest_file, content)
+        run(
+            ["zip", INSTALL_PATH_STEPFUNCTIONS_JAR, "META-INF/MANIFEST.MF"],
+            cwd=INSTALL_DIR_STEPFUNCTIONS,
+        )
+
+    # download additional jar libs
+    for jar_url in JAR_URLS:
+        target = os.path.join(INSTALL_DIR_STEPFUNCTIONS, os.path.basename(jar_url))
+        if not file_exists_not_empty(target):
+            download(jar_url, target)
 
 
 def add_file_to_jar(class_file, class_url, target_jar, base_dir=None):

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -89,11 +89,7 @@ SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
 MAVEN_REPO = "https://repo1.maven.org/maven2"
 URL_ASPECTJRT = f"{MAVEN_REPO}/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar"
 URL_ASPECTJWEAVER = f"{MAVEN_REPO}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7.jar"
-URL_KRYO = f"{MAVEN_REPO}/com/esotericsoftware/kryo/5.2.0/kryo-5.2.0.jar"
-URL_OBJENESIS = f"{MAVEN_REPO}/org/objenesis/objenesis/3.2/objenesis-3.2.jar"
-URL_MINLOG = f"{MAVEN_REPO}/com/esotericsoftware/minlog/1.3.1/minlog-1.3.1.jar"
-URL_REFLECTASM = f"{MAVEN_REPO}/com/esotericsoftware/reflectasm/1.11.9/reflectasm-1.11.9.jar"
-JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER, URL_KRYO, URL_OBJENESIS, URL_MINLOG, URL_REFLECTASM]
+JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
 # kinesis-mock version
 KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.0"

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -82,7 +82,7 @@ SFN_PATCH_CLASS2 = (
     "com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class"
 )
 SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
-SFN_PATCH_CLASS_REGION = "cloud/localstack/StepFunctionsStarter$RegionAspect.class"
+SFN_PATCH_CLASS_REGION = "cloud/localstack/RegionAspect.class"
 SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
 
 # additional JAR libs required for multi-region and persistence (PRO only) support

--- a/localstack/services/stepfunctions/stepfunctions_listener.py
+++ b/localstack/services/stepfunctions/stepfunctions_listener.py
@@ -1,35 +1,20 @@
 import json
 import logging
-import re
-
-from requests.models import Request
 
 from localstack.services.generic_proxy import ProxyListener
 from localstack.utils.analytics import event_publisher
-from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_responses import set_response_content
 from localstack.utils.common import to_str
 
 LOG = logging.getLogger(__name__)
 
 SM_ARN_REGEX = r'(arn:aws:states):([^:]+):([^:]+:(stateMachine|execution)):((([^_]+)_)?([^"]+))'
-default_region = "us-east-1"
 
 
 class ProxyListenerStepFunctions(ProxyListener):
     def forward_request(self, method, path, data, headers):
         if method == "OPTIONS":
             return 200
-        data = json.loads(to_str(data or "{}"))
-        region_name = aws_stack.get_region()
-        if data.get("name"):
-            # inject region name as prefix, as StepFunctions is currently not capable of handling multi-region requests
-            data["name"] = f"{region_name}_{data['name']}"
-
-        data = json.dumps(data)
-        replace = r"\1:%s:\3:\2_\5" % default_region
-        data_replaced = re.sub(SM_ARN_REGEX, replace, data)
-        return Request(method=method, data=data_replaced, headers=headers)
+        return True
 
     def return_response(self, method, path, data, headers, response):
         data = json.loads(to_str(data or "{}"))
@@ -47,27 +32,6 @@ class ProxyListenerStepFunctions(ProxyListener):
                 event_publisher.EVENT_STEPFUNCTIONS_DELETE_SM,
                 payload={"m": event_publisher.get_hash(name)},
             )
-
-        content = to_str(response.content or "") or "{}"
-        replace = r"\1:\7:\3:\8"
-        content = re.sub(SM_ARN_REGEX, replace, content)
-        content = json.loads(content)
-
-        def fix_name(obj):
-            if obj.get("name"):
-                obj["name"] = re.sub(r"^([^_]+)_(.*)", r"\2", obj["name"])
-
-        fix_name(content)
-        machines = content.get("stateMachines")
-        if machines:
-            region_part = ":%s:" % aws_stack.get_region()
-            machines = [sm for sm in machines if region_part in sm["stateMachineArn"]]
-            for machine in machines:
-                fix_name(machine)
-            content["stateMachines"] = machines
-
-        content = json.dumps(content)
-        set_response_content(response, content)
 
 
 # instantiate listener

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -20,13 +20,11 @@ PROCESS_THREAD = None
 def get_command(backend_port):
     cmd = (
         "cd %s; PORT=%s java -Dcom.amazonaws.sdk.disableCertChecking -Xmx%s "
-        "-jar StepFunctionsLocal.jar --aws-region %s --aws-account %s"
+        "-jar StepFunctionsLocal.jar --aws-account %s"
     ) % (
         install.INSTALL_DIR_STEPFUNCTIONS,
         backend_port,
         MAX_HEAP_SIZE,
-        # doesn't matter, because we patch multi-region. just needs to correspond to patches in stepfunctions_listener
-        stepfunctions_listener.default_region,
         TEST_AWS_ACCOUNT_ID,
     )
     if config.STEPFUNCTIONS_LAMBDA_ENDPOINT.lower() != "default":

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -19,7 +19,10 @@ PROCESS_THREAD = None
 
 def get_command(backend_port):
     cmd = (
-        "cd %s; PORT=%s java -Dcom.amazonaws.sdk.disableCertChecking -Xmx%s "
+        "cd %s; PORT=%s java "
+        "-javaagent:aspectjweaver-1.9.7.jar "
+        "-Dorg.aspectj.weaver.loadtime.configuration=META-INF/community.xml "
+        "-Dcom.amazonaws.sdk.disableCertChecking -Xmx%s "
         "-jar StepFunctionsLocal.jar --aws-account %s"
     ) % (
         install.INSTALL_DIR_STEPFUNCTIONS,

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -21,7 +21,7 @@ def get_command(backend_port):
     cmd = (
         "cd %s; PORT=%s java "
         "-javaagent:aspectjweaver-1.9.7.jar "
-        "-Dorg.aspectj.weaver.loadtime.configuration=META-INF/community.xml "
+        "-Dorg.aspectj.weaver.loadtime.configuration=META-INF/aop.xml "
         "-Dcom.amazonaws.sdk.disableCertChecking -Xmx%s "
         "-jar StepFunctionsLocal.jar --aws-account %s"
     ) % (

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 
+import mypy_boto3_stepfunctions
 import pytest
 
 from localstack.services.awslambda import lambda_api
@@ -9,6 +10,7 @@ from localstack.services.events.events_listener import TEST_EVENTS_CACHE
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import clone, load_file, retry, short_uid
+from localstack.utils.generic.wait_utils import wait_until
 
 from .lambdas import lambda_environment
 
@@ -477,36 +479,73 @@ TEST_STATE_MACHINE = {
     "States": {"s0": {"Type": "Pass", "Result": {}, "End": True}},
 }
 
+TEST_STATE_MACHINE_2 = {
+    "StartAt": "s1",
+    "States": {
+        "s1": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync",
+            "Parameters": {
+                "Input": {"Comment": "Hello world!"},
+                "StateMachineArn": "__machine_arn__",
+                "Name": "ExecutionName",
+            },
+            "End": True,
+        }
+    },
+}
 
-@pytest.mark.parametrize("region_name", ("us-east-1", "us-east-2", "eu-west-1"))
-def test_multiregion(region_name):
-    other_region = "us-east-1" if region_name != "us-east-1" else "us-east-2"
-    # TODO: create client factory fixture
-    client1 = aws_stack.create_external_boto_client("stepfunctions", region_name=region_name)
-    client2 = aws_stack.create_external_boto_client("stepfunctions", region_name=other_region)
 
+@pytest.mark.xfail(
+    reason="will fail until artifacts repo supports multiple regions for nested executions"
+)
+@pytest.mark.parametrize("region_name", ("us-east-1", "us-east-2", "eu-west-1", "eu-central-1"))
+def test_multiregion_nested(region_name):
+    client1: mypy_boto3_stepfunctions.SFNClient = aws_stack.create_external_boto_client(
+        "stepfunctions", region_name=region_name
+    )
     # create state machine
-    name = "sf-%s" % short_uid()
+    child_machine_name = f"sf-child-{short_uid()}"
+    role = aws_stack.role_arn("sfn_role")
+    child_machine_result = client1.create_state_machine(
+        name=child_machine_name, definition=json.dumps(TEST_STATE_MACHINE), roleArn=role
+    )
+    child_machine_arn = child_machine_result["stateMachineArn"]
+
+    # create parent state machine
+    name = f"sf-parent-{short_uid()}"
     role = aws_stack.role_arn("sfn_role")
     result = client1.create_state_machine(
-        name=name, definition=json.dumps(TEST_STATE_MACHINE), roleArn=role
+        name=name,
+        definition=json.dumps(TEST_STATE_MACHINE_2).replace("__machine_arn__", child_machine_arn),
+        roleArn=role,
     )
     machine_arn = result["stateMachineArn"]
+    try:
+        # list state machine
+        result = client1.list_state_machines()["stateMachines"]
+        assert len(result) > 0
+        assert len([sm for sm in result if sm["name"] == name]) == 1
+        assert len([sm for sm in result if sm["name"] == child_machine_name]) == 1
 
-    # list state machine
-    result = client1.list_state_machines()["stateMachines"]
-    result = [sm for sm in result if sm["name"] == name]
-    assert len(result) > 0
+        # start state machine execution
+        result = client1.start_execution(stateMachineArn=machine_arn)
 
-    # start state machine execution
-    result = client1.start_execution(stateMachineArn=machine_arn)
-    assert f":{region_name}:" in result["executionArn"]
-    assert f":{region_name}_" not in result["executionArn"]
+        execution = client1.describe_execution(executionArn=result["executionArn"])
+        assert execution["stateMachineArn"] == machine_arn
+        assert execution["status"] in ["RUNNING", "SUCCEEDED"]
 
-    # assert state machine does not exist in other region
-    result = client2.list_state_machines()["stateMachines"]
-    result = [sm for sm in result if sm["name"] == name]
-    assert len(result) == 0
+        def assert_success():
+            return (
+                client1.describe_execution(executionArn=result["executionArn"])["status"]
+                == "SUCCEEDED"
+            )
 
-    with pytest.raises(Exception):
-        client1.start_execution(stateMachineArn=machine_arn.replace(region_name, other_region))
+        wait_until(assert_success)
+
+        result = client1.describe_state_machine_for_execution(executionArn=result["executionArn"])
+        assert result["stateMachineArn"] == machine_arn
+
+    finally:
+        client1.delete_state_machine(stateMachineArn=machine_arn)
+        client1.delete_state_machine(stateMachineArn=child_machine_arn)

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -2,7 +2,6 @@ import json
 import os
 import unittest
 
-import mypy_boto3_stepfunctions
 import pytest
 
 from localstack.services.awslambda import lambda_api
@@ -498,9 +497,7 @@ TEST_STATE_MACHINE_2 = {
 
 @pytest.mark.parametrize("region_name", ("us-east-1", "us-east-2", "eu-west-1", "eu-central-1"))
 def test_multiregion_nested(region_name):
-    client1: mypy_boto3_stepfunctions.SFNClient = aws_stack.create_external_boto_client(
-        "stepfunctions", region_name=region_name
-    )
+    client1 = aws_stack.create_external_boto_client("stepfunctions", region_name=region_name)
     # create state machine
     child_machine_name = f"sf-child-{short_uid()}"
     role = aws_stack.role_arn("sfn_role")

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -496,9 +496,6 @@ TEST_STATE_MACHINE_2 = {
 }
 
 
-@pytest.mark.xfail(
-    reason="will fail until artifacts repo supports multiple regions for nested executions"
-)
 @pytest.mark.parametrize("region_name", ("us-east-1", "us-east-2", "eu-west-1", "eu-central-1"))
 def test_multiregion_nested(region_name):
     client1: mypy_boto3_stepfunctions.SFNClient = aws_stack.create_external_boto_client(


### PR DESCRIPTION
- adds an integration test for multiple regions and nested state machine execution (currently needs the new patch in the artifacts repo and only works with PRO enabled until the aspectj support is moved here)
- removes the region patching from the stepfunctions listener since this is now done in the stepfunctions backend
