### PR TITLE
Refactor lambda executors to allow modification of the container execution with hooks

### DIFF
--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -8,6 +8,7 @@ HOOKS_INSTALL = "localstack.hooks.install"
 HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
 HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
 HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
+HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION = "localstack.hooks.lambda_docker_separate_execution"
 
 
 def hook(namespace: str, priority: int = 0, **kwargs):
@@ -77,3 +78,6 @@ prepare_host = hook_spec(HOOKS_PREPARE_HOST)
 # infra (runtime) lifecycle hooks
 on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
 on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)
+
+# lambda (executor) hooks
+on_docker_separate_execution = hook_spec(HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION)

--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -8,7 +8,7 @@ HOOKS_INSTALL = "localstack.hooks.install"
 HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
 HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
 HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
-HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION = "localstack.hooks.lambda_docker_separate_execution"
+HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION = "localstack.hooks.on_docker_separate_execution"
 
 
 def hook(namespace: str, priority: int = 0, **kwargs):

--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -9,6 +9,9 @@ HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
 HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
 HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
 HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION = "localstack.hooks.on_docker_separate_execution"
+HOOKS_ON_LAMBDA_DOCKER_REUSE_CONTAINER_CREATION = (
+    "localstack.hooks.on_docker_reuse_container_creation"
+)
 
 
 def hook(namespace: str, priority: int = 0, **kwargs):
@@ -81,3 +84,4 @@ on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)
 
 # lambda (executor) hooks
 on_docker_separate_execution = hook_spec(HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION)
+on_docker_reuse_container_creation = hook_spec(HOOKS_ON_LAMBDA_DOCKER_REUSE_CONTAINER_CREATION)

--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -8,10 +8,6 @@ HOOKS_INSTALL = "localstack.hooks.install"
 HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
 HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
 HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
-HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION = "localstack.hooks.on_docker_separate_execution"
-HOOKS_ON_LAMBDA_DOCKER_REUSE_CONTAINER_CREATION = (
-    "localstack.hooks.on_docker_reuse_container_creation"
-)
 
 
 def hook(namespace: str, priority: int = 0, **kwargs):
@@ -81,7 +77,3 @@ prepare_host = hook_spec(HOOKS_PREPARE_HOST)
 # infra (runtime) lifecycle hooks
 on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
 on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)
-
-# lambda (executor) hooks
-on_docker_separate_execution = hook_spec(HOOKS_ON_LAMBDA_DOCKER_SEPARATE_EXECUTION)
-on_docker_reuse_container_creation = hook_spec(HOOKS_ON_LAMBDA_DOCKER_REUSE_CONTAINER_CREATION)

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -12,12 +12,12 @@ import time
 import traceback
 import uuid
 from datetime import datetime
+from io import StringIO
 from threading import BoundedSemaphore
 from typing import Any, Dict, List, Optional, Tuple, Type
+from urllib.parse import urlparse
 
 from flask import Flask, Response, jsonify, request
-from six.moves import cStringIO as StringIO
-from six.moves.urllib.parse import urlparse
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON, TEST_AWS_ACCOUNT_ID

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1164,7 +1164,6 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
         docker_image = Util.docker_image_for_lambda(lambda_function)
         container_config = ContainerConfiguration(image_name=docker_image)
 
-        # initialize env vars value - needed so further key assignments will not fail
         container_config.env_vars = inv_context.environment
         if inv_context.lambda_command:
             container_config.entrypoint = ""
@@ -1216,6 +1215,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                 additional_flags=container_config.additional_flags,
                 ports=container_config.ports,
                 command=container_config.command,
+                workdir=container_config.workdir,
             )
             for path_tuple in transfer_paths:
                 DOCKER_CLIENT.copy_into_container(container_id, path_tuple[0], path_tuple[1])
@@ -1245,6 +1245,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                     additional_flags=container_config.additional_flags,
                     command=container_config.command,
                     mount_volumes=container_config.volumes,
+                    workdir=container_config.workdir,
                     stdin=stdin,
                 )
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1216,6 +1216,8 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                 ports=container_config.ports,
                 command=container_config.command,
                 workdir=container_config.workdir,
+                user=container_config.user,
+                cap_add=container_config.cap_add,
             )
             for path_tuple in transfer_paths:
                 DOCKER_CLIENT.copy_into_container(container_id, path_tuple[0], path_tuple[1])
@@ -1246,6 +1248,8 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
                     command=container_config.command,
                     mount_volumes=container_config.volumes,
                     workdir=container_config.workdir,
+                    user=container_config.user,
+                    cap_add=container_config.cap_add,
                     stdin=stdin,
                 )
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -804,7 +805,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
         )
 
         if not inv_context.lambda_command and inv_context.handler:
-            command = container_info.entry_point.split()
+            command = shlex.split(container_info.entry_point)
             command.append(inv_context.handler)
             inv_context.lambda_command = command
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -964,14 +964,15 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
 
         container_config.dns = config.LAMBDA_DOCKER_DNS
 
-        if config.LAMBDA_REMOTE_DOCKER:
-            container_config.required_files.append((f"{lambda_cwd}/.", DOCKER_TASK_FOLDER))
-        else:
-            lambda_cwd_on_host = Util.get_host_path_for_path_in_docker(lambda_cwd)
-            # TODO not necessary after Windows 10. Should be deprecated and removed in the future
-            if ":" in lambda_cwd and "\\" in lambda_cwd:
-                lambda_cwd_on_host = Util.format_windows_path(lambda_cwd_on_host)
-            container_config.required_files.append((lambda_cwd_on_host, DOCKER_TASK_FOLDER))
+        if lambda_cwd:
+            if config.LAMBDA_REMOTE_DOCKER:
+                container_config.required_files.append((f"{lambda_cwd}/.", DOCKER_TASK_FOLDER))
+            else:
+                lambda_cwd_on_host = Util.get_host_path_for_path_in_docker(lambda_cwd)
+                # TODO not necessary after Windows 10. Should be deprecated and removed in the future
+                if ":" in lambda_cwd and "\\" in lambda_cwd:
+                    lambda_cwd_on_host = Util.format_windows_path(lambda_cwd_on_host)
+                container_config.required_files.append((lambda_cwd_on_host, DOCKER_TASK_FOLDER))
 
         container_config.entrypoint = "/bin/bash"
         container_config.interactive = True
@@ -1205,7 +1206,7 @@ class LambdaExecutorSeparateContainers(LambdaExecutorContainers):
         hooks.on_docker_separate_execution.run(lambda_function, container_config)
 
         # actual execution
-        # TODO make docker client directly accept ContainerConfiguration (?)
+        # TODO make container client directly accept ContainerConfiguration (?)
         if not config.LAMBDA_REMOTE_DOCKER and container_config.required_files:
             container_config.volumes = container_config.volumes or []
             container_config.volumes += container_config.required_files

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1011,6 +1011,9 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             dns=container_config.dns,
             mount_volumes=container_config.volumes,
             additional_flags=container_config.additional_flags,
+            workdir=container_config.workdir,
+            user=container_config.user,
+            cap_add=container_config.cap_add,
         )
         if config.LAMBDA_REMOTE_DOCKER and container_config.required_files:
             for source, target in container_config.required_files:

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -429,6 +429,7 @@ def extract_port_flags(user_flags, port_mappings: PortMappings):
     return user_flags
 
 
+# TODO merge with docker_utils.py:ContainerConfiguration
 class LocalstackContainer:
     name: str
     image_name: str

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -278,6 +278,31 @@ class VolumeMappings:
         return self.mappings.__iter__()
 
 
+@dataclasses.dataclass
+class ContainerConfiguration:
+    image_name: str
+    name: Optional[str] = None
+    volumes: Optional[VolumeMappings] = None
+    ports: Optional[PortMappings] = None
+    entrypoint: Optional[str] = None
+    additional_flags: Optional[List[str]] = None
+    command: Optional[List[str]] = None
+
+    privileged: Optional[bool] = None
+    remove: Optional[bool] = None
+    interactive: Optional[bool] = None
+    tty: Optional[bool] = None
+    detach: Optional[bool] = None
+    inherit_env: Optional[bool] = None
+
+    stdin: Optional[str] = None
+    user: Optional[str] = None
+    cap_add: Optional[str] = None
+    network: Optional[str] = None
+    dns: Optional[str] = None
+    workdir: Optional[str] = None
+
+
 class ContainerClient(metaclass=ABCMeta):
     STOP_TIMEOUT = 0
 

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -287,13 +287,13 @@ class ContainerConfiguration:
     entrypoint: Optional[str] = None
     additional_flags: Optional[List[str]] = None
     command: Optional[List[str]] = None
+    env_vars: Optional[Dict[str, str]] = None
 
     privileged: Optional[bool] = None
     remove: Optional[bool] = None
     interactive: Optional[bool] = None
     tty: Optional[bool] = None
     detach: Optional[bool] = None
-    inherit_env: Optional[bool] = None
 
     stdin: Optional[str] = None
     user: Optional[str] = None

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -287,7 +287,7 @@ class ContainerConfiguration:
     entrypoint: Optional[str] = None
     additional_flags: Optional[List[str]] = None
     command: Optional[List[str]] = None
-    env_vars: Optional[Dict[str, str]] = None
+    env_vars: Dict[str, str] = dataclasses.field(default_factory=dict)
 
     privileged: Optional[bool] = None
     remove: Optional[bool] = None

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -456,14 +456,14 @@ class ContainerClient(metaclass=ABCMeta):
         """
         pass
 
-    def get_image_cmd(self, docker_image: str, pull: bool = True) -> str:
+    def get_image_cmd(self, docker_image: str, pull: bool = True) -> List[str]:
         """Get the command for the given image
         :param docker_image: Docker image to inspect
         :param pull: Whether to pull if image is not present
-        :return: Image command
+        :return: Image command in its array form
         """
         cmd_list = self.inspect_image(docker_image, pull)["Config"]["Cmd"] or []
-        return " ".join(cmd_list)
+        return cmd_list
 
     def get_image_entrypoint(self, docker_image: str, pull: bool = True) -> str:
         """Get the entry point for the given image
@@ -473,7 +473,7 @@ class ContainerClient(metaclass=ABCMeta):
         """
         LOG.debug("Getting the entrypoint for image: %s", docker_image)
         entrypoint_list = self.inspect_image(docker_image, pull)["Config"]["Entrypoint"] or []
-        return " ".join(entrypoint_list)
+        return shlex.join(entrypoint_list)
 
     @abstractmethod
     def has_docker(self) -> bool:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -573,7 +573,7 @@ class TestDockerClient:
 
     def test_get_container_command(self, docker_client: ContainerClient):
         command = docker_client.get_image_cmd("alpine")
-        assert "/bin/sh" == command
+        assert ["/bin/sh"] == command
 
     def test_get_container_command_not_pulled_image(self, docker_client: ContainerClient):
         try:
@@ -582,7 +582,7 @@ class TestDockerClient:
         except ContainerException:
             pass
         command = docker_client.get_image_cmd("alpine")
-        assert "/bin/sh" == command
+        assert ["/bin/sh"] == command
 
     def test_get_container_command_non_existing_image(self, docker_client: ContainerClient):
         with pytest.raises(NoSuchImage):
@@ -709,7 +709,7 @@ class TestDockerClient:
         with pytest.raises(NoSuchImage):
             docker_client.get_image_cmd("alpine", pull=False)
         docker_client.pull_image("alpine")
-        assert "/bin/sh" == docker_client.get_image_cmd("alpine", pull=False).strip()
+        assert ["/bin/sh"] == docker_client.get_image_cmd("alpine", pull=False)
 
     @pytest.mark.skip_offline
     def test_pull_non_existent_docker_image(self, docker_client: ContainerClient):
@@ -726,7 +726,7 @@ class TestDockerClient:
         with pytest.raises(NoSuchImage):
             docker_client.get_image_cmd("alpine", pull=False)
         docker_client.pull_image("alpine:3.13")
-        assert "/bin/sh" == docker_client.get_image_cmd("alpine:3.13", pull=False).strip()
+        assert ["/bin/sh"] == docker_client.get_image_cmd("alpine:3.13", pull=False)
         assert "alpine:3.13" in docker_client.inspect_image("alpine:3.13", pull=False)["RepoTags"]
 
     @pytest.mark.skip_offline
@@ -741,12 +741,9 @@ class TestDockerClient:
         docker_client.pull_image(
             "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"
         )
-        assert (
-            "/bin/sh"
-            == docker_client.get_image_cmd(
-                "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
-                pull=False,
-            ).strip()
+        assert ["/bin/sh"] == docker_client.get_image_cmd(
+            "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
+            pull=False,
         )
         assert (
             "alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a"

--- a/tests/integration/test_lambda.py
+++ b/tests/integration/test_lambda.py
@@ -2176,10 +2176,14 @@ class TestDockerBehaviour(LambdaTestBase):
 
         # simulate an idle container
         executor.function_invoke_times[func_arn] = (
-            time.time() - lambda_executors.MAX_CONTAINER_IDLE_TIME_MS
+            int(time.time() * 1000) - lambda_executors.MAX_CONTAINER_IDLE_TIME_MS
         )
         executor.idle_container_destroyer()
-        self.assertEqual(0, len(executor.get_all_container_names()))
+
+        def assert_container_destroyed():
+            self.assertEqual(0, len(executor.get_all_container_names()))
+
+        retry(assert_container_destroyed, retries=3)
 
         # clean up
         testutil.delete_lambda_function(func_name)


### PR DESCRIPTION
This change allows us to hook into the Lambda execution and perform modifications to the container configuration before execution.
At various points of the code base, it is now possible to hook into the execution if needed, and modify its parameters.

In addition to introducing a ContainerConfiguration and LambdaContainerConfiguration class used for this purpose, there was also some cleanup of leftover logic:

* If LAMBDA_REMOTE_DOCKER was true, multiple copies into the container could take place, potentially slowing down the first invocation unnecessarily.
* Removed leftovers of `six` in lambda code
* Remove logic for using `run` instead of `create` and `start` if `LAMBDA_REMOTE_DOCKER=false`, since this code adds complexity and is basically identical anyway.
* Especially if `LAMBDA_REMOTE_DOCKER=True`, the removing of the container can take a little bit more time than with volume mounts. This leads to the `test_destroy_idle_containers` test to become flaky, which is now fixed using a retry.