### PR TITLE
Upgrade python version to 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,15 @@
 version: 2.1
 
+commands:
+  install-python:
+    steps:
+      - run:
+          name: Install python 3.10
+          command: |
+            (cd $(pyenv root) && git checkout master && git pull)
+            pyenv install 3.10.3
+            pyenv global 3.10.3
+
 jobs:
   install:
     machine:
@@ -13,7 +23,8 @@ jobs:
           name: Install prerequisites
           command: |
             sudo apt-get update
-            sudo apt-get install -y libsasl2-dev python3.8-venv python3.8-dev
+            sudo apt-get install -y libsasl2-dev
+      - install-python
       - run:
           name: Setup environment
           environment:
@@ -33,23 +44,25 @@ jobs:
             - repo
 
   preflight:
-    docker:
-      - image: buildpack-deps:focal
+    machine:
+      image: ubuntu-2004:202107-02
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Linting
           command: make lint
 
   unit-tests:
-    docker:
-      - image: buildpack-deps:focal
+    machine:
+      image: ubuntu-2004:202107-02
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Unit tests
           environment:
@@ -76,6 +89,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Pull Lambda runtimes
           command: |
@@ -140,6 +154,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Test ElasticMQ SQS provider
           environment:
@@ -176,6 +191,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Test ASF Lambda provider
           environment:
@@ -203,6 +219,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Run bootstrap tests
           environment:
@@ -333,12 +350,13 @@ jobs:
             - repo/target/coverage/
 
   report:
-    docker:
-      - image: buildpack-deps:focal
+    machine:
+      image: ubuntu-2004:202107-02
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Collect coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,11 @@ jobs:
           name: Install prerequisites
           command: |
             sudo apt-get update
-            sudo apt-get install -y libsasl2-dev
-      - run:
-          name: Install python 3.10
-          command: |
-            pyenv install 3.10.2
-            pyenv global 3.10.2
+            sudo apt-get install -y libsasl2-dev python3.8-venv python3.8-dev
       - run:
           name: Setup environment
           environment:
-            VENV_CMD: "python3.10 -m venv"
+            VENV_BIN: "/usr/bin/python3.8 -m venv"
           command: |
             make install
             mkdir -p target/reports
@@ -39,7 +34,7 @@ jobs:
 
   preflight:
     docker:
-      - image: cimg/python:3.10.2
+      - image: buildpack-deps:focal
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -50,7 +45,7 @@ jobs:
 
   unit-tests:
     docker:
-      - image: cimg/python:3.10.2
+      - image: buildpack-deps:focal
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -82,12 +77,16 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
+<<<<<<< HEAD
           name: Install python 3.10
           command: |
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:
           name: Pull Lambda runtimes
+=======
+          name: Pull lambda runtimes
+>>>>>>> 40d11ac0 (Revert "try updating circleci to python3.10")
           command: |
             sudo useradd localstack -s /bin/bash
             docker pull -q lambci/lambda:20191117-nodejs8.10
@@ -151,12 +150,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Install python 3.10
-          command: |
-            pyenv install 3.10.2
-            pyenv global 3.10.2
-      - run:
-          name: Test ElasticMQ SQS provider
+          name: Test elasticmq SQS provider
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu-amd64-machine-image:
     type: string
-    default: "ubuntu-2004:202201-02"
+    default: "ubuntu-2004:2022.04.1"
   ubuntu-arm64-machine-image:
     type: string
-    default: "ubuntu-2004:202101-01"
+    default: "ubuntu-2004:2022.04.1"
 
 executors:
   ubuntu-machine-amd64:
@@ -250,32 +250,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - when:
-          condition:
-            equal: [ arm64, << parameters.platform >> ]
-          steps:
-            - run:
-                # Since we are using an old version of ubuntu, we need to install the latest version of docker
-                name: Update docker engine to most current
-                command: |
-                  # Remove old version
-                  sudo apt-get remove --purge docker docker-engine docker.io containerd runc -y
-                  # Install Docker deb package repo
-                  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-                    sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-                  echo "deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-                    | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-                  sudo apt-get update
-                  # Install the latest version of Docker and haveged
-                  # (https://github.com/docker/compose/issues/6678#issuecomment-526831488)
-                  sudo apt-get install docker-ce docker-ce-cli containerd.io haveged -y
-                  sudo usermod -aG docker $USER
-            - run:
-                # since the 2022 image of ubuntu2004 is not available for arm, we need to manually update pyenv and install python 3.10.2
-                name: Install python version 3.10.2
-                command: |
-                  (cd $(pyenv root) && git checkout master && git pull)
-                  pyenv install 3.10.2
       - run:
           name: Build full docker image
           command: make docker-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,16 @@ jobs:
           name: Install prerequisites
           command: |
             sudo apt-get update
-            sudo apt-get install -y libsasl2-dev python3.8-venv python3.8-dev
+            sudo apt-get install -y libsasl2-dev
+      - run:
+          name: Install python 3.10
+          command: |
+            pyenv install 3.10.2
+            pyenv global 3.10.2
       - run:
           name: Setup environment
           environment:
-            VENV_BIN: "/usr/bin/python3.8 -m venv"
+            VENV_CMD: "python3.10 -m venv"
           command: |
             make install
             mkdir -p target/reports
@@ -34,7 +39,7 @@ jobs:
 
   preflight:
     docker:
-      - image: buildpack-deps:focal
+      - image: cimg/python:3.10.2
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -45,7 +50,7 @@ jobs:
 
   unit-tests:
     docker:
-      - image: buildpack-deps:focal
+      - image: cimg/python:3.10.2
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -76,6 +81,11 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Install python 3.10
+          command: |
+            pyenv install 3.10.2
+            pyenv global 3.10.2
       - run:
           name: Pull Lambda runtimes
           command: |
@@ -141,7 +151,16 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
+<<<<<<< HEAD
           name: Test ElasticMQ SQS provider
+=======
+          name: Install python 3.10
+          command: |
+            pyenv install 3.10.2
+            pyenv global 3.10.2
+      - run:
+          name: Test elasticmq SQS provider
+>>>>>>> 3fa6b680 (try updating circleci to python3.10)
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,5 @@
 version: 2.1
 
-commands:
-  install-python:
-    steps:
-      - run:
-          name: Install python 3.10
-          command: |
-            (cd $(pyenv root) && git checkout master && git pull)
-            pyenv install 3.10.2
-            pyenv global 3.10.2
-
 jobs:
   install:
     machine:
@@ -24,7 +14,12 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install -y libsasl2-dev
-      - install-python
+      - run:
+          name: Install python 3.10
+          command: |
+            (cd $(pyenv root) && git checkout master && git pull)
+            pyenv install 3.10.2
+            pyenv global 3.10.2
       - run:
           name: Setup environment
           environment:
@@ -87,7 +82,12 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
+      - run:
+          name: Install python 3.10
+          command: |
+            (cd $(pyenv root) && git checkout master && git pull)
+            pyenv install 3.10.2
+            pyenv global 3.10.2
       - run:
           name: Pull Lambda runtimes
           command: |
@@ -152,7 +152,12 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
+      - run:
+          name: Install python 3.10
+          command: |
+            (cd $(pyenv root) && git checkout master && git pull)
+            pyenv install 3.10.2
+            pyenv global 3.10.2
       - run:
           name: Test ElasticMQ SQS provider
           environment:
@@ -216,7 +221,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Run bootstrap tests
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,12 @@ commands:
       - run:
           name: Install python 3.10
           command: |
-            (cd $(pyenv root) && git checkout master && git pull)
-            pyenv install 3.10.3
-            pyenv global 3.10.3
+            python --version
 
 parameters:
   ubuntu-amd64-machine-image:
     type: string
-    default: "ubuntu-2004:202107-02"
+    default: "ubuntu-2004:202201-02"
   ubuntu-arm64-machine-image:
     type: string
     default: "ubuntu-2004:202101-01"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ jobs:
             sudo apt-get install -y libsasl2-dev
       - run:
           name: Setup environment
-          environment:
-            VENV_BIN: "python3 -m venv"
           command: |
             make install
             mkdir -p target/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
       - install-python
       - run:
           name: Setup environment
+          environment:
+            VENV_BIN: "python3.10 -m venv"
           command: |
             make install
             mkdir -p target/reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,16 +77,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-<<<<<<< HEAD
-          name: Install python 3.10
-          command: |
-            pyenv install 3.10.2
-            pyenv global 3.10.2
-      - run:
           name: Pull Lambda runtimes
-=======
-          name: Pull lambda runtimes
->>>>>>> 40d11ac0 (Revert "try updating circleci to python3.10")
           command: |
             sudo useradd localstack -s /bin/bash
             docker pull -q lambci/lambda:20191117-nodejs8.10
@@ -150,7 +141,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Test elasticmq SQS provider
+          name: Test ElasticMQ SQS provider
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2.1
 
-commands:
-  install-python:
-    steps:
-      - run:
-          name: Install python 3.10
-          command: |
-            python3 --version
-
 parameters:
   ubuntu-amd64-machine-image:
     type: string
@@ -34,7 +26,6 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install -y libsasl2-dev
-      - install-python
       - run:
           name: Setup environment
           environment:
@@ -59,7 +50,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Linting
           command: make lint
@@ -70,7 +60,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Unit tests
           environment:
@@ -96,7 +85,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Pull Lambda runtimes
           command: |
@@ -160,7 +148,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Test ElasticMQ SQS provider
           environment:
@@ -196,7 +183,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Test ASF Lambda provider
           environment:
@@ -223,7 +209,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Run bootstrap tests
           environment:
@@ -285,6 +270,12 @@ jobs:
                   # (https://github.com/docker/compose/issues/6678#issuecomment-526831488)
                   sudo apt-get install docker-ce docker-ce-cli containerd.io haveged -y
                   sudo usermod -aG docker $USER
+            - run:
+                # since the 2022 image of ubuntu2004 is not available for arm, we need to manually update pyenv and install python 3.10.2
+                name: Install python version 3.10.2
+                command: |
+                  (cd $(pyenv root) && git checkout master && git pull)
+                  pyenv install 3.10.2
       - run:
           name: Build full docker image
           command: make docker-build
@@ -322,7 +313,7 @@ jobs:
         type: string
       machine_image:
         description: "CircleCI machine type to run at"
-        default: "ubuntu-2004:202107-02"
+        default: << pipeline.parameters.ubuntu-amd64-machine-image >>
         type: string
     machine:
       image: << parameters.machine_image >>
@@ -359,7 +350,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - install-python
       - run:
           name: Collect coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,15 @@
 version: 2.1
 
+commands:
+  install-python:
+    steps:
+      - run:
+          name: Install python 3.10
+          command: |
+            (cd $(pyenv root) && git checkout master && git pull)
+            pyenv install 3.10.2
+            pyenv global 3.10.2
+
 jobs:
   install:
     machine:
@@ -14,12 +24,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install -y libsasl2-dev
-      - run:
-          name: Install python 3.10
-          command: |
-            (cd $(pyenv root) && git checkout master && git pull)
-            pyenv install 3.10.2
-            pyenv global 3.10.2
+      - install-python
       - run:
           name: Setup environment
           environment:
@@ -82,12 +87,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run:
-          name: Install python 3.10
-          command: |
-            (cd $(pyenv root) && git checkout master && git pull)
-            pyenv install 3.10.2
-            pyenv global 3.10.2
+      - install-python
       - run:
           name: Pull Lambda runtimes
           command: |
@@ -152,18 +152,9 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
-<<<<<<< HEAD
           name: Test ElasticMQ SQS provider
-=======
-          name: Install python 3.10
-          command: |
-            (cd $(pyenv root) && git checkout master && git pull)
-            pyenv install 3.10.2
-            pyenv global 3.10.2
-      - run:
-          name: Test elasticmq SQS provider
->>>>>>> 3fa6b680 (try updating circleci to python3.10)
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"
@@ -225,6 +216,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - install-python
       - run:
           name: Run bootstrap tests
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - run:
           name: Install python 3.10
           command: |
+            (cd $(pyenv root) && git checkout master && git pull)
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:
@@ -84,6 +85,7 @@ jobs:
       - run:
           name: Install python 3.10
           command: |
+            (cd $(pyenv root) && git checkout master && git pull)
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:
@@ -156,6 +158,7 @@ jobs:
 =======
           name: Install python 3.10
           command: |
+            (cd $(pyenv root) && git checkout master && git pull)
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
       - run:
           name: Install python 3.10
           command: |
-            (cd $(pyenv root) && git checkout master && git pull)
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:
@@ -85,7 +84,6 @@ jobs:
       - run:
           name: Install python 3.10
           command: |
-            (cd $(pyenv root) && git checkout master && git pull)
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:
@@ -155,7 +153,6 @@ jobs:
       - run:
           name: Install python 3.10
           command: |
-            (cd $(pyenv root) && git checkout master && git pull)
             pyenv install 3.10.2
             pyenv global 3.10.2
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,22 @@ commands:
             pyenv install 3.10.3
             pyenv global 3.10.3
 
+parameters:
+  ubuntu-amd64-machine-image:
+    type: string
+    default: "ubuntu-2004:202107-02"
+  ubuntu-arm64-machine-image:
+    type: string
+    default: "ubuntu-2004:202101-01"
+
+executors:
+  ubuntu-machine-amd64:
+    machine:
+      image: << pipeline.parameters.ubuntu-amd64-machine-image >>
+
 jobs:
   install:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - checkout
@@ -27,8 +39,6 @@ jobs:
       - install-python
       - run:
           name: Setup environment
-          environment:
-            VENV_BIN: "/usr/bin/python3.8 -m venv"
           command: |
             make install
             mkdir -p target/reports
@@ -44,8 +54,7 @@ jobs:
             - repo
 
   preflight:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -56,8 +65,7 @@ jobs:
           command: make lint
 
   unit-tests:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -83,8 +91,7 @@ jobs:
             - repo/target/coverage/
 
   itest-lambda-docker:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -148,8 +155,7 @@ jobs:
           path: target/reports/
 
   itest-sqs-provider:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -185,8 +191,7 @@ jobs:
           path: target/reports/
 
   itest-lambda-provider:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -213,8 +218,7 @@ jobs:
           path: target/reports/
 
   itest-bootstrap:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -350,8 +354,7 @@ jobs:
             - repo/target/coverage/
 
   report:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -376,8 +379,7 @@ jobs:
           path: htmlcov/
 
   docker-push:
-    machine:
-      image: ubuntu-2004:202107-02
+    executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
     steps:
       - attach_workspace:
@@ -456,7 +458,7 @@ workflows:
       - docker-build:
           name: docker-build-amd64
           platform: amd64
-          machine_image: ubuntu-2004:202107-02
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
           resource_class: medium
           requires:
             - preflight
@@ -465,7 +467,7 @@ workflows:
           platform: arm64
           # The latest version of ubuntu is not yet supported for ARM:
           # https://circleci.com/docs/2.0/arm-resources/
-          machine_image: ubuntu-2004:202101-01
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
           resource_class: arm.medium
           requires:
             - preflight
@@ -473,14 +475,14 @@ workflows:
           name: docker-test-arm64
           platform: arm64
           resource_class: arm.medium
-          machine_image: ubuntu-2004:202101-01
+          machine_image: << pipeline.parameters.ubuntu-arm64-machine-image >>
           requires:
             - docker-build-arm64
       - docker-test:
           name: docker-test-amd64
           platform: amd64
           resource_class: medium
-          machine_image: ubuntu-2004:202107-02
+          machine_image: << pipeline.parameters.ubuntu-amd64-machine-image >>
           requires:
             - docker-build-amd64
       - report:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
       - run:
           name: Install python 3.10
           command: |
-            python --version
+            python3 --version
 
 parameters:
   ubuntu-amd64-machine-image:
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Setup environment
           environment:
-            VENV_BIN: "python3.10 -m venv"
+            VENV_BIN: "python3 -m venv"
           command: |
             make install
             mkdir -p target/reports

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -38,7 +38,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Set up Node 14.x
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -34,11 +34,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: localstack
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         id: setup-python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Set up Node 14.x
         uses: actions/setup-node@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_TYPE=full
 
 # java-builder: Stage to build a custom JRE (with jlink)
-FROM python:3.10.2-slim-buster@sha256:32190393b82d91e98ae65b1071273e5fa32e737c855b589488d90d257a022503 as java-builder
+FROM python:3.10.4-slim-buster@sha256:48c4a798972f30b485fea59076ec186644da63c1845f38e32b6c2fada51e7144 as java-builder
 ARG TARGETARCH
 
 # install OpenJDK 11
@@ -34,7 +34,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java, maven,...)
-FROM python:3.10.2-slim-buster@sha256:32190393b82d91e98ae65b1071273e5fa32e737c855b589488d90d257a022503 as base
+FROM python:3.10.4-slim-buster@sha256:48c4a798972f30b485fea59076ec186644da63c1845f38e32b6c2fada51e7144 as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_TYPE=full
 
 # java-builder: Stage to build a custom JRE (with jlink)
-FROM python:3.8.13-slim-buster@sha256:8b65f13c26b411a8dd331e60ab12e36058aef2a4586eaf0da6b6cc5522f9852d as java-builder
+FROM python:3.10.2-slim-buster@sha256:32190393b82d91e98ae65b1071273e5fa32e737c855b589488d90d257a022503 as java-builder
 ARG TARGETARCH
 
 # install OpenJDK 11
@@ -34,7 +34,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java, maven,...)
-FROM python:3.8.13-slim-buster@sha256:8b65f13c26b411a8dd331e60ab12e36058aef2a4586eaf0da6b6cc5522f9852d as base
+FROM python:3.10.2-slim-buster@sha256:32190393b82d91e98ae65b1071273e5fa32e737c855b589488d90d257a022503 as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: Apache Software License
     Topic :: Internet
     Topic :: Software Development :: Testing

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     License :: OSI Approved :: Apache Software License
     Topic :: Internet
     Topic :: Software Development :: Testing


### PR DESCRIPTION
# Update LocalStack images & runtime to python 3.10

This PR makes couple of significant changes to the build pipeline in order to fully support python3.10 features over the build pipeline:
* Usage of machine executors throughout the pipeline: In contrast to the current state, we now use machine executors for all steps of the pipeline, instead of just the steps needing docker. This is necessary due to the passing of the virtual environment from the install steps to later steps, and the difference in pathing between machine (using pyenv) and docker (installing in /usr/bin) images. Alternative would have been rebuilding the venv every time or trying to fix the venv paths for every job, which just begs for errors to occur.
* Update of machine images: In order to use python 3.10.3 throughout the pipeline (and 3.10.4 in the docker image), I updated the machine images to ubuntu-2004:2022.04.1, which is available for both arm64 and amd64 machine executors (https://discuss.circleci.com/t/ubuntu-linux-vm-machine-images-2022-april-q2-update/43749).
* In order to make future updating of machine images simpler, they are now defined as pipeline parameter on top of the config.yml file (split between amd64 and arm64, if different image versions should be necessary at some point, as was in the past), as well as the amd64 machine executor.
* Updating docker is not necessary anymore, due to the updated images.
* Adds python 3.10 as classifier in setup.cfg.

Other changes:
* Update dockerfile for python 3.10.4 (to include fixes also made by #5856 )
* Update tests against pro for python 3.10 