### PR TITLE
Fix replacement of AWS::NoValue, add default props for Elasticsearch::Domain resources

### DIFF
--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -43,12 +43,12 @@ def param_defaults(param_func, defaults):
 
 
 def remove_none_values(params):
-    """Remove None values recursively in the given object."""
+    """Remove None values and AWS::NoValue placeholders (recursively) in the given object."""
 
     def remove_nones(o, **kwargs):
         if isinstance(o, dict):
             for k, v in dict(o).items():
-                if v is None:
+                if v in [None, PLACEHOLDER_AWS_NO_VALUE]:
                     o.pop(k)
         if isinstance(o, list):
             common.run_safe(o.remove, None)

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -1,6 +1,7 @@
-from localstack.services.cloudformation.deployment_utils import select_parameters
+from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
+from localstack.utils.common import select_attributes
 
 
 def es_add_tags_params(params, **kwargs):
@@ -32,24 +33,35 @@ class ElasticsearchDomain(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
+        def _create_params(params, **kwargs):
+            attributes = [
+                "AccessPolicies",
+                "AdvancedOptions",
+                "CognitoOptions",
+                "DomainName",
+                "EBSOptions",
+                "ElasticsearchClusterConfig",
+                "ElasticsearchVersion",
+                "EncryptionAtRestOptions",
+                "LogPublishingOptions",
+                "NodeToNodeEncryptionOptions",
+                "SnapshotOptions",
+                "VPCOptions",
+            ]
+            result = select_attributes(params, attributes)
+            result = remove_none_values(result)
+            cluster_config = result.setdefault("ElasticsearchClusterConfig", {})
+            if not cluster_config.get("DedicatedMasterType"):
+                # set defaults required for boto3 calls
+                cluster_config.setdefault("DedicatedMasterType", "m3.medium.elasticsearch")
+                cluster_config.setdefault("WarmType", "ultrawarm1.medium.elasticsearch")
+            return result
+
         return {
             "create": [
                 {
                     "function": "create_elasticsearch_domain",
-                    "parameters": select_parameters(
-                        "AccessPolicies",
-                        "AdvancedOptions",
-                        "CognitoOptions",
-                        "DomainName",
-                        "EBSOptions",
-                        "ElasticsearchClusterConfig",
-                        "ElasticsearchVersion",
-                        "EncryptionAtRestOptions",
-                        "LogPublishingOptions",
-                        "NodeToNodeEncryptionOptions",
-                        "SnapshotOptions",
-                        "VPCOptions",
-                    ),
+                    "parameters": _create_params,
                 },
                 {"function": "add_tags", "parameters": es_add_tags_params},
             ],

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -50,8 +50,8 @@ class ElasticsearchDomain(GenericBaseModel):
             ]
             result = select_attributes(params, attributes)
             result = remove_none_values(result)
-            cluster_config = result.setdefault("ElasticsearchClusterConfig", {})
-            if not cluster_config.get("DedicatedMasterType"):
+            cluster_config = result.get("ElasticsearchClusterConfig")
+            if isinstance(cluster_config, dict):
                 # set defaults required for boto3 calls
                 cluster_config.setdefault("DedicatedMasterType", "m3.medium.elasticsearch")
                 cluster_config.setdefault("WarmType", "ultrawarm1.medium.elasticsearch")

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -117,6 +117,11 @@ Resources:
     Type: AWS::Elasticsearch::Domain
     Properties:
       DomainName: !Ref "DomainName"
+      ElasticsearchClusterConfig:
+        InstanceCount: 1
+        InstanceType: 'm5.large.elasticsearch'
+        ZoneAwarenessEnabled: false
+        # remaining required attributes (DedicatedMasterType, WarmType) should get filled in by template deployer
       Tags:
         - Key: k1
           Value: v1

--- a/tests/unit/test_cloudformation.py
+++ b/tests/unit/test_cloudformation.py
@@ -1,6 +1,10 @@
 import re
 
 from localstack.services.cloudformation.cloudformation_api import Stack
+from localstack.services.cloudformation.deployment_utils import (
+    PLACEHOLDER_AWS_NO_VALUE,
+    remove_none_values,
+)
 from localstack.services.cloudformation.models.stepfunctions import _apply_substitutions
 from localstack.utils.cloudformation import template_deployer, template_preparer
 
@@ -53,3 +57,15 @@ def test_apply_substitutions():
     subs = {"foo": "bar", "test": "resolved"}
 
     assert _apply_substitutions(blubstr, subs) == "something bar and resolved + bar"
+
+
+def test_remove_none_values():
+    template = {
+        "Properties": {
+            "prop1": 123,
+            "nested": {"test1": PLACEHOLDER_AWS_NO_VALUE, "test2": None},
+            "list": [1, 2, PLACEHOLDER_AWS_NO_VALUE, 3, None],
+        }
+    }
+    result = remove_none_values(template)
+    assert result == {"Properties": {"prop1": 123, "nested": {}, "list": [1, 2, 3]}}


### PR DESCRIPTION
* fix replacement of `AWS::NoValue` in dict values
* add default props for `Elasticsearch::Domain` CloudFormation resources