### PR TITLE
Provide better log warning when cloudformation resource can't be found

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -859,7 +859,9 @@ def execute_resource_action(resource_id, resources, stack_name, action_name):
         if resource_type in ["Parameter"]:
             return
         LOG.warning(
-            'Action "%s" for resource type %s not yet implemented', action_name, resource_type
+            f"Action {action_name} for resource type {resource_type} not available. "
+            f"To see if {resource_type} is supported in LocalStack PRO"
+            f"please check out https://docs.localstack.cloud/aws/cloudformation/#resources-pro--enterprise-edition"
         )
         return
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -860,8 +860,8 @@ def execute_resource_action(resource_id, resources, stack_name, action_name):
             return
         LOG.warning(
             f"Action {action_name} for resource type {resource_type} not available. "
-            f"To see if {resource_type} is supported in LocalStack PRO"
-            f"please check out https://docs.localstack.cloud/aws/cloudformation/#resources-pro--enterprise-edition"
+            f"To find out if {resource_type} is supported in LocalStack Pro, "
+            "please check out our docs at https://docs.localstack.cloud/aws/cloudformation"
         )
         return
 


### PR DESCRIPTION
Adds a hint that the resource might be available in PRO and the corresponding URL to look this up.