### PR TITLE
Fix request parser to enable X-Amz-Target strings with multiple dots

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -813,7 +813,8 @@ class JSONRequestParser(BaseJSONRequestParser):
 
     def parse(self, request: HttpRequest) -> Tuple[OperationModel, Any]:
         target = request.headers["X-Amz-Target"]
-        _, operation_name = target.split(".")
+        # assuming that the last part of the target string (e.g., "x.y.z.MyAction") contains the operation name
+        operation_name = target.rpartition(".")[2]
         operation = self.service.operation_model(operation_name)
         shape = operation.input_shape
         path_regex = self._get_request_uri_regex(operation)

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -608,6 +608,17 @@ def test_query_parser_path_params_with_slashes():
     assert params == {"ResourceArn": resource_arn}
 
 
+def test_parse_cloudtrail_with_botocore():
+    _botocore_parser_integration_test(
+        service="cloudtrail",
+        action="DescribeTrails",
+        headers={
+            "X-Amz-Target": "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DescribeTrails"
+        },
+        trailNameList=["t1"],
+    )
+
+
 # TODO Add additional tests (or even automate the creation)
 # - Go to the Boto3 Docs (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/index.html)
 # - Look for boto3 request syntax definition for services that use the protocol you want to test

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -202,6 +202,8 @@ def _botocore_parser_integration_test(
     serialized_request = serializer.serialize_to_request(kwargs, service.operation_model(action))
     body = serialized_request["body"]
     query_string = urlencode(serialized_request.get("query_string") or "", doseq=False)
+    # use custom headers (if provided), or headers from serialized request as default
+    headers = serialized_request.get("headers") if headers is None else headers
 
     if service.protocol in ["query", "ec2"]:
         # Serialize the body as query parameter
@@ -612,9 +614,6 @@ def test_parse_cloudtrail_with_botocore():
     _botocore_parser_integration_test(
         service="cloudtrail",
         action="DescribeTrails",
-        headers={
-            "X-Amz-Target": "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DescribeTrails"
-        },
         trailNameList=["t1"],
     )
 


### PR DESCRIPTION
Minor fix for request parser to enable `X-Amz-Target` strings that contain multiple dots. (surfaced during migration of CloudTrail API)