### PR TITLE
migrate from localstack-plugin-loader to plux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,7 @@ RUN make init
 
 # Install the latest version of localstack-ext and generate the plugin entrypoints
 RUN (virtualenv .venv && source .venv/bin/activate && \
-      pip3 install --upgrade localstack-ext localstack-plugin-loader)
+      pip3 install --upgrade localstack-ext plux)
 RUN make entrypoints
 
 # Add the build date and git hash at last (changes everytime)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ usage:                    ## Show this help
 
 $(VENV_ACTIVATE): setup.py requirements.txt
 	test -d $(VENV_DIR) || $(VENV_BIN) $(VENV_DIR)
-	$(VENV_RUN); $(PIP_CMD) install --upgrade pip setuptools wheel localstack-plugin-loader
+	$(VENV_RUN); $(PIP_CMD) install --upgrade pip setuptools wheel plux
 	touch $(VENV_ACTIVATE)
 
 venv: $(VENV_ACTIVATE)    ## Create a new (empty) virtual environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # LocalStack project configuration
 [build-system]
-requires = ['setuptools', 'wheel', 'localstack-plugin-loader']
+requires = ['setuptools', 'wheel', 'plux>=1.2.0']
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ dataclasses; python_version < '3.7'
 #dnspython==1.16.0
 localstack-client>=1.31
 localstack-ext>=0.14.0
-localstack-plugin-loader>=0.1.0
+plux>=1.2.0
 psutil>=5.4.8,<6.0.0
 python-dotenv>=0.19.1
 pyyaml>=5.1


### PR DESCRIPTION
This is in preparation for using the new plugin discovery mechanism introduced with plux 1.3.0, and also to phase out localstack-plugin-loader in favor of plux