### PR TITLE
Fix nested stack outputs in CloudFormation

### DIFF
--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -270,10 +270,6 @@ class Stack(object):
     def outputs_list(self) -> List[Dict]:
         """Returns a copy of the outputs of this stack."""
         result = []
-        # first, fetch the outputs of nested child stacks
-        for stack in self.nested_stacks:
-            result.extend(stack.outputs_list())
-        # now, fetch the outputs of this stack
         for k, details in self.outputs.items():
             value = None
             try:

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -406,8 +406,8 @@ def get_attr_from_model_instance(resource, attribute, resource_type, resource_id
     try:
         inst = model_class(resource_name=resource_id, resource_json=resource)
         return inst.get_cfn_attribute(attribute)
-    except Exception:
-        pass
+    except Exception as e:
+        LOG.debug("Failed to retrieve model attribute: %s", attribute, exc_info=e)
 
 
 def resolve_ref(stack, ref, attribute):

--- a/tests/integration/cloudformation/test_cloudformation_nestedstacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_nestedstacks.py
@@ -1,0 +1,37 @@
+import os
+
+from localstack.utils.strings import short_uid
+
+
+def test_nested_stack_output_refs(cfn_client, deploy_cfn_template, s3_client):
+    """test output handling of nested stacks incl. referencing the nested output in the parent stack"""
+    bucket = f"test-bucket-{short_uid()}"
+    nested_bucket = f"test-bucket-nested-{short_uid()}"
+    key = f"test-key-{short_uid()}"
+    create_response = s3_client.create_bucket(Bucket=bucket)
+    s3_client.upload_file(
+        os.path.join(
+            os.path.dirname(__file__), "../templates/nested-stack-output-refs.nested.yaml"
+        ),
+        Bucket=bucket,
+        Key=key,
+    )
+    result = deploy_cfn_template(
+        template_file_name="nested-stack-output-refs.yaml",
+        template_mapping={
+            "s3_bucket_url": f"{create_response['Location']}/{key}",
+            "nested_bucket_name": nested_bucket,
+        },
+    )
+
+    nested_stack_id = result.outputs["CustomNestedStackId"]
+    nested_stack_details = cfn_client.describe_stacks(StackName=nested_stack_id)
+    nested_stack_outputs = nested_stack_details["Stacks"][0]["Outputs"]
+    assert "InnerCustomOutput" not in result.outputs
+    assert (
+        nested_bucket
+        == [
+            o["OutputValue"] for o in nested_stack_outputs if o["OutputKey"] == "InnerCustomOutput"
+        ][0]
+    )
+    assert f"{nested_bucket}-suffix" == result.outputs["CustomOutput"]

--- a/tests/integration/cloudformation/test_cloudformation_nestedstacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_nestedstacks.py
@@ -3,24 +3,23 @@ import os
 from localstack.utils.strings import short_uid
 
 
-def test_nested_stack_output_refs(cfn_client, deploy_cfn_template, s3_client):
+def test_nested_stack_output_refs(cfn_client, deploy_cfn_template, s3_client, s3_create_bucket):
     """test output handling of nested stacks incl. referencing the nested output in the parent stack"""
-    bucket = f"test-bucket-{short_uid()}"
-    nested_bucket = f"test-bucket-nested-{short_uid()}"
+    bucket_name = s3_create_bucket()
+    nested_bucket_name = f"test-bucket-nested-{short_uid()}"
     key = f"test-key-{short_uid()}"
-    create_response = s3_client.create_bucket(Bucket=bucket)
     s3_client.upload_file(
         os.path.join(
             os.path.dirname(__file__), "../templates/nested-stack-output-refs.nested.yaml"
         ),
-        Bucket=bucket,
+        Bucket=bucket_name,
         Key=key,
     )
     result = deploy_cfn_template(
         template_file_name="nested-stack-output-refs.yaml",
         template_mapping={
-            "s3_bucket_url": f"{create_response['Location']}/{key}",
-            "nested_bucket_name": nested_bucket,
+            "s3_bucket_url": f"/{bucket_name}/{key}",
+            "nested_bucket_name": nested_bucket_name,
         },
     )
 
@@ -29,9 +28,9 @@ def test_nested_stack_output_refs(cfn_client, deploy_cfn_template, s3_client):
     nested_stack_outputs = nested_stack_details["Stacks"][0]["Outputs"]
     assert "InnerCustomOutput" not in result.outputs
     assert (
-        nested_bucket
+        nested_bucket_name
         == [
             o["OutputValue"] for o in nested_stack_outputs if o["OutputKey"] == "InnerCustomOutput"
         ][0]
     )
-    assert f"{nested_bucket}-suffix" == result.outputs["CustomOutput"]
+    assert f"{nested_bucket_name}-suffix" == result.outputs["CustomOutput"]

--- a/tests/integration/templates/nested-stack-output-refs.nested.yaml
+++ b/tests/integration/templates/nested-stack-output-refs.nested.yaml
@@ -1,0 +1,13 @@
+Parameters:
+  NestedBucketName:
+    Type: String
+Resources:
+  CustomBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName:
+        Ref: NestedBucketName
+Outputs:
+  InnerCustomOutput:
+    Value:
+      Ref: CustomBucket

--- a/tests/integration/templates/nested-stack-output-refs.yaml
+++ b/tests/integration/templates/nested-stack-output-refs.yaml
@@ -1,0 +1,28 @@
+Resources:
+  CustomNestedStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        NestedBucketName: {{ nested_bucket_name }}
+      TemplateURL:
+        Fn::Join:
+          - ""
+          - - https://s3.
+            - Ref: AWS::Region
+            - "."
+            - Ref: AWS::URLSuffix
+            - {{ s3_bucket_url }}
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+Outputs:
+  CustomNestedStackId:
+    Value:
+      Ref: CustomNestedStack
+  CustomOutput:
+    Value:
+      Fn::Join:
+        - "-"
+        - - Fn::GetAtt:
+              - CustomNestedStack
+              - Outputs.InnerCustomOutput
+          - suffix


### PR DESCRIPTION
Fixes an issue in CloudFormation nested stacks where it couldn't resolve outputs from nested stacks in the parent stack. 
Outputs from nested stacks were also merged into the parent stack for some reason which has been removed again to be in parity with AWS.



/cc @alexrashed 