### PR TITLE
Handling edge case of empty prefix for firehose s3 upload properly

### DIFF
--- a/localstack/services/firehose/firehose_api.py
+++ b/localstack/services/firehose/firehose_api.py
@@ -273,7 +273,8 @@ def get_s3_object_path(stream_name, prefix):
     # See https://aws.amazon.com/kinesis/data-firehose/faqs/#Data_delivery
     # Path prefix pattern: myApp/YYYY/MM/DD/HH/
     # Object name pattern: DeliveryStreamName-DeliveryStreamVersion-YYYY-MM-DD-HH-MM-SS-RandomString
-    prefix = "%s%s" % (prefix, "" if prefix.endswith("/") else "/")
+    if not prefix.endswith("/") and prefix != "":
+        prefix = prefix + "/"
     pattern = "{pre}%Y/%m/%d/%H/{name}-%Y-%m-%d-%H-%M-%S-{rand}"
     path = pattern.format(pre=prefix, name=stream_name, rand=str(uuid.uuid4()))
     path = timestamp(format=path)


### PR DESCRIPTION
This PR addresses the issue https://github.com/localstack/localstack/issues/4224 and provides a fix for the edge case of the s3 prefix being empty on s3 upload by the firehose service.