### PR TITLE
Fixing integration tests against pro

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -74,6 +74,7 @@ jobs:
         working-directory: localstack
         run: |
           make install
+          make init
       - name: Link community LocalStack into Pro venv
         run: |
           source .venv/bin/activate

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1326,6 +1326,7 @@ class LambdaExecutorLocal(LambdaExecutor):
 
         lambda_cwd = lambda_function.cwd
         environment = self._prepare_environment(lambda_function)
+        Util.inject_endpoints_into_env(env_vars=environment)
 
         environment["EDGE_PORT"] = str(config.EDGE_PORT)
         if lambda_function.timeout:

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1326,8 +1326,8 @@ class LambdaExecutorLocal(LambdaExecutor):
 
         lambda_cwd = lambda_function.cwd
         environment = self._prepare_environment(lambda_function)
-        Util.inject_endpoints_into_env(env_vars=environment)
 
+        environment["LOCALSTACK_HOSTNAME"] = config.LOCALSTACK_HOSTNAME
         environment["EDGE_PORT"] = str(config.EDGE_PORT)
         if lambda_function.timeout:
             environment["AWS_LAMBDA_FUNCTION_TIMEOUT"] = str(lambda_function.timeout)

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -75,7 +75,7 @@ URL_LOCALSTACK_FAT_JAR = (
 ).format(v=LOCALSTACK_MAVEN_VERSION)
 
 MARKER_FILE_LIGHT_VERSION = "%s/.light-version" % dirs.static_libs
-IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local"
+IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local:1.7.9"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
     f"{ARTIFACTS_REPO}/raw/2958554c8aeadff0e8f5d0e35f6e520d834854ea/stepfunctions-local-patch"

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -72,13 +72,14 @@ def start_stepfunctions(port=None, asynchronous=False, update_listener=None):
     log_startup_message("StepFunctions")
     start_proxy_for_service("stepfunctions", port, backend_port, update_listener)
     global PROCESS_THREAD
+    # TODO: change ports in stepfunctions.jar, then update here
     PROCESS_THREAD = do_run(
         cmd,
         asynchronous,
         strip_color=True,
         env_vars={
-            "EDGE_PORT": config.EDGE_PORT_HTTP,  # TODO: change ports in stepfunctions.jar, then update here
-            "EDGE_PORT_HTTP": config.EDGE_PORT_HTTP,
+            "EDGE_PORT": config.EDGE_PORT_HTTP or config.EDGE_PORT,
+            "EDGE_PORT_HTTP": config.EDGE_PORT_HTTP or config.EDGE_PORT,
             "DATA_DIR": config.DATA_DIR,
         },
     )

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -72,7 +72,16 @@ def start_stepfunctions(port=None, asynchronous=False, update_listener=None):
     log_startup_message("StepFunctions")
     start_proxy_for_service("stepfunctions", port, backend_port, update_listener)
     global PROCESS_THREAD
-    PROCESS_THREAD = do_run(cmd, asynchronous, strip_color=True)
+    PROCESS_THREAD = do_run(
+        cmd,
+        asynchronous,
+        strip_color=True,
+        env_vars={
+            "EDGE_PORT": config.EDGE_PORT_HTTP,  # TODO: change ports in stepfunctions.jar, then update here
+            "EDGE_PORT_HTTP": config.EDGE_PORT_HTTP,
+            "DATA_DIR": config.DATA_DIR,
+        },
+    )
     return PROCESS_THREAD
 
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import base64
 import json
 import os
 import unittest
@@ -685,7 +686,12 @@ class EventsTest(unittest.TestCase):
             self.assertTrue("key" in paths_list[0] and "value" in paths_list[0])
             self.assertTrue(events[0].get("key") == "value")
 
-            self.assertTrue("Basic user:pass" in headers_list)
+            # TODO examine behavior difference between LS pro/community
+            # Pro seems to (correctly) use base64 for basic authentication instead of plaintext
+            user_pass = to_str(base64.b64encode(b"user:pass"))
+            self.assertTrue(
+                "Basic user:pass" in headers_list or f"Basic {user_pass}" in headers_list
+            )
             self.assertTrue("apikey_secret" in headers_list)
             self.assertTrue(bearer in headers_list)
 


### PR DESCRIPTION
PR #5389 introduced a regression by disabling the automatic setting of LOCALSTACK_HOSTNAME, which the local lambda executor relied on.
This PR will, as a first step to get builds green again, inject the endpoint again into the environment variables of the process.