### PR TITLE
fix ASF parser and serializer issues - round 5

### DIFF
--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -73,8 +73,7 @@ class AsfWithFallbackListener(AwsApiListener):
     def forward_request(self, method, path, data, headers):
         try:
             return super().forward_request(method, path, data, headers)
-        except (NotImplementedError, KeyError):
-            # FIXME: KeyError may be an ASF parser error, that indicates that the request cannot be parsed
+        except (NotImplementedError):
             LOG.debug("no ASF handler for %s %s, using fallback listener", method, path)
             return self.fallback.forward_request(method, path, data, headers)
 

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -45,6 +45,9 @@ def to_valid_python_name(spec_name: str) -> str:
     if is_keyword(sanitized):
         sanitized += "_"
 
+    if sanitized.startswith("__"):
+        sanitized = sanitized[1:]
+
     return sanitized
 
 
@@ -63,14 +66,16 @@ class ShapeNode:
             operation = self.service.operation_model(operation_name)
             if operation.input_shape is None:
                 continue
-            if self.shape.name == operation.input_shape.name:
+            if to_valid_python_name(self.shape.name) == to_valid_python_name(
+                operation.input_shape.name
+            ):
                 return True
 
         return False
 
     @property
     def name(self) -> str:
-        return self.shape.name
+        return to_valid_python_name(self.shape.name)
 
     @property
     def is_exception(self):
@@ -90,11 +95,11 @@ class ShapeNode:
         shape = self.shape
 
         if isinstance(shape, StructureShape):
-            return [v.name for v in shape.members.values()]
+            return [to_valid_python_name(v.name) for v in shape.members.values()]
         if isinstance(shape, ListShape):
-            return [shape.member.name]
+            return [to_valid_python_name(shape.member.name)]
         if isinstance(shape, MapShape):
-            return [shape.key.name, shape.value.name]
+            return [to_valid_python_name(shape.key.name), to_valid_python_name(shape.value.name)]
 
         return []
 
@@ -115,7 +120,7 @@ class ShapeNode:
         self._print_as_class(output, base, doc, quote_types)
 
     def _print_as_class(self, output, base: str, doc=True, quote_types=False):
-        output.write(f"class {self.shape.name}({base}):\n")
+        output.write(f"class {to_valid_python_name(self.shape.name)}({base}):\n")
 
         q = '"' if quote_types else ""
 
@@ -127,19 +132,19 @@ class ShapeNode:
 
         for k, v in self.shape.members.items():
             if k in self.shape.required_members:
-                output.write(f"    {k}: {q}{v.name}{q}\n")
+                output.write(f"    {k}: {q}{to_valid_python_name(v.name)}{q}\n")
             else:
-                output.write(f"    {k}: Optional[{q}{v.name}{q}]\n")
+                output.write(f"    {k}: Optional[{q}{to_valid_python_name(v.name)}{q}]\n")
 
     def _print_as_typed_dict(self, output, doc=True, quote_types=False):
-        name = self.shape.name
+        name = to_valid_python_name(self.shape.name)
         q = '"' if quote_types else ""
         output.write('%s = TypedDict("%s", {\n' % (name, name))
         for k, v in self.shape.members.items():
             if k in self.shape.required_members:
-                output.write(f'    "{k}": {q}{v.name}{q},\n')
+                output.write(f'    "{k}": {q}{to_valid_python_name(v.name)}{q},\n')
             else:
-                output.write(f'    "{k}": Optional[{q}{v.name}{q}],\n')
+                output.write(f'    "{k}": Optional[{q}{to_valid_python_name(v.name)}{q}],\n')
         output.write("}, total=False)")
 
     def print_shape_doc(self, output, shape):
@@ -161,35 +166,43 @@ class ShapeNode:
         if isinstance(shape, StructureShape):
             self._print_structure_declaration(output, doc, quote_types)
         elif isinstance(shape, ListShape):
-            output.write(f"{shape.name} = List[{q}{shape.member.name}{q}]")
+            output.write(
+                f"{to_valid_python_name(shape.name)} = List[{q}{to_valid_python_name(shape.member.name)}{q}]"
+            )
         elif isinstance(shape, MapShape):
-            output.write(f"{shape.name} = Dict[{q}{shape.key.name}{q}, {q}{shape.value.name}{q}]")
+            output.write(
+                f"{to_valid_python_name(shape.name)} = Dict[{q}{to_valid_python_name(shape.key.name)}{q}, {q}{to_valid_python_name(shape.value.name)}{q}]"
+            )
         elif isinstance(shape, StringShape):
             if shape.enum:
-                output.write(f"class {shape.name}(str):\n")
+                output.write(f"class {to_valid_python_name(shape.name)}(str):\n")
                 for value in shape.enum:
                     name = to_valid_python_name(value)
                     output.write(f'    {name} = "{value}"\n')
             else:
-                output.write(f"{shape.name} = str")
+                output.write(f"{to_valid_python_name(shape.name)} = str")
         elif shape.type_name == "string":
-            output.write(f"{shape.name} = str")
+            output.write(f"{to_valid_python_name(shape.name)} = str")
         elif shape.type_name == "integer":
-            output.write(f"{shape.name} = int")
+            output.write(f"{to_valid_python_name(shape.name)} = int")
         elif shape.type_name == "long":
-            output.write(f"{shape.name} = int")
+            output.write(f"{to_valid_python_name(shape.name)} = int")
         elif shape.type_name == "double":
-            output.write(f"{shape.name} = float")
+            output.write(f"{to_valid_python_name(shape.name)} = float")
         elif shape.type_name == "float":
-            output.write(f"{shape.name} = float")
+            output.write(f"{to_valid_python_name(shape.name)} = float")
         elif shape.type_name == "boolean":
-            output.write(f"{shape.name} = bool")
+            output.write(f"{to_valid_python_name(shape.name)} = bool")
         elif shape.type_name == "blob":
-            output.write(f"{shape.name} = bytes")  # FIXME check what type blob really is
+            output.write(
+                f"{to_valid_python_name(shape.name)} = bytes"
+            )  # FIXME check what type blob really is
         elif shape.type_name == "timestamp":
-            output.write(f"{shape.name} = datetime")
+            output.write(f"{to_valid_python_name(shape.name)} = datetime")
         else:
-            output.write(f"# unknown shape type for {shape.name}: {shape.type_name}")
+            output.write(
+                f"# unknown shape type for {to_valid_python_name(shape.name)}: {shape.type_name}"
+            )
         # TODO: BoxedInteger?
 
         output.write("\n")
@@ -230,7 +243,7 @@ def generate_service_types(output, service: ServiceModel, doc=True):
 
     for shape_name in service.shape_names:
         shape = service.shape_for(shape_name)
-        nodes[shape_name] = ShapeNode(service, shape)
+        nodes[to_valid_python_name(shape_name)] = ShapeNode(service, shape)
 
     # output.write("__all__ = [\n")
     # for name in nodes.keys():
@@ -280,7 +293,7 @@ def generate_service_api(output, service: ServiceModel, doc=True):
         fn_name = camel_to_snake_case(op_name)
 
         if operation.output_shape:
-            output_shape = operation.output_shape.name
+            output_shape = to_valid_python_name(operation.output_shape.name)
         else:
             output_shape = "None"
 
@@ -294,16 +307,16 @@ def generate_service_api(output, service: ServiceModel, doc=True):
             for m in input_shape.required_members:
                 members.remove(m)
                 m_shape = input_shape.members[m]
-                parameters[xform_name(m)] = m_shape.name
+                parameters[xform_name(m)] = to_valid_python_name(m_shape.name)
                 param_shapes[xform_name(m)] = m_shape
             for m in members:
                 m_shape = input_shape.members[m]
                 param_shapes[xform_name(m)] = m_shape
-                parameters[xform_name(m)] = f"{m_shape.name} = None"
+                parameters[xform_name(m)] = f"{to_valid_python_name(m_shape.name)} = None"
 
         if any(map(is_bad_param_name, parameters.keys())):
             # if we cannot render the parameter name, don't expand the parameters in the handler
-            param_list = f"request: {input_shape.name}" if input_shape else ""
+            param_list = f"request: {to_valid_python_name(input_shape.name)}" if input_shape else ""
             output.write(f'    @handler("{operation.name}", expand=False)\n')
         else:
             param_list = ", ".join([f"{k}: {v}" for k, v in parameters.items()])
@@ -332,11 +345,11 @@ def generate_service_api(output, service: ServiceModel, doc=True):
 
             # return value
             if operation.output_shape:
-                output.write(f":returns: {operation.output_shape.name}\n")
+                output.write(f":returns: {to_valid_python_name(operation.output_shape.name)}\n")
 
             # errors
             for error in operation.error_shapes:
-                output.write(f":raises {error.name}:\n")
+                output.write(f":raises {to_valid_python_name(error.name)}:\n")
 
             output.write('        """\n')
 

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -21,8 +21,8 @@ from typing_extensions import OrderedDict
 from localstack.aws.spec import load_service
 from localstack.utils.common import camel_to_snake_case, snake_to_camel_case
 
-# Some minification packages might treat "type" as a keyword.
-KEYWORDS = list(keyword.kwlist) + ["type"]
+# Some minification packages might treat "type" as a keyword, some specs define shapes called like the type "Optional"
+KEYWORDS = list(keyword.kwlist) + ["type", "Optional"]
 is_keyword = KEYWORDS.__contains__
 
 
@@ -409,13 +409,13 @@ def generate_code(service_name: str, doc: bool = False) -> str:
         from black import FileMode, format_str
 
         # try to format with black
-        code = format_str(code, mode=FileMode())
+        code = format_str(code, mode=FileMode(line_length=100))
 
         # try to remove unused imports
-        code = autoflake.fix_code(code)
+        code = autoflake.fix_code(code, remove_all_unused_imports=True)
 
         # try to sort imports
-        code = isort.code(code)
+        code = isort.code(code, config=isort.Config(profile="black", line_length=100))
     except Exception:
         pass
 

--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -1,3 +1,5 @@
+from types import ModuleType
+
 import pytest
 from click.testing import CliRunner
 
@@ -6,11 +8,20 @@ from localstack.aws.scaffold import generate
 
 @pytest.mark.skip_offline
 @pytest.mark.parametrize(
-    "service", ["apigateway", "autoscaling", "cloudformation", "dynamodb", "sqs"]
+    "service", ["apigateway", "autoscaling", "cloudformation", "kafka", "dynamodb", "sqs"]
 )
 def test_generated_code_compiles(service):
     runner = CliRunner()
     result = runner.invoke(generate, [service, "--no-doc", "--print"])
     assert result.exit_code == 0
+
+    # Get the generated code
     code = result.output
-    compile(code, "<string>", "exec")
+
+    # Make sure the code is compilable
+    compiled = compile(code, "<string>", "exec")
+
+    # Make sure the code is importable
+    # (f.e. Kafka contains types with double underscores in the spec, which would result in an import error)
+    module = ModuleType(service)
+    exec(compiled, module.__dict__)


### PR DESCRIPTION
After https://github.com/localstack/localstack/pull/5488, https://github.com/localstack/localstack/pull/5470, https://github.com/localstack/localstack/pull/5512, and https://github.com/localstack/localstack/pull/5567, this is the fifth round of fixes for the scaffold, parsers, and serializers of ASF.
This PR contains the following changes:
- fix error handling in parser and serializer
  - Introduces a clear exception handling for the parsers and the serializers. They either raise an exception which clearly states that the input data is invalid (a protocol error) or that an unknown error occurred.
- fix formatting of generated code in scaffold
  - Fixes the code which is generated by the scaffold such that it passes our linting.
  - Adds "Optional" to the list of keywords to fix generated APIs which define a shape called "Optional".
  - This will fix https://github.com/localstack/localstack/pull/5600.
- fix scaffolding for types names which are not valid python names
  - Fixes the code generation for shape names which are not valid python types (f.e. Kafka with shapes that have a double-underscore prefix).