### PR TITLE
Add config for host path to fix mounting of libs_dir

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -87,9 +87,11 @@ class Directories:
     @staticmethod
     def from_config():
         """Returns Localstack directory paths from the config/environment variables defined by the config."""
+        # Note that the entries should be unique, as further downstream in docker_utils.py we're removing
+        # duplicate host paths in the volume mounts via `dict(mount_volumes)`.
         return Directories(
             static_libs=INSTALL_DIR_INFRA,
-            var_libs=TMP_FOLDER,  # TODO: add variable
+            var_libs=VAR_LIBS_DIR,
             cache=CACHE_DIR,
             tmp=TMP_FOLDER,  # TODO: should inherit from root value for /var/lib/localstack (e.g., MOUNT_ROOT)
             functions=HOST_TMP_FOLDER,  # TODO: rename variable/consider a volume
@@ -293,8 +295,10 @@ if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_
 # temporary folder of the host (required when running in Docker). Fall back to local tmp folder if not set
 HOST_TMP_FOLDER = os.environ.get("HOST_TMP_FOLDER", TMP_FOLDER)
 
-# ephemeral cache dir that persists over reboots
+# ephemeral cache dir that persists across reboots
 CACHE_DIR = os.environ.get("CACHE_DIR", os.path.join(TMP_FOLDER, "cache")).strip()
+# libs cache dir that persists across reboots
+VAR_LIBS_DIR = os.environ.get("VAR_LIBS_DIR", os.path.join(TMP_FOLDER, "var_libs")).strip()
 
 # whether to enable verbose debug logging
 LS_LOG = eval_log_type("LS_LOG")

--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -33,8 +33,9 @@ def check_lambda(expect_shutdown=False, print_error=False):
         from localstack.utils.common import wait_for_port_open
 
         # wait for port to be opened
+        # TODO get lambda port in a cleaner way
         port = PROXY_LISTENERS.get("lambda")[1]
-        wait_for_port_open(port)  # TODO get lambda port in a cleaner way
+        wait_for_port_open(port, sleep_time=0.5, retries=20)
 
         endpoint_url = f"http://127.0.0.1:{port}"
         out = aws_stack.connect_to_service(

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -563,10 +563,11 @@ def prepare_docker_start():
     if DOCKER_CLIENT.is_container_running(container_name):
         raise ContainerExists('LocalStack container named "%s" is already running' % container_name)
     if config.dirs.tmp != config.dirs.functions and not config.LAMBDA_REMOTE_DOCKER:
+        # Logger is not initialized at this point, so the warning is displayed via print
         print(
             f"WARNING: The detected temp folder for localstack ({config.dirs.tmp}) is not equal to the "
             f"HOST_TMP_FOLDER environment variable set ({config.dirs.functions})."
-        )  # Logger is not initialized at this point, so the warning is displayed via print
+        )
 
     os.environ[ENV_SCRIPT_STARTING_DOCKER] = "1"
 


### PR DESCRIPTION
Add config for host path to fix mounting of libs_dir - resolves the `TODO` that's currently in the code. This resolves the current behavior where libs (e.g., Azure specs) are re-downloaded on every `localstack start` (as the `var_libs` volume mount gets removed from the dict and is not being added to `docker run ...` in certain situations).

PR also contains a minor increase in the timeout for the Lambda API (from 5 to 10 secs), to help debug a customer issue.