### PR TITLE
Remove redundant EC2 test

### DIFF
--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -277,22 +277,3 @@ class TestEc2Integrations:
 
         # clean up
         ec2_client.delete_vpc(VpcId=vpc_id)
-
-    def test_terminate_instances(self, ec2_client):
-        kwargs = {
-            "MinCount": 1,
-            "MaxCount": 1,
-            "ImageId": "ami-d3adb33f",
-            "KeyName": "the_key",
-            "InstanceType": "t1.micro",
-            "BlockDeviceMappings": [{"DeviceName": "/dev/sda2", "Ebs": {"VolumeSize": 50}}],
-        }
-
-        resp1 = ec2_client.run_instances(**kwargs)
-
-        instances = []
-        for instance in resp1["Instances"]:
-            instances.append(instance.get("InstanceId"))
-
-        resp = ec2_client.terminate_instances(InstanceIds=instances)
-        assert instances[0] == resp["TerminatingInstances"][0]["InstanceId"]


### PR DESCRIPTION
An EC2 test for terminate instance fails with: 

```
         if http.status_code >= 300:
            error_code = parsed_response.get("Error", {}).get("Code")
            error_class = self.exceptions.from_code(error_code)
>           raise error_class(parsed_response, operation_name)
E           botocore.exceptions.ClientError: An error occurred (InvalidAMIID.NotFound) when calling the RunInstances operation: The image id 'ami-d3adb33f' does not exist

/home/runner/work/localstack/localstack/localstack-ext/.venv/lib/python3.8/site-packages/botocore/client.py:725: ClientError
```
Reason for failure: The CI runs this test against the pro edition. The Docker EC2 provider expects a valid AMI ID corresponding to a Docker image.

This test is removed as redundant because:
- The functionality is tested in -ext https://github.com/localstack/localstack-ext/blob/master/tests/integration/test_ec2.py#L83
- And in moto https://github.com/spulec/moto/blob/29d01c3/tests/test_ec2/test_instances.py#L39
- There is no custom functionality for terminate instances in community provider