### PR TITLE
perf: Pass string format arguments as logging method parameters

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -784,7 +784,7 @@ if LS_LOG in TRACE_LOG_LEVELS:
     load_end_time = time.time()
     LOG = logging.getLogger(__name__)
     LOG.debug(
-        "Initializing the configuration took %s ms" % int((load_end_time - load_start_time) * 1000)
+        "Initializing the configuration took %s ms", int((load_end_time - load_start_time) * 1000)
     )
 
 

--- a/localstack/dashboard/infra.py
+++ b/localstack/dashboard/infra.py
@@ -152,7 +152,7 @@ def get_lambda_functions(filter=".*", details=False, pool=None, env=None, region
                     code_map = get_lambda_code(func_name, env=env)
                     f.targets = extract_endpoints(code_map, pool)
                 except Exception:
-                    LOG.warning("Unable to get code for lambda '%s'" % func_name)
+                    LOG.warning("Unable to get code for lambda '%s'", func_name)
 
     try:
         lambda_client = _connect("lambda", env=env, region=region)

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -424,7 +424,7 @@ def apply_response_parameters(invocation_context: ApiInvocationContext):
     return_code = str(response.status_code)
     if return_code not in entries:
         if len(entries) > 1:
-            LOG.info("Found multiple integration response status codes: %s" % entries)
+            LOG.info("Found multiple integration response status codes: %s", entries)
             return response
         return_code = entries[0]
     response_params = int_responses[return_code].get("responseParameters", {})
@@ -624,7 +624,7 @@ def invoke_rest_api_integration_backend(
                 data_str = base64.b64encode(data_str)
                 is_base64_encoded = True
             except Exception as e:
-                LOG.warning("Unable to convert API Gateway payload to str: %s" % (e))
+                LOG.warning("Unable to convert API Gateway payload to str: %s", (e))
                 pass
 
             # Sample request context:
@@ -678,7 +678,7 @@ def invoke_rest_api_integration_backend(
                             body_bytes = base64.b64decode(body_bytes)
                         response._content = body_bytes
                 except Exception as e:
-                    LOG.warning("Couldn't set Lambda response content: %s" % e)
+                    LOG.warning("Couldn't set Lambda response content: %s", e)
                     response._content = "{}"
                 update_content_length(response)
                 response.multi_value_headers = parsed_result.get("multiValueHeaders") or {}
@@ -845,7 +845,7 @@ def invoke_rest_api_integration_backend(
 
                 if response_template is None:
                     msg = "Invalid response template defined in integration response."
-                    LOG.info("%s Existing: %s" % (msg, response_templates))
+                    LOG.info("%s Existing: %s", msg, response_templates)
                     return make_error_response(msg, 404)
 
                 response_template = json.loads(response_template)

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -1027,7 +1027,7 @@ def apply_json_patch_safe(subject, patch_operations, in_place=True, return_list=
                 operation["value"] = ""
 
             if operation["op"] != "remove" and operation.get("value") is None:
-                LOG.info('Missing "value" in JSONPatch operation for %s: %s' % (subject, operation))
+                LOG.info('Missing "value" in JSONPatch operation for %s: %s', subject, operation)
                 continue
 
             if operation["op"] == "add":

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -244,8 +244,10 @@ class EventSourceListenerSQS(EventSourceListener):
                 return False
 
             LOG.debug(
-                "Found %s source mappings for event from SQS queue %s: %s"
-                % (len(arns), queue_arn, arns)
+                "Found %s source mappings for event from SQS queue %s: %s",
+                len(arns),
+                queue_arn,
+                arns,
             )
             # TODO: support message BatchSize here, same as for polling mode below
             messages = event["Messages"]
@@ -293,9 +295,7 @@ class EventSourceListenerSQS(EventSourceListener):
                     except Exception as e:
                         if "NonExistentQueue" not in str(e):
                             # TODO: remove event source if queue does no longer exist?
-                            LOG.debug(
-                                "Unable to poll SQS messages for queue %s: %s" % (queue_arn, e)
-                            )
+                            LOG.debug("Unable to poll SQS messages for queue %s: %s", queue_arn, e)
 
             except Exception:
                 pass
@@ -307,7 +307,7 @@ class EventSourceListenerSQS(EventSourceListener):
         queue_arn = source["EventSourceArn"]
         region_name = queue_arn.split(":")[3]
         queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
-        LOG.debug("Sending event from event source %s to Lambda %s" % (queue_arn, lambda_arn))
+        LOG.debug("Sending event from event source %s to Lambda %s", queue_arn, lambda_arn)
         res = self._send_event_to_lambda(
             queue_arn,
             queue_url,
@@ -508,8 +508,8 @@ def use_docker():
                         "Lambda executor configured as LAMBDA_EXECUTOR=%s but Docker "
                         "is not accessible. Please make sure to mount the Docker socket "
                         "/var/run/docker.sock into the container."
-                    )
-                    % config.LAMBDA_EXECUTOR
+                    ),
+                    config.LAMBDA_EXECUTOR,
                 )
             DO_USE_DOCKER = has_docker
     return DO_USE_DOCKER
@@ -572,8 +572,10 @@ def process_apigateway_invocation(
         if stage_variables:
             event["stageVariables"] = stage_variables
         LOG.debug(
-            "Running Lambda function %s from API Gateway invocation: %s %s"
-            % (func_arn, method or "GET", path)
+            "Running Lambda function %s from API Gateway invocation: %s %s",
+            func_arn,
+            method or "GET",
+            path,
         )
         asynchronous = not config.SYNCHRONOUS_API_GATEWAY_EVENTS
         inv_result = run_lambda(
@@ -585,8 +587,7 @@ def process_apigateway_invocation(
         return inv_result.result
     except Exception as e:
         LOG.warning(
-            "Unable to run Lambda function on API Gateway message: %s %s"
-            % (e, traceback.format_exc())
+            "Unable to run Lambda function on API Gateway message: %s %s", e, traceback.format_exc()
         )
 
 
@@ -698,7 +699,7 @@ def process_kinesis_records(records, stream_name):
                 )
     except Exception as e:
         LOG.warning(
-            "Unable to run Lambda function on Kinesis records: %s %s" % (e, traceback.format_exc())
+            "Unable to run Lambda function on Kinesis records: %s %s", e, traceback.format_exc()
         )
 
 
@@ -784,7 +785,7 @@ def run_lambda(
         func_arn = aws_stack.fix_arn(func_arn)
         lambda_function = region.lambdas.get(func_arn)
         if not lambda_function:
-            LOG.debug("Unable to find details for Lambda %s in region %s" % (func_arn, region_name))
+            LOG.debug("Unable to find details for Lambda %s in region %s", func_arn, region_name)
             result = not_found_error(msg="The resource specified in the request does not exist.")
             return InvocationResult(result)
 
@@ -808,9 +809,7 @@ def run_lambda(
             "errorMessage": str(e),
             "stackTrace": traceback.format_tb(exc_traceback),
         }
-        LOG.info(
-            "Error executing Lambda function %s: %s %s" % (func_arn, e, traceback.format_exc())
-        )
+        LOG.info("Error executing Lambda function %s: %s %s", func_arn, e, traceback.format_exc())
         log_output = e.log_output if isinstance(e, lambda_executors.InvocationException) else ""
         return InvocationResult(Response(json.dumps(response), status=500), log_output)
     finally:
@@ -861,7 +860,7 @@ def exec_lambda_code(script, handler_function="handler", lambda_cwd=None, lambda
                     if key not in pre_sys_modules_keys:
                         sys.modules.pop(key)
         except Exception as e:
-            LOG.error("Unable to exec: %s %s" % (script, traceback.format_exc()))
+            LOG.error("Unable to exec: %s %s", script, traceback.format_exc())
             raise e
         finally:
             if lambda_cwd or lambda_env:
@@ -1071,7 +1070,7 @@ def do_set_function_code(lambda_function: LambdaFunction):
                     use_docker(),
                     config.LAMBDA_REMOTE_DOCKER,
                 )
-                LOG.debug("Lambda archive content:\n%s" % file_list)
+                LOG.debug("Lambda archive content:\n%s", file_list)
                 raise ClientError(
                     error_response(
                         f"Unable to find handler script ({main_file}) in Lambda archive. {config_debug}",
@@ -1802,7 +1801,7 @@ def invoke_function(function):
             if forward_result is not None:
                 return _create_response(forward_result)
         except Exception as e:
-            LOG.debug('Unable to forward Lambda invocation to fallback URL: "%s" - %s' % (data, e))
+            LOG.debug('Unable to forward Lambda invocation to fallback URL: "%s" - %s', data, e)
         return not_found
 
     if invocation_type == "RequestResponse":

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -159,11 +159,11 @@ def get_main_endpoint_from_container():
         try:
             if config.is_in_docker:
                 DOCKER_MAIN_CONTAINER_IP = bootstrap.get_main_container_ip()
-                LOG.info("Determined main container target IP: %s" % DOCKER_MAIN_CONTAINER_IP)
+                LOG.info("Determined main container target IP: %s", DOCKER_MAIN_CONTAINER_IP)
         except Exception as e:
             container_name = bootstrap.get_main_container_name()
             LOG.info(
-                'Unable to get IP address of main Docker container "%s": %s' % (container_name, e)
+                'Unable to get IP address of main Docker container "%s": %s', container_name, e
             )
     # return (1) predefined endpoint host, or (2) main container IP, or (3) Docker host (e.g., bridge IP)
     return (

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -276,7 +276,7 @@ class Stack(object):
                 template_deployer.resolve_refs_recursively(self.stack_name, details, self.resources)
                 value = details["Value"]
             except Exception as e:
-                LOG.debug("Unable to resolve references in stack outputs: %s - %s" % (details, e))
+                LOG.debug("Unable to resolve references in stack outputs: %s - %s", details, e)
             exports = details.get("Export") or {}
             export = exports.get("Name")
             export = template_deployer.resolve_refs_recursively(
@@ -439,8 +439,10 @@ class CloudFormationRegion(RegionBackend):
                 if export_name in output_keys:
                     # TODO: raise exception on stack creation in case of duplicate exports
                     LOG.warning(
-                        "Found duplicate export name %s in stacks: %s %s"
-                        % (export_name, output_keys[export_name], stack.stack_id)
+                        "Found duplicate export name %s in stacks: %s %s",
+                        export_name,
+                        output_keys[export_name],
+                        stack.stack_id,
                     )
                 entry = {
                     "ExportingStackId": stack.stack_id,
@@ -477,8 +479,7 @@ def create_stack(req_params):
 
     state.stacks[stack.stack_id] = stack
     LOG.debug(
-        'Creating stack "%s" with %s resources ...'
-        % (stack.stack_name, len(stack.template_resources))
+        'Creating stack "%s" with %s resources ...', stack.stack_name, len(stack.template_resources)
     )
     deployer = template_deployer.TemplateDeployer(stack)
     try:
@@ -487,7 +488,7 @@ def create_stack(req_params):
     except Exception as e:
         stack.set_stack_status("CREATE_FAILED")
         msg = 'Unable to create stack "%s": %s' % (stack.stack_name, e)
-        LOG.debug("%s %s" % (msg, traceback.format_exc()))
+        LOG.debug("%s %s", msg, traceback.format_exc())
         return error_response(msg, code=400, code_string="ValidationError")
     result = {"StackId": stack.stack_id}
     return result
@@ -521,7 +522,7 @@ def create_stack_instances(req_params):
     for account in accounts:
         for region in regions:
             # deploy new stack
-            LOG.debug('Deploying instance for stack set "%s" in region "%s"' % (set_name, region))
+            LOG.debug('Deploying instance for stack set "%s" in region "%s"', set_name, region)
             cf_client = aws_stack.connect_to_service("cloudformation", region_name=region)
             kwargs = select_attributes(sset_meta, "TemplateBody") or select_attributes(
                 sset_meta, "TemplateURL"
@@ -590,7 +591,7 @@ def update_stack(req_params):
     except Exception as e:
         stack.set_stack_status("UPDATE_FAILED")
         msg = 'Unable to update stack "%s": %s' % (stack_name, e)
-        LOG.debug("%s %s" % (msg, traceback.format_exc()))
+        LOG.debug("%s %s", msg, traceback.format_exc())
         return error_response(msg, code=400, code_string="ValidationError")
     result = {"StackId": stack.stack_id}
     return result
@@ -806,8 +807,10 @@ def execute_change_set(req_params):
             'Unable to find change set "%s" for stack "%s"' % (cs_name, stack_name)
         )
     LOG.debug(
-        'Executing change set "%s" for stack "%s" with %s resources ...'
-        % (cs_name, stack_name, len(change_set.template_resources))
+        'Executing change set "%s" for stack "%s" with %s resources ...',
+        cs_name,
+        stack_name,
+        len(change_set.template_resources),
     )
     deployer = template_deployer.TemplateDeployer(change_set.stack)
     deployer.apply_change_set(change_set)
@@ -866,8 +869,10 @@ def describe_stack_set_operation(req_params):
     result = stack_set.operations.get(op_id)
     if not result:
         LOG.debug(
-            'Unable to find operation ID "%s" for stack set "%s" in list: %s'
-            % (op_id, set_name, list(stack_set.operations.keys()))
+            'Unable to find operation ID "%s" for stack set "%s" in list: %s',
+            op_id,
+            set_name,
+            list(stack_set.operations.keys()),
         )
         return not_found_error(
             'Unable to find operation ID "%s" for stack set "%s"' % (op_id, set_name)
@@ -1050,7 +1055,7 @@ def clone_stack_params(stack_params):
     try:
         return clone(stack_params)
     except Exception as e:
-        LOG.info("Unable to clone stack parameters: %s" % e)
+        LOG.info("Unable to clone stack parameters: %s", e)
         return stack_params
 
 

--- a/localstack/services/cloudformation/cloudformation_starter.py
+++ b/localstack/services/cloudformation/cloudformation_starter.py
@@ -98,7 +98,7 @@ def update_physical_resource_id(resource):
         resource.physical_resource_id = resource.id
 
     else:
-        LOG.warning("Unable to determine physical_resource_id for resource %s" % type(resource))
+        LOG.warning("Unable to determine physical_resource_id for resource %s", type(resource))
 
 
 def start_cloudformation(port=None, asynchronous=False):

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -66,8 +66,7 @@ class LambdaFunction(GenericBaseModel):
             code = props["Code"] or {}
             if not code.get("ZipFile"):
                 LOG.debug(
-                    'Updating code for Lambda "%s" from location: %s'
-                    % (props["FunctionName"], code)
+                    'Updating code for Lambda "%s" from location: %s', props["FunctionName"], code
                 )
             code = LambdaFunction.get_lambda_code_param(props, _include_arch=True)
             client.update_function_code(FunctionName=props["FunctionName"], **code)

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -236,8 +236,7 @@ class IAMRole(GenericBaseModel, MotoRole):
                 continue
             if not isinstance(policy, dict):
                 LOG.info(
-                    'Invalid format of policy for IAM role "%s": %s'
-                    % (props.get("RoleName"), policy)
+                    'Invalid format of policy for IAM role "%s": %s', props.get("RoleName"), policy
                 )
                 continue
             pol_name = policy.get("PolicyName")

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -123,7 +123,7 @@ class GenericBaseModel(CloudFormationModel):
             if not template_deployer.check_not_found_exception(
                 e, self.resource_type, self.properties
             ):
-                LOG.debug("Unable to fetch state for resource %s: %s" % (self, e))
+                LOG.debug("Unable to fetch state for resource %s: %s", self, e)
 
     def fetch_state_if_missing(self, *args, **kwargs):
         if not self.state:

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -1084,7 +1084,7 @@ def dynamodb_extract_keys(item, table_name):
     result = {}
     table_definitions = DynamoDBRegion.get().table_definitions
     if table_name not in table_definitions:
-        LOGGER.warning("Unknown table: %s not found in %s" % (table_name, table_definitions))
+        LOGGER.warning("Unknown table: %s not found in %s", table_name, table_definitions)
         return None
 
     for key in table_definitions[table_name]["KeySchema"]:
@@ -1105,8 +1105,10 @@ def dynamodb_get_table_stream_specification(table_name):
         return get_table_schema(table_name)["Table"].get("StreamSpecification")
     except Exception as e:
         LOGGER.info(
-            "Unable to get stream specification for table %s : %s %s"
-            % (table_name, e, traceback.format_exc())
+            "Unable to get stream specification for table %s : %s %s",
+            table_name,
+            e,
+            traceback.format_exc(),
         )
         raise e
 

--- a/localstack/services/ec2/ec2_listener.py
+++ b/localstack/services/ec2/ec2_listener.py
@@ -11,7 +11,7 @@ def fix_creation_date(method, path, response):
     try:
         content = to_str(response._content)
     except Exception:
-        LOG.info("Unable to convert EC2 response to string: %s" % response._content)
+        LOG.info("Unable to convert EC2 response to string: %s", response._content)
         return
     response._content = re.sub(
         r">\s*([0-9-]+) ([0-9:.]+)Z?\s*</creationTimestamp>",

--- a/localstack/services/ec2/ec2_starter.py
+++ b/localstack/services/ec2/ec2_starter.py
@@ -121,7 +121,7 @@ def patch_ec2():
                     )
                 ]
             else:
-                LOG.debug('Unsupported VPC endpoint service filter "%s"' % filter["Name"])
+                LOG.debug('Unsupported VPC endpoint service filter "%s"', filter["Name"])
         service_names = [s["serviceName"] for s in services]
         services = [{**s, "serviceType": {"item": s["serviceType"]}} for s in services]
         services = [{**s, "availabilityZones": {"item": s["availabilityZones"]}} for s in services]
@@ -159,7 +159,7 @@ def patch_ec2():
             if filter["Name"] == "prefix-list-name":
                 entries = [s for s in entries if s["prefixListName"] in filter["Values"]]
             else:
-                LOG.debug('Unsupported VPC endpoint service filter "%s"' % filter["Name"])
+                LOG.debug('Unsupported VPC endpoint service filter "%s"', filter["Name"])
         result = {
             "DescribePrefixListsResponse": {
                 "@xmlns": XMLNS_EC2,

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -110,15 +110,14 @@ class ProxyListenerEdge(ProxyListener):
         if api and should_log_trace:
             # print request trace for debugging, if enabled
             LOG.debug(
-                'IN(%s): "%s %s" - headers: %s - data: %s'
-                % (api, method, path, dict(headers), data)
+                'IN(%s): "%s %s" - headers: %s - data: %s', api, method, path, dict(headers), data
             )
 
         if not port:
             if method == "OPTIONS":
                 if api and should_log_trace:
                     # print request trace for debugging, if enabled
-                    LOG.debug('IN(%s): "%s %s" - status: %s' % (api, method, path, 200))
+                    LOG.debug('IN(%s): "%s %s" - status: %s', api, method, path, 200)
                 return 200
 
             if api in ["", None, API_UNKNOWN]:
@@ -128,16 +127,21 @@ class ProxyListenerEdge(ProxyListener):
                         (
                             'Unable to find forwarding rule for host "%s", path "%s %s", '
                             'target header "%s", auth header "%s", data "%s"'
-                        )
-                        % (host, method, path, target, auth_header, truncated)
+                        ),
+                        host,
+                        method,
+                        path,
+                        target,
+                        auth_header,
+                        truncated,
                     )
             else:
                 LOG.info(
                     (
                         'Unable to determine forwarding port for API "%s" - please '
                         "make sure this API is enabled via the SERVICES configuration"
-                    )
-                    % api
+                    ),
+                    api,
                 )
             response = Response()
             response.status_code = 404

--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -129,7 +129,7 @@ def handle_put_rule(data: Dict):
     if schedule:
         job_func = get_scheduled_rule_func(data)
         cron = convert_schedule_to_cron(schedule)
-        LOG.debug("Adding new scheduled Events rule with cron schedule %s" % cron)
+        LOG.debug("Adding new scheduled Events rule with cron schedule %s", cron)
 
         job_id = JobScheduler.instance().add_job(job_func, cron, enabled)
         rule_scheduled_jobs = EventsBackend.get().rule_scheduled_jobs

--- a/localstack/services/events/events_starter.py
+++ b/localstack/services/events/events_starter.py
@@ -113,7 +113,7 @@ def filter_event_based_on_event_format(self, rule_name: str, event: Dict[str, An
 
     rule_information = self.events_backend.describe_rule(rule_name)
     if not rule_information:
-        LOG.info('Unable to find rule "%s" in backend: %s' % (rule_name, rule_information))
+        LOG.info('Unable to find rule "%s" in backend: %s', rule_name, rule_information)
         return False
     if rule_information.event_pattern._pattern:
         event_pattern = rule_information.event_pattern._pattern

--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -21,7 +21,7 @@ class Job(object):
             if self.should_run_now() and self.is_enabled:
                 self.do_run()
         except Exception as e:
-            LOG.debug("Unable to run scheduled function %s: %s" % (self.job_func, e))
+            LOG.debug("Unable to run scheduled function %s: %s", self.job_func, e)
 
     def should_run_now(self):
         schedule = CronTab(self.schedule)

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -195,7 +195,7 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
                 try:
                     es.create(index=es_index, doc_type=es_type, id=obj_id, body=body)
                 except Exception as e:
-                    LOG.error("Unable to put record to stream: %s %s" % (e, traceback.format_exc()))
+                    LOG.error("Unable to put record to stream: %s %s", e, traceback.format_exc())
                     raise e
         if "S3DestinationDescription" in dest:
             s3_dest = dest["S3DestinationDescription"]
@@ -209,7 +209,7 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
             try:
                 s3.Object(bucket, obj_path).put(Body=batched_data)
             except Exception as e:
-                LOG.error("Unable to put record to stream: %s %s" % (e, traceback.format_exc()))
+                LOG.error("Unable to put record to stream: %s %s", e, traceback.format_exc())
                 raise e
         if "HttpEndpointDestinationDescription" in dest:
             http_dest = dest["HttpEndpointDestinationDescription"]
@@ -230,8 +230,10 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
                 requests.post(url, json=record_to_send, headers=headers)
             except Exception as e:
                 LOG.info(
-                    "Unable to put Firehose records to HTTP endpoint %s: %s %s"
-                    % (url, e, traceback.format_exc())
+                    "Unable to put Firehose records to HTTP endpoint %s: %s %s",
+                    url,
+                    e,
+                    traceback.format_exc(),
                 )
                 raise e
     return {"RecordId": str(uuid.uuid4())}

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -437,7 +437,7 @@ def do_start_infra(asynchronous, apis, is_in_docker):
         install.install_debugpy_and_dependencies()
         import debugpy
 
-        LOG.info("Starting debug server at: %s:%s" % (constants.BIND_HOST, config.DEVELOP_PORT))
+        LOG.info("Starting debug server at: %s:%s", constants.BIND_HOST, config.DEVELOP_PORT)
         debugpy.listen((constants.BIND_HOST, config.DEVELOP_PORT))
 
         if config.WAIT_FOR_DEBUGGER:

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -173,7 +173,7 @@ def install_elasticsearch(version=None):
             plugin_binary = os.path.join(install_dir, "bin", "elasticsearch-plugin")
             plugin_dir = os.path.join(install_dir, "plugins", plugin)
             if not os.path.exists(plugin_dir):
-                LOG.info("Installing Elasticsearch plugin %s" % plugin)
+                LOG.info("Installing Elasticsearch plugin %s", plugin)
 
                 def try_install():
                     safe_run([plugin_binary, "install", "-b", plugin])
@@ -512,7 +512,7 @@ def install_debugpy_and_dependencies():
 
 def log_install_msg(component, verbatim=False):
     component = component if verbatim else "local %s server" % component
-    LOG.info("Downloading and installing %s. This may take some time." % component)
+    LOG.info("Downloading and installing %s. This may take some time.", component)
 
 
 def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archive=None):
@@ -547,7 +547,7 @@ def download_and_extract_with_retry(archive_url, tmp_archive, target_dir):
         download_and_extract(archive_url, target_dir, tmp_archive=tmp_archive)
     except Exception as e:
         # try deleting and re-downloading the zip file
-        LOG.info("Unable to extract file, re-downloading ZIP archive %s: %s" % (tmp_archive, e))
+        LOG.info("Unable to extract file, re-downloading ZIP archive %s: %s", tmp_archive, e)
         rm_rf(tmp_archive)
         download_and_extract(archive_url, target_dir, tmp_archive=tmp_archive)
 

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -350,8 +350,8 @@ def subscribe_to_shard(data, headers):
             except Exception as e:
                 if "ResourceNotFoundException" in str(e):
                     LOG.debug(
-                        'Kinesis stream "%s" has been deleted, closing shard subscriber'
-                        % stream_name
+                        'Kinesis stream "%s" has been deleted, closing shard subscriber',
+                        stream_name,
                     )
                     return
                 raise

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -155,7 +155,7 @@ def filter_rules_match(filters, object_path):
             if not object_path.endswith(rule["Value"]):
                 return False
         else:
-            LOGGER.warning('Unknown filter name: "%s"' % rule["Name"])
+            LOGGER.warning('Unknown filter name: "%s"', rule["Name"])
     return True
 
 
@@ -294,8 +294,10 @@ def send_notification_for_subscriber(
             )
         except Exception as e:
             LOGGER.warning(
-                'Unable to send notification for S3 bucket "%s" to SQS queue "%s": %s'
-                % (bucket_name, notif["Queue"], e)
+                'Unable to send notification for S3 bucket "%s" to SQS queue "%s": %s',
+                bucket_name,
+                notif["Queue"],
+                e,
             )
     if notif.get("Topic"):
         region = aws_stack.extract_region_from_arn(notif["Topic"])
@@ -308,8 +310,10 @@ def send_notification_for_subscriber(
             )
         except Exception as e:
             LOGGER.warning(
-                'Unable to send notification for S3 bucket "%s" to SNS topic "%s": %s'
-                % (bucket_name, notif["Topic"], e)
+                'Unable to send notification for S3 bucket "%s" to SNS topic "%s": %s',
+                bucket_name,
+                notif["Topic"],
+                e,
             )
     # CloudFunction and LambdaFunction are semantically identical
     lambda_function_config = notif.get("CloudFunction") or notif.get("LambdaFunction")
@@ -328,13 +332,14 @@ def send_notification_for_subscriber(
             )
         except Exception:
             LOGGER.warning(
-                'Unable to send notification for S3 bucket "%s" to Lambda function "%s".'
-                % (bucket_name, lambda_function_config)
+                'Unable to send notification for S3 bucket "%s" to Lambda function "%s".',
+                bucket_name,
+                lambda_function_config,
             )
 
     if not filter(lambda x: notif.get(x), NOTIFICATION_DESTINATION_TYPES):
         LOGGER.warning(
-            "Neither of %s defined for S3 notification." % "/".join(NOTIFICATION_DESTINATION_TYPES)
+            "Neither of %s defined for S3 notification.", "/".join(NOTIFICATION_DESTINATION_TYPES)
         )
 
 
@@ -592,18 +597,18 @@ def append_last_modified_headers(response, content=None):
                 )
                 response.headers["Last-Modified"] = last_modified_time_format
     except TypeError as err:
-        LOGGER.debug("No parsable content: %s" % err)
+        LOGGER.debug("No parsable content: %s", err)
     except ValueError as err:
-        LOGGER.error("Failed to parse LastModified: %s" % err)
+        LOGGER.error("Failed to parse LastModified: %s", err)
     except Exception as err:
-        LOGGER.error("Caught generic exception (parsing LastModified): %s" % err)
+        LOGGER.error("Caught generic exception (parsing LastModified): %s", err)
     # if cannot parse any LastModified, just continue
 
     try:
         if response.headers.get("Last-Modified", "") == "":
             response.headers["Last-Modified"] = datetime.datetime.now().strftime(time_format)
     except Exception as err:
-        LOGGER.error("Caught generic exception (setting LastModified header): %s" % err)
+        LOGGER.error("Caught generic exception (setting LastModified header): %s", err)
 
 
 def append_list_objects_marker(method, path, data, response):
@@ -1617,7 +1622,7 @@ def serve_static_website(headers, path, bucket_name):
             path = path.lstrip("/")
             return respond_with_key(status_code=200, key=path)
     except ClientError:
-        LOGGER.debug("No such key found. %s" % path)
+        LOGGER.debug("No such key found. %s", path)
 
     website_config = s3_client.get_bucket_website(Bucket=bucket_name)
     path_suffix = website_config.get("IndexDocument", {}).get("Suffix", "").lstrip("/")

--- a/localstack/services/s3/s3_utils.py
+++ b/localstack/services/s3/s3_utils.py
@@ -198,7 +198,7 @@ def authenticate_presign_url(method, path, headers, data=None):
     if forwarded_for:
         url = re.sub("://[^/]+", "://%s" % forwarded_for, url)
 
-    LOGGER.debug("Received presign S3 URL: %s" % url)
+    LOGGER.debug("Received presign S3 URL: %s", url)
 
     sign_headers = {}
     query_string = {}
@@ -324,7 +324,7 @@ def authenticate_presign_url(method, path, headers, data=None):
         )
 
     if response is not None:
-        LOGGER.info("Presign signature calculation failed: %s" % response)
+        LOGGER.info("Presign signature calculation failed: %s", response)
         return response
     LOGGER.debug("Valid presign url.")
 

--- a/localstack/services/secretsmanager/secretsmanager_listener.py
+++ b/localstack/services/secretsmanager/secretsmanager_listener.py
@@ -22,8 +22,9 @@ class ProxyListenerSecretsManager(PersistingProxyListener):
             parts = secret_id.split(":")
             if parts[3] != aws_stack.get_region():
                 LOG.info(
-                    'Unexpected request region %s for secret "%s"'
-                    % (aws_stack.get_region(), secret_id)
+                    'Unexpected request region %s for secret "%s"',
+                    aws_stack.get_region(),
+                    secret_id,
                 )
             # secret ARN ends with "-<randomId>" which we remove in the request for upstream compatibility
             # if the full arn is being sent then we remove the string in the end

--- a/localstack/services/ses/ses_starter.py
+++ b/localstack/services/ses/ses_starter.py
@@ -62,7 +62,7 @@ def apply_patches():
 
         raw_data = to_str(base64.b64decode(self.querystring.get("RawMessage.Data")[0]))
 
-        LOGGER.debug("Raw email:\n%s" % raw_data)
+        LOGGER.debug("Raw email:\n%s", raw_data)
 
         source = get_source_from_raw(raw_data)
         if not source:
@@ -99,8 +99,11 @@ def apply_patches():
                 "Must specify all of Body, Subject, Source for the email message"
             )
         LOGGER.debug(
-            "Sending email\nFrom: %s\nTo: %s\nSubject: %s\nBody:\n%s"
-            % (source, destinations, subject, body)
+            "Sending email\nFrom: %s\nTo: %s\nSubject: %s\nBody:\n%s",
+            source,
+            destinations,
+            subject,
+            body,
         )
 
         return email_responses_send_email_orig(self)

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -407,8 +407,7 @@ async def message_to_subscriber(
     message_attributes = get_message_attributes(req_data)
     if not skip_checks and not check_filter_policy(filter_policy, message_attributes):
         LOG.info(
-            "SNS filter policy %s does not match attributes %s"
-            % (filter_policy, message_attributes)
+            "SNS filter policy %s does not match attributes %s", filter_policy, message_attributes
         )
         return
     if subscriber["Protocol"] == "sms":
@@ -473,13 +472,14 @@ async def message_to_subscriber(
             )
             store_delivery_log(subscriber, True, message, message_id)
         except Exception as exc:
-            LOG.info("Unable to forward SNS message to SQS: %s %s" % (exc, traceback.format_exc()))
+            LOG.info("Unable to forward SNS message to SQS: %s %s", exc, traceback.format_exc())
             store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
             if "NonExistentQueue" in str(exc):
                 LOG.info(
-                    'Removing non-existent queue "%s" subscribed to topic "%s"'
-                    % (queue_url, topic_arn)
+                    'Removing non-existent queue "%s" subscribed to topic "%s"',
+                    queue_url,
+                    topic_arn,
                 )
                 subscriptions.remove(subscriber)
         return
@@ -518,8 +518,7 @@ async def message_to_subscriber(
                     )
         except Exception as exc:
             LOG.info(
-                "Unable to run Lambda function on SNS message: %s %s"
-                % (exc, traceback.format_exc())
+                "Unable to run Lambda function on SNS message: %s %s", exc, traceback.format_exc()
             )
             store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
@@ -556,7 +555,7 @@ async def message_to_subscriber(
             response.raise_for_status()
         except Exception as exc:
             LOG.info(
-                "Received error on sending SNS message, putting to DLQ (if configured): %s" % exc
+                "Received error on sending SNS message, putting to DLQ (if configured): %s", exc
             )
             store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
@@ -569,8 +568,9 @@ async def message_to_subscriber(
             store_delivery_log(subscriber, True, message, message_id)
         except Exception as exc:
             LOG.warning(
-                "Unable to forward SNS message to SNS platform app: %s %s"
-                % (exc, traceback.format_exc())
+                "Unable to forward SNS message to SNS platform app: %s %s",
+                exc,
+                traceback.format_exc(),
             )
             store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
@@ -592,7 +592,7 @@ async def message_to_subscriber(
             )
             store_delivery_log(subscriber, True, message, message_id)
     else:
-        LOG.warning('Unexpected protocol "%s" for SNS subscription' % subscriber["Protocol"])
+        LOG.warning('Unexpected protocol "%s" for SNS subscription', subscriber["Protocol"])
 
 
 def publish_message(topic_arn, req_data, headers, subscription_arn=None, skip_checks=False):
@@ -607,7 +607,7 @@ def publish_message(topic_arn, req_data, headers, subscription_arn=None, skip_ch
         )
         cache.append(req_data)
 
-    LOG.debug("Publishing message to TopicArn: %s | Message: %s" % (topic_arn, message))
+    LOG.debug("Publishing message to TopicArn: %s | Message: %s", topic_arn, message)
     start_thread(
         lambda _: message_to_subscribers(
             message_id,

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -725,7 +725,7 @@ def fix_arn(arn):
         parts = arn.split(":")
         region = parts[3] if parts[3] in config.VALID_REGIONS else get_region()
         return lambda_function_arn(lambda_function_name(arn), region_name=region)
-    LOG.warning("Unable to fix/canonicalize ARN: %s" % arn)
+    LOG.warning("Unable to fix/canonicalize ARN: %s", arn)
     return arn
 
 
@@ -1009,7 +1009,7 @@ def create_api_gateway(
     usage_plan_name = usage_plan_name or "Basic Usage"
     description = description or 'Test description for API "%s"' % name
 
-    LOG.info('Creating API resources under API Gateway "%s".' % name)
+    LOG.info('Creating API resources under API Gateway "%s".', name)
     api = client.create_rest_api(name=name, description=description)
     api_id = api["id"]
 

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -52,7 +52,7 @@ def lambda_error_to_dead_letter_queue(func_details: LambdaFunction, event: Dict,
 def _send_to_dead_letter_queue(source_type: str, source_arn: str, dlq_arn: str, event: Dict, error):
     if not dlq_arn:
         return
-    LOG.info("Sending failed execution %s to dead letter queue %s" % (source_arn, dlq_arn))
+    LOG.info("Sending failed execution %s to dead letter queue %s", source_arn, dlq_arn)
     messages = _prepare_messages_to_dlq(source_arn, event, error)
     if ":sqs:" in dlq_arn:
         queue_url = aws_stack.get_sqs_queue_url(dlq_arn)
@@ -83,7 +83,7 @@ def _send_to_dead_letter_queue(source_type: str, source_arn: str, dlq_arn: str, 
                 MessageAttributes=message["MessageAttributes"],
             )
     else:
-        LOG.warning("Unsupported dead letter queue type: %s" % dlq_arn)
+        LOG.warning("Unsupported dead letter queue type: %s", dlq_arn)
     return dlq_arn
 
 

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -138,7 +138,7 @@ def send_event_to_target(
             logEvents=[{"timestamp": now_utc(millis=True), "message": json.dumps(event)}],
         )
     else:
-        LOG.warning('Unsupported Events rule target ARN: "%s"' % target_arn)
+        LOG.warning('Unsupported Events rule target ARN: "%s"', target_arn)
 
 
 def send_event_to_api_destination(target_arn, event):
@@ -156,7 +156,7 @@ def send_event_to_api_destination(target_arn, event):
     endpoint = destination.get("InvocationEndpoint")
     state = destination.get("ApiDestinationState") or "ACTIVE"
 
-    LOG.debug('Calling EventBridge API destination (state "%s"): %s %s' % (state, method, endpoint))
+    LOG.debug('Calling EventBridge API destination (state "%s"): %s %s', state, method, endpoint)
     headers = {
         # default headers AWS sends with every api destination call
         "User-Agent": "Amazon/EventBridge/ApiDestinations",
@@ -175,9 +175,7 @@ def send_event_to_api_destination(target_arn, event):
         method=method, url=endpoint, data=json.dumps(event or {}), headers=headers
     )
     if result.status_code >= 400:
-        LOG.debug(
-            "Received code %s forwarding events: %s %s" % (result.status_code, method, endpoint)
-        )
+        LOG.debug("Received code %s forwarding events: %s %s", result.status_code, method, endpoint)
         if result.status_code == 429 or 500 <= result.status_code <= 600:
             pass  # TODO: retry logic (only retry on 429 and 5xx response status)
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -152,7 +152,7 @@ def get_resource_name(resource):
         name = instance.get_resource_name()
 
     if not name:
-        LOG.debug('Unable to extract name for resource type "%s"' % res_type)
+        LOG.debug('Unable to extract name for resource type "%s"', res_type)
     return name
 
 
@@ -169,7 +169,7 @@ def get_client(resource, func_config):
             return aws_stack.connect_to_resource(service)
         return aws_stack.connect_to_service(service)
     except Exception as e:
-        LOG.warning('Unable to get client for "%s" API, skipping deployment: %s' % (service, e))
+        LOG.warning('Unable to get client for "%s" API, skipping deployment: %s', service, e)
         return None
 
 
@@ -182,8 +182,10 @@ def describe_stack_resource(stack_name, logical_resource_id):
         return result["StackResourceDetail"]
     except Exception as e:
         LOG.warning(
-            'Unable to get details for resource "%s" in CloudFormation stack "%s": %s'
-            % (logical_resource_id, stack_name, e)
+            'Unable to get details for resource "%s" in CloudFormation stack "%s": %s',
+            logical_resource_id,
+            stack_name,
+            e,
         )
 
 
@@ -218,8 +220,10 @@ def retrieve_resource_details(resource_id, resource_status, resources, stack_nam
 
         # if is_deployable_resource(resource):
         LOG.warning(
-            "Unexpected resource type %s when resolving references of resource %s: %s"
-            % (resource_type, resource_id, resource)
+            "Unexpected resource type %s when resolving references of resource %s: %s",
+            resource_type,
+            resource_id,
+            resource,
         )
 
     except DependencyNotYetSatisfied:
@@ -244,8 +248,11 @@ def check_not_found_exception(e, resource_type, resource, resource_status=None):
     ]
     if not list(filter(lambda marker, e=e: marker in str(e), markers)):
         LOG.warning(
-            "Unexpected error retrieving details for resource type %s: Exception: %s - %s - status: %s"
-            % (resource_type, e, resource, resource_status)
+            "Unexpected error retrieving details for resource type %s: Exception: %s - %s - status: %s",
+            resource_type,
+            e,
+            resource,
+            resource_status,
         )
 
         return False
@@ -262,7 +269,7 @@ def extract_resource_attribute(
     resources=None,
     stack_name=None,
 ):
-    LOG.debug("Extract resource attribute: %s %s" % (resource_type, attribute))
+    LOG.debug("Extract resource attribute: %s %s", resource_type, attribute)
     is_ref_attribute = attribute in ["PhysicalResourceId", "Ref"]
     is_ref_attr_or_arn = is_ref_attribute or attribute == "Arn"
     resource = resource or {}
@@ -418,7 +425,7 @@ def get_attr_from_model_instance(resource, attribute, resource_type, resource_id
     model_class = RESOURCE_MODELS.get(resource_type)
     if not model_class:
         if resource_type not in ["AWS::Parameter", "Parameter"]:
-            LOG.debug('Unable to find model class for resource type "%s"' % resource_type)
+            LOG.debug('Unable to find model class for resource type "%s"', resource_type)
         return
     try:
         inst = model_class(resource_name=resource_id, resource_json=resource)
@@ -485,8 +492,10 @@ def resolve_ref(stack_name, ref, resources, attribute):
     )
     if result is None:
         LOG.warning(
-            'Unable to extract reference attribute "%s" from resource: %s %s'
-            % (attribute, resource_new, resource)
+            'Unable to extract reference attribute "%s" from resource: %s %s',
+            attribute,
+            resource_new,
+            resource,
         )
     return result
 
@@ -523,7 +532,7 @@ def _resolve_refs_recursively(stack_name, value, resources):
             ref = resolve_ref(stack_name, value["Ref"], resources, attribute="Ref")
             if ref is None:
                 msg = 'Unable to resolve Ref for resource "%s" (yet)' % value["Ref"]
-                LOG.debug("%s - %s" % (msg, resources.get(value["Ref"]) or set(resources.keys())))
+                LOG.debug("%s - %s", msg, resources.get(value["Ref"]) or set(resources.keys()))
                 raise DependencyNotYetSatisfied(resource_ids=value["Ref"], message=msg)
             ref = resolve_refs_recursively(stack_name, ref, resources)
             return ref
@@ -583,8 +592,10 @@ def _resolve_refs_recursively(stack_name, value, resources):
             stack_export = stack.exports_map.get(import_value_key) or {}
             if not stack_export.get("Value"):
                 LOG.info(
-                    'Unable to find export "%s" in stack "%s", existing export names: %s'
-                    % (import_value_key, stack_name, list(stack.exports_map.keys()))
+                    'Unable to find export "%s" in stack "%s", existing export names: %s',
+                    import_value_key,
+                    stack_name,
+                    list(stack.exports_map.keys()),
                 )
                 return None
             return stack_export["Value"]
@@ -727,9 +738,9 @@ def update_resource(resource_id, resources, stack_name):
     resource = resources[resource_id]
     resource_type = get_resource_type(resource)
     if resource_type not in UPDATEABLE_RESOURCES:
-        LOG.warning('Unable to update resource type "%s", id "%s"' % (resource_type, resource_id))
+        LOG.warning('Unable to update resource type "%s", id "%s"', resource_type, resource_id)
         return
-    LOG.info("Updating resource %s of type %s" % (resource_id, resource_type))
+    LOG.info("Updating resource %s of type %s", resource_id, resource_type)
 
     instance = get_resource_model_instance(resource_id, resources)
     if instance:
@@ -819,7 +830,7 @@ def execute_resource_action_fallback(
     if not clazz:
         LOG.warning(msg)
         return
-    LOG.info("%s - using fallback mechanism" % msg)
+    LOG.info("%s - using fallback mechanism", msg)
     if action_name == ACTION_CREATE:
         resource_name = get_resource_name(resource) or resource_id
         result = clazz.create_from_cloudformation_json(
@@ -841,8 +852,10 @@ def execute_resource_action(resource_id, resources, stack_name, action_name):
         )
 
     LOG.debug(
-        'Running action "%s" for resource type "%s" id "%s"'
-        % (action_name, resource_type, resource_id)
+        'Running action "%s" for resource type "%s" id "%s"',
+        action_name,
+        resource_type,
+        resource_id,
     )
     func_details = func_details[action_name]
     func_details = func_details if isinstance(func_details, list) else [func_details]
@@ -967,8 +980,11 @@ def configure_resource_via_sdk(
     # invoke function
     try:
         LOG.debug(
-            'Request for resource type "%s" in region %s: %s %s'
-            % (resource_type, aws_stack.get_region(), func_details["function"], params)
+            'Request for resource type "%s" in region %s: %s %s',
+            resource_type,
+            aws_stack.get_region(),
+            func_details["function"],
+            params,
         )
         try:
             result = function(**params)
@@ -980,9 +996,7 @@ def configure_resource_via_sdk(
     except Exception as e:
         if action_name == "delete" and check_not_found_exception(e, resource_type, resource):
             return
-        LOG.warning(
-            "Error calling %s with params: %s for resource: %s" % (function, params, resource)
-        )
+        LOG.warning("Error calling %s with params: %s for resource: %s", function, params, resource)
         raise e
 
     return result
@@ -1068,8 +1082,9 @@ def determine_resource_physical_id(
         return result
 
     LOG.info(
-        'Unable to determine PhysicalResourceId for "%s" resource, ID "%s"'
-        % (resource_type, resource_id)
+        'Unable to determine PhysicalResourceId for "%s" resource, ID "%s"',
+        resource_type,
+        resource_id,
     )
 
 
@@ -1181,7 +1196,7 @@ class TemplateDeployer(object):
                 action="CREATE",
             )
         except Exception as e:
-            LOG.info("Unable to create stack %s: %s" % (self.stack.stack_name, e))
+            LOG.info("Unable to create stack %s: %s", self.stack.stack_name, e)
             self.stack.set_stack_status("CREATE_FAILED")
             raise
 
@@ -1197,7 +1212,7 @@ class TemplateDeployer(object):
             )
         except Exception as e:
             LOG.info(
-                "Unable to apply change set %s: %s" % (change_set.metadata.get("ChangeSetName"), e)
+                "Unable to apply change set %s: %s", change_set.metadata.get("ChangeSetName"), e
             )
             change_set.metadata["Status"] = "%s_FAILED" % action
             self.stack.set_stack_status("%s_FAILED" % action)
@@ -1238,7 +1253,7 @@ class TemplateDeployer(object):
             long_res_type = canonical_resource_type(resource_type)
             if long_res_type in parsing.MODEL_MAP:
                 return True
-            LOG.warning('Unable to deploy resource type "%s": %s' % (resource_type, resource))
+            LOG.warning('Unable to deploy resource type "%s": %s', resource_type, resource)
         return bool(entry and entry.get(ACTION_CREATE))
 
     def is_deployed(self, resource):
@@ -1272,8 +1287,10 @@ class TemplateDeployer(object):
             if self.is_deployable_resource(resource):
                 if not self.is_deployed(resource):
                     LOG.debug(
-                        "Dependency for resource %s not yet deployed: %s %s"
-                        % (depending_resource, resource_id, resource)
+                        "Dependency for resource %s not yet deployed: %s %s",
+                        depending_resource,
+                        resource_id,
+                        resource,
                     )
                     result[resource_id] = resource
                     if return_first:
@@ -1506,8 +1523,10 @@ class TemplateDeployer(object):
                 status = "%s_COMPLETE" % action
             except Exception as e:
                 LOG.debug(
-                    'Error applying changes for CloudFormation stack "%s": %s %s'
-                    % (stack.stack_name, e, traceback.format_exc())
+                    'Error applying changes for CloudFormation stack "%s": %s %s',
+                    stack.stack_name,
+                    e,
+                    traceback.format_exc(),
                 )
                 status = "%s_FAILED" % action
             stack.set_stack_status(status)
@@ -1555,16 +1574,14 @@ class TemplateDeployer(object):
                             resource_id, change, stack, new_resources
                         )
                         LOG.debug(
-                            'Handling "%s" for resource "%s" (%s/%s) type "%s" in loop iteration %s (should_deploy=%s)'
-                            % (
-                                action,
-                                resource_id,
-                                j + 1,
-                                len(changes),
-                                res_change["ResourceType"],
-                                i + 1,
-                                should_deploy,
-                            )
+                            'Handling "%s" for resource "%s" (%s/%s) type "%s" in loop iteration %s (should_deploy=%s)',
+                            action,
+                            resource_id,
+                            j + 1,
+                            len(changes),
+                            res_change["ResourceType"],
+                            i + 1,
+                            should_deploy,
                         )
                         if not should_deploy:
                             del changes[j]
@@ -1580,8 +1597,9 @@ class TemplateDeployer(object):
                     updated = True
                 except DependencyNotYetSatisfied as e:
                     LOG.debug(
-                        'Dependencies for "%s" not yet satisfied, retrying in next loop: %s'
-                        % (resource_id, e)
+                        'Dependencies for "%s" not yet satisfied, retrying in next loop: %s',
+                        resource_id,
+                        e,
                     )
                     j += 1
             if not changes:
@@ -1606,8 +1624,7 @@ class TemplateDeployer(object):
         # check resource condition, if present
         if not evaluate_resource_condition(resource, stack.stack_name, new_resources):
             LOG.debug(
-                'Skipping deployment of "%s", as resource condition evaluates to false'
-                % resource_id
+                'Skipping deployment of "%s", as resource condition evaluates to false', resource_id
             )
             return
 
@@ -1623,8 +1640,8 @@ class TemplateDeployer(object):
                     return False
             if action == "Modify" and not self.is_updateable(resource):
                 LOG.debug(
-                    'Action "update" not yet implemented for CF resource type %s'
-                    % resource.get("Type")
+                    'Action "update" not yet implemented for CF resource type %s',
+                    resource.get("Type"),
                 )
                 return False
         return True

--- a/localstack/utils/cloudformation/template_preparer.py
+++ b/localstack/utils/cloudformation/template_preparer.py
@@ -123,8 +123,9 @@ def get_template_body(req_data):
                 parts = parsed_path.partition("/")
                 client = aws_stack.connect_to_service("s3")
                 LOG.debug(
-                    "Download CloudFormation template content from local S3: %s - %s"
-                    % (parts[0], parts[2])
+                    "Download CloudFormation template content from local S3: %s - %s",
+                    parts[0],
+                    parts[2],
                 )
                 result = client.get_object(Bucket=parts[0], Key=parts[2])
                 body = to_str(result["Body"].read())
@@ -149,7 +150,7 @@ def parse_template(template):
             try:
                 return clone_safe(yaml.load(template, Loader=NoDatesSafeLoader))
             except Exception as e:
-                LOG.debug("Unable to parse CloudFormation template (%s): %s" % (e, template))
+                LOG.debug("Unable to parse CloudFormation template (%s): %s", e, template)
                 raise
 
 

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -41,7 +41,7 @@ def publish_lambda_metric(metric, value, kwargs):
             ],
         )
     except Exception as e:
-        LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %s' % (metric, e))
+        LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %s', metric, e)
 
 
 def publish_lambda_duration(time_before, kwargs):
@@ -133,7 +133,7 @@ def publish_result(ns, time_before, result, kwargs):
         publish_lambda_result(time_before, result, kwargs)
         publish_event(time_before, "success", kwargs)
     else:
-        LOG.info("Unexpected CloudWatch namespace: %s" % ns)
+        LOG.info("Unexpected CloudWatch namespace: %s", ns)
 
 
 def publish_error(ns, time_before, e, kwargs):
@@ -141,7 +141,7 @@ def publish_error(ns, time_before, e, kwargs):
         publish_lambda_error(time_before, kwargs)
         publish_event(time_before, "error", kwargs)
     else:
-        LOG.info("Unexpected CloudWatch namespace: %s" % ns)
+        LOG.info("Unexpected CloudWatch namespace: %s", ns)
 
 
 def cloudwatched(ns):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -185,8 +185,7 @@ class ShellCommandThread(FuncThread):
             ):
                 return self.process.returncode if self.process else None
             LOG.info(
-                "Restarting process (received exit code %s): %s"
-                % (self.process.returncode, self.cmd)
+                "Restarting process (received exit code %s): %s", self.process.returncode, self.cmd
             )
 
     def do_run_cmd(self):
@@ -247,9 +246,9 @@ class ShellCommandThread(FuncThread):
         except Exception as e:
             self.result_future.set_exception(e)
             if self.process and not self.quiet:
-                LOG.warning('Shell command error "%s": %s' % (e, self.cmd))
+                LOG.warning('Shell command error "%s": %s', e, self.cmd)
         if self.process and not self.quiet and self.process.returncode != 0:
-            LOG.warning('Shell command exit code "%s": %s' % (self.process.returncode, self.cmd))
+            LOG.warning('Shell command exit code "%s": %s', self.process.returncode, self.cmd)
 
     def is_killed(self):
         if not self.process:
@@ -267,7 +266,7 @@ class ShellCommandThread(FuncThread):
         if self.stopped:
             return
         if not self.process:
-            LOG.warning("No process found for command '%s'" % self.cmd)
+            LOG.warning("No process found for command '%s'", self.cmd)
             return
 
         parent_pid = self.process.pid
@@ -1052,7 +1051,7 @@ def ensure_readable(file_path: str, default_perms: int = None):
         with open(file_path, "rb"):
             pass
     except Exception:
-        LOG.info("Updating permissions as file is currently not readable: %s" % file_path)
+        LOG.info("Updating permissions as file is currently not readable: %s", file_path)
         os.chmod(file_path, default_perms)
 
 
@@ -1145,14 +1144,7 @@ def cp_r(src: str, dst: str, rm_dest_on_conflict=False, ignore_copystat_errors=F
                 os.path.islink(_path),
             )
 
-        LOG.debug(
-            "Error copying files from %s to %s: %s"
-            % (
-                _info(src),
-                _info(dst),
-                e,
-            )
-        )
+        LOG.debug("Error copying files from %s to %s: %s", _info(src), _info(dst), e)
         raise
     finally:
         shutil.copystat = copystat_orig
@@ -1231,8 +1223,7 @@ def download(url: str, path: str, verify_ssl: bool = True, timeout: float = None
         if not os.path.exists(os.path.dirname(path)):
             os.makedirs(os.path.dirname(path))
         LOG.debug(
-            "Starting download from %s to %s (%s bytes)"
-            % (url, path, r.headers.get("Content-Length"))
+            "Starting download from %s to %s (%s bytes)", url, path, r.headers.get("Content-Length")
         )
         with open(path, "wb") as f:
             iter_length = 0
@@ -1243,18 +1234,18 @@ def download(url: str, path: str, verify_ssl: bool = True, timeout: float = None
                 if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
                 else:
-                    LOG.debug("Empty chunk %s (total %s) from %s" % (chunk, total, url))
+                    LOG.debug("Empty chunk %s (total %s) from %s", chunk, total, url)
                 if iter_length >= iter_limit:
-                    LOG.debug("Written %s bytes (total %s) to %s" % (iter_length, total, path))
+                    LOG.debug("Written %s bytes (total %s) to %s", iter_length, total, path)
                     iter_length = 0
             f.flush()
             os.fsync(f)
         if os.path.getsize(path) == 0:
-            LOG.warning("Zero bytes downloaded from %s, retrying" % url)
+            LOG.warning("Zero bytes downloaded from %s, retrying", url)
             download(url, path, verify_ssl)
             return
         LOG.debug(
-            "Done downloading %s, response code %s, total bytes %d" % (url, r.status_code, total)
+            "Done downloading %s, response code %s, total bytes %d", url, r.status_code, total
         )
     except requests.exceptions.ReadTimeout as e:
         raise TimeoutError(f"Timeout ({timeout}) reached on download: {url} - {e}")
@@ -1444,8 +1435,10 @@ def assign_to_path(target, path: str, value, delimiter: str = "."):
     parent = extract_from_jsonpointer_path(target, path_to_parent, auto_create=True)
     if not isinstance(parent, dict):
         LOG.debug(
-            'Unable to find parent (type %s) for path "%s" in object: %s'
-            % (type(parent), path, target)
+            'Unable to find parent (type %s) for path "%s" in object: %s',
+            type(parent),
+            path,
+            target,
         )
         return
     path_end = int(parts[-1]) if is_number(parts[-1]) else parts[-1]
@@ -1461,9 +1454,7 @@ def extract_from_jsonpointer_path(target, path: str, delimiter: str = "/", auto_
             if path_part == "-":
                 # special case where path is like /path/to/list/- where "/-" means "append to list"
                 continue
-            LOG.warning(
-                'Attempting to extract non-int index "%s" from list: %s' % (path_part, target)
-            )
+            LOG.warning('Attempting to extract non-int index "%s" from list: %s', path_part, target)
             return None
         target_new = target[path_part] if isinstance(target, list) else target.get(path_part)
         if target_new is None:
@@ -1697,13 +1688,13 @@ def unzip(path, target_dir, overwrite=True):
         except Exception as e:
             error_str = truncate(str(e), max_length=200)
             LOG.info(
-                'Unable to use native "unzip" command (using fallback mechanism): %s' % error_str
+                'Unable to use native "unzip" command (using fallback mechanism): %s', error_str
             )
 
     try:
         zip_ref = zipfile.ZipFile(path, "r")
     except Exception as e:
-        LOG.warning("Unable to open zip file: %s: %s" % (path, e))
+        LOG.warning("Unable to open zip file: %s: %s", path, e)
         raise e
 
     def _unzip_file_entry(zip_ref, file_entry, target_dir):
@@ -1790,7 +1781,7 @@ def generate_ssl_cert(
         except Exception as e:
             # fall back to temporary files if we cannot store/overwrite the files above
             LOG.info(
-                "Error storing key/cert SSL files (falling back to random tmp file names): %s" % e
+                "Error storing key/cert SSL files (falling back to random tmp file names): %s", e
             )
             target_file_tmp = new_tmp_file()
             cert_file_name, key_file_name = store_cert_key_files(target_file_tmp)
@@ -1862,8 +1853,9 @@ def generate_ssl_cert(
                     if i > 0:
                         raise
                     LOG.info(
-                        "Unable to store certificate file under %s, using tmp file instead: %s"
-                        % (target_file, e)
+                        "Unable to store certificate file under %s, using tmp file instead: %s",
+                        target_file,
+                        e,
                     )
                     # Fix for https://github.com/localstack/localstack/issues/1743
                     target_file = "%s.pem" % new_tmp_file()
@@ -1912,7 +1904,7 @@ def run_safe(_python_lambda, *args, _default=None, **kwargs):
         return _python_lambda(*args, **kwargs)
     except Exception as e:
         if print_error:
-            LOG.warning("Unable to execute function: %s" % e)
+            LOG.warning("Unable to execute function: %s", e)
         return _default
 
 

--- a/localstack/utils/config_listener.py
+++ b/localstack/utils/config_listener.py
@@ -21,7 +21,7 @@ def trigger_config_listeners(variable, new_value):
 
 def update_config_variable(variable, new_value):
     if new_value is not None:
-        LOG.info('Updating value of config variable "%s": %s' % (variable, new_value))
+        LOG.info('Updating value of config variable "%s": %s', variable, new_value)
         setattr(config, variable, new_value)
         trigger_config_listeners(variable, new_value)
 

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -678,7 +678,7 @@ class CmdDockerClient(ContainerClient):
                 Util.append_without_latest(image_names)
             return image_names
         except Exception as e:
-            LOG.info('Unable to list Docker images via "%s": %s' % (cmd, e))
+            LOG.info('Unable to list Docker images via "%s": %s', cmd, e)
             return []
 
     def get_container_logs(self, container_name_or_id: str, safe=False) -> str:

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -111,7 +111,7 @@ class KinesisProcessor(kcl.RecordProcessorBase):
         try:
             retry(do_checkpoint, retries=CHECKPOINT_RETRIES, sleep=CHECKPOINT_SLEEP_SECS)
         except Exception as e:
-            LOGGER.warning("Unable to checkpoint Kinesis after retries: %s" % e)
+            LOGGER.warning("Unable to checkpoint Kinesis after retries: %s", e)
 
     def should_update_sequence(self, sequence_number, sub_sequence_number):
         return (
@@ -201,7 +201,7 @@ class OutputReaderThread(FuncThread):
                 if re.match(subscriber.regex, line):
                     subscriber.update(line)
             except Exception as e:
-                LOGGER.warning("Unable to notify log subscriber: %s" % e)
+                LOGGER.warning("Unable to notify log subscriber: %s", e)
 
     def start_reading(self, params):
         # FIXME: consider using common.FileListener

--- a/localstack/utils/kinesis/kinesis_util.py
+++ b/localstack/utils/kinesis/kinesis_util.py
@@ -31,9 +31,7 @@ class EventFileReaderThread(FuncThread):
                 thread = FuncThread(self.handle_connection, conn)
                 thread.start()
             except Exception as e:
-                LOGGER.error(
-                    "Error dispatching client request: %s %s" % (e, traceback.format_exc())
-                )
+                LOGGER.error("Error dispatching client request: %s %s", e, traceback.format_exc())
         sock.close()
 
     def handle_connection(self, conn):
@@ -57,7 +55,10 @@ class EventFileReaderThread(FuncThread):
                     self.callback(records)
             except Exception as e:
                 LOGGER.warning(
-                    "Unable to process JSON line: '%s': %s %s. Callback: %s"
-                    % (truncate(line), e, traceback.format_exc(), self.callback)
+                    "Unable to process JSON line: '%s': %s %s. Callback: %s",
+                    truncate(line),
+                    e,
+                    traceback.format_exc(),
+                    self.callback,
                 )
         conn.close()

--- a/localstack/utils/persistence.py
+++ b/localstack/utils/persistence.py
@@ -127,7 +127,7 @@ def record(api, method=None, path=None, data=None, headers=None, response=None, 
                 try:
                     request_data = to_bytes(request_data)
                 except Exception as ex:
-                    LOG.warning("Unable to call to_bytes: %s" % ex)
+                    LOG.warning("Unable to call to_bytes: %s", ex)
                 request_data = to_str(base64.b64encode(request_data))
             return request_data
 
@@ -194,7 +194,7 @@ def replay(api):
     finally:
         CURRENTLY_REPLAYING.pop(0)
     if count:
-        LOG.info("Restored %s API calls from persistent file: %s" % (count, file_path))
+        LOG.info("Restored %s API calls from persistent file: %s", count, file_path)
 
 
 def restore_persisted_data(apis):

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -156,8 +156,11 @@ class FuncThread(threading.Thread):
             result = e
             if not self.quiet:
                 LOG.info(
-                    "Thread run method %s(%s) failed: %s %s"
-                    % (self.func, self.params, e, traceback.format_exc())
+                    "Thread run method %s(%s) failed: %s %s",
+                    self.func,
+                    self.params,
+                    e,
+                    traceback.format_exc(),
                 )
         finally:
             try:

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -161,8 +161,11 @@ def run_server(port, bind_address, handler=None, asynchronous=True, ssl_creds=No
                     raise result
             except Exception as e:
                 LOG.warning(
-                    "Error in proxy handler for request %s %s: %s %s"
-                    % (request.method, request.url, e, traceback.format_exc())
+                    "Error in proxy handler for request %s %s: %s %s",
+                    request.method,
+                    request.url,
+                    e,
+                    traceback.format_exc(),
                 )
                 response.status_code = 500
                 if isinstance(e, HTTPErrorResponse):
@@ -223,8 +226,10 @@ def run_server(port, bind_address, handler=None, asynchronous=True, ssl_creds=No
                 return loop.run_until_complete(serve(app, config, **run_kwargs))
             except Exception as e:
                 LOG.info(
-                    "Error running server event loop on port %s: %s %s"
-                    % (port, e, traceback.format_exc())
+                    "Error running server event loop on port %s: %s %s",
+                    port,
+                    e,
+                    traceback.format_exc(),
                 )
                 if "SSL" in str(e):
                     c_exists = os.path.exists(cert_file_name)
@@ -232,15 +237,13 @@ def run_server(port, bind_address, handler=None, asynchronous=True, ssl_creds=No
                     c_size = len(load_file(cert_file_name)) if c_exists else 0
                     k_size = len(load_file(key_file_name)) if k_exists else 0
                     LOG.warning(
-                        "Unable to create SSL context. Cert files exist: %s %s (%sB), %s %s (%sB)"
-                        % (
-                            cert_file_name,
-                            c_exists,
-                            c_size,
-                            key_file_name,
-                            k_exists,
-                            k_size,
-                        )
+                        "Unable to create SSL context. Cert files exist: %s %s (%sB), %s %s (%sB)",
+                        cert_file_name,
+                        c_exists,
+                        c_size,
+                        key_file_name,
+                        k_exists,
+                        k_size,
                     )
                 raise
         finally:

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -119,7 +119,7 @@ def _do_start_ssl_proxy(port: int, target: str, target_ssl=False):
 
     if ":" not in str(target):
         target = "127.0.0.1:%s" % target
-    LOG.debug("Starting SSL proxy server %s -> %s" % (port, target))
+    LOG.debug("Starting SSL proxy server %s -> %s", port, target)
 
     # create server and remote connection
     server = pproxy.Server("secure+tunnel://0.0.0.0:%s" % port)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -264,7 +264,7 @@ class IntegrationTest(unittest.TestCase):
             num_events_ddb - num_put_new_items - num_put_existing_items - num_batch_items
         )
 
-        LOGGER.info("Putting %s items to table..." % num_events_ddb)
+        LOGGER.info("Putting %s items to table...", num_events_ddb)
         table = dynamodb.Table(table_name)
         for i in range(0, num_put_new_items):
             table.put_item(Item={PARTITION_KEY: "testId%s" % i, "data": "foobar123"})
@@ -294,8 +294,7 @@ class IntegrationTest(unittest.TestCase):
         num_events_kinesis = 1
         num_kinesis_records = 10
         LOGGER.info(
-            "Putting %s records in %s event to stream..."
-            % (num_kinesis_records, num_events_kinesis)
+            "Putting %s records in %s event to stream...", num_kinesis_records, num_events_kinesis
         )
         kinesis.put_records(
             Records=[
@@ -768,14 +767,12 @@ def test_sqs_batch_lambda_forward(lambda_client, sqs_client, create_lambda_funct
 
         delayed_count = int(attributes.get("ApproximateNumberOfMessagesDelayed"))
         if delayed_count != 0:
-            LOGGER.warning(
-                "SQS delayed message count (actual/expected): %s/%s" % (delayed_count, 0)
-            )
+            LOGGER.warning("SQS delayed message count (actual/expected): %s/%s", delayed_count, 0)
 
         not_visible_count = int(attributes.get("ApproximateNumberOfMessagesNotVisible"))
         if not_visible_count != 0:
             LOGGER.warning(
-                "SQS messages not visible (actual/expected): %s/%s" % (not_visible_count, 0)
+                "SQS messages not visible (actual/expected): %s/%s", not_visible_count, 0
             )
 
         assert 0 == delayed_count, "no messages waiting for retry"


### PR DESCRIPTION
## Description

The logging statement has the call of the form `logging.(format_string % (format_args...))`. For such calls, it is recommended to leave string interpolation to the logging method itself and be written as `logging.(format_string, format_args...)`.

References:

[https://docs.python.org/3/library/logging.html](https://docs.python.org/3/library/logging.html)
