### PR TITLE
fix expectations around kinesis record encoding

### DIFF
--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -334,9 +334,6 @@ def subscribe_to_shard(data, headers):
     iterator = kinesis.get_shard_iterator(
         StreamName=stream_name, ShardId=data["ShardId"], ShardIteratorType=iter_type, **kwargs
     )["ShardIterator"]
-    data_needs_encoding = False
-    if "java" in headers.get("User-Agent", "").split(" ")[0]:
-        data_needs_encoding = True
 
     def send_events():
         yield convert_to_binary_event_payload("", event_type="initial-response")
@@ -361,9 +358,8 @@ def subscribe_to_shard(data, headers):
                 record["ApproximateArrivalTimestamp"] = record[
                     "ApproximateArrivalTimestamp"
                 ].timestamp()
-                if data_needs_encoding:
-                    record["Data"] = base64.b64encode(record["Data"])
-                record["Data"] = to_str(record["Data"])
+                # boto3 automatically decodes records in get_records(), so we must re-encode
+                record["Data"] = to_str(base64.b64encode(record["Data"]))
                 last_sequence_number = record["SequenceNumber"]
             if not records:
                 time.sleep(1)

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -94,10 +94,9 @@ class TestKinesis(unittest.TestCase):
         # put records
         num_records = 5
         msg = b"Hello world"
-        msg_b64 = base64.b64encode(msg)
         for i in range(num_records):
             client.put_records(
-                StreamName=stream_name, Records=[{"Data": msg_b64, "PartitionKey": "1"}]
+                StreamName=stream_name, Records=[{"Data": msg, "PartitionKey": "1"}]
             )
 
         # assert results
@@ -128,6 +127,7 @@ class TestKinesis(unittest.TestCase):
         client = aws_stack.create_external_boto_client("kinesis")
         stream_name = "test-%s" % short_uid()
         stream_arn = aws_stack.kinesis_stream_arn(stream_name)
+        record_data = "Hello world"
 
         # create stream and consumer
         result = client.create_stream(StreamName=stream_name, ShardCount=1)
@@ -161,7 +161,7 @@ class TestKinesis(unittest.TestCase):
         for i in range(num_records):
             client.put_records(
                 StreamName=stream_name,
-                Records=[{"Data": "SGVsbG8gd29ybGQ=", "PartitionKey": "1"}],
+                Records=[{"Data": record_data, "PartitionKey": "1"}],
             )
 
         results = []
@@ -174,7 +174,7 @@ class TestKinesis(unittest.TestCase):
         # assert results
         self.assertEqual(num_records, len(results))
         for record in results:
-            self.assertEqual(b"Hello world", record["Data"])
+            self.assertEqual(str.encode(record_data), record["Data"])
 
         # clean up
         client.deregister_stream_consumer(StreamARN=stream_arn, ConsumerName="c1")

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -1,4 +1,3 @@
-import base64
 import logging
 import re
 import unittest
@@ -95,9 +94,7 @@ class TestKinesis(unittest.TestCase):
         num_records = 5
         msg = b"Hello world"
         for i in range(num_records):
-            client.put_records(
-                StreamName=stream_name, Records=[{"Data": msg, "PartitionKey": "1"}]
-            )
+            client.put_records(StreamName=stream_name, Records=[{"Data": msg, "PartitionKey": "1"}])
 
         # assert results
         results = []
@@ -216,6 +213,31 @@ class TestKinesis(unittest.TestCase):
 
         # clean up
         client.delete_stream(StreamName=stream_name)
+
+    def test_record_lifecycle_data_integrity(self):
+        """
+        kinesis records should contain the same data from when they are sent to when they are received
+        """
+        client = aws_stack.create_external_boto_client("kinesis")
+        stream_name = "test-%s" % short_uid()
+        records_data = {"test", "ünicödé 统一码 💣💻🔥", "a" * 1000, ""}
+
+        client.create_stream(StreamName=stream_name, ShardCount=1)
+        sleep(1.5)
+        iterator = self._get_shard_iterator(stream_name)
+
+        for record_data in records_data:
+            client.put_record(
+                StreamName=stream_name,
+                Data=record_data,
+                PartitionKey="1",
+            )
+
+        response = client.get_records(ShardIterator=iterator)
+        response_records = response.get("Records")
+        self.assertEqual(len(records_data), len(response_records))
+        for response_record in response_records:
+            self.assertIn(response_record.get("Data").decode("utf-8"), records_data)
 
     def _get_shard_iterator(self, stream_name):
         client = aws_stack.create_external_boto_client("kinesis")


### PR DESCRIPTION
This PR should fix https://github.com/localstack/localstack/issues/4095. It took me a little while to figure out what was causing boto to throw a base64 decode error when retrieving records from Kinesis, but ultimately I identified two problems:

* The Kinesis tests make faulty assumptions about how kinesis/boto handle record encoding/decoding
* The `subscribe_to_shard` function has a special case for re-encoding records when talking to a Java client, but in fact this should happen always.

According to the [Kinesis docs](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecordsRequestEntry.html), Kinesis expects records to consist of base64 encoded data when you `PUT` them to the API. However, boto takes care of this for you behind the scenes: it automatically base64 encodes your data before it sends it to the API, and automatically decodes it when you retrieve the records. To sanity check this, I wrote this simple script for creating a stream, putting a record, and retrieving it.
```
import boto3
from time import sleep
boto3.set_stream_logger(name='botocore')

client = boto3.client('kinesis')
client.create_stream(StreamName='test', ShardCount=1)
sleep(10)
client.put_record(StreamName='test', Data='this is raw data', PartitionKey='foo')

iterator = client.get_shard_iterator( StreamName="test", ShardId='shardId-000000000000', ShardIteratorType='TRIM_HORIZON')["ShardIterator"]

result = client.get_records(ShardIterator=iterator)
print(result)
```
I made boto do verbose logging so that we can see the request and response bodies. I won't include the full output here because it includes sensitive data, but here are some snippets that illustrate that the record data is automatically encoded before it is sent and after it is retrieved:
```
[...]
# sending record, note that the data is automatically encoded
2022-01-13 12:33:21,902 botocore.hooks [DEBUG] Event before-call.kinesis.PutRecord: calling handler <function inject_api_version_header_if_needed at 0x11003cb80>
2022-01-13 12:33:21,902 botocore.endpoint [DEBUG] Making request for OperationModel(name=PutRecord) with params: {'url_path': '/', 'query_string': '', 'method': 'POST', 'headers': {...}, 'body': b'{"StreamName": "test", "Data": "dGhpcyBpcyByYXcgZGF0YQ==", "PartitionKey": "foo"}', 'url': 'https://kinesis.us-east-1.amazonaws.com/', 'context': {...}}

[...]

# API response for getting record
2022-01-13 12:33:23,011 botocore.parsers [DEBUG] Response body:
b'{"MillisBehindLatest":0,"NextShardIterator":"...","Records":[{"ApproximateArrivalTimestamp":1.642102402844E9,"Data":"dGhpcyBpcyByYXcgZGF0YQ==","PartitionKey":"foo","SequenceNumber":"..."}]}'

# finally printing the resulting records at the end of the script. Note how boto automatically decoded the record data.
{'Records': [{'SequenceNumber': '...', 'ApproximateArrivalTimestamp': '...', 'Data': b'this is raw data', 'PartitionKey': 'foo'}], 'NextShardIterator': ...}
```

Judging by the way the tests were written, it seems like we assumed that boto would automatically decode record data blobs, but not automatically encode them. I fixed this and added a more comprehensive test to ensure that unicode can be properly encoded/decoded as well.

Finally, it seems like this bug sort of surfaced in the past because of [this](https://github.com/localstack/localstack/blob/master/localstack/services/kinesis/kinesis_listener.py#L338) special case for re-encoding records for Java clients. In fact, we should always re-encode here because the prior call to `get_records()` gives us automatically decoded records, so we must re-encode them before returning them to the client.