### PR TITLE
remove deprecated use of localstack version constant

### DIFF
--- a/localstack/utils/persistence.py
+++ b/localstack/utils/persistence.py
@@ -225,14 +225,14 @@ class StartupInfo(NamedTuple):
 
 
 def save_startup_info():
-    from localstack_ext.constants import VERSION as LOCALSTACK_EXT_VERSION
+    from localstack_ext import __version__ as localstack_ext_version
 
     file_path = os.path.join(config.dirs.data, STARTUP_INFO_FILE)
 
     info = StartupInfo(
         timestamp=datetime.datetime.now().isoformat(),
         localstack_version=constants.VERSION,
-        localstack_ext_version=LOCALSTACK_EXT_VERSION,
+        localstack_ext_version=localstack_ext_version,
         pro_activated=is_env_true(constants.ENV_PRO_ACTIVATED),
     )
     LOG.debug("saving startup info %s", info)

--- a/tests/unit/utils/test_persistence.py
+++ b/tests/unit/utils/test_persistence.py
@@ -1,8 +1,9 @@
 import json
 
-from localstack_ext import constants as ext_constants
+from localstack_ext import __version__ as localstack_ext_version
 
-from localstack import config, constants
+from localstack import __version__ as localstack_version
+from localstack import config
 from localstack.utils.persistence import (
     STARTUP_INFO_FILE,
     StartupInfo,
@@ -64,6 +65,6 @@ class TestStartupInfo:
         d = doc[0]
 
         assert d["timestamp"]
-        assert d["localstack_version"] == constants.VERSION
-        assert d["localstack_ext_version"] == ext_constants.VERSION
+        assert d["localstack_version"] == localstack_version
+        assert d["localstack_ext_version"] == localstack_ext_version
         assert d["pro_activated"] in [False, True]


### PR DESCRIPTION
minor change to remove the deprecated use of `loclastack_ext.constants.VERSION`