### PR TITLE
Minor fix in extracting error details from Lambda responses

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -815,7 +815,8 @@ def run_lambda(
         }
         LOG.info("Error executing Lambda function %s: %s %s", func_arn, e, traceback.format_exc())
         if isinstance(e, lambda_executors.InvocationException):
-            response = run_safe(lambda: json.loads(e.result)) or response
+            exc_result = e.result
+            response = run_safe(lambda: json.loads(exc_result)) or response
         log_output = e.log_output if isinstance(e, lambda_executors.InvocationException) else ""
         return InvocationResult(Response(json.dumps(response), status=500), log_output)
     finally:

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -72,6 +72,7 @@ from localstack.utils.common import (
     unzip,
 )
 from localstack.utils.docker_utils import DOCKER_CLIENT
+from localstack.utils.functions import run_safe
 from localstack.utils.generic.singleton_utils import SubtypesInstanceManager
 from localstack.utils.http import canonicalize_headers, parse_chunked_data
 from localstack.utils.run import FuncThread
@@ -814,7 +815,7 @@ def run_lambda(
         }
         LOG.info("Error executing Lambda function %s: %s %s", func_arn, e, traceback.format_exc())
         if isinstance(e, lambda_executors.InvocationException):
-            response = json.loads(e.result)
+            response = run_safe(lambda: json.loads(e.result)) or response
         log_output = e.log_output if isinstance(e, lambda_executors.InvocationException) else ""
         return InvocationResult(Response(json.dumps(response), status=500), log_output)
     finally:


### PR DESCRIPTION
Minor fix in extracting error details from Lambda responses. Addresses:
```
...
  File "/opt/code/localstack/localstack/services/awslambda/lambda_api.py", line 1831, in invoke_function
    result = run_lambda(
  File "/opt/code/localstack/localstack/services/awslambda/lambda_api.py", line 817, in run_lambda
    response = json.loads(e.result)
  File "/usr/local/lib/python3.8/json/__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```