### PR TITLE
Update timescaledb to version 2.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN apt-get update && apt-get install -y autoconf automake cmake libsasl2-dev \
 
 # Install timescaledb into postgresql
 RUN (cd /tmp && git clone https://github.com/timescale/timescaledb.git) && \
-    (cd /tmp/timescaledb && git checkout 2.0.0-rc4 && ./bootstrap -DREGRESS_CHECKS=OFF && \
+    (cd /tmp/timescaledb && git checkout 2.3.1 && ./bootstrap -DREGRESS_CHECKS=OFF && \
       cd build && make && make install)
 
 # init environment and cache some dependencies

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,7 @@ ci-pro-smoke-tests:
 	awslocal rds describe-db-instances
 	awslocal xray get-trace-summaries --start-time 2020-01-01 --end-time 2030-12-31
 	awslocal lambda list-layers
+	awslocal timestream-write create-database --database-name db1
 	localstack stop
 
 lint:              		  ## Run code linter to check code style


### PR DESCRIPTION
For versions of TimescaleDB > 2.4 a newer version of PostgreSQL is required. To avoid a chained change that would require testing in all the services that use PostgreSQL, I pushed to the latest version of TImescaleDB that is supported in PostgreSQL 11 (our current version).

This PR updates TimescaleDB to version **2.3.1**

## Verification Steps

1. Pull this branch and run,

```
make docker-build
```

2. Then run the built container with your API key.
```
docker run --rm --name localstack_main -v /tmp/localstack:/tmp/localstack -e SERVICES=timestream -e LOCALSTACK_API_KEY=$LOCALSTACK_API_KEY -p 4566:4566 -e DEBUG=1 localstack/localstack-full
```

3. Run the following commands against timestream, the last command should return the inserted values.
```
awslocal timestream-write create-database --database-name timeStreamDB
awslocal timestream-write create-table --database-name timeStreamDB --table-name timeStreamTable

awslocal timestream-write write-records --database-name timeStreamDB --table-name timeStreamTable --records '[{"MeasureName":"cpu","MeasureValue":"60","TimeUnit":"SECONDS","Time":"1636986409"}]'

awslocal timestream-write write-records --database-name timeStreamDB --table-name timeStreamTable --records '[{"MeasureName":"cpu","MeasureValue":"80","TimeUnit":"SECONDS","Time":"1636986412"}]'

awslocal timestream-write write-records --database-name timeStreamDB --table-name timeStreamTable --records '[{"MeasureName":"cpu","MeasureValue":"70","TimeUnit":"SECONDS","Time":"1636986414"}]'

awslocal timestream-query query --query-string "SELECT CREATE_TIME_SERIES(time, measure_value::double) as cpu FROM timeStreamDB.timeStreamTable WHERE measure_name='cpu'"
```

4. Login into the container with
```
docker exec -ti localstack_main bash
```

Then, connect to the postgresql server with, 
```
psql -p 52169 -h 127.0.0.1 -U test

```
Then, run the following SQL query to determine TimescaleDB version,
```
SELECT default_version, installed_version FROM pg_available_extensions where name = 'timescaledb';
```
and it should output something like,
```
 default_version | installed_version 
-----------------+-------------------
 2.3.1           | 
(1 row)
```

Tthe integration tests are passing,

```
tests/integration/test_timestream.py::TestTimestream::test_timestream_query PASSED
tests/integration/test_timestream.py::TestTimestream::test_query_pagination PASSED
tests/integration/test_timestream.py::TestTimestream::test_query_special_functions PASSED
```