### PR TITLE
update exposed ports and example docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,9 +121,6 @@ ENV LOCALSTACK_HOSTNAME=localhost
 
 RUN mkdir /root/.serverless; chmod -R 777 /root/.serverless
 
-# add trusted CA certificates to the cert store
-RUN curl https://letsencrypt.org/certs/letsencryptauthorityx3.pem.txt >> /etc/ssl/certs/ca-certificates.crt
-
 
 
 # builder: Stage which installs/builds the dependencies and infra-components of LocalStack
@@ -217,7 +214,7 @@ LABEL authors="LocalStack Contributors"
 LABEL maintainer="LocalStack Team (info@localstack.cloud)"
 LABEL description="LocalStack Docker image"
 
-# Copy in the build dependencies
+# Copy the build dependencies
 COPY --from=builder /opt/code/localstack/ /opt/code/localstack/
 
 # Copy in postgresql extensions
@@ -260,8 +257,8 @@ ARG LOCALSTACK_BUILD_GIT_HASH
 ENV LOCALSTACK_BUILD_DATE=${LOCALSTACK_BUILD_DATE}
 ENV LOCALSTACK_BUILD_GIT_HASH=${LOCALSTACK_BUILD_GIT_HASH}
 
-# expose edge service, ElasticSearch & debugpy ports
-EXPOSE 4566 4571 5678
+# expose edge service, external service ports, and debugpy
+EXPOSE 4566 4510-4559 5678
 
 # define command at startup
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,11 @@ services:
     image: localstack/localstack
     network_mode: bridge
     ports:
-      - "127.0.0.1:53:53"                # only required for Pro
-      - "127.0.0.1:53:53/udp"            # only required for Pro
-      - "127.0.0.1:443:443"              # only required for Pro
-      - "127.0.0.1:4510-4559:4510-4559"
-      - "127.0.0.1:4566:4566"
-      - "127.0.0.1:4571:4571"
+      - "127.0.0.1:53:53"                # only required for Pro (DNS)
+      - "127.0.0.1:53:53/udp"            # only required for Pro (DNS)
+      - "127.0.0.1:443:443"              # only required for Pro (LocalStack HTTPS Edge Proxy)
+      - "127.0.0.1:4510-4559:4510-4559"  # external service port range
+      - "127.0.0.1:4566:4566"            # LocalStack Edge Proxy
     environment:
       - SERVICES=${SERVICES-}
       - DEBUG=${DEBUG-}


### PR DESCRIPTION
This PR contains the following changes:
- Removes the explicit download of the LetsEncrypt CA (LetsEncrypt R3 is already contained in the python base image).
- Removes the elasticsearch port from docker-compose and the exposed port list in the Dockerfile (ElasticSearch and OpenSearch are now using the external service port range).
- Exposes the external service port range in the Dockerfile / the resulting docker image.
- Describes the different bound ports in the example `docker-compose.yml`.