### PR TITLE
Add deep copy of handler results to avoid unwanted mutations

### DIFF
--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import logging
 from typing import Any, Callable, Dict, NamedTuple, Optional, Union
@@ -168,8 +169,11 @@ class Skeleton:
         if isinstance(result, HttpResponse):
             return result
 
+        # use a deep copy of the dict result to avoid unwanted mutations in service backends
+        copied_result = copy.deepcopy(result)
+
         # Serialize result dict to an HTTPResponse and return it
-        return self.serializer.serialize_to_response(result, operation)
+        return self.serializer.serialize_to_response(copied_result, operation)
 
     def on_service_exception(
         self, context: RequestContext, exception: ServiceException

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -1,4 +1,3 @@
-import copy
 import inspect
 import logging
 from typing import Any, Callable, Dict, NamedTuple, Optional, Union
@@ -169,11 +168,8 @@ class Skeleton:
         if isinstance(result, HttpResponse):
             return result
 
-        # use a deep copy of the dict result to avoid unwanted mutations in service backends
-        copied_result = copy.deepcopy(result)
-
         # Serialize result dict to an HTTPResponse and return it
-        return self.serializer.serialize_to_response(copied_result, operation)
+        return self.serializer.serialize_to_response(result, operation)
 
     def on_service_exception(
         self, context: RequestContext, exception: ServiceException

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -998,3 +998,23 @@ def test_all_non_existing_key():
             },
         },
     )
+
+
+def test_no_mutation_of_parameters():
+    service = load_service("appconfig")
+    response_serializer = create_serializer(service)
+
+    parameters = {
+        "ApplicationId": "app_id",
+        "ConfigurationProfileId": "conf_id",
+        "VersionNumber": 1,
+        "Content": b'{"Id":"foo"}',
+        "ContentType": "application/json",
+    }
+    expected = parameters.copy()
+
+    # serialize response and check whether parameters are unchanged
+    _ = response_serializer.serialize_to_response(
+        parameters, service.operation_model("CreateHostedConfigurationVersion")
+    )
+    assert parameters == expected


### PR DESCRIPTION
In instances where the result of API calls needs to split up into body and header fields, the result given by the handlers is edited in place. This can lead to unwanted mutations which affect the service state. By using a deep copy of the result for serialization this can easily be avoided.