### PR TITLE
Remove obsolete moto imports in CloudFormation resource classes

### DIFF
--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -1,8 +1,6 @@
 import json
 import logging
 
-from moto.iam.models import Role as MotoRole
-
 from localstack.services.awslambda.lambda_api import IAM_POLICY_VERSION
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
@@ -156,7 +154,7 @@ class IAMUser(GenericBaseModel):
         }
 
 
-class IAMRole(GenericBaseModel, MotoRole):
+class IAMRole(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::IAM::Role"

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -1,8 +1,6 @@
 import json
 import re
 
-from moto.s3.models import FakeBucket
-
 from localstack.constants import AWS_REGION_US_EAST_1, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
@@ -44,8 +42,7 @@ class S3BucketPolicy(GenericBaseModel):
         }
 
 
-# TODO: moto dependency
-class S3Bucket(GenericBaseModel, FakeBucket):
+class S3Bucket(GenericBaseModel):
     def get_resource_name(self):
         return self.normalize_bucket_name(self.props.get("BucketName"))
 

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -43,6 +43,10 @@ class S3BucketPolicy(GenericBaseModel):
 
 
 class S3Bucket(GenericBaseModel):
+    @staticmethod
+    def cloudformation_type():
+        return "AWS::S3::Bucket"
+
     def get_resource_name(self):
         return self.normalize_bucket_name(self.props.get("BucketName"))
 

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -2,7 +2,6 @@ import json
 import logging
 
 from botocore.exceptions import ClientError
-from moto.sqs.models import Queue as MotoQueue
 
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
@@ -63,7 +62,7 @@ class QueuePolicy(GenericBaseModel):
         }
 
 
-class SQSQueue(GenericBaseModel, MotoQueue):
+class SQSQueue(GenericBaseModel):
     @classmethod
     def cloudformation_type(cls):
         return "AWS::SQS::Queue"

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -103,20 +103,22 @@ def patch_instance_tracker_meta():
     Avoid instance collection for moto dashboard
     """
 
-    def new_intance(meta, name, bases, dct):
-        cls = super(moto_core.models.InstanceTrackerMeta, meta).__new__(meta, name, bases, dct)
+    def new_instance(meta, name, bases, dct):
+        cls = super(InstanceTrackerMeta, meta).__new__(meta, name, bases, dct)
         if name == "BaseModel":
             return cls
         cls.instances = []
         return cls
 
-    moto_core.models.InstanceTrackerMeta.__new__ = new_intance
+    InstanceTrackerMeta = moto_core.models.InstanceTrackerMeta
+    InstanceTrackerMeta.__new__ = new_instance
 
     def new_basemodel(cls, *args, **kwargs):
-        instance = super(moto_core.models.BaseModel, cls).__new__(cls)
+        instance = super(BaseModel, cls).__new__(cls)
         return instance
 
-    moto_core.models.BaseModel.__new__ = new_basemodel
+    BaseModel = moto_core.models.BaseModel
+    BaseModel.__new__ = new_basemodel
 
 
 def get_multiserver_or_free_service_port():

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -101,9 +101,10 @@ def patch_urllib3_connection_pool(**constructor_kwargs):
 
 
 def patch_instance_tracker_meta():
-    """
-    Avoid instance collection for moto dashboard
-    """
+    """Avoid instance collection for moto dashboard"""
+
+    if hasattr(InstanceTrackerMeta, "_ls_patch_applied"):
+        return  # ensure we're not applying the patch multiple times
 
     @patch(InstanceTrackerMeta.__new__, pass_target=False)
     def new_instance(meta, name, bases, dct):
@@ -118,6 +119,8 @@ def patch_instance_tracker_meta():
         # skip cls.instances.append(..) which is done by the original/upstream constructor
         instance = super(BaseModel, cls).__new__(cls)
         return instance
+
+    InstanceTrackerMeta._ls_patch_applied = True
 
 
 def get_multiserver_or_free_service_port():


### PR DESCRIPTION
Minor fixes:
* Remove obsolete moto imports in CloudFormation resource classes /cc @dominikschubert 
* Fix/refactor some patches with the new decorator