### PR TITLE
Addition of a SNS validation negative test and test_sns.py migration

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -73,7 +73,7 @@ class SNSTest(unittest.TestCase):
             msg_received = msgs["Messages"][0]
             msg_received = json.loads(to_str(msg_received["Body"]))
             msg_received = msg_received["Message"]
-            self.assertEqual(message, msg_received)
+            assert message == msg_received
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
@@ -95,16 +95,15 @@ class SNSTest(unittest.TestCase):
         self.sns_client.subscribe(TopicArn=self.topic_arn, Protocol="http", Endpoint=queue_arn)
 
         def received():
-            self.assertEqual(records[0][0]["Type"], "SubscriptionConfirmation")
-            self.assertEqual(records[0][1]["x-amz-sns-message-type"], "SubscriptionConfirmation")
+            assert records[0][0]["Type"] == "SubscriptionConfirmation"
+            assert records[0][1]["x-amz-sns-message-type"] == "SubscriptionConfirmation"
 
             token = records[0][0]["Token"]
             subscribe_url = records[0][0]["SubscribeURL"]
 
-            self.assertEqual(
-                subscribe_url,
+            assert subscribe_url == (
                 "%s/?Action=ConfirmSubscription&TopicArn=%s&Token=%s"
-                % (external_service_url("sns"), self.topic_arn, token),
+                % (external_service_url("sns"), self.topic_arn, token)
             )
 
             self.assertIn("Signature", records[0][0])
@@ -135,7 +134,7 @@ class SNSTest(unittest.TestCase):
         )["Attributes"]
 
         # assert the attributes are well set
-        self.assertTrue(actual_attributes["RawMessageDelivery"])
+        assert actual_attributes["RawMessageDelivery"]
 
         # publish message to SNS, receive it from SQS, assert that messages are equal and that they are Raw
         message = "This is a test message"
@@ -154,11 +153,8 @@ class SNSTest(unittest.TestCase):
             )
             msg_received = msgs["Messages"][0]
 
-            self.assertEqual(message, msg_received["Body"])
-            self.assertEqual(
-                binary_attribute,
-                msg_received["MessageAttributes"]["store"]["BinaryValue"],
-            )
+            assert message == msg_received["Body"]
+            assert binary_attribute == msg_received["MessageAttributes"]["store"]["BinaryValue"]
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
@@ -189,7 +185,7 @@ class SNSTest(unittest.TestCase):
             num_msgs_1 = len(
                 self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
             )
-            self.assertEqual(num_msgs_1, num_msgs_0 + 1)
+            assert num_msgs_1 == (num_msgs_0 + 1)
             return num_msgs_1
 
         num_msgs_1 = retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -206,7 +202,7 @@ class SNSTest(unittest.TestCase):
             num_msgs_2 = len(
                 self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
             )
-            self.assertEqual(num_msgs_2, num_msgs_1)
+            assert num_msgs_2 == num_msgs_1
             return num_msgs_2
 
         retry(check_message2, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -247,7 +243,7 @@ class SNSTest(unittest.TestCase):
             num_msgs_1 = len(
                 self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
             )
-            self.assertEqual(num_msgs_1, num_msgs_0 + 1)
+            assert num_msgs_1 == (num_msgs_0 + 1)
             return num_msgs_1
 
         num_msgs_1 = retry(check_message1, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -264,7 +260,7 @@ class SNSTest(unittest.TestCase):
             num_msgs_2 = len(
                 self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
             )
-            self.assertEqual(num_msgs_2, num_msgs_1)
+            assert num_msgs_2 == num_msgs_1
             return num_msgs_2
 
         retry(check_message2, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -295,7 +291,7 @@ class SNSTest(unittest.TestCase):
                     "Messages", []
                 )
             )
-            self.assertEqual(num_msgs_1, num_msgs_0)
+            assert num_msgs_1 == num_msgs_0
             return num_msgs_1
 
         num_msgs_1 = retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -314,7 +310,7 @@ class SNSTest(unittest.TestCase):
                     "Messages", []
                 )
             )
-            self.assertEqual(num_msgs_2, num_msgs_1)
+            assert num_msgs_2 == num_msgs_1
             return num_msgs_2
 
         retry(check_message3, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -333,10 +329,7 @@ class SNSTest(unittest.TestCase):
             messages = self.sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)[
                 "Messages"
             ]
-            self.assertEqual(
-                json.loads(messages[0]["Body"])["MessageAttributes"]["attr1"]["Value"],
-                "99.12",
-            )
+            assert json.loads(messages[0]["Body"])["MessageAttributes"]["attr1"]["Value"] == "99.12"
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
@@ -357,7 +350,7 @@ class SNSTest(unittest.TestCase):
 
         # assert that message has been received
         def check_message():
-            self.assertGreater(len(sns_backend.platform_endpoint_messages[platform_arn]), 0)
+            assert len(sns_backend.platform_endpoint_messages[platform_arn]) > 0
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
@@ -388,26 +381,26 @@ class SNSTest(unittest.TestCase):
     def test_unknown_topic_publish(self):
         fake_arn = "arn:aws:sns:us-east-1:123456789012:i_dont_exist"
         message = "This is a test message"
-        try:
+
+        with pytest.raises(ClientError) as e:
             self.sns_client.publish(TopicArn=fake_arn, Message=message)
-            self.fail("This call should not be successful as the topic does not exist")
-        except ClientError as e:
-            self.assertEqual(e.response["Error"]["Code"], "NotFound")
-            self.assertEqual(e.response["Error"]["Message"], "Topic does not exist")
-            self.assertEqual(e.response["ResponseMetadata"]["HTTPStatusCode"], 404)
+
+        assert e.value.response["Error"]["Code"] == "NotFound"
+        assert e.value.response["Error"]["Message"] == "Topic does not exist"
+        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
 
     def test_publish_sms(self):
         response = self.sns_client.publish(PhoneNumber="+33000000000", Message="This is a SMS")
-        self.assertTrue("MessageId" in response)
-        self.assertEqual(response["ResponseMetadata"]["HTTPStatusCode"], 200)
+        assert "MessageId" in response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     def test_publish_target(self):
         response = self.sns_client.publish(
             TargetArn="arn:aws:sns:us-east-1:000000000000:endpoint/APNS/abcdef/0f7d5971-aa8b-4bd5-b585-0826e9f93a66",
             Message="This is a push notification",
         )
-        self.assertTrue("MessageId" in response)
-        self.assertEqual(response["ResponseMetadata"]["HTTPStatusCode"], 200)
+        assert "MessageId" in response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     def test_tags(self):
         self.sns_client.tag_resource(
@@ -424,28 +417,28 @@ class SNSTest(unittest.TestCase):
             tag for idx, tag in enumerate(tags["Tags"]) if tag not in tags["Tags"][:idx]
         ]
         # test for duplicate tags
-        self.assertEqual(len(tags["Tags"]), len(distinct_tags))
-        self.assertEqual(len(tags["Tags"]), 2)
-        self.assertEqual(tags["Tags"][0]["Key"], "123")
-        self.assertEqual(tags["Tags"][0]["Value"], "abc")
-        self.assertEqual(tags["Tags"][1]["Key"], "456")
-        self.assertEqual(tags["Tags"][1]["Value"], "def")
+        assert len(tags["Tags"]) == len(distinct_tags)
+        assert len(tags["Tags"]) == 2
+        assert tags["Tags"][0]["Key"] == "123"
+        assert tags["Tags"][0]["Value"] == "abc"
+        assert tags["Tags"][1]["Key"] == "456"
+        assert tags["Tags"][1]["Value"] == "def"
 
         self.sns_client.untag_resource(ResourceArn=self.topic_arn, TagKeys=["123"])
 
         tags = self.sns_client.list_tags_for_resource(ResourceArn=self.topic_arn)
-        self.assertEqual(len(tags["Tags"]), 1)
-        self.assertEqual(tags["Tags"][0]["Key"], "456")
-        self.assertEqual(tags["Tags"][0]["Value"], "def")
+        assert len(tags["Tags"]) == 1
+        assert tags["Tags"][0]["Key"] == "456"
+        assert tags["Tags"][0]["Value"] == "def"
 
         self.sns_client.tag_resource(
             ResourceArn=self.topic_arn, Tags=[{"Key": "456", "Value": "pqr"}]
         )
 
         tags = self.sns_client.list_tags_for_resource(ResourceArn=self.topic_arn)
-        self.assertEqual(len(tags["Tags"]), 1)
-        self.assertEqual(tags["Tags"][0]["Key"], "456")
-        self.assertEqual(tags["Tags"][0]["Value"], "pqr")
+        assert len(tags["Tags"]) == 1
+        assert tags["Tags"][0]["Key"] == "456"
+        assert tags["Tags"][0]["Value"] == "pqr"
 
     def test_topic_subscription(self):
         subscription = self.sns_client.subscribe(
@@ -456,11 +449,11 @@ class SNSTest(unittest.TestCase):
         def check_subscription():
             subscription_arn = subscription["SubscriptionArn"]
             subscription_obj = sns_backend.subscription_status[subscription_arn]
-            self.assertEqual(subscription_obj["Status"], "Not Subscribed")
+            assert subscription_obj["Status"] == "Not Subscribed"
 
             _token = subscription_obj["Token"]
             self.sns_client.confirm_subscription(TopicArn=self.topic_arn, Token=_token)
-            self.assertEqual(subscription_obj["Status"], "Subscribed")
+            assert subscription_obj["Status"] == "Subscribed"
 
         retry(check_subscription, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
@@ -492,10 +485,10 @@ class SNSTest(unittest.TestCase):
                 QueueUrl=queue_url, MessageAttributeNames=["All"]
             )
             msg_attrs = result["Messages"][0]["MessageAttributes"]
-            self.assertGreater(len(result["Messages"]), 0)
-            self.assertIn("RequestID", msg_attrs)
-            self.assertIn("ErrorCode", msg_attrs)
-            self.assertIn("ErrorMessage", msg_attrs)
+            assert len(result["Messages"]) > 0
+            assert "RequestID" in msg_attrs
+            assert "ErrorCode" in msg_attrs
+            assert "ErrorMessage" in msg_attrs
 
         retry(receive_dlq, retries=8, sleep=2)
 
@@ -542,10 +535,10 @@ class SNSTest(unittest.TestCase):
             result = self.sqs_client.receive_message(
                 QueueUrl=self.dlq_url, MessageAttributeNames=["All"]
             )
-            self.assertGreater(len(result["Messages"]), 0)
-            self.assertEqual(
-                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"],
-                "test_redrive_policy",
+            assert len(result["Messages"]) > 0
+            assert (
+                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"]
+                == "test_redrive_policy"
             )
 
         retry(receive_dlq, retries=7, sleep=2.5)
@@ -585,10 +578,10 @@ class SNSTest(unittest.TestCase):
             result = self.sqs_client.receive_message(
                 QueueUrl=self.dlq_url, MessageAttributeNames=["All"]
             )
-            self.assertGreater(len(result["Messages"]), 0)
-            self.assertEqual(
-                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"],
-                "test_redrive_policy",
+            assert len(result["Messages"]) > 0
+            assert (
+                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"]
+                == "test_redrive_policy"
             )
 
         retry(receive_dlq, retries=10, sleep=2)
@@ -619,10 +612,10 @@ class SNSTest(unittest.TestCase):
             result = self.sqs_client.receive_message(
                 QueueUrl=self.dlq_url, MessageAttributeNames=["All"]
             )
-            self.assertGreater(len(result["Messages"]), 0)
-            self.assertEqual(
-                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"],
-                "test_redrive_policy",
+            assert len(result["Messages"]) > 0
+            assert (
+                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"]
+                == "test_redrive_policy"
             )
 
         retry(receive_dlq, retries=10, sleep=2)
@@ -634,19 +627,16 @@ class SNSTest(unittest.TestCase):
         rs = self.sns_client.publish(
             TopicArn=topic_arn, Message=json.dumps({"message": "test_publish"})
         )
-        self.assertEqual(rs["ResponseMetadata"]["HTTPStatusCode"], 200)
+        assert rs["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-        try:
-            # Publish with empty subject
+        with pytest.raises(ClientError) as e:
             self.sns_client.publish(
                 TopicArn=topic_arn,
                 Subject="",
                 Message=json.dumps({"message": "test_publish"}),
             )
-            self.fail("This call should not be successful as the subject is empty")
 
-        except ClientError as e:
-            self.assertEqual(e.response["Error"]["Code"], "InvalidParameter")
+        assert e.value.response["Error"]["Code"] == "InvalidParameter"
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
@@ -655,8 +645,8 @@ class SNSTest(unittest.TestCase):
         response = self.sns_client.create_topic(Name=TEST_TOPIC_NAME)
         topic_arn_params = response["TopicArn"].split(":")
         testutil.response_arn_matches_partition(self.sns_client, response["TopicArn"])
-        self.assertEqual(topic_arn_params[4], TEST_AWS_ACCOUNT_ID)
-        self.assertEqual(topic_arn_params[5], TEST_TOPIC_NAME)
+        assert topic_arn_params[4] == TEST_AWS_ACCOUNT_ID
+        assert topic_arn_params[5] == TEST_TOPIC_NAME
 
     def test_publish_message_by_target_arn(self):
         self.unsubscribe_all_from_sns()
@@ -705,11 +695,11 @@ class SNSTest(unittest.TestCase):
             expected_length=2,
         )
         # Lambda invoked 1 more time
-        self.assertEqual(len(events), 2)
+        assert len(events) == 2
 
         for event in events:
             message = event["Records"][0]
-            self.assertEqual(message["EventSubscriptionArn"], subscription_arn)
+            assert message["EventSubscriptionArn"] == subscription_arn
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
@@ -730,7 +720,7 @@ class SNSTest(unittest.TestCase):
         rs = self.sns_client.publish(
             TopicArn=topic_arn, Subject="test subject", Message="test_message_1"
         )
-        self.assertEqual(rs["ResponseMetadata"]["HTTPStatusCode"], 200)
+        assert rs["ResponseMetadata"]["HTTPStatusCode"] == 200
 
         self.sns_client.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
 
@@ -740,7 +730,7 @@ class SNSTest(unittest.TestCase):
         rs = self.sns_client.publish(
             TopicArn=topic_arn, Subject=message_subject, Message=message_body
         )
-        self.assertEqual(rs["ResponseMetadata"]["HTTPStatusCode"], 200)
+        assert rs["ResponseMetadata"]["HTTPStatusCode"] == 200
         message_id = rs["MessageId"]
 
         def get_message(q_url):
@@ -748,9 +738,9 @@ class SNSTest(unittest.TestCase):
             return json.loads(resp["Messages"][0]["Body"])
 
         message = retry(get_message, retries=3, sleep=2, q_url=queue_url)
-        self.assertEqual(message["MessageId"], message_id)
-        self.assertEqual(message["Subject"], message_subject)
-        self.assertEqual(message["Message"], message_body)
+        assert message["MessageId"] == message_id
+        assert message["Subject"] == message_subject
+        assert message["Message"] == message_body
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
@@ -762,14 +752,11 @@ class SNSTest(unittest.TestCase):
 
         with self.assertRaises(ClientError) as ctx:
             self.sns_client.create_topic(Name=topic_name, Tags=[{"Key": "456", "Value": "pqr"}])
-            self.fail(
-                "This call should not be successful as the topic already exists with different tags"
-            )
 
         e = ctx.exception
-        self.assertEqual(e.response["Error"]["Code"], "InvalidParameter")
-        self.assertEqual(e.response["Error"]["Message"], "Topic already exists with different tags")
-        self.assertEqual(e.response["ResponseMetadata"]["HTTPStatusCode"], 400)
+        assert e.response["Error"]["Code"] == "InvalidParameter"
+        assert e.response["Error"]["Message"] == "Topic already exists with different tags"
+        assert e.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
@@ -788,7 +775,7 @@ class SNSTest(unittest.TestCase):
             responses.append(self.sns_client.create_topic(Name=topic_name, **arg))
         # assert TopicArn is returned by all the above create_topic calls
         for i in range(len(responses)):
-            self.assertIn("TopicArn", responses[i])
+            assert "TopicArn" in responses[i]
         # clean up
         self.sns_client.delete_topic(TopicArn=responses[0]["TopicArn"])
 
@@ -814,7 +801,7 @@ class SNSTest(unittest.TestCase):
             )
         # Assert endpointarn is returned in every call create platform call
         for i in range(len(responses)):
-            self.assertIn("EndpointArn", responses[i])
+            assert "EndpointArn" in responses[i]
         endpoint_arn = responses[0]["EndpointArn"]
         # clean up
         self.sns_client.delete_endpoint(EndpointArn=endpoint_arn)
@@ -841,15 +828,15 @@ class SNSTest(unittest.TestCase):
             url="{}/?{}".format(base_url, path),
             headers=aws_stack.mock_aws_request_headers("sns"),
         )
-        self.assertEqual(r.status_code, 200)
+        assert r.status_code == 200
 
         def get_notification(q_url):
             resp = self.sqs_client.receive_message(QueueUrl=q_url)
             return json.loads(resp["Messages"][0]["Body"])
 
         notification = retry(get_notification, retries=3, sleep=2, q_url=queue_url)
-        self.assertEqual(notification["TopicArn"], topic_arn)
-        self.assertEqual(notification["Message"], message)
+        assert notification["TopicArn"] == topic_arn
+        assert notification["Message"] == message
 
         # clean up
         self.sns_client.delete_topic(TopicArn=topic_arn)
@@ -881,10 +868,9 @@ class SNSTest(unittest.TestCase):
 
         # fetch subscription information
         subscription_list = self.sns_client.list_subscriptions()
-        self.assertEqual(subscription_list["ResponseMetadata"]["HTTPStatusCode"], 200)
-        self.assertEqual(len(subscription_list["Subscriptions"]), number_of_subscriptions)
-
-        self.assertEqual(number_of_subscriptions, len(records))
+        assert subscription_list["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert len(subscription_list["Subscriptions"]) == number_of_subscriptions
+        assert number_of_subscriptions == len(records)
 
         for proxy in proxies:
             proxy.stop()
@@ -919,7 +905,7 @@ class SNSTest(unittest.TestCase):
                         sms_was_found = True
                         break
 
-                self.assertTrue(sms_was_found)
+                assert sms_was_found
 
         retry(check_messages, sleep=0.5)
 
@@ -945,10 +931,9 @@ class SNSTest(unittest.TestCase):
             response = self.sqs_client.receive_message(
                 QueueUrl=queue_url, MessageAttributeNames=["All"]
             )
-            self.assertEqual(
-                response["Messages"][0]["MessageAttributes"],
-                {"attr1": {"DataType": "Number", "StringValue": "99.12"}},
-            )
+            assert response["Messages"][0]["MessageAttributes"] == {
+                "attr1": {"DataType": "Number", "StringValue": "99.12"}
+            }
             self.sqs_client.delete_message(
                 QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
             )
@@ -970,11 +955,9 @@ class SNSTest(unittest.TestCase):
             response = self.sqs_client.receive_message(
                 QueueUrl=queue_url, MessageAttributeNames=["All"]
             )
-            self.assertIsNone(response["Messages"][0].get("MessageAttributes"))
-            self.assertIn(
-                "100.12",
-                response["Messages"][0]["Body"],
-            )
+            assert response["Messages"][0].get("MessageAttributes") is None
+            assert "100.12" in response["Messages"][0]["Body"]
+
             self.sqs_client.delete_message(
                 QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
             )
@@ -1009,13 +992,13 @@ class SNSTest(unittest.TestCase):
             WaitTimeSeconds=2,
         )
 
-        self.assertEqual(len(response["Messages"]), 1)
+        assert len(response["Messages"]) == 1
         message = response["Messages"][0]
-        self.assertTrue("Attributes" in message)
-        self.assertTrue("AWSTraceHeader" in message["Attributes"])
-        self.assertEqual(
-            message["Attributes"]["AWSTraceHeader"],
-            "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1",
+        assert "Attributes" in message
+        assert "AWSTraceHeader" in message["Attributes"]
+        assert (
+            message["Attributes"]["AWSTraceHeader"]
+            == "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
         )
 
     def test_create_topic_after_delete_with_new_tags(self):
@@ -1028,7 +1011,7 @@ class SNSTest(unittest.TestCase):
         topic1 = self.sns_client.create_topic(
             Name=topic_name, Tags=[{"Key": "Name", "Value": "abc"}]
         )
-        self.assertEqual(topic["TopicArn"], topic1["TopicArn"])
+        assert topic["TopicArn"] == topic1["TopicArn"]
 
         # cleanup
         self.sns_client.delete_topic(TopicArn=topic1["TopicArn"])
@@ -1051,20 +1034,20 @@ class SNSTest(unittest.TestCase):
             SubscriptionArn=subscription["SubscriptionArn"]
         )
 
-        self.assertEqual(
-            subscription_attributes.get("Attributes").get("SubscriptionArn"),
-            subscription["SubscriptionArn"],
+        assert (
+            subscription_attributes.get("Attributes").get("SubscriptionArn")
+            == subscription["SubscriptionArn"]
         )
 
         self.sns_client.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
 
-        with self.assertRaises(ClientError) as ctx:
+        with pytest.raises(ClientError) as e:
             self.sns_client.get_subscription_attributes(
                 SubscriptionArn=subscription["SubscriptionArn"]
             )
 
-        self.assertEqual(ctx.exception.response["Error"]["Code"], "NotFound")
-        self.assertEqual(ctx.exception.response["ResponseMetadata"]["HTTPStatusCode"], 404)
+        assert e.value.response["Error"]["Code"] == "NotFound"
+        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
 
         # cleanup
         self.sns_client.delete_topic(TopicArn=topic_arn)
@@ -1092,7 +1075,7 @@ class SNSTest(unittest.TestCase):
 
         def get_message():
             received = self.sqs_client.receive_message(QueueUrl=queue_url)["Messages"][0]["Body"]
-            self.assertEqual(json.loads(received)["Message"], message)
+            assert json.loads(received)["Message"] == message
 
         retry(get_message, retries=5, sleep=2)
 


### PR DESCRIPTION
This PR is an extension of #5175.

Changes: 
- Addition of a negative test that validates the correct parameters for a Fifo SNS message publication and the FIFO queue subscription.
- Migration of all the tests from the file `/tests/integration/test_sns.py` to the pytest format of assertions.
