### PR TITLE
fix eager deserialization for for 404 responses that come from lambda

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -152,13 +152,15 @@ class ProxyListenerApiGateway(ProxyListener):
 
         # add missing implementations
         if response.status_code == 404:
-            data = data and json.loads(to_str(data))
             result = None
             if path == "/account":
+                data = data and json.loads(to_str(data))
                 result = handle_accounts(method, path, data, headers)
             elif path.startswith("/vpclinks"):
+                data = data and json.loads(to_str(data))
                 result = handle_vpc_links(method, path, data, headers)
             elif re.match(PATH_REGEX_CLIENT_CERTS, path):
+                data = data and json.loads(to_str(data))
                 result = handle_client_certificates(method, path, data, headers)
 
             if result is not None:


### PR DESCRIPTION
This PR fixes a scenario where the lambda response has a `404` as a status code (check https://github.com/localstack/localstack/issues/5689 for details) and it was entering this unrelated code path. Moving the deserialization code under the respective code path avoids decoding a binary response

Test example https://github.com/localstack/troubleshooting-issues/tree/main/issue_5689
Addresses https://github.com/localstack/localstack/issues/5689