### PR TITLE
Support "Accept" header to switch response format; fix Flask app routes for Lambda API

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -75,6 +75,7 @@ from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.functions import run_safe
 from localstack.utils.generic.singleton_utils import SubtypesInstanceManager
 from localstack.utils.http import canonicalize_headers, parse_chunked_data
+from localstack.utils.patch import patch
 from localstack.utils.run import FuncThread
 
 # logger
@@ -106,6 +107,13 @@ BATCH_SIZE_RANGES = {
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f+00:00"
 
 app = Flask(APP_NAME)
+
+
+@patch(app.route)
+def app_route(self, fn, *args, **kwargs):
+    # make sure all routes can be called with/without trailing slashes, without triggering 308 forwards
+    return fn(*args, strict_slashes=False, **kwargs)
+
 
 # mutex for access to CWD and ENV
 EXEC_MUTEX = threading.RLock()
@@ -1848,7 +1856,7 @@ def invoke_function(function):
     )
 
 
-@app.route("%s/event-source-mappings" % API_PATH_ROOT, methods=["GET"], strict_slashes=False)
+@app.route("%s/event-source-mappings" % API_PATH_ROOT, methods=["GET"])
 def get_event_source_mappings():
     """List event source mappings
     ---
@@ -1887,7 +1895,7 @@ def get_event_source_mapping(mapping_uuid):
     return jsonify(mappings[0])
 
 
-@app.route("%s/event-source-mappings" % API_PATH_ROOT, methods=["POST"], strict_slashes=False)
+@app.route("%s/event-source-mappings" % API_PATH_ROOT, methods=["POST"])
 def create_event_source_mapping():
     """Create new event source mapping
     ---

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -214,7 +214,7 @@ class ProxyListenerEdge(ProxyListener):
                     content = xmltodict.parse(to_str(response._content))
                     response._content = strip_xmlns(content)
             except Exception as e:
-                LOG.debug("Unable to convert XML response to JSON: %s", e)
+                LOG.debug("Unable to convert XML response to JSON", exc_info=e)
 
         if (
             response._content

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -658,6 +658,8 @@ def modify_and_forward(
 
         # make sure we drop "chunked" transfer encoding from the headers to be forwarded
         headers_to_send.pop("Transfer-Encoding", None)
+        if headers_to_send.get("Host") == "localhost":
+            headers_to_send.pop("Host", None)
         response = requests.request(
             method_to_send,
             request_url,

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -9,7 +9,7 @@ import xmltodict
 from requests.models import Request as RequestsRequest
 
 from localstack import config
-from localstack.constants import HEADER_LOCALSTACK_EDGE_URL, TEST_AWS_ACCOUNT_ID
+from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL, TEST_AWS_ACCOUNT_ID
 from localstack.services.generic_proxy import (
     MessageModifyingProxyListener,
     ProxyListener,
@@ -275,7 +275,7 @@ class TestEdgeAPI:
         assert content1_result["Account"] == TEST_AWS_ACCOUNT_ID
 
         headers = aws_stack.mock_aws_request_headers("sts")
-        headers["Accept"] = "application/json"
+        headers["Accept"] = APPLICATION_JSON
         response = requests.post(url, data=data, headers=headers)
         assert response
         content2 = json.loads(to_str(response.content))

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -3,11 +3,13 @@ import json
 import os
 import time
 
+import pytest
 import requests
+import xmltodict
 from requests.models import Request as RequestsRequest
 
 from localstack import config
-from localstack.constants import HEADER_LOCALSTACK_EDGE_URL
+from localstack.constants import HEADER_LOCALSTACK_EDGE_URL, TEST_AWS_ACCOUNT_ID
 from localstack.services.generic_proxy import (
     MessageModifyingProxyListener,
     ProxyListener,
@@ -18,6 +20,7 @@ from localstack.services.messages import Request, Response
 from localstack.utils.aws import aws_stack
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.common import get_free_tcp_port, short_uid, to_str
+from localstack.utils.xml import strip_xmlns
 
 
 class TestEdgeAPI:
@@ -256,3 +259,39 @@ class TestEdgeAPI:
         )
         assert update_path_in_url("http://foo:123/test", "/") == "http://foo:123/"
         assert update_path_in_url("//foo:123/test/123", "bar/1/2/3") == "//foo:123/bar/1/2/3"
+
+    def test_response_content_type(self):
+        url = config.get_edge_url()
+        data = {"Action": "GetCallerIdentity", "Version": "2011-06-15"}
+
+        headers = aws_stack.mock_aws_request_headers("sts")
+        response = requests.post(url, data=data, headers=headers)
+        assert response
+        content1 = to_str(response.content)
+        with pytest.raises(json.decoder.JSONDecodeError):
+            json.loads(content1)
+        content1 = xmltodict.parse(content1)
+        content1_result = content1["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
+        assert content1_result["Account"] == TEST_AWS_ACCOUNT_ID
+
+        headers = aws_stack.mock_aws_request_headers("sts")
+        headers["Accept"] = "application/json"
+        response = requests.post(url, data=data, headers=headers)
+        assert response
+        content2 = json.loads(to_str(response.content))
+        content2_result = content2["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
+        assert content2_result["Account"] == TEST_AWS_ACCOUNT_ID
+        assert strip_xmlns(content1) == content2
+
+    def test_request_with_custom_host_header(self):
+        url = config.get_edge_url()
+
+        headers = aws_stack.mock_aws_request_headers("lambda")
+
+        # using a simple for-loop here (instead of pytest parametrization), for simplicity
+        for host in ["localhost", "example.com"]:
+            for port in ["", ":123", f":{config.EDGE_PORT}"]:
+                headers["Host"] = f"{host}:{port}"
+                response = requests.get(f"{url}/2015-03-31/functions", headers=headers)
+                assert response
+                assert "Functions" in json.loads(to_str(response.content))

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -264,6 +264,7 @@ class TestEdgeAPI:
         url = config.get_edge_url()
         data = {"Action": "GetCallerIdentity", "Version": "2011-06-15"}
 
+        # receive response as XML (default)
         headers = aws_stack.mock_aws_request_headers("sts")
         response = requests.post(url, data=data, headers=headers)
         assert response
@@ -274,6 +275,7 @@ class TestEdgeAPI:
         content1_result = content1["GetCallerIdentityResponse"]["GetCallerIdentityResult"]
         assert content1_result["Account"] == TEST_AWS_ACCOUNT_ID
 
+        # receive response as JSON (via Accept header)
         headers = aws_stack.mock_aws_request_headers("sts")
         headers["Accept"] = APPLICATION_JSON
         response = requests.post(url, data=data, headers=headers)

--- a/tests/integration/test_sts.py
+++ b/tests/integration/test_sts.py
@@ -9,6 +9,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 from localstack.utils.numbers import is_number
 from localstack.utils.strings import to_str
+from tests.integration.fixtures import only_localstack
 
 TEST_SAML_ASSERTION = """
 <?xml version="1.0"?>
@@ -181,6 +182,7 @@ class TestSTSIntegrations:
         assert response["User"]["UserName"] == test_name
         assert response["User"]["UserId"] == test_id
 
+    @only_localstack
     def test_expiration_date_format(self):
         url = config.get_edge_url()
         data = {"Action": "GetSessionToken", "Version": "2011-06-15"}

--- a/tests/integration/test_sts.py
+++ b/tests/integration/test_sts.py
@@ -1,7 +1,14 @@
+import json
 from base64 import b64encode
 
+import requests
+
 from localstack import config
+from localstack.constants import APPLICATION_JSON
+from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
+from localstack.utils.numbers import is_number
+from localstack.utils.strings import to_str
 
 TEST_SAML_ASSERTION = """
 <?xml version="1.0"?>
@@ -173,3 +180,15 @@ class TestSTSIntegrations:
         response = iam_client.get_user()
         assert response["User"]["UserName"] == test_name
         assert response["User"]["UserId"] == test_id
+
+    def test_expiration_date_format(self):
+        url = config.get_edge_url()
+        data = {"Action": "GetSessionToken", "Version": "2011-06-15"}
+        headers = aws_stack.mock_aws_request_headers("sts")
+        headers["Accept"] = APPLICATION_JSON
+        response = requests.post(url, data=data, headers=headers)
+        assert response
+        content = json.loads(to_str(response.content))
+        # Expiration field should be numeric (tested against AWS)
+        result = content["GetSessionTokenResponse"]["GetSessionTokenResult"]
+        assert is_number(result["Credentials"]["Expiration"])


### PR DESCRIPTION
Minor fixes for issues that were discovered during testing the integration with [Mulesoft AnyConnect](https://www.mulesoft.com/platform/cloud-connectors) and when testing against AWS:

1. Support "Accept" header to switch response format. Currently supports only XML->JSON conversion - this will be more nicely generalized once we have the new Gateway in place. /cc @thrau @alexrashed 
2. Fix Flask app routes in Lambda API, to avoid returning 308 redirects for trailing slashes. This can ultimately cause invalid redirects and connection errors in our [edge proxy forwarding](https://github.com/localstack/localstack/blob/ae986b92e74e9d00f13c5a8162867dd94e42c5b2/localstack/services/generic_proxy.py#L661-L668). (as flask is internally using `werkzeug` to [construct the redirect URL](https://github.com/pallets/werkzeug/blob/560dd5f320bff318175f209595d42f5a80045417/src/werkzeug/routing.py#L2149-L2151), which [uses the HTTP `Host` header](https://github.com/pallets/werkzeug/blob/560dd5f320bff318175f209595d42f5a80045417/src/werkzeug/routing.py#L1630) passed in the request). This will become largely obsolete once we have moved off flask, but is still something we may want to be mindful about for the external service providers (DynamoDB, StepFunctions, etc).
3. Fix date format of STS session token `Expiration` for JSON responses. This is only a quick fix for this particular case for now - we'll need a more generic approach to convert timestamp strings to int/double for JSON responses (to be verified with different AWS API calls..).

Point 1 can be replicated via a script like this:
```
import boto3

def add_accept_header(request, **kwargs):
    request.headers.add_header('Accept', 'application/json')

client = boto3.client('sts')
client.meta.events.register_first('before-sign.sts', add_accept_header)
result = client.get_session_token()
print(result)
```

This is an interesting case - the result is returned as JSON, but then the botocore parser is unable to parse the shape (as it is expecting an XML response):
```
botocore.parsers.ResponseParserError: Unable to parse response (not well-formed (invalid token): line 1, column 0), invalid XML received. Further retries may succeed:
b'{"GetSessionTokenResponse":{"GetSessionTokenResult":{"Credentials":{"AccessKeyId":"ASIARCSPW2WN5VEJAONP","Expiration":1.647589601E9,"SecretAccessKey":"vz6xCiLX2vFaioY9hl0gZD2t+TViN5XL1F3Xk4Ed","SessionToken":"FwoGZXIvYXdzEEUaDCJEiCkdpc1hiO9VSiKCAfO0huwDtqmUuQUfxHEau4OVCv98mc2J2pEVE9K5QorMoJf27inhZwFof4TpYtbV/gfUQLyYNH8PcZebY963xY3h30KtA7y8d9heGbgo/GFv4sAxLutQBpMhgz+A8re7cDoN4/0yu7bnv3SXzCA56wg0Ca2pqAZFScBPvIj4L3npkVoooaDOkQYyKIlQuo+SW9D9Ux9/7TsitEXxNWerxyksgkpflIqdqvGqd/rgAv00HrE="}},"ResponseMetadata":{"RequestId":"cf015640-4a1d-489a-9ca2-57901616deaa"}}}'
```