### PR TITLE
add utilities for migrating services to ASF

### DIFF
--- a/tests/unit/aws/test_proxy.py
+++ b/tests/unit/aws/test_proxy.py
@@ -1,8 +1,10 @@
 import boto3
 
 from localstack.aws.api import handler
-from localstack.aws.proxy import AwsApiListener
+from localstack.aws.proxy import AsfWithFallbackListener, AwsApiListener
+from localstack.services.generic_proxy import ProxyListener
 from localstack.utils import testutil
+from localstack.utils.aws.aws_responses import requests_response
 
 
 class TestAwsApiListener:
@@ -35,3 +37,55 @@ class TestAwsApiListener:
             assert result["QueueUrls"] == [
                 "http://localhost:4566/000000000000/foo-queue",
             ]
+
+
+class TestAsfWithFallbackListener:
+    def test_request_response(self):
+        provider_calls = []
+        fallback_calls = []
+
+        class Provider:
+            @handler("ListQueues", expand=False)
+            def list_queues(self, context, request):
+                return {
+                    "QueueUrls": [
+                        "http://localhost:4566/000000000000/foo-queue",
+                    ],
+                }
+
+            @handler("DeleteQueue", expand=False)
+            def delete_queue(self, context, request):
+                provider_calls.append((context, request))
+                raise NotImplementedError
+
+        class Fallback(ProxyListener):
+            def forward_request(self, method: str, path: str, data, headers):
+                fallback_calls.append((method, path, data, headers))
+                return requests_response("<Response></Response>")
+
+        # create a proxy listener for the provider
+        listener = AsfWithFallbackListener("sqs", Provider(), Fallback())
+
+        # start temp proxy listener and connect to it
+        with testutil.proxy_server(listener) as url:
+            client = boto3.client(
+                "sqs",
+                aws_access_key_id="test",
+                aws_secret_access_key="test",
+                aws_session_token="test",
+                region_name="us-east-1",
+                endpoint_url=url,
+            )
+
+            # check that provider is called correctly
+            result = client.list_queues()
+            assert result["QueueUrls"] == [
+                "http://localhost:4566/000000000000/foo-queue",
+            ]
+            assert len(provider_calls) == 0
+            assert len(fallback_calls) == 0
+
+            # check that fallback is called correctly
+            client.delete_queue(QueueUrl="http://localhost:4566/000000000000/somequeue")
+            assert len(provider_calls) == 1
+            assert len(fallback_calls) == 1


### PR DESCRIPTION
This PR adds code utilities and mechanisms to migrate services to the new ASF as described in #5222 

* adds the `AsfWithFallbackListener` and `AsfWithPersistingFallbackListener` as described in #5222 
* SNS example can be found in the [asf-migration-sns](https://github.com/localstack/localstack/tree/asf-migration-sns) branch in da433bdd8b571e43e67ca214438d4a32f41e85ac. however, this would currently break the pro SNS provider that needs to be updated.