### PR TITLE
Minor fix in printing result for local node.js Lambda executor

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1466,13 +1466,9 @@ class LambdaExecutorLocal(LambdaExecutor):
         cmd = [
             "node",
             "-e",
-            'require("%s").%s(%s,%s).then(r => process.stdout.write(JSON.stringify(r)))'
-            % (
-                main_file,
-                function,
-                event_json_string,
-                context_json_string,
-            ),
+            f'const res = require("{main_file}").{function}({event_json_string},{context_json_string}); '
+            f"const log = (rs) => console.log(JSON.stringify(rs)); "
+            "res && res.then ? res.then(r => log(r)) : log(res)",
         ]
         LOG.info(cmd)
         result = self._execute_in_custom_runtime(cmd, lambda_function=lambda_function)


### PR DESCRIPTION
Tiny change that should fix an issue we're currently seeing in our CI builds (if node.js Lambda handlers are returning `undefined` instead of a Thenable):

```
TypeError: Cannot read property 'then' of undefined
    at [eval]:1:1082
    at Script.runInThisContext (vm.js:134:12)
    at Object.runInThisContext (vm.js:310:38)
    at internal/process/execution.js:81:19
    at [eval]-wrapper:6:22
    at evalScript (internal/process/execution.js:80:60)
    at internal/main/eval_string.js:27:3   File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 1370, in _execute
```

(On a side note, the way we're passing the args to the node process could be problematic from a security PoV. This entire logic may become obsolete once we move to the new Lambda executor - yet worthwhile fixing for now)