### PR TITLE
Add ability to customize default IAM/STS user

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -182,6 +182,80 @@ def load_environment(profile: str = None):
     dotenv.load_dotenv(path, override=False)
 
 
+def has_docker():
+    try:
+        with open(os.devnull, "w") as devnull:
+            subprocess.check_output("docker ps", stderr=devnull, shell=True)
+        return True
+    except Exception:
+        return False
+
+
+def is_linux():
+    return platform.system() == "Linux"
+
+
+def ping(host):
+    """Returns True if host responds to a ping request"""
+    is_windows = platform.system().lower() == "windows"
+    ping_opts = "-n 1" if is_windows else "-c 1"
+    args = "ping %s %s" % (ping_opts, host)
+    return (
+        subprocess.call(args, shell=not is_windows, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        == 0
+    )
+
+
+def in_docker():
+    """
+    Returns True if running in a docker container, else False
+    Ref. https://docs.docker.com/config/containers/runmetrics/#control-groups
+    """
+    if OVERRIDE_IN_DOCKER:
+        return True
+
+    # details: https://github.com/localstack/localstack/pull/4352
+    if os.path.exists("/.dockerenv"):
+        return True
+    if os.path.exists("/run/.containerenv"):
+        return True
+
+    if not os.path.exists("/proc/1/cgroup"):
+        return False
+    try:
+        if any(
+            [
+                os.path.exists("/sys/fs/cgroup/memory/docker/"),
+                any(
+                    "docker-" in file_names
+                    for file_names in os.listdir("/sys/fs/cgroup/memory/system.slice")
+                ),
+                os.path.exists("/sys/fs/cgroup/docker/"),
+                any(
+                    "docker-" in file_names
+                    for file_names in os.listdir("/sys/fs/cgroup/system.slice/")
+                ),
+            ]
+        ):
+            return False
+    except Exception:
+        pass
+    with open("/proc/1/cgroup", "rt") as ifh:
+        content = ifh.read()
+        if "docker" in content:
+            return True
+        os_hostname = socket.gethostname()
+        if os_hostname and os_hostname in content:
+            return True
+    return False
+
+
+# whether the in_docker check should always return true
+OVERRIDE_IN_DOCKER = is_env_true("OVERRIDE_IN_DOCKER")
+
+is_in_docker = in_docker()
+is_in_linux = is_linux()
+
 # the configuration profile to load
 CONFIG_PROFILE = os.environ.get("CONFIG_PROFILE", "").strip()
 
@@ -195,84 +269,16 @@ except ImportError:
     # dotenv may not be available in lambdas or other environments where config is loaded
     pass
 
-# java options to Lambda
-LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
-
-# limit in which to kinesalite will start throwing exceptions
-KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
-
-# delay in kinesalite response when making changes to streams
-KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
-
-# Kinesis provider - either "kinesis-mock" or "kinesalite"
-KINESIS_PROVIDER = os.environ.get("KINESIS_PROVIDER") or "kinesis-mock"
-
 # default AWS region
 if "DEFAULT_REGION" not in os.environ:
     os.environ["DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or AWS_REGION_US_EAST_1
 DEFAULT_REGION = os.environ["DEFAULT_REGION"]
 
-# Whether or not to handle lambda event sources as synchronous invocations
-SYNCHRONOUS_SNS_EVENTS = is_env_true("SYNCHRONOUS_SNS_EVENTS")
-SYNCHRONOUS_SQS_EVENTS = is_env_true("SYNCHRONOUS_SQS_EVENTS")
-SYNCHRONOUS_API_GATEWAY_EVENTS = is_env_not_false("SYNCHRONOUS_API_GATEWAY_EVENTS")
-SYNCHRONOUS_KINESIS_EVENTS = is_env_not_false("SYNCHRONOUS_KINESIS_EVENTS")
-SYNCHRONOUS_DYNAMODB_EVENTS = is_env_not_false("SYNCHRONOUS_DYNAMODB_EVENTS")
-
-# randomly inject faults to Kinesis
-KINESIS_ERROR_PROBABILITY = float(os.environ.get("KINESIS_ERROR_PROBABILITY", "").strip() or 0.0)
-
-# randomly inject faults to DynamoDB
-DYNAMODB_ERROR_PROBABILITY = float(os.environ.get("DYNAMODB_ERROR_PROBABILITY", "").strip() or 0.0)
-DYNAMODB_READ_ERROR_PROBABILITY = float(
-    os.environ.get("DYNAMODB_READ_ERROR_PROBABILITY", "").strip() or 0.0
-)
-DYNAMODB_WRITE_ERROR_PROBABILITY = float(
-    os.environ.get("DYNAMODB_WRITE_ERROR_PROBABILITY", "").strip() or 0.0
-)
-
-# JAVA EE heap size for dynamodb
-DYNAMODB_HEAP_SIZE = os.environ.get("DYNAMODB_HEAP_SIZE", "").strip() or "256m"
-
 # expose services on a specific host externally
 HOSTNAME_EXTERNAL = os.environ.get("HOSTNAME_EXTERNAL", "").strip() or LOCALHOST
 
-# expose SQS on a specific port externally
-SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
-
 # name of the host under which the LocalStack services are available
 LOCALSTACK_HOSTNAME = os.environ.get("LOCALSTACK_HOSTNAME", "").strip() or LOCALHOST
-
-# host under which the LocalStack services are available from Lambda Docker containers
-HOSTNAME_FROM_LAMBDA = os.environ.get("HOSTNAME_FROM_LAMBDA", "").strip()
-
-# whether to remotely copy the lambda code or locally mount a volume
-LAMBDA_REMOTE_DOCKER = is_env_true("LAMBDA_REMOTE_DOCKER")
-
-# Marker name to indicate that a bucket represents the local file system. This is used for testing
-# Serverless applications where we mount the Lambda code directly into the container from the host OS.
-BUCKET_MARKER_LOCAL = (
-    os.environ.get("BUCKET_MARKER_LOCAL", "").strip() or DEFAULT_BUCKET_MARKER_LOCAL
-)
-
-# network that the docker lambda container will be joining
-LAMBDA_DOCKER_NETWORK = os.environ.get("LAMBDA_DOCKER_NETWORK", "").strip()
-
-# custom DNS server that the docker lambda container will use
-LAMBDA_DOCKER_DNS = os.environ.get("LAMBDA_DOCKER_DNS", "").strip()
-
-# additional flags passed to Lambda Docker run/create commands
-LAMBDA_DOCKER_FLAGS = os.environ.get("LAMBDA_DOCKER_FLAGS", "").strip()
-
-# default container registry for lambda execution images
-LAMBDA_CONTAINER_REGISTRY = (
-    os.environ.get("LAMBDA_CONTAINER_REGISTRY", "").strip() or DEFAULT_LAMBDA_CONTAINER_REGISTRY
-)
-
-# whether to remove containers after Lambdas finished executing
-LAMBDA_REMOVE_CONTAINERS = (
-    os.environ.get("LAMBDA_REMOVE_CONTAINERS", "").lower().strip() not in FALSE_STRINGS
-)
 
 # directory for persisting data
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()
@@ -368,14 +374,6 @@ SKIP_INFRA_DOWNLOADS = os.environ.get("SKIP_INFRA_DOWNLOADS", "").strip()
 # whether to enable legacy record&replay persistence mechanism (default true, but will be disabled in a future release!)
 LEGACY_PERSISTENCE = is_env_not_false("LEGACY_PERSISTENCE")
 
-# Adding Stepfunctions default port
-LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
-# Stepfunctions lambda endpoint override
-STEPFUNCTIONS_LAMBDA_ENDPOINT = os.environ.get("STEPFUNCTIONS_LAMBDA_ENDPOINT", "").strip()
-
-# path prefix for windows volume mounting
-WINDOWS_DOCKER_MOUNT_PREFIX = os.environ.get("WINDOWS_DOCKER_MOUNT_PREFIX", "/host_mnt")
-
 # name of the main Docker container
 MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack_main"
 
@@ -385,31 +383,157 @@ LOCALSTACK_BUILD_GIT_HASH = os.environ.get("LOCALSTACK_BUILD_GIT_HASH", "").stri
 # the date on which the docker image was created
 LOCALSTACK_BUILD_DATE = os.environ.get("LOCALSTACK_BUILD_DATE", "").strip() or None
 
-# whether to skip S3 presign URL signature validation (TODO: currently enabled, until all issues are resolved)
-S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false("S3_SKIP_SIGNATURE_VALIDATION")
+# Equivalent to HTTP_PROXY, but only applicable for external connections
+OUTBOUND_HTTP_PROXY = os.environ.get("OUTBOUND_HTTP_PROXY", "")
+
+# Equivalent to HTTPS_PROXY, but only applicable for external connections
+OUTBOUND_HTTPS_PROXY = os.environ.get("OUTBOUND_HTTPS_PROXY", "")
+
+# Whether to enable the partition adjustment listener (in order to support other partitions that the default)
+ARN_PARTITION_REWRITING = is_env_true("ARN_PARTITION_REWRITING")
 
 # whether to skip waiting for the infrastructure to shut down, or exit immediately
 FORCE_SHUTDOWN = is_env_not_false("FORCE_SHUTDOWN")
 
-# whether the in_docker check should always return true
-OVERRIDE_IN_DOCKER = is_env_true("OVERRIDE_IN_DOCKER")
-
 # whether to return mocked success responses for still unimplemented API methods
 MOCK_UNIMPLEMENTED = is_env_true("MOCK_UNIMPLEMENTED")
 
+# set variables no_proxy, i.e., run internal service calls directly
+no_proxy = ",".join([LOCALSTACK_HOSTNAME, LOCALHOST, LOCALHOST_IP, "[::1]"])
+if os.environ.get("no_proxy"):
+    os.environ["no_proxy"] += "," + no_proxy
+elif os.environ.get("NO_PROXY"):
+    os.environ["NO_PROXY"] += "," + no_proxy
+else:
+    os.environ["no_proxy"] = no_proxy
 
-def has_docker():
-    try:
-        with open(os.devnull, "w") as devnull:
-            subprocess.check_output("docker ps", stderr=devnull, shell=True)
-        return True
-    except Exception:
-        return False
+# additional CLI commands, can be set by plugins
+CLI_COMMANDS = {}
+
+# set of valid regions
+VALID_PARTITIONS = set(Session().get_available_partitions())
+VALID_REGIONS = set()
+for partition in VALID_PARTITIONS:
+    for region in Session().get_available_regions("sns", partition):
+        VALID_REGIONS.add(region)
 
 
-def is_linux():
-    return platform.system() == "Linux"
+# determine IP of Docker bridge
+if not DOCKER_BRIDGE_IP:
+    DOCKER_BRIDGE_IP = "172.17.0.1"
+    if is_in_docker:
+        candidates = (DOCKER_BRIDGE_IP, "172.18.0.1")
+        for ip in candidates:
+            if ping(ip):
+                DOCKER_BRIDGE_IP = ip
+                break
 
+# determine route to Docker host from container
+try:
+    DOCKER_HOST_FROM_CONTAINER = DOCKER_BRIDGE_IP
+    if not is_in_docker and not is_in_linux:
+        # If we're running outside docker, and would like the Lambda containers to be able
+        # to access services running on the local machine, set DOCKER_HOST_FROM_CONTAINER accordingly
+        if LOCALSTACK_HOSTNAME == LOCALHOST:
+            DOCKER_HOST_FROM_CONTAINER = "host.docker.internal"
+    # update LOCALSTACK_HOSTNAME if host.docker.internal is available
+    if is_in_docker:
+        DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.docker.internal")
+        if LOCALSTACK_HOSTNAME == DOCKER_BRIDGE_IP:
+            LOCALSTACK_HOSTNAME = DOCKER_HOST_FROM_CONTAINER
+except socket.error:
+    pass
+
+
+# -----
+# SERVICE-SPECIFIC CONFIGS BELOW
+# -----
+
+# java options to Lambda
+LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
+
+# limit in which to kinesalite will start throwing exceptions
+KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
+
+# delay in kinesalite response when making changes to streams
+KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
+
+# Kinesis provider - either "kinesis-mock" or "kinesalite"
+KINESIS_PROVIDER = os.environ.get("KINESIS_PROVIDER") or "kinesis-mock"
+
+# Whether or not to handle lambda event sources as synchronous invocations
+SYNCHRONOUS_SNS_EVENTS = is_env_true("SYNCHRONOUS_SNS_EVENTS")
+SYNCHRONOUS_SQS_EVENTS = is_env_true("SYNCHRONOUS_SQS_EVENTS")
+SYNCHRONOUS_API_GATEWAY_EVENTS = is_env_not_false("SYNCHRONOUS_API_GATEWAY_EVENTS")
+SYNCHRONOUS_KINESIS_EVENTS = is_env_not_false("SYNCHRONOUS_KINESIS_EVENTS")
+SYNCHRONOUS_DYNAMODB_EVENTS = is_env_not_false("SYNCHRONOUS_DYNAMODB_EVENTS")
+
+# randomly inject faults to Kinesis
+KINESIS_ERROR_PROBABILITY = float(os.environ.get("KINESIS_ERROR_PROBABILITY", "").strip() or 0.0)
+
+# randomly inject faults to DynamoDB
+DYNAMODB_ERROR_PROBABILITY = float(os.environ.get("DYNAMODB_ERROR_PROBABILITY", "").strip() or 0.0)
+DYNAMODB_READ_ERROR_PROBABILITY = float(
+    os.environ.get("DYNAMODB_READ_ERROR_PROBABILITY", "").strip() or 0.0
+)
+DYNAMODB_WRITE_ERROR_PROBABILITY = float(
+    os.environ.get("DYNAMODB_WRITE_ERROR_PROBABILITY", "").strip() or 0.0
+)
+
+# JAVA EE heap size for dynamodb
+DYNAMODB_HEAP_SIZE = os.environ.get("DYNAMODB_HEAP_SIZE", "").strip() or "256m"
+
+# expose SQS on a specific port externally
+SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
+
+# host under which the LocalStack services are available from Lambda Docker containers
+HOSTNAME_FROM_LAMBDA = os.environ.get("HOSTNAME_FROM_LAMBDA", "").strip()
+
+# whether to remotely copy the Lambda code or locally mount a volume
+LAMBDA_REMOTE_DOCKER = is_env_true("LAMBDA_REMOTE_DOCKER")
+# make sure we default to LAMBDA_REMOTE_DOCKER=true if running in Docker
+if is_in_docker and not os.environ.get("LAMBDA_REMOTE_DOCKER", "").strip():
+    LAMBDA_REMOTE_DOCKER = True
+
+# Marker name to indicate that a bucket represents the local file system. This is used for testing
+# Serverless applications where we mount the Lambda code directly into the container from the host OS.
+BUCKET_MARKER_LOCAL = (
+    os.environ.get("BUCKET_MARKER_LOCAL", "").strip() or DEFAULT_BUCKET_MARKER_LOCAL
+)
+
+# network that the docker lambda container will be joining
+LAMBDA_DOCKER_NETWORK = os.environ.get("LAMBDA_DOCKER_NETWORK", "").strip()
+
+# custom DNS server that the docker lambda container will use
+LAMBDA_DOCKER_DNS = os.environ.get("LAMBDA_DOCKER_DNS", "").strip()
+
+# additional flags passed to Lambda Docker run/create commands
+LAMBDA_DOCKER_FLAGS = os.environ.get("LAMBDA_DOCKER_FLAGS", "").strip()
+
+# default container registry for lambda execution images
+LAMBDA_CONTAINER_REGISTRY = (
+    os.environ.get("LAMBDA_CONTAINER_REGISTRY", "").strip() or DEFAULT_LAMBDA_CONTAINER_REGISTRY
+)
+
+# whether to remove containers after Lambdas finished executing
+LAMBDA_REMOVE_CONTAINERS = (
+    os.environ.get("LAMBDA_REMOVE_CONTAINERS", "").lower().strip() not in FALSE_STRINGS
+)
+
+# Adding Stepfunctions default port
+LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
+# Stepfunctions lambda endpoint override
+STEPFUNCTIONS_LAMBDA_ENDPOINT = os.environ.get("STEPFUNCTIONS_LAMBDA_ENDPOINT", "").strip()
+
+# path prefix for windows volume mounting
+WINDOWS_DOCKER_MOUNT_PREFIX = os.environ.get("WINDOWS_DOCKER_MOUNT_PREFIX", "/host_mnt")
+
+# whether to skip S3 presign URL signature validation (TODO: currently enabled, until all issues are resolved)
+S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false("S3_SKIP_SIGNATURE_VALIDATION")
+
+# user ID of default user, to be returned on sts.get_caller_identity
+TEST_IAM_USER_ID = str(os.environ.get("TEST_IAM_USER_ID") or "").strip()
+TEST_IAM_USER_NAME = str(os.environ.get("TEST_IAM_USER_NAME") or "").strip()
 
 # whether to use Lambda functions in a Docker container
 LAMBDA_EXECUTOR = os.environ.get("LAMBDA_EXECUTOR", "").strip()
@@ -431,6 +555,9 @@ LAMBDA_FORWARD_URL = os.environ.get("LAMBDA_FORWARD_URL", "").strip()
 # to avoid client/network timeout issues
 LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
 
+# whether lambdas should use stay open mode if executed in "docker-reuse" executor
+LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")
+
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup.
 # For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
@@ -447,90 +574,83 @@ ES_ENDPOINT_STRATEGY = os.environ.get("ES_ENDPOINT_STRATEGY", "").strip() or "do
 # Whether to start one cluster per domain (default), or multiplex domains to a single clusters
 ES_MULTI_CLUSTER = is_env_not_false("ES_MULTI_CLUSTER")
 
-# Equivalent to HTTP_PROXY, but only applicable for external connections
-OUTBOUND_HTTP_PROXY = os.environ.get("OUTBOUND_HTTP_PROXY", "")
-
-# Equivalent to HTTPS_PROXY, but only applicable for external connections
-OUTBOUND_HTTPS_PROXY = os.environ.get("OUTBOUND_HTTPS_PROXY", "")
-
-# Whether to enable the partition adjustment listener (in order to support other partitions that the default)
-ARN_PARTITION_REWRITING = is_env_true("ARN_PARTITION_REWRITING")
-
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = [
-    "SERVICES",
-    "HOSTNAME",
-    "HOSTNAME_EXTERNAL",
-    "LOCALSTACK_HOSTNAME",
-    "LAMBDA_FALLBACK_URL",
-    "LAMBDA_EXECUTOR",
-    "LAMBDA_REMOTE_DOCKER",
-    "LAMBDA_DOCKER_NETWORK",
-    "LAMBDA_REMOVE_CONTAINERS",
-    "USE_SSL",
-    "USE_SINGLE_REGION",
+    "BUCKET_MARKER_LOCAL",
     "DEBUG",
-    "KINESIS_ERROR_PROBABILITY",
+    "DEFAULT_REGION",
+    "DEVELOP",
+    "DEVELOP_PORT",
+    "DISABLE_CORS_CHECKS",
+    "DISABLE_CUSTOM_CORS_APIGATEWAY",
+    "DISABLE_CUSTOM_CORS_S3",
+    "DISABLE_EVENTS",
+    "DOCKER_BRIDGE_IP",
     "DYNAMODB_ERROR_PROBABILITY",
+    "DYNAMODB_HEAP_SIZE",
     "DYNAMODB_READ_ERROR_PROBABILITY",
     "DYNAMODB_WRITE_ERROR_PROBABILITY",
+    "EAGER_SERVICE_LOADING",
+    "EDGE_FORWARD_URL",
+    "EDGE_PORT",
+    "EDGE_PORT_HTTP",
+    "ENABLE_CONFIG_UPDATES",
     "ES_CUSTOM_BACKEND",
     "ES_ENDPOINT_STRATEGY",
     "ES_MULTI_CLUSTER",
-    "DOCKER_BRIDGE_IP",
-    "DEFAULT_REGION",
-    "LAMBDA_JAVA_OPTS",
-    "LOCALSTACK_API_KEY",
+    "EXTRA_CORS_ALLOWED_HEADERS",
+    "EXTRA_CORS_ALLOWED_ORIGINS",
+    "EXTRA_CORS_EXPOSE_HEADERS",
+    "HOSTNAME",
+    "HOSTNAME_EXTERNAL",
+    "HOSTNAME_FROM_LAMBDA",
+    "KINESIS_ERROR_PROBABILITY",
+    "KINESIS_INITIALIZE_STREAMS",
+    "LAMBDA_CODE_EXTRACT_TIME",
     "LAMBDA_CONTAINER_REGISTRY",
-    "TEST_AWS_ACCOUNT_ID",
-    "DISABLE_EVENTS",
-    "EDGE_PORT",
+    "LAMBDA_DOCKER_DNS",
+    "LAMBDA_DOCKER_FLAGS",
+    "LAMBDA_DOCKER_NETWORK",
+    "LAMBDA_EXECUTOR",
+    "LAMBDA_FALLBACK_URL",
+    "LAMBDA_FORWARD_URL",
+    "LAMBDA_JAVA_OPTS",
+    "LAMBDA_REMOTE_DOCKER",
+    "LAMBDA_REMOVE_CONTAINERS",
+    "LAMBDA_STAY_OPEN_MODE",
+    "LEGACY_DOCKER_CLIENT",
+    "LOCALSTACK_API_KEY",
+    "LOCALSTACK_HOSTNAME",
+    "LOG_LICENSE_ISSUES",
     "LS_LOG",
-    "EDGE_PORT_HTTP",
-    "EDGE_FORWARD_URL",
+    "MAIN_CONTAINER_NAME",
+    "OUTBOUND_HTTP_PROXY",
+    "OUTBOUND_HTTPS_PROXY",
+    "PERSISTENCE_SINGLE_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "S3_SKIP_SIGNATURE_VALIDATION",
+    "SERVICES",
     "SKIP_INFRA_DOWNLOADS",
     "STEPFUNCTIONS_LAMBDA_ENDPOINT",
-    "WINDOWS_DOCKER_MOUNT_PREFIX",
-    "HOSTNAME_FROM_LAMBDA",
-    "LOG_LICENSE_ISSUES",
     "SYNCHRONOUS_API_GATEWAY_EVENTS",
+    "SYNCHRONOUS_DYNAMODB_EVENTS",
     "SYNCHRONOUS_KINESIS_EVENTS",
-    "BUCKET_MARKER_LOCAL",
     "SYNCHRONOUS_SNS_EVENTS",
     "SYNCHRONOUS_SQS_EVENTS",
-    "SYNCHRONOUS_DYNAMODB_EVENTS",
-    "DYNAMODB_HEAP_SIZE",
-    "MAIN_CONTAINER_NAME",
-    "LAMBDA_DOCKER_DNS",
-    "PERSISTENCE_SINGLE_FILE",
-    "S3_SKIP_SIGNATURE_VALIDATION",
-    "DEVELOP",
-    "DEVELOP_PORT",
-    "WAIT_FOR_DEBUGGER",
-    "KINESIS_INITIALIZE_STREAMS",
+    "TEST_AWS_ACCOUNT_ID",
+    "TEST_IAM_USER_ID",
+    "TEST_IAM_USER_NAME",
     "TF_COMPAT_MODE",
-    "LAMBDA_DOCKER_FLAGS",
-    "LAMBDA_FORWARD_URL",
-    "LAMBDA_CODE_EXTRACT_TIME",
     "THUNDRA_APIKEY",
     "THUNDRA_AGENT_JAVA_VERSION",
     "THUNDRA_AGENT_NODE_VERSION",
     "THUNDRA_AGENT_PYTHON_VERSION",
-    "DISABLE_CORS_CHECKS",
-    "DISABLE_CUSTOM_CORS_S3",
-    "DISABLE_CUSTOM_CORS_APIGATEWAY",
-    "EXTRA_CORS_ALLOWED_HEADERS",
-    "EXTRA_CORS_EXPOSE_HEADERS",
-    "EXTRA_CORS_ALLOWED_ORIGINS",
-    "ENABLE_CONFIG_UPDATES",
-    "LOCALSTACK_HTTP_PROXY",
-    "LOCALSTACK_HTTPS_PROXY",
-    "REQUESTS_CA_BUNDLE",
-    "LEGACY_DOCKER_CLIENT",
-    "EAGER_SERVICE_LOADING",
-    "LAMBDA_STAY_OPEN_MODE",
+    "USE_SINGLE_REGION",
+    "USE_SSL",
+    "WAIT_FOR_DEBUGGER",
+    "WINDOWS_DOCKER_MOUNT_PREFIX",
 ]
 
 for key, value in six.iteritems(DEFAULT_SERVICE_PORTS):
@@ -563,117 +683,6 @@ def collect_config_items() -> List[Tuple[str, Any]]:
         result.append((k, v))
     result.sort()
     return result
-
-
-def ping(host):
-    """Returns True if host responds to a ping request"""
-    is_windows = platform.system().lower() == "windows"
-    ping_opts = "-n 1" if is_windows else "-c 1"
-    args = "ping %s %s" % (ping_opts, host)
-    return (
-        subprocess.call(args, shell=not is_windows, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        == 0
-    )
-
-
-def in_docker():
-    """
-    Returns True if running in a docker container, else False
-    Ref. https://docs.docker.com/config/containers/runmetrics/#control-groups
-    """
-    if OVERRIDE_IN_DOCKER:
-        return True
-
-    # details: https://github.com/localstack/localstack/pull/4352
-    if os.path.exists("/.dockerenv"):
-        return True
-    if os.path.exists("/run/.containerenv"):
-        return True
-
-    if not os.path.exists("/proc/1/cgroup"):
-        return False
-    try:
-        if any(
-            [
-                os.path.exists("/sys/fs/cgroup/memory/docker/"),
-                any(
-                    "docker-" in file_names
-                    for file_names in os.listdir("/sys/fs/cgroup/memory/system.slice")
-                ),
-                os.path.exists("/sys/fs/cgroup/docker/"),
-                any(
-                    "docker-" in file_names
-                    for file_names in os.listdir("/sys/fs/cgroup/system.slice/")
-                ),
-            ]
-        ):
-            return False
-    except Exception:
-        pass
-    with open("/proc/1/cgroup", "rt") as ifh:
-        content = ifh.read()
-        if "docker" in content:
-            return True
-        os_hostname = socket.gethostname()
-        if os_hostname and os_hostname in content:
-            return True
-    return False
-
-
-is_in_docker = in_docker()
-is_in_linux = is_linux()
-
-# determine IP of Docker bridge
-if not DOCKER_BRIDGE_IP:
-    DOCKER_BRIDGE_IP = "172.17.0.1"
-    if is_in_docker:
-        candidates = (DOCKER_BRIDGE_IP, "172.18.0.1")
-        for ip in candidates:
-            if ping(ip):
-                DOCKER_BRIDGE_IP = ip
-                break
-
-# determine route to Docker host from container
-try:
-    DOCKER_HOST_FROM_CONTAINER = DOCKER_BRIDGE_IP
-    if not is_in_docker and not is_in_linux:
-        # If we're running outside docker, and would like the Lambda containers to be able
-        # to access services running on the local machine, set DOCKER_HOST_FROM_CONTAINER accordingly
-        if LOCALSTACK_HOSTNAME == LOCALHOST:
-            DOCKER_HOST_FROM_CONTAINER = "host.docker.internal"
-    # update LOCALSTACK_HOSTNAME if host.docker.internal is available
-    if is_in_docker:
-        DOCKER_HOST_FROM_CONTAINER = socket.gethostbyname("host.docker.internal")
-        if LOCALSTACK_HOSTNAME == DOCKER_BRIDGE_IP:
-            LOCALSTACK_HOSTNAME = DOCKER_HOST_FROM_CONTAINER
-except socket.error:
-    pass
-
-# make sure we default to LAMBDA_REMOTE_DOCKER=true if running in Docker
-if is_in_docker and not os.environ.get("LAMBDA_REMOTE_DOCKER", "").strip():
-    LAMBDA_REMOTE_DOCKER = True
-
-# whether lambdas should use stay open mode if executed in "docker-reuse" executor
-LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")
-
-# set variables no_proxy, i.e., run internal service calls directly
-no_proxy = ",".join(set((LOCALSTACK_HOSTNAME, LOCALHOST, LOCALHOST_IP, "[::1]")))
-if os.environ.get("no_proxy"):
-    os.environ["no_proxy"] += "," + no_proxy
-elif os.environ.get("NO_PROXY"):
-    os.environ["NO_PROXY"] += "," + no_proxy
-else:
-    os.environ["no_proxy"] = no_proxy
-
-# additional CLI commands, can be set by plugins
-CLI_COMMANDS = {}
-
-# set of valid regions
-VALID_PARTITIONS = set(Session().get_available_partitions())
-VALID_REGIONS = set()
-for partition in VALID_PARTITIONS:
-    for region in Session().get_available_regions("sns", partition):
-        VALID_REGIONS.add(region)
 
 
 def parse_service_ports() -> Dict[str, int]:

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -36,7 +36,7 @@ DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
 # host to bind to when starting the services
 BIND_HOST = "0.0.0.0"
 
-# AWS user account ID used for tests
+# AWS user account ID used for tests - TODO move to config.py
 if "TEST_AWS_ACCOUNT_ID" not in os.environ:
     os.environ["TEST_AWS_ACCOUNT_ID"] = "000000000000"
 TEST_AWS_ACCOUNT_ID = os.environ["TEST_AWS_ACCOUNT_ID"]

--- a/localstack/services/iam/iam_starter.py
+++ b/localstack/services/iam/iam_starter.py
@@ -192,7 +192,6 @@ def apply_patches():
 
     # patch/implement simulate_principal_policy
 
-    @patch(IamResponse.simulate_principal_policy, pass_target=False)
     def iam_response_simulate_principal_policy(self):
         def build_evaluation(action_name, resource_name, policy_statements):
             for statement in policy_statements:
@@ -227,6 +226,9 @@ def apply_patches():
 
         template = self.response_template(SIMULATE_PRINCIPAL_POLICY_RESPONSE)
         return template.render(evaluations=evaluations)
+
+    if not hasattr(IamResponse, "simulate_principal_policy"):
+        IamResponse.simulate_principal_policy = iam_response_simulate_principal_policy
 
     # patch policy __init__ to set document as attribute
 

--- a/localstack/services/iam/iam_starter.py
+++ b/localstack/services/iam/iam_starter.py
@@ -25,6 +25,7 @@ from moto.iam.responses import (
 from localstack import config, constants
 from localstack.services.infra import start_moto_server
 from localstack.utils.common import short_uid
+from localstack.utils.patch import patch
 
 XMLNS_IAM = "https://iam.amazonaws.com/doc/2010-05-08/"
 
@@ -128,24 +129,30 @@ def apply_patches():
     if "Principal" not in VALID_STATEMENT_ELEMENTS:
         VALID_STATEMENT_ELEMENTS.append("Principal")
 
+    @patch(IAMPolicyDocumentValidator._validate_resource_syntax, pass_target=False)
     def _validate_resource_syntax(statement, *args, **kwargs):
         # Note: Serverless generates policies without "Resource" section (only "Effect"/"Principal"/"Action"),
         # which causes several policy validators in moto to fail
         if statement.get("Resource") in [None, [None]]:
             statement["Resource"] = ["*"]
 
-    IAMPolicyDocumentValidator._validate_resource_syntax = _validate_resource_syntax
-
     # patch get_user to include tags
 
-    def iam_response_get_user(self):
-        result = iam_response_get_user_orig(self)
-        user_name = re.sub(
-            r".*<UserName>\s*([^\s]+)\s*</UserName>.*",
-            r"\1",
-            result,
-            flags=re.MULTILINE | re.DOTALL,
-        )
+    @patch(IamResponse.get_user)
+    def iam_response_get_user(fn, self):
+        result = fn(self)
+        regex = r"(.*<UserName>\s*)([^\s]+)(\s*</UserName>.*)"
+        regex2 = r"(.*<UserId>\s*)([^\s]+)(\s*</UserId>.*)"
+        flags = re.MULTILINE | re.DOTALL
+
+        user_name = re.match(regex, result, flags=flags).group(2)
+        # replace default user id/name in response
+        if config.TEST_IAM_USER_NAME:
+            result = re.sub(regex, r"\g<1>%s\3" % config.TEST_IAM_USER_NAME, result)
+            user_name = config.TEST_IAM_USER_NAME
+        if config.TEST_IAM_USER_ID:
+            result = re.sub(regex2, r"\g<1>%s\3" % config.TEST_IAM_USER_ID, result)
+
         user = moto_iam_backend.users.get(user_name)
         if not user:
             return result
@@ -160,11 +167,9 @@ def apply_patches():
             result = result.replace("</Arn>", "</Arn><Tags>%s</Tags>" % tags_str)
         return result
 
-    iam_response_get_user_orig = IamResponse.get_user
-    IamResponse.get_user = iam_response_get_user
-
     # patch delete_policy
 
+    @patch(IamResponse.delete_policy, pass_target=False)
     def iam_response_delete_policy(self):
         policy_arn = self._get_param("PolicyArn")
         if moto_iam_backend.managed_policies.get(policy_arn):
@@ -174,10 +179,9 @@ def apply_patches():
         else:
             raise IAMNotFoundException("Policy {0} was not found.".format(policy_arn))
 
-    IamResponse.delete_policy = iam_response_delete_policy
-
     # patch detach_role_policy
 
+    @patch(moto_iam_backend.detach_role_policy, pass_target=False)
     def iam_backend_detach_role_policy(policy_arn, role_name):
         try:
             role = moto_iam_backend.get_role(role_name)
@@ -186,10 +190,9 @@ def apply_patches():
         except KeyError:
             raise IAMNotFoundException("Policy {0} was not found.".format(policy_arn))
 
-    moto_iam_backend.detach_role_policy = iam_backend_detach_role_policy
-
     # patch/implement simulate_principal_policy
 
+    @patch(IamResponse.simulate_principal_policy, pass_target=False)
     def iam_response_simulate_principal_policy(self):
         def build_evaluation(action_name, resource_name, policy_statements):
             for statement in policy_statements:
@@ -225,21 +228,18 @@ def apply_patches():
         template = self.response_template(SIMULATE_PRINCIPAL_POLICY_RESPONSE)
         return template.render(evaluations=evaluations)
 
-    IamResponse.simulate_principal_policy = iam_response_simulate_principal_policy
-
     # patch policy __init__ to set document as attribute
 
+    @patch(Policy.__init__)
     def policy__init__(
-        self, name, default_version_id=None, description=None, document=None, **kwargs
+        fn, self, name, default_version_id=None, description=None, document=None, **kwargs
     ):
-        policy_init_orig(self, name, default_version_id, description, document, **kwargs)
+        fn(self, name, default_version_id, description, document, **kwargs)
         self.document = document
-
-    policy_init_orig = Policy.__init__
-    Policy.__init__ = policy__init__
 
     # patch list_roles
 
+    @patch(IamResponse.list_roles, pass_target=False)
     def iam_response_list_roles(self):
         roles = moto_iam_backend.get_roles()
         items = []
@@ -261,19 +261,15 @@ def apply_patches():
         template = self.response_template(LIST_ROLES_TEMPLATE)
         return template.render(roles=items)
 
-    IamResponse.list_roles = iam_response_list_roles
-
     # patch unapply_policy
 
-    def inline_policy_unapply_policy(self, backend):
+    @patch(InlinePolicy.unapply_policy)
+    def inline_policy_unapply_policy(fn, self, backend):
         try:
-            inline_policy_unapply_policy_orig(self, backend)
+            fn(self, backend)
         except Exception:
             # Actually role can be deleted before policy being deleted in cloudformation
             pass
-
-    inline_policy_unapply_policy_orig = InlinePolicy.unapply_policy
-    InlinePolicy.unapply_policy = inline_policy_unapply_policy
 
     # support update_group
 
@@ -287,6 +283,7 @@ def apply_patches():
         moto_iam_backend.groups[new_group_name] = moto_iam_backend.groups.pop(group_name)
         return ""
 
+    # TODO: potentially extend @patch utility to allow "conditional" patches like below ...
     if not hasattr(IamResponse, "update_group"):
         IamResponse.update_group = update_group
 

--- a/localstack/services/sts/sts_starter.py
+++ b/localstack/services/sts/sts_starter.py
@@ -1,10 +1,24 @@
+from moto.sts.responses import TokenResponse
+
 from localstack import config
 from localstack.services.infra import start_moto_server
 
 
-def start_sts(port=None, asynchronous=False, update_listener=None):
-    port = port or config.PORT_STS
+def apply_patches():
+    def get_caller_identity(self, *args, **kwargs):
+        result = get_caller_identity_orig(self, *args, **kwargs)
+        username = config.TEST_IAM_USER_NAME or "localstack"
+        result = result.replace("user/moto", f"user/{username}")
+        return result
 
+    get_caller_identity_orig = TokenResponse.get_caller_identity
+    TokenResponse.get_caller_identity = get_caller_identity
+
+
+def start_sts(port=None, asynchronous=False, update_listener=None):
+    apply_patches()
+
+    port = port or config.PORT_STS
     return start_moto_server(
         "sts",
         port,

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from mypy_boto3_sqs import SQSClient
     from mypy_boto3_ssm import SSMClient
     from mypy_boto3_stepfunctions import SFNClient
+    from mypy_boto3_sts import STSClient
 
 LOG = logging.getLogger(__name__)
 
@@ -144,6 +145,11 @@ def firehose_client() -> "FirehoseClient":
 @pytest.fixture(scope="class")
 def cloudwatch_client() -> "CloudWatchClient":
     return _client("cloudwatch")
+
+
+@pytest.fixture(scope="class")
+def sts_client() -> "STSClient":
+    return _client("sts")
 
 
 @pytest.fixture

--- a/tests/integration/test_sts.py
+++ b/tests/integration/test_sts.py
@@ -1,49 +1,9 @@
-import unittest
 from base64 import b64encode
 
-from localstack.utils.aws import aws_stack
+from localstack import config
+from localstack.utils.common import short_uid
 
-
-class TestSTSIntegrations(unittest.TestCase):
-    def setUp(self):
-        self.sts_client = aws_stack.create_external_boto_client("sts")
-
-    def test_assume_role(self):
-        test_role_session_name = "s3-access-example"
-        test_role_arn = "arn:aws:sts::000000000000:role/rd_role"
-        response = self.sts_client.assume_role(
-            RoleArn=test_role_arn, RoleSessionName=test_role_session_name
-        )
-
-        self.assertTrue(response["Credentials"])
-        self.assertTrue(response["Credentials"]["SecretAccessKey"])
-        if response["AssumedRoleUser"]["AssumedRoleId"]:
-            assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
-            self.assertEqual(test_role_session_name, assume_role_id_parts[1])
-
-    def test_assume_role_with_web_identity(self):
-        test_role_session_name = "web_token"
-        test_role_arn = "arn:aws:sts::000000000000:role/rd_role"
-        test_web_identity_token = "token"
-        response = self.sts_client.assume_role_with_web_identity(
-            RoleArn=test_role_arn,
-            RoleSessionName=test_role_session_name,
-            WebIdentityToken=test_web_identity_token,
-        )
-
-        self.assertTrue(response["Credentials"])
-        self.assertTrue(response["Credentials"]["SecretAccessKey"])
-        if response["AssumedRoleUser"]["AssumedRoleId"]:
-            assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
-            self.assertEqual(test_role_session_name, assume_role_id_parts[1])
-
-    def test_assume_role_with_saml(self):
-        account_id = "000000000000"
-        role_name = "test-role"
-        provider_name = "TestProvFed"
-        fed_name = "testuser"
-
-        saml_assertion = """
+TEST_SAML_ASSERTION = """
 <?xml version="1.0"?>
 <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
     ID="_00000000-0000-0000-0000-000000000000" Version="2.0"
@@ -117,14 +77,52 @@ class TestSTSIntegrations(unittest.TestCase):
       </AuthnContext>
     </AuthnStatement>
   </Assertion>
-</samlp:Response>""".format(
+</samlp:Response>
+"""
+
+
+class TestSTSIntegrations:
+    def test_assume_role(self, sts_client):
+        test_role_session_name = "s3-access-example"
+        test_role_arn = "arn:aws:sts::000000000000:role/rd_role"
+        response = sts_client.assume_role(
+            RoleArn=test_role_arn, RoleSessionName=test_role_session_name
+        )
+
+        assert response["Credentials"]
+        assert response["Credentials"]["SecretAccessKey"]
+        if response["AssumedRoleUser"]["AssumedRoleId"]:
+            assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
+            assert assume_role_id_parts[1] == test_role_session_name
+
+    def test_assume_role_with_web_identity(self, sts_client):
+        test_role_session_name = "web_token"
+        test_role_arn = "arn:aws:sts::000000000000:role/rd_role"
+        test_web_identity_token = "token"
+        response = sts_client.assume_role_with_web_identity(
+            RoleArn=test_role_arn,
+            RoleSessionName=test_role_session_name,
+            WebIdentityToken=test_web_identity_token,
+        )
+
+        assert response["Credentials"]
+        assert response["Credentials"]["SecretAccessKey"]
+        if response["AssumedRoleUser"]["AssumedRoleId"]:
+            assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
+            assert assume_role_id_parts[1] == test_role_session_name
+
+    def test_assume_role_with_saml(self, sts_client):
+        account_id = "000000000000"
+        role_name = "test-role"
+        provider_name = "TestProvFed"
+        fed_name = "testuser"
+
+        saml_assertion = TEST_SAML_ASSERTION.format(
             account_id=account_id,
             role_name=role_name,
             provider_name=provider_name,
             fed_name=fed_name,
-        ).replace(
-            "\n", ""
-        )
+        ).replace("\n", "")
 
         role_arn = "arn:aws:iam::{account_id}:role/{role_name}".format(
             account_id=account_id, role_name=role_name
@@ -133,25 +131,37 @@ class TestSTSIntegrations(unittest.TestCase):
             account_id=account_id, provider_name=provider_name
         )
         base64_saml_assertion = b64encode(saml_assertion.encode("utf-8")).decode("utf-8")
-        response = self.sts_client.assume_role_with_saml(
+        response = sts_client.assume_role_with_saml(
             RoleArn=role_arn,
             PrincipalArn=principal_arn,
             SAMLAssertion=base64_saml_assertion,
         )
 
-        self.assertTrue(response["Credentials"])
-        self.assertTrue(response["Credentials"]["SecretAccessKey"])
+        assert response["Credentials"]
+        assert response["Credentials"]["SecretAccessKey"]
         if response["AssumedRoleUser"]["AssumedRoleId"]:
             assume_role_id_parts = response["AssumedRoleUser"]["AssumedRoleId"].split(":")
-            self.assertEqual(fed_name, assume_role_id_parts[1])
+            assert assume_role_id_parts[1] == fed_name
 
-    def test_get_federation_token(self):
+    def test_get_federation_token(self, sts_client):
         token_name = "TestName"
-        response = self.sts_client.get_federation_token(Name=token_name)
+        response = sts_client.get_federation_token(Name=token_name)
 
-        self.assertTrue(response["Credentials"])
-        self.assertTrue(response["Credentials"]["SecretAccessKey"])
-        self.assertTrue(response["Credentials"]["SessionToken"])
-        self.assertTrue(response["Credentials"]["Expiration"])
+        assert response["Credentials"]
+        assert response["Credentials"]["SecretAccessKey"]
+        assert response["Credentials"]["SessionToken"]
+        assert response["Credentials"]["Expiration"]
         federated_user_info = response["FederatedUser"]["FederatedUserId"].split(":")
-        self.assertEqual(token_name, federated_user_info[1])
+        assert federated_user_info[1] == token_name
+
+    def test_get_caller_identity(self, sts_client, monkeypatch):
+        response = sts_client.get_caller_identity()
+        assert ":user/localstack" in response.get("Arn")
+
+        test_name = f"u-{short_uid()}"
+        test_id = short_uid()
+        monkeypatch.setattr(config, "TEST_IAM_USER_NAME", test_name)
+        monkeypatch.setattr(config, "TEST_IAM_USER_ID", test_id)
+        response = sts_client.get_caller_identity()
+        assert f":user/{test_name}" in response.get("Arn")
+        # assert response.get("UserId") == test_id


### PR DESCRIPTION
* add ability to customize default IAM/STS user - similar to `TEST_AWS_ACCOUNT_ID`, this now allows to specify `TEST_IAM_USER_ID` and `TEST_IAM_USER_NAME` to customize the default user id/name
* small fix for IAM issue reported in #5196
* refactor config values - trying to group configs by service and into logical units (this is just a first step toward config refactoring, more will follow..)
* migrate to using `@patch` decorator for IAM patches
* convert STS tests from `unittest`->`pytest`

Follow-up items:
- [ ] add new config options to docs /cc @HarshCasper could you help out with that please? 🙏 