### PR TITLE
Addition of connection parameters to api destinations (EventBridge)

### DIFF
--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -206,7 +206,7 @@ def auth_keys_from_connection(connection: dict):
     return headers
 
 
-def list_of_parameters_to_object(items: list[dict]):
+def list_of_parameters_to_object(items):
     new_object = {}
     for item in items:
         new_object.update({item.get("Key"): item.get("Value")})

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -12,6 +12,7 @@ from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.common import (
     get_free_tcp_port,
     get_service_protocol,
@@ -571,92 +572,122 @@ class EventsTest(unittest.TestCase):
         self.sfn_client.delete_state_machine(stateMachineArn=state_machine_arn)
 
     def test_api_destinations(self):
+
+        token = short_uid()
+        bearer = "Bearer %s" % token
+
         class HttpEndpointListener(ProxyListener):
             def forward_request(self, method, path, data, headers):
                 event = json.loads(to_str(data))
                 events.append(event)
-                paths.append(path)
-                headers_list.append(headers)
+                paths_list.append(path)
+                auth = headers.get("Api") or headers.get("Authorization")
+                if auth not in headers_list:
+                    headers_list.append(auth)
 
-                return 200
+                return requests_response(
+                    {
+                        "access_token": token,
+                        "token_type": "Bearer",
+                        "expires_in": 86400,
+                    }
+                )
 
         events = []
-        paths = []
+        paths_list = []
         headers_list = []
+
         local_port = get_free_tcp_port()
         proxy = start_proxy(local_port, update_listener=HttpEndpointListener())
         wait_for_port_open(local_port)
-
         events_client = aws_stack.create_external_boto_client("events")
-        # TODO implement test for oauth variant
-        connection_arn = events_client.create_connection(
-            Name="TestConnection",
-            AuthorizationType="OAUTH_CLIENT_CREDENTIALS",
-            AuthParameters={
-                "BasicAuthParameters": {"Username": "user", "Password": "pass"},
-                # "ApiKeyAuthParameters": {"ApiKeyName": "Api", "ApiKeyValue": "val"},
-                # "OAuthParameters": {
-                #     "AuthorizationEndpoint": "https://run.mocky.io/v3/7b1e87a0-7b13-4b6d-b603-b3c0891a742f",
-                #     "ClientParameters": {
-                #         "ClientID": "id",
-                #         "ClientSecret": "password"
-                #     },
-                #     "HttpMethod": "put"
-                # },
-                "InvocationHttpParameters": {
-                    "BodyParameters": [{"Key": "key", "Value": "value", "IsValueSecret": False}],
-                    "HeaderParameters": [{"Key": "key", "Value": "value", "IsValueSecret": False}],
-                    "QueryStringParameters": [
-                        {"Key": "key", "Value": "value", "IsValueSecret": False}
-                    ],
+        url = "http://localhost:%s" % local_port
+
+        auth_types = [
+            {
+                "type": "BASIC",
+                "key": "BasicAuthParameters",
+                "parameters": {"Username": "user", "Password": "pass"},
+            },
+            {
+                "type": "API_KEY",
+                "key": "ApiKeyAuthParameters",
+                "parameters": {"ApiKeyName": "Api", "ApiKeyValue": "apikey_secret"},
+            },
+            {
+                "type": "OAUTH_CLIENT_CREDENTIALS",
+                "key": "OAuthParameters",
+                "parameters": {
+                    "AuthorizationEndpoint": url,
+                    "ClientParameters": {"ClientID": "id", "ClientSecret": "password"},
+                    "HttpMethod": "put",
                 },
             },
-        )["ConnectionArn"]
+        ]
 
-        # create api destination
-        dest_name = "d-%s" % short_uid()
-        url = "http://localhost:%s" % local_port
-        result = self.events_client.create_api_destination(
-            Name=dest_name,
-            ConnectionArn=connection_arn,
-            InvocationEndpoint=url,
-            HttpMethod="POST",
-        )
+        for auth in auth_types:
+            connection_name = "c-%s" % short_uid()
+            connection_arn = events_client.create_connection(
+                Name=connection_name,
+                AuthorizationType=auth.get("type"),
+                AuthParameters={
+                    auth.get("key"): auth.get("parameters"),
+                    "InvocationHttpParameters": {
+                        "BodyParameters": [
+                            {"Key": "key", "Value": "value", "IsValueSecret": False}
+                        ],
+                        "HeaderParameters": [
+                            {"Key": "key", "Value": "value", "IsValueSecret": False}
+                        ],
+                        "QueryStringParameters": [
+                            {"Key": "key", "Value": "value", "IsValueSecret": False}
+                        ],
+                    },
+                },
+            )["ConnectionArn"]
 
-        # create rule and target
-        rule_name = "r-%s" % short_uid()
-        target_id = "target-{}".format(short_uid())
-        pattern = json.dumps({"source": ["source-123"], "detail-type": ["type-123"]})
-        self.events_client.put_rule(Name=rule_name, EventPattern=pattern)
-        self.events_client.put_targets(
-            Rule=rule_name,
-            Targets=[{"Id": target_id, "Arn": result["ApiDestinationArn"]}],
-        )
+            # create api destination
+            dest_name = "d-%s" % short_uid()
+            result = self.events_client.create_api_destination(
+                Name=dest_name,
+                ConnectionArn=connection_arn,
+                InvocationEndpoint=url,
+                HttpMethod="POST",
+            )
 
-        # put events, to trigger rules
-        num_events = 5
-        for i in range(num_events):
+            # create rule and target
+            rule_name = "r-%s" % short_uid()
+            target_id = "target-{}".format(short_uid())
+            pattern = json.dumps({"source": ["source-123"], "detail-type": ["type-123"]})
+            self.events_client.put_rule(Name=rule_name, EventPattern=pattern)
+            self.events_client.put_targets(
+                Rule=rule_name,
+                Targets=[{"Id": target_id, "Arn": result["ApiDestinationArn"]}],
+            )
+
             entries = [
                 {
                     "Source": "source-123",
                     "DetailType": "type-123",
-                    "Detail": '{"i": %s}' % i,
+                    "Detail": '{"i": %s}' % 0,
                 }
             ]
             self.events_client.put_events(Entries=entries)
 
+            # cleaning
+            self.events_client.delete_connection(Name=connection_name)
+            self.events_client.delete_api_destination(Name=dest_name)
+            self.events_client.delete_rule(Name=rule_name, Force=True)
+
         # assert that all events have been received in the HTTP server listener
         def check():
-            self.assertEqual(len(events), num_events)
+            self.assertTrue(len(events) >= len(auth_types))
+            self.assertTrue("key" in paths_list[0] and "value" in paths_list[0])
+            self.assertTrue(events[0].get("key") == "value")
 
-            self.assertTrue("key" in paths[0])
-            self.assertTrue("value" in paths[0])
-
-            self.assertEqual(events[0].get("key"), "value")
-
-            print(headers_list[0])
-
-            self.assertEqual("Basic user:pass" in headers_list[0].get("Authorization"))
+            self.assertTrue("Basic user:pass" in headers_list)
+            self.assertTrue("apikey_secret" in headers_list)
+            self.assertTrue(bearer in headers_list)
 
         retry(check, sleep=0.5, retries=5)
 


### PR DESCRIPTION
This PR addresses issue #5229. where the user describes that the EventBridge service discards the requests parameters set up in the `connection` resource for the `api destinations`.

Changes:
 - Before the service sends a request to the `api destination,` it integrates the parameters described in the connection resource (query, body, header and auth parameters).
 - If the connection resource describes  OAuth credentials, the service will try to obtain the token.
 - The test that validates the delivery of the events also validates the 3 different types of auth parameters that could be set in a `connection` resource. 
