### PR TITLE
Cloudwatch implement set_alarm_state

### DIFF
--- a/localstack/services/cloudwatch/cloudwatch_starter.py
+++ b/localstack/services/cloudwatch/cloudwatch_starter.py
@@ -1,7 +1,15 @@
+import json
+import logging
+
 import moto.cloudwatch.responses as cloudwatch_responses
+from moto.cloudwatch.models import FakeAlarm
 
 from localstack import config
 from localstack.services.infra import start_moto_server
+from localstack.utils.aws import aws_stack
+from localstack.utils.patch import patch
+
+LOG = logging.getLogger(__name__)
 
 
 def apply_patches():
@@ -20,6 +28,86 @@ def apply_patches():
 
     if not hasattr(cloudwatch_responses.CloudWatchResponse, "put_composite_alarm"):
         cloudwatch_responses.CloudWatchResponse.put_composite_alarm = put_composite_alarm
+
+    @patch(target=FakeAlarm.update_state)
+    def update_state(target, self, reason, reason_data, state_value):
+        old_state = self.state_value
+        target(self, reason, reason_data, state_value)
+
+        # check the state and trigger required actions
+        if not self.actions_enabled or old_state == self.state_value:
+            return
+        actions = None
+        if self.state_value == "OK":
+            actions = self.ok_actions
+        elif self.state_value == "ALARM":
+            actions = self.alarm_actions
+        else:
+            actions = self.insufficient_data_actions
+        for action in actions:
+            data = aws_stack.parse_arn(action)
+            # test for sns - can this be done in a more generic way?
+            if data["service"] == "sns":
+                service = aws_stack.connect_to_service(data["service"])
+                subject = f"""{self.state_value}: "{self.name}" in {self.region_name}"""
+                message = create_message_response_update_state(self, old_state)
+                service.publish(TopicArn=action, Subject=subject, Message=message)
+            else:
+                # TODO: support other actions
+                LOG.warning(
+                    "Action for service %s not implemented, action '%s' will not be triggered.",
+                    data["service"],
+                    action,
+                )
+
+
+def create_message_response_update_state(alarm, old_state):
+    response = {
+        "OldStateValue": old_state,
+        "AlarmName": alarm.name,
+        "AlarmDescription": alarm.description or "",
+        "AlarmConfigurationUpdatedTimestamp": alarm.configuration_updated_timestamp,
+        "NewStateValue": alarm.state_value,
+        "NewStateReason": alarm.state_reason,
+        "StateChangeTime": alarm.state_updated_timestamp,
+        "Region": alarm.region_name,
+        "AlarmArn": alarm.alarm_arn,
+        "OKActions": alarm.ok_actions or "",
+        "AlarmActions": alarm.alarm_actions or "",
+        "InsufficientDataActions": alarm.insufficient_data_actions or "",
+    }
+
+    # collect trigger details
+    details = {
+        "MetricName": alarm.metric_name or "",
+        "Namespace": alarm.namespace or "",
+        "Unit": alarm.unit or "",
+        "Period": int(alarm.period) if alarm.period else 0,
+        "EvaluationPeriods": int(alarm.evaluation_periods) if alarm.evaluation_periods else 0,
+        "ComparisonOperator": alarm.comparison_operator or "",
+        "Threshold": float(alarm.threshold) if alarm.threshold else 0.0,
+        "TreatMissingData": alarm.treat_missing_data or "",
+        "EvaluateLowSampleCountPercentile": alarm.evaluate_low_sample_count_percentile or "",
+    }
+
+    # Dimensions not serializable
+    dimensions = []
+    if alarm.dimensions:
+        for d in alarm.dimensions:
+            dimensions.append({"value": d.value, "name": d.name})
+
+    details["Dimensions"] = dimensions or ""
+
+    if alarm.statistic:
+        details["StatisticType"] = "Statistic"
+        details["Statistic"] = alarm.statistic.upper()  # AWS returns uppercase
+    elif alarm.extended_statistic:
+        details["StatisticType"] = "ExtendedStatistic"
+        details["ExtendedStatistic"] = alarm.extended_statistic
+
+    response["Trigger"] = details
+
+    return json.dumps(response)
 
 
 def start_cloudwatch(port=None, asynchronous=False, update_listener=None):

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -1,6 +1,5 @@
 import gzip
 import json
-import unittest
 from datetime import datetime, timedelta
 from urllib.request import Request, urlopen
 
@@ -15,12 +14,10 @@ from localstack.utils.common import retry, short_uid, to_str
 PUBLICATION_RETRIES = 5
 
 
-class CloudWatchTest(unittest.TestCase):
-    def test_put_metric_data(self):
+class TestCloudwatch:
+    def test_put_metric_data(self, cloudwatch_client):
         metric_name = "metric-%s" % short_uid()
         namespace = "namespace-%s" % short_uid()
-
-        client = aws_stack.create_external_boto_client("cloudwatch")
 
         # Put metric data without value
         data = [
@@ -31,11 +28,11 @@ class CloudWatchTest(unittest.TestCase):
                 "Unit": "Seconds",
             }
         ]
-        rs = client.put_metric_data(Namespace=namespace, MetricData=data)
-        self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
+        rs = cloudwatch_client.put_metric_data(Namespace=namespace, MetricData=data)
+        assert 200 == rs["ResponseMetadata"]["HTTPStatusCode"]
 
         # Get metric statistics
-        rs = client.get_metric_statistics(
+        rs = cloudwatch_client.get_metric_statistics(
             Namespace=namespace,
             MetricName=metric_name,
             StartTime=datetime(2019, 1, 1),
@@ -43,15 +40,15 @@ class CloudWatchTest(unittest.TestCase):
             Period=120,
             Statistics=["Average"],
         )
-        self.assertEqual(metric_name, rs["Label"])
-        self.assertEqual(1, len(rs["Datapoints"]))
-        self.assertEqual(data[0]["Timestamp"], rs["Datapoints"][0]["Timestamp"])
+        assert metric_name == rs["Label"]
+        assert 1 == len(rs["Datapoints"])
+        assert data[0]["Timestamp"] == rs["Datapoints"][0]["Timestamp"]
 
-        rs = client.list_metrics(Namespace=namespace, MetricName=metric_name)
-        self.assertEqual(1, len(rs["Metrics"]))
-        self.assertEqual(namespace, rs["Metrics"][0]["Namespace"])
+        rs = cloudwatch_client.list_metrics(Namespace=namespace, MetricName=metric_name)
+        assert 1 == len(rs["Metrics"])
+        assert namespace == rs["Metrics"][0]["Namespace"]
 
-    def test_put_metric_data_gzip(self):
+    def test_put_metric_data_gzip(self, cloudwatch_client):
         metric_name = "test-metric"
         namespace = "namespace"
         data = (
@@ -78,25 +75,24 @@ class CloudWatchTest(unittest.TestCase):
         request = Request(url, encoded_data, headers, method="POST")
         urlopen(request)
 
-        client = aws_stack.create_external_boto_client("cloudwatch")
-        rs = client.list_metrics(Namespace=namespace, MetricName=metric_name)
-        self.assertEqual(1, len(rs["Metrics"]))
-        self.assertEqual(namespace, rs["Metrics"][0]["Namespace"])
+        rs = cloudwatch_client.list_metrics(Namespace=namespace, MetricName=metric_name)
+        assert 1 == len(rs["Metrics"])
+        assert namespace == rs["Metrics"][0]["Namespace"]
 
-    def test_get_metric_data(self):
+    def test_get_metric_data(self, cloudwatch_client):
 
-        conn = aws_stack.create_external_boto_client("cloudwatch")
-
-        conn.put_metric_data(
+        cloudwatch_client.put_metric_data(
             Namespace="some/thing", MetricData=[dict(MetricName="someMetric", Value=23)]
         )
-        conn.put_metric_data(
+        cloudwatch_client.put_metric_data(
             Namespace="some/thing", MetricData=[dict(MetricName="someMetric", Value=18)]
         )
-        conn.put_metric_data(Namespace="ug/thing", MetricData=[dict(MetricName="ug", Value=23)])
+        cloudwatch_client.put_metric_data(
+            Namespace="ug/thing", MetricData=[dict(MetricName="ug", Value=23)]
+        )
 
         # filtering metric data with current time interval
-        response = conn.get_metric_data(
+        response = cloudwatch_client.get_metric_data(
             MetricDataQueries=[
                 {
                     "Id": "some",
@@ -122,16 +118,16 @@ class CloudWatchTest(unittest.TestCase):
             EndTime=datetime.utcnow(),
         )
 
-        self.assertEqual(2, len(response["MetricDataResults"]))
+        assert 2 == len(response["MetricDataResults"])
 
         for data_metric in response["MetricDataResults"]:
             if data_metric["Id"] == "some":
-                self.assertEqual(41.0, data_metric["Values"][0])
+                assert 41.0 == data_metric["Values"][0]
             if data_metric["Id"] == "part":
-                self.assertEqual(23.0, data_metric["Values"][0])
+                assert 23.0 == data_metric["Values"][0]
 
         # filtering metric data with current time interval
-        response = conn.get_metric_data(
+        response = cloudwatch_client.get_metric_data(
             MetricDataQueries=[
                 {
                     "Id": "some",
@@ -159,19 +155,18 @@ class CloudWatchTest(unittest.TestCase):
 
         for data_metric in response["MetricDataResults"]:
             if data_metric["Id"] == "some":
-                self.assertEqual(0, len(data_metric["Values"]))
+                assert len(data_metric["Values"]) == 0
             if data_metric["Id"] == "part":
-                self.assertEqual(0, len(data_metric["Values"]))
+                assert len(data_metric["Values"]) == 0
 
         # get raw metric data
         url = "%s%s" % (config.get_edge_url(), PATH_GET_RAW_METRICS)
         result = requests.get(url)
-        self.assertEqual(200, result.status_code)
+        assert 200 == result.status_code
         result = json.loads(to_str(result.content))
-        self.assertGreaterEqual(len(result["metrics"]), 3)
+        assert len(result["metrics"]) >= 3
 
-    def test_multiple_dimensions(self):
-        client = aws_stack.create_external_boto_client("cloudwatch")
+    def test_multiple_dimensions(self, cloudwatch_client):
 
         namespaces = [
             "ns1-%s" % short_uid(),
@@ -181,7 +176,7 @@ class CloudWatchTest(unittest.TestCase):
         num_dimensions = 2
         for ns in namespaces:
             for i in range(3):
-                rs = client.put_metric_data(
+                rs = cloudwatch_client.put_metric_data(
                     Namespace=ns,
                     MetricData=[
                         {
@@ -196,44 +191,41 @@ class CloudWatchTest(unittest.TestCase):
                         }
                     ],
                 )
-                self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
+                assert 200 == rs["ResponseMetadata"]["HTTPStatusCode"]
 
-        rs = client.list_metrics()
+        rs = cloudwatch_client.list_metrics()
         metrics = [m for m in rs["Metrics"] if m.get("Namespace") in namespaces]
-        self.assertTrue(metrics)
-        self.assertEqual(len(metrics), len(namespaces) * num_dimensions)
+        assert metrics
+        assert len(metrics) == len(namespaces) * num_dimensions
 
-    def test_store_tags(self):
-        cloudwatch = aws_stack.create_external_boto_client("cloudwatch")
-
+    def test_store_tags(self, cloudwatch_client):
         alarm_name = "a-%s" % short_uid()
-        response = cloudwatch.put_metric_alarm(
+        response = cloudwatch_client.put_metric_alarm(
             AlarmName=alarm_name,
             EvaluationPeriods=1,
             ComparisonOperator="GreaterThanThreshold",
         )
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
+        assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
         alarm_arn = aws_stack.cloudwatch_alarm_arn(alarm_name)
 
         tags = [{"Key": "tag1", "Value": "foo"}, {"Key": "tag2", "Value": "bar"}]
-        response = cloudwatch.tag_resource(ResourceARN=alarm_arn, Tags=tags)
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-        response = cloudwatch.list_tags_for_resource(ResourceARN=alarm_arn)
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-        self.assertEqual(tags, response["Tags"])
-        response = cloudwatch.untag_resource(ResourceARN=alarm_arn, TagKeys=["tag1"])
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-        response = cloudwatch.list_tags_for_resource(ResourceARN=alarm_arn)
-        self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
-        self.assertEqual([{"Key": "tag2", "Value": "bar"}], response["Tags"])
+        response = cloudwatch_client.tag_resource(ResourceARN=alarm_arn, Tags=tags)
+        assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
+        response = cloudwatch_client.list_tags_for_resource(ResourceARN=alarm_arn)
+        assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
+        assert tags, response["Tags"]
+        response = cloudwatch_client.untag_resource(ResourceARN=alarm_arn, TagKeys=["tag1"])
+        assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
+        response = cloudwatch_client.list_tags_for_resource(ResourceARN=alarm_arn)
+        assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
+        assert [{"Key": "tag2", "Value": "bar"}] == response["Tags"]
 
         # clean up
-        cloudwatch.delete_alarms(AlarmNames=[alarm_name])
+        cloudwatch_client.delete_alarms(AlarmNames=[alarm_name])
 
-    def test_list_metrics_uniqueness(self):
-        cloudwatch = aws_stack.create_external_boto_client("cloudwatch")
+    def test_list_metrics_uniqueness(self, cloudwatch_client):
         # create metrics with same namespace and dimensions but different metric names
-        cloudwatch.put_metric_data(
+        cloudwatch_client.put_metric_data(
             Namespace="AWS/EC2",
             MetricData=[
                 {
@@ -243,7 +235,7 @@ class CloudWatchTest(unittest.TestCase):
                 }
             ],
         )
-        cloudwatch.put_metric_data(
+        cloudwatch_client.put_metric_data(
             Namespace="AWS/EC2",
             MetricData=[
                 {
@@ -253,10 +245,10 @@ class CloudWatchTest(unittest.TestCase):
                 }
             ],
         )
-        results = cloudwatch.list_metrics(Namespace="AWS/EC2")["Metrics"]
-        self.assertEqual(2, len(results))
+        results = cloudwatch_client.list_metrics(Namespace="AWS/EC2")["Metrics"]
+        assert 2 == len(results)
         # duplicating existing metric
-        cloudwatch.put_metric_data(
+        cloudwatch_client.put_metric_data(
             Namespace="AWS/EC2",
             MetricData=[
                 {
@@ -267,57 +259,9 @@ class CloudWatchTest(unittest.TestCase):
             ],
         )
         # asserting only unique values are returned
-        results = cloudwatch.list_metrics(Namespace="AWS/EC2")["Metrics"]
-        self.assertEqual(2, len(results))
+        results = cloudwatch_client.list_metrics(Namespace="AWS/EC2")["Metrics"]
+        assert 2 == len(results)
 
-
-def check_message(
-    sqs_client,
-    expected_queue_url,
-    expected_topic_arn,
-    expected_new,
-    expected_reason,
-    alarm_name,
-    alarm_description,
-    expected_trigger,
-):
-    receive_result = sqs_client.receive_message(QueueUrl=expected_queue_url)
-    message = None
-    for msg in receive_result["Messages"]:
-        body = json.loads(msg["Body"])
-        if body["TopicArn"] == expected_topic_arn:
-            message = json.loads(body["Message"])
-            break
-    assert message["NewStateValue"] == expected_new
-    assert message["NewStateReason"] == expected_reason
-    assert message["AlarmName"] == alarm_name
-    assert message["AlarmDescription"] == alarm_description
-    assert message["Trigger"] == expected_trigger
-    return message
-
-
-def get_sqs_policy(sqs_queue_arn, sns_topic_arn):
-    return f"""
-{{
-  "Version":"2012-10-17",
-  "Statement":[
-    {{
-      "Effect": "Allow",
-      "Principal": {{ "AWS": "*" }},
-      "Action": "sqs:SendMessage",
-      "Resource": "{sqs_queue_arn}",
-      "Condition":{{
-        "ArnEquals":{{
-        "aws:SourceArn":"{sns_topic_arn}"
-        }}
-      }}
-    }}
-  ]
-}}
-"""
-
-
-class TestCloudwatch:
     def test_set_alarm(
         self, sns_client, cloudwatch_client, sqs_client, sns_create_topic, sqs_create_queue
     ):
@@ -437,3 +381,49 @@ class TestCloudwatch:
             sns_client.unsubscribe(SubscriptionArn=subscription_alarm["SubscriptionArn"])
             sns_client.unsubscribe(SubscriptionArn=subscription_ok["SubscriptionArn"])
             cloudwatch_client.delete_alarms(AlarmNames=[alarm_name])
+
+
+def check_message(
+    sqs_client,
+    expected_queue_url,
+    expected_topic_arn,
+    expected_new,
+    expected_reason,
+    alarm_name,
+    alarm_description,
+    expected_trigger,
+):
+    receive_result = sqs_client.receive_message(QueueUrl=expected_queue_url)
+    message = None
+    for msg in receive_result["Messages"]:
+        body = json.loads(msg["Body"])
+        if body["TopicArn"] == expected_topic_arn:
+            message = json.loads(body["Message"])
+            break
+    assert message["NewStateValue"] == expected_new
+    assert message["NewStateReason"] == expected_reason
+    assert message["AlarmName"] == alarm_name
+    assert message["AlarmDescription"] == alarm_description
+    assert message["Trigger"] == expected_trigger
+    return message
+
+
+def get_sqs_policy(sqs_queue_arn, sns_topic_arn):
+    return f"""
+{{
+  "Version":"2012-10-17",
+  "Statement":[
+    {{
+      "Effect": "Allow",
+      "Principal": {{ "AWS": "*" }},
+      "Action": "sqs:SendMessage",
+      "Resource": "{sqs_queue_arn}",
+      "Condition":{{
+        "ArnEquals":{{
+        "aws:SourceArn":"{sns_topic_arn}"
+        }}
+      }}
+    }}
+  ]
+}}
+"""


### PR DESCRIPTION
This PR enables the triggering of actions that are set on alarms, when calling `set_alarm_state`.
Limitations: 
 - Currently only SNS is supported as action. 
 - Metrics are not yet evaluated, only the `set_alarm_state` will change the state of an alarm and therefore trigger actions. 