### PR TITLE
CircleCI workflow revamp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,11 +227,8 @@ jobs:
           name: Build full docker image
           command: make docker-build
       - run:
-          name: Run tests
-          command: |
-            PYTEST_ARGS='--junitxml=target/reports/test-report-<< parameters.platform >>.xml' \
-            COVERAGE_FILE='target/coverage/.coverage.<< parameters.platform >>' \
-            make docker-run-tests
+          name: Save full docker image
+          command: PLATFORM="<< parameters.platform >>" make docker-save-image
       - when:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
@@ -243,9 +240,6 @@ jobs:
                 name: Run pre-release smoke tests
                 command: make ci-pro-smoke-tests
             - run:
-                name: Save full docker image
-                command: PLATFORM="<< parameters.platform >>" make docker-save-image
-            - run:
                 name: Save light docker image
                 command: PLATFORM="<< parameters.platform >>" make docker-save-image-light
       - persist_to_workspace:
@@ -253,6 +247,30 @@ jobs:
             /tmp/workspace
           paths:
             - repo/target/
+
+  docker-test:
+    parameters:
+      platform:
+        description: "Platform to build for"
+        default: "amd64"
+        type: string
+    machine:
+      image: "ubuntu-2004:202107-02"
+      docker_layer_caching: true
+    resource_class: "medium"
+    working_directory: /tmp/workspace/repo
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load docker localstack-full image
+          command: docker load -i target/localstack-docker-image-<< parameters.platform >>.tar
+      - run:
+          name: Run tests
+          command: |
+            PYTEST_ARGS='--junitxml=target/reports/test-report-<< parameters.platform >>.xml' \
+            COVERAGE_FILE='target/coverage/.coverage.<< parameters.platform >>' \
+            make docker-run-tests
       - store_test_results:
           path: target/reports/
 
@@ -346,13 +364,23 @@ workflows:
           resource_class: arm.medium
           requires:
             - preflight
+      - docker-test:
+          name: docker-test-arm64
+          platform: arm64
+          requires:
+            - docker-build-arm64
+      - docker-test:
+          name: docker-test-amd64
+          platform: amd64
+          requires:
+            - docker-build-amd64
       - report:
           requires:
             - itest-lambda-docker
             - itest-sqs-provider
             - itest-bootstrap
-            - docker-build-amd64
-            - docker-build-arm64
+            - docker-test-amd64
+            - docker-test-arm64
       - docker-push:
           filters:
             branches:
@@ -361,5 +389,5 @@ workflows:
             - itest-lambda-docker
             - itest-sqs-provider
             - itest-bootstrap
-            - docker-build-amd64
-            - docker-build-arm64
+            - docker-test-amd64
+            - docker-test-arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,10 +254,17 @@ jobs:
         description: "Platform to build for"
         default: "amd64"
         type: string
+      resource_class:
+        description: "CircleCI machine type to run at"
+        default: "medium"
+        type: string
+      machine_image:
+        description: "CircleCI machine type to run at"
+        default: "ubuntu-2004:202107-02"
+        type: string
     machine:
-      image: "ubuntu-2004:202107-02"
-      docker_layer_caching: true
-    resource_class: "medium"
+      image: << parameters.machine_image >>
+    resource_class: << parameters.resource_class >>
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -367,11 +374,15 @@ workflows:
       - docker-test:
           name: docker-test-arm64
           platform: arm64
+          resource_class: arm.medium
+          machine_image: ubuntu-2004:202101-01
           requires:
             - docker-build-arm64
       - docker-test:
           name: docker-test-amd64
           platform: amd64
+          resource_class: medium
+          machine_image: ubuntu-2004:202107-02
           requires:
             - docker-build-amd64
       - report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,7 @@ jobs:
             /tmp/workspace
           paths:
             - repo/target/reports/
+            - repo/target/coverage/
 
   report:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,11 @@ jobs:
             make docker-run-tests
       - store_test_results:
           path: target/reports/
+      - persist_to_workspace:
+          root:
+            /tmp/workspace
+          paths:
+            - repo/target/reports/
 
   report:
     docker:

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -150,7 +150,9 @@ def get_elasticsearch_install_version(version: str) -> str:
 
 
 def get_elasticsearch_install_dir(version: str) -> str:
-    if version == ELASTICSEARCH_DEFAULT_VERSION and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
+    if version == get_elasticsearch_install_version(
+        ELASTICSEARCH_DEFAULT_VERSION
+    ) and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
         LOG.debug(
             "Chose to install to static_libs, version %s, path light exists: %s, path light: %s",
             version,

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -151,9 +151,21 @@ def get_elasticsearch_install_version(version: str) -> str:
 
 def get_elasticsearch_install_dir(version: str) -> str:
     if version == ELASTICSEARCH_DEFAULT_VERSION and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
+        LOG.debug(
+            "Chose to install to static_libs, version %s, path light exists: %s, path light: %s",
+            version,
+            os.path.exists(MARKER_FILE_LIGHT_VERSION),
+            MARKER_FILE_LIGHT_VERSION,
+        )
         # install the default version into a subfolder of the code base
         install_dir = os.path.join(dirs.static_libs, "elasticsearch")
     else:
+        LOG.debug(
+            "Chose to install to var_libs, version %s, path light exists: %s, path light: %s",
+            version,
+            os.path.exists(MARKER_FILE_LIGHT_VERSION),
+            MARKER_FILE_LIGHT_VERSION,
+        )
         # put all other versions into the TMP_FOLDER
         install_dir = os.path.join(config.dirs.var_libs, "elasticsearch", version)
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -153,21 +153,9 @@ def get_elasticsearch_install_dir(version: str) -> str:
     if version == get_elasticsearch_install_version(
         ELASTICSEARCH_DEFAULT_VERSION
     ) and not os.path.exists(MARKER_FILE_LIGHT_VERSION):
-        LOG.debug(
-            "Chose to install to static_libs, version %s, path light exists: %s, path light: %s",
-            version,
-            os.path.exists(MARKER_FILE_LIGHT_VERSION),
-            MARKER_FILE_LIGHT_VERSION,
-        )
         # install the default version into a subfolder of the code base
         install_dir = os.path.join(dirs.static_libs, "elasticsearch")
     else:
-        LOG.debug(
-            "Chose to install to var_libs, version %s, path light exists: %s, path light: %s",
-            version,
-            os.path.exists(MARKER_FILE_LIGHT_VERSION),
-            MARKER_FILE_LIGHT_VERSION,
-        )
         # put all other versions into the TMP_FOLDER
         install_dir = os.path.join(config.dirs.var_libs, "elasticsearch", version)
 
@@ -209,7 +197,8 @@ def install_elasticsearch(version=None):
                 LOG.info("Installing Elasticsearch plugin %s", plugin)
 
                 def try_install():
-                    safe_run([plugin_binary, "install", "-b", plugin])
+                    output = safe_run([plugin_binary, "install", "-b", plugin])
+                    LOG.debug("Plugin installation output: %s", output)
 
                 # We're occasionally seeing javax.net.ssl.SSLHandshakeException -> add download retries
                 download_attempts = 3

--- a/localstack/services/opensearch/versions.py
+++ b/localstack/services/opensearch/versions.py
@@ -185,7 +185,8 @@ def get_install_version(version: str) -> str:
     return install_versions[version]
 
 
-def _opensearch_url(install_version: semver.VersionInfo, arch: str) -> str:
+def _opensearch_url(install_version: semver.VersionInfo) -> str:
+    arch = "x64" if get_arch() == "amd64" else "arm64"
     version = str(install_version)
     return (
         f"https://artifacts.opensearch.org/releases/bundle/opensearch/"
@@ -193,22 +194,22 @@ def _opensearch_url(install_version: semver.VersionInfo, arch: str) -> str:
     )
 
 
-def _es_url(install_version: semver.VersionInfo, arch: str) -> str:
+def _es_url(install_version: semver.VersionInfo) -> str:
+    arch = "x86_64" if get_arch() == "amd64" else "aarch64"
     version = str(install_version)
     repo = "https://artifacts.elastic.co/downloads/elasticsearch"
     if install_version.major <= 6:
         return f"{repo}/elasticsearch-{version}.tar.gz"
 
-    return f"{repo}/elasticsearch-{version}-linux-x86_64.tar.gz"
+    return f"{repo}/elasticsearch-{version}-linux-{arch}.tar.gz"
 
 
 def get_download_url(install_version: str, engine_type: EngineType) -> str:
     install_version = semver.VersionInfo.parse(install_version)
-    arch_str = "x64" if get_arch() == "amd64" else "arm64"
     if engine_type == EngineType.OpenSearch:
-        return _opensearch_url(install_version, arch_str)
+        return _opensearch_url(install_version)
     elif engine_type == EngineType.Elasticsearch:
-        return _es_url(install_version, arch_str)
+        return _es_url(install_version)
 
 
 def fetch_latest_versions() -> Dict[str, str]:  # pragma: no cover

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,9 +48,9 @@ def pytest_runtestloop(session):
         # OpenSearch is a pytest, not a unit test class, therefore we check based on the item parent's name
         # (test_opensearch.py).
         if "opensearch" in str(item.parent).lower():
-            test_init_functions.add(opensearch_install_async())
+            test_init_functions.add(opensearch_install_async)
         if "es" in str(item.parent).lower():
-            test_init_functions.add(es_install_async())
+            test_init_functions.add(es_install_async)
 
     # add init functions for certain tests that download/install things
     for test_class in test_classes:


### PR DESCRIPTION
This PR will separate the jobs for building the container and testing the container, allowing for future test parallelism and reduced per-job runtime.

Also, the ARM tests now run without any emulation of AMD64, ElasticSearch uses again the statically bundled version in the -full image, some test cleanups in ES/opensearch tests and installing the correct architecture of ES if installed dynamically. 