### PR TITLE
handle SSE for sqs

### DIFF
--- a/localstack/aws/api/sqs/__init__.py
+++ b/localstack/aws/api/sqs/__init__.py
@@ -1,4 +1,10 @@
-from typing import Dict, List, Optional, TypedDict
+import sys
+from typing import Dict, List, Optional
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 from localstack.aws.api import RequestContext, ServiceException, ServiceRequest, handler
 
@@ -49,6 +55,7 @@ class QueueAttributeName(str):
     DeduplicationScope = "DeduplicationScope"
     FifoThroughputLimit = "FifoThroughputLimit"
     RedriveAllowPolicy = "RedriveAllowPolicy"
+    SqsManagedSseEnabled = "SqsManagedSseEnabled"
 
 
 class BatchEntryIdsNotDistinct(ServiceException):
@@ -162,7 +169,6 @@ class UnsupportedOperation(ServiceException):
 
 
 AWSAccountIdList = List[String]
-
 ActionNameList = List[String]
 
 
@@ -188,7 +194,6 @@ class BatchResultErrorEntry(TypedDict, total=False):
 
 
 BatchResultErrorEntryList = List[BatchResultErrorEntry]
-
 Binary = bytes
 BinaryList = List[Binary]
 
@@ -594,7 +599,7 @@ class SqsApi:
         :param queue_url: The URL of the Amazon SQS queue to which permissions are added.
         :param label: The unique identification of the permission you're setting (for example,
         ``AliceSendMessage``).
-        :param aws_account_ids: The account numbers of the
+        :param aws_account_ids: The Amazon Web Services account numbers of the
         `principals <https://docs.
         :param actions: The action the client wants to allow for the specified principal.
         :raises OverLimit:
@@ -914,7 +919,8 @@ class SqsApi:
         in the *Amazon SQS Developer Guide*.
 
         :param queue_name: The name of the queue whose URL must be fetched.
-        :param queue_owner_aws_account_id: The account ID of the account that created the queue.
+        :param queue_owner_aws_account_id: The Amazon Web Services account ID of the account that created the
+        queue.
         :returns: GetQueueUrlResult
         :raises QueueDoesNotExist:
         """
@@ -1140,13 +1146,13 @@ class SqsApi:
         message_deduplication_id: String = None,
         message_group_id: String = None,
     ) -> SendMessageResult:
-        """Delivers a message to the specified queue.
+        r"""Delivers a message to the specified queue.
 
         A message can include only XML, JSON, and unformatted text. The
         following Unicode characters are allowed:
 
-        ``#x9`` | ``#xA`` | ``#xD`` | ``#x20`` to ``#xD7FF`` | ``#xE000`` to
-        ``#xFFFD`` | ``#x10000`` to ``#x10FFFF``
+        ``#x9`` \| ``#xA`` \| ``#xD`` \| ``#x20`` to ``#xD7FF`` \| ``#xE000`` to
+        ``#xFFFD`` \| ``#x10000`` to ``#x10FFFF``
 
         Any characters not included in this list will be rejected. For more
         information, see the `W3C specification for
@@ -1172,7 +1178,7 @@ class SqsApi:
         queue_url: String,
         entries: SendMessageBatchRequestEntryList,
     ) -> SendMessageBatchResult:
-        """Delivers up to ten messages to the specified queue. This is a batch
+        r"""Delivers up to ten messages to the specified queue. This is a batch
         version of ``SendMessage.`` For a FIFO queue, multiple messages within a
         single batch are enqueued in the order they are sent.
 
@@ -1188,8 +1194,8 @@ class SqsApi:
         A message can include only XML, JSON, and unformatted text. The
         following Unicode characters are allowed:
 
-        ``#x9`` | ``#xA`` | ``#xD`` | ``#x20`` to ``#xD7FF`` | ``#xE000`` to
-        ``#xFFFD`` | ``#x10000`` to ``#x10FFFF``
+        ``#x9`` \| ``#xA`` \| ``#xD`` \| ``#x20`` to ``#xD7FF`` \| ``#xE000`` to
+        ``#xFFFD`` \| ``#x10000`` to ``#x10FFFF``
 
         Any characters not included in this list will be rejected. For more
         information, see the `W3C specification for

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -415,8 +415,6 @@ class SqsQueue:
 
     def validate_queue_attributes(self, attributes):
         valid = [k[1] for k in inspect.getmembers(QueueAttributeName)]
-        # attributes of cli v2
-        valid = valid + [k[1] for k in inspect.getmembers(QueueAttributeNameV2)]
         del valid[valid.index(QueueAttributeName.FifoQueue)]
 
         for k in attributes.keys():
@@ -529,8 +527,6 @@ class FifoQueue(SqsQueue):
 
     def validate_queue_attributes(self, attributes):
         valid = [k[1] for k in inspect.getmembers(QueueAttributeName)]
-        # attributes of cli v2
-        valid = valid + [k[1] for k in inspect.getmembers(QueueAttributeNameV2)]
 
         for k in attributes.keys():
             if k not in valid:
@@ -857,10 +853,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             try:
                 getattr(QueueAttributeName, attr)
             except AttributeError:
-                try:
-                    getattr(QueueAttributeNameV2, attr)
-                except AttributeError:
-                    raise InvalidAttributeName(f"Unknown attribute {attr}.")
+                raise InvalidAttributeName(f"Unknown attribute {attr}.")
 
             if callable(queue.attributes.get(attr)):
                 func = queue.attributes.get(attr)
@@ -1240,7 +1233,6 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
     def _validate_queue_attributes(self, attributes: QueueAttributeMap):
         valid = [k[1] for k in inspect.getmembers(QueueAttributeName)]
-        valid = valid + [k[1] for k in inspect.getmembers(QueueAttributeNameV2)]
 
         for k in attributes.keys():
             if k not in valid:
@@ -1343,17 +1335,3 @@ def resolve_queue_key(
             queue_name = get_queue_name_from_url(context.request.base_url)
 
     return QueueKey(region=context.region, account_id=context.account_id, name=queue_name)
-
-
-class QueueAttributeNameV2:
-    """
-    Includes only attributes that are not covered by the aws-cli v1.
-    Remove/integrate once v2 support is established.
-    """
-
-    KmsMasterKeyId = "KmsMasterKeyId"
-    KmsDataKeyReusePeriodSeconds = "KmsDataKeyReusePeriodSeconds"
-    SqsManagedSseEnabled = "SqsManagedSseEnabled"
-
-
-AttributeNameListV2 = List[QueueAttributeNameV2]

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1590,7 +1590,7 @@ class TestSqsProvider:
             "Messages"
         )[0].get("MD5OfBody")
 
-    def test_cli_v2_attributes_are_accepted(self, sqs_client, sqs_create_queue):
+    def test_sse_attributes_are_accepted(self, sqs_client, sqs_create_queue):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         attributes = {

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1590,6 +1590,10 @@ class TestSqsProvider:
             "Messages"
         )[0].get("MD5OfBody")
 
+    @pytest.mark.skipif(
+        os.environ.get("PROVIDER_OVERRIDE_SQS") != "asf",
+        reason="New provider test which isn't covered by old one",
+    )
     def test_sse_attributes_are_accepted(self, sqs_client, sqs_create_queue):
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1590,6 +1590,23 @@ class TestSqsProvider:
             "Messages"
         )[0].get("MD5OfBody")
 
+    def test_cli_v2_attributes_are_accepted(self, sqs_client, sqs_create_queue):
+        queue_name = f"queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        attributes = {
+            "KmsMasterKeyId": "testKeyId",
+            "KmsDataKeyReusePeriodSeconds": "6000",
+            "SqsManagedSseEnabled": "true",
+        }
+        sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes=attributes)
+        result_attributes = sqs_client.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["All"]
+        )["Attributes"]
+        keys = result_attributes.keys()
+        for k in attributes.keys():
+            assert k in keys
+            assert attributes[k] == result_attributes[k]
+
 
 def get_region():
     return os.environ.get("AWS_DEFAULT_REGION") or TEST_REGION


### PR DESCRIPTION
~ASF apparently is generated against cli v1, how to deal with this discrepancy?
For now, add v2 attributes similar to v1 ones so LocalStack accepts them.~
Turns out that the api simply needed re-generating
resolves #5322 
