### PR TITLE
Remove obsolete `docker` client binary from image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,6 @@ RUN apt-get update && \
 
 SHELL [ "/bin/bash", "-c" ]
 
-# install Docker (CLI only)
-RUN DOCKER_VERSION=20.10.7; \
-  TARGETARCH_SYNONYM=$([[ "$TARGETARCH" == "amd64" ]] && echo "x86_64" || echo "aarch64"); \
-  curl -fsSLO https://download.docker.com/linux/static/stable/${TARGETARCH_SYNONYM}/docker-${DOCKER_VERSION}.tgz \
-  && tar xzvf docker-${DOCKER_VERSION}.tgz \
-  && mv docker/docker /usr/local/bin \
-  && rm -r docker docker-${DOCKER_VERSION}.tgz
-
 # Install Java 11
 ENV LANG C.UTF-8
 RUN { \


### PR DESCRIPTION
Remove obsolete `docker` client binary from the image - no longer required, as we're now using `SdkDockerClient` by default. Should save another ~58MB (uncompressed) size in the final image.

For users depending on having the `docker` command available for their startup/init scripts (which should rarely be the case), you can install the apt package as part of a startup script in `/docker-entrypoint-initaws.d/...`:
```
apt install -y docker
```