### PR TITLE
Fix name autogeneration for SQS fifo queues

### DIFF
--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -107,10 +107,13 @@ class SQSQueue(GenericBaseModel):
     @staticmethod
     def add_defaults(resource, stack_name: str):
         role_name = resource.get("Properties", {}).get("QueueName")
+
         if not role_name:
             resource["Properties"]["QueueName"] = generate_default_name(
                 stack_name, resource["LogicalResourceId"]
             )
+            if resource["Properties"].get("FifoQueue"):
+                resource["Properties"]["QueueName"] += ".fifo"
 
     @classmethod
     def get_deploy_templates(cls):

--- a/tests/integration/cloudformation/test_cloudformation_sqs.py
+++ b/tests/integration/cloudformation/test_cloudformation_sqs.py
@@ -1,41 +1,21 @@
-from localstack.utils.common import short_uid
-from localstack.utils.generic.wait_utils import wait_until
-from tests.integration.cloudformation.test_cloudformation_changesets import load_template_raw
+def test_sqs_queue_policy(sqs_client, deploy_cfn_template):
+    result = deploy_cfn_template(template_file_name="sqs_with_queuepolicy.yaml")
+    queue_url = result.outputs["QueueUrlOutput"]
+    resp = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["Policy"])
+    assert (
+        "Statement" in resp["Attributes"]["Policy"]
+    )  # just kind of a smoke test to see if its set
 
 
-def test_sqs_queue_policy(
-    cfn_client,
-    sqs_client,
-    cleanup_stacks,
-    cleanup_changesets,
-    is_change_set_created_and_available,
-    is_stack_created,
-):
-    stack_name = f"stack-{short_uid()}"
-    change_set_name = f"change-set-{short_uid()}"
-
-    template_rendered = load_template_raw("sqs_with_queuepolicy.yaml")
-    response = cfn_client.create_change_set(
-        StackName=stack_name,
-        ChangeSetName=change_set_name,
-        TemplateBody=template_rendered,
-        ChangeSetType="CREATE",
+def test_sqs_fifo_queue_generates_valid_name(deploy_cfn_template):
+    result = deploy_cfn_template(
+        template_file_name="sqs_fifo_autogenerate_name.yaml", template_mapping={"is_fifo": "true"}
     )
-    change_set_id = response["Id"]
-    stack_id = response["StackId"]
+    assert ".fifo" in result.outputs["FooQueueName"]
 
-    try:
-        wait_until(is_change_set_created_and_available(change_set_id))
-        cfn_client.execute_change_set(ChangeSetName=change_set_id)
-        wait_until(is_stack_created(stack_id))
-        outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["Outputs"]
-        assert len(outputs) == 1
-        queue_url = outputs[0]["OutputValue"]
-        resp = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["Policy"])
-        assert (
-            "Statement" in resp["Attributes"]["Policy"]
-        )  # just kind of a smoke test to see if its set
 
-    finally:
-        cleanup_changesets([change_set_id])
-        cleanup_stacks([stack_id])
+def test_sqs_non_fifo_queue_generates_valid_name(deploy_cfn_template):
+    result = deploy_cfn_template(
+        template_file_name="sqs_fifo_autogenerate_name.yaml", template_mapping={"is_fifo": "false"}
+    )
+    assert ".fifo" not in result.outputs["FooQueueName"]

--- a/tests/integration/templates/sqs_fifo_autogenerate_name.yaml
+++ b/tests/integration/templates/sqs_fifo_autogenerate_name.yaml
@@ -1,0 +1,15 @@
+Resources:
+  FooQueueA2A23E59:
+    Type: AWS::SQS::Queue
+    Properties:
+      ContentBasedDeduplication: true
+      FifoQueue: {{ is_fifo }}
+      VisibilityTimeout: 300
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+Outputs:
+  FooQueueName:
+    Value:
+      Fn::GetAtt:
+        - FooQueueA2A23E59
+        - QueueName


### PR DESCRIPTION
A recent fix in moto lead to issues for customers using FIFO queues because we didn't account for the required FIFO queue suffix `.fifo` when auto-creating the names with CloudFormation.

Fixes #5692