### PR TITLE
invalidate builder stage in dockerfile on package version changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,6 +153,8 @@ RUN (virtualenv .venv && source .venv/bin/activate && pip3 install --upgrade pip
 
 # add files necessary to install all dependencies
 ADD Makefile setup.py requirements.txt pyproject.toml ./
+# add the root package init to invalidate docker layers with version bumps
+ADD localstack/__init__.py localstack/
 # add the localstack start scripts (necessary for the installation of the runtime dependencies, i.e. `pip install -e .`)
 ADD bin/localstack bin/localstack.bat bin/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ dataclasses; python_version < '3.7'
 #docopt>=0.6.2
 docker==5.0.0
 localstack-client>=1.31
-localstack-ext>=0.13.2
+localstack-ext>=0.13.3
 localstack-plugin-loader>=0.1.0
 psutil>=5.4.8,<6.0.0
 python-dotenv>=0.19.1


### PR DESCRIPTION
This PR contains the following changes:
- Make sure that the Docker layers are invalidated when the package version changes in `localstack/__init__py`.
- Align the required version of `localstack-ext` with `localstack`.