### PR TITLE
Fix the region fallbacks by use boto session region before the default

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -923,7 +923,9 @@ def invoke_rest_api_integration_backend(
 
 def get_target_resource_details(invocation_context: ApiInvocationContext) -> Tuple[str, Dict]:
     """Look up and return the API GW resource (path pattern + resource dict) for the given invocation context."""
-    path_map = helpers.get_rest_api_paths(rest_api_id=invocation_context.api_id)
+    path_map = helpers.get_rest_api_paths(
+        rest_api_id=invocation_context.api_id, region_name=invocation_context.region_name
+    )
     relative_path = invocation_context.invocation_path
     try:
         extracted_path, resource = get_resource_for_path(path=relative_path, path_map=path_map)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -220,7 +220,7 @@ def get_local_region():
     if LOCAL_REGION is None:
         session = boto3.session.Session()
         LOCAL_REGION = session.region_name or ""
-    return config.DEFAULT_REGION or LOCAL_REGION
+    return LOCAL_REGION or config.DEFAULT_REGION
 
 
 def is_internal_call_context(headers):


### PR DESCRIPTION
This PR fixes the order of precedence of fallbacks to obtain the region.

I reproduced the issue where a region couldn't be determined or wrongly determined with the following scenario:

[openapi.json](https://gist.github.com/calvernaz/737625957a947b1e1fb460f4015a8059)
```
awslocal  apigateway import-rest-api --fail-on-warnings --body 'file://openapi.json'
```

* awslocal is configured to use the `eu-west-1` region.

The following request will fail with an error saying the API can't be found - in fact the API exists but not in the region where is being searched (fallback is using the default region `us-east-1`).

```
curl "http://localhost:4566/restapis/<rest-api-id>/local/_user_request_/pets"
```

This PR fixes the issue above giving precedence to boto which gets the region from the local configuration, however, it should have never gotten this low in the chain of fallbacks.

