### PR TITLE
Fixes error responses from lambda when handler throws an exception

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -807,13 +807,14 @@ def run_lambda(
 
     except Exception as e:
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        # TODO: wrong mapping
         response = {
             "errorType": str(exc_type.__name__),
             "errorMessage": str(e),
             "stackTrace": traceback.format_tb(exc_traceback),
         }
         LOG.info("Error executing Lambda function %s: %s %s", func_arn, e, traceback.format_exc())
+        if isinstance(e, lambda_executors.InvocationException):
+            response = json.loads(e.result)
         log_output = e.log_output if isinstance(e, lambda_executors.InvocationException) else ""
         return InvocationResult(Response(json.dumps(response), status=500), log_output)
     finally:

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1422,7 +1422,14 @@ class LambdaExecutorLocal(LambdaExecutor):
                 error,
                 "".join(traceback.format_tb(error.__traceback__)),
             )
-            raise InvocationException(result, log_output)
+            result = json.dumps(
+                {
+                    "errorType": error.__class__.__name__,
+                    "errorMessage": error.args[0],
+                    "stackTrace": traceback.format_tb(error.__traceback__),
+                }
+            )
+            raise InvocationException(result, log_output=log_output, result=result)
 
         # construct final invocation result
         invocation_result = InvocationResult(result, log_output=log_output)

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -86,7 +86,7 @@ STATE_MACHINE_CATCH = {
             "Catch": [
                 {
                     "ErrorEquals": [
-                        "InvocationException",
+                        "Exception",
                         "Lambda.Unknown",
                         "ValueError",
                     ],


### PR DESCRIPTION
Fixes #4651


Should now correctly return a json response when an uncaught exception is thrown during the handler execution.