### PR TITLE
Add ability to specify timeout and max content length for HTTP server

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -944,7 +944,7 @@ def start_proxy_server(
     asynchronous=True,
     check_port=True,
     max_content_length: int = None,
-    timeout: int = None,
+    send_timeout: int = None,
 ):
     bind_address = bind_address if bind_address else BIND_HOST
 
@@ -988,7 +988,7 @@ def start_proxy_server(
         asynchronous=asynchronous,
         ssl_creds=ssl_creds,
         max_content_length=max_content_length,
-        timeout=timeout,
+        send_timeout=send_timeout,
     )
     if asynchronous and check_port:
         wait_for_port_open(port, sleep_time=0.2, retries=12)

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -943,6 +943,8 @@ def start_proxy_server(
     params=None,  # TODO: not being used - should be investigated/removed
     asynchronous=True,
     check_port=True,
+    max_content_length: int = None,
+    timeout: int = None,
 ):
     bind_address = bind_address if bind_address else BIND_HOST
 
@@ -980,7 +982,13 @@ def start_proxy_server(
         ssl_creds = (cert_file_name, key_file_name)
 
     result = http2_server.run_server(
-        port, bind_address, handler=handler, asynchronous=asynchronous, ssl_creds=ssl_creds
+        port,
+        bind_address,
+        handler=handler,
+        asynchronous=asynchronous,
+        ssl_creds=ssl_creds,
+        max_content_length=max_content_length,
+        timeout=timeout,
     )
     if asynchronous and check_port:
         wait_for_port_open(port, sleep_time=0.2, retries=12)


### PR DESCRIPTION
Add ability to specify request timeout and max content length for HTTP server. Preparation for a fix for #5598