### PR TITLE
Add handling for DynamoDB stream iterator expiration, bump kinesis-mock to 0.2.2

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -95,7 +95,7 @@ URL_ASPECTJWEAVER = f"{MAVEN_REPO}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
 # kinesis-mock version
-KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.0"
+KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.2"
 KINESIS_MOCK_RELEASE_URL = (
     "https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/" + KINESIS_MOCK_VERSION
 )


### PR DESCRIPTION
This PR mappes the ExpiredIteratorException from the boto3 kinesis getrecords call to the identically named exception for DynamoDBstreams.

This results in clients like the [DynamoDB Streams Kinesis Adapter](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.KCLAdapter.html) to correctly map the exception back to kinesis and request a new shard iterator if needed.

This is a first hotfix for the issues with expiring shard iterators for dynamodbstreams.

Future iterations should contain a 15 minutes shard expiration time instead of the current 5 minutes forced by the kinesis-mock backend.

Also, this PR bumps kinesis-mock to version 0.2.2, to fix issue https://github.com/etspaceman/kinesis-mock/issues/260 and achieve more parity with AWS, and reducing the occurrence of ExpiredShardIterator exceptions if no records are recieved for 5 minutes.

Addresses #5182 

@SwatsonCodes Slight changes in kinesis/kinesis tests, FYI