### PR TITLE
fix some ASF parser, serializer, and scaffold issues

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -75,7 +75,7 @@ from abc import ABC
 from collections import OrderedDict, defaultdict
 from email.utils import parsedate_to_datetime
 from typing import Any, DefaultDict, Dict, List, Optional, Pattern, Tuple, Union
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, unquote
 from xml.etree import ElementTree as ETree
 
 import dateutil.parser
@@ -192,7 +192,7 @@ class RequestParser(abc.ABC):
             elif location == "uri":
                 regex_group_name = shape.serialization.get("name")
                 match = path_regex.match(request.path)
-                payload = match.group(regex_group_name)
+                payload = unquote(match.group(regex_group_name))
             else:
                 raise RequestParserError("Unknown shape location '%s'." % location)
         else:

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -590,12 +590,16 @@ class BaseRestRequestParser(RequestParser):
                 body = self._create_event_stream(request, body_shape)
                 payload_parsed[payload_member_name] = body
             elif body_shape.type_name == "string":
-                body = request.data
-                if isinstance(body, bytes):
-                    body = body.decode(self.DEFAULT_ENCODING)
-                payload_parsed[payload_member_name] = body
+                # Only set the value if it's not empty (the request's data is an empty binary by default)
+                if request.data:
+                    body = request.data
+                    if isinstance(body, bytes):
+                        body = body.decode(self.DEFAULT_ENCODING)
+                    payload_parsed[payload_member_name] = body
             elif body_shape.type_name == "blob":
-                payload_parsed[payload_member_name] = request.data
+                # Only set the value if it's not empty (the request's data is an empty binary by default)
+                if request.data:
+                    payload_parsed[payload_member_name] = request.data
             else:
                 original_parsed = self._initial_body_parse(request.data)
                 payload_parsed[payload_member_name] = self._parse_shape(

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -21,9 +21,9 @@ from typing_extensions import OrderedDict
 from localstack.aws.spec import load_service
 from localstack.utils.common import camel_to_snake_case, mkdir, snake_to_camel_case
 
-
-def is_keyword(name: str) -> bool:
-    return name in keyword.kwlist
+# Some minification packages might treat "type" as a keyword.
+KEYWORDS = list(keyword.kwlist) + ["type"]
+is_keyword = KEYWORDS.__contains__
 
 
 def is_bad_param_name(name: str) -> bool:

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -18,7 +18,6 @@ import requests
 from plugin import Plugin, PluginManager
 
 from localstack import config
-from localstack.aws.api.opensearch import EngineType
 from localstack.config import dirs, has_docker
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS,
@@ -166,6 +165,8 @@ def get_elasticsearch_install_dir(version: str) -> str:
 
 
 def install_elasticsearch(version=None):
+    # locally import to avoid having a dependency on ASF when starting the CLI
+    from localstack.aws.api.opensearch import EngineType
     from localstack.services.opensearch import versions
 
     if not version:
@@ -250,6 +251,8 @@ def get_opensearch_install_dir(version: str) -> str:
 
 
 def install_opensearch(version=None):
+    # locally import to avoid having a dependency on ASF when starting the CLI
+    from localstack.aws.api.opensearch import EngineType
     from localstack.services.opensearch import versions
 
     if not version:

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -557,7 +557,7 @@ def test_restjson_awslambda_invoke_with_botocore():
         service="lambda",
         action="Invoke",
         headers={},
-        expected={"FunctionName": "test-function", "Payload": ""},
+        expected={"FunctionName": "test-function", "Payload": b""},
         FunctionName="test-function",
     )
 
@@ -660,6 +660,20 @@ def test_parse_opensearch_conflicting_request_uris():
         service="opensearch",
         action="DescribeDomain",
         DomainName="test-domain",
+    )
+
+
+def test_parse_appconfig_non_json_blob_payload():
+    """
+    Tests if the parsing works correctly if the request contains a blob payload shape which does not contain valid JSON.
+    """
+    _botocore_parser_integration_test(
+        service="appconfig",
+        action="CreateHostedConfigurationVersion",
+        ApplicationId="test-application-id",
+        ConfigurationProfileId="test-configuration-profile-id",
+        Content=b"<html></html>",
+        ContentType="application/html",
     )
 
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -702,6 +702,20 @@ def test_parse_s3_with_extended_uri_pattern():
     )
 
 
+def test_parse_restjson_uri_location():
+    """
+    Tests if the parsing of uri parameters works correctly for the rest-json protocol
+    """
+    _botocore_parser_integration_test(
+        service="lambda",
+        action="AddPermission",
+        Action="lambda:InvokeFunction",
+        FunctionName="arn:aws:lambda:us-east-1:000000000000:function:test-forward-sns",
+        Principal="sns.amazonaws.com",
+        StatementId="2e25f762",
+    )
+
+
 # TODO Add additional tests (or even automate the creation)
 # - Go to the Boto3 Docs (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/index.html)
 # - Look for boto3 request syntax definition for services that use the protocol you want to test

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -556,8 +556,6 @@ def test_restjson_awslambda_invoke_with_botocore():
     _botocore_parser_integration_test(
         service="lambda",
         action="Invoke",
-        headers={},
-        expected={"FunctionName": "test-function", "Payload": b""},
         FunctionName="test-function",
     )
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -677,6 +677,31 @@ def test_parse_appconfig_non_json_blob_payload():
     )
 
 
+def test_parse_s3_with_extended_uri_pattern():
+    """
+    Tests if the parsing works for operations where the operation defines a request URI with a "+" in the variable name,
+    (for example "requestUri":"/{Bucket}/{Key+}").
+    The parameter with the "+" directive is greedy. There can only be one explicitly greedy param.
+    The corresponding shape definition does not contain the "+" in the "locationName" directive.
+    """
+    _botocore_parser_integration_test(
+        service="s3",
+        action="ListParts",
+        Bucket="foo",
+        Key="bar/test",
+        UploadId="test-upload-id",
+        expected={
+            "Bucket": "foo",
+            "Key": "bar/test",
+            "UploadId": "test-upload-id",
+            "ExpectedBucketOwner": None,
+            "MaxParts": None,
+            "PartNumberMarker": None,
+            "RequestPayer": None,
+        },
+    )
+
+
 # TODO Add additional tests (or even automate the creation)
 # - Go to the Boto3 Docs (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/index.html)
 # - Look for boto3 request syntax definition for services that use the protocol you want to test

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -768,6 +768,41 @@ def test_restjson_payload_serialization():
     assert headers["content-type"] == "application/json"
 
 
+def test_restjson_none_serialization():
+    parameters = {
+        "FunctionName": "test-name",
+        "VpcConfig": {"SubnetIds": None, "SecurityGroupIds": [None], "VpcId": "123"},
+        "TracingConfig": None,
+        "DeadLetterConfig": {},
+    }
+    expected = {
+        "FunctionName": "test-name",
+        "VpcConfig": {"SecurityGroupIds": [], "VpcId": "123"},
+        "DeadLetterConfig": {},
+    }
+    _botocore_serializer_integration_test(
+        "lambda", "CreateFunction", parameters, status_code=201, expected_response_content=expected
+    )
+
+
+def test_restxml_none_serialization():
+    # Structure = None
+    _botocore_serializer_integration_test(
+        "route53", "ListHostedZonesByName", {}, expected_response_content={}
+    )
+    # Structure Value = None
+    parameters = {"HostedZones": None}
+    _botocore_serializer_integration_test(
+        "route53", "ListHostedZonesByName", parameters, expected_response_content={}
+    )
+    # List Value = None
+    parameters = {"HostedZones": [None]}
+    expected = {"HostedZones": []}
+    _botocore_serializer_integration_test(
+        "route53", "ListHostedZonesByName", parameters, expected_response_content=expected
+    )
+
+
 @pytest.mark.xfail(
     reason="fails until botocore#2609 is fixed: https://github.com/boto/botocore/issues/2609"
 )


### PR DESCRIPTION
This PR contains a set of fixes for the ASF parser, serializer, and scaffold:
- (misc) remove an unexpected CLI dependency on ASF/werkzeug due to a module import in `install.py`.
- (scaffold) fix issues with minifying generated APIs when parameters or types are called `type`.
- (parser) fix invalid blob payload decoding
- (parser) fix greedy URI path param handling
- (parser) fix uri location decoding
- (parser) fix empty payload handling
- (serializer) fix None list/structure/map serializations

The fixes have been verified by newly written or adapted unit tests, as well as with the ASF parser challenger executed in the pipeline of PR #5411.
Since each commit contains explicitly one fix, it might make sense to avoid squashing these commits (for the sake of traceability).