### PR TITLE
update renovatebot config to ignore Dockerfile.rh

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   "enabledManagers": ["dockerfile"],
   "docker": {
     "pinDigests": true,
-    "ignorePaths": ["bin/lambda/Dockerfile.nodejs14x"]
+    "ignorePaths": ["bin/lambda/Dockerfile.nodejs14x", "Dockerfile.rh"]
   },
   "major": {
     "enabled": false


### PR DESCRIPTION
This PR adds the `Dockerfile.rh` to the `ignoredPaths` in the config of RenovateBot.
After this PR is merged, Renovate should close the PR it created to pin the sha on the base image automatically (https://github.com/localstack/localstack/pull/5533).