### PR TITLE
Fix logs subscription filter

### DIFF
--- a/localstack/services/logs/provider.py
+++ b/localstack/services/logs/provider.py
@@ -175,9 +175,7 @@ def moto_put_log_events(_, self, log_group_name, log_stream_name, log_events, se
     output = io.BytesIO()
     with GzipFile(fileobj=output, mode="w") as f:
         f.write(json.dumps(data, separators=(",", ":")).encode("utf-8"))
-    # payload_gz_encoded = base64.b64encode(output.getvalue()).decode("utf-8")
     payload_gz_encoded = output.getvalue()
-    # event = {"awslogs": {"data": payload_gz_encoded}}
     event = {"awslogs": {"data": base64.b64encode(output.getvalue()).decode("utf-8")}}
 
     if self.destination_arn:
@@ -196,10 +194,8 @@ def moto_put_log_events(_, self, log_group_name, log_stream_name, log_events, se
         if ":firehose:" in self.destination_arn:
             client = aws_stack.connect_to_service("firehose")
             firehose_name = aws_stack.firehose_name(self.destination_arn)
-            # payload_gz_encoded = base64.b64encode(output.getvalue()).decode("utf-8")
             client.put_record(
                 DeliveryStreamName=firehose_name,
-                # Record={"Data": json.dumps(payload_gz_encoded)},
                 Record={"Data": payload_gz_encoded},
             )
 

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -590,7 +590,10 @@ def check_expected_lambda_log_events_length(expected_length, function_name, rege
 
 
 def list_all_log_events(log_group_name: str) -> List[Dict]:
-    logs = aws_stack.connect_to_service("logs")
+    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
+        logs = boto3.client("logs")
+    else:
+        logs = aws_stack.connect_to_service("logs")
     return list_all_resources(
         lambda kwargs: logs.filter_log_events(logGroupName=log_group_name, **kwargs),
         last_token_attr_name="nextToken",
@@ -599,11 +602,14 @@ def list_all_log_events(log_group_name: str) -> List[Dict]:
 
 
 def get_lambda_log_events(
-    function_name, delay_time=DEFAULT_GET_LOG_EVENTS_DELAY, regex_filter: Optional[str] = None
+    function_name,
+    delay_time=DEFAULT_GET_LOG_EVENTS_DELAY,
+    regex_filter: Optional[str] = None,
+    log_group=None,
 ):
     def get_log_events(func_name, delay):
         time.sleep(delay)
-        log_group_name = get_lambda_log_group_name(func_name)
+        log_group_name = log_group or get_lambda_log_group_name(func_name)
         return list_all_log_events(log_group_name)
 
     try:

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -17,6 +17,7 @@ from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
 from localstack.utils.testutil import start_http_server
 from tests.integration.cloudformation.utils import render_template, template_path
+from tests.integration.util import is_aws_cloud
 
 if TYPE_CHECKING:
     from mypy_boto3_acm import ACMClient
@@ -226,7 +227,14 @@ def s3_create_bucket(s3_client):
     # cleanup
     for bucket in buckets:
         try:
-            s3_client.delete_bucket(Bucket=bucket)
+            if is_aws_cloud():
+                # bucket might not be empty -> try to delete everything
+                # there is currently no way to do this with s3_client
+                bucket = boto3.resource("s3").Bucket(bucket)
+                bucket.objects.all().delete()
+                bucket.delete()
+            else:
+                s3_client.delete_bucket(Bucket=bucket)
         except Exception as e:
             LOG.debug("error cleaning up bucket %s: %s", bucket, e)
 


### PR DESCRIPTION
This PR should address issue https://github.com/localstack/localstack/issues/5627, which resulted in double base64 encoded output for kinesis records that have been received by cloudwatch subscription filter.

Same behavior was witnessed for firehose and s3 uploads when using cloudwatch subscription filter.
