### PR TITLE
Add optimizing and sorting of imports to scaffold

### DIFF
--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -371,10 +371,18 @@ def generate(service: str, doc: bool, save: bool):
     code = output.getvalue()
 
     try:
-        # try to format with black
+        import autoflake
+        import isort
         from black import FileMode, format_str
 
+        # try to format with black
         code = format_str(code, mode=FileMode())
+
+        # try to remove unused imports
+        code = autoflake.fix_code(code)
+
+        # try to sort imports
+        code = isort.code(code)
     except Exception:
         pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,3 +80,4 @@ pyproject-flake8
 isort==5.9.1
 pandoc
 pypandoc
+autoflake==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,4 +80,4 @@ pyproject-flake8
 isort==5.9.1
 pandoc
 pypandoc
-autoflake==1.4
+autoflake


### PR DESCRIPTION
Currently the ASF scaffold only formats the file with black. Often there still is the problem that the imports are unsorted or contain packages which are unused (notably datetime). By adding autoflake and isort to the formatting section of scaffold these problems and future problems adding new imports are resolved.
