### PR TITLE
add Dockerfile and GitHub action to smoke-test RedHat compatibility

### DIFF
--- a/.github/workflows/rh-support.yml
+++ b/.github/workflows/rh-support.yml
@@ -1,0 +1,29 @@
+name: smoke-tests-against-redhat
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test-redhat:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Open Source
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Build RH Docker Image
+        run: |
+          docker build  -t localstack-redhat -f ./Dockerfile.rh \
+            --build-arg LOCALSTACK_BUILD_GIT_HASH=$(shell git rev-parse --short HEAD) \
+            --build-arg=LOCALSTACK_BUILD_DATE=$(shell date -u +"%Y-%m-%d") \
+            .
+
+      - name: Execute Smoke Tests
+        run: |
+          CI_SMOKE_IMAGE_NAME="localstack-redhat" make ci-pro-smoke-tests

--- a/.github/workflows/rh-support.yml
+++ b/.github/workflows/rh-support.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     branches:
       - master
+# TODO remove pull request trigger and uncomment trigger below before merge
+#  push:
+#    branches:
+#      - master
 
 jobs:
   test-redhat:

--- a/.github/workflows/rh-support.yml
+++ b/.github/workflows/rh-support.yml
@@ -1,12 +1,8 @@
 name: smoke-tests-against-redhat
 on:
-  pull_request:
+  push:
     branches:
       - master
-# TODO remove pull request trigger and uncomment trigger below before merge
-#  push:
-#    branches:
-#      - master
 
 jobs:
   test-redhat:

--- a/.github/workflows/rh-support.yml
+++ b/.github/workflows/rh-support.yml
@@ -29,5 +29,7 @@ jobs:
             .
 
       - name: Execute Smoke Tests
+        env:
+          TEST_LOCALSTACK_API_KEY: ${{ secrets.TEST_LOCALSTACK_API_KEY }}
         run: |
           CI_SMOKE_IMAGE_NAME="localstack-redhat" make ci-pro-smoke-tests

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -1,0 +1,46 @@
+# Disclaimer: This Dockerfile is used to regularly test compatibility with RedHat based images.
+#             It is _not_ the usually Dockerfile and currently _not_ officially supported.
+
+FROM redhat/ubi8
+
+LABEL authors="LocalStack Contributors"
+LABEL maintainer="LocalStack Team (info@localstack.cloud)"
+LABEL description="LocalStack Docker image"
+
+RUN dnf install -y cyrus-sasl-devel gcc gcc-c++ git iputils make npm openssl-devel procps python38-devel zip \
+  && dnf clean all \
+  && rm -rf /var/cache/yum
+
+# Create a localstack user
+RUN useradd -ms /bin/bash localstack
+
+# Install python packages
+RUN python3 -m pip install supervisor awscli awscli-local localstack[runtime]>=0.14.0 localstack-ext[runtime]>=0.14.0 --upgrade --no-cache-dir
+# Install the basic libraries
+RUN python3 -m localstack.services.install libs
+
+# install entrypoint script
+ADD bin/docker-entrypoint.sh /usr/local/bin/
+# add the script to start LocalStack and add the supervisor.d config
+RUN mkdir -p /opt/code/localstack/bin/
+WORKDIR /opt/code/localstack/
+ADD bin/localstack /opt/code/localstack/bin/
+ADD bin/supervisord.conf /etc/supervisord.conf
+
+# Set default settings
+ENV USER=localstack
+ENV PYTHONUNBUFFERED=1
+ENV EDGE_BIND_HOST=0.0.0.0
+ENV LOCALSTACK_HOSTNAME=localhost
+
+# Add the build date and git hash at last (changes everytime)
+ARG LOCALSTACK_BUILD_DATE
+ARG LOCALSTACK_BUILD_GIT_HASH
+ENV LOCALSTACK_BUILD_DATE=${LOCALSTACK_BUILD_DATE}
+ENV LOCALSTACK_BUILD_GIT_HASH=${LOCALSTACK_BUILD_GIT_HASH}
+
+# expose ports
+EXPOSE 4510-4559 4566
+
+# define command at startup
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -15,7 +15,7 @@ RUN dnf install -y cyrus-sasl-devel gcc gcc-c++ git iputils make npm openssl-dev
 RUN useradd -ms /bin/bash localstack
 
 # Install python packages
-RUN python3 -m pip install supervisor awscli awscli-local localstack[runtime]>=0.14.0 localstack-ext[runtime]>=0.14.0 --upgrade --no-cache-dir
+RUN python3 -m pip install supervisor awscli awscli-local 'localstack[runtime]>=0.14.0' 'localstack-ext[runtime]>=0.14.0' --upgrade --no-cache-dir
 # Install the basic libraries
 RUN python3 -m localstack.services.install libs
 

--- a/bin/localstack
+++ b/bin/localstack
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import os

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -4,7 +4,9 @@ logfile=/tmp/supervisord.log
 
 [program:infra]
 directory=/opt/code/localstack
-command=make infra
+command=bin/localstack start --host --no-banner
+environment=
+    LOCALSTACK_INFRA_PROCESS=1
 autostart=true
 autorestart=true
 stdout_logfile=/tmp/localstack_infra.log

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -335,7 +335,7 @@ def terminate_all_processes_in_docker():
         return
     print("INFO: Received command to restart all processes ...")
     cmd = (
-        'ps aux | grep -v supervisor | grep -v docker-entrypoint.sh | grep -v "make infra" | '
+        'ps aux | grep -v supervisor | grep -v docker-entrypoint.sh | grep -v "bin/localstack" | '
         "grep -v localstack_infra.log | awk '{print $1}' | grep -v PID"
     )
     pids = run(cmd).strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ dataclasses; python_version < '3.7'
 #docopt>=0.6.2
 docker==5.0.0
 localstack-client>=1.31
-localstack-ext>=0.13.3
+localstack-ext>=0.14.0
 localstack-plugin-loader>=0.1.0
 psutil>=5.4.8,<6.0.0
 python-dotenv>=0.19.1


### PR DESCRIPTION
This PR contains changes to smoke-test LocalStack against RedHat / rpm based operating systems:
- Add a `Dockerfile.rh` which is based on  `redhat/ubi8` in order to build LocalStack on a RedHat / rpm based system.
  - This Dockerfile - in contrast to the default Dockerfile - does _not_ add the latest source code to the image, but installs the latest packages from PyPi. This means that the image may _not_ contain the latest changes in the repo.
- Add a new GitHub action (`smoke-tests-against-redhat`) to build the image and perform the CI smoke tests.
- Removes the deprecated `infra` make target (since there is no code in the RedHat Docker image).

What's left to do:
- [x] Add changes to our extensions (installing libs is currently not working).
- [x] Make sure the GitHub action works correctly.
- [x] Change the GitHub action trigger to a fixed schedule (as it's not coupled to the source code directly).