### PR TITLE
fix python 3.7 compatibility with TypedDict for cli

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -1,7 +1,12 @@
 import json
 import os
 import sys
-from typing import Dict, Optional, TypedDict
+from typing import Dict, Optional
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 import click
 


### PR DESCRIPTION
Apparently we lost python 3.7 compatibility when we updated the `localstack status` command. The culprit was the `TypedDict` import, see discussion here: https://github.com/localstack/plux/issues/1