### PR TITLE
Fix S3 moto invocations

### DIFF
--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -233,7 +233,7 @@ def apply_patches():
     </DeleteResult>"""
 
     @patch(s3_responses.S3ResponseInstance._bucket_response_delete_keys, pass_target=False)
-    def s3_bucket_response_delete_keys(self, body, bucket_name):
+    def s3_bucket_response_delete_keys(self, body, bucket_name, *args, **kwargs):
         template = self.response_template(s3_delete_keys_response_template)
         elements = minidom.parseString(body).getElementsByTagName("Object")
         if len(elements) == 0:

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -159,10 +159,8 @@ def apply_patches():
 
     # patch _key_response_put(..)
     @patch(s3_responses.S3ResponseInstance._key_response_put)
-    def s3_key_response_put(
-        self, fn, request, body, bucket_name, query, key_name, headers, *args, **kwargs
-    ):
-        result = fn(request, body, bucket_name, query, key_name, headers, *args, **kwargs)
+    def s3_key_response_put(self, fn, request, body, bucket_name, query, key_name, *args, **kwargs):
+        result = fn(request, body, bucket_name, query, key_name, *args, **kwargs)
         s3_update_acls(self, request, query, bucket_name, key_name)
         return result
 
@@ -235,7 +233,7 @@ def apply_patches():
     </DeleteResult>"""
 
     @patch(s3_responses.S3ResponseInstance._bucket_response_delete_keys, pass_target=False)
-    def s3_bucket_response_delete_keys(self, request, body, bucket_name):
+    def s3_bucket_response_delete_keys(self, body, bucket_name):
         template = self.response_template(s3_delete_keys_response_template)
         elements = minidom.parseString(body).getElementsByTagName("Object")
         if len(elements) == 0:
@@ -310,7 +308,7 @@ def apply_patches():
             is_delete_keys_v3 = (
                 query and ("delete" in query) and get_safe(query, "$.x-id.0") == "DeleteObjects"
             )
-            return is_delete_keys_v3 or is_delete_keys(request, path, bucket_name)
+            return is_delete_keys_v3 or is_delete_keys(request, path)
         else:
             return utils_is_delete_keys(request, path, bucket_name)
 


### PR DESCRIPTION
Changes introduced in https://github.com/spulec/moto/pull/4929 and https://github.com/localstack/moto/commit/eed32a5f72fbdc0d33c4876d1b5439dfd1efd5d8 break the S3 provider.

```
...
 File "/opt/code/localstack/localstack/utils/patch.py", line 38, in proxy
   return new(target, *args, **kwargs)
 File "/opt/code/localstack/localstack/utils/aws/request_context.py", line 163, in convert_to_flask_response_call
   return fn(*args, **kwargs)
 File "/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/core/utils.py", line 127, in __call__
   result = self.callback(request, request.url, dict(request.headers))
 File "/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/core/utils.py", line 261, in _wrapper
   response = f(*args, **kwargs)
 File "/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/s3/responses.py", line 261, in bucket_response
   response = self._bucket_response(request, full_url)
 File "/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/s3/responses.py", line 313, in _bucket_response
   return self._bucket_response_post(request, body, bucket_name)
 File "/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/s3/responses.py", line 937, in _bucket_response_post
if self.is_delete_keys(request, path, bucket_name):
 File "/opt/code/localstack/localstack/services/s3/s3_starter.py", line 311, in s3_response_is_delete_keys
   return is_delete_keys_v3 or is_delete_keys(request, path, bucket_name)
TypeError: is_delete_keys() takes 2 positional arguments but 3 were given
```

Support ticket: u0325dr4l8m