### PR TITLE
Allow use of anonymous credentials to get an S3 object or bucket

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -454,15 +454,12 @@ def get_api_from_custom_rules(method, path, data, headers):
 
     # TODO: move S3 public URLs to a separate port/endpoint, OR check ACLs here first
     stripped = path.strip("/")
-    if method in ["GET", "HEAD"] and "/" in stripped:
+    if method in ["GET", "HEAD"] and stripped:
         # assume that this is an S3 GET request with URL path `/<bucket>/<key ...>`
         return "s3", config.PORT_S3
 
     # detect S3 URLs
     if stripped and "/" not in stripped:
-        if method == "HEAD":
-            # assume that this is an S3 HEAD bucket request with URL path `/<bucket>`
-            return "s3", config.PORT_S3
         if method == "PUT":
             # assume that this is an S3 PUT bucket request with URL path `/<bucket>`
             return "s3", config.PORT_S3


### PR DESCRIPTION
This PR addresses issue #5111. Even thought the user found out the solution to the problem, this [documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_anonymous.html) shows that it should be possible to access an S3 bucket or an S3 key with anonymous credentials (only if the policy allows it but i don't think that's necessary) 

Changes:
- Redirect the GET or HEAD requests to S3 if there is an URI.
- Test to assert access to key with anonymous credentials.
