### PR TITLE
Automatic docker network detection for lambdas

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -19,6 +19,7 @@ from localstack.constants import DEFAULT_LAMBDA_CONTAINER_REGISTRY
 from localstack.services.awslambda.lambda_utils import (
     API_PATH_ROOT,
     LAMBDA_RUNTIME_PROVIDED,
+    get_container_network_for_lambda,
     get_main_endpoint_from_container,
     get_record_from_event,
     is_java_lambda,
@@ -968,7 +969,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
         # make sure AWS_LAMBDA_EVENT_BODY is not set (otherwise causes issues with "docker exec ..." above)
         env_vars.pop("AWS_LAMBDA_EVENT_BODY", None)
 
-        network = config.LAMBDA_DOCKER_NETWORK
+        network = get_container_network_for_lambda()
         additional_flags = docker_flags
 
         dns = config.LAMBDA_DOCKER_DNS
@@ -1167,7 +1168,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
             inv_context.lambda_command = inv_context.handler
 
         # add Docker Lambda env vars
-        network = config.LAMBDA_DOCKER_NETWORK or None
+        network = get_container_network_for_lambda()
         if network == "host":
             port = get_free_tcp_port()
             env_vars["DOCKER_LAMBDA_API_PORT"] = port

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1092,7 +1092,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             # Get the container name.
             container_name = self.get_container_name(func_arn)
 
-            container_network = DOCKER_CLIENT.get_network(container_name)
+            container_network = DOCKER_CLIENT.get_networks(container_name)[0]
 
             return container_network
 

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -195,6 +195,18 @@ def get_container_network_for_lambda():
         except Exception as e:
             container_name = bootstrap.get_main_container_name()
             LOG.info('Unable to get network name of main container "%s": %s', container_name, e)
+    elif (
+        config.LAMBDA_DOCKER_NETWORK
+        and config.is_in_docker
+        and config.LAMBDA_DOCKER_NETWORK
+        not in DOCKER_CLIENT.get_networks(bootstrap.get_main_container_name())
+    ):
+        LOG.warning(
+            "Your specified LAMBDA_DOCKER_NETWORK '%s' is not connected to the main LocalStack container '%s'. "
+            "Lambda functionality might be severely limited.",
+            config.LAMBDA_DOCKER_NETWORK,
+            bootstrap.get_main_container_name(),
+        )
     return config.LAMBDA_DOCKER_NETWORK or LAMBDA_CONTAINER_NETWORK
 
 

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -195,18 +195,6 @@ def get_container_network_for_lambda():
         except Exception as e:
             container_name = bootstrap.get_main_container_name()
             LOG.info('Unable to get network name of main container "%s": %s', container_name, e)
-    elif (
-        config.LAMBDA_DOCKER_NETWORK
-        and config.is_in_docker
-        and config.LAMBDA_DOCKER_NETWORK
-        not in DOCKER_CLIENT.get_networks(bootstrap.get_main_container_name())
-    ):
-        LOG.warning(
-            "Your specified LAMBDA_DOCKER_NETWORK '%s' is not connected to the main LocalStack container '%s'. "
-            "Lambda functionality might be severely limited.",
-            config.LAMBDA_DOCKER_NETWORK,
-            bootstrap.get_main_container_name(),
-        )
     return config.LAMBDA_DOCKER_NETWORK or LAMBDA_CONTAINER_NETWORK
 
 

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -164,7 +164,12 @@ def get_main_endpoint_from_container():
                     container_name_or_id=container_name,
                     container_network=get_container_network_for_lambda(),
                 )
-                LOG.info("Determined main container target IP: %s", DOCKER_MAIN_CONTAINER_IP)
+            else:
+                # default gateway for the network should be the host
+                DOCKER_MAIN_CONTAINER_IP = DOCKER_CLIENT.inspect_network(
+                    get_container_network_for_lambda()
+                )["IPAM"]["Config"][0]["Gateway"]
+            LOG.info("Determined main container target IP: %s", DOCKER_MAIN_CONTAINER_IP)
         except Exception as e:
             LOG.info(
                 'Unable to get IP address of main Docker container "%s": %s', container_name, e

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -191,6 +191,7 @@ def get_container_network_for_lambda():
                 LAMBDA_CONTAINER_NETWORK = (
                     "bridge"  # use the default bridge network in case of host mode
                 )
+            LOG.info("Determined lambda container network: %s", LAMBDA_CONTAINER_NETWORK)
         except Exception as e:
             container_name = bootstrap.get_main_container_name()
             LOG.info('Unable to get network name of main container "%s": %s', container_name, e)

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -182,7 +182,9 @@ def get_main_endpoint_from_container():
 
 def get_container_network_for_lambda():
     global LAMBDA_CONTAINER_NETWORK
-    if not config.LAMBDA_DOCKER_NETWORK and LAMBDA_CONTAINER_NETWORK is None:
+    if config.LAMBDA_DOCKER_NETWORK:
+        return config.LAMBDA_DOCKER_NETWORK
+    if LAMBDA_CONTAINER_NETWORK is None:
         try:
             if config.is_in_docker:
                 networks = DOCKER_CLIENT.get_networks(bootstrap.get_main_container_name())
@@ -195,7 +197,7 @@ def get_container_network_for_lambda():
         except Exception as e:
             container_name = bootstrap.get_main_container_name()
             LOG.info('Unable to get network name of main container "%s": %s', container_name, e)
-    return config.LAMBDA_DOCKER_NETWORK or LAMBDA_CONTAINER_NETWORK
+    return LAMBDA_CONTAINER_NETWORK
 
 
 def rm_docker_container(container_name_or_id, check_existence=False, safe=False):

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -157,12 +157,15 @@ def get_main_endpoint_from_container():
     global DOCKER_MAIN_CONTAINER_IP
     if not config.HOSTNAME_FROM_LAMBDA and DOCKER_MAIN_CONTAINER_IP is None:
         DOCKER_MAIN_CONTAINER_IP = False
+        container_name = bootstrap.get_main_container_name()
         try:
             if config.is_in_docker:
-                DOCKER_MAIN_CONTAINER_IP = bootstrap.get_main_container_ip()
+                DOCKER_MAIN_CONTAINER_IP = DOCKER_CLIENT.get_container_ipv4_for_network(
+                    container_name_or_id=container_name,
+                    container_network=get_container_network_for_lambda(),
+                )
                 LOG.info("Determined main container target IP: %s", DOCKER_MAIN_CONTAINER_IP)
         except Exception as e:
-            container_name = bootstrap.get_main_container_name()
             LOG.info(
                 'Unable to get IP address of main Docker container "%s": %s', container_name, e
             )

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -94,6 +94,9 @@ _unprintables = (
 REGEX_UNPRINTABLE_CHARS = re.compile(
     f"[{re.escape(''.join(map(chr, itertools.chain(*_unprintables))))}]"
 )
+IP_REGEX = (
+    r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+)
 
 # user of the currently running process
 CACHED_USER = None
@@ -1670,6 +1673,15 @@ def is_ip_address(addr):
         return True
     except socket.error:
         return False
+
+
+def is_ipv4_address(address: str) -> bool:
+    """
+    Checks if passed string looks like an IPv4 address
+    :param address: Possible IPv4 address
+    :return: True if string looks like IPv4 address, False otherwise
+    """
+    return bool(re.match(IP_REGEX, address))
 
 
 def is_zip_file(content):

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -317,7 +317,10 @@ class ContainerClient(metaclass=ABCMeta):
             )
         try:
             ip = str(ipaddress.IPv4Interface(containers[container_id]["IPv4Address"]).ip)
-        except Exception:
+        except Exception as e:
+            raise ContainerException(
+                f"Unable to detect IP address for container {container_name_or_id} in network {container_network}: {e}"
+            )
             raise ContainerException(
                 f"Unable to detect IP address for container {container_name_or_id} in network {container_network}"
             )

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -321,9 +321,6 @@ class ContainerClient(metaclass=ABCMeta):
             raise ContainerException(
                 f"Unable to detect IP address for container {container_name_or_id} in network {container_network}: {e}"
             )
-            raise ContainerException(
-                f"Unable to detect IP address for container {container_name_or_id} in network {container_network}"
-            )
         return ip
 
     @abstractmethod

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -282,13 +282,13 @@ class TestDockerClient:
         safe_run(["docker", "network", "connect", network_id, dummy_container.container_id])
         docker_client.start_container(dummy_container.container_id)
         result_bridge_network = docker_client.get_container_ipv4_for_network(
-            container_name=dummy_container.container_id, container_network="bridge"
+            container_name_or_id=dummy_container.container_id, container_network="bridge"
         ).strip()
         assert re.match(IP_REGEX, result_bridge_network)
         bridge_network = docker_client.inspect_network("bridge")["IPAM"]["Config"][0]["Subnet"]
         assert ipaddress.IPv4Address(result_bridge_network) in ipaddress.IPv4Network(bridge_network)
         result_custom_network = docker_client.get_container_ipv4_for_network(
-            container_name=dummy_container.container_id, container_network=network_name
+            container_name_or_id=dummy_container.container_id, container_network=network_name
         ).strip()
         assert re.match(IP_REGEX, result_custom_network)
         assert result_custom_network != result_bridge_network
@@ -302,13 +302,13 @@ class TestDockerClient:
         create_network(network_name)
         docker_client.start_container(dummy_container.container_id)
         result_bridge_network = docker_client.get_container_ipv4_for_network(
-            container_name=dummy_container.container_id, container_network="bridge"
+            container_name_or_id=dummy_container.container_id, container_network="bridge"
         ).strip()
         assert re.match(r"172\.17\.0\.\d", result_bridge_network)
 
         with pytest.raises(ContainerException):
             docker_client.get_container_ipv4_for_network(
-                container_name=dummy_container.container_id, container_network=network_name
+                container_name_or_id=dummy_container.container_id, container_network=network_name
             )
 
     def test_get_container_ip_for_network_non_existent_network(
@@ -318,7 +318,7 @@ class TestDockerClient:
         docker_client.start_container(dummy_container.container_id)
         with pytest.raises(NoSuchNetwork):
             docker_client.get_container_ipv4_for_network(
-                container_name=dummy_container.container_id, container_network=network_name
+                container_name_or_id=dummy_container.container_id, container_network=network_name
             )
 
     def test_create_with_host_network(self, docker_client: ContainerClient, create_container):

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -258,8 +258,16 @@ class TestDockerClient:
         n = docker_client.get_networks(dummy_container.container_name)
         assert ["bridge"] == n
 
-    def test_get_network_multiple_networks(self, docker_client: ContainerClient, create_container):
-        pass
+    def test_get_network_multiple_networks(
+        self, docker_client: ContainerClient, dummy_container, create_network
+    ):
+        network_id = create_network("test-network")
+        safe_run(["docker", "network", "connect", network_id, dummy_container.container_id])
+        docker_client.start_container(dummy_container.container_id)
+        networks = docker_client.get_networks(dummy_container.container_id)
+        assert "test-network" in networks
+        assert "bridge" in networks
+        assert len(networks) == 2
 
     def test_create_with_host_network(self, docker_client: ContainerClient, create_container):
         info = create_container("alpine", network="host")

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -255,13 +255,16 @@ class TestDockerClient:
             docker_client.start_container("this_container_does_not_exist")
 
     def test_get_network(self, docker_client: ContainerClient, dummy_container):
-        n = docker_client.get_network(dummy_container.container_name)
-        assert "default" == n
+        n = docker_client.get_networks(dummy_container.container_name)
+        assert ["bridge"] == n
+
+    def test_get_network_multiple_networks(self, docker_client: ContainerClient, create_container):
+        pass
 
     def test_create_with_host_network(self, docker_client: ContainerClient, create_container):
         info = create_container("alpine", network="host")
-        network = docker_client.get_network(info.container_name)
-        assert "host" == network
+        network = docker_client.get_networks(info.container_name)
+        assert ["host"] == network
 
     def test_create_with_port_mapping(self, docker_client: ContainerClient, create_container):
         ports = PortMappings()
@@ -421,7 +424,7 @@ class TestDockerClient:
 
     def test_get_network_non_existing_container(self, docker_client: ContainerClient):
         with pytest.raises(ContainerException):
-            docker_client.get_network("this_container_does_not_exist")
+            docker_client.get_networks("this_container_does_not_exist")
 
     def test_list_containers(self, docker_client: ContainerClient, create_container):
         c1 = create_container("alpine", command=["echo", "1"])

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -287,6 +287,22 @@ class TestDockerClient:
         assert re.match(r"172\.(\d{1,4})\.0\.(\d{1,4})", result_custom_network)
         assert result_custom_network != result_bridge_network
 
+    def test_get_container_ip_for_network_wrong_network(
+        self, docker_client: ContainerClient, dummy_container, create_network
+    ):
+        network_name = f"test-network-{short_uid()}"
+        create_network(network_name)
+        docker_client.start_container(dummy_container.container_id)
+        result_bridge_network = docker_client.get_container_ip_for_network(
+            container_name=dummy_container.container_id, container_network="bridge"
+        ).strip()
+        assert re.match(r"172\.17\.0\.\d", result_bridge_network)
+
+        with pytest.raises(ContainerException):
+            docker_client.get_container_ip_for_network(
+                container_name=dummy_container.container_id, container_network=network_name
+            )
+
     def test_create_with_host_network(self, docker_client: ContainerClient, create_container):
         info = create_container("alpine", network="host")
         network = docker_client.get_networks(info.container_name)

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -2074,13 +2074,13 @@ class TestDockerBehaviour(LambdaTestBase):
 
         assert payload["Hello"] == "Elon Musk"
 
-    def test_prime_and_destroy_containers(self):
-        # run these tests only for the "reuse containers" Lambda executor
-        if not isinstance(
+    @pytest.mark.skipif(
+        condition=not isinstance(
             lambda_api.LAMBDA_EXECUTOR, lambda_executors.LambdaExecutorReuseContainers
-        ):
-            return
-
+        ),
+        reason="Test only applicable if docker-reuse executor is selected",
+    )
+    def test_prime_and_destroy_containers(self):
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = "test_prime_and_destroy_containers"
         func_arn = lambda_api.func_arn(func_name)
@@ -2131,7 +2131,7 @@ class TestDockerBehaviour(LambdaTestBase):
         self.assertEqual(1, status)
 
         container_network = executor.get_docker_container_network(func_arn)
-        self.assertEqual("default", container_network)
+        self.assertEqual("bridge", container_network)
 
         executor.cleanup()
         status = executor.get_docker_container_status(func_arn)
@@ -2142,13 +2142,13 @@ class TestDockerBehaviour(LambdaTestBase):
         # clean up
         testutil.delete_lambda_function(func_name)
 
-    def test_destroy_idle_containers(self):
-        # run these tests only for the "reuse containers" Lambda executor
-        if not isinstance(
+    @pytest.mark.skipif(
+        condition=not isinstance(
             lambda_api.LAMBDA_EXECUTOR, lambda_executors.LambdaExecutorReuseContainers
-        ):
-            pytest.skip("only testing docker reuse executor")
-
+        ),
+        reason="Test only applicable if docker-reuse executor is selected",
+    )
+    def test_destroy_idle_containers(self):
         executor = lambda_api.LAMBDA_EXECUTOR
         func_name = "test_destroy_idle_containers"
         func_arn = lambda_api.func_arn(func_name)


### PR DESCRIPTION
This PR will work towards a automatic docker network detection for lambdas, so `LAMBDA_DOCKER_NETWORK` should only need to be set on very specific edge cases, and not in the normal docker-compose case.

This PR introduces a new behavior:

- per default, Lambda containers will be spawned connected to the same network as LocalStack itself. If there are multiple applicable, it will take the first in the list of `docker container inspect`.
- In host mode, the endpoint detection will fallback to `172.17.0.1`, which is accepted since host mode is not supported. In host mode, lambdas will be spawned as well in host mode with all the disadvantages that brings. Use `LAMBDA_DOCKER_NETWORK=bridge` to force the "old" behavior in host mode (still not officially supported)
- If LocalStack is connected to multiple networks, you can still use `LAMBDA_DOCKER_NETWORK` to force the use of a specific one (instead of the first defined for the container).
- The LocalStack endpoint for lambdas will be automatically set to the endpoint matching the lambda docker network. If you have two networks connected to LocalStack, and force the use of one with `LAMBDA_DOCKER_NETWORK`, the endpoint for the lambda will be the interface address of LocalStack matching that network.

There are also changes to the Container client, which will now return a list of networks (since multiple are possible) instead of the primary network for a container. Also, if at runtime connected/disconnected from networks, this should now be reflected correctly.