### PR TITLE
Add support for AWS::CDK::Metadata

### DIFF
--- a/localstack/services/cloudformation/models/__init__.py
+++ b/localstack/services/cloudformation/models/__init__.py
@@ -1,5 +1,6 @@
 __all__ = [
     "apigateway",
+    "cdk",
     "certificatemanager",
     "cloudformation",
     "cloudwatch",

--- a/localstack/services/cloudformation/models/cdk.py
+++ b/localstack/services/cloudformation/models/cdk.py
@@ -1,0 +1,16 @@
+from localstack.services.cloudformation.service_models import GenericBaseModel
+
+
+class CDKMetadata(GenericBaseModel):
+    """Used by CDK for analytics/tracking purposes"""
+
+    @staticmethod
+    def cloudformation_type():
+        return "AWS::CDK::Metadata"
+
+    @staticmethod
+    def get_deploy_templates():
+        return {
+            "create": {},
+            "delete": {},
+        }

--- a/localstack/services/cloudformation/models/cdk.py
+++ b/localstack/services/cloudformation/models/cdk.py
@@ -12,5 +12,4 @@ class CDKMetadata(GenericBaseModel):
     def get_deploy_templates():
         return {
             "create": {},
-            "delete": {},
         }

--- a/tests/integration/cloudformation/test_cloudformation_s3.py
+++ b/tests/integration/cloudformation/test_cloudformation_s3.py
@@ -9,7 +9,7 @@ def test_bucketpolicy(
     deploy_cfn_template,
 ):
     bucket_name = f"ls-bucket-{short_uid()}"
-    deploy_cfn_template(
+    deploy_result = deploy_cfn_template(
         template_file_name="s3_bucketpolicy.yaml",
         template_mapping={"bucket_name": bucket_name, "include_policy": True},
     )
@@ -18,6 +18,7 @@ def test_bucketpolicy(
 
     deploy_cfn_template(
         is_update=True,
+        stack_name=deploy_result.stack_id,
         template_file_name="s3_bucketpolicy.yaml",
         template_mapping={"bucket_name": bucket_name, "include_policy": False},
     )

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -487,17 +487,21 @@ def deploy_cfn_template(
     is_change_set_created_and_available,
     is_change_set_finished,
 ):
-    stack_name = f"stack-{short_uid()}"
     state = []
 
     def _deploy(
         *,
         is_update: Optional[bool] = False,
+        stack_name: Optional[str] = None,
         template: Optional[str] = None,
         template_file_name: Optional[str] = None,
         template_mapping: Optional[Dict[str, any]] = None,
         parameters: Optional[Dict[str, str]] = None,
     ) -> DeployResult:
+        if is_update:
+            assert stack_name
+        else:
+            stack_name = f"stack-{short_uid()}"
         change_set_name = f"change-set-{short_uid()}"
 
         if template_file_name is not None and os.path.exists(template_path(template_file_name)):

--- a/tests/integration/templates/cdk_init_template.yaml
+++ b/tests/integration/templates/cdk_init_template.yaml
@@ -1,0 +1,102 @@
+Resources:
+  CDKMetadata:
+    Type: AWS::CDK::Metadata
+    Properties:
+      Analytics: v2:deflate64:H4sIAAABACAA/zPSMzTTO1BMLC/WTU8J1s3JTNKrDo5JTM7WcU7LC0otzi8tSk4FsZ3z81IySzIz82p18vJTUvWygvXLDE30DE31jBWzijMzdYtK10oyc3P1giA0AIArdnxZAAPA
+    Metadata:
+      aws:cdk:path: Tmp2Stack/CDKMetadata/Default
+    Condition: CDKMetadataAvailable
+Conditions:
+  CDKMetadataAvailable:
+    Fn::Or:
+      - Fn::Or:
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - af-south-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ap-east-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ap-northeast-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ap-northeast-2
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ap-south-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ap-southeast-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ap-southeast-2
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - ca-central-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - cn-north-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - cn-northwest-1
+      - Fn::Or:
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - eu-central-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - eu-north-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - eu-south-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - eu-west-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - eu-west-2
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - eu-west-3
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - me-south-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - sa-east-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - us-east-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - us-east-2
+      - Fn::Or:
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - us-west-1
+          - Fn::Equals:
+              - Ref: AWS::Region
+              - us-west-2
+Parameters:
+  BootstrapVersion:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /cdk-bootstrap/hnb659fds/version
+    Description: Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]
+Outputs:
+  BootstrapVersionOutput:
+    Value:
+      Fn::Sub: ${BootstrapVersion}
+Rules:
+  CheckBootstrapVersion:
+    Assertions:
+      - Assert:
+          Fn::Not:
+            - Fn::Contains:
+                - - "1"
+                  - "2"
+                  - "3"
+                  - "4"
+                  - "5"
+                - Ref: BootstrapVersion
+        AssertDescription: CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.


### PR DESCRIPTION
Just a small dummy Cloudformation resource for the AWS::CDK::Metadata resource type that is by default added to every stack deployed via CDK. 