### PR TITLE
Fix accessing external SQS port for intra-service communication

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -787,16 +787,17 @@ def populate_configs(service_ports=None):
     CONFIG_ENV_VARS = list(set(CONFIG_ENV_VARS))
 
 
-def service_port(service_key):
+def service_port(service_key: str, external: bool = False) -> int:
     service_key = service_key.lower()
+    if external:
+        if service_key == "sqs" and SQS_PORT_EXTERNAL:
+            return SQS_PORT_EXTERNAL
     if FORWARD_EDGE_INMEM:
         if service_key == "elasticsearch":
             # TODO Elasticsearch domains are a special case - we do not want to route them through
             #  the edge service, as that would require too many route mappings. In the future, we
             #  should integrate them with the port range for external services (4510-4530)
             return SERVICE_PORTS.get(service_key, 0)
-        if service_key == "sqs" and SQS_PORT_EXTERNAL:
-            return SQS_PORT_EXTERNAL
         return get_edge_port_http()
     return SERVICE_PORTS.get(service_key, 0)
 
@@ -807,8 +808,8 @@ def get_protocol():
 
 def external_service_url(service_key, host=None, port=None):
     host = host or HOSTNAME_EXTERNAL
-    port = port or service_port(service_key)
-    return "%s://%s:%s" % (get_protocol(), host, port)
+    port = port or service_port(service_key, external=True)
+    return f"{get_protocol()}://{host}:{port}"
 
 
 def get_edge_port_http():

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -337,8 +337,12 @@ class TestSNS:
         # clean up
         self.sqs_client.delete_queue(QueueUrl=queue_url)
 
-    def test_subscribe_sqs_queue(self):
+    @pytest.mark.parametrize("external_sqs_port", [None, 12345])
+    def test_subscribe_sqs_queue(self, monkeypatch, external_sqs_port):
         _, queue_arn, queue_url = self._create_queue()
+
+        if external_sqs_port:
+            monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_sqs_port)
 
         # publish message
         subscription = self._publish_sns_message_with_attrs(queue_arn, "sqs")

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+from urllib.parse import urlencode
 
 import pytest
 import requests
@@ -10,7 +11,6 @@ from botocore.auth import SIGV4_TIMESTAMP, SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.credentials import Credentials
 from botocore.exceptions import ClientError
-from six.moves.urllib.parse import urlencode
 
 from localstack import config, constants
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
@@ -414,7 +414,6 @@ class TestSqsProvider:
         assert len(result_send["Failed"]) == 1
 
     @only_localstack
-    @pytest.mark.xfail  # We are deprecating this and see what breaks
     def test_external_hostname(self, monkeypatch, sqs_client, sqs_create_queue):
         external_host = "external-host"
         external_port = "12345"

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -417,14 +417,13 @@ class TestSqsProvider:
     def test_external_hostname(self, monkeypatch, sqs_client, sqs_create_queue):
         external_host = "external-host"
         external_port = "12345"
-        SQS_PORT_EXTERNAL = "SQS_PORT_EXTERNAL"
 
-        monkeypatch.setattr(config, SQS_PORT_EXTERNAL, external_port)
+        monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_port)
         monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", external_host)
         # TODO: remove once the old provider is discontinued
         from localstack.services.sqs import sqs_listener as old_sqs_listener
 
-        monkeypatch.setattr(old_sqs_listener, SQS_PORT_EXTERNAL, external_port)
+        monkeypatch.setattr(old_sqs_listener, "SQS_PORT_EXTERNAL", external_port)
 
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)


### PR DESCRIPTION
Fix accessing external SQS port for intra-service communication. The port should only be reported in the queue URL to the outside world, but should not be used for internal service-to-service communication. Addresses #5337