### PR TITLE
Add PaginatedList for paginating and filtering response lists

### DIFF
--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -493,9 +493,9 @@ class PaginatedList(list):
 
     def get_page(
         self,
-        next_token: str,
         token_generator: Callable,
-        page_size: int,
+        next_token: str = None,
+        page_size: int = None,
         filter_function: Callable = None,
     ) -> (list, str):
         if filter_function is not None:
@@ -517,8 +517,10 @@ class PaginatedList(list):
         except StopIteration:
             pass
 
-        if start_idx + page_size <= len(result_list[start_idx:]):
+        if start_idx + page_size <= len(result_list):
             next_token = token_generator(result_list[start_idx + page_size])
+        else:
+            next_token = None
 
         return result_list[start_idx : start_idx + page_size], next_token
 

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -486,6 +486,43 @@ class HashableList(list):
         return result
 
 
+class PaginatedList(list):
+    """List which can be paginated and filtered. For usage in AWS APIs with paginated responses"""
+
+    DEFAULT_PAGE_SIZE = 50
+
+    def get_page(
+        self,
+        next_token: str,
+        token_generator: Callable,
+        page_size: int,
+        filter_function: Callable = None,
+    ) -> (list, str):
+        if filter_function is not None:
+            result_list = list(filter(filter_function, self))
+        else:
+            result_list = self
+
+        if page_size is None:
+            page_size = self.DEFAULT_PAGE_SIZE
+
+        if len(result_list) <= page_size:
+            return result_list, None
+
+        start_idx = 0
+
+        try:
+            start_item = next(item for item in result_list if token_generator(item) == next_token)
+            start_idx = result_list.index(start_item)
+        except StopIteration:
+            pass
+
+        if start_idx + page_size <= len(result_list[start_idx:]):
+            next_token = token_generator(result_list[start_idx + page_size])
+
+        return result_list[start_idx : start_idx + page_size], next_token
+
+
 class FileMappedDocument(dict):
     """A dictionary that is mapped to a json document on disk.
 


### PR DESCRIPTION
This PR adds a helper class for handling paging and filtering in AWS services in a unified way. This is useful for avoiding boilerplate code in ASF implementations of services.

An example usage would be: 

```python
[...]

paginated_list = PaginatedList(EntityRegion.get().entity.values())

page, next_token = paginated_list.get_page(
     next_page_token,
     lambda entity: entity[Id],
     page_size=max_results,
     filter_function= lambda entity: entity["Name"] != "BAD"
)

[...]
```