### PR TITLE
SNS HTTP Subscription - 'Response' object has no attribute 'get_data'

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -636,7 +636,7 @@ async def message_to_subscriber(
 
             delivery = {
                 "statusCode": response.status_code,
-                "providerResponse": response.get_data(),
+                "providerResponse": response.content.decode("utf-8"),
             }
             store_delivery_log(subscriber, True, message, message_id, delivery)
 


### PR DESCRIPTION
While using SNS Http Subscription, even though the request has been sent to correct destination, inside localstack`s log we`re receiving error while getting responses body through `requests` lib.