### PR TITLE
Match the most specific path

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -948,8 +948,12 @@ def get_stage_variables(api_id: str, stage: str) -> Dict[str, str]:
         return {}
     region_name = [name for name, region in apigateway_backends.items() if api_id in region.apis][0]
     api_gateway_client = aws_stack.connect_to_service("apigateway", region_name=region_name)
-    response = api_gateway_client.get_stage(restApiId=api_id, stageName=stage)
-    return response.get("variables")
+    try:
+        response = api_gateway_client.get_stage(restApiId=api_id, stageName=stage)
+        return response.get("variables")
+    except Exception:
+        LOG.info(f"Failed to get stage {stage} for api id {api_id}")
+        return {}
 
 
 def get_event_request_context(invocation_context: ApiInvocationContext):

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -972,7 +972,9 @@ def get_resource_for_path(path: str, path_map: Dict[str, Dict]) -> Optional[Tupl
         for match in matches:
             if match[0] == path:
                 return match
-            # not an exact match but parameters can fit in
+
+        # not an exact match but parameters can fit in
+        for match in matches:
             if path_matches_pattern(path, match[0]):
                 return match
 


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/5226

This PR splits the pattern matching into two loops to force precedence. Another issue found was the call to get the stage, for some reason, the API deployment with terraform doesn't set up a "local" stage. For those cases, we ignore the stage variables.