### PR TITLE
Allow specifying working directory when running Docker exec

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -617,6 +617,7 @@ class ContainerClient(metaclass=ABCMeta):
         env_vars: Optional[Dict[str, Optional[str]]] = None,
         stdin: Optional[bytes] = None,
         user: Optional[str] = None,
+        workdir: Optional[str] = None,
     ) -> Tuple[bytes, bytes]:
         """Execute a given command in a container
 

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -451,6 +451,7 @@ class CmdDockerClient(ContainerClient):
         env_vars: Optional[Dict[str, Optional[str]]] = None,
         stdin: Optional[bytes] = None,
         user: Optional[str] = None,
+        workdir: Optional[str] = None,
     ) -> Tuple[bytes, bytes]:
         env_file = None
         cmd = self._docker_cmd()
@@ -461,6 +462,8 @@ class CmdDockerClient(ContainerClient):
             cmd.append("--detach")
         if user:
             cmd += ["--user", user]
+        if workdir:
+            cmd += ["--workdir", workdir]
         if env_vars:
             env_flag, env_file = Util.create_env_vars_file_flag(env_vars)
             cmd += env_flag

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -592,6 +592,7 @@ class SdkDockerClient(ContainerClient):
         env_vars: Optional[Dict[str, Optional[str]]] = None,
         stdin: Optional[bytes] = None,
         user: Optional[str] = None,
+        workdir: Optional[str] = None,
     ) -> Tuple[bytes, bytes]:
         LOG.debug("Executing command in container %s: %s", container_name_or_id, command)
         try:
@@ -606,6 +607,7 @@ class SdkDockerClient(ContainerClient):
                 stdout=True,
                 stderr=True,
                 demux=True,
+                workdir=workdir,
             )
             tty = False
             if interactive and stdin:  # result is a socket


### PR DESCRIPTION
### Summary

Updates the `exec_in_container` helper for Docker client to accept working directory.