### PR TITLE
Add GetAtt support for AWS::EC2::VPC DefaultSecurityGroup and DefaultNetworkAcl

### DIFF
--- a/tests/integration/cloudformation/test_cloudformation_ec2.py
+++ b/tests/integration/cloudformation/test_cloudformation_ec2.py
@@ -1,5 +1,6 @@
 def test_vpc_creates_default_sg(deploy_cfn_template, ec2_client):
     """tests GetAtt references to default security groups and network ACLs for VPCs"""
+
     result = deploy_cfn_template(template_file_name="ec2_vpc_default_sg.yaml")
 
     vpc_id = result.outputs.get("VpcId")

--- a/tests/integration/cloudformation/test_cloudformation_ec2.py
+++ b/tests/integration/cloudformation/test_cloudformation_ec2.py
@@ -1,0 +1,17 @@
+def test_vpc_creates_default_sg(deploy_cfn_template, ec2_client):
+    """tests GetAtt references to default security groups and network ACLs for VPCs"""
+    result = deploy_cfn_template(template_file_name="ec2_vpc_default_sg.yaml")
+
+    vpc_id = result.outputs.get("VpcId")
+    default_sg = result.outputs.get("VpcDefaultSG")
+    default_acl = result.outputs.get("VpcDefaultAcl")
+
+    assert vpc_id
+    assert default_sg
+    assert default_acl
+
+    security_groups = ec2_client.describe_security_groups(GroupIds=[default_sg])["SecurityGroups"]
+    assert security_groups[0]["VpcId"] == vpc_id
+
+    acls = ec2_client.describe_network_acls(NetworkAclIds=[default_acl])["NetworkAcls"]
+    assert acls[0]["VpcId"] == vpc_id

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     from mypy_boto3_logs import CloudWatchLogsClient
     from mypy_boto3_opensearch import OpenSearchServiceClient
     from mypy_boto3_redshift import RedshiftClient
+    from mypy_boto3_resourcegroupstaggingapi import ResourceGroupsTaggingAPIClient
+    from mypy_boto3_route53 import Route53Client
     from mypy_boto3_s3 import S3Client
     from mypy_boto3_secretsmanager import SecretsManagerClient
     from mypy_boto3_ses import SESClient
@@ -180,6 +182,16 @@ def sts_client() -> "STSClient":
 @pytest.fixture(scope="class")
 def ec2_client() -> "EC2Client":
     return _client("ec2")
+
+
+@pytest.fixture(scope="class")
+def rgsa_client() -> "ResourceGroupsTaggingAPIClient":
+    return _client("resourcegroupstaggingapi")
+
+
+@pytest.fixture(scope="class")
+def route53_client() -> "Route53Client":
+    return _client("route53")
 
 
 @pytest.fixture
@@ -709,3 +721,14 @@ def tmp_http_server():
     test_port, invocations, proxy = start_http_server()
     yield test_port, invocations, proxy
     proxy.stop()
+
+
+@pytest.fixture(autouse=True)
+def check_vpc_delete():
+    ec2_client = _client("ec2")
+    before = ec2_client.describe_vpcs().get("Vpcs")
+
+    yield
+
+    after = ec2_client.describe_vpcs().get("Vpcs")
+    assert before == after

--- a/tests/integration/templates/ec2_vpc_default_sg.yaml
+++ b/tests/integration/templates/ec2_vpc_default_sg.yaml
@@ -1,0 +1,190 @@
+Resources:
+  vpcA2121C38:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: RdsTestStack/vpc
+  vpcPublicSubnet1Subnet2E65531E:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.0.0/18
+      VpcId:
+        Ref: vpcA2121C38
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: aws-cdk:subnet-name
+          Value: Public
+        - Key: aws-cdk:subnet-type
+          Value: Public
+        - Key: Name
+          Value: RdsTestStack/vpc/PublicSubnet1
+  vpcPublicSubnet1RouteTable48A2DF9B:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: vpcA2121C38
+      Tags:
+        - Key: Name
+          Value: RdsTestStack/vpc/PublicSubnet1
+  vpcPublicSubnet1RouteTableAssociation5D3F4579:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: vpcPublicSubnet1RouteTable48A2DF9B
+      SubnetId:
+        Ref: vpcPublicSubnet1Subnet2E65531E
+  vpcPublicSubnet1DefaultRoute10708846:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: vpcPublicSubnet1RouteTable48A2DF9B
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: vpcIGWE57CBDCA
+    DependsOn:
+      - vpcVPCGW7984C166
+  vpcPublicSubnet2Subnet009B674F:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.64.0/18
+      VpcId:
+        Ref: vpcA2121C38
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: aws-cdk:subnet-name
+          Value: Public
+        - Key: aws-cdk:subnet-type
+          Value: Public
+        - Key: Name
+          Value: RdsTestStack/vpc/PublicSubnet2
+  vpcPublicSubnet2RouteTableEB40D4CB:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: vpcA2121C38
+      Tags:
+        - Key: Name
+          Value: RdsTestStack/vpc/PublicSubnet2
+  vpcPublicSubnet2RouteTableAssociation21F81B59:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: vpcPublicSubnet2RouteTableEB40D4CB
+      SubnetId:
+        Ref: vpcPublicSubnet2Subnet009B674F
+  vpcPublicSubnet2DefaultRouteA1EC0F60:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId:
+        Ref: vpcPublicSubnet2RouteTableEB40D4CB
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId:
+        Ref: vpcIGWE57CBDCA
+    DependsOn:
+      - vpcVPCGW7984C166
+  vpcIsolatedSubnet1Subnet8B28CEB3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.128.0/18
+      VpcId:
+        Ref: vpcA2121C38
+      AvailabilityZone:
+        Fn::Select:
+          - 0
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: aws-cdk:subnet-name
+          Value: Isolated
+        - Key: aws-cdk:subnet-type
+          Value: Isolated
+        - Key: Name
+          Value: RdsTestStack/vpc/IsolatedSubnet1
+  vpcIsolatedSubnet1RouteTable0D6B2D3D:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: vpcA2121C38
+      Tags:
+        - Key: Name
+          Value: RdsTestStack/vpc/IsolatedSubnet1
+  vpcIsolatedSubnet1RouteTableAssociation172210D4:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: vpcIsolatedSubnet1RouteTable0D6B2D3D
+      SubnetId:
+        Ref: vpcIsolatedSubnet1Subnet8B28CEB3
+  vpcIsolatedSubnet2Subnet2C6B375C:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.192.0/18
+      VpcId:
+        Ref: vpcA2121C38
+      AvailabilityZone:
+        Fn::Select:
+          - 1
+          - Fn::GetAZs: ""
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: aws-cdk:subnet-name
+          Value: Isolated
+        - Key: aws-cdk:subnet-type
+          Value: Isolated
+        - Key: Name
+          Value: RdsTestStack/vpc/IsolatedSubnet2
+  vpcIsolatedSubnet2RouteTable3455CBFC:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId:
+        Ref: vpcA2121C38
+      Tags:
+        - Key: Name
+          Value: RdsTestStack/vpc/IsolatedSubnet2
+  vpcIsolatedSubnet2RouteTableAssociation8A8FAF70:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId:
+        Ref: vpcIsolatedSubnet2RouteTable3455CBFC
+      SubnetId:
+        Ref: vpcIsolatedSubnet2Subnet2C6B375C
+  vpcIGWE57CBDCA:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: RdsTestStack/vpc
+  vpcVPCGW7984C166:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId:
+        Ref: vpcA2121C38
+      InternetGatewayId:
+        Ref: vpcIGWE57CBDCA
+Outputs:
+  VpcDefaultSG:
+    Value:
+      Fn::GetAtt:
+        - vpcA2121C38
+        - DefaultSecurityGroup
+  VpcId:
+    Value:
+      Ref: vpcA2121C38
+  VpcDefaultAcl:
+    Value:
+      Fn::GetAtt:
+        - vpcA2121C38
+        - DefaultNetworkAcl

--- a/tests/integration/test_rgsa.py
+++ b/tests/integration/test_rgsa.py
@@ -1,24 +1,15 @@
-import unittest
+class TestRGSAIntegrations:
+    def test_get_resources(self, ec2_client, rgsa_client):
+        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+        try:
+            ec2_client.create_tags(
+                Resources=[vpc.get("Vpc").get("VpcId")],
+                Tags=[{"Key": "test", "Value": "test"}],
+            )
 
-from localstack.utils.aws import aws_stack
-
-
-class TestRGSAIntegrations(unittest.TestCase):
-    def setUp(self):
-        self.rgsa_client = aws_stack.create_external_boto_client("resourcegroupstaggingapi")
-        self.ec2_client = aws_stack.create_external_boto_client("ec2")
-
-    def test_get_resources(self):
-        vpc = self.ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-        self.ec2_client.create_tags(
-            Resources=[vpc.get("Vpc").get("VpcId")],
-            Tags=[{"Key": "test", "Value": "test"}],
-        )
-
-        def assert_response(resp):
+            resp = rgsa_client.get_resources(ResourceTypeFilters=["ec2"])
             results = resp.get("ResourceTagMappingList", [])
-            self.assertEqual(1, len(results))
-            self.assertEqual([{"Key": "test", "Value": "test"}], results[0].get("Tags"))
-
-        resp = self.rgsa_client.get_resources(ResourceTypeFilters=["ec2"])
-        assert_response(resp)
+            assert 1 == len(results)
+            assert [{"Key": "test", "Value": "test"}] == results[0].get("Tags")
+        finally:
+            ec2_client.delete_vpc(VpcId=vpc["Vpc"]["VpcId"])

--- a/tests/integration/test_route53.py
+++ b/tests/integration/test_route53.py
@@ -7,6 +7,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 
 
+# TODO: add proper cleanup
 class TestRoute53:
     def test_create_hosted_zone(self):
         route53 = aws_stack.create_external_boto_client("route53")
@@ -17,12 +18,9 @@ class TestRoute53:
         response = route53.get_change(Id="string")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-    def test_associate_vpc_with_hosted_zone(self):
-        ec2 = aws_stack.create_external_boto_client("ec2")
-        route53 = aws_stack.create_external_boto_client("route53")
-
+    def test_associate_vpc_with_hosted_zone(self, ec2_client, route53_client):
         name = "zone123"
-        response = route53.create_hosted_zone(
+        response = route53_client.create_hosted_zone(
             Name=name,
             CallerReference="ref123",
             HostedZoneConfig={"PrivateZone": True, "Comment": "test"},
@@ -31,10 +29,10 @@ class TestRoute53:
         zone_id = zone_id.replace("/hostedzone/", "")
 
         # associate zone with VPC
-        vpc = ec2.create_vpc(CidrBlock="10.0.0.0/24")
+        vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/24")
         vpc_id = vpc["Vpc"]["VpcId"]
         vpc_region = aws_stack.get_region()
-        result = route53.associate_vpc_with_hosted_zone(
+        result = route53_client.associate_vpc_with_hosted_zone(
             HostedZoneId=zone_id,
             VPC={"VPCRegion": vpc_region, "VPCId": vpc_id},
             Comment="test 123",
@@ -42,7 +40,7 @@ class TestRoute53:
         assert result["ChangeInfo"].get("Id")
 
         # list zones by VPC
-        result = route53.list_hosted_zones_by_vpc(VPCId=vpc_id, VPCRegion=vpc_region)[
+        result = route53_client.list_hosted_zones_by_vpc(VPCId=vpc_id, VPCRegion=vpc_region)[
             "HostedZoneSummaries"
         ]
         expected = {
@@ -53,17 +51,17 @@ class TestRoute53:
         assert expected in result
 
         # list zones by name
-        result = route53.list_hosted_zones_by_name(DNSName=name).get("HostedZones")
+        result = route53_client.list_hosted_zones_by_name(DNSName=name).get("HostedZones")
         assert result[0]["Name"] == "zone123."
-        result = route53.list_hosted_zones_by_name(DNSName="%s." % name).get("HostedZones")
+        result = route53_client.list_hosted_zones_by_name(DNSName="%s." % name).get("HostedZones")
         assert result[0]["Name"] == "zone123."
 
         # assert that VPC is attached in Zone response
-        result = route53.get_hosted_zone(Id=zone_id)
+        result = route53_client.get_hosted_zone(Id=zone_id)
         assert result["VPCs"] == [{"VPCRegion": vpc_region, "VPCId": vpc_id}]
 
         # disassociate
-        route53.disassociate_vpc_from_hosted_zone(
+        route53_client.disassociate_vpc_from_hosted_zone(
             HostedZoneId=zone_id,
             VPC={"VPCRegion": aws_stack.get_region(), "VPCId": vpc_id},
             Comment="test2",
@@ -71,7 +69,7 @@ class TestRoute53:
         assert response["ResponseMetadata"]["HTTPStatusCode"] in [200, 201]
         # subsequent call (after disassociation) should fail with 404 error
         with pytest.raises(Exception):
-            route53.disassociate_vpc_from_hosted_zone(
+            route53_client.disassociate_vpc_from_hosted_zone(
                 HostedZoneId=zone_id,
                 VPC={"VPCRegion": aws_stack.get_region(), "VPCId": vpc_id},
             )


### PR DESCRIPTION
VPCs come with a default security group and a default network ACL. 
This PR adds the corresponding support for using CloudFormation GetAtt/Ref.