### PR TITLE
Minor refactoring in selecting proxy listener in edge.py for better extensibility

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -234,13 +234,14 @@ def do_forward_request(api, method, path, data, headers, port=None):
     return result
 
 
+def get_handler_for_api(api, headers):
+    return PROXY_LISTENERS.get(api)
+
+
 def do_forward_request_inmem(api, method, path, data, headers, port=None):
-    listener_details = PROXY_LISTENERS.get(api)
+    listener_details = get_handler_for_api(api, headers)
     if not listener_details:
-        message = (
-            'Unable to find listener for service "%s" - please make sure to include it in $SERVICES'
-            % api
-        )
+        message = f'Unable to find listener for service "{api}" - please make sure to include it in $SERVICES'
         LOG.warning(message)
         raise HTTPErrorResponse(message, code=400)
     service_name, backend_port, listener = listener_details

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -404,6 +404,8 @@ def start_infra(asynchronous=False, apis=None):
         # set up logging
         setup_logging()
 
+        # run hooks, to allow them to apply patches and changes
+        hooks.on_infra_start.run()
         # with changes that hooks have made, now start the infrastructure
         thread = do_start_infra(asynchronous, apis, is_in_docker)
 
@@ -426,7 +428,6 @@ def start_infra(asynchronous=False, apis=None):
 
 
 def do_start_infra(asynchronous, apis, is_in_docker):
-    hooks.on_infra_start.run()
 
     event_publisher.fire_event(
         event_publisher.EVENT_START_INFRA,

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -2166,6 +2166,10 @@ def get_all_subclasses(clazz: Type) -> List[Type]:
     return result
 
 
+def fully_qualified_class_name(klass: Type) -> str:
+    return f"{klass.__module__}.{klass.__name__}"
+
+
 def parallelize(func: Callable, arr: List, size: int = None):
     if not size:
         size = len(arr)


### PR DESCRIPTION
* minor refactoring in selecting proxy listener in `edge.py` for better extensibility. 
* move `hooks.on_infra_start.run()` to allow startup hooks to patch `do_start_infra` itself (which is currently not working and breaking some features in -ext)
* migrate some tests from `unittest`->`pytest`