### PR TITLE
add flag to call_moto to exclude the ResponseMetadata

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# format the codebase with black and isort
+8c006f122803dd06811343782b34f067f0622baf
+# reorganize utility package
+a7602821ac8666c9ab3a253457eb99570908ac8e

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -35,11 +35,12 @@ MotoDispatcher = Callable[[HttpRequest, str, dict], MotoResponse]
 user_agent = f"Localstack/{localstack_version} Python/{sys.version.split(' ')[0]}"
 
 
-def call_moto(context: RequestContext) -> ServiceResponse:
+def call_moto(context: RequestContext, include_response_metadata=False) -> ServiceResponse:
     """
     Call moto with the given request context and receive a parsed ServiceResponse.
 
     :param context: the request context
+    :param include_response_metadata: whether to include botocore's "ResponseMetadata" attribute
     :return: a serialized AWS ServiceResponse (same as boto3 would return)
     """
     status, headers, content = dispatch_to_moto(context)
@@ -64,6 +65,9 @@ def call_moto(context: RequestContext) -> ServiceResponse:
             status_code=status,
             message=error.get("Message", ""),
         )
+
+    if not include_response_metadata:
+        response.pop("ResponseMetadata", None)
 
     return response
 

--- a/tests/integration/test_moto.py
+++ b/tests/integration/test_moto.py
@@ -11,7 +11,8 @@ def test_call_with_sqs_creates_state_correctly():
     qname = f"queue-{short_uid()}"
 
     response = moto.call_moto(
-        moto.create_aws_request_context("sqs", "CreateQueue", {"QueueName": qname})
+        moto.create_aws_request_context("sqs", "CreateQueue", {"QueueName": qname}),
+        include_response_metadata=True,
     )
     url = response["QueueUrl"]
 
@@ -72,6 +73,16 @@ def test_call_with_sqs_modifies_state_in_moto_backend():
     assert qname not in sqs_backends.get(config.AWS_REGION_US_EAST_1).queues
 
 
+def test_call_include_response_metadata():
+    ctx = moto.create_aws_request_context("sqs", "ListQueues")
+
+    response = moto.call_moto(ctx)
+    assert "ResponseMetadata" not in response
+
+    response = moto.call_moto(ctx, include_response_metadata=True)
+    assert "ResponseMetadata" in response
+
+
 def test_call_with_modified_request():
     from moto.sqs.models import sqs_backends
 
@@ -98,7 +109,8 @@ def test_call_with_es_creates_state_correctly():
                 "DomainName": domain_name,
                 "ElasticsearchVersion": "7.10",
             },
-        )
+        ),
+        include_response_metadata=True,
     )
 
     try:
@@ -109,7 +121,8 @@ def test_call_with_es_creates_state_correctly():
         response = moto.call_moto(
             moto.create_aws_request_context(
                 "es", "DeleteElasticsearchDomain", {"DomainName": domain_name}
-            )
+            ),
+            include_response_metadata=True,
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 


### PR DESCRIPTION
* addresses what we are seeing in #5456 
```
localstack  | 2022-02-25T17:20:57.061:ERROR:localstack.aws.protocol.serializer: Response object contains a member which is not specified: ResponseMetadata
localstack  | Traceback (most recent call last):
localstack  |   File "/opt/code/localstack/localstack/aws/protocol/serializer.py", line 903, in _serialize_type_structure
localstack  |     member_shape = members[member_key]
localstack  | KeyError: 'ResponseMetadata'
localstack  | {
localstack  |     "Version": 1
localstack  | }
```

since `response` contained the `ResponseMetadata` object as expected, from the botocore response parser, the subsequent ASF serialization process of `call_moto` calls would raise this error if you didn't explicitly remove the attribute. the regular way was to do th efollowing in ASF handlers which arguably is a bit silly.
```python
def do_a_thing(context: RequestContext, ...):
	response = moto.call_moto(context)

	del response['ResponseMetadata']

	return response
```

