### PR TITLE
try to fix localstack-ext by correctly restarting kinesis

### DIFF
--- a/localstack/services/kinesis/kinesis_starter.py
+++ b/localstack/services/kinesis/kinesis_starter.py
@@ -84,4 +84,4 @@ def restart_kinesis():
         _server = None
 
     LOG.debug("Restarting Kinesis process ...")
-    start_kinesis(update_listener=kinesis_listener)
+    start_kinesis(update_listener=kinesis_listener.UPDATE_KINESIS)


### PR DESCRIPTION

attempt to fix failure in `localstack-ext` by correcting reference to kinesis listener instance