### PR TITLE
Refactor request and response templates.

### DIFF
--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -87,6 +87,7 @@ class ApiInvocationContext:
         self.response_templates = {}
         self.stage_variables = {}
         self.is_data_base64_encoded = False
+        self.path_params = {}
 
     @property
     def resource_id(self) -> Optional[str]:
@@ -122,8 +123,7 @@ class ApiInvocationContext:
     def auth_context(self) -> Optional[Dict]:
         if isinstance(self.auth_info, dict):
             context = self.auth_info.setdefault("context", {})
-            principal = self.auth_info.get("principalId")
-            if principal:
+            if principal := self.auth_info.get("principalId"):
                 context["principalId"] = principal
             return context
 

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -57,8 +57,6 @@ class ApiInvocationContext:
 
     stage_variables: Dict
 
-    is_data_base64_encoded: bool
-
     def __init__(
         self,
         method,
@@ -86,7 +84,6 @@ class ApiInvocationContext:
         self.path_with_query_string = None
         self.response_templates = {}
         self.stage_variables = {}
-        self.is_data_base64_encoded = False
         self.path_params = {}
 
     @property
@@ -147,11 +144,18 @@ class ApiInvocationContext:
             return list(cookies.split(";"))
         return []
 
+    @property
+    def is_data_base64_encoded(self):
+        try:
+            json.dumps(self.data) if isinstance(self.data, (dict, list)) else to_str(self.data)
+            return False
+        except UnicodeDecodeError:
+            return True
+
     def data_as_string(self) -> Union[str, bytes]:
         try:
             return (
                 json.dumps(self.data) if isinstance(self.data, (dict, list)) else to_str(self.data)
             )
         except UnicodeDecodeError:
-            self.is_data_base64_encoded = True
             return base64.b64encode(self.data)

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -718,7 +718,7 @@ def get_stage_variables(context: ApiInvocationContext) -> Optional[Dict[str, str
         response = api_gateway_client.get_stage(restApiId=context.api_id, stageName=context.stage)
         return response.get("variables")
     except Exception:
-        LOG.info(f"Failed to get stage {context.stage} for api id " f"{context.api_id}")
+        LOG.info("Failed to get stage %s for API id %s", context.stage, context.api_id)
         return {}
 
 

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -1,12 +1,20 @@
+import base64
 import json
 import logging
+import re
+from urllib.parse import quote_plus, unquote_plus
+
+import airspeed
 
 from localstack import config
+from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.context import ApiInvocationContext
-from localstack.services.apigateway.helpers import apply_template
 from localstack.utils.aws import aws_stack
-from localstack.utils.http import make_http_request
-from localstack.utils.strings import to_str
+from localstack.utils.aws.templating import DictWrapper
+from localstack.utils.common import make_http_request, to_str
+from localstack.utils.json import extract_jsonpath, json_safe
+from localstack.utils.numbers import is_number, to_number
+from localstack.utils.objects import recurse_object
 
 LOG = logging.getLogger(__name__)
 
@@ -18,29 +26,17 @@ class BackendIntegration:
 
 
 class SnsIntegration(BackendIntegration):
-    __slots__ = ["invocation_context"]
-
-    def __init__(self, invocation_context: ApiInvocationContext):
-        self.invocation_context = invocation_context
-
-    def invoke(self):
+    @classmethod
+    def invoke(cls, invocation_context: ApiInvocationContext):
         try:
-            data = self.invocation_context.data
-            data = json.dumps(data) if isinstance(data, (dict, list)) else to_str(data)
-            payload = apply_template(
-                self.invocation_context.integration,
-                "request",
-                data,
-                path_params=self.invocation_context.path_params,
-                query_params=self.invocation_context.query_params(),
-                headers=self.invocation_context.headers,
-            )
+            request_templates = RequestTemplates()
+            payload = request_templates.render(invocation_context)
         except Exception as e:
             LOG.warning("Failed to apply template for SNS integration", e)
             raise
         uri = (
-            self.invocation_context.integration.get("uri")
-            or self.invocation_context.integration.get("integrationUri")
+            invocation_context.integration.get("uri")
+            or invocation_context.integration.get("integrationUri")
             or ""
         )
         region_name = uri.split(":")[3]
@@ -48,3 +44,252 @@ class SnsIntegration(BackendIntegration):
         return make_http_request(
             config.service_url("sns"), method="POST", headers=headers, data=payload
         )
+
+
+class VtlTemplate:
+    class VelocityUtil(object):
+        """
+        Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration
+        velocity templates.
+        See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+        """
+
+        def base64Encode(self, s):
+            if not isinstance(s, str):
+                s = json.dumps(s)
+            encoded_str = s.encode(config.DEFAULT_ENCODING)
+            encoded_b64_str = base64.b64encode(encoded_str)
+            return encoded_b64_str.decode(config.DEFAULT_ENCODING)
+
+        def base64Decode(self, s):
+            if not isinstance(s, str):
+                s = json.dumps(s)
+            return base64.b64decode(s)
+
+        def toJson(self, obj):
+            return obj and json.dumps(obj)
+
+        def urlEncode(self, s):
+            return quote_plus(s)
+
+        def urlDecode(self, s):
+            return unquote_plus(s)
+
+        def escapeJavaScript(self, s):
+            try:
+                return json.dumps(json.loads(s))
+            except Exception:
+                primitive_types = (str, int, bool, float, type(None))
+                s = s if isinstance(s, primitive_types) else str(s)
+            if str(s).strip() in ["true", "false"]:
+                s = bool(s)
+            elif s not in [True, False] and is_number(s):
+                s = to_number(s)
+            return json.dumps(s)
+
+    class VelocityInput(object):
+        """
+        Simple class to mimic the behavior of variable '$input' in AWS API Gateway integration
+        velocity templates.
+        See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+        """
+
+        def __init__(self, body, params):
+            self.parameters = self._attach_missing_functions(params or {})
+            self.value = self._attach_missing_functions(body)
+
+        def path(self, path):
+            if not self.value:
+                return {}
+            value = self.value if isinstance(self.value, dict) else json.loads(self.value)
+            return extract_jsonpath(value, path)
+
+        def json(self, path):
+            path = path or "$"
+            matching = self.path(path)
+            if isinstance(matching, (list, dict)):
+                matching = json_safe(matching)
+            return json.dumps(matching)
+
+        @property
+        def body(self):
+            return self.value
+
+        def params(self, name=None):
+            if not name:
+                return self.parameters
+            for k in ["path", "querystring", "header"]:
+                if val := self.parameters.get(k).get(name):
+                    return val
+            return ""
+
+        def __getattr__(self, name):
+            return self.value.get(name)
+
+        def __repr__(self):
+            return "$input"
+
+        @staticmethod
+        def _attach_missing_functions(value):
+            if value:
+
+                def _fix(obj, **kwargs):
+                    return DictWrapper(obj) if isinstance(obj, dict) else obj
+
+                value = recurse_object(value, _fix)
+            return value
+
+    def render_vtl(self, template, variables=None, as_json=False):
+        if variables is None:
+            variables = {}
+
+        if not template:
+            return template
+
+        # fix "#set" commands
+        template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
+
+        # enable syntax like "test#${foo.bar}"
+        empty_placeholder = " __pLaCe-HoLdEr__ "
+        template = re.sub(
+            r"([^\s]+)#\$({)?(.*)",
+            r"\1#%s$\2\3" % empty_placeholder,
+            template,
+            re.MULTILINE,
+        )
+
+        # add extensions for common string functions below
+
+        class ExtendedString(str):
+            def trim(self, *args, **kwargs):
+                return ExtendedString(self.strip(*args, **kwargs))
+
+            def toLowerCase(self, *args, **kwargs):
+                return ExtendedString(self.lower(*args, **kwargs))
+
+            def toUpperCase(self, *args, **kwargs):
+                return ExtendedString(self.upper(*args, **kwargs))
+
+        def apply(obj, **kwargs):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    if isinstance(v, str):
+                        obj[k] = ExtendedString(v)
+                    if isinstance(v, dict):
+                        obj[k] = DictWrapper(v)
+            return obj
+
+        # loop through the variables and enable certain additional util functions (e.g.,
+        # string utils)
+        variables = variables or {}
+        recurse_object(variables, apply)
+
+        # prepare and render template
+        context_var = variables.get("context") or {}
+        input_var = variables.get("input") or {}
+        stage_var = variables.get("stage_variables") or {}
+        t = airspeed.Template(template)
+        namespace = {
+            "input": self.VelocityInput(input_var.get("body"), input_var.get("params")),
+            "util": self.VelocityUtil(),
+            "context": context_var,
+            "stageVariables": stage_var,
+        }
+        rendered_template = t.merge(namespace)
+
+        # revert temporary changes from the fixes above
+        rendered_template = rendered_template.replace(empty_placeholder, "")
+
+        if as_json:
+            rendered_template = json.loads(rendered_template)
+        return rendered_template
+
+
+class Templates:
+    __slots__ = ["vtl"]
+
+    def __init__(self):
+        self.vtl = VtlTemplate()
+
+    def render(self, api_context: ApiInvocationContext):
+        pass
+
+    def render_vtl(self, template, variables):
+        return self.vtl.render_vtl(template, variables=variables)
+
+
+class RequestTemplates(Templates):
+    """
+    Handles request template rendering
+    """
+
+    def render(self, api_context: ApiInvocationContext):
+        LOG.info(
+            f"Method request body before transformations: {to_str(api_context.data_as_string())}"
+        )
+        request_templates = api_context.integration.get("requestTemplates", {})
+        template = request_templates.get(APPLICATION_JSON, {})
+        if not template:
+            return api_context.data_as_string()
+
+        variables = {
+            "context": api_context.context or {},
+            "stage_variables": api_context.stage_variables or {},
+            "input": {
+                "body": api_context.data_as_string(),
+                "params": {
+                    "path": api_context.path_params,
+                    "querystring": api_context.query_params(),
+                    "header": api_context.headers,
+                },
+            },
+        }
+
+        result = self.render_vtl(template, variables=variables)
+        LOG.info(f"Endpoint request body after transformations:\n{result}")
+        return result
+
+
+class ResponseTemplates(Templates):
+    """
+    Handles response template rendering
+    """
+
+    def render(self, api_context: ApiInvocationContext):
+        LOG.info(
+            f"Method response body after transformations: "
+            f"{to_str(api_context.response._content) if not api_context.is_data_base64_encoded else ''}"
+        )
+        response = api_context.response
+        integration = api_context.integration
+        int_responses = integration.get("integrationResponses") or {}
+        if not int_responses:
+            return response._content
+        entries = list(int_responses.keys())
+        return_code = str(response.status_code)
+        if return_code not in entries and len(entries) > 1:
+            LOG.info("Found multiple integration response status codes: %s", entries)
+            return response._content
+        return_code = entries[0]
+
+        response_templates = int_responses[return_code].get("responseTemplates", {})
+        template = response_templates.get(APPLICATION_JSON, {})
+        if not template:
+            return response
+
+        variables = {
+            "context": api_context.context or {},
+            "stage_variables": api_context.stage_variables or {},
+            "input": {
+                "body": api_context.data_as_string(),
+                "params": {
+                    "path": api_context.path_params,
+                    "querystring": api_context.query_params(),
+                    "header": api_context.headers,
+                },
+            },
+        }
+
+        response._content = self.render_vtl(template, variables=variables)
+        LOG.info(f"Endpoint response body after transformations:\n{response._content}")
+        return response._content

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -304,5 +304,5 @@ class ResponseTemplates(Templates):
         }
 
         response._content = self.render_vtl(template, variables=variables)
-        LOG.info(f"Endpoint response body after transformations:\n{response._content}")
+        LOG.info("Endpoint response body after transformations:\n%s", response._content)
         return response._content

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -233,7 +233,7 @@ class RequestTemplates(Templates):
 
     def render(self, api_context: ApiInvocationContext):
         LOG.info(
-            f"Method request body before transformations: {to_str(api_context.data_as_string())}"
+            "Method request body before transformations: %s", to_str(api_context.data_as_string())
         )
         request_templates = api_context.integration.get("requestTemplates", {})
         template = request_templates.get(APPLICATION_JSON, {})

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -175,6 +175,8 @@ class VtlTemplate:
                 for k, v in obj.items():
                     if isinstance(v, str):
                         obj[k] = ExtendedString(v)
+                    if isinstance(v, dict):
+                        obj[k] = DictWrapper(v)
                 return DictWrapper(obj)
             return obj
 

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -49,7 +49,7 @@ class SnsIntegration(BackendIntegration):
 class VtlTemplate:
     class VelocityUtil(object):
         """
-        Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration
+        Simple class to mimic the behavior of variable '$util' in AWS API Gateway integration
         velocity templates.
         See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
         """
@@ -175,8 +175,7 @@ class VtlTemplate:
                 for k, v in obj.items():
                     if isinstance(v, str):
                         obj[k] = ExtendedString(v)
-                    if isinstance(v, dict):
-                        obj[k] = DictWrapper(v)
+                return DictWrapper(obj)
             return obj
 
         # loop through the variables and enable certain additional util functions (e.g.,
@@ -268,10 +267,6 @@ class ResponseTemplates(Templates):
     """
 
     def render(self, api_context: ApiInvocationContext):
-        LOG.info(
-            f"Method response body after transformations: "
-            f"{to_str(api_context.response._content) if not api_context.is_data_base64_encoded else ''}"
-        )
         response = api_context.response
         integration = api_context.integration
         # we set context data with the response content because later on we use context data as

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -36,7 +36,6 @@ from localstack.constants import (
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
-from localstack.utils.aws import templating
 from localstack.utils.aws.aws_models import KinesisStream
 from localstack.utils.collections import pick_attributes
 from localstack.utils.functions import run_safe
@@ -377,11 +376,6 @@ def get_s3_hostname():
     if CACHE_S3_HOSTNAME_DNS_STATUS:
         return S3_VIRTUAL_HOSTNAME
     return LOCALHOST
-
-
-# TODO remove from here in the future
-def render_velocity_template(*args, **kwargs):
-    return templating.VtlTemplate().render_velocity_template(*args, **kwargs)
 
 
 def generate_presigned_url(*args, **kwargs):

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -381,7 +381,7 @@ def get_s3_hostname():
 
 # TODO remove from here in the future
 def render_velocity_template(*args, **kwargs):
-    return templating.render_velocity_template(*args, **kwargs)
+    return templating.VtlTemplate().render_velocity_template(*args, **kwargs)
 
 
 def generate_presigned_url(*args, **kwargs):

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -1,15 +1,16 @@
+import base64
+import json
 import re
+from urllib.parse import quote_plus, unquote_plus
 
 import airspeed
 
+from localstack import config
+from localstack.utils.common import recurse_object
+from localstack.utils.json import extract_jsonpath, json_safe
+from localstack.utils.numbers import is_number, to_number
 from localstack.utils.patch import patch
-
-
-# TODO: remove code below once this PR is merged/released: https://github.com/purcell/airspeed/pull/56
-# TODO: potentially replace with generic proxy wrapper class
-class DictWrapper(dict):
-    def keySet(self):
-        return self.keys()
+from localstack.utils.strings import short_uid
 
 
 class DefineDefinition(airspeed.MacroDefinition):
@@ -71,3 +72,155 @@ def block_parse(self, *args, **kwargs):
             )
         except airspeed.NoMatch:
             break
+
+
+# remove all the code below after removing references in:
+# - invocations.py
+# - graphql_executor.py
+
+
+class DictWrapper(dict):
+    def keySet(self):
+        return self.keys()
+
+
+class VelocityInput(object):
+    """Simple class to mimick the behavior of variable '$input' in AWS API Gateway integration
+    velocity templates.
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template
+    -reference.html"""
+
+    def __init__(self, value):
+        self.value = self._attach_missing_functions(value)
+
+    def path(self, path):
+        if not self.value:
+            return {}
+        value = self.value if isinstance(self.value, dict) else json.loads(self.value)
+        return extract_jsonpath(value, path)
+
+    def json(self, path):
+        path = path or "$"
+        matching = self.path(path)
+        if isinstance(matching, (list, dict)):
+            matching = json_safe(matching)
+        return json.dumps(matching)
+
+    def __getattr__(self, name):
+        return self.value.get(name)
+
+    def __repr__(self):
+        return "$input"
+
+    def _attach_missing_functions(self, value):
+        if value:
+
+            def _fix(obj, **kwargs):
+                if isinstance(obj, dict):
+                    return DictWrapper(obj)
+                return obj
+
+            value = recurse_object(value, _fix)
+        return value
+
+
+class VelocityUtil(object):
+    """Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration
+    velocity templates.
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template
+    -reference.html"""
+
+    def base64Encode(self, s):
+        if not isinstance(s, str):
+            s = json.dumps(s)
+        encoded_str = s.encode(config.DEFAULT_ENCODING)
+        encoded_b64_str = base64.b64encode(encoded_str)
+        return encoded_b64_str.decode(config.DEFAULT_ENCODING)
+
+    def base64Decode(self, s):
+        if not isinstance(s, str):
+            s = json.dumps(s)
+        return base64.b64decode(s)
+
+    def toJson(self, obj):
+        return obj and json.dumps(obj)
+
+    def urlEncode(self, s):
+        return quote_plus(s)
+
+    def urlDecode(self, s):
+        return unquote_plus(s)
+
+    def escapeJavaScript(self, s):
+        try:
+            return json.dumps(json.loads(s))
+        except Exception:
+            primitive_types = (str, int, bool, float, type(None))
+            s = s if isinstance(s, primitive_types) else str(s)
+        if str(s).strip() in ["true", "false"]:
+            s = bool(s)
+        elif s not in [True, False] and is_number(s):
+            s = to_number(s)
+        return json.dumps(s)
+
+
+def render_velocity_template(template, context, variables=None, as_json=False):
+    if variables is None:
+        variables = {}
+
+    if not template:
+        return template
+
+    # fix "#set" commands
+    template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
+
+    # enable syntax like "test#${foo.bar}"
+    empty_placeholder = " __pLaCe-HoLdEr__ "
+    template = re.sub(
+        r"([^\s]+)#\$({)?(.*)",
+        r"\1#%s$\2\3" % empty_placeholder,
+        template,
+        re.MULTILINE,
+    )
+
+    # add extensions for common string functions below
+
+    class ExtendedString(str):
+        def trim(self, *args, **kwargs):
+            return ExtendedString(self.strip(*args, **kwargs))
+
+        def toLowerCase(self, *args, **kwargs):
+            return ExtendedString(self.lower(*args, **kwargs))
+
+        def toUpperCase(self, *args, **kwargs):
+            return ExtendedString(self.upper(*args, **kwargs))
+
+    def apply(obj, **kwargs):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if isinstance(v, str):
+                    obj[k] = ExtendedString(v)
+        return obj
+
+    # loop through the variables and enable certain additional util functions (e.g., string utils)
+    variables = variables or {}
+    recurse_object(variables, apply)
+
+    # prepare and render template
+    context_var = variables.get("context") or {}
+    context_var.setdefault("requestId", short_uid())
+    t = airspeed.Template(template)
+    var_map = {
+        "input": VelocityInput(context),
+        "util": VelocityUtil(),
+        "context": context_var,
+    }
+    var_map.update(variables or {})
+    replaced = t.merge(var_map)
+
+    # revert temporary changes from the fixes above
+    replaced = replaced.replace(empty_placeholder, "")
+
+    if as_json:
+        replaced = json.loads(replaced)
+    return replaced

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -1,101 +1,15 @@
-import base64
-import json
 import re
-from urllib.parse import quote_plus, unquote_plus
 
 import airspeed
 
-from localstack import config
-from localstack.utils.json import extract_jsonpath, json_safe
-from localstack.utils.numbers import is_number, to_number
-from localstack.utils.objects import recurse_object
 from localstack.utils.patch import patch
-from localstack.utils.strings import short_uid
 
 
+# TODO: remove code below once this PR is merged/released: https://github.com/purcell/airspeed/pull/56
 # TODO: potentially replace with generic proxy wrapper class
 class DictWrapper(dict):
     def keySet(self):
         return self.keys()
-
-
-class VelocityInput(object):
-    """Simple class to mimick the behavior of variable '$input' in AWS API Gateway integration velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
-
-    def __init__(self, value):
-        self.value = self._attach_missing_functions(value)
-
-    def path(self, path):
-        if not self.value:
-            return {}
-        value = self.value if isinstance(self.value, dict) else json.loads(self.value)
-        return extract_jsonpath(value, path)
-
-    def json(self, path):
-        path = path or "$"
-        matching = self.path(path)
-        if isinstance(matching, (list, dict)):
-            matching = json_safe(matching)
-        return json.dumps(matching)
-
-    def __getattr__(self, name):
-        return self.value.get(name)
-
-    def __repr__(self):
-        return "$input"
-
-    def _attach_missing_functions(self, value):
-        if value:
-
-            def _fix(obj, **kwargs):
-                if isinstance(obj, dict):
-                    return DictWrapper(obj)
-                return obj
-
-            value = recurse_object(value, _fix)
-        return value
-
-
-class VelocityUtil(object):
-    """Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
-
-    def base64Encode(self, s):
-        if not isinstance(s, str):
-            s = json.dumps(s)
-        encoded_str = s.encode(config.DEFAULT_ENCODING)
-        encoded_b64_str = base64.b64encode(encoded_str)
-        return encoded_b64_str.decode(config.DEFAULT_ENCODING)
-
-    def base64Decode(self, s):
-        if not isinstance(s, str):
-            s = json.dumps(s)
-        return base64.b64decode(s)
-
-    def toJson(self, obj):
-        return obj and json.dumps(obj)
-
-    def urlEncode(self, s):
-        return quote_plus(s)
-
-    def urlDecode(self, s):
-        return unquote_plus(s)
-
-    def escapeJavaScript(self, s):
-        try:
-            return json.dumps(json.loads(s))
-        except Exception:
-            primitive_types = (str, int, bool, float, type(None))
-            s = s if isinstance(s, primitive_types) else str(s)
-        if str(s).strip() in ["true", "false"]:
-            s = bool(s)
-        elif s not in [True, False] and is_number(s):
-            s = to_number(s)
-        return json.dumps(s)
-
-
-# TODO: remove code below once this PR is merged/released: https://github.com/purcell/airspeed/pull/56
 
 
 class DefineDefinition(airspeed.MacroDefinition):
@@ -157,65 +71,3 @@ def block_parse(self, *args, **kwargs):
             )
         except airspeed.NoMatch:
             break
-
-
-def render_velocity_template(template, context, variables=None, as_json=False):
-    if variables is None:
-        variables = {}
-
-    if not template:
-        return template
-
-    # fix "#set" commands
-    template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
-
-    # enable syntax like "test#${foo.bar}"
-    empty_placeholder = " __pLaCe-HoLdEr__ "
-    template = re.sub(
-        r"([^\s]+)#\$({)?(.*)",
-        r"\1#%s$\2\3" % empty_placeholder,
-        template,
-        re.MULTILINE,
-    )
-
-    # add extensions for common string functions below
-
-    class ExtendedString(str):
-        def trim(self, *args, **kwargs):
-            return ExtendedString(self.strip(*args, **kwargs))
-
-        def toLowerCase(self, *args, **kwargs):
-            return ExtendedString(self.lower(*args, **kwargs))
-
-        def toUpperCase(self, *args, **kwargs):
-            return ExtendedString(self.upper(*args, **kwargs))
-
-    def apply(obj, **kwargs):
-        if isinstance(obj, dict):
-            for k, v in obj.items():
-                if isinstance(v, str):
-                    obj[k] = ExtendedString(v)
-        return obj
-
-    # loop through the variables and enable certain additional util functions (e.g., string utils)
-    variables = variables or {}
-    recurse_object(variables, apply)
-
-    # prepare and render template
-    context_var = variables.get("context") or {}
-    context_var.setdefault("requestId", short_uid())
-    t = airspeed.Template(template)
-    var_map = {
-        "input": VelocityInput(context),
-        "util": VelocityUtil(),
-        "context": context_var,
-    }
-    var_map.update(variables or {})
-    replaced = t.merge(var_map)
-
-    # revert temporary changes from the fixes above
-    replaced = replaced.replace(empty_placeholder, "")
-
-    if as_json:
-        replaced = json.loads(replaced)
-    return replaced

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -87,8 +87,7 @@ class DictWrapper(dict):
 class VelocityInput(object):
     """Simple class to mimick the behavior of variable '$input' in AWS API Gateway integration
     velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template
-    -reference.html"""
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
 
     def __init__(self, value):
         self.value = self._attach_missing_functions(value)
@@ -127,8 +126,7 @@ class VelocityInput(object):
 class VelocityUtil(object):
     """Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration
     velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template
-    -reference.html"""
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
 
     def base64Encode(self, s):
         if not isinstance(s, str):

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -4,9 +4,9 @@ import re
 from urllib.parse import quote_plus, unquote_plus
 
 import airspeed
+from localstack.utils.objects import recurse_object
 
 from localstack import config
-from localstack.utils.common import recurse_object
 from localstack.utils.json import extract_jsonpath, json_safe
 from localstack.utils.numbers import is_number, to_number
 from localstack.utils.patch import patch
@@ -113,12 +113,8 @@ class VelocityInput(object):
 
     def _attach_missing_functions(self, value):
         if value:
-
             def _fix(obj, **kwargs):
-                if isinstance(obj, dict):
-                    return DictWrapper(obj)
-                return obj
-
+                return DictWrapper(obj) if isinstance(obj, dict) else obj
             value = recurse_object(value, _fix)
         return value
 

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -4,11 +4,11 @@ import re
 from urllib.parse import quote_plus, unquote_plus
 
 import airspeed
-from localstack.utils.objects import recurse_object
 
 from localstack import config
 from localstack.utils.json import extract_jsonpath, json_safe
 from localstack.utils.numbers import is_number, to_number
+from localstack.utils.objects import recurse_object
 from localstack.utils.patch import patch
 from localstack.utils.strings import short_uid
 
@@ -81,7 +81,7 @@ def block_parse(self, *args, **kwargs):
 
 class DictWrapper(dict):
     def keySet(self):
-        return self.keys()
+        return list(self.keys())
 
 
 class VelocityInput(object):
@@ -113,8 +113,10 @@ class VelocityInput(object):
 
     def _attach_missing_functions(self, value):
         if value:
+
             def _fix(obj, **kwargs):
                 return DictWrapper(obj) if isinstance(obj, dict) else obj
+
             value = recurse_object(value, _fix)
         return value
 

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -81,7 +81,7 @@ def block_parse(self, *args, **kwargs):
 
 class DictWrapper(dict):
     def keySet(self):
-        return list(self.keys())
+        return self.keys()
 
 
 class VelocityInput(object):

--- a/localstack/utils/objects.py
+++ b/localstack/utils/objects.py
@@ -108,7 +108,7 @@ def not_none_or(value: Optional[Any], alternative: Any) -> Any:
 
 
 def recurse_object(obj: ComplexType, func: Callable, path: str = "") -> ComplexType:
-    """Recursively apply `func` to `obj` (may be a list, dict, or other object)."""
+    """Recursively apply `func` to `obj` (might be a list, dict, or other object)."""
     obj = func(obj, path=path)
     if isinstance(obj, list):
         for i in range(len(obj)):
@@ -116,7 +116,7 @@ def recurse_object(obj: ComplexType, func: Callable, path: str = "") -> ComplexT
             obj[i] = recurse_object(obj[i], func, tmp_path)
     elif isinstance(obj, dict):
         for k, v in obj.items():
-            tmp_path = "%s%s" % ((path + ".") if path else "", k)
+            tmp_path = "%s%s" % (f'{path}.' if path else "", k)
             obj[k] = recurse_object(v, func, tmp_path)
     return obj
 

--- a/localstack/utils/objects.py
+++ b/localstack/utils/objects.py
@@ -116,7 +116,7 @@ def recurse_object(obj: ComplexType, func: Callable, path: str = "") -> ComplexT
             obj[i] = recurse_object(obj[i], func, tmp_path)
     elif isinstance(obj, dict):
         for k, v in obj.items():
-            tmp_path = "%s%s" % (f'{path}.' if path else "", k)
+            tmp_path = "%s%s" % (f"{path}." if path else "", k)
             obj[k] = recurse_object(v, func, tmp_path)
     return obj
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -193,7 +193,7 @@ class ApiGatewayPathsTest(unittest.TestCase):
 
 
 def test_render_template_values():
-    util = VtlTemplate().VelocityUtil()
+    util = VtlTemplate.VelocityUtil()
 
     encoded = util.urlEncode("x=a+b")
     assert encoded == "x%3Da%2Bb"

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from localstack.utils.aws.templating import VtlTemplate
+from localstack.services.apigateway.integration import VtlTemplate
 from localstack.utils.common import to_str
 
 # template used to transform incoming requests at the API Gateway (forward to Kinesis)
@@ -91,10 +91,14 @@ def velocity_template():
 class TestMessageTransformation:
     def test_array_size(self, velocity_template):
         template = "#set($list = $input.path('$.records')) $list.size()"
-        context = {"records": [{"data": {"foo": "bar1"}}, {"data": {"foo": "bar2"}}]}
-        result = velocity_template.render_velocity_template(template, context)
-        assert result == " 2"
-        result = velocity_template.render_velocity_template(template, json.dumps(context))
+        body = {"records": [{"data": {"foo": "bar1"}}, {"data": {"foo": "bar2"}}]}
+        variables = {
+            "input": {
+                "body": body,
+            },
+        }
+
+        result = velocity_template.render_vtl(template, variables)
         assert result == " 2"
 
     def test_message_transformation(self, velocity_template):
@@ -103,54 +107,55 @@ class TestMessageTransformation:
             {"data": {"foo": "foo1", "bar": "bar2"}},
             {"data": {"foo": "foo1", "bar": "bar2"}, "partitionKey": "key123"},
         ]
-        context = {"records": records}
+        variables = {"input": {"body": {"records": records}}}
 
-        def do_test(context):
-            result = velocity_template.render_velocity_template(template, context, as_json=True)
+        def do_test(variables):
+            result = velocity_template.render_vtl(template, variables, as_json=True)
             result_decoded = json.loads(to_str(base64.b64decode(result["Records"][0]["Data"])))
             assert result_decoded == records[0]["data"]
             assert result["Records"][0]["PartitionKey"] == "$elem.partitionKey"
             assert result["Records"][1]["PartitionKey"] == "key123"
 
         # try rendering the template
-        do_test(context)
-        # try again with context as string
-        do_test(json.dumps(context))
+        do_test(variables)
 
         # test with empty array
         records = []
-        context = {"records": records}
+        variables = {"input": {"body": {"records": records}}}
         # try rendering the template
-        result = velocity_template.render_velocity_template(template, context, as_json=True)
+        result = velocity_template.render_vtl(template, variables, as_json=True)
         assert result["Records"] == []
 
     def test_array_in_set_expr(self, velocity_template):
         template = "#set ($bar = $input.path('$.foo')[1]) \n $bar"
-        context = {"foo": ["e1", "e2", "e3", "e4"]}
-        result = velocity_template.render_velocity_template(template, context).strip()
+        variables = {"input": {"body": {"foo": ["e1", "e2", "e3", "e4"]}}}
+        result = velocity_template.render_vtl(template, variables).strip()
         assert result == "e2"
 
         template = "#set ($bar = $input.path('$.foo')[1][1][1]) $bar"
-        context = {"foo": [["e1"], ["e2", ["e3", "e4"]]]}
-        result = velocity_template.render_velocity_template(template, context).strip()
+        variables = {"input": {"body": {"foo": [["e1"], ["e2", ["e3", "e4"]]]}}}
+        result = velocity_template.render_vtl(template, variables).strip()
         assert result == "e4"
 
     def test_string_methods(self, velocity_template):
         context = {"foo": {"bar": "BAZ baz"}}
+        variables = {"input": {"body": context}}
         template1 = "${foo.bar.strip().lower().replace(' ','-')}"
         template2 = "${foo.bar.trim().toLowerCase().replace(' ','-')}"
         for template in [template1, template2]:
-            result = velocity_template.render_velocity_template(template, {}, variables=context)
+            result = velocity_template.render_vtl(template, variables=variables)
             assert result == "baz-baz"
 
     def test_render_urlencoded_string_data(self, velocity_template):
         template = "MessageBody=$util.base64Encode($input.json('$'))"
-        result = velocity_template.render_velocity_template(template, b'{"spam": "eggs"}')
+        variables = {"input": {"body": {"spam": "eggs"}}}
+        result = velocity_template.render_vtl(template, variables)
         assert result == "MessageBody=eyJzcGFtIjogImVnZ3MifQ=="
 
     def test_construct_json_using_define(self, velocity_template):
         template = APIGW_TEMPLATE_CONSTRUCT_JSON
-        context = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
-        result = velocity_template.render_velocity_template(template, context).strip()
+        data = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
+        variables = {"input": {"body": data}}
+        result = velocity_template.render_vtl(template, variables).strip()
         result = json.loads(result)
-        assert result == {"p0": True, **context}
+        assert result == {"p0": True, **data}

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -1,7 +1,9 @@
 import base64
 import json
 
-from localstack.utils.aws.aws_stack import render_velocity_template
+import pytest
+
+from localstack.utils.aws.templating import VtlTemplate
 from localstack.utils.common import to_str
 
 # template used to transform incoming requests at the API Gateway (forward to Kinesis)
@@ -45,17 +47,57 @@ APIGW_TEMPLATE_CONSTRUCT_JSON = """
 }
 """
 
+APIGW_TEMPLATE_CUSTOM_BODY = """
+#set( $body = $input.json("$") )
+
+#define( $loop )
+{
+    #foreach($key in $map.keySet())
+        #set( $k = $util.escapeJavaScript($key) )
+        #set( $v = $util.escapeJavaScript($map.get($key)).replaceAll("\\'", "'") )
+        "$k": "$v"
+        #if( $foreach.hasNext ) , #end
+    #end
+}
+#end
+
+  {
+    #set( $map = $context.authorizer )
+    "enhancedAuthContext": $loop,
+
+    #set( $map = $input.params().header )
+    "headers": $loop,
+
+    #set( $map = $input.params().querystring )
+    "query": $loop,
+
+    #set( $map = $input.params().path )
+    "path": $loop,
+
+    #set( $map = $context.identity )
+    "identity": $loop,
+
+    #set( $map = $stageVariables )
+    "stageVariables": $loop,
+}
+"""
+
+
+@pytest.fixture
+def velocity_template():
+    return VtlTemplate()
+
 
 class TestMessageTransformation:
-    def test_array_size(self):
+    def test_array_size(self, velocity_template):
         template = "#set($list = $input.path('$.records')) $list.size()"
         context = {"records": [{"data": {"foo": "bar1"}}, {"data": {"foo": "bar2"}}]}
-        result = render_velocity_template(template, context)
+        result = velocity_template.render_velocity_template(template, context)
         assert result == " 2"
-        result = render_velocity_template(template, json.dumps(context))
+        result = velocity_template.render_velocity_template(template, json.dumps(context))
         assert result == " 2"
 
-    def test_message_transformation(self):
+    def test_message_transformation(self, velocity_template):
         template = APIGW_TEMPLATE_TRANSFORM_KINESIS
         records = [
             {"data": {"foo": "foo1", "bar": "bar2"}},
@@ -64,7 +106,7 @@ class TestMessageTransformation:
         context = {"records": records}
 
         def do_test(context):
-            result = render_velocity_template(template, context, as_json=True)
+            result = velocity_template.render_velocity_template(template, context, as_json=True)
             result_decoded = json.loads(to_str(base64.b64decode(result["Records"][0]["Data"])))
             assert result_decoded == records[0]["data"]
             assert result["Records"][0]["PartitionKey"] == "$elem.partitionKey"
@@ -79,36 +121,36 @@ class TestMessageTransformation:
         records = []
         context = {"records": records}
         # try rendering the template
-        result = render_velocity_template(template, context, as_json=True)
+        result = velocity_template.render_velocity_template(template, context, as_json=True)
         assert result["Records"] == []
 
-    def test_array_in_set_expr(self):
+    def test_array_in_set_expr(self, velocity_template):
         template = "#set ($bar = $input.path('$.foo')[1]) \n $bar"
         context = {"foo": ["e1", "e2", "e3", "e4"]}
-        result = render_velocity_template(template, context).strip()
+        result = velocity_template.render_velocity_template(template, context).strip()
         assert result == "e2"
 
         template = "#set ($bar = $input.path('$.foo')[1][1][1]) $bar"
         context = {"foo": [["e1"], ["e2", ["e3", "e4"]]]}
-        result = render_velocity_template(template, context).strip()
+        result = velocity_template.render_velocity_template(template, context).strip()
         assert result == "e4"
 
-    def test_string_methods(self):
+    def test_string_methods(self, velocity_template):
         context = {"foo": {"bar": "BAZ baz"}}
         template1 = "${foo.bar.strip().lower().replace(' ','-')}"
         template2 = "${foo.bar.trim().toLowerCase().replace(' ','-')}"
         for template in [template1, template2]:
-            result = render_velocity_template(template, {}, variables=context)
+            result = velocity_template.render_velocity_template(template, {}, variables=context)
             assert result == "baz-baz"
 
-    def test_render_urlencoded_string_data(self):
+    def test_render_urlencoded_string_data(self, velocity_template):
         template = "MessageBody=$util.base64Encode($input.json('$'))"
-        result = render_velocity_template(template, b'{"spam": "eggs"}')
+        result = velocity_template.render_velocity_template(template, b'{"spam": "eggs"}')
         assert result == "MessageBody=eyJzcGFtIjogImVnZ3MifQ=="
 
-    def test_construct_json_using_define(self):
+    def test_construct_json_using_define(self, velocity_template):
         template = APIGW_TEMPLATE_CONSTRUCT_JSON
         context = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
-        result = render_velocity_template(template, context).strip()
+        result = velocity_template.render_velocity_template(template, context).strip()
         result = json.loads(result)
         assert result == {"p0": True, **context}

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -161,8 +161,8 @@ class TestMessageTransformation:
         assert result == {"p0": True, **data}
 
     def test_keyset_functions(self, velocity_template):
-        template = "#set($list = $input.path('$..var1[1]').keySet()) $list.size()"
-        body = {"var1": [{"d": 1}, {"d": 2}]}
+        template = "#set($list = $input.path('$..var1[1]').keySet()) #foreach($e in $list)$e#end"
+        body = {"var1": [{"a": 1}, {"b": 2}]}
         variables = {"input": {"body": body}}
         result = velocity_template.render_vtl(template, variables)
-        assert result == " 1"
+        assert result == " b"

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -159,3 +159,10 @@ class TestMessageTransformation:
         result = velocity_template.render_vtl(template, variables).strip()
         result = json.loads(result)
         assert result == {"p0": True, **data}
+
+    def test_keyset_functions(self, velocity_template):
+        template = "#set($list = $input.path('$..var1[1]').keySet()) $list.size()"
+        body = {"var1": [{"d": 1}, {"d": 2}]}
+        variables = {"input": {"body": body}}
+        result = velocity_template.render_vtl(template, variables)
+        assert result == " 1"

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -245,7 +245,7 @@ def test_generate_ssl_cert():
         assert PEM_CERT_START in cert
         assert PEM_CERT_END in cert
         assert re.match(PEM_KEY_START_REGEX, key.replace("\n", " "))
-        assert re.match(fr".*{PEM_KEY_END_REGEX}", key.replace("\n", " "))
+        assert re.match(rf".*{PEM_KEY_END_REGEX}", key.replace("\n", " "))
 
     # generate cert and get content directly
     cert = generate_ssl_cert()


### PR DESCRIPTION
This PR is mostly an effort to normalise request templates and response templates:

* Adds two new classes to handle templating, `RequestTemplates` and `ResponseTemplates`. Adds some logging similar to AWS transformations and creates the namespace only with `variables`.
* Adds a new class `VtlTemplate` and nests two existing classes `VelocityUtil` and `VelocityInput`. Fixes the namespace creation that will make it possible to handle AWS template mapping features. 

Yet to finish on another PR:
- Migrate all integrations (SNS, etc..) to the new request/response templates. Lacking testing on those integrations made me think that we should increase coverage before making these changes.

Fixes https://github.com/localstack/localstack/issues/5587

Relates with https://github.com/localstack/localstack-ext/pull/417

Tested with apigateway v1 examples from https://github.com/localstack/localstack-terraform-samples