### PR TITLE
Allow container client to connect/disconnect containers to/from a network

### DIFF
--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -1457,12 +1457,12 @@ class SdkDockerClient(ContainerClient):
         )
         try:
             network = self.client().networks.get(network_name)
+        except NotFound:
+            raise NoSuchNetwork(network_name)
+        try:
             network.connect(container=container_name_or_id, aliases=aliases)
-        except NotFound as e:
-            if "No such container" in e.explanation:
-                raise NoSuchContainer(container_name_or_id)
-            else:
-                raise NoSuchNetwork(network_name)
+        except NotFound:
+            raise NoSuchContainer(container_name_or_id)
         except APIError:
             raise ContainerException()
 
@@ -1473,13 +1473,14 @@ class SdkDockerClient(ContainerClient):
             "Disconnecting container '%s' from network '%s'", container_name_or_id, network_name
         )
         try:
-            network = self.client().networks.get(network_name)
-            network.disconnect(container_name_or_id)
-        except NotFound as e:
-            if "No such container" in e.explanation:
-                raise NoSuchContainer(container_name_or_id)
-            else:
+            try:
+                network = self.client().networks.get(network_name)
+            except NotFound:
                 raise NoSuchNetwork(network_name)
+            try:
+                network.disconnect(container_name_or_id)
+            except NotFound:
+                raise NoSuchContainer(container_name_or_id)
         except APIError:
             raise ContainerException()
 


### PR DESCRIPTION
When connecting a container to a non-default network with an alias, it will be reachable by that alias in that network (additionally to its name). This behavior is helpful when integrating LocalStack into third party services.
This functionality will be needed for integrations between EKS/ECR, and might come in handy in the future as well.

This PR introduces two new methods in the ContainerClient:
* connect_container_to_network
* disconnect_container_from_network

Also, the usage of this methods is tested by querying the docker client, and using the aliases for inter-container communication in simple test cases.