### PR TITLE
implement location trait serialization for json rest protocol

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -741,6 +741,9 @@ class JSONResponseSerializer(ResponseSerializer):
     ) -> None:
         """Serializes all top-level shape members whose location is header, headers, or statusCode into the
         HttpRequest object."""
+        if not shape_members:
+            return
+
         headers = dict()
 
         for name in shape_members:
@@ -750,7 +753,6 @@ class JSONResponseSerializer(ResponseSerializer):
                 continue
 
             if name not in parameters:
-                # TODO: check if required and raise validation error?
                 continue
 
             if location == "header":

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -786,6 +786,9 @@ class JSONResponseSerializer(ResponseSerializer):
         # a payload can be a string, blob, or structure: https://gist.github.com/thrau/39fd20b437f8719ffc361ad9a908c0c6
         if payload_shape.type_name == "structure":
             response.set_json(value if value is not None else {})
+        elif payload_shape.type_name == "blob":
+            # payloads blobs are not base64 encoded, but the `_serialize` recursion doesn't know that
+            response.data = base64.b64decode(value) if value is not None else b""
         else:
             response.data = value if value is not None else b""
 

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -776,10 +776,9 @@ class JSONResponseSerializer(ResponseSerializer):
         payload_shape = shape.members[payload_key]
 
         if payload_key not in body:
-            # TODO: the payload attribute was not in the parameters
-            raise KeyError("missing payload attribute %s in body" % payload_key)
+            LOG.warning("missing payload attribute %s in body", payload_key)
 
-        value = body.pop(payload_key)
+        value = body.pop(payload_key, None)
 
         if body:
             # in principle, if a payload attribute is specified in the shape, all other attributes should be in other
@@ -788,10 +787,9 @@ class JSONResponseSerializer(ResponseSerializer):
 
         # a payload can be a string, blob, or structure: https://gist.github.com/thrau/39fd20b437f8719ffc361ad9a908c0c6
         if payload_shape.type_name == "structure":
-            response.set_json(value)
+            response.set_json(value if value is not None else {})
         else:
-            # FIXME: how to deal with other types?
-            response.data = value
+            response.data = value if value is not None else b""
 
     def _serialize(self, body: dict, value: any, shape, key: Optional[str] = None):
         """This method dynamically invokes the correct `_serialize_type_*` method for each shape type."""

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -757,11 +757,9 @@ class JSONResponseSerializer(ResponseSerializer):
             if not location:
                 body[key] = value
             elif location == "header":
-                # FIXME: what about non-string values?
                 response.headers[key] = value
             elif location == "headers":
-                # FIXME
-                raise NotImplementedError
+                response.headers.update(value)
             elif location == "statusCode":
                 # statusCode is quite rare, and it looks like it's always just an int shape, so taking a shortcut here
                 response.status_code = int(value)

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -743,12 +743,13 @@ class JSONResponseSerializer(ResponseSerializer):
             return
 
         # otherwise, move data attributes into their appropriate locations
-        # (some shapes have a serialization dict, but don't actually have
+        # (some shapes have a serialization dict, but don't actually have attributes with special locations)
         body = {}
         for name in shape_members:
             member_shape = shape_members[name]
             key = member_shape.serialization.get("name", name)
             if key not in data:
+                # ignores optional keys
                 continue
             value = data[key]
 

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -751,12 +751,7 @@ def test_restjson_payload_serialization():
     """
 
     response = {
-        "Content": b'{"foo": "bar"}',
-        "ConfigurationVersion": "123",
-        "ContentType": "application/json",
-    }
-    expected = {
-        "Content": "eyJmb28iOiAiYmFyIn0=",  # base64 encoding of b'{"foo": "bar"}
+        "Content": '{"foo": "bar"}',
         "ConfigurationVersion": "123",
         "ContentType": "application/json",
     }
@@ -766,7 +761,6 @@ def test_restjson_payload_serialization():
         "GetConfiguration",
         response,
         status_code=200,
-        expected_response_content=expected,
     )
     headers = result["ResponseMetadata"]["HTTPHeaders"]
     assert "configuration-version" in headers


### PR DESCRIPTION
implements `header`, `headers`, `statusCode` and `payload` serialization and  for `json-rest` protocol in the ASF serializer.

* i renamed `_serialize_payload`, which was the abstract entry point for serialization, into `_serialize_response`, to indicate that it can handle traits outside the payload
* the method is kinda generic, but can't be re-used yet because it relies on the special `_serialize` method of the `JSONResponseSerializer`, which parses shapes into a dict that can later be used as basis to serialize the request.
* i added two small features to the `_botocore_serializer_integration_test`:
  1. it now returns the parsed response so we can assert header fields
  2. i added a `_skip_assert` sentinel object to skip the internal assert for cases where the response dict may contain unexpected additional attributes (e.g., when the `headers` location trait is used, then all other HTTP headers are also serialized into that field)
* removed base64 encoding for rest-json payloads, since AWS does not seem to base64-encode payload blobs in json-rest. unfortunately the implementation for that is not great (first encoding and then decoding again), but it was the easiest way for now without having to restructure everything.

i also created this gist to validate some assumptions that are made in the method: https://gist.github.com/thrau/eb93d0def52d2c4a23abba4efea5e126

TODO: 
- [x] basic implementations for `header` and `statusCode` (easy)
- [x] implementation of `headers` location
- [x] implementation of payload serialization
- [x] write tests (current test framework needs to be slightly extended)