### PR TITLE
Bump version of moto-ext to 3.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ flask_swagger==0.2.12
 jsonpatch>=1.24,<2.0
 jsonpath-rw>=1.4.0,<2.0.0
 localstack-ext[full]>=0.13.2
-moto-ext[all]>=3.0.0
+moto-ext[all]==3.0.1
 pproxy>=2.7.0
 #pympler>=0.6
 pyopenssl>=21.0.0

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -110,7 +110,7 @@ class TestRoute53:
 
         with pytest.raises(Exception) as ctx:
             client.get_reusable_delegation_set(Id=set_id_1)
-        assert ctx.value.response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        assert ctx.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
 
 
 class TestRoute53Resolver:


### PR DESCRIPTION
Bump version of moto-ext to 3.0.1. Pinning the version for now, to avoid instabilities with upgrades in the future.