### PR TITLE
ASF rest-json parser fixes

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -170,6 +170,9 @@ class RequestParser(abc.ABC):
                     payload = self._parse_shape(
                         request, shape, request.headers[header_name], path_regex
                     )
+                else:
+                    # if header is optional and not set
+                    payload = None
             elif location == "headers":
                 payload = self._parse_header_map(shape, request.headers)
             elif location == "querystring":
@@ -556,10 +559,10 @@ class BaseRestRequestParser(RequestParser):
                 final_parsed[payload_member_name] = self._parse_shape(
                     request, body_shape, original_parsed, path_regex
                 )
-        else:
-            original_parsed = self._initial_body_parse(request.data)
-            body_parsed = self._parse_shape(request, shape, original_parsed, path_regex)
-            final_parsed.update(body_parsed)
+        # even if the payload has been parsed, the rest of the shape needs to be processed as well
+        original_parsed = self._initial_body_parse(request.data)
+        body_parsed = self._parse_shape(request, shape, original_parsed, path_regex)
+        final_parsed.update(body_parsed)
 
     def _initial_body_parse(self, body_contents: bytes) -> any:
         """

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -546,6 +546,16 @@ def test_restjson_opensearch_with_botocore():
     )
 
 
+def test_restjson_awslambda_invoke_with_botocore():
+    _botocore_parser_integration_test(
+        service="lambda",
+        action="Invoke",
+        headers={},
+        expected={"FunctionName": "test-function", "Payload": ""},
+        FunctionName="test-function",
+    )
+
+
 def test_ec2_parser_ec2_with_botocore():
     _botocore_parser_integration_test(
         service="ec2",


### PR DESCRIPTION
This PR fixes problems with the ASF parser, in particular regarding rest-json protocols.

1. If a Header field is set, but the header is not present, the payload attribute was not defined. This is fixed now.
2. If the service definition specifies a payload, but part of the necessary data is also present in other shapes (like an uri shape), they were not parsed. This is also fixed now.

Also added a little test that checks the behavior we experienced.