### PR TITLE
Apply fixes for recent upstream moto changes

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -339,6 +339,9 @@ class EC2VPC(GenericBaseModel):
                 )
                 for rt in resp["RouteTables"]:
                     for assoc in rt.get("Associations", []):
+                        # skipping Main association (accommodating recent upstream change)
+                        if assoc.get("Main"):
+                            continue
                         ec2_client.disassociate_route_table(
                             AssociationId=assoc["RouteTableAssociationId"]
                         )

--- a/localstack/services/ec2/ec2_starter.py
+++ b/localstack/services/ec2/ec2_starter.py
@@ -3,7 +3,6 @@ import re
 
 import xmltodict
 from moto.ec2 import models as ec2_models
-from moto.ec2.exceptions import InvalidPermissionNotFoundError
 from moto.ec2.models import EC2Backend
 from moto.ec2.responses import security_groups, vpcs
 from moto.ec2.responses.reserved_instances import ReservedInstances
@@ -23,15 +22,6 @@ XMLNS_EC2 = "http://ec2.amazonaws.com/doc/2016-11-15/"
 
 
 def patch_ec2():
-    @patch(EC2Backend.revoke_security_group_egress)
-    def revoke_security_group_egress(fn, *args, **kwargs):
-        try:
-            return fn(*args, **kwargs)
-        except InvalidPermissionNotFoundError:
-            # this can happen, as CidrIpv6 is not yet supported by moto
-            if args[4] == []:
-                return "_ignore_"
-
     @patch(EC2Backend.delete_nat_gateway)
     def delete_nat_gateway(fn, *args, **kwargs):
         gateway = fn(*args, **kwargs)

--- a/localstack/services/ec2/ec2_starter.py
+++ b/localstack/services/ec2/ec2_starter.py
@@ -4,12 +4,14 @@ import re
 import xmltodict
 from moto.ec2 import models as ec2_models
 from moto.ec2.exceptions import InvalidPermissionNotFoundError
+from moto.ec2.models import EC2Backend
 from moto.ec2.responses import security_groups, vpcs
 from moto.ec2.responses.reserved_instances import ReservedInstances
 
 from localstack import config
 from localstack.services.infra import start_moto_server
 from localstack.utils.common import long_uid, short_uid
+from localstack.utils.patch import patch
 
 LOG = logging.getLogger(__name__)
 
@@ -21,30 +23,20 @@ XMLNS_EC2 = "http://ec2.amazonaws.com/doc/2016-11-15/"
 
 
 def patch_ec2():
-    def patch_revoke_security_group_egress(backend):
-        revoke_security_group_egress_orig = backend.revoke_security_group_egress
+    @patch(EC2Backend.revoke_security_group_egress)
+    def revoke_security_group_egress(fn, *args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except InvalidPermissionNotFoundError:
+            # this can happen, as CidrIpv6 is not yet supported by moto
+            if args[4] == []:
+                return "_ignore_"
 
-        def revoke_security_group_egress(*args, **kwargs):
-            try:
-                return revoke_security_group_egress_orig(*args, **kwargs)
-            except InvalidPermissionNotFoundError:
-                # this can happen, as CidrIpv6 is not yet supported by moto
-                if args[4] == []:
-                    return "_ignore_"
-
-        return revoke_security_group_egress
-
-    def patch_delete_nat_gateway(backend):
-        def delete_nat_gateway(nat_gateway_id):
-            gateway = backend.nat_gateways.get(nat_gateway_id)
-            if gateway:
-                gateway.state = "deleted"
-
-        return delete_nat_gateway
-
-    for region, backend in ec2_models.ec2_backends.items():
-        backend.revoke_security_group_egress = patch_revoke_security_group_egress(backend)
-        backend.delete_nat_gateway = patch_delete_nat_gateway(backend)
+    @patch(EC2Backend.delete_nat_gateway)
+    def delete_nat_gateway(fn, *args, **kwargs):
+        gateway = fn(*args, **kwargs)
+        if gateway:
+            gateway.state = "deleted"
 
     # TODO Implement Reserved Instance backend
     # https://github.com/localstack/localstack/issues/2435
@@ -253,7 +245,7 @@ def patch_ec2():
         result = xmltodict.unparse(result)
         return result
 
-    if not hasattr(vpcs.VPCs, "delete_vpc_endpoints"):
+    if not hasattr(vpcs.VPCs, "create_vpc_endpoint_service_configuration"):
         vpcs.VPCs.create_vpc_endpoint_service_configuration = (
             create_vpc_endpoint_service_configuration
         )

--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -6,11 +6,11 @@ import re
 from gzip import GzipFile
 from typing import Callable, Dict
 
-from moto.awslambda import models as lambda_models
+from moto.awslambda import models as LambdaBackend
 from moto.core.utils import unix_time_millis
 from moto.logs import models as logs_models
 from moto.logs.exceptions import InvalidParameterException, ResourceNotFoundException
-from moto.logs.models import LogStream
+from moto.logs.models import LogsBackend, LogStream
 from requests.models import Request
 
 from localstack.constants import APPLICATION_AMZ_JSON_1_1, TEST_AWS_ACCOUNT_ID
@@ -164,9 +164,7 @@ def moto_put_log_events(_, self, log_group_name, log_stream_name, log_events, se
             )
 
 
-def moto_put_subscription_filter(put_subscription_filter, *args, **kwargs):
-    self = put_subscription_filter.__self__
-
+def moto_put_subscription_filter(fn, self, *args, **kwargs):
     log_group_name = args[0]
     filter_name = args[1]
     filter_pattern = args[2]
@@ -253,12 +251,9 @@ def moto_filter_log_events(
 
 
 def add_patches(patches: Patches):
-    for lambda_backend in lambda_models.lambda_backends.values():
-        patches.function(lambda_backend.get_function, moto_lambda_get_function)
+    patches.function(LambdaBackend.get_function, moto_lambda_get_function)
 
-    for logs_backend in logs_models.logs_backends.values():
-        patches.function(logs_backend.put_subscription_filter, moto_put_subscription_filter)
-
+    patches.function(LogsBackend.put_subscription_filter, moto_put_subscription_filter)
     patches.function(LogStream.put_log_events, moto_put_log_events)
     patches.function(LogStream.filter_log_events, moto_filter_log_events)
 

--- a/localstack/services/logs/logs_listener.py
+++ b/localstack/services/logs/logs_listener.py
@@ -6,7 +6,7 @@ import re
 from gzip import GzipFile
 from typing import Callable, Dict
 
-from moto.awslambda import models as LambdaBackend
+from moto.awslambda.models import LambdaBackend
 from moto.core.utils import unix_time_millis
 from moto.logs import models as logs_models
 from moto.logs.exceptions import InvalidParameterException, ResourceNotFoundException

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,8 +52,7 @@ flask_swagger==0.2.12
 jsonpatch>=1.24,<2.0
 jsonpath-rw>=1.4.0,<2.0.0
 localstack-ext[full]>=0.13.2
-# TODO: pinning moto to 2.2.8.1 for now, until latest issues are fixed
-moto-ext[all]==2.2.8.1
+moto-ext[all]>=2.2.8.2
 pproxy>=2.7.0
 #pympler>=0.6
 pyopenssl>=21.0.0

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -2181,6 +2181,7 @@ class CloudFormationTest(unittest.TestCase):
         ec2_client = aws_stack.create_external_boto_client("ec2")
 
         resp = ec2_client.describe_vpcs()
+        # TODO: remove/change assertion, to make tests parallelizable!
         vpcs_before = [vpc["VpcId"] for vpc in resp["Vpcs"]]
 
         template = load_file(os.path.join(THIS_FOLDER, "templates", "template33.yaml"))
@@ -2399,6 +2400,7 @@ class CloudFormationTest(unittest.TestCase):
         ec2_client = aws_stack.create_external_boto_client("ec2")
 
         resp = ec2_client.describe_vpcs()
+        # TODO: remove/change assertion, to make tests parallelizable!
         vpcs_before = [vpc["VpcId"] for vpc in resp["Vpcs"]]
 
         template = load_file(os.path.join(THIS_FOLDER, "templates", "template36.yaml"))
@@ -2410,7 +2412,7 @@ class CloudFormationTest(unittest.TestCase):
         self.assertEqual(1, len(vpcs))
 
         resp = ec2_client.describe_route_tables(Filters=[{"Name": "vpc-id", "Values": [vpcs[0]]}])
-        # Cloudformation Template will create more than one route table 2 in template + default
+        # CloudFormation will create more than one route table 2 in template + default
         self.assertEqual(3, len(resp["RouteTables"]))
 
         # Clean up
@@ -2431,8 +2433,8 @@ class CloudFormationTest(unittest.TestCase):
             Filters=[{"Name": "route-table-id", "Values": [route_table_id]}]
         )["RouteTables"][0]
 
-        # # Cloudformation Template will create more than one route table 2 in template + default
-        self.assertEqual(2, len(route_table["Associations"]))
+        # CloudFormation will create more than one route table 2 in template + default
+        self.assertEqual(3, len(route_table["Associations"]))
 
         # Clean up
         self.cleanup(stack_name)

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -235,11 +235,12 @@ class TestEc2Integrations(unittest.TestCase):
             ],
         )
 
+        region = aws_stack.get_region()
         self.assertEqual(200, vpc_endpoint_gateway_services["ResponseMetadata"]["HTTPStatusCode"])
         services = vpc_endpoint_gateway_services["ServiceNames"]
         self.assertEqual(2, len(services))
-        self.assertTrue("com.amazonaws.us-east-1.dynamodb" in services)
-        self.assertTrue("com.amazonaws.us-east-1.s3" in services)
+        self.assertTrue(f"com.amazonaws.{region}.dynamodb" in services)
+        self.assertTrue(f"com.amazonaws.{region}.s3" in services)
         # test filter of Interface endpoint services
         vpc_endpoint_interface_services = ec2.describe_vpc_endpoint_services(
             Filters=[
@@ -250,9 +251,9 @@ class TestEc2Integrations(unittest.TestCase):
         self.assertEqual(200, vpc_endpoint_interface_services["ResponseMetadata"]["HTTPStatusCode"])
         services = vpc_endpoint_interface_services["ServiceNames"]
         self.assertTrue(len(services) > 0)
-        self.assertTrue("com.amazonaws.us-east-1.dynamodb" in services)
-        self.assertTrue("com.amazonaws.us-east-1.s3" in services)
-        self.assertTrue("com.amazonaws.us-east-1.firehose" in services)
+        self.assertTrue(f"com.amazonaws.{region}.dynamodb" in services)
+        self.assertTrue(f"com.amazonaws.{region}.s3" in services)
+        self.assertTrue(f"com.amazonaws.{region}.firehose" in services)
 
         # test filter that does not exist
         vpc_endpoint_interface_services = ec2.describe_vpc_endpoint_services(


### PR DESCRIPTION
Apply fixes for recent upstream moto changes. In particular, the creation of model backends has changed, as well as the logic around default/main associations in route tables [here](https://github.com/spulec/moto/pull/4726). 

Changes were not yet fully verified against AWS, but parity of the EC2 changes has been verified against AWS as  per [this PR comment]([here](https://github.com/spulec/moto/pull/4726)).