### PR TITLE
only lowercase 'accept' headers #4532

### DIFF
--- a/localstack/utils/http_utils.py
+++ b/localstack/utils/http_utils.py
@@ -3,6 +3,8 @@ from typing import Dict, Union
 
 from requests.models import CaseInsensitiveDict
 
+ACCEPT = "accept"
+
 
 def uses_chunked_encoding(response):
     return response.headers.get("Transfer-Encoding", "").lower() == "chunked"
@@ -44,7 +46,9 @@ def canonicalize_headers(headers: Union[Dict, CaseInsensitiveDict]) -> Dict:
         return headers
 
     def _normalize(name):
-        return name.lower()
+        if name.lower().startswith(ACCEPT):
+            return name.lower()
+        return name
 
     result = {_normalize(k): v for k, v in headers.items()}
     return result

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -438,9 +438,9 @@ class TestAPIGateway(unittest.TestCase):
         # assert that header keys are lowercase (as in AWS)
         headers = parsed_body.get("headers") or {}
         header_names = list(headers.keys())
-        self.assertIn("host", header_names)
-        self.assertIn("content-length", header_names)
-        self.assertIn("user-agent", header_names)
+        self.assertIn("Host", header_names)
+        self.assertIn("Content-Length", header_names)
+        self.assertIn("User-Agent", header_names)
 
         result = requests.delete(url, data=json.dumps(data))
         self.assertEqual(204, result.status_code)

--- a/tests/unit/utils/test_http_utils.py
+++ b/tests/unit/utils/test_http_utils.py
@@ -4,27 +4,22 @@ from localstack.utils.http_utils import ACCEPT
 
 def test_canonicalize_headers():
     headers = {
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,'
-                  '*/*;q=0.8',
-        'Accept-encoding': 'gzip, deflate, br',
-        'Accept-language': 'en-GB,en;q=0.9',
-        'Host': 'c2m48evwfk.execute-api.eu-west-1.amazonaws.com',
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
-                      'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 '
-                      'Safari/605.1.15',
-        'X-Amzn-Trace-Id': 'Root=1-61d0de53-5843d28d07bf39f63b105411',
-        'X-Forwarded-For': '37.228.224.133',
-        'X-Forwarded-Port': '443',
-        'X-Forwarded-Proto': 'https'
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9," "*/*;q=0.8",
+        "Accept-encoding": "gzip, deflate, br",
+        "Accept-language": "en-GB,en;q=0.9",
+        "Host": "c2m48evwfk.execute-api.eu-west-1.amazonaws.com",
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 "
+        "Safari/605.1.15",
+        "X-Amzn-Trace-Id": "Root=1-61d0de53-5843d28d07bf39f63b105411",
+        "X-Forwarded-For": "37.228.224.133",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https",
     }
     canonicals_headers = http_utils.canonicalize_headers(headers)
     result_headers = {
-        k: v for k, v in canonicals_headers.items() if not k.lower().startswith(
-            ACCEPT)
+        k: v for k, v in canonicals_headers.items() if not k.lower().startswith(ACCEPT)
     }
-    expected_headers = {
-        k: v for k, v in headers.items() if not k.lower().startswith(
-            ACCEPT)
-    }
+    expected_headers = {k: v for k, v in headers.items() if not k.lower().startswith(ACCEPT)}
 
     assert result_headers == expected_headers

--- a/tests/unit/utils/test_http_utils.py
+++ b/tests/unit/utils/test_http_utils.py
@@ -1,0 +1,30 @@
+from localstack.utils import http_utils
+from localstack.utils.http_utils import ACCEPT
+
+
+def test_canonicalize_headers():
+    headers = {
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,'
+                  '*/*;q=0.8',
+        'Accept-encoding': 'gzip, deflate, br',
+        'Accept-language': 'en-GB,en;q=0.9',
+        'Host': 'c2m48evwfk.execute-api.eu-west-1.amazonaws.com',
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+                      'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 '
+                      'Safari/605.1.15',
+        'X-Amzn-Trace-Id': 'Root=1-61d0de53-5843d28d07bf39f63b105411',
+        'X-Forwarded-For': '37.228.224.133',
+        'X-Forwarded-Port': '443',
+        'X-Forwarded-Proto': 'https'
+    }
+    canonicals_headers = http_utils.canonicalize_headers(headers)
+    result_headers = {
+        k: v for k, v in canonicals_headers.items() if not k.lower().startswith(
+            ACCEPT)
+    }
+    expected_headers = {
+        k: v for k, v in headers.items() if not k.lower().startswith(
+            ACCEPT)
+    }
+
+    assert result_headers == expected_headers


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**

This PR fixes https://github.com/localstack/localstack/issues/4532

AWS documentation is not super clear regarding the header casing. For the lambda integration, only some headers are lowercased, for example the headers starting with 'accept'.

This PR leaves headers untouched unless they are "accept" headers.