### PR TITLE
Minor fixes in patch for bound methods of class instances

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -339,7 +339,7 @@ class EC2VPC(GenericBaseModel):
                 )
                 for rt in resp["RouteTables"]:
                     for assoc in rt.get("Associations", []):
-                        # skipping Main association (accommodating recent upstream change)
+                        # skipping Main association (upstream moto includes default association that cannot be deleted)
                         if assoc.get("Main"):
                             continue
                         ec2_client.disassociate_route_table(

--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -37,6 +37,7 @@ class JobScheduler(object):
     _instance = None
 
     def __init__(self):
+        # TODO: introduce RLock for mutating jobs list
         self.jobs = []
         self.thread = None
 

--- a/localstack/services/iam/iam_starter.py
+++ b/localstack/services/iam/iam_starter.py
@@ -182,7 +182,7 @@ def apply_patches():
     # patch detach_role_policy
 
     @patch(moto_iam_backend.detach_role_policy, pass_target=False)
-    def iam_backend_detach_role_policy(policy_arn, role_name):
+    def iam_backend_detach_role_policy(self, policy_arn, role_name):
         try:
             role = moto_iam_backend.get_role(role_name)
             policy = role.managed_policies[policy_arn]

--- a/tests/unit/utils/test_patch.py
+++ b/tests/unit/utils/test_patch.py
@@ -79,7 +79,7 @@ def test_patch_decorator_on_bound_method_with_pass_target():
     obj = MyEchoer()
 
     @patch(target=obj.do_echo)
-    def uppercase(target, arg):
+    def uppercase(self, target, arg):
         return target(arg).upper()
 
     assert obj.do_echo("foo") == "DO_ECHO: FOO"
@@ -94,7 +94,7 @@ def test_patch_decorator_on_bound_method():
     obj = MyEchoer()
 
     @patch(target=obj.do_echo, pass_target=False)
-    def monkey(arg):
+    def monkey(self, arg):
         return f"monkey: {arg}"
 
     assert obj.do_echo("foo") == "monkey: foo"


### PR DESCRIPTION
Minor fixes in patch for bound methods of class instances. This resolves an issue where patches cannot be re-applied to bound methods as they are reloaded from persistence. 

The change slightly modifies the interface of patched methods (adding `self` as a required parameter), but that is actually a fair assumption for bound methods, which are always executing in the context of a `self` instance. (Still need to verify in which places we need to update the patch targets - so far only spotted `iam_backend_detach_role_policy` and `put_subscription_filter` in this codebase.)