### PR TITLE
Fix : SNS PublishBatch optional subject atttribute

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -725,7 +725,7 @@ def publish_batch(topic_arn, messages, headers):
         data = {}
         data["TopicArn"] = [topic_arn]
         data["Message"] = [message["Message"]]
-        data["Subject"] = [message["Subject"]]
+        data["Subject"] = [message.get("Subject")]
         if ".fifo" in topic_arn:
             data["MessageGroupId"] = message.get("MessageGroupId")
         # TODO: add MessageDeduplication checks once ASF-SQS implementation becomes default

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -725,14 +725,10 @@ def publish_batch(topic_arn, messages, headers):
         data = {}
         data["TopicArn"] = [topic_arn]
         data["Message"] = [message["Message"]]
-<<<<<<< HEAD
         data["Subject"] = [message["Subject"]]
         if ".fifo" in topic_arn:
             data["MessageGroupId"] = message.get("MessageGroupId")
         # TODO: add MessageDeduplication checks once ASF-SQS implementation becomes default
-=======
-        data["Subject"] = [message.get("Subject",None)]
->>>>>>> 99375a7f (Fix SNS PublishBatch optional subject atttribute)
 
         message_attributes = prepare_message_attributes(message.get("MessageAttributes", []))
         try:

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -725,10 +725,14 @@ def publish_batch(topic_arn, messages, headers):
         data = {}
         data["TopicArn"] = [topic_arn]
         data["Message"] = [message["Message"]]
+<<<<<<< HEAD
         data["Subject"] = [message["Subject"]]
         if ".fifo" in topic_arn:
             data["MessageGroupId"] = message.get("MessageGroupId")
         # TODO: add MessageDeduplication checks once ASF-SQS implementation becomes default
+=======
+        data["Subject"] = [message.get("Subject",None)]
+>>>>>>> 99375a7f (Fix SNS PublishBatch optional subject atttribute)
 
         message_attributes = prepare_message_attributes(message.get("MessageAttributes", []))
         try:

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1022,6 +1022,10 @@ class TestSNS:
                     "Message": "Test Message without attribute",
                     "Subject": "Subject",
                 },
+                {
+                    "Id": "4",
+                    "Message": "Test Message without subject",
+                },
             ],
         )
 
@@ -1036,7 +1040,7 @@ class TestSNS:
             response = self.sqs_client.receive_message(
                 QueueUrl=queue_url, MessageAttributeNames=["All"], MaxNumberOfMessages=10
             )
-            assert len(response["Messages"]) == 3
+            assert len(response["Messages"]) == 4
             for message in response["Messages"]:
                 assert "Body" in message
 


### PR DESCRIPTION
Fixes #5305 

Changes
1.  More defensive approach when accessing the optional `subject` attribute value.
2. Extended the existing test to verify the behaviour.
