### PR TITLE
improve cli startup performance

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -2,7 +2,6 @@ import logging
 import os
 import platform
 import re
-import shutil
 import socket
 import subprocess
 import tempfile
@@ -187,13 +186,6 @@ def load_environment(profile: str = None):
     import dotenv
 
     dotenv.load_dotenv(path, override=False)
-
-
-def has_docker():
-    try:
-        return True if shutil.which("docker") else False
-    except Exception:
-        return False
 
 
 def is_linux():

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -549,12 +549,8 @@ S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false("S3_SKIP_SIGNATURE_VALIDATION")
 TEST_IAM_USER_ID = str(os.environ.get("TEST_IAM_USER_ID") or "").strip()
 TEST_IAM_USER_NAME = str(os.environ.get("TEST_IAM_USER_NAME") or "").strip()
 
-# whether to use Lambda functions in a Docker container
+# user-defined lambda executor mode
 LAMBDA_EXECUTOR = os.environ.get("LAMBDA_EXECUTOR", "").strip()
-if not LAMBDA_EXECUTOR:
-    LAMBDA_EXECUTOR = "docker"
-    if not has_docker():
-        LAMBDA_EXECUTOR = "local"
 
 # Fallback URL to use when a non-existing Lambda is invoked. If this matches
 # `dynamodb://<table_name>`, then the invocation is recorded in the corresponding

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import re
+import shutil
 import socket
 import subprocess
 import tempfile
@@ -190,9 +191,7 @@ def load_environment(profile: str = None):
 
 def has_docker():
     try:
-        with open(os.devnull, "w") as devnull:
-            subprocess.check_output("docker ps", stderr=devnull, shell=True)
-        return True
+        return True if shutil.which("docker") else False
     except Exception:
         return False
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -138,18 +138,6 @@ ANALYTICS_API = os.environ.get("ANALYTICS_API") or "https://analytics.localstack
 LOCALSTACK_WEB_PROCESS = "LOCALSTACK_WEB_PROCESS"
 LOCALSTACK_INFRA_PROCESS = "LOCALSTACK_INFRA_PROCESS"
 
-# hardcoded AWS account ID used by moto
-MOTO_ACCOUNT_ID = TEST_AWS_ACCOUNT_ID
-# fix moto account ID - note: keep this at the top level here
-try:
-    from moto import core as moto_core
-    from moto.core import models as moto_core_models
-
-    moto_core.ACCOUNT_ID = moto_core_models.ACCOUNT_ID = MOTO_ACCOUNT_ID
-except Exception:
-    # ignore import errors
-    pass
-
 # default AWS region us-east-1
 AWS_REGION_US_EAST_1 = "us-east-1"
 
@@ -197,3 +185,23 @@ OS_USER_OPENSEARCH = "localstack"
 
 # output string that indicates that the stack is ready
 READY_MARKER_OUTPUT = "Ready."
+
+# hardcoded AWS account ID used by moto
+MOTO_ACCOUNT_ID = TEST_AWS_ACCOUNT_ID
+
+
+def patch_moto_account_id():
+    # fix moto account ID - note: this needs to be executed before any other moto imports
+    try:
+        from moto import core as moto_core
+        from moto.core import models as moto_core_models
+
+        moto_core.ACCOUNT_ID = moto_core_models.ACCOUNT_ID = MOTO_ACCOUNT_ID
+    except Exception:
+        # ignore import errors
+        pass
+
+
+if not os.environ.get("SKIP_PATCH_MOTO_ACCOUNT_ID"):
+    # allow skipping this (importing moto takes a long time, and it's not necessary for the CLI)
+    patch_moto_account_id()

--- a/localstack/contrib/thundra.py
+++ b/localstack/contrib/thundra.py
@@ -23,6 +23,7 @@ from localstack.services.awslambda.lambda_utils import (
     LAMBDA_RUNTIME_PYTHON36,
     LAMBDA_RUNTIME_PYTHON37,
     LAMBDA_RUNTIME_PYTHON38,
+    get_executor_mode,
     is_python_runtime,
 )
 from localstack.utils import common
@@ -406,11 +407,11 @@ def _prepare_invocation_for_python_lambda(
 class LambdaExecutorPluginThundra(LambdaExecutorPlugin):
     def should_apply(self, context: InvocationContext) -> bool:
         # Local executor is not supported yet
-        if "local" in config.LAMBDA_EXECUTOR:
+        if "local" in get_executor_mode():
             return False
 
-        # Plugin can only applied if LAMBDA_REMOTE_DOCKER=0
-        if "docker" in config.LAMBDA_EXECUTOR and config.LAMBDA_REMOTE_DOCKER:
+        # Plugin can only be applied if LAMBDA_REMOTE_DOCKER=0
+        if "docker" in get_executor_mode() and config.LAMBDA_REMOTE_DOCKER:
             return False
 
         # Plugin can only applied if API key is configured

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -33,6 +33,7 @@ from localstack.services.awslambda.lambda_utils import (
     ClientError,
     error_response,
     event_source_arn_matches,
+    get_executor_mode,
     get_handler_file_from_name,
     get_lambda_runtime,
     get_zip_bytes,
@@ -129,7 +130,7 @@ JSON_START_CHARS = tuple(set(functools.reduce(lambda x, y: x + y, JSON_START_CHA
 
 # lambda executor instance
 LAMBDA_EXECUTOR = lambda_executors.AVAILABLE_EXECUTORS.get(
-    config.LAMBDA_EXECUTOR, lambda_executors.DEFAULT_EXECUTOR
+    get_executor_mode(), lambda_executors.DEFAULT_EXECUTOR
 )
 
 # IAM policy constants
@@ -502,7 +503,7 @@ def use_docker():
     global DO_USE_DOCKER
     if DO_USE_DOCKER is None:
         DO_USE_DOCKER = False
-        if "docker" in config.LAMBDA_EXECUTOR:
+        if "docker" in get_executor_mode():
             has_docker = DOCKER_CLIENT.has_docker()
             if not has_docker:
                 LOG.warning(
@@ -511,7 +512,7 @@ def use_docker():
                         "is not accessible. Please make sure to mount the Docker socket "
                         "/var/run/docker.sock into the container."
                     ),
-                    config.LAMBDA_EXECUTOR,
+                    get_executor_mode(),
                 )
             DO_USE_DOCKER = has_docker
     return DO_USE_DOCKER
@@ -2393,7 +2394,7 @@ def on_config_change(config_key: str, config_newvalue: str) -> None:
     )
     LAMBDA_EXECUTOR.cleanup()
     LAMBDA_EXECUTOR = lambda_executors.AVAILABLE_EXECUTORS.get(
-        config_newvalue, lambda_executors.DEFAULT_EXECUTOR
+        get_executor_mode(), lambda_executors.DEFAULT_EXECUTOR
     )
     LAMBDA_EXECUTOR.startup()
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -32,7 +32,7 @@ from localstack.utils.bootstrap import (
 from localstack.utils.files import cleanup_tmp_files
 from localstack.utils.net import get_free_tcp_port, is_port_open
 from localstack.utils.patch import patch
-from localstack.utils.platform import in_docker, is_linux
+from localstack.utils.platform import in_docker
 from localstack.utils.run import ShellCommandThread, run
 from localstack.utils.server import multiserver
 from localstack.utils.sync import poll_condition
@@ -386,22 +386,6 @@ def start_infra(asynchronous=False, apis=None):
         os.environ[LOCALSTACK_INFRA_PROCESS] = "1"
 
         is_in_docker = in_docker()
-        # print a warning if we're not running in Docker but using Docker based LAMBDA_EXECUTOR
-        if not is_in_docker and "docker" in config.LAMBDA_EXECUTOR and not is_linux():
-            print(
-                (
-                    "!WARNING! - Running outside of Docker with $LAMBDA_EXECUTOR=%s can lead to "
-                    "problems on your OS. The environment variable $LOCALSTACK_HOSTNAME may not "
-                    "be properly set in your Lambdas."
-                )
-                % config.LAMBDA_EXECUTOR
-            )
-
-        if is_in_docker and not config.LAMBDA_REMOTE_DOCKER and not config.dirs.functions:
-            print(
-                "!WARNING! - Looks like you have configured $LAMBDA_REMOTE_DOCKER=0 - "
-                "please make sure to configure $HOST_TMP_FOLDER to point to your host's $TMPDIR"
-            )
 
         print_runtime_information(is_in_docker)
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -18,7 +18,7 @@ import requests
 from plugin import Plugin, PluginManager
 
 from localstack import config
-from localstack.config import dirs, has_docker
+from localstack.config import dirs
 from localstack.constants import (
     DEFAULT_SERVICE_PORTS,
     DYNAMODB_JAR_URL,
@@ -417,7 +417,7 @@ def install_local_kms():
 def install_stepfunctions_local():
     if not os.path.exists(INSTALL_PATH_STEPFUNCTIONS_JAR):
         # pull the JAR file from the Docker image, which is more up-to-date than the downloadable JAR file
-        if not has_docker():
+        if not DOCKER_CLIENT.has_docker():
             # TODO: works only when a docker socket is available -> add a fallback if running without Docker?
             LOG.warning("Docker not available - skipping installation of StepFunctions dependency")
             return


### PR DESCRIPTION
This PR is a follow up to #5615 that targets the CLI startup performance. Particularly it addresses two things in config and constants (two modules that are *always* imported):

* `config.py`: checking whether docker is available was done via a `docker ps` subprocess call. that takes about ~250ms on my machine. replacing that with `shutil.which('docker')` reduces that to only 10ms.
* `constants.py`: the patching of `MOTO_ACCOUNT_ID` requires importing moto. however the CLI doesn't really need moto unless we start the infra in host mode. that takes another ~300ms, which we can skip in certain circumstances. so i added a simple env var switch for now.R