### PR TITLE
Add support for intrinsic functions like Fn::Sub in imported API Gateway OpenAPI specs

### DIFF
--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -94,7 +94,7 @@ def apply_patches():
 
     def apigateway_models_backend_put_rest_api(self, function_id, body, query_params):
         rest_api = self.get_rest_api(function_id)
-        return import_api_from_openapi_spec(rest_api, function_id, body, query_params)
+        return import_api_from_openapi_spec(rest_api, body, query_params)
 
     def _patch_api_gateway_entity(self, entity: Dict) -> Optional[Tuple[int, Dict, str]]:
         not_supported_attributes = ["/id", "/region_name", "/create_date"]

--- a/tests/integration/files/pets.json
+++ b/tests/integration/files/pets.json
@@ -49,7 +49,8 @@
             }
           },
           "requestParameters": {
-            "integration.request.path.id": "method.request.path.petId"
+            "integration.request.path.id": "method.request.path.petId",
+            "foo.region": {"Fn::Sub": "test - ${AWS::Region}"}
           },
           "uri": "http://petstore-demo-endpoint.execute-api.com/petstore/pets/{id}",
           "passthroughBehavior": "when_no_match",


### PR DESCRIPTION
Add support for intrinsic functions like Fn::Sub in imported API Gateway OpenAPI specs. Addresses #4619 