### PR TITLE
fix CloudFormation Route53 deployment without ResourceRecords

### DIFF
--- a/localstack/services/cloudformation/models/route53.py
+++ b/localstack/services/cloudformation/models/route53.py
@@ -40,7 +40,8 @@ class Route53RecordSet(GenericBaseModel):
             attrs = select_attributes(params, attr_names)
             alias_target = attrs.get("AliasTarget", {})
             alias_target["EvaluateTargetHealth"] = alias_target.get("EvaluateTargetHealth", False)
-            attrs["ResourceRecords"] = [{"Value": r} for r in attrs["ResourceRecords"]]
+            if "ResourceRecords" in attrs:
+                attrs["ResourceRecords"] = [{"Value": r} for r in attrs["ResourceRecords"]]
             return {
                 "Comment": params.get("Comment", ""),
                 "Changes": [{"Action": "CREATE", "ResourceRecordSet": attrs}],

--- a/tests/integration/cloudformation/test_cloudformation_route53.py
+++ b/tests/integration/cloudformation/test_cloudformation_route53.py
@@ -15,3 +15,14 @@ def test_create_record_set_via_name(deploy_cfn_template, route53_hosted_zone):
     deploy_cfn_template(
         template_file_name="route53_hostedzonename_template.yaml", template_mapping=template_mapping
     )
+
+
+def test_create_record_set_without_resource_record(deploy_cfn_template, route53_hosted_zone):
+    create_zone_response = route53_hosted_zone()
+    hosted_zone_id = create_zone_response["HostedZone"]["Id"]
+    route53_name = create_zone_response["HostedZone"]["Name"]
+    template_mapping = {"HostedZoneId": hosted_zone_id, "Name": route53_name}
+    deploy_cfn_template(
+        template_file_name="route53_recordset_without_resource_records.yaml",
+        template_mapping=template_mapping,
+    )

--- a/tests/integration/templates/route53_recordset_without_resource_records.yaml
+++ b/tests/integration/templates/route53_recordset_without_resource_records.yaml
@@ -1,0 +1,8 @@
+Resources:
+  myDNSWithNameRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: {{HostedZoneId}}
+      Name: {{Name}}
+      TTL: 900
+      Type: A


### PR DESCRIPTION
Fixes a small regression which was introduced with https://github.com/localstack/localstack/pull/5695 where _CloudFormation_ deployments fail if the template contains _Route53_ `RecordSets` which do not have `ResourceRecords` set ([even though these are optional](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordset.html)).