### PR TITLE
None output shape for rest-xml serializer

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -333,6 +333,8 @@ class BaseXMLResponseSerializer(ResponseSerializer):
                     )
                 )
         else:
+            if shape is None and operation_model.service_model.protocol == "rest-xml":
+                return
             # Otherwise, we use the "traditional" way of serializing the whole parameters dict recursively.
             response.data = self._encode_payload(
                 self._serialize_body_params(parameters, shape, operation_model)

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -302,6 +302,10 @@ def test_query_serializer_sqs_empty_return_shape_with_botocore():
     _botocore_serializer_integration_test("sqs", "SetQueueAttributes", {})
 
 
+def test_xml_serializer_cloudfront_empty_return_shape_with_botocore():
+    _botocore_serializer_integration_test("cloudfront", "DeleteDistribution", {}, status_code=204)
+
+
 def test_query_serializer_sqs_flattened_list_with_botocore():
     response = {
         "QueueUrls": [


### PR DESCRIPTION
While migrating CloudFront to ASF, I noticed the following error while trying to delete a distribution:
```
Error in proxy handler for request DELETE http://localhost:4566/2020-05-31/distribution/e774cc30: cannot convert 'NoneType' object to bytes
```
This seems to happen when trying to serialize a `None` shape (i.e., no output shape) for the `rest-xml` protocol. 
To reproduced it, you could simply create a distribution and try to delete it (from the current state of the `asf-cloudfront` branch).
This fix quickly solves it. Maybe there could be a better way to fix it. 