### PR TITLE
refactor utils imports in utils and services packages

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -33,18 +33,15 @@ from localstack.utils import common, persistence
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import is_internal_call_context, set_default_region_in_headers
 from localstack.utils.aws.request_routing import extract_version_and_action, matches_service_action
-from localstack.utils.common import (
-    TMP_THREADS,
-    empty_context_manager,
-    get_service_protocol,
-    is_port_open,
-    is_root,
-    parse_request_data,
-    run,
-)
-from localstack.utils.common import safe_requests as requests
-from localstack.utils.common import sleep_forever, start_thread, to_bytes, to_str, truncate
+from localstack.utils.functions import empty_context_manager
+from localstack.utils.http import parse_request_data
+from localstack.utils.http import safe_requests as requests
+from localstack.utils.net import is_port_open
+from localstack.utils.run import is_root, run
 from localstack.utils.server.http2_server import HTTPErrorResponse
+from localstack.utils.strings import to_bytes, to_str, truncate
+from localstack.utils.sync import sleep_forever
+from localstack.utils.threads import TMP_THREADS, start_thread
 
 LOG = logging.getLogger(__name__)
 
@@ -269,7 +266,7 @@ def do_forward_request_inmem(api, method, path, data, headers, port=None):
 
 def do_forward_request_network(port, method, path, data, headers, target_url=None):
     # TODO: enable per-service endpoints, to allow deploying in distributed settings
-    target_url = target_url or "%s://%s:%s" % (get_service_protocol(), LOCALHOST, port)
+    target_url = target_url or "%s://%s:%s" % (config.get_protocol(), LOCALHOST, port)
     url = "%s%s" % (target_url, path)
     response = requests.request(
         method, url, data=data, headers=headers, verify=False, stream=True, allow_redirects=False

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -41,18 +41,15 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import LambdaResponse
 from localstack.utils.aws.aws_stack import is_internal_call_context
 from localstack.utils.aws.request_context import RequestContextManager, get_proxy_request_for_thread
-from localstack.utils.common import (
-    empty_context_manager,
-    generate_ssl_cert,
-    json_safe,
-    path_from_url,
-    start_thread,
-    to_bytes,
-    to_str,
-    wait_for_port_open,
-)
+from localstack.utils.crypto import generate_ssl_cert
+from localstack.utils.functions import empty_context_manager
+from localstack.utils.json import json_safe
+from localstack.utils.net import wait_for_port_open
 from localstack.utils.server import http2_server
 from localstack.utils.serving import Server
+from localstack.utils.strings import to_bytes, to_str
+from localstack.utils.threads import start_thread
+from localstack.utils.urls import path_from_url
 
 # set up logger
 LOG = logging.getLogger(__name__)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -29,23 +29,20 @@ from localstack.utils.bootstrap import (
     log_duration,
     setup_logging,
 )
-from localstack.utils.common import (
+from localstack.utils.files import cleanup_tmp_files
+from localstack.utils.net import get_free_tcp_port, is_port_open
+from localstack.utils.patch import patch
+from localstack.utils.platform import in_docker, is_linux
+from localstack.utils.run import ShellCommandThread, run
+from localstack.utils.server import multiserver
+from localstack.utils.sync import poll_condition
+from localstack.utils.testutil import is_local_test_mode
+from localstack.utils.threads import (
     TMP_THREADS,
-    ShellCommandThread,
-    get_free_tcp_port,
-    in_docker,
-    is_linux,
-    is_port_open,
-    poll_condition,
-    run,
+    FuncThread,
+    cleanup_threads_and_processes,
     start_thread,
 )
-from localstack.utils.files import cleanup_tmp_files
-from localstack.utils.patch import patch
-from localstack.utils.run import FuncThread
-from localstack.utils.server import multiserver
-from localstack.utils.testutil import is_local_test_mode
-from localstack.utils.threads import cleanup_threads_and_processes
 
 # flag to indicate whether signal handlers have been set up already
 SIGNAL_HANDLERS_SETUP = False
@@ -437,7 +434,6 @@ def start_infra(asynchronous=False, apis=None):
 
 
 def do_start_infra(asynchronous, apis, is_in_docker):
-
     event_publisher.fire_event(
         event_publisher.EVENT_START_INFRA,
         {"d": is_in_docker and 1 or 0, "c": in_ci() and 1 or 0},

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -33,26 +33,23 @@ from localstack.constants import (
     STS_JAR_URL,
 )
 from localstack.runtime import hooks
-from localstack.utils.common import (
+from localstack.utils.archives import untar, unzip
+from localstack.utils.docker_utils import DOCKER_CLIENT
+from localstack.utils.files import (
     chmod_r,
-    download,
     file_exists_not_empty,
-    get_arch,
-    is_windows,
     load_file,
     mkdir,
     new_tmp_file,
-    parallelize,
     replace_in_file,
-    retry,
     rm_rf,
-    run,
-    safe_run,
     save_file,
-    untar,
-    unzip,
 )
-from localstack.utils.docker_utils import DOCKER_CLIENT
+from localstack.utils.http import download
+from localstack.utils.platform import get_arch, is_windows
+from localstack.utils.run import run
+from localstack.utils.sync import retry
+from localstack.utils.threads import parallelize
 
 LOG = logging.getLogger(__name__)
 
@@ -201,7 +198,7 @@ def install_elasticsearch(version=None):
                 LOG.info("Installing Elasticsearch plugin %s", plugin)
 
                 def try_install():
-                    output = safe_run([plugin_binary, "install", "-b", plugin])
+                    output = run([plugin_binary, "install", "-b", plugin])
                     LOG.debug("Plugin installation output: %s", output)
 
                 # We're occasionally seeing javax.net.ssl.SSLHandshakeException -> add download retries

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -13,14 +13,12 @@ from localstack.http import Router
 from localstack.http.adapters import RouterListener
 from localstack.http.dispatcher import resource_dispatcher
 from localstack.services.infra import terminate_all_processes_in_docker
-from localstack.utils.common import (
-    call_safe,
-    load_file,
-    merge_recursive,
-    parse_json_or_yaml,
-    parse_request_data,
-    to_str,
-)
+from localstack.utils.collections import merge_recursive
+from localstack.utils.files import load_file
+from localstack.utils.functions import call_safe
+from localstack.utils.http import parse_request_data
+from localstack.utils.json import parse_json_or_yaml
+from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/services/messages.py
+++ b/localstack/services/messages.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 from typing import Dict, Optional, Union
 
-from localstack.utils.common import to_str
+from localstack.utils.strings import to_str
 
 MessagePayload = Union[str, bytes]
 Headers = Dict[str, str]

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -27,7 +27,7 @@ from localstack.aws.api.core import ServiceRequest, ServiceRequestHandler
 from localstack.aws.skeleton import DispatchTable, create_dispatch_table
 from localstack.aws.spec import load_service
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import to_bytes, to_str
+from localstack.utils.strings import to_bytes, to_str
 
 MotoResponse = Tuple[int, dict, Union[str, bytes]]
 MotoDispatcher = Callable[[HttpRequest, str, dict], MotoResponse]

--- a/localstack/services/motoserver.py
+++ b/localstack/services/motoserver.py
@@ -6,7 +6,7 @@ from moto.server import DomainDispatcherApplication, create_backend_app
 from werkzeug.serving import make_server
 
 from localstack import constants
-from localstack.utils.common import get_free_tcp_port
+from localstack.utils.net import get_free_tcp_port
 from localstack.utils.serving import Server
 
 LOG = logging.getLogger(__name__)

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -14,7 +14,9 @@ from requests.models import Request
 from localstack import config
 from localstack.config import ServiceProviderConfig
 from localstack.utils.bootstrap import get_enabled_apis, is_api_enabled, log_duration
-from localstack.utils.common import call_safe, poll_condition, wait_for_port_status
+from localstack.utils.functions import call_safe
+from localstack.utils.net import wait_for_port_status
+from localstack.utils.sync import poll_condition
 
 # set up logger
 LOG = logging.getLogger(__name__)

--- a/localstack/utils/analytics/client.py
+++ b/localstack/utils/analytics/client.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, List
 import requests
 
 from localstack import config, constants
-from localstack.utils.common import get_proxies, now
+from localstack.utils.http import get_proxies
+from localstack.utils.time import now
 
 from .events import Event, EventMetadata
 from .metadata import ClientMetadata, get_session_id

--- a/localstack/utils/analytics/logger.py
+++ b/localstack/utils/analytics/logger.py
@@ -1,7 +1,8 @@
 import datetime
 import hashlib
 
-from ..common import to_bytes
+from localstack.utils.strings import to_bytes
+
 from .events import Event, EventHandler, EventMetadata, EventPayload
 from .metadata import get_session_id
 

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -6,7 +6,9 @@ import platform
 
 from localstack import config, constants
 from localstack.runtime import hooks
-from localstack.utils.common import FileMappedDocument, call_safe, long_uid, md5, short_uid
+from localstack.utils.functions import call_safe
+from localstack.utils.json import FileMappedDocument
+from localstack.utils.strings import long_uid, md5, short_uid
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -7,7 +7,7 @@ from queue import Full, Queue
 from typing import List, Optional
 
 from localstack import config, constants
-from localstack.utils.common import start_thread, start_worker_thread
+from localstack.utils.threads import start_thread, start_worker_thread
 
 from .client import AnalyticsClient
 from .events import Event, EventHandler

--- a/localstack/utils/archives.py
+++ b/localstack/utils/archives.py
@@ -16,7 +16,7 @@ def is_zip_file(content):
 
 
 def unzip(path, target_dir, overwrite=True):
-    from localstack.utils.common import is_debian
+    from localstack.utils.platform import is_debian
 
     is_in_debian = is_debian()
     if is_in_debian:

--- a/localstack/utils/asyncio.py
+++ b/localstack/utils/asyncio.py
@@ -4,10 +4,8 @@ import functools
 import time
 from contextvars import copy_context
 
-from localstack.utils import common
-
-from .common import TMP_THREADS, start_worker_thread
 from .run import FuncThread
+from .threads import TMP_THREADS, start_worker_thread
 
 # reference to named event loop instances
 EVENT_LOOPS = {}
@@ -122,6 +120,8 @@ def get_named_event_loop(name):
 
 
 async def receive_from_queue(queue):
+    from localstack.utils import common
+
     def get():
         # run in a retry loop (instead of blocking forever) to allow for graceful shutdown
         while True:

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -3,7 +3,7 @@ import logging
 import time
 from datetime import datetime
 
-from localstack.utils.common import timestamp_millis
+from localstack.utils.time import timestamp_millis
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -22,9 +22,9 @@ from localstack.constants import (
     TEST_AWS_ACCOUNT_ID,
 )
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import (
-    json_safe,
-    replace_response_content,
+from localstack.utils.http import replace_response_content
+from localstack.utils.json import json_safe
+from localstack.utils.strings import (
     short_uid,
     str_startswith_ignore_case,
     to_bytes,

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -37,16 +37,11 @@ from localstack.constants import (
 )
 from localstack.utils.aws import templating
 from localstack.utils.aws.aws_models import KinesisStream
-from localstack.utils.common import (
-    get_service_protocol,
-    is_string,
-    is_string_or_bytes,
-    make_http_request,
-    retry,
-    run_safe,
-    to_str,
-)
-from localstack.utils.generic import dict_utils
+from localstack.utils.collections import pick_attributes
+from localstack.utils.functions import run_safe
+from localstack.utils.http import make_http_request
+from localstack.utils.strings import is_string, is_string_or_bytes, to_str
+from localstack.utils.sync import retry
 
 # AWS environment variable names
 ENV_ACCESS_KEY = "AWS_ACCESS_KEY_ID"
@@ -239,7 +234,7 @@ def set_internal_auth(headers):
 def get_local_service_url(service_name_or_port: Union[str, int]) -> str:
     """Return the local service URL for the given service name or port."""
     if isinstance(service_name_or_port, int):
-        return f"{get_service_protocol()}://{LOCALHOST}:{service_name_or_port}"
+        return f"{config.get_protocol()}://{LOCALHOST}:{service_name_or_port}"
     service_name = service_name_or_port
     if service_name == "s3api":
         service_name = "s3"
@@ -769,7 +764,7 @@ def _resource_arn(name: str, pattern: str, account_id: str = None, region_name: 
 
 
 def get_events_target_attributes(target):
-    return dict_utils.pick_attributes(target, EVENT_TARGET_PARAMETERS)
+    return pick_attributes(target, EVENT_TARGET_PARAMETERS)
 
 
 def get_or_create_bucket(bucket_name, s3_client=None):

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -6,7 +6,7 @@ from typing import Dict, List
 
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
-from localstack.utils.common import convert_to_printable_chars, first_char_to_upper
+from localstack.utils.strings import convert_to_printable_chars, first_char_to_upper
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -14,11 +14,11 @@ from localstack.utils.aws.aws_stack import (
     firehose_name,
     get_sqs_queue_url,
 )
-from localstack.utils.common import long_uid, now_utc
-from localstack.utils.common import safe_requests as requests
-from localstack.utils.common import timestamp_millis, to_bytes
 from localstack.utils.generic import dict_utils
 from localstack.utils.http import add_query_params_to_url
+from localstack.utils.http import safe_requests as requests
+from localstack.utils.strings import long_uid, to_bytes
+from localstack.utils.time import now_utc, timestamp_millis
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -16,9 +16,9 @@ from localstack.utils.aws.aws_responses import (
     requests_response,
     requests_to_flask_response,
 )
-from localstack.utils.common import snake_to_camel_case
 from localstack.utils.patch import patch
-from localstack.utils.run import FuncThread
+from localstack.utils.strings import snake_to_camel_case
+from localstack.utils.threads import FuncThread
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/aws/request_routing.py
+++ b/localstack/utils/aws/request_routing.py
@@ -5,7 +5,8 @@ from typing import Dict, Set, Tuple
 
 import botocore
 
-from localstack.utils.common import load_file, to_bytes, to_str
+from localstack.utils.files import load_file
+from localstack.utils.strings import to_bytes, to_str
 
 # maps service names/versions to list of action names
 SERVICE_ACTIONS_CACHE: Dict[str, Set[str]] = {}

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -6,15 +6,11 @@ from urllib.parse import quote_plus, unquote_plus
 import airspeed
 
 from localstack import config
-from localstack.utils.common import (
-    extract_jsonpath,
-    is_number,
-    json_safe,
-    recurse_object,
-    short_uid,
-)
-from localstack.utils.generic.number_utils import to_number
+from localstack.utils.json import extract_jsonpath, json_safe
+from localstack.utils.numbers import is_number, to_number
+from localstack.utils.objects import recurse_object
 from localstack.utils.patch import patch
+from localstack.utils.strings import short_uid
 
 
 # TODO: potentially replace with generic proxy wrapper class

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -12,7 +12,6 @@ from typing import Dict, Iterable, List, Optional, Set
 from localstack import config, constants
 from localstack.config import Directories
 from localstack.runtime import hooks
-from localstack.utils.common import FileListener, chmod_r, mkdir, poll_condition
 from localstack.utils.container_utils.container_client import (
     ContainerException,
     PortMappings,
@@ -22,12 +21,13 @@ from localstack.utils.container_utils.container_client import (
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
-
-# set up logger
-from localstack.utils.generic.file_utils import cache_dir
+from localstack.utils.files import cache_dir, chmod_r, mkdir
 from localstack.utils.run import run, to_str
 from localstack.utils.serving import Server
+from localstack.utils.sync import poll_condition
+from localstack.utils.tail import FileListener
 
+# set up logger
 LOG = logging.getLogger(os.path.basename(__file__))
 
 

--- a/localstack/utils/cloudformation/template_preparer.py
+++ b/localstack/utils/cloudformation/template_preparer.py
@@ -14,7 +14,10 @@ from samtranslator.translator.transform import transform as transform_sam
 from localstack import config, constants
 from localstack.services.s3 import s3_listener, s3_utils
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import clone_safe, run_safe, safe_requests, to_str
+from localstack.utils.functions import run_safe
+from localstack.utils.http import safe_requests
+from localstack.utils.json import clone_safe
+from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -9,7 +9,8 @@ from localstack import config
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
 from localstack.utils.bootstrap import is_api_enabled
-from localstack.utils.common import now_utc, to_str
+from localstack.utils.strings import to_str
+from localstack.utils.time import now_utc
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -209,7 +209,7 @@ def select_attributes(obj: Dict, attributes: List[str]) -> Dict:
 
 def remove_attributes(obj: Dict, attributes: List[str], recursive: bool = False) -> Dict:
     """Remove a set of attributes from the given dict (in-place)"""
-    from localstack.utils.common import recurse_object
+    from localstack.utils.objects import recurse_object
 
     if recursive:
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 from localstack import config
-from localstack.utils.common import TMP_FILES, HashableList, rm_rf, save_file, short_uid
+from localstack.utils.collections import HashableList
+from localstack.utils.files import TMP_FILES, rm_rf, save_file
+from localstack.utils.strings import short_uid
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -8,7 +8,6 @@ import subprocess
 from typing import Dict, List, Optional, Tuple, Union
 
 from localstack import config
-from localstack.utils.common import safe_run
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
     ContainerClient,
@@ -23,7 +22,7 @@ from localstack.utils.container_utils.container_client import (
     SimpleVolumeBind,
     Util,
 )
-from localstack.utils.run import to_str
+from localstack.utils.run import run, to_str
 
 LOG = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ class CmdDockerClient(ContainerClient):
             "--format",
             "{{ .Status }} - {{ .Names }}",
         ]
-        cmd_result = safe_run(cmd)
+        cmd_result = run(cmd)
 
         # filter empty / invalid lines from docker ps output
         cmd_result = next((line for line in cmd_result.splitlines() if container_name in line), "")
@@ -68,7 +67,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["stop", "--time", str(timeout), container_name]
         LOG.debug("Stopping container with cmd %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name, stdout=e.stdout, stderr=e.stderr)
@@ -82,7 +81,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["pause", container_name]
         LOG.debug("Pausing container with cmd %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name, stdout=e.stdout, stderr=e.stderr)
@@ -96,7 +95,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["unpause", container_name]
         LOG.debug("Unpausing container with cmd %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name, stdout=e.stdout, stderr=e.stderr)
@@ -112,7 +111,7 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--force"]
         LOG.debug("Removing image %s %s", image, "(forced)" if force else "")
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such image" in to_str(e.stdout):
                 raise NoSuchImage(image, stdout=e.stdout, stderr=e.stderr)
@@ -133,7 +132,7 @@ class CmdDockerClient(ContainerClient):
             "Creating image from container %s as %s:%s", container_name_or_id, image_name, image_tag
         )
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name_or_id, stdout=e.stdout, stderr=e.stderr)
@@ -151,7 +150,7 @@ class CmdDockerClient(ContainerClient):
         cmd.append(container_name)
         LOG.debug("Removing container with cmd %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name, stdout=e.stdout, stderr=e.stderr)
@@ -173,7 +172,7 @@ class CmdDockerClient(ContainerClient):
         cmd.append("--format")
         cmd.append("{{json . }}")
         try:
-            cmd_result = safe_run(cmd).strip()
+            cmd_result = run(cmd).strip()
         except subprocess.CalledProcessError as e:
             raise ContainerException(
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
@@ -201,7 +200,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["cp", local_path, f"{container_name}:{container_path}"]
         LOG.debug("Copying into container with cmd: %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name)
@@ -216,7 +215,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["cp", f"{container_name}:{container_path}", local_path]
         LOG.debug("Copying from container with cmd: %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such container" in to_str(e.stdout):
                 raise NoSuchContainer(container_name)
@@ -229,7 +228,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["pull", docker_image]
         LOG.debug("Pulling image with cmd: %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "pull access denied" in to_str(e.stdout):
                 raise NoSuchImage(docker_image)
@@ -242,7 +241,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["push", docker_image]
         LOG.debug("Pushing image with cmd: %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "is denied" in to_str(e.stdout):
                 raise AccessDenied(docker_image)
@@ -261,7 +260,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["build", "-t", image_name, "-f", dockerfile_path, context_path]
         LOG.debug("Building Docker image: %s", cmd)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             raise ContainerException(
                 f"Docker build process returned with error code {e.returncode}", e.stdout, e.stderr
@@ -272,7 +271,7 @@ class CmdDockerClient(ContainerClient):
         cmd += ["tag", source_ref, target_name]
         LOG.debug("Tagging Docker image %s as %s", source_ref, target_name)
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such image" in to_str(e.stdout):
                 raise NoSuchImage(source_ref)
@@ -285,7 +284,7 @@ class CmdDockerClient(ContainerClient):
         cmd = self._docker_cmd()
         cmd += ["images", "--format", format_string]
         try:
-            output = safe_run(cmd)
+            output = run(cmd)
 
             image_names = output.splitlines()
             if strip_latest:
@@ -299,7 +298,7 @@ class CmdDockerClient(ContainerClient):
         cmd = self._docker_cmd()
         cmd += ["logs", container_name_or_id]
         try:
-            return safe_run(cmd)
+            return run(cmd)
         except subprocess.CalledProcessError as e:
             if safe:
                 return ""
@@ -314,7 +313,7 @@ class CmdDockerClient(ContainerClient):
         cmd = self._docker_cmd()
         cmd += ["inspect", "--format", "{{json .}}", object_name_or_id]
         try:
-            cmd_result = safe_run(cmd)
+            cmd_result = run(cmd)
         except subprocess.CalledProcessError as e:
             if "No such object" in to_str(e.stdout):
                 raise NoSuchObject(object_name_or_id, stdout=e.stdout, stderr=e.stderr)
@@ -361,7 +360,7 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--alias", ",".join(aliases)]
         cmd += [network_name, container_name_or_id]
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             stdout_str = to_str(e.stdout)
             if re.match(r".*network (.*) not found.*", stdout_str):
@@ -381,7 +380,7 @@ class CmdDockerClient(ContainerClient):
         )
         cmd = self._docker_cmd() + ["network", "disconnect", network_name, container_name_or_id]
         try:
-            safe_run(cmd)
+            run(cmd)
         except subprocess.CalledProcessError as e:
             stdout_str = to_str(e.stdout)
             if re.match(r".*network (.*) not found.*", stdout_str):
@@ -402,7 +401,7 @@ class CmdDockerClient(ContainerClient):
             container_name_or_id,
         ]
         try:
-            result = safe_run(cmd).strip()
+            result = run(cmd).strip()
             return result.split(" ")[0] if result else ""
         except subprocess.CalledProcessError as e:
             if "No such object" in to_str(e.stdout):
@@ -414,7 +413,7 @@ class CmdDockerClient(ContainerClient):
 
     def has_docker(self) -> bool:
         try:
-            safe_run(self._docker_cmd() + ["ps"])
+            run(self._docker_cmd() + ["ps"])
             return True
         except subprocess.CalledProcessError:
             return False
@@ -423,7 +422,7 @@ class CmdDockerClient(ContainerClient):
         cmd, env_file = self._build_run_create_cmd("create", image_name, **kwargs)
         LOG.debug("Create container with cmd: %s", cmd)
         try:
-            container_id = safe_run(cmd)
+            container_id = run(cmd)
             # Note: strip off Docker warning messages like "DNS setting (--dns=127.0.0.1) may fail in containers"
             container_id = container_id.strip().split("\n")[-1]
             return container_id.strip()
@@ -506,7 +505,7 @@ class CmdDockerClient(ContainerClient):
         if stdin:
             kwargs["stdin"] = True
         try:
-            process = safe_run(cmd, **kwargs)
+            process = run(cmd, **kwargs)
             stdout, stderr = process.communicate(input=stdin)
             if process.returncode != 0:
                 raise subprocess.CalledProcessError(

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -22,7 +22,8 @@ from localstack.utils.container_utils.container_client import (
     SimpleVolumeBind,
     Util,
 )
-from localstack.utils.run import run, to_str
+from localstack.utils.run import run
+from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -11,7 +11,6 @@ from docker.errors import APIError, ContainerError, DockerException, ImageNotFou
 from docker.models.containers import Container
 from docker.utils.socket import STDERR, STDOUT, frames_iter
 
-from localstack.utils.common import start_worker_thread, to_bytes
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
     ContainerClient,
@@ -25,7 +24,8 @@ from localstack.utils.container_utils.container_client import (
     SimpleVolumeBind,
     Util,
 )
-from localstack.utils.run import to_str
+from localstack.utils.strings import to_bytes, to_str
+from localstack.utils.threads import start_worker_thread
 
 LOG = logging.getLogger(__name__)
 SDK_ISDIR = 1 << 31

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -7,9 +7,9 @@ from typing import Dict, List, Union
 from localstack import config
 from localstack.utils import bootstrap
 from localstack.utils.bootstrap import get_main_container_name
-from localstack.utils.common import load_file
 from localstack.utils.container_utils.container_client import NoSuchImage
 from localstack.utils.docker_utils import DOCKER_CLIENT
+from localstack.utils.files import load_file
 
 DIAGNOSE_IMAGES = [
     "localstack/lambda:provided",

--- a/localstack/utils/files.py
+++ b/localstack/utils/files.py
@@ -36,7 +36,7 @@ def parse_config_file(file_or_str: str, single_section: bool = True) -> Dict:
 
 
 def cache_dir() -> Path:
-    from localstack.utils.common import is_linux, is_mac_os, is_windows
+    from localstack.utils.platform import is_linux, is_mac_os, is_windows
 
     if is_windows():
         return Path("%LOCALAPPDATA%", "cache", "localstack")
@@ -154,7 +154,8 @@ def rm_rf(path: str):
     """
     Recursively removes a file or directory
     """
-    from localstack.utils.common import is_debian, run
+    from localstack.utils.platform import is_debian
+    from localstack.utils.run import run
 
     if not path or not os.path.exists(path):
         return

--- a/localstack/utils/kinesis/kclipy_helper.py
+++ b/localstack/utils/kinesis/kclipy_helper.py
@@ -6,7 +6,7 @@ from glob import glob
 from amazon_kclpy import kcl
 
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import save_file
+from localstack.utils.files import save_file
 
 
 def get_dir_of_file(f):

--- a/localstack/utils/kinesis/kinesis_util.py
+++ b/localstack/utils/kinesis/kinesis_util.py
@@ -4,8 +4,8 @@ import logging
 import socket
 import traceback
 
-from localstack.utils.common import truncate
-from localstack.utils.run import FuncThread
+from localstack.utils.strings import truncate
+from localstack.utils.threads import FuncThread
 
 # set up local logger
 LOGGER = logging.getLogger(__name__)

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import cachetools
 import dns.resolver
 
+from .numbers import is_number
 from .sync import retry
 
 LOG = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ def is_port_open(
     protocols: Optional[List[str]] = None,
     quiet: bool = True,
 ):
-    from localstack.utils.common import is_number, safe_requests
+    from localstack.utils.http import safe_requests
 
     protocols = protocols or ["tcp"]
     port = port_or_url

--- a/localstack/utils/persistence.py
+++ b/localstack/utils/persistence.py
@@ -15,7 +15,8 @@ from localstack.config import is_env_not_false, is_env_true
 from localstack.services.generic_proxy import ProxyListener
 from localstack.utils.aws import aws_stack
 from localstack.utils.bootstrap import is_api_enabled
-from localstack.utils.common import chmod_r, to_bytes, to_str
+from localstack.utils.files import chmod_r
+from localstack.utils.strings import to_bytes, to_str
 
 USE_SINGLE_DUMP_FILE = is_env_not_false("PERSISTENCE_SINGLE_FILE")
 

--- a/localstack/utils/platform.py
+++ b/localstack/utils/platform.py
@@ -1,8 +1,6 @@
 import platform
 from functools import lru_cache
 
-from localstack import config
-
 
 def is_mac_os() -> bool:
     return "darwin" == platform.system().lower()
@@ -54,4 +52,6 @@ def get_os() -> str:
 
 
 def in_docker() -> bool:
+    from localstack import config
+
     return config.in_docker()

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -20,10 +20,12 @@ from quart import utils as quart_utils
 from quart.app import _cancel_all_tasks
 
 from localstack import config
-from localstack.utils.async_utils import ensure_event_loop, run_coroutine, run_sync
-from localstack.utils.common import TMP_THREADS, load_file, retry
+from localstack.utils.asyncio import ensure_event_loop, run_coroutine, run_sync
+from localstack.utils.files import load_file
 from localstack.utils.http import uses_chunked_encoding
 from localstack.utils.run import FuncThread
+from localstack.utils.sync import retry
+from localstack.utils.threads import TMP_THREADS
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -9,17 +9,12 @@ import requests
 
 from localstack.constants import BIND_HOST, HEADER_ACCEPT_ENCODING, LOCALHOST_IP
 from localstack.services.generic_proxy import ProxyListener, start_proxy_server
-from localstack.utils.async_utils import ensure_event_loop
-from localstack.utils.common import (
-    TMP_THREADS,
-    is_number,
-    new_tmp_file,
-    run_safe,
-    save_file,
-    start_worker_thread,
-    to_bytes,
-)
-from localstack.utils.run import FuncThread
+from localstack.utils.asyncio import ensure_event_loop
+from localstack.utils.files import new_tmp_file, save_file
+from localstack.utils.functions import run_safe
+from localstack.utils.numbers import is_number
+from localstack.utils.strings import to_bytes
+from localstack.utils.threads import TMP_THREADS, FuncThread, start_worker_thread
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/serving.py
+++ b/localstack/utils/serving.py
@@ -3,8 +3,9 @@ import logging
 import threading
 from typing import Optional
 
-from localstack.utils.common import is_port_open, poll_condition, start_thread
-from localstack.utils.run import FuncThread
+from localstack.utils.net import is_port_open
+from localstack.utils.sync import poll_condition
+from localstack.utils.threads import FuncThread, start_thread
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/strings.py
+++ b/localstack/utils/strings.py
@@ -81,7 +81,7 @@ def canonicalize_bool_to_str(val: bool) -> str:
 
 def convert_to_printable_chars(value: Union[List, Dict, str]) -> str:
     """Removes all unprintable characters from the given string."""
-    from localstack.utils.common import recurse_object
+    from localstack.utils.objects import recurse_object
 
     if isinstance(value, (dict, list)):
 

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -29,24 +29,22 @@ from localstack.services.awslambda.lambda_utils import (
     get_handler_file_from_name,
 )
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import (
+from localstack.utils.collections import ensure_list
+from localstack.utils.files import (
     TMP_FILES,
     chmod_r,
-    ensure_list,
-    get_free_tcp_port,
-    is_debian,
     is_empty_dir,
-    is_port_open,
     load_file,
     mkdir,
-    poll_condition,
     rm_rf,
-    run,
     save_file,
-    short_uid,
-    to_str,
 )
-from localstack.utils.run import FuncThread
+from localstack.utils.net import get_free_tcp_port, is_port_open
+from localstack.utils.platform import is_debian
+from localstack.utils.run import run
+from localstack.utils.strings import short_uid, to_str
+from localstack.utils.sync import poll_condition
+from localstack.utils.threads import FuncThread
 
 ARCHIVE_DIR_PREFIX = "lambda.archive."
 DEFAULT_GET_LOG_EVENTS_DELAY = 3

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -23,7 +23,7 @@ class TestDockerClient(unittest.TestCase):
         """Return the string to be used for running Docker commands."""
         return config.DOCKER_CMD.split()
 
-    @patch("localstack.utils.container_utils.docker_cmd_client.safe_run")
+    @patch("localstack.utils.container_utils.docker_cmd_client.run")
     def test_list_containers(self, run_mock):
         mock_container = {
             "ID": "00000000a1",
@@ -49,7 +49,7 @@ class TestDockerClient(unittest.TestCase):
         self.assertIn("-a", call_arguments)
         self.assertIn("--format", call_arguments)
 
-    @patch("localstack.utils.container_utils.docker_cmd_client.safe_run")
+    @patch("localstack.utils.container_utils.docker_cmd_client.run")
     def test_container_status(self, run_mock):
         test_output = "Up 2 minutes - localstack_main"
         run_mock.return_value = test_output


### PR DESCRIPTION
Simply removes `localstack.utils.common` where possible in `utils` and `services` packages

I think you can see the drawback of splitting up the `common` monolith here, as it creates a lot more lines of import statements. one think to maybe think about is to do imports differently on utils code. so instead of writing
```python
from localstack.utils.files import rm_rf, cp_r, ...
rm_rf(...)
```
write
```python
from localstack.utils import files
files.rm_rf(...)
...
```
