### PR TITLE
Fix DomainValidationOptions property in ACM Certificate CFN deployment

### DIFF
--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -34,9 +34,23 @@ class CertificateManagerCertificate(GenericBaseModel):
                     "ValidationMethod",
                 ],
             )
-            logging_pref = params.get("CertificateTransparencyLoggingPreference")
+
+            # adjust domain validation options
+            valid_opts = result.get("DomainValidationOptions")
+            if valid_opts:
+
+                def _convert(opt):
+                    res = select_attributes(opt, ["DomainName", "ValidationDomain"])
+                    res.setdefault("ValidationDomain", res["DomainName"])
+                    return res
+
+                result["DomainValidationOptions"] = [_convert(opt) for opt in valid_opts]
+
+            # adjust logging preferences
+            logging_pref = result.get("CertificateTransparencyLoggingPreference")
             if logging_pref:
                 result["Options"] = {"CertificateTransparencyLoggingPreference": logging_pref}
+
             return result
 
         return {

--- a/tests/integration/cloudformation/test_cloudformation_acm.py
+++ b/tests/integration/cloudformation/test_cloudformation_acm.py
@@ -1,0 +1,25 @@
+from localstack.utils.common import short_uid
+
+TEST_TEMPLATE = """
+Resources:
+  cert1:
+    Type: "AWS::CertificateManager::Certificate"
+    Properties:
+      DomainName: "{{domain}}"
+      DomainValidationOptions:
+        - DomainName: "{{domain}}"
+          HostedZoneId: zone123  # using dummy ID for now
+      ValidationMethod: DNS
+"""
+
+
+def test_cfn_apigateway_aws_integration(
+    deploy_cfn_template,
+    acm_client,
+):
+    domain = f"domain-{short_uid()}.com"
+    deploy_cfn_template(TEST_TEMPLATE, domain=domain)
+
+    result = acm_client.list_certificates()["CertificateSummaryList"]
+    result = [cert for cert in result if cert["DomainName"] == domain]
+    assert result

--- a/tests/integration/cloudformation/test_cloudformation_acm.py
+++ b/tests/integration/cloudformation/test_cloudformation_acm.py
@@ -1,4 +1,5 @@
 from localstack.utils.common import short_uid
+from tests.integration.fixtures import only_localstack
 
 TEST_TEMPLATE = """
 Resources:
@@ -13,10 +14,8 @@ Resources:
 """
 
 
-def test_cfn_apigateway_aws_integration(
-    deploy_cfn_template,
-    acm_client,
-):
+@only_localstack
+def test_cfn_acm_certificate(deploy_cfn_template, acm_client):
     domain = f"domain-{short_uid()}.com"
     deploy_cfn_template(TEST_TEMPLATE, domain=domain)
 

--- a/tests/integration/cloudformation/utils.py
+++ b/tests/integration/cloudformation/utils.py
@@ -7,15 +7,22 @@ from localstack.utils.common import load_file
 
 def load_template(tmpl_path: str, **template_vars) -> str:
     template = load_template_raw(tmpl_path)
+    return render_template(template, **template_vars)
+
+
+def render_template(template_body: str, **template_vars) -> str:
     if template_vars:
-        template = jinja2.Template(template).render(**template_vars)
-    return template
+        template_body = jinja2.Template(template_body).render(**template_vars)
+    return template_body
 
 
-def load_template_raw(tmpl_path: str) -> str:
-    template = load_file(os.path.join(get_templates_folder(), tmpl_path))
-    return template
+def load_template_raw(tmpl_file: str) -> str:
+    return load_file(template_path(tmpl_file))
 
 
-def get_templates_folder():
+def template_path(tmpl_file: str) -> str:
+    return os.path.join(get_templates_folder(), tmpl_file)
+
+
+def get_templates_folder() -> str:
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "templates")


### PR DESCRIPTION
* Fix DomainValidationOptions property in ACM Certificate CFN deployment
* Introduce `deploy_cfn_template` fixture that simplifies creating CFN tests and helps reduce the boilerplate a bit