### PR TITLE
Minor update in patch decorator to allow multiple/composite patches of methods

### DIFF
--- a/localstack/utils/patch.py
+++ b/localstack/utils/patch.py
@@ -32,7 +32,14 @@ def create_patch_proxy(target: Callable, new: Callable):
 
     @functools.wraps(target)
     def proxy(*args, **kwargs):
+        if _is_bound_method:
+            # bound object "self" is passed as first argument if this is a bound method
+            args = args[1:]
         return new(target, *args, **kwargs)
+
+    _is_bound_method = inspect.ismethod(target)
+    if _is_bound_method:
+        proxy = types.MethodType(proxy, target.__self__)
 
     return proxy
 


### PR DESCRIPTION
Minor update in patch decorator to allow multiple/composite patches of methods. This covers a case that has come up recently, as we're now patching certain service methods twice (from community, and pro code base).