### PR TITLE
Do not set AWS_LAMBDA_COGNITO_IDENTITY if cognito identity is empty

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -718,7 +718,8 @@ class LambdaExecutorContainers(LambdaExecutor):
             environment["AWS_LAMBDA_FUNCTION_NAME"] = context.function_name
             environment["AWS_LAMBDA_FUNCTION_VERSION"] = context.function_version
             environment["AWS_LAMBDA_FUNCTION_INVOKED_ARN"] = context.invoked_function_arn
-            environment["AWS_LAMBDA_COGNITO_IDENTITY"] = json.dumps(context.cognito_identity or {})
+            if context.cognito_identity:
+                environment["AWS_LAMBDA_COGNITO_IDENTITY"] = json.dumps(context.cognito_identity)
             if context.client_context is not None:
                 environment["AWS_LAMBDA_CLIENT_CONTEXT"] = json.dumps(
                     to_str(base64.b64decode(to_bytes(context.client_context)))


### PR DESCRIPTION
Currently, we set this value to '{}' even if not applicable.
With this fix, we prevent this from being set, as many runtimes have problems with it (ruby RIC, rust...).


/cc @calvernaz 