### PR TITLE
Adding error check while creating sqs fifo queues

### DIFF
--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -662,6 +662,13 @@ class TestSqsProvider:
         result_recv = sqs_client.receive_message(QueueUrl=queue_url)
         assert result_recv["Messages"][0]["MessageId"] == message_id
 
+    def test_fifo_queue_without_fifo_queue_attribute(self, sqs_create_queue):
+        queue_name = f"invalid-{short_uid()}.fifo"
+
+        with pytest.raises(Exception) as e:
+            sqs_create_queue(QueueName=queue_name)
+        e.match("InvalidParameterValue")
+
     def test_fifo_queue_requires_suffix(self, sqs_create_queue):
         queue_name = f"invalid-{short_uid()}"
         attributes = {"FifoQueue": "true"}


### PR DESCRIPTION
Small PR that checks a fifo queue creation. AWS requires both the name of the queue ending with `.fifo` and the attribute `{FifoQueue: true}` to be present. 
An error should be raised if the attribute is not present and the name ends with `.fifo` (normal queues do not allow the `.` char). The ASF provider already implements this check.