### PR TITLE
Fix: Patch Moto Lambda Backend to access Localstack Lambdas

### DIFF
--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -1,13 +1,28 @@
 import logging
 
+from moto.awslambda import models as moto_awslambda_models
+
 from localstack import config
+from localstack.utils.aws import aws_stack
+from localstack.utils.common import to_bytes
+from localstack.utils.patch import patch
 
 LOG = logging.getLogger(__name__)
+
+
+# temporary state
+TMP_STATE = {}
+TMP_TAG = {}
+
+# Key for tracking patch applience
+PATCHES_APPLIED = "LAMBDA_PATCHED"
 
 
 def start_lambda(port=None, asynchronous=False):
     from localstack.services.awslambda import lambda_api
     from localstack.services.infra import start_local_api
+
+    apply_patches()
 
     port = port or config.service_port("lambda")
     return start_local_api(
@@ -48,3 +63,33 @@ def check_lambda(expect_shutdown=False, print_error=False):
         assert out is None
     else:
         assert out and isinstance(out.get("Functions"), list)
+
+
+def apply_patches():
+    if TMP_STATE.get(PATCHES_APPLIED, False):
+        return
+
+    TMP_STATE[PATCHES_APPLIED] = True
+
+    @patch(moto_awslambda_models.LambdaBackend.get_function)
+    def get_function(fn, self, *args, **kwargs):
+        result = fn(self, *args, **kwargs)
+        if result:
+            return result
+
+        client = aws_stack.connect_to_service("lambda")
+        lambda_name = aws_stack.lambda_function_name(args[0])
+        response = client.get_function(FunctionName=lambda_name)
+
+        spec = response["Configuration"]
+        spec["Code"] = {"ZipFile": "ZW1wdHkgc3RyaW5n"}
+        region = aws_stack.extract_region_from_arn(spec["FunctionArn"])
+        new_function = moto_awslambda_models.LambdaFunction(spec, region)
+
+        return new_function
+
+    @patch(moto_awslambda_models.LambdaFunction.invoke)
+    def invoke(fn, self, *args, **kwargs):
+        payload = to_bytes(args[0])
+        client = aws_stack.connect_to_service("lambda")
+        return client.invoke(FunctionName=self.function_name, Payload=payload)

--- a/tests/integration/test_secretsmanager.py
+++ b/tests/integration/test_secretsmanager.py
@@ -3,8 +3,11 @@ import unittest
 from datetime import datetime
 
 from localstack.constants import TEST_AWS_ACCOUNT_ID
+from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
+from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
+from tests.integration.awslambda.test_lambda import TEST_LAMBDA_PYTHON_VERSION
 
 RESOURCE_POLICY = {
     "Version": "2012-10-17",
@@ -150,6 +153,38 @@ class SecretsManagerTest(unittest.TestCase):
 
         rs = self.secretsmanager_client.delete_resource_policy(SecretId=secret_name)
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
+
+        # clean up
+        self.secretsmanager_client.delete_secret(
+            SecretId=secret_name, ForceDeleteWithoutRecovery=True
+        )
+
+    def test_rotate_secret_with_lambda(self):
+        secret_name = "s-%s" % short_uid()
+
+        self.secretsmanager_client.create_secret(
+            Name=secret_name,
+            SecretString="my_secret",
+            Description="testing rotation of secrets",
+        )
+
+        function_name = "s-%s" % short_uid()
+        function_arn = testutil.create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_VERSION,
+            func_name=function_name,
+            runtime=LAMBDA_RUNTIME_PYTHON36,
+        )["CreateFunctionResponse"]["FunctionArn"]
+
+        response = self.secretsmanager_client.rotate_secret(
+            SecretId=secret_name,
+            RotationLambdaARN=function_arn,
+            RotationRules={
+                "AutomaticallyAfterDays": 1,
+            },
+            RotateImmediately=True,
+        )
+
+        self.assertEqual(response["ResponseMetadata"]["HTTPStatusCode"], 200)
 
         # clean up
         self.secretsmanager_client.delete_secret(

--- a/tests/integration/test_secretsmanager.py
+++ b/tests/integration/test_secretsmanager.py
@@ -190,3 +190,4 @@ class SecretsManagerTest(unittest.TestCase):
         self.secretsmanager_client.delete_secret(
             SecretId=secret_name, ForceDeleteWithoutRecovery=True
         )
+        testutil.delete_lambda_function(function_name)


### PR DESCRIPTION
This PR addresses issue #5279. That shows the SecretManager service from Moto crashing due to trying to invoking a Lambda function that doesn't exist inside Moto.AWSLambda.

Changes:
 - Patch Moto.awslambda.models.LambdaBackend.get_function, to search lambdas from Localstack. 
 - Patch Moto.awslambda.models.LambdaFunction.Invoke to allow the execution of a Localstack Lambda function.
 - Test of the secret_rotate method with a LambdaFunction
 - Deletion of a similar patch that the Logs Service used to apply.
