### PR TITLE
Target HttpParameters and Input support and basic auth fix for Events service

### DIFF
--- a/localstack/services/events/events_listener.py
+++ b/localstack/services/events/events_listener.py
@@ -93,7 +93,7 @@ def get_scheduled_rule_func(data):
             event = json.loads(event_str)
             attr = aws_stack.get_events_target_attributes(target)
             try:
-                send_event_to_target(arn, event, target_attributes=attr)
+                send_event_to_target(arn, event, target_attributes=attr, target=target)
             except Exception as e:
                 LOG.info(
                     f"Unable to send event notification {truncate(event)} to target {target}: {e}"

--- a/localstack/services/events/events_starter.py
+++ b/localstack/services/events/events_starter.py
@@ -126,8 +126,12 @@ def process_events(event: Dict, targets: List[Dict]):
     for target in targets:
         arn = target["Arn"]
         changed_event = filter_event_with_target_input_path(target, event)
+        if target.get("Input"):
+            changed_event = json.loads(target.get("Input"))
         try:
-            send_event_to_target(arn, changed_event, aws_stack.get_events_target_attributes(target))
+            send_event_to_target(
+                arn, changed_event, aws_stack.get_events_target_attributes(target), target=target
+            )
         except Exception as e:
             LOG.info(f"Unable to send event notification {truncate(event)} to target {target}: {e}")
 

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import logging
 import re
@@ -15,9 +16,9 @@ from localstack.utils.aws.aws_stack import (
     get_sqs_queue_url,
 )
 from localstack.utils.generic import dict_utils
-from localstack.utils.http import add_query_params_to_url
+from localstack.utils.http import add_path_parameters_to_url, add_query_params_to_url
 from localstack.utils.http import safe_requests as requests
-from localstack.utils.strings import long_uid, to_bytes
+from localstack.utils.strings import long_uid, to_bytes, to_str
 from localstack.utils.time import now_utc, timestamp_millis
 
 LOG = logging.getLogger(__name__)
@@ -71,7 +72,11 @@ def lambda_result_to_destination(
 
 
 def send_event_to_target(
-    target_arn: str, event: Dict, target_attributes: Dict = None, asynchronous: bool = True
+    target_arn: str,
+    event: Dict,
+    target_attributes: Dict = None,
+    asynchronous: bool = True,
+    target: Dict = {},
 ):
     region = target_arn.split(":")[3]
 
@@ -107,7 +112,7 @@ def send_event_to_target(
 
     elif ":events:" in target_arn:
         if ":api-destination/" in target_arn or ":destination/" in target_arn:
-            send_event_to_api_destination(target_arn, event)
+            send_event_to_api_destination(target_arn, event, target.get("HttpParameters"))
 
         else:
             events_client = connect_to_service("events", region_name=region)
@@ -163,7 +168,10 @@ def auth_keys_from_connection(connection: Dict):
         basic_auth_parameters = auth_parameters.get("BasicAuthParameters", {})
         username = basic_auth_parameters.get("Username", "")
         password = basic_auth_parameters.get("Password", "")
-        headers.update({"authorization": "Basic {}:{}".format(username, password)})
+        auth = "Basic " + to_str(
+            base64.b64encode("{}:{}".format(username, password).encode("ascii"))
+        )
+        headers.update({"authorization": auth})
 
     if auth_type == AUTH_API_KEY:
         api_key_parameters = auth_parameters.get("ApiKeyAuthParameters", {})
@@ -210,7 +218,7 @@ def list_of_parameters_to_object(items):
     return {item.get("Key"): item.get("Value") for item in items}
 
 
-def send_event_to_api_destination(target_arn, event):
+def send_event_to_api_destination(target_arn, event, http_parameters: Dict = None):
     """Send an event to an EventBridge API destination
     See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html"""
 
@@ -236,6 +244,8 @@ def send_event_to_api_destination(target_arn, event):
     }
 
     endpoint = add_api_destination_authorization(destination, headers, event)
+    if http_parameters:
+        endpoint = add_http_parameters(http_parameters, endpoint, headers, event)
 
     result = requests.request(
         method=method, url=endpoint, data=json.dumps(event or {}), headers=headers
@@ -276,4 +286,11 @@ def add_api_destination_authorization(destination, headers, event):
         query_object = list_of_parameters_to_object(query_parameters)
         endpoint = add_query_params_to_url(endpoint, query_object)
 
+    return endpoint
+
+
+def add_http_parameters(http_parameters: Dict, endpoint: str, headers: Dict, body):
+    headers.update(http_parameters.get("HeaderParameters", {}))
+    endpoint = add_path_parameters_to_url(endpoint, http_parameters.get("PathParameterValues", []))
+    endpoint = add_query_params_to_url(endpoint, http_parameters.get("QueryStringParameters", {}))
     return endpoint

--- a/localstack/utils/http.py
+++ b/localstack/utils/http.py
@@ -66,6 +66,15 @@ def canonicalize_headers(headers: Union[Dict, CaseInsensitiveDict]) -> Dict:
     return result
 
 
+def add_path_parameters_to_url(uri: str, path_params: list):
+    url = urlparse(uri)
+    last_character = (
+        "/" if (len(url.path) == 0 or url.path[-1] != "/") and len(path_params) > 0 else ""
+    )
+    new_path = url.path + last_character + "/".join(path_params)
+    return urlunparse(url._replace(path=new_path))
+
+
 def add_query_params_to_url(uri: str, query_params: Dict) -> str:
     """
     Add query parameters to the uri.


### PR DESCRIPTION
Continuation of issue #5229, where apparently I missed the integration of the HttpParameters of the Put Target request.

Changes:
- Fixing of Basic mode Auth header, now it is base64 encoded. 
- Correction of the Basic mode auth test, now the test only expects the correct way.
- The HttpParametes of the PutTarget request are now integrated
- The event to send is replaced for Input parameter if it is defined in the Put target request. As this doc [indicates](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutTargets.html).
- The test for api-destinations now considers the new changes.