### PR TITLE
add utility to manage / reserve ports for external services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "127.0.0.1:53:53"                # only required for Pro
       - "127.0.0.1:53:53/udp"            # only required for Pro
       - "127.0.0.1:443:443"              # only required for Pro
-      - "127.0.0.1:4510-4530:4510-4530"  # only required for Pro
+      - "127.0.0.1:4510-4530:4510-4530"
       - "127.0.0.1:4566:4566"
       - "127.0.0.1:4571:4571"
     environment:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -459,6 +459,18 @@ except socket.error:
 # SERVICE-SPECIFIC CONFIGS BELOW
 # -----
 
+# port ranges for external service instances (f.e. elasticsearch clusters, opensearch clusters,...)
+EXTERNAL_SERVICE_PORTS_START = int(
+    os.environ.get("EXTERNAL_SERVICE_PORTS_START")
+    or os.environ.get("SERVICE_INSTANCES_PORTS_START")
+    or 4510
+)
+EXTERNAL_SERVICE_PORTS_END = int(
+    os.environ.get("EXTERNAL_SERVICE_PORTS_END")
+    or os.environ.get("SERVICE_INSTANCES_PORTS_END")
+    or (EXTERNAL_SERVICE_PORTS_START + 30)
+)
+
 # java options to Lambda
 LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -29,6 +29,7 @@ from queue import Queue
 from typing import Any, Callable, Dict, List, Optional, Sized, Tuple, Type, Union
 from urllib.parse import parse_qs, urlparse
 
+import cachetools
 import dns.resolver
 import requests
 import six
@@ -523,6 +524,64 @@ class FileMappedDocument(dict):
 
         with open(self.path, "w", opener=opener) as fd:
             json.dump(self, fd)
+
+
+class PortNotAvailableException(Exception):
+    """Exception which indicates that the ExternalServicePortsManager could not reserve a port."""
+
+    pass
+
+
+class ExternalServicePortsManager:
+    """Manages the ports used for starting external services like ElasticSearch, OpenSearch,..."""
+
+    def __init__(self):
+        # cache for locally available ports (ports are reserved for a short period of a few seconds)
+        self._PORTS_CACHE = cachetools.TTLCache(maxsize=100, ttl=6)
+        self._PORTS_LOCK = threading.RLock()
+
+    def reserve_port(self, port: int = None) -> int:
+        """
+        Reserves the given port (if it is still free). If the given port is None, it reserves a free port from the
+        configured port range for external services. If a port is given, it has to be within the configured
+        range of external services (i.e. in [config#EXTERNAL_SERVICE_PORTS_START, config#EXTERNAL_SERVICE_PORTS_END)).
+        :param port: explicit port to check or None if a random port from the configured range should be selected
+        :return: reserved, free port number (int)
+        :raises: PortNotAvailableException if the given port is outside the configured range, it is already bound or
+                    reserved, or if the given port is none and there is no free port in the configured service range.
+        """
+        ports_range = range(config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END)
+        if port is not None and port not in ports_range:
+            raise PortNotAvailableException(
+                f"The requested port ({port}) is not in the configured external "
+                f"service port range ({ports_range})."
+            )
+        with self._PORTS_LOCK:
+            if port is not None:
+                return self._check_port(port)
+            else:
+                for port_in_range in ports_range:
+                    try:
+                        return self._check_port(port_in_range)
+                    except PortNotAvailableException:
+                        # We ignore the fact that this single port is reserved, we just check the next one
+                        pass
+        raise PortNotAvailableException(
+            "No free network ports available to start service instance (currently reserved: %s)",
+            list(self._PORTS_CACHE.keys()),
+        )
+
+    def _check_port(self, port: int) -> int:
+        """Checks if the given port is currently not reserved and can be bound."""
+        if not self._PORTS_CACHE.get(port) and port_can_be_bound(port):
+            # reserve the port for a short period of time
+            self._PORTS_CACHE[port] = "__reserved__"
+            return port
+        else:
+            raise PortNotAvailableException(f"The given port ({port}) is already reserved.")
+
+
+external_service_ports = ExternalServicePortsManager()
 
 
 # ----------------


### PR DESCRIPTION
This PR provides a utility (`common#external_service_ports`) to reserve ports for external services (like elasticsearch clusters, external databases,...) for a short period of time.
It can check for a specific port (within a configured range) or otherwise tries to find the first free non-reserved port within the configured range.
It is important to check that a given specific port is within the configured range, since localstack is by default started within its Docker container (where the configured port range needs to be published).

This change itself does not break anything, however as soon as the external ports are used, the docker-compose files (or other means of creating the docker container other than using the CLI) of non-pro users might need to be adjusted (such that they also publish the external service port range). Therefore, this PR also adjusts the example `docker-compose.yaml`.