### PR TITLE
Fix increase in testing time due to missing kwargs in sqs test

### DIFF
--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -601,7 +601,7 @@ def create_lambda_function(lambda_client: "LambdaClient", iam_client):
     lambda_arns = []
     role_names = []
 
-    def _create_lambda_function(*args, **kwargs):
+    def _create_lambda_function(**kwargs):
         kwargs["client"] = lambda_client
 
         if not kwargs.get("role"):
@@ -618,7 +618,7 @@ def create_lambda_function(lambda_client: "LambdaClient", iam_client):
             kwargs["role"] = role["Arn"]
 
         def _create_function():
-            resp = testutil.create_lambda_function(*args, **kwargs)
+            resp = testutil.create_lambda_function(**kwargs)
             lambda_arns.append(resp["CreateFunctionResponse"]["FunctionArn"])
 
             def _is_not_pending():

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -355,7 +355,7 @@ class TestSqsProvider:
 
         lambda_name = f"lambda-{short_uid()}"
         create_lambda_function(
-            lambda_name,
+            func_name=lambda_name,
             libs=TEST_LAMBDA_LIBS,
             handler_file=TEST_LAMBDA_PYTHON,
             runtime=LAMBDA_RUNTIME_PYTHON36,
@@ -968,7 +968,7 @@ class TestSqsProvider:
 
         lambda_name = f"lambda-{short_uid()}"
         create_lambda_function(
-            lambda_name,
+            func_name=lambda_name,
             libs=TEST_LAMBDA_LIBS,
             handler_file=TEST_LAMBDA_PYTHON,
             runtime=LAMBDA_RUNTIME_PYTHON36,
@@ -1438,7 +1438,7 @@ class TestSqsProvider:
 
         lambda_name = "lambda-{}".format(short_uid())
         create_lambda_function(
-            lambda_name,
+            func_name=lambda_name,
             libs=TEST_LAMBDA_LIBS,
             handler_file=TEST_LAMBDA_PYTHON,
             runtime=LAMBDA_RUNTIME_PYTHON36,


### PR DESCRIPTION
Currently, the create_lambda_function fixture depends on the kwargs["func_name"] being set, but that is not set by sqs tests.

Therefore, we have 240s waiting times which are not necessary at all, which can fail the tests due to job execution timeouts.

This should shave off 6-9 min off our test times.

Also the function signature has changed, to prevent this in the future.