### PR TITLE
Capture X-AMAZON-APIGATEWAY-ANY-METHOD for default routes

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -546,7 +546,11 @@ def invoke_rest_api(invocation_context: ApiInvocationContext):
     integrations = resource.get("resourceMethods", {})
     integration = integrations.get(method, {})
     if not integration:
-        integration = integrations.get("ANY", {})
+        # HttpMethod: '*'
+        # ResourcePath: '/*' - produces 'X-AMAZON-APIGATEWAY-ANY-METHOD'
+        integration = integrations.get("ANY", {}) or integrations.get(
+            "X-AMAZON-APIGATEWAY-ANY-METHOD", {}
+        )
     integration = integration.get("methodIntegration")
     if not integration:
         if method == "OPTIONS" and "Origin" in headers:


### PR DESCRIPTION
Fix for https://github.com/localstack/localstack/issues/5105

If no route is specified ($default), we need to capture method key 'X-AMAZON-APIGATEWAY-ANY-METHOD' 
