### PR TITLE
add Cognito::IdentityPoolRoleAttachment in cloudformation

### DIFF
--- a/tests/integration/cloudformation/test_cloudformation_cognito.py
+++ b/tests/integration/cloudformation/test_cloudformation_cognito.py
@@ -1,0 +1,53 @@
+import os
+
+import jinja2
+import pytest
+
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import wait_until
+from tests.integration.cloudformation.utils import load_template_raw
+
+
+@pytest.mark.skipif(
+    not bool(os.environ.get("LOCALSTACK_API_KEY")),
+    reason="test uses pro features, skipped if no pro",
+)
+def test_cognito_role_attachement(
+    cfn_client,
+    cognito_identity_client,
+    cleanup_stacks,
+    cleanup_changesets,
+    is_change_set_created_and_available,
+    is_stack_created,
+):
+    stack_name = f"stack-{short_uid()}"
+    change_set_name = f"change-set-{short_uid()}"
+    user_pool_name = f"user-pool-name-{short_uid()}"
+    identity_pool_name = f"identity-pool-name-{short_uid()}"
+    template_rendered = jinja2.Template(
+        load_template_raw("cognito_identity_pool_role_attachement.yaml")
+    ).render(user_pool_name=user_pool_name, identity_pool_name=identity_pool_name)
+
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName=change_set_name,
+        TemplateBody=template_rendered,
+        ChangeSetType="CREATE",
+    )
+
+    change_set_id = response["Id"]
+    stack_id = response["StackId"]
+
+    try:
+        wait_until(is_change_set_created_and_available(change_set_id))
+        cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        wait_until(is_stack_created(stack_id))
+        final_stack = cfn_client.describe_stacks(StackName=stack_id)
+        assert final_stack["Stacks"][0]["StackStatus"] == "CREATE_COMPLETE"
+        identity_pool_id = final_stack["Stacks"][0]["Outputs"][2]["OutputValue"]
+        roles = cognito_identity_client.get_identity_pool_roles(IdentityPoolId=identity_pool_id)
+        assert roles["RoleMappings"]
+
+    finally:
+        cleanup_changesets([change_set_id])
+        cleanup_stacks([stack_id])

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from mypy_boto3_apigateway import APIGatewayClient
     from mypy_boto3_cloudformation import CloudFormationClient
     from mypy_boto3_cloudwatch import CloudWatchClient
+    from mypy_boto3_cognito_identity import CognitoIdentityClient
     from mypy_boto3_dynamodb import DynamoDBClient
     from mypy_boto3_ec2 import EC2Client
     from mypy_boto3_es import ElasticsearchServiceClient
@@ -192,6 +193,11 @@ def rgsa_client() -> "ResourceGroupsTaggingAPIClient":
 @pytest.fixture(scope="class")
 def route53_client() -> "Route53Client":
     return _client("route53")
+
+
+@pytest.fixture(scope="class")
+def cognito_identity_client() -> "CognitoIdentityClient":
+    return _client("cognito-identity")
 
 
 @pytest.fixture

--- a/tests/integration/templates/cognito_identity_pool_role_attachement.yaml
+++ b/tests/integration/templates/cognito_identity_pool_role_attachement.yaml
@@ -1,0 +1,167 @@
+Resources:
+  userpool38E431F2:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      AccountRecoverySetting:
+        RecoveryMechanisms:
+          - Name: verified_email
+            Priority: 1
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: false
+      AutoVerifiedAttributes:
+        - email
+      EmailVerificationMessage: The verification code to your new account is {####}
+      EmailVerificationSubject: Verify your new account
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 6
+          RequireLowercase: true
+          RequireNumbers: true
+          RequireSymbols: false
+          RequireUppercase: false
+      SmsVerificationMessage: The verification code to your new account is {####}
+      UsernameAttributes:
+        - email
+      UserPoolName: {{user_pool_name}}
+      VerificationMessageTemplate:
+        DefaultEmailOption: CONFIRM_WITH_CODE
+        EmailMessage: The verification code to your new account is {####}
+        EmailSubject: Verify your new account
+        SmsMessage: The verification code to your new account is {####}
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/user-pool/Resource
+  userpoolclient6E7D7551:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      UserPoolId:
+        Ref: userpool38E431F2
+      AllowedOAuthFlows:
+        - implicit
+        - code
+      AllowedOAuthFlowsUserPoolClient: true
+      AllowedOAuthScopes:
+        - profile
+        - phone
+        - email
+        - openid
+        - aws.cognito.signin.user.admin
+      CallbackURLs:
+        - https://example.com
+      ExplicitAuthFlows:
+        - ALLOW_ADMIN_USER_PASSWORD_AUTH
+        - ALLOW_CUSTOM_AUTH
+        - ALLOW_USER_SRP_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+      SupportedIdentityProviders:
+        - COGNITO
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/user-pool-client/Resource
+  identitypool:
+    Type: AWS::Cognito::IdentityPool
+    Properties:
+      AllowUnauthenticatedIdentities: true
+      CognitoIdentityProviders:
+        - ClientId:
+            Ref: userpoolclient6E7D7551
+          ProviderName:
+            Fn::GetAtt:
+              - userpool38E431F2
+              - ProviderName
+      IdentityPoolName: {{identity_pool_name}}
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/identity-pool
+  anonymousgrouprole4CF2AF7A:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                cognito-identity.amazonaws.com:aud:
+                  Ref: identitypool
+              ForAnyValue:StringLike:
+                cognito-identity.amazonaws.com:amr: unauthenticated
+            Effect: Allow
+            Principal:
+              Federated: cognito-identity.amazonaws.com
+        Version: "2012-10-17"
+      Description: Default role for anonymous users
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/anonymous-group-role/Resource
+  usersgrouprole5142F148:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                cognito-identity.amazonaws.com:aud:
+                  Ref: identitypool
+              ForAnyValue:StringLike:
+                cognito-identity.amazonaws.com:amr: authenticated
+            Effect: Allow
+            Principal:
+              Federated: cognito-identity.amazonaws.com
+        Version: "2012-10-17"
+      Description: Default role for authenticated users
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/users-group-role/Resource
+  identitypoolroleattachment:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Properties:
+      IdentityPoolId:
+        Ref: identitypool
+      RoleMappings:
+        mapping:
+          AmbiguousRoleResolution: AuthenticatedRole
+          IdentityProvider:
+            Fn::Join:
+              - ""
+              - - cognito-idp.eu-central-1.amazonaws.com/
+                - Ref: userpool38E431F2
+                - ":"
+                - Ref: userpoolclient6E7D7551
+          Type: Token
+      Roles:
+        authenticated:
+          Fn::GetAtt:
+            - usersgrouprole5142F148
+            - Arn
+        unauthenticated:
+          Fn::GetAtt:
+            - anonymousgrouprole4CF2AF7A
+            - Arn
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/identity-pool-role-attachment
+  CDKMetadata:
+    Type: AWS::CDK::Metadata
+    Properties:
+      Analytics: v2:deflate64:H4sIAAAAAAAAA02OvQ7CMAyEn6V7cKlgKBuoExOoiAeoUgPpT4wSB4SivDsJqNDpzp991hWwKWGZbZunXci2z70kg+BP3MheVBd9cHx3LCrSlo2TnFiNlpyRGERKxcRVKybwZ4vmSDSkm5+fTDUo1Dxf/cm+jUbxawrP55oG3HGscxsjDEI1I/gEP02ihhCEphahs/mjWENRwirrrFIL4+KXEaH+6hvDBBXz6wAAAA==
+    Metadata:
+      aws:cdk:path: cdk-starter-stack/CDKMetadata/Default
+Outputs:
+  userPoolId:
+    Value:
+      Ref: userpool38E431F2
+  userPoolClientId:
+    Value:
+      Ref: userpoolclient6E7D7551
+  identityPoolId:
+    Value:
+      Ref: identitypool


### PR DESCRIPTION
This PR adds support for `Cognito::IdentityPoolRoleAttachment.RoleMappings`.

In CloudFormation the `RoleMappings` field can contain a field `IdentityProvider`, which is not support by the boto client. Instead it's used as a key.

Further Information here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-identitypoolroleattachment-rolemapping.html

related bug: #5669 