### PR TITLE
Enable invocation of local API URLs via stepfunctions

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -78,7 +78,7 @@ MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/a4adc8f4da9c7ec0d93b50ca5b73dd14df791c0e/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/b2d48a8a8715dd31de2af75b0aa04c0c0091fa3c/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -78,7 +78,7 @@ MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/b2d48a8a8715dd31de2af75b0aa04c0c0091fa3c/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/2958554c8aeadff0e8f5d0e35f6e520d834854ea/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -17,6 +17,7 @@ MAX_HEAP_SIZE = "256m"
 PROCESS_THREAD = None
 
 
+# TODO: pass env more explicitly
 def get_command(backend_port):
     cmd = (
         "cd %s; PORT=%s java "
@@ -78,7 +79,6 @@ def start_stepfunctions(port=None, asynchronous=False, update_listener=None):
 def check_stepfunctions(expect_shutdown=False, print_error=False):
     out = None
     try:
-        # check Kinesis
         wait_for_port_open(config.LOCAL_PORT_STEPFUNCTIONS, sleep_time=2)
         endpoint_url = f"http://127.0.0.1:{config.LOCAL_PORT_STEPFUNCTIONS}"
         out = aws_stack.connect_to_service(

--- a/tests/integration/cloudformation/test_cloudformation_stepfunctions.py
+++ b/tests/integration/cloudformation/test_cloudformation_stepfunctions.py
@@ -2,6 +2,7 @@ import json
 import os
 import urllib.parse
 
+from localstack.constants import PATH_USER_REQUEST
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
 from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
@@ -193,7 +194,7 @@ def test_apigateway_invoke_localhost(cfn_client, deploy_cfn_template, stepfuncti
     state["States"]["LsCallApi"]["Parameters"]["ApiEndpoint"] = "localhost:4566"
     state["States"]["LsCallApi"]["Parameters"][
         "Stage"
-    ] = f"restapis/{api_id}/{stage}/_user_request_"
+    ] = f"restapis/{api_id}/{stage}/{PATH_USER_REQUEST}"
     state["States"]["LsCallApi"]["Parameters"]["Path"] = "/"
 
     stepfunctions_client.update_state_machine(
@@ -236,7 +237,7 @@ def test_apigateway_invoke_localhost_with_path(
     state["States"]["LsCallApi"]["Parameters"]["ApiEndpoint"] = "localhost:4566"
     state["States"]["LsCallApi"]["Parameters"][
         "Stage"
-    ] = f"restapis/{api_id}/{stage}/_user_request_"
+    ] = f"restapis/{api_id}/{stage}/{PATH_USER_REQUEST}"
 
     stepfunctions_client.update_state_machine(
         stateMachineArn=state_machine_arn, definition=json.dumps(state)

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -420,7 +420,7 @@ class DeployResult:
     stack_id: str
     stack_name: str
     change_set_name: str
-    outputs: Dict[str,str]
+    outputs: Dict[str, str]
 
 
 @pytest.fixture
@@ -469,9 +469,9 @@ def deploy_cfn_template(
         cfn_client.execute_change_set(ChangeSetName=change_set_id)
         assert wait_until(is_change_set_finished(change_set_id))
 
-        outputs = cfn_client.describe_stacks(StackName=stack_id)['Stacks'][0]['Outputs']
+        outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["Outputs"]
 
-        mapped_outputs = {o['OutputKey']: o['OutputValue'] for o in outputs}
+        mapped_outputs = {o["OutputKey"]: o["OutputValue"] for o in outputs}
 
         state.append({"stack_id": stack_id, "change_set_id": change_set_id})
         return DeployResult(change_set_id, stack_id, stack_name, change_set_name, mapped_outputs)

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -420,6 +420,7 @@ class DeployResult:
     stack_id: str
     stack_name: str
     change_set_name: str
+    outputs: Dict[str,str]
 
 
 @pytest.fixture
@@ -468,8 +469,12 @@ def deploy_cfn_template(
         cfn_client.execute_change_set(ChangeSetName=change_set_id)
         assert wait_until(is_change_set_finished(change_set_id))
 
+        outputs = cfn_client.describe_stacks(StackName=stack_id)['Stacks'][0]['Outputs']
+
+        mapped_outputs = {o['OutputKey']: o['OutputValue'] for o in outputs}
+
         state.append({"stack_id": stack_id, "change_set_id": change_set_id})
-        return DeployResult(change_set_id, stack_id, stack_name, change_set_name)
+        return DeployResult(change_set_id, stack_id, stack_name, change_set_name, mapped_outputs)
 
     yield _deploy
 

--- a/tests/integration/templates/sfn_apigateway.yaml
+++ b/tests/integration/templates/sfn_apigateway.yaml
@@ -1,0 +1,375 @@
+Resources:
+  LsFnServiceRoleFE24FAB1:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  LsFnB43B12A0:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |-
+          exports.handler = async (event, ctx) => {
+              console.log(event);
+              return {
+                  statusCode: 200,
+                  body: "hello from stepfunctions"
+              };
+          };
+      Role:
+        Fn::GetAtt:
+          - LsFnServiceRoleFE24FAB1
+          - Arn
+      Handler: index.handler
+      Runtime: nodejs12.x
+    DependsOn:
+      - LsFnServiceRoleFE24FAB1
+  LsApi42D61DD0:
+    Type: AWS::ApiGateway::RestApi
+  LsApiCloudWatchRoleC538B6E8:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+  LsApiAccountC4165108:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn:
+        Fn::GetAtt:
+          - LsApiCloudWatchRoleC538B6E8
+          - Arn
+    DependsOn:
+      - LsApi42D61DD0
+  LsApiDeployment91771F3772cb22de3018868307c5d4c1339b075a:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: LsApi42D61DD0
+      Description: Automatically created by the RestApi construct
+    DependsOn:
+      - LsApiproxyANYB17F6382
+      - LsApiproxyE04C65C3
+      - LsApiANY7BA2F440
+  LsApiDeploymentStageprod82D8C5E7:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: LsApi42D61DD0
+      DeploymentId:
+        Ref: LsApiDeployment91771F3772cb22de3018868307c5d4c1339b075a
+      StageName: prod
+    DependsOn:
+      - LsApiAccountC4165108
+  LsApiproxyE04C65C3:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId:
+        Fn::GetAtt:
+          - LsApi42D61DD0
+          - RootResourceId
+      PathPart: "{proxy+}"
+      RestApiId:
+        Ref: LsApi42D61DD0
+  LsApiproxyANYApiPermissionStepfunctionsGatewayStackLsApiF631C9DDANYproxyDBAA49CB:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFnB43B12A0
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /
+            - Ref: LsApiDeploymentStageprod82D8C5E7
+            - /*/*
+  LsApiproxyANYApiPermissionTestStepfunctionsGatewayStackLsApiF631C9DDANYproxyCD0CCEC1:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFnB43B12A0
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /test-invoke-stage/*/*
+  LsApiproxyANYB17F6382:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId:
+        Ref: LsApiproxyE04C65C3
+      RestApiId:
+        Ref: LsApi42D61DD0
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - ":apigateway:"
+              - Ref: AWS::Region
+              - :lambda:path/2015-03-31/functions/
+              - Fn::GetAtt:
+                  - LsFnB43B12A0
+                  - Arn
+              - /invocations
+  LsApiANYApiPermissionStepfunctionsGatewayStackLsApiF631C9DDANY529C16EB:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFnB43B12A0
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /
+            - Ref: LsApiDeploymentStageprod82D8C5E7
+            - /*/
+  LsApiANYApiPermissionTestStepfunctionsGatewayStackLsApiF631C9DDANY5CD1E87C:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFnB43B12A0
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /test-invoke-stage/*/
+  LsApiANY7BA2F440:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId:
+        Fn::GetAtt:
+          - LsApi42D61DD0
+          - RootResourceId
+      RestApiId:
+        Ref: LsApi42D61DD0
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - ":apigateway:"
+              - Ref: AWS::Region
+              - :lambda:path/2015-03-31/functions/
+              - Fn::GetAtt:
+                  - LsFnB43B12A0
+                  - Arn
+              - /invocations
+  LsStateMachineRole0FA72689:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::FindInMap:
+                  - ServiceprincipalMap
+                  - Ref: AWS::Region
+                  - states
+        Version: "2012-10-17"
+  LsStateMachineRoleDefaultPolicyF0A7F6AB:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: execute-api:Invoke
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":execute-api:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - ":"
+                  - Ref: LsApi42D61DD0
+                  - /
+                  - Ref: LsApiDeploymentStageprod82D8C5E7
+                  - /GET/*
+        Version: "2012-10-17"
+      PolicyName: LsStateMachineRoleDefaultPolicyF0A7F6AB
+      Roles:
+        - Ref: LsStateMachineRole0FA72689
+  LsStateMachineC3258D1E:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - LsStateMachineRole0FA72689
+          - Arn
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - '{"StartAt":"LsCallApi","States":{"LsCallApi":{"End":true,"Type":"Task","Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::apigateway:invoke","Parameters":{"ApiEndpoint":"
+            - Ref: LsApi42D61DD0
+            - .execute-api.
+            - Ref: AWS::Region
+            - "."
+            - Ref: AWS::URLSuffix
+            - '","Method":"GET","Stage":"'
+            - Ref: LsApiDeploymentStageprod82D8C5E7
+            - '","AuthType":"NO_AUTH"}}}}'
+      StateMachineType: STANDARD
+    DependsOn:
+      - LsStateMachineRoleDefaultPolicyF0A7F6AB
+      - LsStateMachineRole0FA72689
+Outputs:
+  LsApiEndpointA06D37E8:
+    Value:
+      Fn::Join:
+        - ""
+        - - https://
+          - Ref: LsApi42D61DD0
+          - .execute-api.
+          - Ref: AWS::Region
+          - "."
+          - Ref: AWS::URLSuffix
+          - /
+          - Ref: LsApiDeploymentStageprod82D8C5E7
+          - /
+  statemachineOutput:
+    Value:
+      Ref: LsStateMachineC3258D1E
+Mappings:
+  ServiceprincipalMap:
+    af-south-1:
+      states: states.af-south-1.amazonaws.com
+    ap-east-1:
+      states: states.ap-east-1.amazonaws.com
+    ap-northeast-1:
+      states: states.ap-northeast-1.amazonaws.com
+    ap-northeast-2:
+      states: states.ap-northeast-2.amazonaws.com
+    ap-northeast-3:
+      states: states.ap-northeast-3.amazonaws.com
+    ap-south-1:
+      states: states.ap-south-1.amazonaws.com
+    ap-southeast-1:
+      states: states.ap-southeast-1.amazonaws.com
+    ap-southeast-2:
+      states: states.ap-southeast-2.amazonaws.com
+    ap-southeast-3:
+      states: states.ap-southeast-3.amazonaws.com
+    ca-central-1:
+      states: states.ca-central-1.amazonaws.com
+    cn-north-1:
+      states: states.cn-north-1.amazonaws.com
+    cn-northwest-1:
+      states: states.cn-northwest-1.amazonaws.com
+    eu-central-1:
+      states: states.eu-central-1.amazonaws.com
+    eu-north-1:
+      states: states.eu-north-1.amazonaws.com
+    eu-south-1:
+      states: states.eu-south-1.amazonaws.com
+    eu-south-2:
+      states: states.eu-south-2.amazonaws.com
+    eu-west-1:
+      states: states.eu-west-1.amazonaws.com
+    eu-west-2:
+      states: states.eu-west-2.amazonaws.com
+    eu-west-3:
+      states: states.eu-west-3.amazonaws.com
+    me-south-1:
+      states: states.me-south-1.amazonaws.com
+    sa-east-1:
+      states: states.sa-east-1.amazonaws.com
+    us-east-1:
+      states: states.us-east-1.amazonaws.com
+    us-east-2:
+      states: states.us-east-2.amazonaws.com
+    us-gov-east-1:
+      states: states.us-gov-east-1.amazonaws.com
+    us-gov-west-1:
+      states: states.us-gov-west-1.amazonaws.com
+    us-iso-east-1:
+      states: states.amazonaws.com
+    us-iso-west-1:
+      states: states.amazonaws.com
+    us-isob-east-1:
+      states: states.amazonaws.com
+    us-west-1:
+      states: states.us-west-1.amazonaws.com
+    us-west-2:
+      states: states.us-west-2.amazonaws.com

--- a/tests/integration/templates/sfn_apigateway_two_integrations.yaml
+++ b/tests/integration/templates/sfn_apigateway_two_integrations.yaml
@@ -1,0 +1,413 @@
+Resources:
+  LsFnServiceRoleFE24FAB1:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  LsFnB43B12A0:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |-
+          exports.handler = async (event, ctx) => {
+              console.log(event);
+              return {
+                  statusCode: 200,
+                  body: JSON.stringify("hello from stepfunctions")
+              };
+          };
+      Role:
+        Fn::GetAtt:
+          - LsFnServiceRoleFE24FAB1
+          - Arn
+      Handler: index.handler
+      Runtime: nodejs12.x
+    DependsOn:
+      - LsFnServiceRoleFE24FAB1
+  LsFn2ServiceRoleF6685547:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  LsFn2CFAB3A95:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |-
+          exports.handler = async (event, ctx) => {
+              console.log(event);
+              return {
+                  statusCode: 200,
+                  body: JSON.stringify("hello_with_path from stepfunctions")
+              };
+          };
+      Role:
+        Fn::GetAtt:
+          - LsFn2ServiceRoleF6685547
+          - Arn
+      Handler: index.handler
+      Runtime: nodejs12.x
+    DependsOn:
+      - LsFn2ServiceRoleF6685547
+  LsApi42D61DD0:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: LsApi
+  LsApiCloudWatchRoleC538B6E8:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+  LsApiAccountC4165108:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn:
+        Fn::GetAtt:
+          - LsApiCloudWatchRoleC538B6E8
+          - Arn
+    DependsOn:
+      - LsApi42D61DD0
+  LsApiDeployment91771F3725db7d8c256259a6ceeec74dbae61212:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: LsApi42D61DD0
+      Description: Automatically created by the RestApi construct
+    DependsOn:
+      - LsApiGET7AECB186
+      - LsApitestsfnGETE99F6C0F
+      - LsApitestsfnE3C7A38F
+  LsApiDeploymentStageprod82D8C5E7:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: LsApi42D61DD0
+      DeploymentId:
+        Ref: LsApiDeployment91771F3725db7d8c256259a6ceeec74dbae61212
+      StageName: prod
+    DependsOn:
+      - LsApiAccountC4165108
+  LsApiGETApiPermissionStepfunctionsGatewayStackLsApiF631C9DDGETF2B3AE22:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFnB43B12A0
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /
+            - Ref: LsApiDeploymentStageprod82D8C5E7
+            - /GET/
+  LsApiGETApiPermissionTestStepfunctionsGatewayStackLsApiF631C9DDGETBA080860:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFnB43B12A0
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /test-invoke-stage/GET/
+  LsApiGET7AECB186:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: GET
+      ResourceId:
+        Fn::GetAtt:
+          - LsApi42D61DD0
+          - RootResourceId
+      RestApiId:
+        Ref: LsApi42D61DD0
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - ":apigateway:"
+              - Ref: AWS::Region
+              - :lambda:path/2015-03-31/functions/
+              - Fn::GetAtt:
+                  - LsFnB43B12A0
+                  - Arn
+              - /invocations
+  LsApitestsfnE3C7A38F:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId:
+        Fn::GetAtt:
+          - LsApi42D61DD0
+          - RootResourceId
+      PathPart: test-sfn
+      RestApiId:
+        Ref: LsApi42D61DD0
+  LsApitestsfnGETApiPermissionStepfunctionsGatewayStackLsApiF631C9DDGETtestsfn8424795A:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFn2CFAB3A95
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /
+            - Ref: LsApiDeploymentStageprod82D8C5E7
+            - /GET/test-sfn
+  LsApitestsfnGETApiPermissionTestStepfunctionsGatewayStackLsApiF631C9DDGETtestsfn5FA753F2:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - LsFn2CFAB3A95
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: LsApi42D61DD0
+            - /test-invoke-stage/GET/test-sfn
+  LsApitestsfnGETE99F6C0F:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: GET
+      ResourceId:
+        Ref: LsApitestsfnE3C7A38F
+      RestApiId:
+        Ref: LsApi42D61DD0
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - ":apigateway:"
+              - Ref: AWS::Region
+              - :lambda:path/2015-03-31/functions/
+              - Fn::GetAtt:
+                  - LsFn2CFAB3A95
+                  - Arn
+              - /invocations
+  LsStateMachineRole0FA72689:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::FindInMap:
+                  - ServiceprincipalMap
+                  - Ref: AWS::Region
+                  - states
+        Version: "2012-10-17"
+  LsStateMachineRoleDefaultPolicyF0A7F6AB:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: execute-api:Invoke
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":execute-api:"
+                  - Ref: AWS::Region
+                  - ":"
+                  - Ref: AWS::AccountId
+                  - ":"
+                  - Ref: LsApi42D61DD0
+                  - /
+                  - Ref: LsApiDeploymentStageprod82D8C5E7
+                  - /GET/test-sfn
+        Version: "2012-10-17"
+      PolicyName: LsStateMachineRoleDefaultPolicyF0A7F6AB
+      Roles:
+        - Ref: LsStateMachineRole0FA72689
+  LsStateMachineC3258D1E:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - LsStateMachineRole0FA72689
+          - Arn
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - '{"StartAt":"LsCallApi","States":{"LsCallApi":{"End":true,"Type":"Task","Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::apigateway:invoke","Parameters":{"ApiEndpoint":"
+            - Ref: LsApi42D61DD0
+            - .execute-api.
+            - Ref: AWS::Region
+            - "."
+            - Ref: AWS::URLSuffix
+            - '","Method":"GET","Stage":"'
+            - Ref: LsApiDeploymentStageprod82D8C5E7
+            - '","Path":"/test-sfn","AuthType":"NO_AUTH"}}}}'
+      StateMachineType: STANDARD
+    DependsOn:
+      - LsStateMachineRoleDefaultPolicyF0A7F6AB
+      - LsStateMachineRole0FA72689
+Outputs:
+  LsApiEndpointA06D37E8:
+    Value:
+      Fn::Join:
+        - ""
+        - - https://
+          - Ref: LsApi42D61DD0
+          - .execute-api.
+          - Ref: AWS::Region
+          - "."
+          - Ref: AWS::URLSuffix
+          - /
+          - Ref: LsApiDeploymentStageprod82D8C5E7
+          - /
+  statemachineOutput:
+    Value:
+      Ref: LsStateMachineC3258D1E
+Mappings:
+  ServiceprincipalMap:
+    af-south-1:
+      states: states.af-south-1.amazonaws.com
+    ap-east-1:
+      states: states.ap-east-1.amazonaws.com
+    ap-northeast-1:
+      states: states.ap-northeast-1.amazonaws.com
+    ap-northeast-2:
+      states: states.ap-northeast-2.amazonaws.com
+    ap-northeast-3:
+      states: states.ap-northeast-3.amazonaws.com
+    ap-south-1:
+      states: states.ap-south-1.amazonaws.com
+    ap-southeast-1:
+      states: states.ap-southeast-1.amazonaws.com
+    ap-southeast-2:
+      states: states.ap-southeast-2.amazonaws.com
+    ap-southeast-3:
+      states: states.ap-southeast-3.amazonaws.com
+    ca-central-1:
+      states: states.ca-central-1.amazonaws.com
+    cn-north-1:
+      states: states.cn-north-1.amazonaws.com
+    cn-northwest-1:
+      states: states.cn-northwest-1.amazonaws.com
+    eu-central-1:
+      states: states.eu-central-1.amazonaws.com
+    eu-north-1:
+      states: states.eu-north-1.amazonaws.com
+    eu-south-1:
+      states: states.eu-south-1.amazonaws.com
+    eu-south-2:
+      states: states.eu-south-2.amazonaws.com
+    eu-west-1:
+      states: states.eu-west-1.amazonaws.com
+    eu-west-2:
+      states: states.eu-west-2.amazonaws.com
+    eu-west-3:
+      states: states.eu-west-3.amazonaws.com
+    me-south-1:
+      states: states.me-south-1.amazonaws.com
+    sa-east-1:
+      states: states.sa-east-1.amazonaws.com
+    us-east-1:
+      states: states.us-east-1.amazonaws.com
+    us-east-2:
+      states: states.us-east-2.amazonaws.com
+    us-gov-east-1:
+      states: states.us-gov-east-1.amazonaws.com
+    us-gov-west-1:
+      states: states.us-gov-west-1.amazonaws.com
+    us-iso-east-1:
+      states: states.amazonaws.com
+    us-iso-west-1:
+      states: states.amazonaws.com
+    us-isob-east-1:
+      states: states.amazonaws.com
+    us-west-1:
+      states: states.us-west-1.amazonaws.com
+    us-west-2:
+      states: states.us-west-2.amazonaws.com


### PR DESCRIPTION
Corresponds to this PR: https://github.com/localstack/localstack-artifacts/pull/8

This PR simply enables this behavior and adds some tests for both URL schemes we support for local APIs.


Related issue/comment: https://github.com/localstack/localstack/issues/3815#issuecomment-993304614