### PR TITLE
add config variable for SKIP_SSL_CERT_DOWNLOAD

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -380,6 +380,9 @@ EAGER_SERVICE_LOADING = is_env_true("EAGER_SERVICE_LOADING")
 # Whether to skip downloading additional infrastructure components (e.g., custom Elasticsearch versions)
 SKIP_INFRA_DOWNLOADS = os.environ.get("SKIP_INFRA_DOWNLOADS", "").strip()
 
+# Whether to skip downloading our signed SSL cert.
+SKIP_SSL_CERT_DOWNLOAD = is_env_true("SKIP_SSL_CERT_DOWNLOAD")
+
 # whether to enable legacy record&replay persistence mechanism (default true, but will be disabled in a future release!)
 LEGACY_PERSISTENCE = is_env_not_false("LEGACY_PERSISTENCE")
 
@@ -670,6 +673,7 @@ CONFIG_ENV_VARS = [
     "S3_SKIP_SIGNATURE_VALIDATION",
     "SERVICES",
     "SKIP_INFRA_DOWNLOADS",
+    "SKIP_SSL_CERT_DOWNLOAD",
     "SQS_PORT_EXTERNAL",
     "STEPFUNCTIONS_LAMBDA_ENDPOINT",
     "SYNCHRONOUS_API_GATEWAY_EVENTS",

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -27,7 +27,6 @@ from localstack.config import (
     EXTRA_CORS_ALLOWED_HEADERS,
     EXTRA_CORS_ALLOWED_ORIGINS,
     EXTRA_CORS_EXPOSE_HEADERS,
-    is_env_true,
 )
 from localstack.constants import (
     APPLICATION_JSON,
@@ -995,7 +994,7 @@ def install_predefined_cert_if_available():
     try:
         from localstack_ext.bootstrap import install
 
-        if is_env_true("SKIP_SSL_CERT_DOWNLOAD"):
+        if config.SKIP_SSL_CERT_DOWNLOAD:
             LOG.debug("Skipping download of local SSL cert, as SKIP_SSL_CERT_DOWNLOAD=1")
             return
         install.setup_ssl_cert()


### PR DESCRIPTION
Simply pulls out the environment variable into a config var. This will then be used in localstack-ext as well to skip the SSL cert downloading. This is a prerequisite for #5502 
