### PR TITLE
Allow service restart in ServiceContainer from STOPPED state

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -27,7 +27,7 @@ from localstack.services.infra import PROXY_LISTENERS
 from localstack.services.plugins import SERVICE_PLUGINS
 from localstack.services.s3.s3_utils import uses_host_addressing
 from localstack.services.sqs.sqs_listener import is_sqs_queue_url
-from localstack.utils import persistence
+from localstack.utils import common, persistence
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import is_internal_call_context, set_default_region_in_headers
 from localstack.utils.aws.request_routing import extract_version_and_action, matches_service_action
@@ -73,6 +73,9 @@ class ProxyListenerEdge(ProxyListener):
         self.service_manager = service_manager or SERVICE_PLUGINS
 
     def forward_request(self, method, path, data, headers):
+
+        if common.INFRA_STOPPED:
+            return 503
 
         if config.EDGE_FORWARD_URL:
             return do_forward_request_network(

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -285,13 +285,14 @@ def start_local_api(name, port, api, method, asynchronous=False):
 def stop_infra():
     if common.INFRA_STOPPED:
         return
-    common.INFRA_STOPPED = True
+    # also used to signal shutdown for edge proxy so that any further requests will be rejected
+    common.INFRA_STOPPED = True  # TODO: should probably be STOPPING since it isn't stopped yet
 
     event_publisher.fire_event(event_publisher.EVENT_STOP_INFRA)
     analytics.log.event("infra_stop")
 
     try:
-        generic_proxy.QUIET = True
+        generic_proxy.QUIET = True  # TODO: this doesn't seem to be doing anything
         LOG.debug("[shutdown] Cleaning up services ...")
         SERVICE_PLUGINS.stop_all_services()
         LOG.debug("[shutdown] Cleaning up files ...")

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -128,6 +128,7 @@ def build_cluster_run_command(cluster_bin: str, settings: CommandSettings) -> Li
 class OpensearchCluster(Server):
     """Manages an OpenSearch cluster which is installed an operated by LocalStack."""
 
+    # TODO: legacy default port should be removed here
     def __init__(
         self, port=4571, host="localhost", version: str = None, directories: Directories = None
     ) -> None:

--- a/localstack/services/opensearch/cluster_manager.py
+++ b/localstack/services/opensearch/cluster_manager.py
@@ -219,6 +219,10 @@ class ClusterEndpoint(FakeEndpointProxyServer):
     def health(self):
         return super().health() and self.cluster.health()
 
+    def do_shutdown(self):
+        super(FakeEndpointProxyServer, self).do_shutdown()
+        self.cluster.shutdown()
+
 
 def _get_port_from_url(url: str) -> int:
     return int(url.split(":")[2])
@@ -263,8 +267,9 @@ class MultiplexingClusterManager(ClusterManager):
                     self.cluster.start()  # start may block during install
 
                 start_thread(_start_async)
-
-        return ClusterEndpoint(self.cluster, EndpointProxy(url, self.cluster.url))
+            cluster_endpoint = ClusterEndpoint(self.cluster, EndpointProxy(url, self.cluster.url))
+            self.clusters[arn] = cluster_endpoint
+            return cluster_endpoint
 
     def remove(self, arn: str):
         super().remove(arn)  # removes the fake server

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -313,6 +313,10 @@ class ServiceManager:
             if not poll_condition(lambda: container.state != ServiceState.STARTING, timeout=30):
                 raise TimeoutError("gave up waiting for service %s to start" % name)
 
+        if container.state == ServiceState.STOPPING:
+            if not poll_condition(lambda: container.state == ServiceState.STOPPED, timeout=30):
+                raise TimeoutError("gave up waiting for service %s to stop" % name)
+
         with container.lock:
             if container.state == ServiceState.DISABLED:
                 raise ServiceDisabled("service %s is disabled" % name)
@@ -324,7 +328,7 @@ class ServiceManager:
                 # raise any capture error
                 raise container.errors[-1]
 
-            if container.state == ServiceState.AVAILABLE:
+            if container.state == ServiceState.AVAILABLE or container.state == ServiceState.STOPPED:
                 if container.start():
                     return container.service
                 else:

--- a/tests/integration/test_es.py
+++ b/tests/integration/test_es.py
@@ -5,7 +5,7 @@ import botocore.exceptions
 import pytest
 
 from localstack import config
-from localstack.constants import OPENSEARCH_DEFAULT_VERSION
+from localstack.constants import ELASTICSEARCH_DEFAULT_VERSION, OPENSEARCH_DEFAULT_VERSION
 from localstack.services.install import install_elasticsearch, install_opensearch
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import short_uid, start_worker_thread
@@ -103,20 +103,20 @@ class TestElasticsearchProvider:
         assert len(versions) == 0
 
     def test_create_domain(self, es_client, opensearch_create_domain):
-        es_domain = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
+        es_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = es_client.list_domain_names(EngineType="Elasticsearch")
         domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
         assert es_domain in domain_names
 
     def test_create_existing_domain_causes_exception(self, es_client, opensearch_create_domain):
-        domain_name = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
+        domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
 
         with pytest.raises(botocore.exceptions.ClientError) as exc_info:
             es_client.create_elasticsearch_domain(DomainName=domain_name)
         assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
 
     def test_describe_domains(self, es_client, opensearch_create_domain):
-        opensearch_domain = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
+        opensearch_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = es_client.describe_elasticsearch_domains(DomainNames=[opensearch_domain])
         assert len(response["DomainStatusList"]) == 1
         assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
@@ -127,7 +127,7 @@ class TestElasticsearchProvider:
         status = response["DomainStatus"]
         assert "ElasticsearchVersion" in status
         assert status["ElasticsearchVersion"] == OPENSEARCH_DEFAULT_VERSION
-        domain_name = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
+        domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = es_client.describe_elasticsearch_domain(DomainName=domain_name)
         assert "DomainStatus" in response
         status = response["DomainStatus"]

--- a/tests/integration/test_es.py
+++ b/tests/integration/test_es.py
@@ -102,29 +102,21 @@ class TestElasticsearchProvider:
         # The default version is the latest version, which is not compatible with any previous versions
         assert len(versions) == 0
 
-    def test_create_domain(self, es_client):
-        domain_name = f"es-domain-{short_uid()}"
-        try:
+    def test_create_domain(self, es_client, opensearch_create_domain):
+        es_domain = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
+        response = es_client.list_domain_names(EngineType="Elasticsearch")
+        domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
+        assert es_domain in domain_names
+
+    def test_create_existing_domain_causes_exception(self, es_client, opensearch_create_domain):
+        domain_name = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
+
+        with pytest.raises(botocore.exceptions.ClientError) as exc_info:
             es_client.create_elasticsearch_domain(DomainName=domain_name)
+        assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
 
-            response = es_client.list_domain_names(EngineType="Elasticsearch")
-            domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
-
-            assert domain_name in domain_names
-        finally:
-            es_client.delete_elasticsearch_domain(DomainName=domain_name)
-
-    def test_create_existing_domain_causes_exception(self, es_client):
-        domain_name = f"es-domain-{short_uid()}"
-        try:
-            es_client.create_elasticsearch_domain(DomainName=domain_name)
-            with pytest.raises(botocore.exceptions.ClientError) as exc_info:
-                es_client.create_elasticsearch_domain(DomainName=domain_name)
-            assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
-        finally:
-            es_client.delete_elasticsearch_domain(DomainName=domain_name)
-
-    def test_describe_domains(self, es_client, opensearch_domain):
+    def test_describe_domains(self, es_client, opensearch_create_domain):
+        opensearch_domain = opensearch_create_domain(EngineVersion="Elasticsearch_7.10")
         response = es_client.describe_elasticsearch_domains(DomainNames=[opensearch_domain])
         assert len(response["DomainStatusList"]) == 1
         assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain


### PR DESCRIPTION
I guess when a service is in a STOPPED state it should also try to start it again (and wait in case it is currently stopping). 

Also prevents the kinesis restart error spam during test execution.