### PR TITLE
update versions of terraform, aws provider, and API gateway module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ requirements.copy.txt
 *.tfstate
 *.tfstate.*
 *tfplan
+*.terraform.lock.hcl
 
 .python-version
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -116,8 +116,8 @@ GO_INSTALL_FOLDER = os.path.join(config.dirs.var_libs, "awslamba-go-runtime")
 GO_LAMBDA_RUNTIME = os.path.join(GO_INSTALL_FOLDER, "aws-lambda-mock")
 GO_LAMBDA_MOCKSERVER = os.path.join(GO_INSTALL_FOLDER, "mockserver")
 
-# Terraform (used for tests, whose templates require TF < 0.14.0 )
-TERRAFORM_VERSION = "0.13.7"
+# Terraform (used for tests)
+TERRAFORM_VERSION = "1.1.3"
 TERRAFORM_URL_TEMPLATE = (
     "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip"
 )

--- a/tests/integration/terraform/apigateway.tf
+++ b/tests/integration/terraform/apigateway.tf
@@ -1,6 +1,6 @@
 module "api-gateway" {
   source      = "clouddrove/api-gateway/aws"
-  version     = "0.13.0"
+  version     = "0.15.0"
   name        = "tf-apigateway"
   environment = "test"
   label_order = ["environment", "name"]

--- a/tests/integration/terraform/versions.tf
+++ b/tests/integration/terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.7.0, <= 3.79.0"
+      version = ">= 3.71.0, <= 3.79.0"
     }
   }
 

--- a/tests/integration/terraform/versions.tf
+++ b/tests/integration/terraform/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.71.0, <= 3.79.0"
     }
   }
 

--- a/tests/integration/terraform/versions.tf
+++ b/tests/integration/terraform/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.60.0, <= 3.69.0"
+      version = ">= 3.7.0, <= 3.79.0"
     }
   }
 
-  required_version = "0.13.7"
+  required_version = "1.1.3"
 }

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -4,7 +4,6 @@ import threading
 import unittest
 
 import pytest
-from packaging import version
 
 from localstack import config
 from localstack.services.install import TERRAFORM_BIN, install_terraform
@@ -34,7 +33,7 @@ def check_terraform_version():
     ver_string = re.search(r"v(\d+\.\d+\.\d+)", ver_string).group(1)
     if ver_string is None:
         return False, None
-    return version.parse(ver_string) < version.parse("0.15"), ver_string
+    return True, ver_string
 
 
 # TODO: replace "clouddrove/api-gateway/aws" with normal apigateway module and update terraform


### PR DESCRIPTION
**Please refer to the contribution guidelines in the README when submitting PRs.**
Update Terraform version, AWS provider version, and API Gateway module version in integration tests.

I started looking into this as part of my investigation into https://github.com/localstack/localstack/issues/5197. The root of the issue seems to have been with AWS provider `3.70.0`. Our tests failed to detect this compatibility issue because they are using outdated dependencies.