### PR TITLE
fix opensearch cluster shutdown in tests

### DIFF
--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -505,8 +505,14 @@ class TestSingletonClusterManager:
         # check if the second url matches the first one
         assert cluster_0.url == cluster_1.url
 
-        call_safe(cluster_0.shutdown)
-        call_safe(cluster_1.shutdown)
+        try:
+            # wait for the two clusters
+            assert cluster_0.wait_is_up(240)
+            # make sure cluster_0 (which is equal to cluster_1) is reachable
+            retry(lambda: try_cluster_health(cluster_0.url), retries=3, sleep=5)
+        finally:
+            call_safe(cluster_0.shutdown)
+            call_safe(cluster_1.shutdown)
 
 
 class TestCustomBackendManager:


### PR DESCRIPTION
Currently, the integration test which tests the SingletonClusterManager (which is managing the cluster if the `OPENSEARCH_ENDPOINT_STRATEGY=port` and `OPENSEARCH_MULTI_CLUSTER=false`) does not wait for the cluster to be up or tests if the cluster can be reached.
Since the cluster is not yet started, it cannot be properly shut down (Server#do_shutdown raises an exception which is swallowed by #call_safe).
This PR fixes the cleanup by extending the test to wait for the cluster to be up and testing if the cluster really is reachable.

/cc @dfangl 
