### PR TITLE
fix opensearch pro integration

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -2,10 +2,11 @@ import json
 import logging
 
 from localstack import config
-from localstack.services.apigateway.apigateway_listener import apply_template
 from localstack.services.apigateway.context import ApiInvocationContext
+from localstack.services.apigateway.helpers import apply_template
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import make_http_request, to_str
+from localstack.utils.http import make_http_request
+from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -95,11 +95,8 @@ def resolve_directories(version: str, cluster_path: str, data_root: str = None) 
 
     modules_dir = os.path.join(install_dir, "modules")
 
-    if data_root is None:
-        if config.dirs.data:
-            data_root = config.dirs.data
-        else:
-            data_root = config.dirs.tmp
+    if not data_root:
+        data_root = config.dirs.data or config.dirs.tmp
 
     if engine_type == EngineType.OpenSearch:
         data_path = os.path.join(data_root, "opensearch", cluster_path)


### PR DESCRIPTION
This PR is a fix for the recently introduce persistence changes in ext. The `data_root` would be empty, despite the fact that `PERSIST_ALL` is set to `True`. The `if data_root not None` check would not capture that, so we introduce a falsyness check instead of a `not None`.

The apigateway change is just a minor fix that removes a warning when generating the plugins.