### PR TITLE
Add support for #define function in API Gateway velocity templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ api_states
 
 /integration/lambdas/golang/handler.zip
 /tests/integration/lambdas/golang/handler.zip
+tmp/

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -3,6 +3,8 @@ import json
 import re
 from urllib.parse import quote_plus, unquote_plus
 
+import airspeed
+
 from localstack import config
 from localstack.utils.common import (
     extract_jsonpath,
@@ -12,6 +14,13 @@ from localstack.utils.common import (
     short_uid,
 )
 from localstack.utils.generic.number_utils import to_number
+from localstack.utils.patch import patch
+
+
+# TODO: potentially replace with generic proxy wrapper class
+class DictWrapper(dict):
+    def keySet(self):
+        return self.keys()
 
 
 class VelocityInput(object):
@@ -19,7 +28,7 @@ class VelocityInput(object):
     See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
 
     def __init__(self, value):
-        self.value = value
+        self.value = self._attach_missing_functions(value)
 
     def path(self, path):
         if not self.value:
@@ -39,6 +48,17 @@ class VelocityInput(object):
 
     def __repr__(self):
         return "$input"
+
+    def _attach_missing_functions(self, value):
+        if value:
+
+            def _fix(obj, **kwargs):
+                if isinstance(obj, dict):
+                    return DictWrapper(obj)
+                return obj
+
+            value = recurse_object(value, _fix)
+        return value
 
 
 class VelocityUtil(object):
@@ -79,10 +99,73 @@ class VelocityUtil(object):
         return json.dumps(s)
 
 
+# TODO: remove code below once this PR is merged/released: https://github.com/purcell/airspeed/pull/56
+
+
+class DefineDefinition(airspeed.MacroDefinition):
+    START = re.compile(r"#define\b(.*)", re.S + re.I)
+    NAME = re.compile(r"\s*(\$[a-z][a-z_0-9]*)\b(.*)", re.S + re.I)
+
+    def evaluate_raw(self, stream, namespace, loader):
+        global_ns = namespace.top()
+        macro_key = self.macro_name.lower()
+        macro_key = macro_key.lstrip("$")
+        if macro_key in global_ns:
+            raise Exception("cannot redefine macro {0}".format(macro_key))
+
+        class ParamWrapper:
+            def __init__(self, value):
+                self.value = value
+
+            def calculate(self, namespace, loader):
+                return self.value
+
+        class ExecuteFunc:
+            def __call__(_self, *args, **kwargs):
+                args = [ParamWrapper(arg) for arg in args]
+                _stream = airspeed.StoppableStream()
+                self.execute_macro(_stream, namespace, args, loader)
+                return _stream.getvalue()
+
+            def __repr__(self):
+                return self.__call__()
+
+        global_ns[macro_key] = ExecuteFunc()
+
+
+@patch(airspeed.Block.parse, pass_target=False)
+def block_parse(self, *args, **kwargs):
+    self.children = []
+    while True:
+        try:
+            self.children.append(
+                self.next_element(
+                    (
+                        airspeed.Text,
+                        airspeed.FormalReference,
+                        airspeed.Comment,
+                        airspeed.IfDirective,
+                        airspeed.SetDirective,
+                        airspeed.ForeachDirective,
+                        airspeed.IncludeDirective,
+                        airspeed.ParseDirective,
+                        airspeed.MacroDefinition,
+                        DefineDefinition,
+                        airspeed.StopDirective,
+                        airspeed.UserDefinedDirective,
+                        airspeed.EvaluateDirective,
+                        airspeed.MacroCall,
+                        airspeed.FallthroughHashText,
+                    )
+                )
+            )
+        except airspeed.NoMatch:
+            break
+
+
 def render_velocity_template(template, context, variables=None, as_json=False):
     if variables is None:
         variables = {}
-    import airspeed
 
     if not template:
         return template

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -1,12 +1,11 @@
 import base64
 import json
-import unittest
 
 from localstack.utils.aws.aws_stack import render_velocity_template
 from localstack.utils.common import to_str
 
 # template used to transform incoming requests at the API Gateway (forward to Kinesis)
-APIGATEWAY_TRANSFORMATION_TEMPLATE = """{
+APIGW_TEMPLATE_TRANSFORM_KINESIS = """{
     "StreamName": "stream-1",
     "Records": [
         #set( $numRecords = $input.path('$.records').size() )
@@ -25,18 +24,39 @@ APIGATEWAY_TRANSFORMATION_TEMPLATE = """{
     ]
 }"""
 
+# template used to construct JSON via #define method
+APIGW_TEMPLATE_CONSTRUCT_JSON = """
+#set( $body = $input.json("$") )
 
-class TestMessageTransformation(unittest.TestCase):
+#define( $loop $map )
+{
+    #foreach($key in $map.keySet())
+        #set( $k = $util.escapeJavaScript($key) )
+        #set( $v = $util.escapeJavaScript($map.get($key)).replaceAll("\\\\'", "'") )
+        $k: $v
+        #if( $foreach.hasNext ) , #end
+    #end
+}
+#end
+{
+    "p0": true,
+    "p1": $loop($input.path('$.p1')),
+    "p2": $loop($input.path('$.p2'))
+}
+"""
+
+
+class TestMessageTransformation:
     def test_array_size(self):
         template = "#set($list = $input.path('$.records')) $list.size()"
         context = {"records": [{"data": {"foo": "bar1"}}, {"data": {"foo": "bar2"}}]}
         result = render_velocity_template(template, context)
-        self.assertEqual(" 2", result)
+        assert result == " 2"
         result = render_velocity_template(template, json.dumps(context))
-        self.assertEqual(" 2", result)
+        assert result == " 2"
 
     def test_message_transformation(self):
-        template = APIGATEWAY_TRANSFORMATION_TEMPLATE
+        template = APIGW_TEMPLATE_TRANSFORM_KINESIS
         records = [
             {"data": {"foo": "foo1", "bar": "bar2"}},
             {"data": {"foo": "foo1", "bar": "bar2"}, "partitionKey": "key123"},
@@ -46,9 +66,9 @@ class TestMessageTransformation(unittest.TestCase):
         def do_test(context):
             result = render_velocity_template(template, context, as_json=True)
             result_decoded = json.loads(to_str(base64.b64decode(result["Records"][0]["Data"])))
-            self.assertEqual(records[0]["data"], result_decoded)
-            self.assertGreater(len(result["Records"][0]["PartitionKey"]), 0)
-            self.assertEqual("key123", result["Records"][1]["PartitionKey"])
+            assert result_decoded == records[0]["data"]
+            assert result["Records"][0]["PartitionKey"] == "$elem.partitionKey"
+            assert result["Records"][1]["PartitionKey"] == "key123"
 
         # try rendering the template
         do_test(context)
@@ -60,18 +80,18 @@ class TestMessageTransformation(unittest.TestCase):
         context = {"records": records}
         # try rendering the template
         result = render_velocity_template(template, context, as_json=True)
-        self.assertEqual([], result["Records"])
+        assert result["Records"] == []
 
     def test_array_in_set_expr(self):
         template = "#set ($bar = $input.path('$.foo')[1]) \n $bar"
         context = {"foo": ["e1", "e2", "e3", "e4"]}
         result = render_velocity_template(template, context).strip()
-        self.assertEqual("e2", result)
+        assert result == "e2"
 
         template = "#set ($bar = $input.path('$.foo')[1][1][1]) $bar"
         context = {"foo": [["e1"], ["e2", ["e3", "e4"]]]}
         result = render_velocity_template(template, context).strip()
-        self.assertEqual("e4", result)
+        assert result == "e4"
 
     def test_string_methods(self):
         context = {"foo": {"bar": "BAZ baz"}}
@@ -79,9 +99,16 @@ class TestMessageTransformation(unittest.TestCase):
         template2 = "${foo.bar.trim().toLowerCase().replace(' ','-')}"
         for template in [template1, template2]:
             result = render_velocity_template(template, {}, variables=context)
-            self.assertEqual("baz-baz", result)
+            assert result == "baz-baz"
 
     def test_render_urlencoded_string_data(self):
         template = "MessageBody=$util.base64Encode($input.json('$'))"
         result = render_velocity_template(template, b'{"spam": "eggs"}')
-        self.assertEqual("MessageBody=eyJzcGFtIjogImVnZ3MifQ==", result)
+        assert result == "MessageBody=eyJzcGFtIjogImVnZ3MifQ=="
+
+    def test_construct_json_using_define(self):
+        template = APIGW_TEMPLATE_CONSTRUCT_JSON
+        context = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
+        result = render_velocity_template(template, context).strip()
+        result = json.loads(result)
+        assert result == {"p0": True, **context}


### PR DESCRIPTION
* add support for `#define` function in API Gateway velocity templates. Addresses https://github.com/localstack/localstack/issues/5587
* migrate tests to `pytest`