### PR TITLE
Add resolve_hostname(..) util function, refactor some utils into sub-modules

### DIFF
--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -10,8 +10,8 @@ from localstack.utils.common import (
     json_safe,
     recurse_object,
     short_uid,
-    to_number,
 )
+from localstack.utils.generic.number_utils import to_number
 
 
 class VelocityInput(object):

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -13,7 +13,6 @@ import os
 import platform
 import re
 import shutil
-import socket
 import subprocess
 import sys
 import tarfile
@@ -22,7 +21,6 @@ import threading
 import time
 import uuid
 import zipfile
-from contextlib import closing
 from datetime import date, datetime, timezone, tzinfo
 from json import JSONDecodeError
 from multiprocessing.dummy import Pool
@@ -31,7 +29,6 @@ from typing import Any, Callable, Dict, List, Optional, Sized, Tuple, Type, Unio
 from urllib.parse import parse_qs, urlparse
 
 import cachetools
-import dns.resolver
 import requests
 from requests import Response
 from requests.models import CaseInsensitiveDict
@@ -40,7 +37,27 @@ import localstack.utils.run
 from localstack import config
 from localstack.config import DEFAULT_ENCODING
 from localstack.constants import ENV_DEV
+from localstack.utils.generic.number_utils import format_number, is_number
+
+# TODO: remove imports from here (need to update any client code that imports these from utils.common)
+from localstack.utils.generic.wait_utils import poll_condition, retry  # noqa
+
+# TODO: remove imports from here (need to update any client code that imports these from utils.common)
+from localstack.utils.net_utils import (  # noqa
+    get_free_tcp_port,
+    is_ip_address,
+    is_ipv4_address,
+    is_port_open,
+    port_can_be_bound,
+    resolve_hostname,
+    wait_for_port_closed,
+    wait_for_port_open,
+    wait_for_port_status,
+)
 from localstack.utils.run import FuncThread
+
+# set up logger
+LOG = logging.getLogger(__name__)
 
 # arrays for temporary files and resources
 TMP_FILES = []
@@ -62,9 +79,6 @@ CODEC_HANDLER_UNDERSCORE = "underscore"
 
 # chunk size for file downloads
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
-
-# set up logger
-LOG = logging.getLogger(__name__)
 
 # flag to indicate whether we've received and processed the stop signal
 INFRA_STOPPED = False
@@ -94,9 +108,6 @@ _unprintables = (
 )
 REGEX_UNPRINTABLE_CHARS = re.compile(
     f"[{re.escape(''.join(map(chr, itertools.chain(*_unprintables))))}]"
-)
-IP_REGEX = (
-    r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
 )
 
 # user of the currently running process
@@ -782,129 +793,6 @@ def path_from_url(url: str) -> str:
     return "/%s" % str(url).partition("://")[2].partition("/")[2] if "://" in url else url
 
 
-def is_port_open(
-    port_or_url: Union[int, str],
-    http_path: str = None,
-    expect_success: bool = True,
-    protocols: Optional[List[str]] = None,
-    quiet: bool = True,
-):
-    protocols = protocols or ["tcp"]
-    port = port_or_url
-    if is_number(port):
-        port = int(port)
-    host = "localhost"
-    protocol = "http"
-    protocols = protocols if isinstance(protocols, list) else [protocols]
-    if isinstance(port, str):
-        url = urlparse(port_or_url)
-        port = url.port
-        host = url.hostname
-        protocol = url.scheme
-    nw_protocols = []
-    nw_protocols += [socket.SOCK_STREAM] if "tcp" in protocols else []
-    nw_protocols += [socket.SOCK_DGRAM] if "udp" in protocols else []
-    for nw_protocol in nw_protocols:
-        with closing(socket.socket(socket.AF_INET, nw_protocol)) as sock:
-            sock.settimeout(1)
-            if nw_protocol == socket.SOCK_DGRAM:
-                try:
-                    if port == 53:
-                        dnshost = "127.0.0.1" if host == "localhost" else host
-                        resolver = dns.resolver.Resolver()
-                        resolver.nameservers = [dnshost]
-                        resolver.timeout = 1
-                        resolver.lifetime = 1
-                        answers = resolver.query("google.com", "A")
-                        assert len(answers) > 0
-                    else:
-                        sock.sendto(bytes(), (host, port))
-                        sock.recvfrom(1024)
-                except Exception:
-                    if not quiet:
-                        LOG.exception("Error connecting to UDP port %s:%s", host, port)
-                    return False
-            elif nw_protocol == socket.SOCK_STREAM:
-                result = sock.connect_ex((host, port))
-                if result != 0:
-                    if not quiet:
-                        LOG.warning(
-                            "Error connecting to TCP port %s:%s (result=%s)", host, port, result
-                        )
-                    return False
-    if "tcp" not in protocols or not http_path:
-        return True
-    url = "%s://%s:%s%s" % (protocol, host, port, http_path)
-    try:
-        response = safe_requests.get(url, verify=False)
-        return not expect_success or response.status_code < 400
-    except Exception:
-        return False
-
-
-def wait_for_port_open(port, http_path=None, expect_success=True, retries=10, sleep_time=0.5):
-    """Ping the given network port until it becomes available (for a given number of retries).
-    If 'http_path' is set, make a GET request to this path and assert a non-error response."""
-    return wait_for_port_status(
-        port,
-        http_path=http_path,
-        expect_success=expect_success,
-        retries=retries,
-        sleep_time=sleep_time,
-    )
-
-
-def wait_for_port_closed(port, http_path=None, expect_success=True, retries=10, sleep_time=0.5):
-    return wait_for_port_status(
-        port,
-        http_path=http_path,
-        expect_success=expect_success,
-        retries=retries,
-        sleep_time=sleep_time,
-        expect_closed=True,
-    )
-
-
-def wait_for_port_status(
-    port, http_path=None, expect_success=True, retries=10, sleep_time=0.5, expect_closed=False
-):
-    """Ping the given network port until it becomes (un)available (for a given number of retries)."""
-
-    def check():
-        status = is_port_open(port, http_path=http_path, expect_success=expect_success)
-        if bool(status) != (not expect_closed):
-            raise Exception(
-                "Port %s (path: %s) was not %s"
-                % (port, http_path, "closed" if expect_closed else "open")
-            )
-
-    return retry(check, sleep=sleep_time, retries=retries)
-
-
-def port_can_be_bound(port):
-    """Return whether a local port can be bound to. Note that this is a stricter check
-    than is_port_open(...) above, as is_port_open() may return False if the port is
-    not accessible (i.e., does not respond), yet cannot be bound to."""
-    try:
-        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        tcp.bind(("", port))
-        return True
-    except Exception:
-        return False
-
-
-def get_free_tcp_port(blacklist=None):
-    blacklist = blacklist or []
-    for i in range(10):
-        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        tcp.bind(("", 0))
-        addr, port = tcp.getsockname()
-        tcp.close()
-        if port not in blacklist:
-            return port
-    raise Exception("Unable to determine free TCP port with blacklist %s" % blacklist)
-
-
 def sleep_forever():
     while True:
         time.sleep(1)
@@ -968,43 +856,6 @@ def parse_timestamp(ts_str: str) -> datetime:
         except ValueError:
             pass
     raise Exception("Unable to parse timestamp string with any known formats: %s" % ts_str)
-
-
-def retry(function, retries=3, sleep=1.0, sleep_before=0, **kwargs):
-    raise_error = None
-    if sleep_before > 0:
-        time.sleep(sleep_before)
-    retries = int(retries)
-    for i in range(0, retries + 1):
-        try:
-            return function(**kwargs)
-        except Exception as error:
-            raise_error = error
-            time.sleep(sleep)
-    raise raise_error
-
-
-def poll_condition(condition, timeout: float = None, interval: float = 0.5) -> bool:
-    """
-    Poll evaluates the given condition until a truthy value is returned. It does this every `interval` seconds
-    (0.5 by default), until the timeout (in seconds, if any) is reached.
-
-    Poll returns True once `condition()` returns a truthy value, or False if the timeout is reached.
-    """
-    remaining = 0
-    if timeout is not None:
-        remaining = timeout
-
-    while not condition():
-        if timeout is not None:
-            remaining -= interval
-
-            if remaining <= 0:
-                return False
-
-        time.sleep(interval)
-
-    return True
 
 
 def merge_recursive(source, destination, none_values=None, overwrite=False):
@@ -1293,7 +1144,7 @@ def format_bytes(count: float, default: str = "n/a"):
     for unit in units:
         if cnt < 1000 or unit == units[-1]:
             # FIXME: will return '1e+03TB' for 1000TB
-            return "%s%s" % (format_number(cnt, decimals=3), unit)
+            return f"{format_number(cnt, decimals=3)}{unit}"
         cnt = cnt / 1000.0
     return count
 
@@ -1393,31 +1244,6 @@ def first_char_to_lower(s: str) -> str:
 
 def first_char_to_upper(s: str) -> str:
     return s and "%s%s" % (s[0].upper(), s[1:])
-
-
-def format_number(number: float, decimals: int = 2):
-    # Note: interestingly, f"{number:.3g}" seems to yield incorrect results in some cases.
-    # The logic below seems to be the most stable/reliable.
-    result = f"{number:.{decimals}f}"
-    if "." in result:
-        result = result.rstrip("0").rstrip(".")
-    return result
-
-
-def is_number(s: Any) -> bool:
-    try:
-        float(s)  # for int, long and float
-        return True
-    except (TypeError, ValueError):
-        return False
-
-
-def to_number(s: Any) -> Union[int, float]:
-    """Cast the string representation of the given object to a number (int or float), or raise ValueError."""
-    try:
-        return int(str(s))
-    except ValueError:
-        return float(str(s))
 
 
 def is_mac_os() -> bool:
@@ -1783,23 +1609,6 @@ def new_tmp_dir():
     rm_rf(folder)
     mkdir(folder)
     return folder
-
-
-def is_ip_address(addr):
-    try:
-        socket.inet_aton(addr)
-        return True
-    except socket.error:
-        return False
-
-
-def is_ipv4_address(address: str) -> bool:
-    """
-    Checks if passed string looks like an IPv4 address
-    :param address: Possible IPv4 address
-    :return: True if string looks like IPv4 address, False otherwise
-    """
-    return bool(re.match(IP_REGEX, address))
 
 
 def is_zip_file(content):

--- a/localstack/utils/generic/number_utils.py
+++ b/localstack/utils/generic/number_utils.py
@@ -1,0 +1,26 @@
+from typing import Any, Union
+
+
+def format_number(number: float, decimals: int = 2):
+    # Note: interestingly, f"{number:.3g}" seems to yield incorrect results in some cases.
+    # The logic below seems to be the most stable/reliable.
+    result = f"{number:.{decimals}f}"
+    if "." in result:
+        result = result.rstrip("0").rstrip(".")
+    return result
+
+
+def is_number(s: Any) -> bool:
+    try:
+        float(s)  # for int, long and float
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def to_number(s: Any) -> Union[int, float]:
+    """Cast the string representation of the given object to a number (int or float), or raise ValueError."""
+    try:
+        return int(str(s))
+    except ValueError:
+        return float(str(s))

--- a/localstack/utils/net_utils.py
+++ b/localstack/utils/net_utils.py
@@ -1,0 +1,176 @@
+import logging
+import re
+import socket
+from contextlib import closing
+from typing import List, Optional, Union
+from urllib.parse import urlparse
+
+import dns.resolver
+
+from localstack.utils.generic.wait_utils import retry
+
+LOG = logging.getLogger(__name__)
+
+# regular expression for IPv4 addresses
+IP_REGEX = (
+    r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+)
+
+
+def is_port_open(
+    port_or_url: Union[int, str],
+    http_path: str = None,
+    expect_success: bool = True,
+    protocols: Optional[List[str]] = None,
+    quiet: bool = True,
+):
+    from localstack.utils.common import is_number, safe_requests
+
+    protocols = protocols or ["tcp"]
+    port = port_or_url
+    if is_number(port):
+        port = int(port)
+    host = "localhost"
+    protocol = "http"
+    protocols = protocols if isinstance(protocols, list) else [protocols]
+    if isinstance(port, str):
+        url = urlparse(port_or_url)
+        port = url.port
+        host = url.hostname
+        protocol = url.scheme
+    nw_protocols = []
+    nw_protocols += [socket.SOCK_STREAM] if "tcp" in protocols else []
+    nw_protocols += [socket.SOCK_DGRAM] if "udp" in protocols else []
+    for nw_protocol in nw_protocols:
+        with closing(socket.socket(socket.AF_INET, nw_protocol)) as sock:
+            sock.settimeout(1)
+            if nw_protocol == socket.SOCK_DGRAM:
+                try:
+                    if port == 53:
+                        dnshost = "127.0.0.1" if host == "localhost" else host
+                        resolver = dns.resolver.Resolver()
+                        resolver.nameservers = [dnshost]
+                        resolver.timeout = 1
+                        resolver.lifetime = 1
+                        answers = resolver.query("google.com", "A")
+                        assert len(answers) > 0
+                    else:
+                        sock.sendto(bytes(), (host, port))
+                        sock.recvfrom(1024)
+                except Exception:
+                    if not quiet:
+                        LOG.exception("Error connecting to UDP port %s:%s", host, port)
+                    return False
+            elif nw_protocol == socket.SOCK_STREAM:
+                result = sock.connect_ex((host, port))
+                if result != 0:
+                    if not quiet:
+                        LOG.warning(
+                            "Error connecting to TCP port %s:%s (result=%s)", host, port, result
+                        )
+                    return False
+    if "tcp" not in protocols or not http_path:
+        return True
+    url = "%s://%s:%s%s" % (protocol, host, port, http_path)
+    try:
+        response = safe_requests.get(url, verify=False)
+        return not expect_success or response.status_code < 400
+    except Exception:
+        return False
+
+
+def wait_for_port_open(
+    port: int, http_path: str = None, expect_success=True, retries=10, sleep_time=0.5
+):
+    """Ping the given network port until it becomes available (for a given number of retries).
+    If 'http_path' is set, make a GET request to this path and assert a non-error response."""
+    return wait_for_port_status(
+        port,
+        http_path=http_path,
+        expect_success=expect_success,
+        retries=retries,
+        sleep_time=sleep_time,
+    )
+
+
+def wait_for_port_closed(
+    port: int, http_path: str = None, expect_success=True, retries=10, sleep_time=0.5
+):
+    return wait_for_port_status(
+        port,
+        http_path=http_path,
+        expect_success=expect_success,
+        retries=retries,
+        sleep_time=sleep_time,
+        expect_closed=True,
+    )
+
+
+def wait_for_port_status(
+    port: int,
+    http_path: str = None,
+    expect_success=True,
+    retries=10,
+    sleep_time=0.5,
+    expect_closed=False,
+):
+    """Ping the given network port until it becomes (un)available (for a given number of retries)."""
+
+    def check():
+        status = is_port_open(port, http_path=http_path, expect_success=expect_success)
+        if bool(status) != (not expect_closed):
+            raise Exception(
+                "Port %s (path: %s) was not %s"
+                % (port, http_path, "closed" if expect_closed else "open")
+            )
+
+    return retry(check, sleep=sleep_time, retries=retries)
+
+
+def port_can_be_bound(port: int) -> bool:
+    """Return whether a local port can be bound to. Note that this is a stricter check
+    than is_port_open(...) above, as is_port_open() may return False if the port is
+    not accessible (i.e., does not respond), yet cannot be bound to."""
+    try:
+        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tcp.bind(("", port))
+        return True
+    except Exception:
+        return False
+
+
+def get_free_tcp_port(blacklist: List[int] = None) -> int:
+    blacklist = blacklist or []
+    for i in range(10):
+        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tcp.bind(("", 0))
+        addr, port = tcp.getsockname()
+        tcp.close()
+        if port not in blacklist:
+            return port
+    raise Exception("Unable to determine free TCP port with blacklist %s" % blacklist)
+
+
+def resolve_hostname(hostname: str) -> Optional[str]:
+    """Resolve the given hostname and return its IP address, or None if it cannot be resolved."""
+    try:
+        return socket.gethostbyname(hostname)
+    except socket.error:
+        return None
+
+
+def is_ip_address(addr: str) -> bool:
+    try:
+        socket.inet_aton(addr)
+        return True
+    except socket.error:
+        return False
+
+
+def is_ipv4_address(address: str) -> bool:
+    """
+    Checks if passed string looks like an IPv4 address
+    :param address: Possible IPv4 address
+    :return: True if string looks like IPv4 address, False otherwise
+    """
+    return bool(re.match(IP_REGEX, address))

--- a/tests/unit/utils/analytics/test_metadata.py
+++ b/tests/unit/utils/analytics/test_metadata.py
@@ -35,10 +35,15 @@ def test_get_session_id_cache_not_process_local():
     def _do_get_session_id():
         calls.put(get_session_id())
 
-    multiprocessing.Process(target=_do_get_session_id).start()
-    multiprocessing.Process(target=_do_get_session_id).start()
+    try:
+        multiprocessing.Process(target=_do_get_session_id).start()
+        multiprocessing.Process(target=_do_get_session_id).start()
 
-    sid1 = calls.get(timeout=2)
-    sid2 = calls.get(timeout=2)
+        sid1 = calls.get(timeout=2)
+        sid2 = calls.get(timeout=2)
 
-    assert sid1 == sid2
+        assert sid1 == sid2
+    except AttributeError as e:
+        # fix for MacOS (and potentially other systems) where local functions cannot be used for multiprocessing
+        if "Can't pickle local object" not in str(e):
+            raise

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -4,6 +4,6 @@ from localstack.utils.net_utils import resolve_hostname
 
 
 def test_resolve_hostname():
-    assert "127.0." in resolve_hostname(LOCALHOST)
+    assert "127." in resolve_hostname(LOCALHOST)
     assert resolve_hostname("example.com")
     assert resolve_hostname(f"non-existing-host-{short_uid()}") is None

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -1,0 +1,9 @@
+from localstack.constants import LOCALHOST
+from localstack.utils.common import short_uid
+from localstack.utils.net_utils import resolve_hostname
+
+
+def test_resolve_hostname():
+    assert "127.0." in resolve_hostname(LOCALHOST)
+    assert resolve_hostname("example.com")
+    assert resolve_hostname(f"non-existing-host-{short_uid()}") is None


### PR DESCRIPTION
Add `resolve_hostname(..)` util function, refactor some utils into sub-modules.

Currently still leaving the imports in `common.py` to keep them accessible from other places - left a `TODO` to refactor the imports in the remaining codebase, so we can later remove the imports from `common.py`