### PR TITLE
Remove obsolete patch in cloudwatch

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_starter.py
+++ b/localstack/services/cloudwatch/cloudwatch_starter.py
@@ -1,10 +1,7 @@
-import moto.cloudwatch.models as cloudwatch_models
 import moto.cloudwatch.responses as cloudwatch_responses
 
 from localstack import config
 from localstack.services.infra import start_moto_server
-from localstack.utils.common import to_unique_items_list
-from localstack.utils.patch import patch
 
 
 def apply_patches():
@@ -15,20 +12,6 @@ def apply_patches():
                 "</AlarmName><TreatMissingData>{{ alarm.treat_missing_data }}</TreatMissingData>",
             )
         )
-
-    @patch(cloudwatch_models.CloudWatchBackend.list_metrics)
-    def list_metrics(list_metrics_orig, self, *args, **kwargs):
-        # Filter results to return only unique combinations of (Namespace, MetricName, Dimensions)
-        # TODO: This is hugely inefficient (!), especially as the number of metric data is growing.
-        #       Should be fixed upstream, or we should roll our own implementation!
-        def comparator(i1, i2):
-            i1 = (i1.namespace, i1.name, set((d.name, d.value) for d in i1.dimensions))
-            i2 = (i2.namespace, i2.name, set((d.name, d.value) for d in i2.dimensions))
-            return i1 == i2
-
-        token, metric_list = list_metrics_orig(self, *args, **kwargs)
-        metric_list = to_unique_items_list(metric_list, comparator=comparator)
-        return token, metric_list
 
     # add put_composite_alarm
 


### PR DESCRIPTION
Since the PR spulec/moto#4732 is merged in upstream, the patch we are using now can be removed .
The `TODO` in the patch were addressed (while fixing the issue #5000)  in the merged PR in the upstream. 

Added Integration test to verify, only the unique metrics(unique combinations of name, namespace and dimensions)  are returned.
