### PR TITLE
fix issue not passing parameters to HTTP integration (#5125)

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -6,7 +6,6 @@ import re
 import time
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple, Union
-from urllib.parse import urlencode
 
 import pytz
 import requests
@@ -376,7 +375,14 @@ def apply_request_parameters(
             if request_parameters.get(request_param_key, None) == request_param_value:
                 uri = uri.replace(f"{{{key}}}", path_params[key])
 
-    # include the request query to the uri
+    if integration.get("type") != "HTTP_PROXY" and request_parameters:
+        for key in query_params.copy():
+            request_query_key = f"integration.request.querystring.{key}"
+            request_param_val = f"method.request.querystring.{key}"
+            if request_parameters.get(request_query_key, None) != \
+                request_param_val:
+                query_params.pop(key)
+
     return add_query_params_to_url(uri, query_params)
 
 

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -379,8 +379,7 @@ def apply_request_parameters(
         for key in query_params.copy():
             request_query_key = f"integration.request.querystring.{key}"
             request_param_val = f"method.request.querystring.{key}"
-            if request_parameters.get(request_query_key, None) != \
-                request_param_val:
+            if request_parameters.get(request_query_key, None) != request_param_val:
                 query_params.pop(key)
 
     return add_query_params_to_url(uri, query_params)

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -51,7 +51,7 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
-from localstack.utils import common
+from localstack.utils import common, http_utils
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_responses, aws_stack
 from localstack.utils.aws.aws_responses import (
@@ -65,6 +65,8 @@ from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, TH
 from localstack.utils.common import camel_to_snake_case, json_safe, long_uid, to_bytes, to_str
 
 # set up logger
+from localstack.utils.http_utils import add_query_params_to_url
+
 LOG = logging.getLogger(__name__)
 
 # target ARN patterns
@@ -375,7 +377,7 @@ def apply_request_parameters(
                 uri = uri.replace(f"{{{key}}}", path_params[key])
 
     # include the request query to the uri
-    return f"{uri}?{urlencode(query_params)}"
+    return add_query_params_to_url(uri, query_params)
 
 
 def apply_template(

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -50,7 +50,7 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
-from localstack.utils import common, http_utils
+from localstack.utils import common
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_responses, aws_stack
 from localstack.utils.aws.aws_responses import (

--- a/localstack/utils/http_utils.py
+++ b/localstack/utils/http_utils.py
@@ -1,5 +1,6 @@
 import re
 from typing import Dict, Union
+from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 
 from requests.models import CaseInsensitiveDict
 
@@ -48,3 +49,29 @@ def canonicalize_headers(headers: Union[Dict, CaseInsensitiveDict]) -> Dict:
 
     result = {_normalize(k): v for k, v in headers.items()}
     return result
+
+
+def add_query_params_to_url(uri: str, query_params: Dict) -> str:
+    """
+    Add query parameters to the uri.
+    :param uri: the base uri it can contains path arguments and query parameters
+    :param query_params: new query parameters to be added
+    :return: the resulting URL
+    """
+
+    # parse the incoming uri
+    url = urlparse(uri)
+
+    # parses the query part, if exists, into a dict
+    query_dict = dict(parse_qsl(url.query))
+
+    # updates the dict with new query parameters
+    query_dict.update(query_params)
+
+    # encodes query parameters
+    url_query = urlencode(query_dict)
+
+    # replaces the existing query
+    url_parse = url._replace(query=url_query)
+
+    return urlunparse(url_parse)

--- a/localstack/utils/http_utils.py
+++ b/localstack/utils/http_utils.py
@@ -1,6 +1,6 @@
 import re
 from typing import Dict, Union
-from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from requests.models import CaseInsensitiveDict
 

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1550,24 +1550,23 @@ class TestAPIGateway(unittest.TestCase):
             path = "/"
         resources = {}
         resource_path = path.replace("/", "")
-        resources[resource_path] = []
         req_templates = (
             {"application/json": json.dumps({"foo": "bar"})} if int_type == "custom" else {}
         )
-        for method in methods:
-            resources[resource_path].append(
-                {
-                    "httpMethod": method,
-                    "integrations": [
-                        {
-                            "type": "HTTP" if int_type == "custom" else "HTTP_PROXY",
-                            "uri": target_url,
-                            "requestTemplates": req_templates,
-                            "responseTemplates": {},
-                        }
-                    ],
-                }
-            )
+        resources[resource_path] = [
+            {
+                "httpMethod": method,
+                "integrations": [
+                    {
+                        "type": "HTTP" if int_type == "custom" else "HTTP_PROXY",
+                        "uri": target_url,
+                        "requestTemplates": req_templates,
+                        "responseTemplates": {},
+                    }
+                ],
+            }
+            for method in methods
+        ]
         return aws_stack.create_api_gateway(
             name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
         )

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -76,6 +76,26 @@ class ApiGatewayPathsTest(unittest.TestCase):
         result = apigateway_listener.get_resource_for_path("/foo/bar/baz", path_args)
         self.assertEqual(None, result)
 
+    def test_apply_request_parameters(self):
+        integration = {
+            "type": "HTTP_PROXY",
+            "httpMethod": "ANY",
+            "uri": "https://httpbin.org/anything/{proxy}",
+            "requestParameters": {"integration.request.path.proxy": "method.request.path.proxy"},
+            "passthroughBehavior": "WHEN_NO_MATCH",
+            "timeoutInMillis": 29000,
+            "cacheNamespace": "041fa782",
+            "cacheKeyParameters": [],
+        }
+
+        uri = apigateway_listener.apply_request_parameters(
+            uri="https://httpbin.org/anything/{proxy}",
+            integration=integration,
+            path_params={"proxy": "foo/bar/baz"},
+            query_params={"param": "foobar"},
+        )
+        self.assertEqual("https://httpbin.org/anything/foo/bar/baz?param=foobar", uri)
+
 
 def test_render_template_values():
     util = templating.VelocityUtil()

--- a/tests/unit/test_http_utils.py
+++ b/tests/unit/test_http_utils.py
@@ -1,0 +1,36 @@
+from localstack.utils import http_utils
+
+
+def test_add_query_params_to_url():
+
+    tt = [
+        {
+            "uri": "http://localhost.localstack.cloud",
+            "query_params": {"param": "122323"},
+            "expected": "http://localhost.localstack.cloud?param=122323",
+        },
+        {
+            "uri": "http://localhost.localstack.cloud?foo=bar",
+            "query_params": {"param": "122323"},
+            "expected": "http://localhost.localstack.cloud?foo=bar&param" "=122323",
+        },
+        {
+            "uri": "http://localhost.localstack.cloud/foo/bar",
+            "query_params": {"param": "122323"},
+            "expected": "http://localhost.localstack.cloud/foo/bar?param" "=122323",
+        },
+        {
+            "uri": "http://localhost.localstack.cloud/foo/bar?foo=bar",
+            "query_params": {"param": "122323"},
+            "expected": "http://localhost.localstack.cloud/foo/bar?foo=bar" "&param=122323",
+        },
+        {
+            "uri": "http://localhost.localstack.cloud?foo=bar",
+            "query_params": {"foo": "bar"},
+            "expected": "http://localhost.localstack.cloud?foo=bar",
+        },
+    ]
+
+    for t in tt:
+        result = http_utils.add_query_params_to_url(t["uri"], t["query_params"])
+        assert result == t["expected"]


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/5125

Using HTTP_PROXY integration using proxy resources should include all sub-resources and query parameters. This PR adds the query parameters to the resolved uri. 