### PR TITLE
Fix CloudFormation deployment of SNS::TopicPolicy

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1585,7 +1585,7 @@ class Util:
 
 def log_lambda_result(func_arn, result, log_output):
     result = to_str(result or "")
-    log_output = truncate(to_str(log_output or ""), max_length=1500)
+    log_output = truncate(to_str(log_output or ""), max_length=2000)
     log_formatted = log_output.strip().replace("\n", "\n> ")
     LOG.debug("Lambda %s result / log output:\n%s\n> %s", func_arn, result.strip(), log_formatted)
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1585,8 +1585,8 @@ class Util:
 
 def log_lambda_result(func_arn, result, log_output):
     result = to_str(result or "")
-    log_output = truncate(to_str(log_output or ""), max_length=1000)
-    log_formatted = truncate(log_output.strip().replace("\n", "\n> "), max_length=1000)
+    log_output = truncate(to_str(log_output or ""), max_length=1500)
+    log_formatted = log_output.strip().replace("\n", "\n> ")
     LOG.debug("Lambda %s result / log output:\n%s\n> %s", func_arn, result.strip(), log_formatted)
 
 

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -166,9 +166,11 @@ def get_main_endpoint_from_container():
                 )
             else:
                 # default gateway for the network should be the host
-                DOCKER_MAIN_CONTAINER_IP = DOCKER_CLIENT.inspect_network(
-                    get_container_network_for_lambda()
-                )["IPAM"]["Config"][0]["Gateway"]
+                # (only under Linux - otherwise fall back to DOCKER_HOST_FROM_CONTAINER below)
+                if config.is_in_linux:
+                    DOCKER_MAIN_CONTAINER_IP = DOCKER_CLIENT.inspect_network(
+                        get_container_network_for_lambda()
+                    )["IPAM"]["Config"][0]["Gateway"]
             LOG.info("Determined main container target IP: %s", DOCKER_MAIN_CONTAINER_IP)
         except Exception as e:
             LOG.info(

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -1,20 +1,11 @@
-import os
-
 import jinja2
 import pytest
 from botocore.exceptions import ClientError
 
-from localstack.utils.common import load_file, short_uid
+from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
+from tests.integration.cloudformation.utils import load_template_raw
 from tests.integration.util import is_aws_cloud
-
-
-def load_template_raw(tmpl_path: str) -> str:
-    template = load_file(
-        os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "templates", tmpl_path)
-    )
-    return template
-
 
 # TODO: create util function for asserting some common stack/change set verification patterns here
 

--- a/tests/integration/cloudformation/test_cloudformation_integration.py
+++ b/tests/integration/cloudformation/test_cloudformation_integration.py
@@ -1,6 +1,7 @@
+from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
-from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+from tests.integration.cloudformation.utils import load_template
 
 
 def test_events_sqs_sns_lambda(
@@ -11,13 +12,15 @@ def test_events_sqs_sns_lambda(
     is_change_set_created_and_available,
     is_stack_created,
     events_client,
+    sns_client,
 ):
     stack_name = f"stack-{short_uid()}"
     change_set_name = f"change-set-{short_uid()}"
+    ref_id = short_uid()
     response = cfn_client.create_change_set(
         StackName=stack_name,
         ChangeSetName=change_set_name,
-        TemplateBody=load_template_raw("integration_events_sns_sqs_lambda.yaml"),
+        TemplateBody=load_template("integration_events_sns_sqs_lambda.yaml", ref_id=ref_id),
         ChangeSetType="CREATE",
         Capabilities=["CAPABILITY_IAM"],
     )
@@ -36,6 +39,13 @@ def test_events_sqs_sns_lambda(
         bus_name = [o["OutputValue"] for o in stack["Outputs"] if o["OutputKey"] == "EventBusName"][
             0
         ]
+
+        # verify SNS topic policy is present
+        topic_arn = aws_stack.sns_topic_arn(f"topic-{ref_id}")
+        result = sns_client.get_topic_attributes(TopicArn=topic_arn)["Attributes"]
+        assert result.get("Policy")
+
+        # put events
         events_client.put_events(
             Entries=[
                 {

--- a/tests/integration/cloudformation/utils.py
+++ b/tests/integration/cloudformation/utils.py
@@ -1,0 +1,21 @@
+import os
+
+import jinja2
+
+from localstack.utils.common import load_file
+
+
+def load_template(tmpl_path: str, **template_vars) -> str:
+    template = load_template_raw(tmpl_path)
+    if template_vars:
+        template = jinja2.Template(template).render(**template_vars)
+    return template
+
+
+def load_template_raw(tmpl_path: str) -> str:
+    template = load_file(os.path.join(get_templates_folder(), tmpl_path))
+    return template
+
+
+def get_templates_folder():
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "templates")

--- a/tests/integration/templates/integration_events_sns_sqs_lambda.yaml
+++ b/tests/integration/templates/integration_events_sns_sqs_lambda.yaml
@@ -48,7 +48,7 @@ Resources:
         Fn::GetAtt:
           - LogFnServiceRoleA176C900
           - Arn
-      FunctionName: enterprise-fn
+      FunctionName: fn-{{ref_id}}
       Handler: index.handler
       Runtime: python3.8
     DependsOn:
@@ -95,7 +95,7 @@ Resources:
   queue276F7297:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: enterprise-queue
+      QueueName: queue-{{ref_id}}
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
   queuePolicy89DB7105:
@@ -126,7 +126,7 @@ Resources:
   topic69831491:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: enterprise-topic
+      TopicName: topic-{{ref_id}}
   topicPolicyBC9D8025:
     Type: AWS::SNS::TopicPolicy
     Properties:
@@ -145,7 +145,7 @@ Resources:
   bus707364D1:
     Type: AWS::Events::EventBus
     Properties:
-      Name: enterprise-bus
+      Name: bus-{{ref_id}}
   ruleF2C1DCDC:
     Type: AWS::Events::Rule
     Properties:
@@ -154,7 +154,7 @@ Resources:
       EventPattern:
         version:
           - "0"
-      Name: enterprise-rule
+      Name: rule-{{ref_id}}
       State: ENABLED
       Targets:
         - Arn:


### PR DESCRIPTION
Minor changes to fix CloudFormation deployment of SNS::TopicPolicy (`fetch_state(..)` method currently still missing, which can lead to failed deployments). /cc @dominikschubert 