### PR TITLE
Fix race condition where services could startup multiple times

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -513,7 +513,7 @@ class ServicePluginManager(ServiceManager):
             return None
 
         with self._mutex:
-            if plugin.service not in self._services:
+            if plugin.service.name() not in self._services:
                 super().add_service(plugin.service)
 
         return super().get_service_container(name)

--- a/localstack/services/sqs/sqs_starter.py
+++ b/localstack/services/sqs/sqs_starter.py
@@ -9,11 +9,7 @@ from moto.sqs.exceptions import QueueDoesNotExist
 from moto.sqs.models import Queue
 
 from localstack import config
-from localstack.services.infra import (
-    log_startup_message,
-    start_moto_server,
-    start_proxy_for_service,
-)
+from localstack.services.infra import start_moto_server, start_proxy_for_service
 from localstack.services.install import SQS_BACKEND_IMPL
 from localstack.services.sqs.elasticmq import ElasticMQSerer
 from localstack.utils.aws import aws_stack
@@ -62,8 +58,6 @@ def start_sqs(*args, **kwargs):
 
     if _server:
         return _server
-
-    log_startup_message("SQS")
 
     if SQS_BACKEND_IMPL == "elasticmq":
         _server = start_sqs_elasticmq(*args, **kwargs)


### PR DESCRIPTION
Currently, the condition on line plugins.py:516 does not match the adding-service in line plugins.py:273. Once, as key, the name is added, in the other case, at the assertion if the service is already present, the whole class is the key.

This leads to a possible race condition where two ServiceContainers exist, for the same Service, with different states and different locks, and can lead to multiple starts of a service (as in #5160 with SQS).
This, until now, did not surface since most services can be created multiple time without too-serious issues, but the patch utility decorator introduced in #5024 does not allow this anymore and will fail the whole service (the second service fails, but already replaced the first at this point).

To make startup of sqs clearer, I removed one of the startup messages, since it is otherwise printed twice, and since it uses the logger of infra, makes things harder to debug.

The race condition was quite hard to reproduce in the case of sqs, since line sqs_starter.py:59-60 has another condition in there, which can prevent the initialization of the second service.

Should address #5160