### PR TITLE
Fix service provider configuration override

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -867,12 +867,17 @@ class ServiceProviderConfig(Mapping[str, str]):
 
 SERVICE_PROVIDER_CONFIG = ServiceProviderConfig("default")
 
-override_prefix = "PROVIDER_OVERRIDE_"
-for key, value in os.environ.items():
-    if key.startswith(override_prefix):
-        SERVICE_PROVIDER_CONFIG.set_provider(
-            key[len(override_prefix) :].lower().replace("_", "-"), value
-        )
+
+def process_provider_overrides(provider_config):
+    override_prefix = "PROVIDER_OVERRIDE_"
+    for key, value in os.environ.items():
+        if key.startswith(override_prefix):
+            provider_config.set_provider(
+                key[len(override_prefix) :].lower().replace("_", "-"), value
+            )
+
+
+process_provider_overrides(SERVICE_PROVIDER_CONFIG)
 
 # initialize directories
 if is_in_docker:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -839,9 +839,9 @@ class ServiceProviderConfig(Mapping[str, str]):
         self._provider_config = {}
         self.default_value = default_value
 
-    def load_from_environment(self, env: Dict[str, str] = None):
+    def load_from_environment(self, env: Mapping[str, str] = None):
         if env is None:
-            env = dict(os.environ)
+            env = os.environ
         for key, value in env.items():
             if key.startswith(self.override_prefix):
                 self.set_provider(key[len(self.override_prefix) :].lower().replace("_", "-"), value)

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -867,10 +867,11 @@ class ServiceProviderConfig(Mapping[str, str]):
 
 SERVICE_PROVIDER_CONFIG = ServiceProviderConfig("default")
 
+override_prefix = "PROVIDER_OVERRIDE_"
 for key, value in os.environ.items():
-    if key.startswith("PROVIDER_OVERRIDE_"):
+    if key.startswith(override_prefix):
         SERVICE_PROVIDER_CONFIG.set_provider(
-            key.lstrip("PROVIDER_OVERRIDE_").lower().replace("_", "-"), value
+            key[len(override_prefix) :].lower().replace("_", "-"), value
         )
 
 # initialize directories

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -16,6 +16,51 @@ def temporary_env(env: Dict[str, Any]):
         os.environ.update(old)
 
 
+class TestProviderConfig:
+    def test_provider_default_value(self):
+        default_value = "default_value"
+        override_value = "override_value"
+        provider_config = config.ServiceProviderConfig(default_value=default_value)
+        assert provider_config.get_provider("ec2") == default_value
+        provider_config.set_provider("ec2", override_value)
+        assert provider_config.get_provider("ec2") == override_value
+
+    def test_provider_set_if_not_exists(self):
+        default_value = "default_value"
+        override_value = "override_value"
+        provider_config = config.ServiceProviderConfig(default_value=default_value)
+        provider_config.set_provider("ec2", default_value)
+        provider_config.set_provider_if_not_exists("ec2", override_value)
+        assert provider_config.get_provider("ec2") == default_value
+
+    def test_provider_config_overrides(self, monkeypatch):
+        default_value = "default_value"
+        override_value = "override_value"
+        provider_config = config.ServiceProviderConfig(default_value=default_value)
+        monkeypatch.setenv("PROVIDER_OVERRIDE_EC2", override_value)
+        config.process_provider_overrides(provider_config)
+        assert provider_config.get_provider("ec2") == override_value
+        assert provider_config.get_provider("sqs") == default_value
+        monkeypatch.setenv("PROVIDER_OVERRIDE_SQS", override_value)
+        config.process_provider_overrides(provider_config)
+        assert provider_config.get_provider("sqs") == override_value
+
+    def test_bulk_set_if_not_exists(self):
+        default_value = "default_value"
+        custom_value = "custom_value"
+        override_value = "override_value"
+        override_services = ["sqs", "sns", "lambda", "ec2"]
+        provider_config = config.ServiceProviderConfig(default_value=default_value)
+        provider_config.set_provider("ec2", default_value)
+        provider_config.set_provider("lambda", custom_value)
+        provider_config.bulk_set_provider_if_not_exists(override_services, override_value)
+        assert provider_config.get_provider("sqs") == override_value
+        assert provider_config.get_provider("sns") == override_value
+        assert provider_config.get_provider("lambda") == custom_value
+        assert provider_config.get_provider("ec2") == default_value
+        assert provider_config.get_provider("kinesis") == default_value
+
+
 class TestParseServicePorts:
     def test_returns_default_service_ports(self):
         result = config.parse_service_ports()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,11 +38,11 @@ class TestProviderConfig:
         override_value = "override_value"
         provider_config = config.ServiceProviderConfig(default_value=default_value)
         monkeypatch.setenv("PROVIDER_OVERRIDE_EC2", override_value)
-        config.process_provider_overrides(provider_config)
+        provider_config.load_from_environment()
         assert provider_config.get_provider("ec2") == override_value
         assert provider_config.get_provider("sqs") == default_value
         monkeypatch.setenv("PROVIDER_OVERRIDE_SQS", override_value)
-        config.process_provider_overrides(provider_config)
+        provider_config.load_from_environment()
         assert provider_config.get_provider("sqs") == override_value
 
     def test_bulk_set_if_not_exists(self):


### PR DESCRIPTION
Embarrassingly, the current implementation uses lstrip, which is the completely wrong method for the purpose. (shame on me)

This PR changes the stripping of the provider override to a substring operation (removeprefix is sadly only available in python3.9 and upward), instead of the currently completely wrong lstrip.

Also, some unit tests are added to test the behavior of the ProviderConfig class in general.