### PR TITLE
Hardcode container tmp and data folder to prevent host settings from propagating into the container

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -116,13 +116,19 @@ class Directories:
             or "/var/lib/localstack/var_libs"
         )
         cache = os.environ.get("CONTAINER_CACHE_FOLDER", "").strip() or "/var/lib/localstack/cache"
+        tmp = (
+            os.environ.get("CONTAINER_TMP_FOLDER", "").strip() or "/tmp/localstack"
+        )  # TODO: discuss movement to /var/lib/localstack/tmp
+        data_dir = os.environ.get("CONTAINER_DATA_DIR_FOLDER", "").strip() or (
+            DATA_DIR if in_docker() else "/tmp/localstack_data"
+        )  # TODO: move to /var/lib/localstack/data
         return Directories(
             static_libs=INSTALL_DIR_INFRA,
             var_libs=var_libs,
             cache=cache,
-            tmp=TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp - or /tmp/localstack
+            tmp=tmp,
             functions=HOST_TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
-            data=DATA_DIR,  # TODO: move to /var/lib/localstack/data
+            data=data_dir,
             config=None,  # config directory is host-only
             logs="/var/lib/localstack/logs",
             init="/docker-entrypoint-initaws.d",


### PR DESCRIPTION
Currently, when using the localstack CLI, it will mount the tmp folder both on host and in the container in the same path, due to the usage of the TMP_FOLDER variable here (same for DATA_DIR).

While this most likely works on most systems, it leads to a major problem when using the CLI on windows hosts, since the paths will not match (see #5173).

This PR changes the container side of the directories to the default directories before this change happened, with an option to override by environment variable.

For DATA_DIR, note that this variable will be set by the CLI into the container, so we can respect this variable if we are in docker.