### PR TITLE
fix encoding problem for AlarmDescription in put-metric-alarm

### DIFF
--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -1,8 +1,9 @@
 import json
 import logging
+from xml.sax.saxutils import escape
 
 from moto.cloudwatch import cloudwatch_backends
-from moto.cloudwatch.models import FakeAlarm
+from moto.cloudwatch.models import CloudWatchBackend, FakeAlarm
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.cloudwatch import (
@@ -58,6 +59,64 @@ def update_state(target, self, reason, reason_data, state_value):
                 data["service"],
                 action,
             )
+
+
+@patch(target=CloudWatchBackend.put_metric_alarm)
+def put_metric_alarm(
+    target,
+    self,
+    name,
+    namespace,
+    metric_name,
+    metric_data_queries,
+    comparison_operator,
+    evaluation_periods,
+    datapoints_to_alarm,
+    period,
+    threshold,
+    statistic,
+    extended_statistic,
+    description,
+    dimensions,
+    alarm_actions,
+    ok_actions,
+    insufficient_data_actions,
+    unit,
+    actions_enabled,
+    treat_missing_data,
+    evaluate_low_sample_count_percentile,
+    threshold_metric_id,
+    rule=None,
+    tags=None,
+):
+    if description:
+        description = escape(description)
+    target(
+        self,
+        name,
+        namespace,
+        metric_name,
+        metric_data_queries,
+        comparison_operator,
+        evaluation_periods,
+        datapoints_to_alarm,
+        period,
+        threshold,
+        statistic,
+        extended_statistic,
+        description,
+        dimensions,
+        alarm_actions,
+        ok_actions,
+        insufficient_data_actions,
+        unit,
+        actions_enabled,
+        treat_missing_data,
+        evaluate_low_sample_count_percentile,
+        threshold_metric_id,
+        rule,
+        tags,
+    )
 
 
 def create_message_response_update_state(alarm, old_state):

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -294,6 +294,23 @@ class TestCloudwatch:
         results = cloudwatch_client.list_metrics(Namespace="AWS/EC2")["Metrics"]
         assert 2 == len(results)
 
+    def test_put_metric_alarm_escape_character(self, cloudwatch_client):
+        cloudwatch_client.put_metric_alarm(
+            AlarmName="cpu-mon",
+            AlarmDescription="<",
+            MetricName="CPUUtilization",
+            Namespace="AWS/EC2",
+            Statistic="Sum",
+            Period=180,
+            Threshold=1,
+            ComparisonOperator="GreaterThanThreshold",
+            EvaluationPeriods=1,
+            AlarmActions=["arn:aws:sns:us-east-1:111122223333:MyTopic"],
+        )
+
+        result = cloudwatch_client.describe_alarms()
+        assert result.get("MetricAlarms")[0]["AlarmDescription"] == "<"
+
     def test_set_alarm(
         self, sns_client, cloudwatch_client, sqs_client, sns_create_topic, sqs_create_queue
     ):


### PR DESCRIPTION
This PR fixes an encoding issue for the `AlarmDescription` set with the `put-metric-alarm` for cloudwatch.

https://github.com/localstack/localstack/issues/5489
