### PR TITLE
fix opensearch url matching (ignore host header)

### DIFF
--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -316,8 +316,10 @@ class EdgeProxiedOpensearchCluster(Server):
         self.cluster_port = get_free_tcp_port()
         self.cluster = self._backend_cluster()
         self.cluster.start()
-
-        self.proxy = EndpointProxy(self.url, self.cluster.url)
+        # Disable the host matching (by stripping the url) to match incoming requests which resolve here but have a
+        # different host header than the host field in the base url. f.e. when using docker-compose service resolution.
+        url_path = self._url.path
+        self.proxy = EndpointProxy(base_url=url_path, forward_url=self.cluster.url)
         LOG.info("registering an endpoint proxy for %s => %s", self.url, self.cluster.url)
         self.proxy.register()
 

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -375,7 +375,9 @@ class TestEdgeProxiedOpensearchCluster:
             cluster.start()
             assert cluster.wait_is_up(240), "gave up waiting for server"
 
-            response = requests.get(cluster_url)
+            # The host header has to be ignored (to match requests which resolve from somewhere else than localhost),
+            # therefore it's explicitly set to something else here.
+            response = requests.get(cluster_url, headers={"Host": "example.com"})
             assert response.ok, f"cluster endpoint returned an error: {response.text}"
             assert response.json()["version"]["number"] == "1.1.0"
 


### PR DESCRIPTION
This PR fixes the URL matching for OpenSearch when the `OPENSEARCH_ENDPOINT_STRATEGY` is set to `path` (i.e. we route the incoming requests through localstack using a path matching).
It explicitly disables the match check based on the HTTP `host` header, since clients might resolve to LocalStack using different hostnames (f.e. when using Docker network name resolution).