### PR TITLE
upgrade airspeed dependency and remove custom patches

### DIFF
--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -87,36 +87,6 @@ def render_velocity_template(template, context, variables=None, as_json=False):
     if not template:
         return template
 
-    # Apply a few fixes below, to properly prepare the template...
-
-    # TODO: remove once this PR is merged: https://github.com/purcell/airspeed/pull/48
-    def expr_parse(self):
-        try:
-            self.identity_match(self.DOT)
-            self.expression = self.next_element(airspeed.VariableExpression)
-        except airspeed.NoMatch:
-            self.expression = self.next_element(airspeed.ArrayIndex)
-            self.subexpression = None
-            try:
-                self.subexpression = self.next_element(airspeed.SubExpression)
-            except airspeed.NoMatch:
-                pass
-
-    airspeed.SubExpression.parse = expr_parse
-
-    # TODO: remove once this PR is merged: https://github.com/purcell/airspeed/pull/48
-    def expr_calculate(self, current_object, loader, global_namespace):
-        args = [current_object, loader]
-        if not isinstance(self.expression, airspeed.ArrayIndex):
-            return self.expression.calculate(*(args + [global_namespace]))
-        index = self.expression.calculate(*args)
-        result = current_object[index]
-        if self.subexpression:
-            result = self.subexpression.calculate(result, loader, global_namespace)
-        return result
-
-    airspeed.SubExpression.calculate = expr_calculate
-
     # fix "#set" commands
     template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ typing-extensions; python_version < '3.8'
 tailer>=0.4.1
 
 # extra=runtime
-airspeed>=0.5.14
+airspeed>=0.5.18
 # Use our "ext" version until this bug is fixed: https://github.com/awslabs/amazon-kinesis-client-python/issues/99
 amazon_kclpy-ext==1.5.1
 # amazon-kclpy==1.5.1


### PR DESCRIPTION
This PR upgrades `airspeed` to the latest version and removes previous custom patches.
