### PR TITLE
fix ACM DomainValidationOptions to support waiters

### DIFF
--- a/localstack/services/acm/provider.py
+++ b/localstack/services/acm/provider.py
@@ -20,9 +20,7 @@ def describe(describe_orig, self):
         "ExtendedKeyUsages": [],
         "Options": {"CertificateTransparencyLoggingPreference": "ENABLED"},
     }
-    addenda["DomainValidationOptions"] = options = (
-        getattr(self, "domain_validation_options", None) or []
-    )
+    addenda["DomainValidationOptions"] = options = cert.get("DomainValidationOptions")
     if not options:
         options = addenda["DomainValidationOptions"] = [
             {"ValidationMethod": cert.get("ValidationMethod")}

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -710,6 +710,29 @@ def create_secret(secretsmanager_client):
         secretsmanager_client.delete_secret(SecretId=item)
 
 
+@pytest.fixture
+def acm_request_certificate(acm_client):
+    certificate_arns = []
+
+    def factory(**kwargs) -> str:
+        if "DomainName" not in kwargs:
+            kwargs["DomainName"] = f"test-domain-{short_uid()}.localhost.localstack.cloud"
+
+        response = acm_client.request_certificate(**kwargs)
+        created_certificate_arn = response["CertificateArn"]
+        certificate_arns.append(created_certificate_arn)
+        return created_certificate_arn
+
+    yield factory
+
+    # cleanup
+    for certificate_arn in certificate_arns:
+        try:
+            acm_client.delete_certificate(CertificateArn=certificate_arn)
+        except Exception as e:
+            LOG.debug("error cleaning up certificate %s: %s", certificate_arn, e)
+
+
 only_localstack = pytest.mark.skipif(
     os.environ.get("TEST_TARGET") == "AWS_CLOUD",
     reason="test only applicable if run against localstack",


### PR DESCRIPTION
Fixes the `DomainValidationOptions` for ACM's `DescribeCertificate` operation.
The previous implementation did not use the existing array of the cert in the CertBundle, but tried to resolve a non-existing attribute, which in the end wasn't set (since the `addenda` would only be used for non-existing keys in the result).

This fix is necessary to fix the ACM waiter on `certificate-validation`, which can be executed with awscli / awscli-local:
```
$ awslocal awslocal acm request-certificate --domain-name test-domain.localhost.localstack.cloud
{
    "CertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/1547a44e-8ff9-4ee3-92f3-7e0f2bcf9b74"
}
$ awslocal acm wait certificate-validated --certificate-arn "arn:aws:acm:us-east-1:000000000000:certificate/1547a44e-8ff9-4ee3-92f3-7e0f2bcf9b74"
```
Without this fix, the latter call would not be successful (because the `DomainValidationOptions` of `DescribeCertificate` would never state that the `ValidationStatus` is `SUCCESSFUL`). 
The same mechanism is used when creating a `DnsValidatedCertificate` with CDK.