### PR TITLE
make lambda output truncation configurable

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -581,7 +581,7 @@ LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
 LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")
 
 # truncate output string slices value
-LAMBDA_TRUNCATE_STDOUT = os.getenv("TRUNCATE_STDOUT", 2000)
+LAMBDA_TRUNCATE_STDOUT = os.getenv("LAMBDA_TRUNCATE_STDOUT", 2000)
 
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -581,7 +581,7 @@ LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
 LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")
 
 # truncate output string slices value
-LAMBDA_TRUNCATE_STDOUT = os.getenv("LAMBDA_TRUNCATE_STDOUT", 2000)
+LAMBDA_TRUNCATE_STDOUT = int(os.getenv("LAMBDA_TRUNCATE_STDOUT") or 2000)
 
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup.

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -580,6 +580,9 @@ LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
 # whether lambdas should use stay open mode if executed in "docker-reuse" executor
 LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")
 
+# truncate output string slices value
+LAMBDA_TRUNCATE_STDOUT = os.getenv("TRUNCATE_STDOUT", 2000)
+
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup.
 # For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
@@ -654,6 +657,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_REMOTE_DOCKER",
     "LAMBDA_REMOVE_CONTAINERS",
     "LAMBDA_STAY_OPEN_MODE",
+    "LAMBDA_TRUNCATE_STDOUT",
     "LEGACY_DOCKER_CLIENT",
     "LOCALSTACK_API_KEY",
     "LOCALSTACK_HOSTNAME",

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1633,13 +1633,6 @@ class Util:
         return env_vars
 
 
-# def log_lambda_result(func_arn, result, log_output, max_length: int = 2000):
-#     result = to_str(result or "")
-#     log_output = truncate(to_str(log_output or ""), max_length)
-#     log_formatted = log_output.strip().replace("\n", "\n> ")
-#     LOG.debug("Lambda %s result / log output:\n%s\n> %s", func_arn, result.strip(), log_formatted)
-
-
 class OutputLog:
 
     __slots__ = ["_stdout", "_stderr"]

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -17,6 +18,7 @@ from multiprocessing import Process, Queue
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from localstack import config
+from localstack.config import LAMBDA_TRUNCATE_STDOUT, TMP_FOLDER
 from localstack.constants import DEFAULT_LAMBDA_CONTAINER_REGISTRY
 from localstack.runtime.hooks import hook_spec
 from localstack.services.awslambda.lambda_utils import (
@@ -645,7 +647,7 @@ class LambdaExecutorContainers(LambdaExecutor):
             result = to_str(result).strip()
         except Exception:
             pass
-        log_output = to_str(log_output).strip()
+
         # Note: The user's code may have been logging to stderr, in which case the logs
         # will be part of the "result" variable here. Hence, make sure that we extract
         # only the *last* line of "result" and consider anything above that as log output.
@@ -660,12 +662,19 @@ class LambdaExecutorContainers(LambdaExecutor):
                 log_output += "\n%s" % additional_logs
 
         func_arn = lambda_function and lambda_function.arn()
-        log_lambda_result(func_arn, result, log_output)
+
+        output = OutputLog(result, log_output)
+        LOG.debug(
+            f"Lambda {func_arn} result / log output:"
+            f"\n{output.stdout_formatted()}"
+            f"\n>{output.stderr_formatted()}"
+        )
 
         # store log output - TODO get live logs from `process` above?
         store_lambda_logs(lambda_function, log_output)
 
         if error:
+            output.output_file()
             raise InvocationException(
                 "Lambda process returned with error. Result: %s. Output:\n%s"
                 % (result, log_output),
@@ -1277,6 +1286,7 @@ class LambdaExecutorLocal(LambdaExecutor):
 
         process = run(cmd, stderr=subprocess.PIPE, outfile=subprocess.PIPE, **kwargs)
         result, log_output = process.communicate()
+
         try:
             result = to_str(result).strip()
         except Exception:
@@ -1299,12 +1309,18 @@ class LambdaExecutorLocal(LambdaExecutor):
                 log_output += "\n%s" % additional_logs
 
         func_arn = lambda_function and lambda_function.arn()
-        log_lambda_result(func_arn, result, log_output)
+        output = OutputLog(result, log_output)
+        LOG.debug(
+            f"Lambda {func_arn} result / log output:"
+            f"\n{output.stdout_formatted()}"
+            f"\n>{output.stderr_formatted()}"
+        )
 
         # store log output - TODO get live logs from `process` above?
         # store_lambda_logs(lambda_function, log_output)
 
         if return_code != 0:
+            output.output_file()
             raise InvocationException(
                 "Lambda process returned error status code: %s. Result: %s. Output:\n%s"
                 % (return_code, result, log_output),
@@ -1617,11 +1633,33 @@ class Util:
         return env_vars
 
 
-def log_lambda_result(func_arn, result, log_output):
-    result = to_str(result or "")
-    log_output = truncate(to_str(log_output or ""), max_length=2000)
-    log_formatted = log_output.strip().replace("\n", "\n> ")
-    LOG.debug("Lambda %s result / log output:\n%s\n> %s", func_arn, result.strip(), log_formatted)
+# def log_lambda_result(func_arn, result, log_output, max_length: int = 2000):
+#     result = to_str(result or "")
+#     log_output = truncate(to_str(log_output or ""), max_length)
+#     log_formatted = log_output.strip().replace("\n", "\n> ")
+#     LOG.debug("Lambda %s result / log output:\n%s\n> %s", func_arn, result.strip(), log_formatted)
+
+
+class OutputLog:
+
+    __slots__ = ["_stdout", "_stderr"]
+
+    def __init__(self, stdout, stderr):
+        self._stdout = stdout
+        self._stderr = stderr
+
+    def stderr_formatted(self, truncated_to: int = LAMBDA_TRUNCATE_STDOUT):
+        return truncate(to_str(self._stderr).strip().replace("\n", "\n> "), truncated_to)
+
+    def stdout_formatted(self, truncated_to: int = LAMBDA_TRUNCATE_STDOUT):
+        return truncate(to_str(self._stdout).strip(), truncated_to)
+
+    def output_file(self):
+        with tempfile.NamedTemporaryFile(
+            dir=TMP_FOLDER, delete=False, suffix=".log", prefix="lambda_"
+        ) as f:
+            LOG.info(f"writing log to file '{f.name}'")
+            f.write(self._stderr)
 
 
 # --------------

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -226,21 +226,19 @@ class LambdaFunction(Component):
         response = {}
 
         if self.max_retry_attempts is not None:
-            response.update({"MaximumRetryAttempts": self.max_retry_attempts})
-
+            response["MaximumRetryAttempts"] = self.max_retry_attempts
         if self.max_event_age is not None:
-            response.update({"MaximumEventAgeInSeconds": self.max_event_age})
-
+            response["MaximumEventAgeInSeconds"] = self.max_event_age
         if self.on_successful_invocation or self.on_failed_invocation:
-            response.update({"DestinationConfig": {}})
-            if self.on_successful_invocation:
-                response["DestinationConfig"].update(
-                    {"OnSuccess": {"Destination": self.on_successful_invocation}}
-                )
-            if self.on_failed_invocation:
-                response["DestinationConfig"].update(
-                    {"OnFailure": {"Destination": self.on_failed_invocation}}
-                )
+            response["DestinationConfig"] = {}
+        if self.on_successful_invocation:
+            response["DestinationConfig"].update(
+                {"OnSuccess": {"Destination": self.on_successful_invocation}}
+            )
+        if self.on_failed_invocation:
+            response["DestinationConfig"].update(
+                {"OnFailure": {"Destination": self.on_failed_invocation}}
+            )
         if not response:
             return None
         response.update(

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -1047,18 +1047,18 @@ class TestLambdaAPI(unittest.TestCase):
 
     @mock.patch("tempfile.NamedTemporaryFile")
     def test_lambda_output(self, temp):
-        stderr = """START RequestId: 14c6eaeb-9183-4461-b520-10c4c64a2b07 Version: $LATEST 
-        2022-01-27T12:57:39.071Z	14c6eaeb-9183-4461-b520-10c4c64a2b07 INFO {} 
-        2022-01-27T12:57:39.071Z	14c6eaeb-9183-4461-b520-10c4c64a2b07 INFO { 
-        callbackWaitsForEmptyEventLoop: [Getter/Setter], succeed: [Function (anonymous)], 
-        fail: [Function (anonymous)], done: [Function (anonymous)], functionVersion: '$LATEST', 
-        functionName: 'hello', memoryLimitInMB: '128', logGroupName: '/aws/lambda/hello', 
-        logStreamName: '2022/01/27/[$LATEST]44deffbc11404f459e2cf38bb2fae611', clientContext: 
-        undefined, identity: undefined, invokedFunctionArn: 
-        'arn:aws:lambda:eu-west-1:659676821118:function:hello', awsRequestId: 
-        '14c6eaeb-9183-4461-b520-10c4c64a2b07', getRemainingTimeInMillis: [Function: 
-        getRemainingTimeInMillis] } END RequestId: 14c6eaeb-9183-4461-b520-10c4c64a2b07 REPORT 
-        RequestId: 14c6eaeb-9183-4461-b520-10c4c64a2b07	Duration: 1.61 ms	Billed Duration: 2 
+        stderr = """START RequestId: 14c6eaeb-9183-4461-b520-10c4c64a2b07 Version: $LATEST
+        2022-01-27T12:57:39.071Z	14c6eaeb-9183-4461-b520-10c4c64a2b07 INFO {}
+        2022-01-27T12:57:39.071Z	14c6eaeb-9183-4461-b520-10c4c64a2b07 INFO {
+        callbackWaitsForEmptyEventLoop: [Getter/Setter], succeed: [Function (anonymous)],
+        fail: [Function (anonymous)], done: [Function (anonymous)], functionVersion: '$LATEST',
+        functionName: 'hello', memoryLimitInMB: '128', logGroupName: '/aws/lambda/hello',
+        logStreamName: '2022/01/27/[$LATEST]44deffbc11404f459e2cf38bb2fae611', clientContext:
+        undefined, identity: undefined, invokedFunctionArn:
+        'arn:aws:lambda:eu-west-1:659676821118:function:hello', awsRequestId:
+        '14c6eaeb-9183-4461-b520-10c4c64a2b07', getRemainingTimeInMillis: [Function:
+        getRemainingTimeInMillis] } END RequestId: 14c6eaeb-9183-4461-b520-10c4c64a2b07 REPORT
+        RequestId: 14c6eaeb-9183-4461-b520-10c4c64a2b07	Duration: 1.61 ms	Billed Duration: 2
         ms	Memory Size: 128 MB	Max Memory Used: 58 MB """
 
         output = OutputLog(stdout='{"hello":"world"}', stderr=stderr)


### PR DESCRIPTION
This PR makes the output truncation configurable, providing a default that keeps backwards compatibility.

The new introduced variable is called `LAMBDA_TRUNCATE_STDOUT`