### PR TITLE
sources domain and domain prefix from invocation context

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -903,13 +903,12 @@ def get_event_request_context(invocation_context: ApiInvocationContext):
     integration_uri = integration_uri or ""
     account_id = integration_uri.split(":lambda:path")[-1].split(":function:")[0].split(":")[-1]
     account_id = account_id or TEST_AWS_ACCOUNT_ID
-    domain_name = f"{api_id}.execute-api.{LOCALHOST_HOSTNAME}"
     request_context = {
         "accountId": account_id,
         "apiId": api_id,
         "resourcePath": resource_path or relative_path,
-        "domainPrefix": api_id,
-        "domainName": domain_name,
+        "domainPrefix": invocation_context.domain_prefix,
+        "domainName": invocation_context.domain_name,
         "resourceId": resource_id,
         "requestId": long_uid(),
         "identity": {

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, Union
 
 from responses import Response
 
+from localstack.constants import HEADER_LOCALSTACK_EDGE_URL
 from localstack.utils.aws.aws_responses import parse_query_string
 
 # type definition for data parameters (i.e., invocation payloads)
@@ -159,3 +160,16 @@ class ApiInvocationContext:
             )
         except UnicodeDecodeError:
             return base64.b64encode(self.data)
+
+    def _extract_host_from_header(self):
+        host = self.headers.get(HEADER_LOCALSTACK_EDGE_URL) or self.headers.get("host", "")
+        return host.split("://")[-1].split("/")[0].split(":")[0]
+
+    @property
+    def domain_name(self):
+        return self._extract_host_from_header()
+
+    @property
+    def domain_prefix(self):
+        host = self._extract_host_from_header()
+        return host.split(".")[0]


### PR DESCRIPTION
Sources the `domainName` and `domainPrefix` from invocation context setup downstream.

Addresses https://github.com/localstack/localstack/issues/5603