### PR TITLE
Fix CLI/runtime dependency issue with typing_extensions

### DIFF
--- a/localstack/utils/generic/wait_utils.py
+++ b/localstack/utils/generic/wait_utils.py
@@ -1,7 +1,11 @@
+import sys
 import time
 from typing import Callable
 
-from typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 class ShortCircuitWaitException(Exception):


### PR DESCRIPTION
The wait_utlis.py has an unconditional import to typing_extensions, which is only a dependency for python versions < 3.8 currently.

This leads to errors (most notably in the CLI) when trying to use this module.

This PR fixes this behavior by introducing a check for the python version, to use the typing import instead of the typing_extensions import for versions that support it.