### PR TITLE
Support for dynamic references in CloudFormation

### DIFF
--- a/tests/integration/cloudformation/test_cloudformation_dynamic_parameters.py
+++ b/tests/integration/cloudformation/test_cloudformation_dynamic_parameters.py
@@ -1,0 +1,142 @@
+import jinja2 as jinja2
+
+from localstack.utils.common import short_uid
+from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+
+
+def test_resolve_ssm(
+    ssm_client,
+    cfn_client,
+    is_change_set_created_and_available,
+    is_stack_created,
+    cleanup_changesets,
+    cleanup_stacks,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    parameter_key = f"param-key-{short_uid()}"
+    parameter_value = f"param-value-{short_uid()}"
+    ssm_client.put_parameter(Name=parameter_key, Value=parameter_value, Type="String")
+    template_rendered = jinja2.Template(load_template_raw("resolve_ssm.yaml")).render(
+        parameter_key=parameter_key,
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        describe_result = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+        assert describe_result["StackStatus"] == "CREATE_COMPLETE"
+
+        topic_name = [
+            o["OutputValue"] for o in describe_result["Outputs"] if o["OutputKey"] == "TopicName"
+        ][0]
+        assert topic_name == parameter_value
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])
+        ssm_client.delete_parameter(Name=parameter_key)
+
+
+def test_resolve_ssm_secure(
+    ssm_client,
+    cfn_client,
+    is_change_set_created_and_available,
+    is_stack_created,
+    cleanup_changesets,
+    cleanup_stacks,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    parameter_key = f"param-key-{short_uid()}"
+    parameter_value = f"param-value-{short_uid()}"
+
+    ssm_client.put_parameter(Name=parameter_key, Value=parameter_value, Type="SecureString")
+
+    template_rendered = jinja2.Template(load_template_raw("resolve_ssm_secure.yaml")).render(
+        parameter_key=parameter_key,
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        describe_result = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+        assert describe_result["StackStatus"] == "CREATE_COMPLETE"
+
+        topic_name = [
+            o["OutputValue"] for o in describe_result["Outputs"] if o["OutputKey"] == "TopicName"
+        ][0]
+        assert topic_name == parameter_value
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])
+        ssm_client.delete_parameter(Name=parameter_key)
+
+
+def test_resolve_secretsmanager(
+    secretsmanager_client,
+    cfn_client,
+    is_change_set_created_and_available,
+    is_stack_created,
+    create_secret,
+    create_parameter,
+    cleanup_changesets,
+    cleanup_stacks,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    parameter_key = f"param-key-{short_uid()}"
+    parameter_value = f"param-value-{short_uid()}"
+
+    create_secret(Name=parameter_key, SecretString=parameter_value)
+
+    template_rendered = jinja2.Template(load_template_raw("resolve_secretsmanager.yaml")).render(
+        parameter_key=parameter_key,
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        describe_result = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+        assert describe_result["StackStatus"] == "CREATE_COMPLETE"
+
+        topic_name = [
+            o["OutputValue"] for o in describe_result["Outputs"] if o["OutputKey"] == "TopicName"
+        ][0]
+        assert topic_name == parameter_value
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/cloudformation/test_cloudformation_dynamic_parameters.py
+++ b/tests/integration/cloudformation/test_cloudformation_dynamic_parameters.py
@@ -1,4 +1,5 @@
 import jinja2 as jinja2
+import pytest as pytest
 
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
@@ -12,12 +13,13 @@ def test_resolve_ssm(
     is_stack_created,
     cleanup_changesets,
     cleanup_stacks,
+    create_parameter,
 ):
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"change-set-{short_uid()}"
     parameter_key = f"param-key-{short_uid()}"
     parameter_value = f"param-value-{short_uid()}"
-    ssm_client.put_parameter(Name=parameter_key, Value=parameter_value, Type="String")
+    create_parameter(Name=parameter_key, Value=parameter_value, Type="String")
     template_rendered = jinja2.Template(load_template_raw("resolve_ssm.yaml")).render(
         parameter_key=parameter_key,
     )
@@ -46,7 +48,60 @@ def test_resolve_ssm(
     finally:
         cleanup_changesets([change_set_id])
         cleanup_stacks([stack_id])
-        ssm_client.delete_parameter(Name=parameter_key)
+
+
+def test_resolve_ssm_withversion(
+    ssm_client,
+    cfn_client,
+    is_change_set_created_and_available,
+    is_stack_created,
+    cleanup_changesets,
+    cleanup_stacks,
+    create_parameter,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    parameter_key = f"param-key-{short_uid()}"
+    parameter_value_v0 = f"param-value-{short_uid()}"
+    parameter_value_v1 = f"param-value-{short_uid()}"
+    parameter_value_v2 = f"param-value-{short_uid()}"
+
+    create_parameter(Name=parameter_key, Type="String", Value=parameter_value_v0)
+    v1 = ssm_client.put_parameter(
+        Name=parameter_key, Overwrite=True, Type="String", Value=parameter_value_v1
+    )
+    ssm_client.put_parameter(
+        Name=parameter_key, Overwrite=True, Type="String", Value=parameter_value_v2
+    )
+
+    template_rendered = jinja2.Template(load_template_raw("resolve_ssm_withversion.yaml")).render(
+        parameter_key=parameter_key, parameter_version=str(v1["Version"])
+    )
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        describe_result = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+        assert describe_result["StackStatus"] == "CREATE_COMPLETE"
+
+        topic_name = [
+            o["OutputValue"] for o in describe_result["Outputs"] if o["OutputKey"] == "TopicName"
+        ][0]
+        assert topic_name == parameter_value_v1
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])
 
 
 def test_resolve_ssm_secure(
@@ -56,13 +111,14 @@ def test_resolve_ssm_secure(
     is_stack_created,
     cleanup_changesets,
     cleanup_stacks,
+    create_parameter,
 ):
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"change-set-{short_uid()}"
     parameter_key = f"param-key-{short_uid()}"
     parameter_value = f"param-value-{short_uid()}"
 
-    ssm_client.put_parameter(Name=parameter_key, Value=parameter_value, Type="SecureString")
+    create_parameter(Name=parameter_key, Value=parameter_value, Type="SecureString")
 
     template_rendered = jinja2.Template(load_template_raw("resolve_ssm_secure.yaml")).render(
         parameter_key=parameter_key,
@@ -92,9 +148,11 @@ def test_resolve_ssm_secure(
     finally:
         cleanup_changesets([change_set_id])
         cleanup_stacks([stack_id])
-        ssm_client.delete_parameter(Name=parameter_key)
 
 
+@pytest.mark.parametrize(
+    "template_name", ["resolve_secretsmanager_full.yaml", "resolve_secretsmanager.yaml"]
+)
 def test_resolve_secretsmanager(
     secretsmanager_client,
     cfn_client,
@@ -104,6 +162,7 @@ def test_resolve_secretsmanager(
     create_parameter,
     cleanup_changesets,
     cleanup_stacks,
+    template_name,
 ):
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"change-set-{short_uid()}"
@@ -112,7 +171,7 @@ def test_resolve_secretsmanager(
 
     create_secret(Name=parameter_key, SecretString=parameter_value)
 
-    template_rendered = jinja2.Template(load_template_raw("resolve_secretsmanager.yaml")).render(
+    template_rendered = jinja2.Template(load_template_raw(template_name)).render(
         parameter_key=parameter_key,
     )
 

--- a/tests/integration/templates/resolve_secretsmanager.yaml
+++ b/tests/integration/templates/resolve_secretsmanager.yaml
@@ -1,0 +1,11 @@
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: {{ "'{{resolve:secretsmanager:" + parameter_key + "}}'" }}
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName

--- a/tests/integration/templates/resolve_secretsmanager_full.yaml
+++ b/tests/integration/templates/resolve_secretsmanager_full.yaml
@@ -1,0 +1,20 @@
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName:
+        Fn::Join:
+          - ""
+          - - {% raw %}"{{resolve:secretsmanager:arn:"{% endraw %}
+            - Ref: AWS::Partition
+            - ":secretsmanager:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            -  :secret:{{parameter_key}}:SecretString:::}}
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName

--- a/tests/integration/templates/resolve_ssm.yaml
+++ b/tests/integration/templates/resolve_ssm.yaml
@@ -1,0 +1,11 @@
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: {{ "'{{resolve:ssm:" + parameter_key + "}}'" }}
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName

--- a/tests/integration/templates/resolve_ssm_secure.yaml
+++ b/tests/integration/templates/resolve_ssm_secure.yaml
@@ -1,0 +1,11 @@
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: {{ "'{{resolve:ssm-secure:" + parameter_key + "}}'" }}
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName

--- a/tests/integration/templates/resolve_ssm_withversion.yaml
+++ b/tests/integration/templates/resolve_ssm_withversion.yaml
@@ -1,0 +1,11 @@
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: {{ "'{{resolve:ssm:" + parameter_key + ":" + parameter_version +"}}'" }}
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName


### PR DESCRIPTION
Adds support for dynamic references in CloudFormation such as:

```yaml
Properties:
      TopicName: "{{resolve:secretsmanager:mytopicname}}"

```

See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html

Addresses #5195