### PR TITLE
refactor config imports

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -8,8 +8,6 @@ import tempfile
 import time
 from typing import Any, Dict, List, Mapping, Tuple
 
-from boto3 import Session
-
 from localstack.constants import (
     AWS_REGION_US_EAST_1,
     DEFAULT_BUCKET_MARKER_LOCAL,
@@ -422,14 +420,6 @@ else:
 
 # additional CLI commands, can be set by plugins
 CLI_COMMANDS = {}
-
-# set of valid regions
-VALID_PARTITIONS = set(Session().get_available_partitions())
-VALID_REGIONS = set()
-for partition in VALID_PARTITIONS:
-    for region in Session().get_available_regions("sns", partition):
-        VALID_REGIONS.add(region)
-
 
 # determine IP of Docker bridge
 if not DOCKER_BRIDGE_IP:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -17,6 +17,7 @@ from localstack.constants import (
     DEFAULT_LAMBDA_CONTAINER_REGISTRY,
     DEFAULT_PORT_EDGE,
     DEFAULT_SERVICE_PORTS,
+    ENV_INTERNAL_TEST_RUN,
     FALSE_STRINGS,
     INSTALL_DIR_INFRA,
     LOCALHOST,
@@ -694,6 +695,11 @@ CONFIG_ENV_VARS = [
     "WAIT_FOR_DEBUGGER",
     "WINDOWS_DOCKER_MOUNT_PREFIX",
 ]
+
+
+def is_local_test_mode() -> bool:
+    """Returns True if we are running in the context of our local integration tests."""
+    return is_env_true(ENV_INTERNAL_TEST_RUN)
 
 
 def collect_config_items() -> List[Tuple[str, Any]]:

--- a/localstack/runtime/events.py
+++ b/localstack/runtime/events.py
@@ -1,0 +1,6 @@
+import threading
+
+infra_starting = threading.Event()
+infra_ready = threading.Event()
+infra_stopping = threading.Event()
+infra_stopped = threading.Event()

--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -6,7 +6,7 @@ import time
 from typing import Dict
 
 from localstack import config
-from localstack.constants import ENV_INTERNAL_TEST_RUN, MOTO_ACCOUNT_ID, TEST_AWS_ACCOUNT_ID
+from localstack.constants import MOTO_ACCOUNT_ID, TEST_AWS_ACCOUNT_ID
 from localstack.services.events.scheduler import JobScheduler
 from localstack.services.generic_proxy import ProxyListener, RegionBackend
 from localstack.utils.aws import aws_stack
@@ -176,7 +176,7 @@ class ProxyListenerEvents(ProxyListener):
 
             elif action == "PutEvents":
                 # keep track of events for local integration testing
-                if os.environ.get(ENV_INTERNAL_TEST_RUN):
+                if config.is_local_test_mode():
                     TEST_EVENTS_CACHE.extend(parsed_data.get("Entries", []))
 
         return True

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -36,7 +36,6 @@ from localstack.utils.platform import in_docker, is_linux
 from localstack.utils.run import ShellCommandThread, run
 from localstack.utils.server import multiserver
 from localstack.utils.sync import poll_condition
-from localstack.utils.testutil import is_local_test_mode
 from localstack.utils.threads import (
     TMP_THREADS,
     FuncThread,
@@ -459,7 +458,7 @@ def do_start_infra(asynchronous, apis, is_in_docker):
         os.environ["AWS_REGION"] = config.DEFAULT_REGION
         os.environ["ENV"] = ENV_DEV
         # register signal handlers
-        if not is_local_test_mode():
+        if not config.is_local_test_mode():
             register_signal_handlers()
         # make sure AWS credentials are configured, otherwise boto3 bails on us
         check_aws_credentials()

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -105,6 +105,7 @@ class ResourceGraph:
 
 class CloudFormationUi:
     def on_get(self, request):
+        from localstack.utils.aws.aws_stack import get_valid_regions
 
         path = request.path
         data = request.data
@@ -119,7 +120,7 @@ class CloudFormationUi:
             "stackName": "stack1",
             "templateBody": "{}",
             "errorMessage": "''",
-            "regions": json.dumps(sorted(list(config.VALID_REGIONS))),
+            "regions": json.dumps(sorted(list(get_valid_regions()))),
         }
 
         download_url = req_params.get("templateURL")

--- a/localstack/utils/analytics/event_publisher.py
+++ b/localstack/utils/analytics/event_publisher.py
@@ -51,16 +51,13 @@ def fire_event(event_type, payload=None):
         return
 
     from localstack.utils.analytics import log
-    from localstack.utils.testutil import (  # leave here to avoid circular dependency
-        is_local_test_mode,
-    )
 
     if payload is None:
         payload = {}
     if isinstance(payload, dict):
         if is_travis():
             payload["travis"] = True
-        if is_local_test_mode():
+        if config.is_local_test_mode():
             payload["int"] = True
 
     log.event("legacy", {"event": event_type, "payload": payload})

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -53,7 +53,7 @@ def read_client_metadata() -> ClientMetadata:
         version=get_version_string(),
         is_ci=os.getenv("CI") is not None,
         is_docker=config.is_in_docker,
-        is_testing=config.is_env_true(constants.ENV_INTERNAL_TEST_RUN),
+        is_testing=config.is_local_test_mode(),
     )
 
 

--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -6,7 +6,7 @@ import time
 from queue import Full, Queue
 from typing import List, Optional
 
-from localstack import config, constants
+from localstack import config
 from localstack.utils.threads import start_thread, start_worker_thread
 
 from .client import AnalyticsClient
@@ -185,7 +185,7 @@ class GlobalAnalyticsBus(PublisherBuffer):
         if config.DISABLE_EVENTS:
             return True
         # don't track for internal test runs (like integration tests)
-        if config.is_env_true(constants.ENV_INTERNAL_TEST_RUN):
+        if config.is_local_test_mode():
             return True
         if self.tracking_disabled:
             return True

--- a/localstack/utils/asyncio.py
+++ b/localstack/utils/asyncio.py
@@ -120,13 +120,13 @@ def get_named_event_loop(name):
 
 
 async def receive_from_queue(queue):
-    from localstack.utils import common
+    from localstack.runtime import events
 
     def get():
         # run in a retry loop (instead of blocking forever) to allow for graceful shutdown
         while True:
             try:
-                if common.INFRA_STOPPED:
+                if events.infra_stopping.is_set():
                     return
                 return queue.get(timeout=1)
             except Exception:

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -212,9 +212,6 @@ from localstack.utils.urls import path_from_url  # noqa
 # TODO: remove imports from here (need to update any client code that imports these from utils.common)
 from localstack.utils.xml import obj_to_xml, strip_xmlns  # noqa
 
-# flag to indicate whether we've received and processed the stop signal
-INFRA_STOPPED = False
-
 
 # TODO: move somewhere sensible (probably localstack.runtime)
 class ExternalServicePortsManager(PortRange):

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -224,10 +224,10 @@ class ShellCommandThread(FuncThread):
     def run_cmd(self, params):
         while True:
             self.do_run_cmd()
-            from localstack.utils import common
+            from localstack.runtime import events
 
             if (
-                common.INFRA_STOPPED  # FIXME: this is the wrong level of abstraction
+                events.infra_stopping.is_set()  # FIXME: this is the wrong level of abstraction
                 or not self.auto_restart
                 or not self.process
                 or self.process.returncode == 0
@@ -300,11 +300,11 @@ class ShellCommandThread(FuncThread):
             LOG.warning('Shell command exit code "%s": %s', self.process.returncode, self.cmd)
 
     def is_killed(self):
-        from localstack.utils import common
+        from localstack.runtime import events
 
         if not self.process:
             return True
-        if common.INFRA_STOPPED:  # FIXME
+        if events.infra_stopping.is_set():  # FIXME
             return True
         # Note: Do NOT import "psutil" at the root scope, as this leads
         # to problems when importing this file from our test Lambdas in Docker

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -16,7 +16,6 @@ import requests
 
 from localstack import config
 from localstack.constants import (
-    ENV_INTERNAL_TEST_RUN,
     LAMBDA_TEST_ROLE,
     LOCALSTACK_ROOT_FOLDER,
     LOCALSTACK_VENV_FOLDER,
@@ -54,8 +53,7 @@ MAX_LAMBDA_ARCHIVE_UPLOAD_SIZE = 50_000_000
 
 
 def is_local_test_mode():
-    """Whether we are running in the context of our local integration tests."""
-    return bool(os.environ.get(ENV_INTERNAL_TEST_RUN))
+    return config.is_local_test_mode()
 
 
 def copy_dir(source, target):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,7 @@ import pytest
 from localstack import config
 from localstack.config import is_env_true
 from localstack.constants import ENV_INTERNAL_TEST_RUN
+from localstack.runtime import events
 from localstack.services import infra
 from localstack.utils.common import safe_requests
 from tests.integration.test_es import install_async as es_install_async
@@ -140,7 +141,7 @@ def run_localstack():
             logger.exception("exception while running init function for test")
 
     logger.info("waiting for infra to be ready")
-    infra.INFRA_READY.wait()  # wait for infra to start (threading event)
+    events.infra_ready.wait()  # wait for infra to start (threading event)
     localstack_started.set()  # set conftest inter-process Event
 
     logger.info("waiting for shutdown")


### PR DESCRIPTION
This PR removes the boto3 dependency of config.py, and removes the dependency to `common.INFRA_READY`, as well as a dependency from various packages to `utils.testutil`.

This is in preparation for the standalone cli package, to remove the runtime dependency to boto