### PR TITLE
Changed postional vars to named

### DIFF
--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -935,7 +935,7 @@ def get_template(req_params):
     cs_name = req_params.get("ChangeSetName")
     stack = find_stack(stack_name)
     if cs_name:
-        stack = find_change_set(stack_name, cs_name)
+        stack = find_change_set(stack_name=stack_name, cs_name=cs_name)
     if not stack:
         return stack_not_found_error(stack_name)
     result = {"TemplateBody": json.dumps(stack._template_raw)}


### PR DESCRIPTION
The `find_change_set` function call within the `get_template` function had its parameters mistakenly inverted. This caused a GetTemplate request which had both a **stack-name** and **change-set-name** to fail.

I changed the positional parameters to named parameters because I'm unsure if there are other areas of localstack which also call `find_change_set` and didn't want to risk breaking them with this change.

![image](https://user-images.githubusercontent.com/1309341/151671218-881e5bd3-8c5b-4274-bac0-c6587e8f6801.png)

## To  Test:
**Note**: I'm quite new to localstack and CDK so I'm not sure how to build automated tests yet. Hopefully my textual description and screenshot are sufficient to evaluate this PR?

1. Before fix
    1. Install CDK 2.9.0 && cdklocal
    2. `mkdir my-first-cdk && cd my-first-cdk`
    3. `cdklocal init sample-app --language python`
    4. Bootstrap CDK
    5. `cdklocal deploy`
    6. Comment out `topic.add_subscription(subs.SqsSubscription(queue))` in _my_first_cdk_stack.py_.
    7. `cdklocal deploy`
    8. Try to get combined template: `awslocal cloudformation get-template --stack-name my-first-cdk --change-set-name cdk-deploy-change-set`. This will return an error: `An error occurred (ValidationError) when calling the GetTemplate operation: Stack with id my-first-cdk does not exist.`

2. After the fix:
    1.   Running command: `awslocal cloudformation get-template --stack-name my-first-cdk --change-set-name cdk-deploy-change-set` will return a populated template.

