### PR TITLE
Bump moto-ext to 3.0.6

### DIFF
--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -159,10 +159,8 @@ def apply_patches():
 
     # patch _key_response_put(..)
     @patch(s3_responses.S3ResponseInstance._key_response_put)
-    def s3_key_response_put(
-        self, fn, request, body, bucket_name, query, key_name, headers, *args, **kwargs
-    ):
-        result = fn(request, body, bucket_name, query, key_name, headers, *args, **kwargs)
+    def s3_key_response_put(self, fn, request, body, bucket_name, query, key_name, *args, **kwargs):
+        result = fn(request, body, bucket_name, query, key_name, *args, **kwargs)
         s3_update_acls(self, request, query, bucket_name, key_name)
         return result
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[full]>=0.13.2
-    moto-ext[all]==3.0.5
+    moto-ext[all]==3.0.6
     opensearch-py>=1.0.0
     pproxy>=2.7.0
     #pympler>=0.6


### PR DESCRIPTION
Bump `moto-ext` to 3.0.6. Initial test run - may require more adjustments due to recent upstream changes.