### PR TITLE
implement in-memory request dispatching to moto

### DIFF
--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -2,7 +2,7 @@ import functools
 import json
 import sys
 from io import BytesIO
-from typing import IO, Any, Callable, Dict, NamedTuple, Optional, Type, Union
+from typing import IO, Any, Callable, Dict, NamedTuple, Optional, Tuple, Type, Union
 
 from localstack.utils.common import to_bytes
 
@@ -70,6 +70,7 @@ class HttpRequest(_SansIORequest):
         root_path: str = "/",
         query_string: Union[bytes, str] = b"",
         remote_addr: str = None,
+        server: Optional[Tuple[str, Optional[int]]] = None,
     ):
         if not headers:
             self.headers = Headers()
@@ -88,7 +89,7 @@ class HttpRequest(_SansIORequest):
         super(HttpRequest, self).__init__(
             method=method,
             scheme=scheme,
-            server=("127.0.0.1", None),
+            server=server or ("127.0.0.1", None),
             root_path=root_path,
             path=path,
             query_string=to_bytes(query_string),

--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -219,7 +219,9 @@ class RequestContext:
         return ServiceOperation(self.service.service_name, self.operation.name)
 
 
-ServiceRequestHandler = Callable[[RequestContext, ServiceRequest], Optional[ServiceResponse]]
+ServiceRequestHandler = Callable[
+    [RequestContext, ServiceRequest], Optional[Union[ServiceResponse, HttpResponse]]
+]
 
 
 def handler(operation: str = None, context: bool = True, expand: bool = True):

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -163,6 +163,11 @@ class Skeleton:
 
         # Call the appropriate handler
         result = handler(context, instance) or {}
+
+        # if the service handler returned an HTTP request, forego serialization and return immediately
+        if isinstance(result, HttpResponse):
+            return result
+
         # Serialize result dict to an HTTPResponse and return it
         return self.serializer.serialize_to_response(result, operation)
 

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -1,31 +1,49 @@
-from localstack.aws.api import RequestContext
+from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.cloudwatch import (
     AmazonResourceName,
     CloudwatchApi,
     ListTagsForResourceOutput,
+    PutMetricAlarmInput,
     TagKeyList,
     TagList,
     TagResourceOutput,
     UntagResourceOutput,
 )
-from localstack.services.cloudwatch.cloudwatch_listener import TAGS
+from localstack.services import moto
+from localstack.utils.aws import aws_stack
+from localstack.utils.tagging import TaggingService
 
 
 class CloudwatchProvider(CloudwatchApi):
+    def __init__(self):
+        self.tags = TaggingService()
+
     def list_tags_for_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName
     ) -> ListTagsForResourceOutput:
-        tags = TAGS.list_tags_for_resource(resource_arn)
+        tags = self.tags.list_tags_for_resource(resource_arn)
         return ListTagsForResourceOutput(Tags=tags.get("Tags", []))
 
     def untag_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName, tag_keys: TagKeyList
     ) -> UntagResourceOutput:
-        TAGS.untag_resource(resource_arn, tag_keys)
+        self.tags.untag_resource(resource_arn, tag_keys)
         return UntagResourceOutput()
 
     def tag_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName, tags: TagList
     ) -> TagResourceOutput:
-        TAGS.tag_resource(resource_arn, tags)
+        self.tags.tag_resource(resource_arn, tags)
         return TagResourceOutput()
+
+    @handler("PutMetricAlarm", expand=False)
+    def put_metric_alarm(
+        self,
+        context: RequestContext,
+        request: PutMetricAlarmInput,
+    ) -> None:
+        moto.call_moto(context)
+
+        name = request.get("AlarmName")
+        arn = aws_stack.cloudwatch_alarm_arn(name)
+        self.tags.tag_resource(arn, request.get("Tags"))

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -657,7 +657,8 @@ def run_process_as_sudo(component, port, asynchronous=False, env_vars=None):
         sudo_cmd,
         env_vars_str,
         python_cmd,
-        __file__,
+        "-m",
+        "localstack.services.edge",
         component,
         str(port),
     ]

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -1,0 +1,172 @@
+import sys
+from functools import lru_cache
+from typing import Callable, Dict, Optional, Tuple, Union
+from urllib.parse import urlsplit
+
+from botocore.awsrequest import create_request_object, prepare_request_dict
+from botocore.parsers import create_parser
+from botocore.serialize import create_serializer
+from moto.backends import get_backend as get_moto_backend
+from moto.core.utils import BackendDict
+from moto.server import RegexConverter
+from werkzeug.datastructures import Headers
+from werkzeug.routing import Map, Rule
+
+import localstack
+from localstack import config
+from localstack.aws.api import HttpRequest, RequestContext, ServiceResponse
+from localstack.aws.spec import load_service
+from localstack.utils.common import to_str
+
+MotoResponse = Tuple[str, dict, Union[str, bytes]]
+MotoDispatcher = Callable[[HttpRequest, str, dict], MotoResponse]
+
+user_agent = f"Localstack/{localstack.__version__} Python/{sys.version.split(' ')[0]}"
+
+
+@lru_cache()
+def get_moto_routing_table(service: str) -> Map:
+    """Cached version of load_moto_routing_table."""
+    return load_moto_routing_table(service)
+
+
+def load_moto_routing_table(service: str) -> Map:
+    """
+    Creates from moto service url_paths a werkzeug URL rule map that can be used to locate moto methods to dispatch
+    requests to.
+
+    :param service: the service to get the map for.
+    :return: a new Map object
+    """
+    # code from moto.server.create_backend_app
+    backend_dict: BackendDict = get_moto_backend(service)
+    if "us-east-1" in backend_dict:
+        backend = backend_dict["us-east-1"]
+    else:
+        backend = backend_dict["global"]
+
+    url_map = Map()
+    url_map.converters["regex"] = RegexConverter
+
+    for url_path, handler in backend.flask_paths.items():
+        # kinda abusing the werkzeug routing internals here. normally endpoint would be a string, but it works
+        url_map.add(Rule(url_path, endpoint=handler))
+
+    return url_map
+
+
+def get_dispatcher(service: str, path: str) -> MotoDispatcher:
+    url_map = get_moto_routing_table(service)
+
+    if len(url_map._rules) == 1:
+        # in most cases, there will only be one dispatch method in the list of urls, so no need to do matching
+        endpoint, _ = next(url_map.iter_rules())
+        return endpoint
+
+    matcher = url_map.bind(config.LOCALSTACK_HOSTNAME)
+    endpoint, _ = matcher.match(path_info=path)
+    return endpoint
+
+
+def call_moto(context: RequestContext) -> ServiceResponse:
+    service = context.service
+    operation_model = context.operation
+    request = context.request
+
+    # hack to avoid call to request.form (see moto's BaseResponse.dispatch)
+    setattr(request, "body", request.data)
+
+    # this is where we skip the HTTP roundtrip between the moto server and the boto client
+    dispatch = get_dispatcher(service.service_name, request.path)
+
+    status, headers, content = dispatch(request, request.url, request.headers)
+    response_dict = {  # this is what botocore.endpoint.convert_to_response_dict normally does
+        "headers": headers,
+        "status_code": status,
+        "body": content,
+        "context": {
+            "operation_name": operation_model.name,
+        },
+    }
+
+    parser = create_parser(service.protocol)
+    response = parser.parse(response_dict, operation_model.output_shape)
+    # TODO: handle errors (raise exceptions from error messages)
+    return response
+
+
+def create_aws_request_context(
+    service_name: str,
+    action: str,
+    parameters: Dict,
+    region: str = config.AWS_REGION_US_EAST_1,
+    endpoint_url: Optional[str] = None,
+) -> RequestContext:
+    """
+    This is a stripped-down version of what the botocore client does to create an http request from a client call. A
+    client call looks something like this: boto3.client("sqs").create_queue(QueueName="myqueue"), which will be
+    serialized into an HTTP request. This method does the same, without performing the actual request, and with a
+    more low-level interface. An equivalent call would be
+
+         create_aws_request_context("sqs", "CreateQueue", {"QueueName": "myqueue"})
+
+    :param service_name: the AWS service
+    :param action: the action to invoke
+    :param parameters: the invocation parameters
+    :param region: the region name (default is us-east-1)
+    :param endpoint_url: the endpoint to call (defaults to localstack)
+    :return: a RequestContext object that describes this request
+    """
+    if endpoint_url is None:
+        endpoint_url = config.get_edge_url()
+
+    service = load_service(service_name)
+    operation = service.operation_model(action)
+    request_context = {
+        "client_region": region,
+        "has_streaming_input": operation.has_streaming_input,
+        "auth_type": operation.auth_type,
+    }
+
+    # serialize the request into an AWS request object and prepare the request
+    serializer = create_serializer(service.protocol)
+    serialized_request = serializer.serialize_to_request(parameters, operation)
+    prepare_request_dict(
+        serialized_request,
+        endpoint_url=endpoint_url,
+        user_agent=user_agent,
+        context=request_context,
+    )
+    aws_request = create_request_object(serialized_request)
+    aws_request = aws_request.prepare()
+
+    # create HttpRequest from AWSRequest
+    split_url = urlsplit(aws_request.url)
+    host = split_url.netloc.split(":")
+    if len(host) == 1:
+        server = (to_str(host[0]), None)
+    elif len(host) == 2:
+        server = (to_str(host[0]), int(host[1]))
+    else:
+        raise ValueError
+
+    # Use our parser to parse the serialized body
+    headers = Headers()
+    for k, v in aws_request.headers.items():
+        headers[k] = v
+    request = HttpRequest(
+        method=aws_request.method,
+        path=split_url.path,
+        query_string=split_url.query,
+        headers=headers,
+        body=aws_request.body,
+        server=server,
+    )
+
+    context = RequestContext()
+    context.service = service
+    context.operation = operation
+    context.region = region
+    context.request = request
+
+    return context

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -84,7 +84,7 @@ def proxy_moto(context: RequestContext) -> HttpResponse:
 def MotoFallbackDispatcher(provider: object) -> DispatchTable:
     """
     Wraps a provider with a moto fallthrough mechanism. It does by creating a new DispatchTable from the original
-    provider, and wrapping each method with a fallthrough method that calls ``reqest`` if the original provider
+    provider, and wrapping each method with a fallthrough method that calls ``request`` if the original provider
     raises a ``NotImplementedError``.
 
     :param provider: the ASF provider
@@ -120,7 +120,7 @@ def dispatch_to_moto(context: RequestContext) -> MotoResponse:
     request = context.request
 
     # hack to avoid call to request.form (see moto's BaseResponse.dispatch)
-    setattr(request, "body", request.data)
+    request.body = request.data
 
     # this is where we skip the HTTP roundtrip between the moto server and the boto client
     dispatch = get_dispatcher(service.service_name, request.path)

--- a/tests/integration/test_moto.py
+++ b/tests/integration/test_moto.py
@@ -1,0 +1,195 @@
+import pytest
+
+from localstack import config
+from localstack.aws.api import ServiceException, handler
+from localstack.services import moto
+from localstack.services.moto import MotoFallbackDispatcher
+from localstack.utils.common import short_uid, to_str
+
+
+def test_call_with_sqs_creates_state_correctly():
+    qname = f"queue-{short_uid()}"
+
+    response = moto.call_moto(
+        moto.create_aws_request_context("sqs", "CreateQueue", {"QueueName": qname})
+    )
+    url = response["QueueUrl"]
+
+    try:
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert response["QueueUrl"].endswith(f"/{qname}")
+
+        response = moto.call_moto(moto.create_aws_request_context("sqs", "ListQueues"))
+        assert url in response["QueueUrls"]
+    finally:
+        moto.call_moto(moto.create_aws_request_context("sqs", "DeleteQueue", {"QueueUrl": url}))
+
+    response = moto.call_moto(moto.create_aws_request_context("sqs", "ListQueues"))
+    assert url not in response.get("QueueUrls", [])
+
+
+def test_call_sqs_invalid_call_raises_http_exception():
+    with pytest.raises(ServiceException) as e:
+        moto.call_moto(
+            moto.create_aws_request_context(
+                "sqs",
+                "DeleteQueue",
+                {
+                    "QueueUrl": "http://0.0.0.0/nonexistingqueue",
+                },
+            )
+        )
+    e.match("The specified queue does not exist")
+
+
+def test_call_non_implemented_operation():
+    with pytest.raises(NotImplementedError):
+        # we'll need to keep finding methods that moto doesn't implement ;-)
+        moto.call_moto(
+            moto.create_aws_request_context("athena", "DeleteDataCatalog", {"Name": "foo"})
+        )
+
+
+def test_proxy_non_implemented_operation():
+    with pytest.raises(NotImplementedError):
+        moto.proxy_moto(
+            moto.create_aws_request_context("athena", "DeleteDataCatalog", {"Name": "foo"})
+        )
+
+
+def test_call_with_sqs_modifies_state_in_moto_backend():
+    """Whitebox test to check that moto backends are populated correctly"""
+    from moto.sqs.models import sqs_backends
+
+    qname = f"queue-{short_uid()}"
+
+    response = moto.call_moto(
+        moto.create_aws_request_context("sqs", "CreateQueue", {"QueueName": qname})
+    )
+    url = response["QueueUrl"]
+    assert qname in sqs_backends.get(config.AWS_REGION_US_EAST_1).queues
+    moto.call_moto(moto.create_aws_request_context("sqs", "DeleteQueue", {"QueueUrl": url}))
+    assert qname not in sqs_backends.get(config.AWS_REGION_US_EAST_1).queues
+
+
+def test_call_with_es_creates_state_correctly():
+    domain_name = f"domain-{short_uid()}"
+    response = moto.call_moto(
+        moto.create_aws_request_context(
+            "es",
+            "CreateElasticsearchDomain",
+            {
+                "DomainName": domain_name,
+                "ElasticsearchVersion": "7.10",
+            },
+        )
+    )
+
+    try:
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert response["DomainStatus"]["DomainName"] == domain_name
+        assert response["DomainStatus"]["ElasticsearchVersion"] == "7.10"
+    finally:
+        response = moto.call_moto(
+            moto.create_aws_request_context(
+                "es", "DeleteElasticsearchDomain", {"DomainName": domain_name}
+            )
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def test_call_multi_region_backends():
+    from moto.sqs.models import sqs_backends
+
+    qname_us = f"queue-us-{short_uid()}"
+    qname_eu = f"queue-eu-{short_uid()}"
+
+    moto.call_moto(
+        moto.create_aws_request_context(
+            "sqs", "CreateQueue", {"QueueName": qname_us}, region="us-east-1"
+        )
+    )
+    moto.call_moto(
+        moto.create_aws_request_context(
+            "sqs", "CreateQueue", {"QueueName": qname_eu}, region="eu-central-1"
+        )
+    )
+
+    assert qname_us in sqs_backends.get("us-east-1").queues
+    assert qname_eu not in sqs_backends.get("us-east-1").queues
+
+    assert qname_us not in sqs_backends.get("eu-central-1").queues
+    assert qname_eu in sqs_backends.get("eu-central-1").queues
+
+    del sqs_backends.get("us-east-1").queues[qname_us]
+    del sqs_backends.get("eu-central-1").queues[qname_eu]
+
+
+def test_proxy_with_sqs_invalid_call_returns_error():
+    response = moto.proxy_moto(
+        moto.create_aws_request_context(
+            "sqs",
+            "DeleteQueue",
+            {
+                "QueueUrl": "http://0.0.0.0/nonexistingqueue",
+            },
+        )
+    )
+
+    assert response.status_code == 400
+    assert "NonExistentQueue" in to_str(response.data)
+
+
+def test_proxy_with_sqs_returns_http_response():
+    qname = f"queue-{short_uid()}"
+
+    response = moto.proxy_moto(
+        moto.create_aws_request_context("sqs", "CreateQueue", {"QueueName": qname})
+    )
+
+    assert response.status_code == 200
+    assert f"{qname}</QueueUrl>" in to_str(response.data)
+    assert "x-amzn-requestid" in response.headers
+
+
+class FakeSqsApi:
+    @handler("ListQueues", expand=False)
+    def list_queues(self, context, request):
+        raise NotImplementedError
+
+    @handler("CreateQueue", expand=False)
+    def create_queue(self, context, request):
+        raise NotImplementedError
+
+
+class FakeSqsProvider(FakeSqsApi):
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = []
+
+    @handler("ListQueues", expand=False)
+    def list_queues(self, context, request):
+        self.calls.append(context)
+        return moto.call_moto(context)
+
+
+def test_moto_fallback_dispatcher():
+    provider = FakeSqsProvider()
+    dispatcher = MotoFallbackDispatcher(provider)
+
+    assert "ListQueues" in dispatcher
+    assert "CreateQueue" in dispatcher
+
+    def _dispatch(action, params):
+        context = moto.create_aws_request_context("sqs", action, params)
+        return dispatcher[action](context, params)
+
+    qname = f"queue-{short_uid()}"
+    # when falling through the dispatcher returns an HTTP response
+    http_response = _dispatch("CreateQueue", {"QueueName": qname})
+    assert http_response.status_code == 200
+
+    # this returns an
+    response = _dispatch("ListQueues", None)
+    assert len(provider.calls) == 1
+    assert len([url for url in response["QueueUrls"] if qname in url])


### PR DESCRIPTION
This PR adds a simple API and the underlying machinery to dispatch ASF requests to moto without an HTTP roundtrip. IThe API facilitates migration of services to ASF that rely heavily on moto by providing three basic request patterns. The PR also demonstrates a simple migration of CloudWatch. 

The three patterns are:
* Proxy an HTTP request to moto
* Call moto to receive an AWS response dictionary
* Wrap an ASF provider to route all non-implemented methods to moto 

## Proxy an HTTP request to moto

Forwards a request to moto and forego parsing of the response, and instead just returns the HttpResponse

```python
def proxy_moto(context: RequestContext) -> HttpResponse:
```

In an ASF provider, this method can be useful if you want do something on the low-level http response rather than the higher-level AWS response dict. To enable this, the PR adapts the Skeleton to allow providers to return `HttpResponse` instances directly.
```python
class SqsProvider:
    @handler("ListQueues", expand=False)
    def list_queues(self, context, request) -> HttpResponse:
        http_response = moto.proxy_moto(context)
        print(http_response.get_data(as_text=True)) # will print the XML response
        return http_response
```

## Calling moto and receiving an AWS response dictionary

This dispatches the request to moto, and parses moto's HTTP response using the botocore parser.

```python
def call_moto(context: RequestContext) -> ServiceResponse:
```
This can be used in ASF providers that want the convenience of operating directly on the typed botocore response (that is completely compatible with ASF)

```python
class Ec2Provider:
    @handler("RunInstances", expand=False)
    def run_instances(self, context: Requestcontext, request: RunInstancesRequest) -> Reservation:
        reservation = moto.call_moto(context)
        # do something with the AWS response, knowing that moto has accepted the
        # request (service exceptions are also deserialized and raised)
        reservation["AvailabilityZoneId"] = "..."
        return reservation
```


## Wrap an ASF provider to route all non-implemented methods to moto 

Before passing the ASF provider to the proxy listener, wrap the provider with a `MotoFallbackDispatcher`, this will make all non-implemented handler methods fall through to call `proxy_moto(context)`
https://github.com/localstack/localstack/blob/68c225b9714e0bd025a42c327f8d9ca61db720af/localstack/services/providers.py#L43-L47