### PR TITLE
fix query request parser for operations without input shape

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -426,7 +426,9 @@ class QueryRequestParser(RequestParser):
         request_uri_regex = self._get_request_uri_regex(operation)
         input_shape: StructureShape = operation.input_shape
         parsed = self._parse_shape(request, input_shape, instance, request_uri_regex)
-        return operation, parsed if parsed is not None else {}
+        if parsed is None:
+            return operation, {}
+        return operation, parsed
 
     def _process_member(
         self,

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -219,6 +219,8 @@ class RequestParser(abc.ABC):
         :param path_regex: regex of the path. This is necessary to extract members located in the URI. Defaults to None.
         :return: result of the parsing operation, the type depends on the shape
         """
+        if shape is None:
+            return None
         location = shape.serialization.get("location")
         if location is not None:
             if location == "header":
@@ -423,7 +425,8 @@ class QueryRequestParser(RequestParser):
         # Extract the URI for the operation and convert it to a regex
         request_uri_regex = self._get_request_uri_regex(operation)
         input_shape: StructureShape = operation.input_shape
-        return operation, self._parse_shape(request, input_shape, instance, request_uri_regex)
+        parsed = self._parse_shape(request, input_shape, instance, request_uri_regex)
+        return operation, parsed if parsed is not None else {}
 
     def _process_member(
         self,

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -317,6 +317,13 @@ def test_query_parser_empty_required_members_sqs_with_botocore():
     )
 
 
+def test_query_parser_no_input_shape_autoscaling_with_botocore():
+    _botocore_parser_integration_test(
+        service="autoscaling",
+        action="DescribeMetricCollectionTypes",
+    )
+
+
 def test_query_parser_cloudformation_with_botocore():
     _botocore_parser_integration_test(
         service="cloudformation",


### PR DESCRIPTION
This PR fixes a small issue in ASF's `QueryRequestParser` for operations without a specified input shape.
- `RequestParser#_parse_shape` now returns `None` if the input shape is not given.
- The `QueryRequestParser` then returns an empty dictionary (i.e. no args for the operation).

/cc @giograno (thanks for the report)