### PR TITLE
Introduce lazily-created localstack-internal-awssdk utility lambda function

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -805,6 +805,7 @@ def run_lambda(
 
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
+        # TODO: wrong mapping
         response = {
             "errorType": str(exc_type.__name__),
             "errorMessage": str(e),

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1326,6 +1326,7 @@ class LambdaExecutorLocal(LambdaExecutor):
         lambda_cwd = lambda_function.cwd
         environment = self._prepare_environment(lambda_function)
 
+        environment["EDGE_PORT"] = str(config.EDGE_PORT)
         if lambda_function.timeout:
             environment["AWS_LAMBDA_FUNCTION_TIMEOUT"] = str(lambda_function.timeout)
         context = inv_context.context

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -77,7 +77,7 @@ MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/997c0a1fb27cbad8d13b976ed849ac1b53f76369/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/190a8e1ba9f780fd2a0a1a8ab9e599a65c58790d/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -77,7 +77,7 @@ MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/047cc6dcd2e31f5ff3ec52d293c61b875f606958/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/997c0a1fb27cbad8d13b976ed849ac1b53f76369/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (
@@ -86,6 +86,7 @@ SFN_PATCH_CLASS2 = (
 SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
 SFN_PATCH_CLASS_REGION = "cloud/localstack/RegionAspect.class"
 SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
+AWS_SDK_LAMBDA_HANDLER = f"{SFN_PATCH_URL_PREFIX}/localstack-internal-awssdk/index.js"
 
 # additional JAR libs required for multi-region and persistence (PRO only) support
 MAVEN_REPO = "https://repo1.maven.org/maven2"
@@ -434,6 +435,11 @@ def install_stepfunctions_local():
         target = os.path.join(INSTALL_DIR_STEPFUNCTIONS, os.path.basename(jar_url))
         if not file_exists_not_empty(target):
             download(jar_url, target)
+
+    # download aws-sdk lambda handler
+    target = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "localstack-internal-awssdk", "index.js")
+    if not file_exists_not_empty(target):
+        download(AWS_SDK_LAMBDA_HANDLER, target)
 
 
 def add_file_to_jar(class_file, class_url, target_jar, base_dir=None):

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -86,7 +86,11 @@ SFN_PATCH_CLASS2 = (
 SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
 SFN_PATCH_CLASS_REGION = "cloud/localstack/RegionAspect.class"
 SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
-AWS_SDK_LAMBDA_HANDLER = f"{SFN_PATCH_URL_PREFIX}/localstack-internal-awssdk/index.js"
+
+SFN_AWS_SDK_URL_PREFIX = (
+    f"{ARTIFACTS_REPO}/raw/504eb5e20664e8e4dcca102479d1b27f90545453/stepfunctions-internal-awssdk"
+)
+SFN_AWS_SDK_LAMBDA_ZIP_FILE = f"{SFN_AWS_SDK_URL_PREFIX}/awssdk.zip"
 
 # additional JAR libs required for multi-region and persistence (PRO only) support
 MAVEN_REPO = "https://repo1.maven.org/maven2"
@@ -437,9 +441,9 @@ def install_stepfunctions_local():
             download(jar_url, target)
 
     # download aws-sdk lambda handler
-    target = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "localstack-internal-awssdk", "index.js")
+    target = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "localstack-internal-awssdk", "awssdk.zip")
     if not file_exists_not_empty(target):
-        download(AWS_SDK_LAMBDA_HANDLER, target)
+        download(SFN_AWS_SDK_LAMBDA_ZIP_FILE, target)
 
 
 def add_file_to_jar(class_file, class_url, target_jar, base_dir=None):

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -77,7 +77,7 @@ MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/190a8e1ba9f780fd2a0a1a8ab9e599a65c58790d/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/a4adc8f4da9c7ec0d93b50ca5b73dd14df791c0e/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (
@@ -85,10 +85,12 @@ SFN_PATCH_CLASS2 = (
 )
 SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
 SFN_PATCH_CLASS_REGION = "cloud/localstack/RegionAspect.class"
+SFN_PATCH_CLASS_ASYNC2SERVICEAPI = "cloud/localstack/Async2ServiceApi.class"
+SFN_PATCH_CLASS_DESCRIBEEXECUTIONPARSED = "cloud/localstack/DescribeExecutionParsed.class"
 SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
 
 SFN_AWS_SDK_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/504eb5e20664e8e4dcca102479d1b27f90545453/stepfunctions-internal-awssdk"
+    f"{ARTIFACTS_REPO}/raw/a4adc8f4da9c7ec0d93b50ca5b73dd14df791c0e/stepfunctions-internal-awssdk"
 )
 SFN_AWS_SDK_LAMBDA_ZIP_FILE = f"{SFN_AWS_SDK_URL_PREFIX}/awssdk.zip"
 
@@ -413,6 +415,8 @@ def install_stepfunctions_local():
         SFN_PATCH_CLASS2,
         SFN_PATCH_CLASS_REGION,
         SFN_PATCH_CLASS_STARTER,
+        SFN_PATCH_CLASS_ASYNC2SERVICEAPI,
+        SFN_PATCH_CLASS_DESCRIBEEXECUTIONPARSED,
         SFN_PATCH_FILE_METAINF,
     ]
     for patch_class in classes:


### PR DESCRIPTION
Lazily creates a utility lambda when encountering a lambda invoke call to the `localstack-internal-awssdk` function.

This is used in tandem with https://github.com/localstack/localstack-artifacts/pull/5 to patch in `aws-sdk` support for the stepfunctions api as a temporary workaround until the image at https://hub.docker.com/r/amazon/aws-stepfunctions-local is updated with the corresponding features.