### PR TITLE
Fix firehose - ElasticSearch integration, allow S3Backup AllDocuments with ElasticSearchDestination

### DIFF
--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -35,6 +35,7 @@ from localstack.utils.common import (
     timestamp,
     to_bytes,
     to_str,
+    truncate,
 )
 from localstack.utils.kinesis import kinesis_connector
 
@@ -156,7 +157,7 @@ def put_records_to_s3_bucket(
     prefix = s3_configuration.get("Prefix", "")
 
     s3 = connect_to_resource("s3")
-    batched_data = b"".join([base64.b64decode(r.get("Data") or r["data"]) for r in records])
+    batched_data = b"".join([base64.b64decode(r.get("Data", r.get("data"))) for r in records])
 
     obj_path = get_s3_object_path(stream_name, prefix)
     try:
@@ -231,7 +232,7 @@ def put_records(stream_name: str, unprocessed_records: List[Dict]) -> Dict:
                     LOG.warning("Elasticsearch only allows json input data!")
                     raise e
 
-                LOG.debug("Publishing to ES destination. Data: %s", data)
+                LOG.debug("Publishing to ES destination. Data: %s", truncate(data, max_length=300))
                 try:
                     es.create(index=es_index, doc_type=es_type, id=obj_id, body=body)
                 except Exception as e:

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -7,7 +7,7 @@ import threading
 import time
 import traceback
 import uuid
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import requests
 from boto3.dynamodb.types import TypeDeserializer
@@ -115,7 +115,7 @@ def preprocess_records(processor: Dict, records: List[Dict]) -> List[Dict]:
     return records
 
 
-def add_missing_record_attributes(records: List[Dict]):
+def add_missing_record_attributes(records: List[Dict]) -> List[Dict]:
     def _get_entry(obj, key):
         return obj.get(key) or obj.get(first_char_to_lower(key))
 
@@ -134,6 +134,7 @@ def add_missing_record_attributes(records: List[Dict]):
                 "sequenceNumber": next_sequence_number(),
                 "subsequenceNumber": "",
             }
+    return records
 
 
 def next_sequence_number() -> int:
@@ -149,7 +150,27 @@ def put_record(stream_name: str, record: Dict) -> Dict:
     return put_records(stream_name, [record])
 
 
-def put_records(stream_name: str, records: List[Dict]) -> Dict:
+def put_records_to_s3_bucket(
+    stream_name: str, records: List[Dict], s3_configuration: Dict[str, Union[str, Dict]]
+):
+    bucket = s3_bucket_name(s3_configuration["BucketARN"])
+    prefix = s3_configuration.get("Prefix", "")
+
+    s3 = connect_to_resource("s3")
+    batched_data = b"".join([base64.b64decode(r.get("Data") or r["data"]) for r in records])
+
+    obj_path = get_s3_object_path(stream_name, prefix)
+    try:
+        LOG.debug("Publishing to S3 destination: %s. Data: %s", bucket, batched_data)
+        s3.Object(bucket, obj_path).put(Body=batched_data)
+    except Exception as e:
+        LOG.error(
+            "Unable to put records %s to s3 bucket: %s %s", records, e, traceback.format_exc()
+        )
+        raise e
+
+
+def put_records(stream_name: str, unprocessed_records: List[Dict]) -> Dict:
     """Put a list of records to the firehose stream - either directly from a PutRecord API call, or
     received from an underlying Kinesis stream (if 'KinesisStreamAsSource' is configured)"""
     stream = get_stream(stream_name)
@@ -157,7 +178,7 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
         return error_not_found(stream_name)
 
     # preprocess records, add any missing attributes
-    add_missing_record_attributes(records)
+    add_missing_record_attributes(unprocessed_records)
 
     for dest in stream.get("Destinations", []):
 
@@ -167,6 +188,7 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
             proc_config = (
                 isinstance(child, dict) and child.get("ProcessingConfiguration") or proc_config
             )
+        records = unprocessed_records
         if proc_config.get("Enabled") is not False:
             for processor in proc_config.get("Processors", []):
                 # TODO: run processors asynchronously, to avoid request timeouts on PutRecord API calls
@@ -179,6 +201,20 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
             es = connect_elasticsearch(
                 endpoint=es_dest.get("ClusterEndpoint"), domain=es_dest.get("DomainARN")
             )
+            # TODO support FailedDocumentsOnly as well
+            if es_dest.get("S3BackupMode") == "AllDocuments":
+                s3_config = es_dest.get("S3Configuration")
+                if s3_config:
+                    try:
+                        put_records_to_s3_bucket(
+                            stream_name=stream_name,
+                            records=unprocessed_records,
+                            s3_configuration=s3_config,
+                        )
+                    except Exception as e:
+                        LOG.warning("Unable to backup unprocessed records to S3. Error: %s", e)
+                else:
+                    LOG.warning("Passed S3BackupMode without S3Configuration. Cannot backup...")
             for record in records:
                 obj_id = uuid.uuid4()
 
@@ -190,27 +226,21 @@ def put_records(stream_name: str, records: List[Dict]) -> Dict:
                 elif "data" in record:
                     data = base64.b64decode(record["data"])
 
-                body = json.loads(data)
+                try:
+                    body = json.loads(data)
+                except Exception as e:
+                    LOG.info("Elasticsearch only allows json input data!")
+                    raise e
 
+                LOG.debug("Publishing to ES destination. Data: %s", data)
                 try:
                     es.create(index=es_index, doc_type=es_type, id=obj_id, body=body)
                 except Exception as e:
                     LOG.error("Unable to put record to stream: %s %s", e, traceback.format_exc())
                     raise e
         if "S3DestinationDescription" in dest:
-            s3_dest = dest["S3DestinationDescription"]
-            bucket = s3_bucket_name(s3_dest["BucketARN"])
-            prefix = s3_dest.get("Prefix", "")
-
-            s3 = connect_to_resource("s3")
-            batched_data = b"".join([base64.b64decode(r.get("Data") or r["data"]) for r in records])
-
-            obj_path = get_s3_object_path(stream_name, prefix)
-            try:
-                s3.Object(bucket, obj_path).put(Body=batched_data)
-            except Exception as e:
-                LOG.error("Unable to put record to stream: %s %s", e, traceback.format_exc())
-                raise e
+            s3_dest_config = dest["S3DestinationDescription"]
+            put_records_to_s3_bucket(stream_name, records, s3_dest_config)
         if "HttpEndpointDestinationDescription" in dest:
             http_dest = dest["HttpEndpointDestinationDescription"]
             end_point = http_dest["EndpointConfiguration"]

--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -115,7 +115,7 @@ def preprocess_records(processor: Dict, records: List[Dict]) -> List[Dict]:
     return records
 
 
-def add_missing_record_attributes(records: List[Dict]) -> List[Dict]:
+def add_missing_record_attributes(records: List[Dict]) -> None:
     def _get_entry(obj, key):
         return obj.get(key) or obj.get(first_char_to_lower(key))
 
@@ -134,7 +134,6 @@ def add_missing_record_attributes(records: List[Dict]) -> List[Dict]:
                 "sequenceNumber": next_sequence_number(),
                 "subsequenceNumber": "",
             }
-    return records
 
 
 def next_sequence_number() -> int:
@@ -229,7 +228,7 @@ def put_records(stream_name: str, unprocessed_records: List[Dict]) -> Dict:
                 try:
                     body = json.loads(data)
                 except Exception as e:
-                    LOG.info("Elasticsearch only allows json input data!")
+                    LOG.warning("Elasticsearch only allows json input data!")
                     raise e
 
                 LOG.debug("Publishing to ES destination. Data: %s", data)

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -773,10 +773,13 @@ class UrlMatchingForwarder(ProxyListener):
         return requests.request(method, url, data=data, headers=headers, stream=True, verify=False)
 
     def matches(self, host, path):
-        # TODO: consider matching default ports (80, 443 if scheme is https). Example: http://localhost:80 matches
-        #  http://localhost) check host rule
+        # TODO: refine matching default ports (80, 443 if scheme is https). Example: http://localhost:80 matches
+        #  http://localhost) check host rule. Can lead to problems with 443-4566 edge proxy forwarding if not enabled
         if self.base_url.netloc:
-            if host != self.base_url.netloc:
+            stripped_netloc, _, port = self.base_url.netloc.rpartition(":")
+            if host != self.base_url.netloc and (
+                host != stripped_netloc or port not in ["80", "443"]
+            ):
                 return False
 
         # check path components

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ dataclasses; python_version < '3.7'
 #docopt>=0.6.2
 docker==5.0.0
 localstack-client>=1.28
-localstack-ext>=0.13.1
+localstack-ext>=0.13.2
 localstack-plugin-loader>=0.1.0
 psutil>=5.4.8,<6.0.0
 python-dotenv>=0.19.1
@@ -51,7 +51,7 @@ flask_swagger==0.2.12
 #jsondiff>=1.2.0
 jsonpatch>=1.24,<2.0
 jsonpath-rw>=1.4.0,<2.0.0
-localstack-ext[full]>=0.13.1
+localstack-ext[full]>=0.13.2
 moto-ext[all]>=2.2.7.1
 pproxy>=2.7.0
 #pympler>=0.6

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -1,6 +1,9 @@
 import base64
 import json
 
+import pytest as pytest
+import requests
+
 from localstack import config
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
@@ -10,6 +13,7 @@ from localstack.utils.aws.aws_stack import lambda_function_arn
 from localstack.utils.common import (
     get_free_tcp_port,
     get_service_protocol,
+    poll_condition,
     retry,
     short_uid,
     to_bytes,
@@ -132,3 +136,106 @@ def test_firehose_http():
     # delete stream
     stream = firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
     assert stream["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+class TestFirehoseIntegration:
+    @pytest.mark.parametrize("es_endpoint_strategy", ["domain", "path"])
+    def test_kinesis_firehose_elasticsearch_s3_backup(
+        self,
+        firehose_client,
+        kinesis_client,
+        es_client,
+        s3_client,
+        s3_bucket,
+        kinesis_create_stream,
+        monkeypatch,
+        es_endpoint_strategy,
+    ):
+        domain_name = f"test-domain-{short_uid()}"
+        stream_name = f"test-stream-{short_uid()}"
+        role_arn = "arn:aws:iam::000000000000:role/Firehose-Role"
+        delivery_stream_name = f"test-delivery-stream-{short_uid()}"
+        monkeypatch.setattr(config, "ES_ENDPOINT_STRATEGY", es_endpoint_strategy)
+        try:
+            es_create_response = es_client.create_elasticsearch_domain(DomainName=domain_name)
+            es_url = f"http://{es_create_response['DomainStatus']['Endpoint']}"
+            es_arn = es_create_response["DomainStatus"]["ARN"]
+
+            # create s3 backup bucket arn
+            bucket_arn = aws_stack.s3_bucket_arn(s3_bucket)
+
+            # create kinesis stream
+            kinesis_create_stream(StreamName=stream_name, ShardCount=2)
+            stream_arn = kinesis_client.describe_stream(StreamName=stream_name)[
+                "StreamDescription"
+            ]["StreamARN"]
+
+            kinesis_stream_source_def = {
+                "KinesisStreamARN": stream_arn,
+                "RoleARN": role_arn,
+            }
+            elasticsearch_destination_configuration = {
+                "RoleARN": role_arn,
+                "DomainARN": es_arn,
+                "IndexName": "activity",
+                "TypeName": "activity",
+                "S3BackupMode": "AllDocuments",
+                "S3Configuration": {
+                    "RoleARN": role_arn,
+                    "BucketARN": bucket_arn,
+                },
+            }
+            firehose_client.create_delivery_stream(
+                DeliveryStreamName=delivery_stream_name,
+                DeliveryStreamType="KinesisStreamAsSource",
+                KinesisStreamSourceConfiguration=kinesis_stream_source_def,
+                ElasticsearchDestinationConfiguration=elasticsearch_destination_configuration,
+            )
+
+            # wait for ES cluster to be ready
+            def check_service_state():
+                result = es_client.describe_elasticsearch_domain(DomainName=domain_name)[
+                    "DomainStatus"
+                ]["Processing"]
+                return not result
+
+            assert poll_condition(check_service_state, 30, 1)
+
+            # put kinesis stream record
+            kinesis_record = {"target": "hello"}
+            kinesis_client.put_record(
+                StreamName=stream_name, Data=to_bytes(json.dumps(kinesis_record)), PartitionKey="1"
+            )
+
+            firehose_record = {"target": "world"}
+            firehose_client.put_record(
+                DeliveryStreamName=delivery_stream_name,
+                Record={"Data": to_bytes(json.dumps(firehose_record))},
+            )
+
+            def assert_elasticsearch_contents():
+                response = requests.get(f"{es_url}/activity/_search")
+                result = response.json()["hits"]["hits"]
+                assert len(result) == 2
+                sources = [item["_source"] for item in result]
+                assert firehose_record in sources
+                assert kinesis_record in sources
+
+            retry(assert_elasticsearch_contents)
+
+            def assert_s3_contents():
+                result = s3_client.list_objects(Bucket=s3_bucket)
+                contents = []
+                for o in result.get("Contents"):
+                    data = s3_client.get_object(Bucket=s3_bucket, Key=o.get("Key"))
+                    content = data["Body"].read()
+                    contents.append(content)
+                assert len(contents) == 2
+                assert to_bytes(json.dumps(firehose_record)) in contents
+                assert to_bytes(json.dumps(kinesis_record)) in contents
+
+            retry(assert_s3_contents)
+
+        finally:
+            firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
+            es_client.delete_elasticsearch_domain(DomainName=domain_name)

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -193,13 +193,13 @@ class TestFirehoseIntegration:
             )
 
             # wait for ES cluster to be ready
-            def check_service_state():
+            def check_domain_state():
                 result = es_client.describe_elasticsearch_domain(DomainName=domain_name)[
                     "DomainStatus"
                 ]["Processing"]
                 return not result
 
-            assert poll_condition(check_service_state, 30, 1)
+            assert poll_condition(check_domain_state, 30, 1)
 
             # put kinesis stream record
             kinesis_record = {"target": "hello"}


### PR DESCRIPTION
After the rework in #4866 , it seems like the elasticsearch connector for firehose was not adapted correctly. (it always used the localhost:4571 endpoint instead of the newly introduced ones).

This PR fixes this behavior and introduces a integration test to test kinesis-firehose-elasticsearch integration to prevent future regression.

Also this PR introduces the AllDocuments S3 backup strategy for ElasticSearch destinations, basic functionality tested with the same test. This backup strategy uses the unprocessed (no lambdas etc) records to backup them into S3. This feature should be seen as incomplete, as it might differ from AWS in terms of buffering multiple records into one file etc.

There is also a small change in the UrlMatchingForwarder, since in host mode, the edge proxy can drop the :443 port when using https and forwarding, so the rules will not match anymore. Mismatches against port 80 and 443 will now no longer prevent a successful match.