### PR TITLE
Add ability to tag and push images using Docker client

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -61,6 +61,20 @@ class NoSuchNetwork(ContainerException):
         self.network_name = network_name
 
 
+class RegistryConnectionError(ContainerException):
+    def __init__(self, details: str, message=None, stdout=None, stderr=None) -> None:
+        message = message or f"Connection error: {details}"
+        super().__init__(message, stdout, stderr)
+        self.details = details
+
+
+class AccessDenied(ContainerException):
+    def __init__(self, object_name: str, message=None, stdout=None, stderr=None) -> None:
+        message = message or f"Access denied to {object_name}"
+        super().__init__(message, stdout, stderr)
+        self.object_name = object_name
+
+
 class PortMappings(object):
     """Maps source to target port ranges for Docker port mappings."""
 
@@ -386,7 +400,12 @@ class ContainerClient(metaclass=ABCMeta):
 
     @abstractmethod
     def pull_image(self, docker_image: str) -> None:
-        """Pulls a image with a given name from a docker registry"""
+        """Pulls a image with a given name from a Docker registry"""
+        pass
+
+    @abstractmethod
+    def push_image(self, docker_image: str) -> None:
+        """Pushes a image with a given name to a Docker registry"""
         pass
 
     @abstractmethod
@@ -396,6 +415,15 @@ class ContainerClient(metaclass=ABCMeta):
         :param dockerfile_path: Path to Dockerfile, or a directory that contains a Dockerfile
         :param image_name: Name of the image to be built
         :param context_path: Path for build context (defaults to dirname of Dockerfile)
+        """
+        pass
+
+    @abstractmethod
+    def tag_image(self, source_ref: str, target_name: str) -> None:
+        """Tags an image with a new name
+
+        :param source_ref: Name or ID of the image to be tagged
+        :param target_name: New name (tag) of the tagged image
         """
         pass
 

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -12,6 +12,7 @@ from localstack import config
 from localstack.config import in_docker
 from localstack.utils.common import is_ipv4_address, safe_run, save_file, short_uid, to_str
 from localstack.utils.container_utils.container_client import (
+    AccessDenied,
     ContainerClient,
     ContainerException,
     DockerContainerStatus,
@@ -19,8 +20,10 @@ from localstack.utils.container_utils.container_client import (
     NoSuchImage,
     NoSuchNetwork,
     PortMappings,
+    RegistryConnectionError,
     Util,
 )
+from localstack.utils.net_utils import get_free_tcp_port
 
 ContainerInfo = NamedTuple(
     "ContainerInfo",
@@ -773,6 +776,55 @@ class TestDockerClient:
         message = "test message"
         stdout, _ = docker_client.run_container("alpine", command=["echo", message], remove=True)
         assert message == stdout.decode(config.DEFAULT_ENCODING).strip()
+
+    @pytest.mark.skip_offline
+    def test_push_non_existent_docker_image(self, docker_client: ContainerClient):
+        with pytest.raises(NoSuchImage):
+            docker_client.push_image("localstack_non_existing_image_for_tests")
+
+    @pytest.mark.skip_offline
+    def test_push_access_denied(self, docker_client: ContainerClient):
+        with pytest.raises(AccessDenied):
+            docker_client.push_image("alpine")
+        with pytest.raises(AccessDenied):
+            docker_client.push_image("alpine:latest")
+
+    @pytest.mark.skip_offline
+    def test_push_invalid_registry(self, docker_client: ContainerClient):
+        image_name = f"localhost:{get_free_tcp_port()}/localstack_dummy_image"
+        try:
+            docker_client.tag_image("alpine", image_name)
+            with pytest.raises(RegistryConnectionError):
+                docker_client.push_image(image_name)
+        finally:
+            docker_client.remove_image(image_name)
+
+    @pytest.mark.skip_offline
+    def test_tag_image(self, docker_client: ContainerClient):
+        docker_client.pull_image("alpine")
+        img_refs = [
+            "localstack_dummy_image",
+            "localstack_dummy_image:latest",
+            "localstack_dummy_image:test",
+            "docker.io/localstack_dummy_image:test2",
+            "example.com:4510/localstack_dummy_image:test3",
+        ]
+        try:
+            for img_ref in img_refs:
+                docker_client.tag_image("alpine", img_ref)
+                images = docker_client.get_docker_image_names(strip_latest=":latest" not in img_ref)
+                expected = img_ref.split("/")[-1] if len(img_ref.split(":")) < 3 else img_ref
+                assert expected in images
+        finally:
+            for img_ref in img_refs:
+                docker_client.remove_image(img_ref)
+
+    @pytest.mark.skip_offline
+    def test_tag_non_existing_image(self, docker_client: ContainerClient):
+        with pytest.raises(NoSuchImage):
+            docker_client.tag_image(
+                "localstack_non_existing_image_for_tests", "localstack_dummy_image"
+            )
 
     @pytest.mark.skip_offline
     @pytest.mark.parametrize("custom_context", [True, False])


### PR DESCRIPTION
Add ability to tag and push images using our Docker clients (helps in removing the dependency to `docker` binary in our tests).

The test contains a few examples of invalid pushes (access denied, connection refused), however no actual successful pushes are added, to avoid spamming the registry with data. (We could consider spinning up a local registry at some point, but seemed too much overhead at this stage.)