### PR TITLE
Allow provider overrides to be passed to docker container

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -539,6 +539,7 @@ for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
         clean_key + "_BACKEND",
         clean_key + "_PORT",
         clean_key + "_PORT_EXTERNAL",
+        "PROVIDER_OVERRIDE_" + clean_key,
     ]
 
 
@@ -827,7 +828,9 @@ SERVICE_PROVIDER_CONFIG = ServiceProviderConfig("default")
 
 for key, value in os.environ.items():
     if key.startswith("PROVIDER_OVERRIDE_"):
-        SERVICE_PROVIDER_CONFIG.set_provider(key.lstrip("PROVIDER_OVERRIDE_").lower(), value)
+        SERVICE_PROVIDER_CONFIG.set_provider(
+            key.lstrip("PROVIDER_OVERRIDE_").lower().replace("_", "-"), value
+        )
 
 # initialize directories
 if is_in_docker:


### PR DESCRIPTION
Fixes #5193 .

Allows the PROVIDER_OVERRIDE variable to be passed to the CLI-started docker container. Also, service names are lowercase and contain dashes, so a mapping is introduced to transform e.g. `PROVIDER_OVERRIDE_RESOURCE_GROUPS` to `resource-groups`.