### PR TITLE
fix linting issues by pinning flake8-black

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ black==21.6b0
 coveralls==3.1.0
 Cython
 flake8>=3.6.0
-flake8-black>=0.2.1
+flake8-black==0.2.3
 flake8-isort>=4.0.0
 flake8-quotes>=0.11.0
 # enables flake8 configuration through pyproject.toml


### PR DESCRIPTION
[flake8-black](https://github.com/peterjc/flake8-black) just released a new version ([0.2.5](https://github.com/peterjc/flake8-black/releases/tag/v0.2.5)) which is not compatible with our pinned black version.
This PR pins the version of flake8-black to avoid these issues.

In the future, we might switch to the newest version of both libraries (f.e. we could enable the preview feature of black to ease upgrades to the next major version of black).