### PR TITLE
Minor fix in DynamoDB region for NoSQL Workbench

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -608,7 +608,8 @@ class ProxyListenerDynamoDB(ProxyListener):
     # UTIL METHODS
     # -------------
 
-    def prepare_request_headers(self, headers):
+    @classmethod
+    def prepare_request_headers(cls, headers):
         def _replace(regex, replace):
             headers["Authorization"] = re.sub(
                 regex, replace, headers.get("Authorization") or "", flags=re.IGNORECASE
@@ -617,10 +618,10 @@ class ProxyListenerDynamoDB(ProxyListener):
         # Note: We need to ensure that the same access key is used here for all requests,
         # otherwise DynamoDBLocal stores tables/items in separate namespaces
         _replace(r"Credential=[^/]+/", r"Credential=%s/" % constants.INTERNAL_AWS_ACCESS_KEY_ID)
-        # Note: The NoSQL Workbench sends "localhost" as the region name, which we need to correct here
+        # Note: The NoSQL Workbench sends "localhost" or "local" as the region name, which we need to fix here
         _replace(
-            r"Credential=([^/]+/[^/]+)/localhost",
-            r"Credential=\1/%s" % aws_stack.get_local_region(),
+            r"Credential=([^/]+/[^/]+)/local(host)?/",
+            rf"Credential=\1/{aws_stack.get_local_region()}/",
         )
 
     def prepare_batch_write_item_records(self, record, data):

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -1,0 +1,13 @@
+from localstack.services.dynamodb.dynamodb_listener import ProxyListenerDynamoDB
+from localstack.utils.aws import aws_stack
+
+
+def test_fix_region_in_headers():
+    # the NoSQL Workbench sends "localhost" or "local" as the region name
+    # TODO: this may need to be updated once we migrate DynamoDB to ASF
+
+    for region_name in ["local", "localhost"]:
+        headers = aws_stack.mock_aws_request_headers("dynamodb", region_name=region_name)
+        assert aws_stack.get_region() not in headers.get("Authorization")
+        ProxyListenerDynamoDB.prepare_request_headers(headers)
+        assert aws_stack.get_region() in headers.get("Authorization")


### PR DESCRIPTION
Minor fix in DynamoDB region for NoSQL Workbench. 

Report from a customer: Interestingly, the request `Authorization` headers seem to be coming through with two different "region" specifiers - "localhost" and "local":
```
20220119/localhost/dynamodb
...
20220119/local/dynamodb
...
```
