### PR TITLE
Minor fixes for API Gateway Lambda request context

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -564,7 +564,6 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
                 method=method,
                 resource_path=resource_path,
                 request_context=invocation_context.context,
-                event_context={},
                 stage_variables=invocation_context.stage_variables,
             )
 

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -72,7 +72,7 @@ class ApiInvocationContext:
         self.path = path
         self.data = data
         self.headers = headers
-        self.context = {"requestId", short_uid()} if context is None else context
+        self.context = {"requestId": short_uid()} if context is None else context
         self.auth_info = {} if auth_info is None else auth_info
         self.apigw_version = None
         self.api_id = api_id

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -553,7 +553,6 @@ def process_apigateway_invocation(
     query_string_params=None,
     stage_variables=None,
     request_context=None,
-    event_context=None,
 ):
     if path_params is None:
         path_params = {}
@@ -561,8 +560,6 @@ def process_apigateway_invocation(
         stage_variables = {}
     if request_context is None:
         request_context = {}
-    if event_context is None:
-        event_context = {}
     try:
         resource_path = resource_path or path
         event = construct_invocation_event(
@@ -585,7 +582,7 @@ def process_apigateway_invocation(
         inv_result = run_lambda(
             func_arn=func_arn,
             event=event,
-            context=event_context,
+            context=request_context,
             asynchronous=asynchronous,
         )
         return inv_result.result


### PR DESCRIPTION
Minor fixes for API Gateway Lambda request context.
* fix initializing dict instead of set in invocation context
* removed obsolete `event_context` parameter which is no longer used (and in fact overwrites the request `context` with Cognito identity information passed in Pro)

This is a follow-up for #5618 - aiming to get this merged once the tests are passing, to restore a 🟢 pipeline.