### PR TITLE
revert Python base image hash to circumvent xmltodict issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_TYPE=full
 
 # java-builder: Stage to build a custom JRE (with jlink)
-FROM python:3.8.12-slim-buster@sha256:ec6843490e39304d45bf83247a1e6c0a1eb0c10c68b26c878e8653640ac63fec as java-builder
+FROM python:3.8.12-slim-buster@sha256:0ac2a12df86b01d6a482fd07b62b6ca2afe3355cd520260c7d561c4e5c966cdb as java-builder
 ARG TARGETARCH
 
 # install OpenJDK 11
@@ -34,7 +34,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java, maven,...)
-FROM python:3.8.12-slim-buster@sha256:ec6843490e39304d45bf83247a1e6c0a1eb0c10c68b26c878e8653640ac63fec as base
+FROM python:3.8.12-slim-buster@sha256:0ac2a12df86b01d6a482fd07b62b6ca2afe3355cd520260c7d561c4e5c966cdb as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies


### PR DESCRIPTION
Unfortunately, the last update of the Docker base image hashes broke the tests due to an issue in `xmltodict` in combination with a new version of `Expat` which landed in Debian last week: 
- https://github.com/libexpat/libexpat/issues/572
- https://github.com/martinblech/xmltodict/issues/289

This issue causes an STS test failure in the following lines in moto: [moto/sts/models.py#L100-L105](https://github.com/spulec/moto/blob/14a69c752477c385d3c80429c719af0aa1cb9d5e/moto/sts/models.py#L100-L105)

This PR reverts the [last change of Renovate](https://github.com/localstack/localstack/commit/a4f3a17a4c50124bb37333578ece0ff9d2cc5fdc) to fix the issue until a fix in `xmltodict` has been pushed.
