### PR TITLE
Fix Terraform creation of EC2 Security Groups with default egress

### DIFF
--- a/tests/integration/terraform/ec2.tf
+++ b/tests/integration/terraform/ec2.tf
@@ -14,3 +14,28 @@ resource "aws_security_group" "test-sg" {
   description = "Test Security Group test-sg"
   vpc_id      = aws_vpc.main-vpc.id
 }
+
+resource "aws_security_group" "tls_allow" {
+  name        = "tls_allow"
+  description = "TF SG with ingress / egress rules"
+  vpc_id      = aws_vpc.main-vpc.id
+
+  ingress {
+    description      = "TLS from VPC"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = [aws_vpc.main-vpc.cidr_block]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}


### PR DESCRIPTION
Fix Terraform creation of EC2 Security Groups with default egress.

Prior to this change, the following TF script:
```

resource "aws_security_group" "tls_allow" {
  name        = "tls_allow"
  vpc_id      = "vpc-..."

  ingress {
    description      = "TLS traffic"
    from_port        = 443
    to_port          = 443
    protocol         = "tcp"
    cidr_blocks      = ["8.0.0.0/24"]
  }

  egress {
    from_port        = 0
    to_port          = 0
    protocol         = "-1"
    cidr_blocks      = ["0.0.0.0/0"]
  }

  tags = {
    Name = "allow_tls"
  }
}
```

... would fail with the following error:
```
2022-03-22T16:46:54.176+0100 [INFO]  provider.terraform-provider-aws_v3.75.0_x5: 2022/03/22 16:46:54 [DEBUG] [aws-sdk-go] DEBUG: Validate Response ec2/RevokeSecurityGroupEgress failed, attempt 0/25, error InvalidPermission.NotFound: The specified rule does not exist in this security group
	status code: 400, request id: 7a62c49f-347e-4fc4-9331-6e8eEXAMPLE: timestamp=2022-03-22T16:46:54.176+0100
╷
│ Error: Error revoking default egress rule for Security Group (sg-de2b193fa7e897815): InvalidPermission.NotFound: The specified rule does not exist in this security group
│ 	status code: 400, request id: 7a62c49f-347e-4fc4-9331-6e8eEXAMPLE
│
│   with aws_security_group.tls_allow,
│   on main.tf line 50, in resource "aws_security_group" "tls_allow":
│   50: resource "aws_security_group" "tls_allow" {
```