### PR TITLE
apigateway s3 integration using action name

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -80,9 +80,7 @@ LOG = logging.getLogger(__name__)
 TARGET_REGEX_PATH_S3_URI = (
     r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
 )
-TARGET_REGEX_ACTION_S3_URI = (
-    r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
-)
+TARGET_REGEX_ACTION_S3_URI = r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
 # regex path pattern for user requests
 PATH_REGEX_USER_REQUEST = (
     r"^/restapis/([A-Za-z0-9_\-]+)(?:/([A-Za-z0-9_\-]+))?/%s/(.*)$" % PATH_USER_REQUEST

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -80,7 +80,9 @@ LOG = logging.getLogger(__name__)
 TARGET_REGEX_PATH_S3_URI = (
     r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
 )
-TARGET_REGEX_ACTION_S3_URI = r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
+TARGET_REGEX_ACTION_S3_URI = (
+    r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
+)
 # regex path pattern for user requests
 PATH_REGEX_USER_REQUEST = (
     r"^/restapis/([A-Za-z0-9_\-]+)(?:/([A-Za-z0-9_\-]+))?/%s/(.*)$" % PATH_USER_REQUEST

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1418,7 +1418,7 @@ class TestAPIGateway(unittest.TestCase):
             self.connect_api_gateway_to_s3(bucket_name, object_name, api_id, "GET")
 
             apigw_client.create_deployment(restApiId=api_id, stageName="test")
-            url = path_based_url(api_id, "test", "/")
+            url = path_based_url(api_id, "test", f"/{object_name}")
             result = requests.get(url)
             self.assertEqual(200, result.status_code)
             self.assertEqual(object_content, result.text)
@@ -1482,8 +1482,8 @@ class TestAPIGateway(unittest.TestCase):
     def connect_api_gateway_to_s3(self, bucket_name, file_name, api_id, method):
         """Connects the root resource of an api gateway to the given object of an s3 bucket."""
         apigw_client = aws_stack.create_external_boto_client("apigateway")
-        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{}".format(
-            aws_stack.get_region(), bucket_name, file_name
+        s3_uri = "arn:aws:apigateway:{}:s3:path/{}/{{proxy}}".format(
+            aws_stack.get_region(), bucket_name
         )
 
         test_role = "test-s3-role"
@@ -1491,9 +1491,14 @@ class TestAPIGateway(unittest.TestCase):
         resources = apigw_client.get_resources(restApiId=api_id)
         # using the root resource '/' directly for this test
         root_resource_id = resources["items"][0]["id"]
+        proxy_resource = apigw_client.create_resource(
+            restApiId=api_id,
+            parentId=root_resource_id,
+            pathPart="{proxy+}"
+        )
         apigw_client.put_method(
             restApiId=api_id,
-            resourceId=root_resource_id,
+            resourceId=proxy_resource['id'],
             httpMethod=method,
             authorizationType="NONE",
             apiKeyRequired=False,
@@ -1501,12 +1506,15 @@ class TestAPIGateway(unittest.TestCase):
         )
         apigw_client.put_integration(
             restApiId=api_id,
-            resourceId=root_resource_id,
+            resourceId=proxy_resource['id'],
             httpMethod=method,
             type="AWS",
             integrationHttpMethod=method,
             uri=s3_uri,
             credentials=role_arn,
+            requestParameters={
+                "integration.request.path.proxy": "method.request.path.proxy"
+            },
         )
 
     def connect_api_gateway_to_kinesis(self, gateway_name, kinesis_stream):

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -1492,13 +1492,11 @@ class TestAPIGateway(unittest.TestCase):
         # using the root resource '/' directly for this test
         root_resource_id = resources["items"][0]["id"]
         proxy_resource = apigw_client.create_resource(
-            restApiId=api_id,
-            parentId=root_resource_id,
-            pathPart="{proxy+}"
+            restApiId=api_id, parentId=root_resource_id, pathPart="{proxy+}"
         )
         apigw_client.put_method(
             restApiId=api_id,
-            resourceId=proxy_resource['id'],
+            resourceId=proxy_resource["id"],
             httpMethod=method,
             authorizationType="NONE",
             apiKeyRequired=False,
@@ -1506,15 +1504,13 @@ class TestAPIGateway(unittest.TestCase):
         )
         apigw_client.put_integration(
             restApiId=api_id,
-            resourceId=proxy_resource['id'],
+            resourceId=proxy_resource["id"],
             httpMethod=method,
             type="AWS",
             integrationHttpMethod=method,
             uri=s3_uri,
             credentials=role_arn,
-            requestParameters={
-                "integration.request.path.proxy": "method.request.path.proxy"
-            },
+            requestParameters={"integration.request.path.proxy": "method.request.path.proxy"},
         )
 
     def connect_api_gateway_to_kinesis(self, gateway_name, kinesis_stream):


### PR DESCRIPTION
This PR adds s3 integration using the action name. We already support `arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}` scheme and this PR adds support to `arn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key}`
Resolve https://github.com/localstack/localstack/issues/5508


