### PR TITLE
fix asf xml-rest parser location- and payload-trait handling

### DIFF
--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -622,6 +622,28 @@ def test_parse_cloudtrail_with_botocore():
     )
 
 
+def test_parse_cloudfront_with_botocore():
+    _botocore_parser_integration_test(
+        service="cloudfront",
+        action="GetDistribution",
+        Id="001",
+    )
+
+
+def test_parse_cloudfront_payload_with_botocore():
+    _botocore_parser_integration_test(
+        service="cloudfront",
+        action="CreateOriginRequestPolicy",
+        OriginRequestPolicyConfig={
+            "Comment": "comment1",
+            "Name": "name",
+            "HeadersConfig": {"HeaderBehavior": "none"},
+            "CookiesConfig": {"CookieBehavior": "all"},
+            "QueryStringsConfig": {"QueryStringBehavior": "all"},
+        },
+    )
+
+
 def test_parse_opensearch_conflicting_request_uris():
     """
     Tests if the operation detection works with conflicting regular expressions:

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -622,7 +622,7 @@ def test_parse_cloudtrail_with_botocore():
     )
 
 
-def test_parse_cloudfront_with_botocore():
+def test_parse_cloudfront_uri_location_with_botocore():
     _botocore_parser_integration_test(
         service="cloudfront",
         action="GetDistribution",


### PR DESCRIPTION
When migrating CloudFront to ASF, I noticed that the provider always gets `None` arguments.
This seems related to some problem in the parser.
When a payload is specified in the output shape, the payload itself is actually parsed correctly (line 592-593) but then the entire dictionary is set to `None` while parsing the rest of the shape.
To get along with the migration, I simply added a `return` after line 594 to temporary fix the problem.
This do not fix the issue when there is no payload (see `test_parse_cloudfront_with_botocore`).

https://github.com/localstack/localstack/blob/75f7e3034bd27e1c9a46a70ededcc06bbe2bd5c5/localstack/aws/protocol/parser.py#L591-L598