### PR TITLE
fix ASF parser and serializer issues - round 4

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -551,7 +551,10 @@ class BaseRestResponseSerializer(ResponseSerializer, ABC):
     ) -> None:
         header_params, payload_params = self._partition_members(parameters, shape)
         self._process_header_members(header_params, response, shape)
-        self._serialize_payload(payload_params, response, shape, shape_members, operation_model)
+        # "HEAD" responeses are basically "GET" responses without the actual body.
+        # Do not process the body payload in this case (setting a body could also manipulate the headers)
+        if operation_model.http.get("method") != "HEAD":
+            self._serialize_payload(payload_params, response, shape, shape_members, operation_model)
         self._serialize_content_type(response, shape, shape_members)
         self._prepare_additional_traits_in_response(response, operation_model)
 

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -664,11 +664,15 @@ class BaseRestResponseSerializer(ResponseSerializer, ABC):
                 continue
             key = member_shape.serialization.get("name", name)
             value = parameters[name]
+            if value is None:
+                continue
             if location == "header":
                 response.headers[key] = self._serialize_header_value(member_shape, value)
             elif location == "headers":
                 header_prefix = key
                 self._serialize_header_map(header_prefix, response, value)
+            elif location == "statusCode":
+                response.status_code = int(value)
 
     def _serialize_header_map(self, prefix: str, response: HttpResponse, params: dict) -> None:
         """Serializes the header map for the location trait "headers"."""

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -76,7 +76,6 @@ not work out-of-the-box.
 """
 import abc
 import base64
-import calendar
 import copy
 import json
 import logging
@@ -655,16 +654,17 @@ class BaseRestResponseSerializer(ResponseSerializer, ABC):
         """Serializes a value for the location trait "header"."""
         if shape.type_name == "timestamp":
             datetime_obj = parse_to_aware_datetime(value)
-            timestamp = calendar.timegm(datetime_obj.utctimetuple())
             timestamp_format = shape.serialization.get(
                 "timestampFormat", self.HEADER_TIMESTAMP_FORMAT
             )
-            return self._convert_timestamp_to_str(timestamp, timestamp_format)
+            return self._convert_timestamp_to_str(datetime_obj, timestamp_format)
         elif shape.type_name == "list":
             converted_value = [
                 self._serialize_header_value(shape.member, v) for v in value if v is not None
             ]
             return ",".join(converted_value)
+        elif shape.type_name == "boolean":
+            return "true" if value else "false"
         elif is_json_value_header(shape):
             # Serialize with no spaces after separators to save space in
             # the header.

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -351,7 +351,7 @@ class BaseXMLResponseSerializer(ResponseSerializer):
             self._default_serialize(error_tag, message, None, "Message")
         if sender_fault:
             # The sender fault is either not set or "Sender"
-            self._default_serialize(error_tag, "Sender", None, "Fault")
+            self._default_serialize(error_tag, "Sender", None, "Type")
 
     def _serialize_body_params(
         self, params: dict, shape: Shape, operation_model: OperationModel

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -818,10 +818,11 @@ class EC2ResponseSerializer(QueryResponseSerializer):
     def _prepare_additional_traits_in_xml(self, root: Optional[ETree.Element]):
         # The EC2 protocol does not use the root output shape, therefore we need to remove the hierarchy level
         # below the root level
-        output_node = root[0]
-        for child in output_node:
-            root.append(child)
-        root.remove(output_node)
+        if len(root) > 0:
+            output_node = root[0]
+            for child in output_node:
+                root.append(child)
+            root.remove(output_node)
 
         # Add the requestId here (it's not defined in the specs)
         # For the ec2 and the query protocol, the root cannot be None at this time.

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -243,7 +243,7 @@ class ResponseSerializer(abc.ABC):
 
     @staticmethod
     def _timestamp_unixtimestamp(value: datetime) -> float:
-        return round(value.timestamp(), 3)
+        return value.timestamp()
 
     def _timestamp_rfc822(self, value: datetime) -> str:
         if isinstance(value, datetime):

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -99,16 +99,6 @@ class InvalidParameterValue(CommonServiceException):
         super().__init__("InvalidParameterValues", message, 400, True)
 
 
-class NonExistentQueue(CommonServiceException):
-    def __init__(self):
-        # TODO: not sure if this is really how AWS behaves
-        super().__init__(
-            "AWS.SimpleQueueService.NonExistentQueue",
-            "The specified queue does not exist for this wsdl version.",
-            status_code=400,
-        )
-
-
 class InvalidAttributeValue(CommonServiceException):
     def __init__(self, message):
         super().__init__("InvalidAttributeValue", message, 400, True)
@@ -682,15 +672,15 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
     def _require_queue(self, key: QueueKey) -> SqsQueue:
         """
-        Returns the queue for the given key, or raises NonExistentQueue if it does not exist.
+        Returns the queue for the given key, or raises QueueDoesNotExist if it does not exist.
 
         :param key: the QueueKey to look for
         :returns: the queue
-        :raises NonExistentQueue: if the queue does not exist
+        :raises QueueDoesNotExist: if the queue does not exist
         """
         with self._mutex:
             if key not in self.queues:
-                raise NonExistentQueue()
+                raise QueueDoesNotExist()
 
             return self.queues[key]
 
@@ -707,13 +697,13 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
     ) -> SqsQueue:
         """
         Uses resolve_queue_key to determine the QueueKey from the given input, and returns the respective queue,
-        or raises NonExistentQueue if it does not exist.
+        or raises QueueDoesNotExist if it does not exist.
 
         :param context: the request context, used for getting region and account_id, and optionally the queue_url
         :param queue_name: the queue name (if this is set, then this will be used for the key)
         :param queue_url: the queue url (if name is not set, this will be used to determine the queue name)
         :returns: the queue
-        :raises NonExistentQueue: if the queue does not exist
+        :raises QueueDoesNotExist: if the queue does not exist
         """
         key = resolve_queue_key(context, queue_name, queue_url)
         return self._require_queue(key)

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -354,6 +354,16 @@ def test_query_parser_cloudformation_with_botocore():
     )
 
 
+def test_query_parser_unflattened_list_of_maps():
+    _botocore_parser_integration_test(
+        service="rds",
+        action="CreateDBCluster",
+        DBClusterIdentifier="mydbcluster",
+        Engine="aurora",
+        Tags=[{"Key": "Hello", "Value": "There"}, {"Key": "Hello1", "Value": "There1"}],
+    )
+
+
 def test_restxml_parser_route53_with_botocore():
     _botocore_parser_integration_test(
         service="route53",

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -2,9 +2,8 @@ import copy
 import re
 from datetime import datetime
 
-import pytest
 from botocore.parsers import ResponseParser, create_parser
-from dateutil.tz import tzutc, tzlocal
+from dateutil.tz import tzlocal, tzutc
 
 from localstack.aws.api import CommonServiceException, ServiceException
 from localstack.aws.protocol.serializer import create_serializer
@@ -204,18 +203,16 @@ def test_rest_xml_serializer_s3_with_botocore():
     _botocore_serializer_integration_test("s3", "GetBucketAnalyticsConfiguration", parameters)
 
 
-@pytest.mark.skip(reason="failing! 'Body' has 'streaming=True'!")
 def test_rest_xml_serializer_s3_2_with_botocore():
+    # These date fields in this response are encoded in the header. The max precision is seconds.
     parameters = {
-        # TODO
-        # 'Body': StreamingBody(),
-        "Body": "Fuu",
+        "Body": "body",
         "DeleteMarker": True,
         "AcceptRanges": "string",
         "Expiration": "string",
         "Restore": "string",
-        "LastModified": datetime(2015, 1, 1, 23, 59, 59, 6000, tzinfo=tzutc()),
-        "ContentLength": 123,
+        "LastModified": datetime(2015, 1, 1, 23, 59, 59, tzinfo=tzutc()),
+        "ContentLength": 4,
         "ETag": "string",
         "MissingMeta": 123,
         "VersionId": "string",
@@ -225,7 +222,7 @@ def test_rest_xml_serializer_s3_2_with_botocore():
         "ContentLanguage": "string",
         "ContentRange": "string",
         "ContentType": "string",
-        "Expires": datetime(2015, 1, 1, 23, 59, 59, 6000, tzinfo=tzutc()),
+        "Expires": datetime(2015, 1, 1, 23, 59, 59, tzinfo=tzutc()),
         "WebsiteRedirectLocation": "string",
         "ServerSideEncryption": "AES256",
         "Metadata": {"string": "string"},
@@ -239,7 +236,7 @@ def test_rest_xml_serializer_s3_2_with_botocore():
         "PartsCount": 123,
         "TagCount": 123,
         "ObjectLockMode": "GOVERNANCE",
-        "ObjectLockRetainUntilDate": datetime(2015, 1, 1, 23, 59, 59, 6000, tzinfo=tzutc()),
+        "ObjectLockRetainUntilDate": datetime(2015, 1, 1, 23, 59, 59, tzinfo=tzutc()),
         "ObjectLockLegalHoldStatus": "ON",
     }
     _botocore_serializer_integration_test("s3", "GetObject", parameters)

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -850,6 +850,10 @@ def test_ec2_serializer_ec2_with_botocore():
     _botocore_serializer_integration_test("ec2", "CreateInstanceEventWindow", parameters)
 
 
+def test_ec2_serializer_ec2_with_empty_response():
+    _botocore_serializer_integration_test("ec2", "CreateTags", {})
+
+
 def test_ec2_protocol_custom_error_serialization():
     exception = CommonServiceException(
         "IdempotentParameterMismatch", "Different payload, same token?!"
@@ -943,6 +947,23 @@ def test_all_non_existing_key():
         expected_response_content={
             "StackResourceDrift": {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/MyStack/d0a825a0-e4cd-xmpl-b9fb-061c69e99204",
+            }
+        },
+    )
+    # ec2
+    _botocore_serializer_integration_test(
+        "ec2",
+        "CreateInstanceEventWindow",
+        {
+            "InstanceEventWindow": {
+                "InstanceEventWindowId": "string",
+                "unknown": {"foo": "bar"},
+            },
+            "unknown": {"foo": "bar"},
+        },
+        expected_response_content={
+            "InstanceEventWindow": {
+                "InstanceEventWindowId": "string",
             }
         },
     )

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import pytest
 from botocore.parsers import ResponseParser, create_parser
-from dateutil.tz import tzutc
+from dateutil.tz import tzutc, tzlocal
 
 from localstack.aws.api import CommonServiceException, ServiceException
 from localstack.aws.protocol.serializer import create_serializer
@@ -587,6 +587,15 @@ def test_json_serializer_cognito_with_botocore():
                     {"Priority": 123, "Name": "verified_email"},
                 ]
             },
+        }
+    }
+    _botocore_serializer_integration_test("cognito-idp", "DescribeUserPool", parameters)
+
+
+def test_json_serializer_date_serialization_with_botocore():
+    parameters = {
+        "UserPool": {
+            "LastModifiedDate": datetime(2022, 2, 8, 9, 17, 40, 122939, tzinfo=tzlocal()),
         }
     }
     _botocore_serializer_integration_test("cognito-idp", "DescribeUserPool", parameters)

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -900,13 +900,9 @@ def test_restxml_headers_location():
         {
             "DeleteMarker": False,
             "Metadata": {"headers_key1": "headers_value1", "headers_key2": "headers_value2"},
-        },
-        # The spec defines the ContentType and the ContentLength, which is automatically set
-        expected_response_content={
-            "DeleteMarker": False,
-            "Metadata": {"headers_key1": "headers_value1", "headers_key2": "headers_value2"},
-            "ContentType": "text/xml",
-            "ContentLength": 59,
+            "ContentType": "application/octet-stream",
+            # The content length should explicitly be tested here.
+            "ContentLength": 159,
         },
     )
 

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -1,6 +1,7 @@
 import copy
 import re
 from datetime import datetime
+from typing import Optional
 
 from botocore.parsers import ResponseParser, create_parser
 from dateutil.tz import tzlocal, tzutc
@@ -80,7 +81,7 @@ def _botocore_error_serializer_integration_test(
     exception: ServiceException,
     code: str,
     status_code: int,
-    message: str,
+    message: Optional[str],
     is_sender_fault: bool = False,
 ):
     """
@@ -850,6 +851,15 @@ def test_restjson_none_serialization():
     _botocore_serializer_integration_test(
         "lambda", "CreateFunction", parameters, status_code=201, expected_response_content=expected
     )
+    exception = CommonServiceException("CodeVerificationFailedException", None)
+    _botocore_error_serializer_integration_test(
+        "lambda",
+        "CreateFunction",
+        exception,
+        "CodeVerificationFailedException",
+        400,
+        "",
+    )
 
 
 def test_restxml_none_serialization():
@@ -867,6 +877,16 @@ def test_restxml_none_serialization():
     expected = {"HostedZones": []}
     _botocore_serializer_integration_test(
         "route53", "ListHostedZonesByName", parameters, expected_response_content=expected
+    )
+    # Exception without a message
+    exception = CommonServiceException("NoSuchKeySigningKey", None)
+    _botocore_error_serializer_integration_test(
+        "route53",
+        "DeleteKeySigningKey",
+        exception,
+        "NoSuchKeySigningKey",
+        400,
+        "",
     )
 
 

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -444,6 +444,28 @@ def test_query_protocol_error_serialization_sender_fault():
     )
 
 
+def test_restxml_protocol_error_serialization_not_specified_for_operation():
+    """
+    Tests if the serializer can serialize an error which is not explicitly defined as an error shape for the
+    specific operation.
+    This can happen if the specification is not specific enough (f.e. S3's GetBucketAcl does not define the NoSuchBucket
+    error, even though it obviously can be raised).
+    """
+
+    class NoSuchBucket(ServiceException):
+        pass
+
+    exception = NoSuchBucket("Exception message!")
+    _botocore_error_serializer_integration_test(
+        "s3",
+        "GetBucketAcl",
+        exception,
+        "NoSuchBucket",
+        400,
+        "Exception message!",
+    )
+
+
 def test_restxml_protocol_error_serialization():
     class CloudFrontOriginAccessIdentityAlreadyExists(ServiceException):
         pass

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -969,6 +969,15 @@ def test_restxml_header_location():
         },
         status_code=201,
     )
+    # Test a boolean header location field
+    parameters = {
+        "ContentLength": 0,
+        "Body": "",
+        "DeleteMarker": True,
+        "ContentType": "string",
+        "Metadata": {"string": "string"},
+    }
+    _botocore_serializer_integration_test("s3", "GetObject", parameters)
 
 
 def test_restxml_headers_location():

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -778,6 +778,20 @@ def test_restjson_headers_target_serialization():
     assert headers["baz"] == "ed"
 
 
+def test_restjson_statuscode_target_serialization():
+    _botocore_serializer_integration_test(
+        "lambda",
+        "Invoke",
+        {
+            "StatusCode": 203,
+            "LogResult": "Log Message!",
+            "ExecutedVersion": "Latest",
+            "Payload": "test payload",
+        },
+        status_code=203,
+    )
+
+
 def test_restjson_payload_serialization():
     """
     Tests the serialization of specific member attributes as payload, based on an appconfig example:


### PR DESCRIPTION
After https://github.com/localstack/localstack/pull/5488, https://github.com/localstack/localstack/pull/5470, and https://github.com/localstack/localstack/pull/5512, this is the fourth round of fixes for the parsers and serializers of ASF.
This PR contains the following changes:
- fix EC2 serialization when root node is empty
  - Fixes the serialization of empty EC2 responses.
- fix json protocol datetime serialization
  - Fixes the datetime serialization for JSON body parameters (by avoiding an unnecessary rounding).
- fix rest-xml protocol header datetime serialization
  - The datetime serialization of header fields according to RFC822.
- fix query protocol parsing of non-flattened list of maps
  - Non-flattened list prefixes are defined by their member's name. Only as a fallback "member." should be used as a prefix.
- fix copying params in serializer
  - Avoids the expensive deep-copy of the response params dict by implementing a partitioning to circumvent the method parameter manipulation.
- fix serialize header params for HEAD responses in rest protocols
  - HEAD responses should not contain a body (and setting a body could manipulate header fields).
- fix xml error serialization with "Sender" fault
  - Fixes the XML member name of the "fault" property of errors.
- fix error shape lookup within the serializer
  - Some operation specs do not define all the exceptions which can be raised. This fix - as a fallback - widens the lookup to all error shapes within the service.
- fix rest statuscode location serialization
  - Location "statuscode" is now handled again for rest-* protocols
- fix None exception message serialization for rest protocols
  - Some exceptions might not contain a message (even though they should). This fix now makes sure that if there is no message, it also doesn't serialize the field.