### PR TITLE
Extend SNS publish batch support for FIFO topics 

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -235,7 +235,34 @@ class ProxyListenerSNS(PersistingProxyListener):
                 return make_response(req_action, message_id=message_id)
 
             elif req_action == "PublishBatch":
-                response = publish_batch(topic_arn, req_data, headers)
+                entries = parse_urlencoded_data(
+                    req_data, "PublishBatchRequestEntries.member", "MessageAttributes.entry"
+                )
+
+                if len(entries) > 10:
+                    return make_error(
+                        message="The batch request contains more entries than permissible",
+                        code=400,
+                        code_string="TooManyEntriesInBatchRequest",
+                    )
+                ids = [entry["Id"] for entry in entries]
+
+                if len(set(ids)) != len(entries):
+                    return make_error(
+                        message="Two or more batch entries in the request have the same Id",
+                        code=400,
+                        code_string="BatchEntryIdsNotDistinct",
+                    )
+
+                if topic_arn and ".fifo" in topic_arn:
+                    if not all(["MessageGroupId" in entry for entry in entries]):
+                        return make_error(
+                            message="The MessageGroupId parameter is required for FIFO topics",
+                            code=400,
+                            code_string="InvalidParameter",
+                        )
+
+                response = publish_batch(topic_arn, entries, headers)
                 return requests_response_xml(
                     req_action, response, xmlns="http://sns.amazonaws.com/doc/2010-03-31/"
                 )
@@ -686,17 +713,16 @@ def publish_message(topic_arn, req_data, headers, subscription_arn=None, skip_ch
     return message_id
 
 
-def publish_batch(topic_arn, req_data, headers):
+def publish_batch(topic_arn, messages, headers):
     response = {"Successful": [], "Failed": []}
-    messages = parse_urlencoded_data(
-        req_data, "PublishBatchRequestEntries.member", "MessageAttributes.entry"
-    )
     for message in messages:
         message_id = str(uuid.uuid4())
         data = {}
         data["TopicArn"] = [topic_arn]
         data["Message"] = [message["Message"]]
         data["Subject"] = [message["Subject"]]
+        if ".fifo" in topic_arn:
+            data["MessageGroupId"] = message.get("MessageGroupId")
 
         message_attributes = prepare_message_attributes(message.get("MessageAttributes", []))
         try:

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -723,6 +723,7 @@ def publish_batch(topic_arn, messages, headers):
         data["Subject"] = [message["Subject"]]
         if ".fifo" in topic_arn:
             data["MessageGroupId"] = message.get("MessageGroupId")
+        # TODO: add MessageDeduplication checks once ASF-SQS implementation becomes default
 
         message_attributes = prepare_message_attributes(message.get("MessageAttributes", []))
         try:

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1060,8 +1060,8 @@ class TestSNS:
         retry(get_messages, retries=5, sleep=1, queue_url=queue_url)
 
     def test_publish_batch_messages_from_fifo_topic_to_fifo_queue(self):
-        topic_name = "topic-{}.fifo".format(short_uid())
-        queue_name = "queue-%s.fifo" % short_uid()
+        topic_name = f"topic-{short_uid()}.fifo"
+        queue_name = f"queue-{short_uid()}.fifo"
 
         topic_arn = self.sns_client.create_topic(Name=topic_name, Attributes={"FifoTopic": "true"})[
             "TopicArn"
@@ -1149,8 +1149,8 @@ class TestSNS:
         retry(get_messages, retries=5, sleep=1, queue_url=queue_url)
 
     def test_publish_batch_exceptions(self):
-        topic_name = "topic-{}.fifo".format(short_uid())
-        queue_name = "queue-%s.fifo" % short_uid()
+        topic_name = f"topic-{short_uid()}.fifo"
+        queue_name = f"queue-{short_uid()}.fifo"
 
         topic_arn = self.sns_client.create_topic(Name=topic_name, Attributes={"FifoTopic": "true"})[
             "TopicArn"
@@ -1181,10 +1181,6 @@ class TestSNS:
                 ],
             )
         assert e.value.response["Error"]["Code"] == "InvalidParameter"
-        assert (
-            e.value.response["Error"]["Message"]
-            == "The MessageGroupId parameter is required for FIFO topics"
-        )
         assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
         with pytest.raises(ClientError) as e:
@@ -1195,10 +1191,6 @@ class TestSNS:
                 ],
             )
         assert e.value.response["Error"]["Code"] == "TooManyEntriesInBatchRequest"
-        assert (
-            e.value.response["Error"]["Message"]
-            == "The batch request contains more entries than permissible"
-        )
         assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
         with pytest.raises(ClientError) as e:
@@ -1209,10 +1201,6 @@ class TestSNS:
                 ],
             )
         assert e.value.response["Error"]["Code"] == "BatchEntryIdsNotDistinct"
-        assert (
-            e.value.response["Error"]["Message"]
-            == "Two or more batch entries in the request have the same Id"
-        )
         assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
         # cleanup


### PR DESCRIPTION
Addresses #5057 
Follow up to #5215

Extended  SNS `PublishBatch` API to support FIFO Topics and common API specific exceptions.


