### PR TITLE
Minor fix in request parsing to match path parameters with slashes

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -294,11 +294,16 @@ class RequestParser(abc.ABC):
         """
         if request_uri is None:
             return None
-        # Replace the variable place holder (f.e. {ConnectionId} in "/fuu/{ConnectionId}/bar/")
-        # with a named regex group.
-        request_uri_regex = re.sub(
-            "{(?P<VariableName>[^/]*)}", "(?P<\\g<VariableName>>[^/]*)", request_uri
-        )
+
+        # Replace the variable placeholder (f.e. {ConnectionId} in "/fuu/{ConnectionId}/bar/")
+        # with a named regex group. Allow slashes, in case the placeholder is at the end of the pattern.
+        def _replace(m):
+            is_path_end = m.group().endswith("}")
+            match_chars = ".*" if is_path_end else "[^/]*"
+            suffix_char = "" if is_path_end else m.group()[-1]
+            return rf"(?P<{m.groupdict()['VariableName']}>{match_chars}){suffix_char}"
+
+        request_uri_regex = re.sub(r"{(?P<VariableName>[^/]*)}(.?)", _replace, request_uri)
         # Put regex in fences to make sure that we do not match any substrings
         request_uri_regex = f"^{request_uri_regex}$"
         # The result is a regex itself.
@@ -520,12 +525,19 @@ class BaseRestRequestParser(RequestParser):
 
     def parse(self, request: HttpRequest) -> Tuple[OperationModel, Any]:
         # Find the regex which matches the given path (as well as its operation)
-        path_regex, operation = next(
+        # Note: using list(filter(..)) here, to avoid "TypeError: StopIteration interacts badly with generators"
+        matching = list(
             filter(
                 lambda item: item[0].match(request.path),
                 self.operation_lookup[request.method].items(),
             )
         )
+        if not matching:
+            raise RequestParserError(
+                f"Unable to find operation for request to service "
+                f"{self.service.service_name}: {request.method} {request.path}"
+            )
+        path_regex, operation = matching[0]
         shape: StructureShape = operation.input_shape
         final_parsed = {}
         if shape is not None:

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode
 from botocore.serialize import create_serializer
 
 from localstack.aws.api import HttpRequest
-from localstack.aws.protocol.parser import QueryRequestParser, create_parser
+from localstack.aws.protocol.parser import QueryRequestParser, RestJSONRequestParser, create_parser
 from localstack.aws.spec import load_service
 from localstack.utils.common import to_bytes
 
@@ -592,6 +592,20 @@ def test_ec2_parser_ec2_with_botocore():
             },
         ],
     )
+
+
+def test_query_parser_path_params_with_slashes():
+    parser = RestJSONRequestParser(load_service("qldb"))
+    resource_arn = "arn:aws:qldb:eu-central-1:000000000000:ledger/c-c67c827a"
+    request = HttpRequest(
+        body=b"",
+        method="GET",
+        headers={},
+        path=f"/tags/{resource_arn}",
+    )
+    operation, params = parser.parse(request)
+    assert operation.name == "ListTagsForResource"
+    assert params == {"ResourceArn": resource_arn}
 
 
 # TODO Add additional tests (or even automate the creation)


### PR DESCRIPTION
Minor fix in request parsing to match path parameters with slashes. This surfaced during migration of the QLDB service to ASF, where boto3 is making the following request:

```
GET /tags/arn:aws:qldb:eu-central-1:000000000000:ledger/c-c67c827a
```
... for the following botocore `requestUri`:
```
/tags/{resourceArn}
```

In this change, the assumption is currently that only trailing path parameters may contain slashes (e.g., `/my/path/{param}`). however this is not yet fully tested against AWS - i.e., haven't yet discovered a case where a parameter in the middle of a path (e.g., `/my/path/{param}/test`) may contain slashes as well. To be discussed/verified @thrau @alexrashed 

The PR also contains a minor change to raise an explicit `RequestParserError` and avoid `TypeError: StopIteration` (surfaced during testing the above issue as well).