### PR TITLE
Rounding ApproximateCreationDateTime to seconds

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -463,7 +463,8 @@ class ProxyListenerDynamoDB(ProxyListener):
             "eventID": "1",
             "eventVersion": "1.1",
             "dynamodb": {
-                "ApproximateCreationDateTime": time.time(),
+                # expects nearest second rounded down
+                "ApproximateCreationDateTime": int(time.time()),
                 # 'StreamViewType': 'NEW_AND_OLD_IMAGES',
                 "SizeBytes": -1,
             },

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -722,6 +722,7 @@ class TestDynamoDB:
             records["Records"][0]["dynamodb"]["ApproximateCreationDateTime"],
             datetime,
         )
+        assert records["Records"][0]["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
         assert records["Records"][0]["eventVersion"] == "1.1"
         assert records["Records"][0]["eventName"] == "INSERT"
         assert "OldImage" not in records["Records"][0]["dynamodb"]
@@ -730,6 +731,7 @@ class TestDynamoDB:
             records["Records"][1]["dynamodb"]["ApproximateCreationDateTime"],
             datetime,
         )
+        assert records["Records"][1]["dynamodb"]["ApproximateCreationDateTime"].microsecond == 0
         assert records["Records"][1]["eventVersion"] == "1.1"
         assert records["Records"][1]["eventName"] == "MODIFY"
         assert "OldImage" in records["Records"][1]["dynamodb"]


### PR DESCRIPTION
[related bug](https://github.com/localstack/localstack/issues/5656)

since time.time() returns a float where the left side is in seconds and the right side is the number of microseconds, down casting to an int removes the microseconds and maintains the seconds.

conversion from epoch to datetime is still working and tests show that the microseconds are now 0