### PR TITLE
Add framework for mocking AWS shapes

### DIFF
--- a/localstack/aws/mocking.py
+++ b/localstack/aws/mocking.py
@@ -1,0 +1,392 @@
+import logging
+import math
+import random
+import re
+from datetime import date, datetime
+from functools import lru_cache, singledispatch
+from typing import Dict, List, Optional, Set, Tuple, Union, cast
+
+import networkx
+import rstr
+from botocore.model import ListShape, MapShape, OperationModel, Shape, StringShape, StructureShape
+
+from localstack.aws.api import RequestContext, ServiceRequest, ServiceResponse
+from localstack.aws.skeleton import DispatchTable, ServiceRequestDispatcher, Skeleton
+from localstack.aws.spec import load_service
+
+LOG = logging.getLogger(__name__)
+
+types = {
+    "timestamp",
+    "string",
+    "blob",
+    "map",
+    "list",
+    "long",
+    "structure",
+    "integer",
+    "double",
+    "float",
+    "boolean",
+}
+
+Instance = Union[
+    Dict[str, "Instance"],
+    List["Instance"],
+    str,
+    bytes,
+    map,
+    list,
+    float,
+    int,
+    bool,
+    date,
+]
+
+# https://github.com/boto/botocore/issues/2623
+StringShape.METADATA_ATTRS.append("pattern")
+
+words = [
+    # a few snazzy six-letter words
+    "snazzy",
+    "mohawk",
+    "poncho",
+    "proton",
+    "foobar",
+    "python",
+    "umlaut",
+    "except",
+    "global",
+    "latest",
+]
+
+
+class ShapeGraph(networkx.DiGraph):
+    root: Union[ListShape, StructureShape, MapShape]
+    cycle: List[Tuple[str, str]]
+    cycle_shapes: List[str]
+
+
+def populate_graph(graph: networkx.DiGraph, root: Shape):
+    stack: List[Shape] = [root]
+    visited: Set[str] = set()
+
+    while stack:
+        cur = stack.pop()
+        if cur is None:
+            continue
+
+        if cur.name in visited:
+            continue
+
+        visited.add(cur.name)
+        graph.add_node(cur.name, shape=cur)
+
+        if isinstance(cur, ListShape):
+            graph.add_edge(cur.name, cur.member.name)
+            stack.append(cur.member)
+        elif isinstance(cur, StructureShape):
+            for member in cur.members.values():
+                stack.append(member)
+                graph.add_edge(cur.name, member.name)
+        elif isinstance(cur, MapShape):
+            stack.append(cur.key)
+            stack.append(cur.value)
+            graph.add_edge(cur.name, cur.key.name)
+            graph.add_edge(cur.name, cur.value.name)
+
+        else:  # leaf types (int, string, bool, ...)
+            pass
+
+
+def shape_graph(root: Shape) -> ShapeGraph:
+    graph = networkx.DiGraph()
+    graph.root = root
+    populate_graph(graph, root)
+
+    cycles = list()
+    shapes = set()
+    for node in graph.nodes:
+        try:
+            cycle = networkx.find_cycle(graph, source=node)
+            for k, v in cycle:
+                shapes.add(k)
+                shapes.add(v)
+
+            if cycle not in cycles:
+                cycles.append(cycle)
+        except networkx.NetworkXNoCycle:
+            pass
+
+    graph.cycles = cycles
+    graph.cycle_shapes = list(shapes)
+
+    return cast(ShapeGraph, graph)
+
+
+def sanitize_pattern(pattern: str) -> str:
+    pattern = pattern.replace("\\p{XDigit}", "[A-Fa-f0-9]")
+    pattern = pattern.replace("\\p{P}", "[.,;]")
+    pattern = pattern.replace("\\p{Punct}", "[.,;]")
+    pattern = pattern.replace("\\p{N}", "[0-9]")
+    pattern = pattern.replace("\\p{L}", "[A-Z]")
+    pattern = pattern.replace("\\p{LD}", "[A-Z]")
+    pattern = pattern.replace("\\p{Z}", "[ ]")
+    pattern = pattern.replace("\\p{S}", "[+\\u-*]")
+    pattern = pattern.replace("\\p{M}", "[`]")
+    pattern = pattern.replace("\\p{IsLetter}", "[a-zA-Z]")
+    pattern = pattern.replace("[:alnum:]", "[a-zA-Z0-9]")
+    return pattern
+
+
+def sanitize_arn_pattern(pattern: str) -> str:
+    # clown emoji
+
+    # some devs were just lazy ...
+    if pattern in [
+        ".*",
+        "arn:.*",
+        "arn:.+",
+        "^arn:.+",
+        "arn:aws.*:*",
+        "^arn:aws.*",
+        "^arn:.*",
+        ".*\\S.*",
+        "^[A-Za-z0-9:\\/_-]*$",
+        "^arn[\\/\\:\\-\\_\\.a-zA-Z0-9]+$",
+        ".{0,1600}",
+        "^arn:[!-~]+$",
+        "[\\S]+",
+        "[\\s\\S]*",
+        "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$",
+        "[a-zA-Z0-9_:\\-\\/]+",
+    ]:
+        pattern = "arn:aws:[a-z]{4}:us-east-1:[0-9]{12}:[a-z]{8}"
+
+    # common pattern to describe a partition
+    pattern = pattern.replace("arn:[^:]*:", "arn:aws:")
+    pattern = pattern.replace("arn:[a-z\\d-]+", "arn:aws")
+    pattern = pattern.replace("arn:[\\w+=\\/,.@-]+", "arn:aws")
+    pattern = pattern.replace("arn:[a-z-]+?", "arn:aws")
+    pattern = pattern.replace("arn:[a-z0-9][-.a-z0-9]{0,62}", "arn:aws")
+    pattern = pattern.replace(":aws(-\\w+)*", ":aws")
+    pattern = pattern.replace(":aws[a-z\\-]*", ":aws")
+    pattern = pattern.replace(":aws(-[\\w]+)*", ":aws")
+    pattern = pattern.replace(":aws[^:\\s]*", ":aws")
+    pattern = pattern.replace(":aws[A-Za-z0-9-]{0,64}", ":aws")
+    # often the account-id
+    pattern = pattern.replace(":[0-9]+:", ":[0-9]{13}:")
+    pattern = pattern.replace(":\\w{12}:", ":[0-9]{13}:")
+    # substitutions
+    pattern = pattern.replace("[a-z\\-\\d]", "[a-z0-9]")
+    pattern = pattern.replace(
+        "[\\u0020-\\uD7FF\\uE000-\\uFFFD\\uD800\\uDC00-\\uDBFF\\uDFFF\\r\\n\\t]", "[a-z0-9]"
+    )
+    pattern = pattern.replace("[\\w\\d-]", "[a-z0-9]")
+    pattern = pattern.replace("[\\w+=/,.@-]", "[a-z]")
+    pattern = pattern.replace("[^:]", "[a-z]")
+    pattern = pattern.replace("[^/]", "[a-z]")
+    pattern = pattern.replace("\\d+", "[0-9]+")
+    pattern = pattern.replace("\\d*", "[0-9]*")
+    pattern = pattern.replace("\\S+", "[a-z]{4}")
+    pattern = pattern.replace("\\d]", "0-9]")
+    pattern = pattern.replace("[a-z\\d", "[a-z0-9")
+    pattern = pattern.replace("[a-zA-Z\\d", "[a-z0-9")
+    pattern = pattern.replace("^$|", "")
+    pattern = pattern.replace("(^$)|", "")
+    pattern = pattern.replace("[:/]", "[a-z]")
+    pattern = pattern.replace("/.{", "/[a-z]{")
+    pattern = pattern.replace(".{", "[a-z]{")
+    pattern = pattern.replace("-*", "-")
+    pattern = pattern.replace("\\n", "")
+    pattern = pattern.replace("\\r", "")
+    # quantifiers
+    pattern = pattern.replace("{11}{0,1011}", "{11}")
+    pattern = pattern.replace("}+", "}")
+    pattern = pattern.replace("]*", "]{6}")
+    pattern = pattern.replace("]+", "]{6}")
+    pattern = pattern.replace(".*", "[a-z]{6}")
+    pattern = pattern.replace(".+", "[a-z]{6}")
+
+    return pattern
+
+
+custom_arns = {
+    "DeviceFarmArn": "arn:aws:devicefarm:us-east-1:1234567890123:mydevicefarm",
+    "KmsKeyArn": "arn:aws:kms:us-east-1:1234567890123:key/somekmskeythatisawesome",
+}
+
+
+@singledispatch
+def generate_instance(shape: Shape, graph: ShapeGraph) -> Optional[Instance]:
+    if shape is None:
+        return None
+    raise ValueError("could not generate shape for type %s" % shape.type_name)
+
+
+@generate_instance.register
+def _(shape: StructureShape, graph: ShapeGraph) -> Dict[str, Instance]:
+    if shape.is_tagged_union:
+        k, v = random.choice(list(shape.members.items()))
+        members = {k: v}
+    else:
+        members = shape.members
+
+    if shape.name in graph.cycle_shapes:
+        return {}
+
+    return {
+        name: generate_instance(member_shape, graph)
+        for name, member_shape in members.items()
+        if member_shape.name != shape.name
+    }
+
+
+@generate_instance.register
+def _(shape: ListShape, graph: ShapeGraph) -> List[Instance]:
+    if shape.name in graph.cycle_shapes:
+        return []
+    return [generate_instance(shape.member, graph) for _ in range(shape.metadata.get("min", 1))]
+
+
+@generate_instance.register
+def _(shape: MapShape, graph: ShapeGraph) -> Dict[str, Instance]:
+    if shape.name in graph.cycle_shapes:
+        return {}
+    return {generate_instance(shape.key, graph): generate_instance(shape.value, graph)}
+
+
+def generate_arn(shape: StringShape):
+    if not shape.metadata:
+        return "arn:aws:ec2:us-east-1:1234567890123:instance/i-abcde0123456789f"
+
+    # some custom hacks
+    if shape.name in custom_arns:
+        return custom_arns[shape.name]
+
+    max_len = shape.metadata.get("max") or math.inf
+    min_len = shape.metadata.get("min") or 0
+
+    pattern = shape.metadata.get("pattern")
+    if pattern:
+        # FIXME: also conforming to length may be difficult
+        pattern = sanitize_arn_pattern(pattern)
+        arn = rstr.xeger(pattern)
+    else:
+        arn = "arn:aws:ec2:us-east-1:1234567890123:instance/i-abcde0123456789f"
+
+    if len(arn) > max_len:
+        arn = arn[:max_len]
+
+    if len(arn) < min_len or len(arn) > max_len:
+        raise ValueError(
+            f"generated arn {arn} for shape {shape.name} does not match constraints {shape.metadata}"
+        )
+
+    return arn
+
+
+custom_strings = {"DailyTime": "12:10", "WeeklyTime": "1:12:10"}
+
+
+@generate_instance.register
+def _(shape: StringShape, graph: ShapeGraph) -> str:
+    if shape.enum:
+        return shape.enum[0]
+
+    if shape.name in custom_strings:
+        return custom_strings[shape.name]
+
+    if (
+        shape.name.endswith("ARN")
+        or shape.name.endswith("Arn")
+        or shape.name == "AmazonResourceName"
+    ):
+        return generate_arn(shape)
+
+    max_len: int = shape.metadata.get("max") or 256
+    min_len: int = shape.metadata.get("min") or 0
+    str_len = min(min_len or 6, max_len)
+
+    pattern = shape.metadata.get("pattern")
+
+    if not pattern or pattern in [".*", "^.*$", ".+"]:
+        if min_len <= 6 and max_len >= 6:
+            # pick a random six-letter word, to spice things up. this will be the case most of the time.
+            return random.choice(words)
+        else:
+            return "a" * str_len
+
+    pattern = sanitize_pattern(pattern)
+
+    try:
+        # try to return something simple first
+        random_string = "a" * str_len
+        if re.match(pattern, random_string):
+            return random_string
+
+        val = rstr.xeger(pattern)
+        # TODO: this will break the pattern if the string needs to end with something that we may cut off.
+        return val[: min(max_len, len(val))]
+    except re.error:
+        # TODO: this will likely break the pattern
+        return "0" * str_len
+
+
+@generate_instance.register
+def _(shape: Shape, graph: ShapeGraph) -> Union[int, float, bool, bytes, date]:
+    if shape.type_name in ["integer", "long"]:
+        return shape.metadata.get("min", 1)
+    if shape.type_name in ["float", "double"]:
+        return shape.metadata.get("min", 1.0)
+    if shape.type_name == "boolean":
+        return True
+    if shape.type_name == "blob":
+        # TODO: better blob generator
+        return b"0" * shape.metadata.get("min", 1)
+    if shape.type_name == "timestamp":
+        return datetime.now()
+
+    raise ValueError("unknown type %s" % shape.type_name)
+
+
+def is_cyclic_shape(shape: Shape) -> bool:
+    return True if shape_graph(shape).cycle else False
+
+
+def generate_response(operation: OperationModel):
+    graph = shape_graph(operation.output_shape)
+    response = generate_instance(graph.root, graph)
+    response.pop("nextToken", None)
+    return response
+
+
+def generate_request(operation: OperationModel):
+    graph = shape_graph(operation.input_shape)
+    return generate_instance(graph.root, graph)
+
+
+def return_mock_response(context: RequestContext, request: ServiceRequest) -> ServiceResponse:
+    return generate_response(context.operation)
+
+
+def create_mocking_dispatch_table(service) -> DispatchTable:
+    dispatch_table = {}
+
+    for operation in service.operation_names:
+        # resolve the bound function of the delegate
+        # create a dispatcher
+        dispatch_table[operation] = ServiceRequestDispatcher(
+            return_mock_response,
+            operation=operation,
+            pass_context=True,
+            expand_parameters=False,
+        )
+
+    return dispatch_table
+
+
+@lru_cache()
+def get_mocking_skeleton(service: str) -> Skeleton:
+    service = load_service(service)
+    return Skeleton(service, create_mocking_dispatch_table(service))

--- a/localstack/aws/protocol/request.py
+++ b/localstack/aws/protocol/request.py
@@ -1,0 +1,139 @@
+import logging
+from typing import NamedTuple, Optional
+
+from werkzeug.http import parse_dict_header
+
+from localstack.aws.spec import ServiceCatalog
+from localstack.http import Request
+
+LOG = logging.getLogger(__name__)
+
+
+class ServiceIndicators(NamedTuple):
+    signing_name: Optional[str] = None
+    target_prefix: Optional[str] = None
+    operation: Optional[str] = None
+
+
+def get_header_indicators(request: Request) -> ServiceIndicators:
+    x_amz_target = request.headers.get("x-amz-target")
+    authorization = request.headers.get("authorization")
+
+    signing_name = None
+    if authorization:
+        auth_type, auth_info = authorization.split(None, 1)
+        auth_type = auth_type.lower().strip()
+
+        if auth_type == "aws4-hmac-sha256":
+            values = parse_dict_header(auth_info)
+            aws_access_key_id, date, region, signing_name, _ = values["Credential"].split("/")
+
+    if x_amz_target:
+        target_prefix, target = x_amz_target.split(".", 1)
+    else:
+        target_prefix, target = None, None
+
+    return ServiceIndicators(signing_name, target_prefix, target)
+
+
+signing_name_path_prefix_rules = {
+    # custom rules based on URI path prefixes that are not easily generalizable
+    "apigateway": {
+        "/v2": "apigatewayv2",
+    },
+    "appconfig": {
+        "/configuration": "appconfigdata",
+    },
+    "execute-api": {
+        "/@connections": "apigatewaymanagementapi",
+        "/participant": "connectparticipant",
+        "*": "iot",
+    },
+    "ses": {
+        "/v2": "sesv2",
+        "/v1": "pinpoint-email",
+    },
+    "greengrass": {"/greengrass/v2/": "greengrassv2"},
+    "cloudsearch": {"/2013-01-01": "cloudsearchdomain"},
+    "s3": {"/v20180820": "s3control"},
+    "iot1click": {
+        "/projects": "iot1click-projects",
+        "/devices": "iot1click-devices",
+    },
+    "es": {
+        "/2015-01-01": "es",
+        "/2021-01-01": "opensearch",
+    },
+}
+
+
+def custom_signing_name_rules(signing_name: str, request: Request) -> Optional[str]:
+    rules = signing_name_path_prefix_rules.get(signing_name)
+    if not rules:
+
+        if signing_name == "servicecatalog":
+            if request.path == "/" and request.method == "POST":
+                return "servicecatalog"
+            else:
+                return "servicecatalog-appregistry"
+
+        return
+
+    for prefix, name in rules.items():
+        if request.path.startswith(prefix):
+            return name
+
+    return rules.get("*", signing_name)
+
+
+def guess_aws_service_name(services: ServiceCatalog, request: Request) -> str:
+    signing_name, target_prefix, operation = get_header_indicators(request)
+
+    candidates = set()
+    if signing_name:
+        by_signing_name = services.by_signing_name(signing_name)
+
+        if len(by_signing_name) == 1:
+            # a unique signing-name -> service name mapping is the case for ~75% of service operations
+            return by_signing_name[0]
+
+        custom_match = custom_signing_name_rules(signing_name, request)
+        if custom_match:
+            return custom_match
+
+        candidates.update(by_signing_name)
+
+    if target_prefix and operation:
+        target_candidates = services.by_target_prefix(target_prefix)
+        if len(target_candidates) == 1:
+            return target_candidates[0]
+
+        candidates.update(target_candidates)
+        for service_name in list(candidates):
+            service = services.get(service_name)
+            if operation not in service.operation_names:
+                candidates.remove(service_name)
+
+    if len(candidates) == 1:
+        return candidates.pop()
+
+    host = request.host
+    if host:
+        for prefix, services in services.endpoint_prefix_index.items():
+            if host.startswith(prefix):
+                if len(services) == 1:
+                    return services[0]
+                candidates.update(services)
+
+    if len(candidates) == 0:
+        raise ValueError(
+            "could not determine service for request %s %s %s"
+            % (request.method, request.url, request.headers)
+        )
+
+    LOG.warning("could not uniquely determine service from request, candidates=%s", candidates)
+
+    if signing_name:
+        return signing_name
+    return candidates.pop()
+    # raise NoRoute(candidates=candidates, indicators=ServiceIndicators(signing_name, target_prefix, operation))

--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -35,7 +35,10 @@ class AwsApiListener(ProxyListenerAdapter):
 
     def __init__(self, api: str, delegate: Any):
         self.service = load_service(api)
-        self.skeleton = Skeleton(self.service, delegate)
+        if isinstance(delegate, Skeleton):
+            self.skeleton = delegate
+        else:
+            self.skeleton = Skeleton(self.service, delegate)
 
     def request(self, request: Request) -> Response:
         context = self.create_request_context(request)

--- a/localstack/aws/spec.py
+++ b/localstack/aws/spec.py
@@ -1,18 +1,64 @@
-from typing import List
+from collections import defaultdict
+from functools import cached_property
+from typing import Dict, List, Optional
 
 from botocore.loaders import create_loader
 from botocore.model import ServiceModel
 
 loader = create_loader()
 
+ServiceName = str
+
 
 def list_services(model_type="service-2") -> List[ServiceModel]:
     return [load_service(service) for service in loader.list_available_services(model_type)]
 
 
-def load_service(service: str, version: str = None, model_type="service-2") -> ServiceModel:
+def load_service(service: ServiceName, version: str = None, model_type="service-2") -> ServiceModel:
     """
     For example: load_service("sqs", "2012-11-05")
     """
     service_description = loader.load_service_model(service, model_type, version)
     return ServiceModel(service_description, service)
+
+
+class ServiceCatalog:
+    def get(self, name: ServiceName) -> Optional[ServiceModel]:
+        return self.services.get(name)
+
+    @cached_property
+    def services(self) -> Dict[ServiceName, ServiceModel]:
+        return {service.service_name: service for service in list_services()}
+
+    @cached_property
+    def service_names(self) -> List[ServiceName]:
+        return list(self.services.keys())
+
+    @cached_property
+    def target_prefix_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self.services.values():
+            target_prefix = service.metadata.get("targetPrefix")
+            if target_prefix:
+                result[target_prefix].append(service.service_name)
+        return dict(result)
+
+    @cached_property
+    def signing_name_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self.services.values():
+            result[service.signing_name].append(service.service_name)
+        return dict(result)
+
+    @cached_property
+    def endpoint_prefix_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self.services.values():
+            result[service.endpoint_prefix].append(service.service_name)
+        return dict(result)
+
+    def by_target_prefix(self, target_prefix: str) -> List[ServiceName]:
+        return self.target_prefix_index.get(target_prefix, [])
+
+    def by_signing_name(self, signing_name: str) -> List[ServiceName]:
+        return self.signing_name_index.get(signing_name, [])

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -11,6 +11,8 @@ from typing import Dict, Optional
 from requests.models import Response
 
 from localstack import config
+from localstack.aws.mocking import get_mocking_skeleton
+from localstack.aws.proxy import AwsApiListener
 from localstack.constants import (
     HEADER_LOCALSTACK_EDGE_URL,
     HEADER_LOCALSTACK_REQUEST_URL,
@@ -166,6 +168,11 @@ class ProxyListenerEdge(ProxyListener):
             data = gzip.decompress(data)
 
         is_internal_call = is_internal_call_context(headers)
+
+        if not self.service_manager.exists(api):
+            return AwsApiListener(api, get_mocking_skeleton(api)).forward_request(
+                method, path, data, headers
+            )
 
         self._require_service(api)
 

--- a/tests/unit/aws/test_mocking.py
+++ b/tests/unit/aws/test_mocking.py
@@ -1,0 +1,80 @@
+import pytest
+from botocore.parsers import create_parser as create_response_parser
+
+from localstack.aws.mocking import generate_request, generate_response
+from localstack.aws.protocol.request import guess_aws_service_name
+from localstack.aws.protocol.serializer import create_serializer as create_response_serializer
+from localstack.aws.spec import ServiceCatalog, load_service
+from localstack.services.moto import create_aws_request_context
+
+services = ServiceCatalog()
+
+
+def collect_operations():
+    for service in services.services.values():
+        for op_name in service.operation_names:
+            yield service.service_name, op_name
+
+
+@pytest.mark.parametrize(
+    "service, op",
+    collect_operations(),
+)
+def test_request_generator(service, op):
+    service = services.get(service)
+    op = service.operation_model(op)
+
+    parameters = generate_request(op)
+    context = create_aws_request_context(service.service_name, op.name, parameters)
+
+    assert context.request.path
+    assert context.request.method
+    assert context.request.headers
+
+
+@pytest.mark.parametrize(
+    "service, op",
+    collect_operations(),
+)
+def test_response_generator(service, op):
+    service = services.get(service)
+    op = service.operation_model(op)
+    serializer = create_response_serializer(service)
+
+    parameters = generate_response(op)
+    print(parameters)
+    serialized_response = serializer.serialize_to_response(parameters, op)
+
+    response_parser = create_response_parser(service.protocol)
+    parsed_response = response_parser.parse(
+        serialized_response.to_readonly_response_dict(),
+        op.output_shape,
+    )
+
+    assert parsed_response
+
+
+@pytest.mark.parametrize(
+    "service, op",
+    collect_operations(),
+)
+def test_guess_aws_service(service, op):
+    service = load_service(service)
+    op = service.operation_model(op)
+
+    parameters = generate_request(op)
+
+    try:
+        url = f"http://{service.endpoint_prefix}.localhost.localstack.cloud"
+        context = create_aws_request_context(
+            service.service_name, op.name, parameters, endpoint_url=url
+        )
+    except Exception as e:
+        pytest.xfail(f"generated request was invalid: {e}")
+        return
+
+    request = context.request
+
+    assert (
+        guess_aws_service_name(services, context.request) == service.service_name
+    ), "incorrect service for request %s %s %s" % (request.method, request.path, request.headers)


### PR DESCRIPTION
This is an experimental PR that enables mocked responses for any AWS service. The framework can generate random instances of AWS shapes, including requests and responses. This can be used for generating random but valid responses for services that have not been implemented.
Additionally, it can be used to generate test cases for both parser and serializer. Using randomly generated requests, I was able to somewhat generalize the logic that determines the AWS service from the request.