### PR TITLE
add endpoint to output diagnostics data

### DIFF
--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -503,10 +503,6 @@ def do_start_infra(asynchronous, apis, is_in_docker):
     @log_duration()
     def start_runtime_components():
         from localstack.services.edge import start_edge
-        from localstack.services.internal import LocalstackResourceHandler, get_internal_apis
-
-        # serve internal APIs through the generic proxy
-        ProxyListener.DEFAULT_LISTENERS.append(LocalstackResourceHandler(get_internal_apis()))
 
         # TODO: we want a composable LocalStack runtime (edge proxy, service manager, dns, ...)
         t = start_thread(start_edge, quiet=False)

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -227,11 +227,11 @@ class DiagnoseResource:
             },
             "health": health,
             "config": config_doc,
-            "logs": logs,
             "docker-inspect": self.inspect_main_container(),
             "docker-dependent-image-hashes": self.get_important_image_hashes(),
             "file-tree": {d: self.traverse_file_tree(d) for d in inspect_directories},
             "important-endpoints": self.resolve_endpoints(),
+            "logs": logs,
         }
 
     @staticmethod

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -202,6 +202,7 @@ class DiagnoseResource:
         config_doc = self.collect_config()
 
         # logs
+        logs = self.collect_logs()
 
         # docker information
         #  - docker inspect <container> output
@@ -223,11 +224,18 @@ class DiagnoseResource:
             },
             "health": health,
             "config": config_doc,
-            "logs": {},
+            "logs": logs,
             "docker-inspect": self.inspect_main_container(),
             "docker-dependent-image-hashes": self.get_important_image_hashes(),
             "file-tree": {d: self.traverse_file_tree(d) for d in inspect_directories},
             "important-endpoints": self.resolve_endpoints(),
+        }
+
+    @staticmethod
+    def collect_logs():
+        return {
+            "stdout": load_file("/tmp/localstack_infra.log", "failed to get localstack_infra.log"),
+            "stderr": load_file("/tmp/localstack_infra.err", "failed to get localstack_infra.err"),
         }
 
     @staticmethod

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -152,6 +152,7 @@ class DiagnoseResource:
         #  - ..
 
         # service health
+        health = requests.get(f"http://localhost:{config.get_edge_port_http()}/health").json()
 
         # config
         for k, v in inspect.getmembers(config):
@@ -177,7 +178,7 @@ class DiagnoseResource:
             "host": {
                 "version": load_file("/proc/version", "failed"),
             },
-            "services": {},
+            "health": health,
             "config": {},
             "logs": {},
             "docker-inspect": self.inspect_main_container(),

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -219,7 +219,7 @@ class DiagnoseResource:
 
         return {
             "version": {
-                "image-version": get_docker_image_details(get_main_container_name()),
+                "image-version": get_docker_image_details(),
                 "localstack-version": self.get_localstack_version(),
             },
             "host": {

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -187,7 +187,13 @@ class LocalstackResources(Router):
         self.add("/health", health_resource)
         self.add("/graph", graph_resource)
         self.add("/cloudformation/deploy", CloudFormationUi())
-        self.add("/diagnose", DiagnoseResource())
+
+        if config.DEBUG:
+            LOG.warning(
+                "Enabling diagnose endpoint, "
+                "please be aware that this can expose sensitive information via your network."
+            )
+            self.add("/diagnose", DiagnoseResource())
 
     def add(self, path, *args, **kwargs):
         super().add(f"{constants.INTERNAL_RESOURCE_PATH}{path}", *args, **kwargs)
@@ -201,7 +207,7 @@ class LocalstackResourceHandler(RouterListener):
     resources: LocalstackResources
 
     def __init__(self, resources: LocalstackResources = None) -> None:
-        super().__init__(resources or LocalstackResources(), fall_through=False)
+        super().__init__(resources or get_internal_apis(), fall_through=False)
 
     def forward_request(self, method, path, data, headers):
         try:

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -236,10 +236,12 @@ class DiagnoseResource:
 
     @staticmethod
     def collect_logs():
-        return {
-            "stdout": load_file("/tmp/localstack_infra.log", "failed to get localstack_infra.log"),
-            "stderr": load_file("/tmp/localstack_infra.err", "failed to get localstack_infra.err"),
-        }
+        try:
+            result = DOCKER_CLIENT.get_container_logs(get_main_container_name())
+        except Exception as e:
+            result = "error getting docker logs for container: %s" % e
+
+        return {"docker": result}
 
     @staticmethod
     def collect_config():

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -1,0 +1,172 @@
+"""Diagnostic tool for a localstack instance running in a container."""
+import inspect
+import os
+import socket
+from typing import Dict, List, Union
+
+from localstack import config
+from localstack.utils import bootstrap
+from localstack.utils.bootstrap import get_main_container_name
+from localstack.utils.common import load_file
+from localstack.utils.container_utils.container_client import NoSuchImage
+from localstack.utils.docker_utils import DOCKER_CLIENT
+
+DIAGNOSE_IMAGES = [
+    "localstack/lambda:provided",
+    "localstack/lambda:ruby2.7",
+    "localstack/lambda:ruby2.5",
+    "localstack/lambda:nodejs14.x",
+    "localstack/lambda:nodejs12.x",
+    "localstack/lambda:nodejs10.x",
+    "localstack/lambda:nodejs8.10",
+    "localstack/lambda:nodejs6.10",
+    "localstack/lambda:nodejs4.3",
+    "localstack/lambda:java8",
+    "localstack/lambda:java11",
+    "localstack/lambda:go1.x",
+    "localstack/lambda:dotnetcore3.1",
+    "localstack/lambda:dotnetcore2.1",
+    "localstack/lambda:dotnetcore2.0",
+    "localstack/lambda:python2.7",
+    "localstack/lambda:python3.6",
+    "localstack/lambda:python3.7",
+    "localstack/lambda:python3.8",
+    "localstack/bigdata",
+    "lambci/lambda:provided",
+    "lambci/lambda:ruby2.7",
+    "lambci/lambda:ruby2.5",
+    "lambci/lambda:nodejs14.x",
+    "lambci/lambda:nodejs12.x",
+    "lambci/lambda:nodejs10.x",
+    "lambci/lambda:nodejs8.10",
+    "lambci/lambda:nodejs6.10",
+    "lambci/lambda:nodejs4.3",
+    "lambci/lambda:java8",
+    "lambci/lambda:java11",
+    "lambci/lambda:go1.x",
+    "lambci/lambda:dotnetcore3.1",
+    "lambci/lambda:dotnetcore2.1",
+    "lambci/lambda:dotnetcore2.0",
+    "lambci/lambda:python2.7",
+    "lambci/lambda:python3.6",
+    "lambci/lambda:python3.7",
+    "lambci/lambda:python3.8",
+    "mongo",
+]
+
+EXCLUDE_CONFIG_KEYS = {
+    "CONFIG_ENV_VARS",
+    "DEFAULT_SERVICE_PORTS",
+    "copyright",
+    "__builtins__",
+    "__cached__",
+    "__doc__",
+    "__file__",
+    "__loader__",
+    "__name__",
+    "__package__",
+    "__spec__",
+}
+ENDPOINT_RESOLVE_LIST = ["localhost.localstack.cloud", "api.localstack.cloud"]
+INSPECT_DIRECTORIES = ["/var/lib/localstack", "/tmp"]
+
+
+def get_localstack_logs() -> Union[str, Dict]:
+    try:
+        result = DOCKER_CLIENT.get_container_logs(get_main_container_name())
+    except Exception as e:
+        result = "error getting docker logs for container: %s" % e
+
+    return {"docker": result}
+
+
+def get_localstack_config() -> Dict:
+    result = {}
+    for k, v in inspect.getmembers(config):
+        if k in EXCLUDE_CONFIG_KEYS:
+            continue
+        if inspect.isbuiltin(v):
+            continue
+        if inspect.isfunction(v):
+            continue
+        if inspect.ismodule(v):
+            continue
+        if inspect.isclass(v):
+            continue
+        if "typing." in str(type(v)):
+            continue
+
+        if hasattr(v, "__dict__"):
+            result[k] = v.__dict__
+        else:
+            result[k] = v
+
+    return result
+
+
+def inspect_main_container() -> Union[str, Dict]:
+    try:
+        return DOCKER_CLIENT.inspect_container(get_main_container_name())
+    except Exception as e:
+        return f"inspect failed: {e}"
+
+
+def get_localstack_version() -> Dict[str, str]:
+    return {
+        "build-date": os.environ.get("LOCALSTACK_BUILD_DATE"),
+        "build-git-hash": os.environ.get("LOCALSTACK_BUILD_GIT_HASH"),
+        "build-version": os.environ.get("LOCALSTACK_BUILD_VERSION"),
+    }
+
+
+def resolve_endpoints() -> Dict[str, str]:
+    result = {}
+    for endpoint in ENDPOINT_RESOLVE_LIST:
+        try:
+            resolved_endpoint = socket.gethostbyname(endpoint)
+        except Exception as e:
+            resolved_endpoint = f"unable_to_resolve {e}"
+        result[endpoint] = resolved_endpoint
+    return result
+
+
+def get_important_image_hashes() -> Dict[str, str]:
+    result = {}
+    for image in DIAGNOSE_IMAGES:
+        try:
+            image_version = DOCKER_CLIENT.inspect_image(image, pull=False)["RepoDigests"]
+        except NoSuchImage:
+            image_version = "not_present"
+        except Exception as e:
+            image_version = f"error: {e}"
+        result[image] = image_version
+    return result
+
+
+def get_service_stats() -> Dict[str, str]:
+    from localstack.services.plugins import SERVICE_PLUGINS
+
+    return {service: state.value for service, state in SERVICE_PLUGINS.get_states().items()}
+
+
+def get_file_tree() -> Dict[str, List[str]]:
+    return {d: traverse_file_tree(d) for d in INSPECT_DIRECTORIES}
+
+
+def traverse_file_tree(root: str) -> List[str]:
+    try:
+        result = []
+        if config.in_docker():
+            for root, _, _ in os.walk(root):
+                result.append(root)
+        return result
+    except Exception as e:
+        return ["traversing files failed %s" % e]
+
+
+def get_docker_image_details() -> Dict[str, str]:
+    return bootstrap.get_docker_image_details()
+
+
+def get_host_kernel_version() -> str:
+    return load_file("/proc/version", "failed").strip()

--- a/tests/integration/utils/test_diagnose.py
+++ b/tests/integration/utils/test_diagnose.py
@@ -1,12 +1,12 @@
-import requests
-
 from localstack import config
+from localstack.http import Request
+from localstack.services.internal import DiagnoseResource
 
 
-def test_diagnose_endpoint():
-    # simple smoke test diagnose endpoint
-
-    result = requests.get(f"{config.get_edge_url()}/_localstack/diagnose").json()
+def test_diagnose_resource():
+    # simple smoke test diagnose resource
+    resource = DiagnoseResource()
+    result = resource.on_get(Request(path="/_localstack/diagnose"))
 
     assert "/tmp" in result["file-tree"]
     assert "/var/lib/localstack" in result["file-tree"]

--- a/tests/integration/utils/test_diagnose.py
+++ b/tests/integration/utils/test_diagnose.py
@@ -1,0 +1,16 @@
+import requests
+
+from localstack import config
+
+
+def test_diagnose_endpoint():
+    # simple smoke test diagnose endpoint
+
+    result = requests.get(f"{config.get_edge_url()}/_localstack/diagnose").json()
+
+    assert "/tmp" in result["file-tree"]
+    assert "/var/lib/localstack" in result["file-tree"]
+    assert result["config"]["EDGE_PORT"] == config.EDGE_PORT
+    assert result["config"]["DATA_DIR"] == config.DATA_DIR
+    assert result["important-endpoints"]["localhost.localstack.cloud"].startswith("127.0.")
+    assert result["logs"]["docker"]


### PR DESCRIPTION
This PR adds an enpoint `/_localstack/daignose` that prints various diagnostic data about localstack that will help with user support. Here is some example output: [diagnostics.txt](https://github.com/localstack/localstack/files/8111599/diagnostics.txt)

To test, first check out the branch, and run `bin/docker-run.sh make infra` in localstack-ext.  Then call `curl localhost:4566/_localstack/diagnose`



