### PR TITLE
fix edge route mapping for STS AssumeRole

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -445,6 +445,9 @@ def get_api_from_custom_rules(method, path, data, headers):
     if _in_path_or_payload("Action=AssumeRoleWithSAML"):
         return "sts", config.service_port("sts")
 
+    if _in_path_or_payload("Action=AssumeRole"):
+        return "sts", config.service_port("sts")
+
     # CloudWatch backdoor API to retrieve raw metrics
     if path.startswith(PATH_GET_RAW_METRICS):
         return "cloudwatch", config.service_port("cloudwatch")


### PR DESCRIPTION
This should fix an issue (`Unable to find forwarding rule for host`) where the forwarding rule is not found when using the AWS SDK v2 in java to call STS assumeRole.