### PR TITLE
Fix uncapped recursion bug in parser

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -67,6 +67,7 @@ not work out-of-the-box.
 """
 import abc
 import base64
+import copy
 import datetime
 import json
 import re
@@ -167,8 +168,10 @@ class RequestParser(abc.ABC):
             if location == "header":
                 header_name = shape.serialization.get("name")
                 if header_name in request.headers:
+                    copied_shape = copy.deepcopy(shape)
+                    copied_shape.serialization["location"] = None
                     payload = self._parse_shape(
-                        request, shape, request.headers[header_name], path_regex
+                        request, copied_shape, request.headers[header_name], path_regex
                     )
                 else:
                     # if header is optional and not set

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -168,6 +168,7 @@ class RequestParser(abc.ABC):
             if location == "header":
                 header_name = shape.serialization.get("name")
                 if header_name in request.headers:
+                    # set the location to None to avoid an unlimited recursion with header parameters
                     copied_shape = copy.deepcopy(shape)
                     copied_shape.serialization["location"] = None
                     payload = self._parse_shape(


### PR DESCRIPTION
This PR fixes an uncapped recursion bug which occurs when parsing API parameters which are delivered via HTTP Headers