### PR TITLE
add timeout to status services cli command

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -84,7 +84,7 @@ def cmd_status_services(format):
     url = config.get_edge_url()
 
     try:
-        health = requests.get(f"{url}/health")
+        health = requests.get(f"{url}/health", timeout=2)
         doc = health.json()
         services = doc.get("services", [])
         if format == "table":


### PR DESCRIPTION
Adds a 2 second timeout to `localstack status services` to avoid long wait times in windows.