### PR TITLE
skip "online-only" tests, fix some tests

### DIFF
--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -416,7 +416,7 @@ class CmdDockerClient(ContainerClient):
         try:
             run(self._docker_cmd() + ["ps"])
             return True
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
     def create_container(self, image_name: str, **kwargs) -> str:

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -1166,6 +1166,7 @@ class TestRubyRuntimes:
 
 
 class TestGolangRuntimes:
+    @pytest.mark.skip
     def test_golang_lambda(self, lambda_client, tmp_path, create_lambda_function):
         # fetch platform-specific example handler
         url = TEST_GOLANG_LAMBDA_URL_TEMPLATE.format(

--- a/tests/integration/docker_utils/conftest.py
+++ b/tests/integration/docker_utils/conftest.py
@@ -1,16 +1,16 @@
 import pytest
 
 from localstack.config import is_env_not_false
+from localstack.utils.container_utils.container_client import ContainerClient
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.container_utils.docker_sdk_client import SdkDockerClient
-from localstack.utils.docker_utils import DOCKER_CLIENT
 
 
-def _check_skip():
+def _check_skip(client: ContainerClient):
     if not is_env_not_false("SKIP_DOCKER_TESTS"):
         pytest.skip("SKIP_DOCKER_TESTS is set")
 
-    if not DOCKER_CLIENT.has_docker():
+    if not client.has_docker():
         pytest.skip("Docker is not available")
 
 
@@ -18,5 +18,8 @@ def _check_skip():
     params=[CmdDockerClient(), SdkDockerClient()], ids=["CmdDockerClient", "SdkDockerClient"]
 )
 def docker_client(request):
-    _check_skip()  # this is a hack to get a global skip for all tests that require the docker client
-    yield request.param
+    client = request.param
+    _check_skip(
+        client
+    )  # this is a hack to get a global skip for all tests that require the docker client
+    yield client

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1198,6 +1198,7 @@ class TestCloudFormation:
         rs = logs_client.describe_log_groups(logGroupNamePrefix=log_group_prefix)
         assert len(rs["logGroups"]) == 0
 
+    @pytest.mark.skip_offline
     def test_cfn_handle_elasticsearch_domain(self):
         stack_name = "stack-%s" % short_uid()
         domain_name = "es-%s" % short_uid()

--- a/tests/integration/test_es.py
+++ b/tests/integration/test_es.py
@@ -139,7 +139,7 @@ class TestElasticsearchProvider:
         assert "ElasticsearchVersion" in status
         assert status["ElasticsearchVersion"] == "7.10"
 
-    @pytest.mark.potentially_fixed
+    @pytest.mark.skip_offline
     def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain, es_client):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
         monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)

--- a/tests/integration/test_es.py
+++ b/tests/integration/test_es.py
@@ -95,6 +95,7 @@ class TestElasticsearchProvider:
             "TargetVersions": ["7.8", "7.9", "7.10", "OpenSearch_1.0", "OpenSearch_1.1"],
         } in versions
 
+    @pytest.mark.skip_offline
     def test_get_compatible_version_for_domain(self, es_client, opensearch_domain):
         response = es_client.get_compatible_elasticsearch_versions(DomainName=opensearch_domain)
         assert "CompatibleElasticsearchVersions" in response
@@ -102,12 +103,14 @@ class TestElasticsearchProvider:
         # The default version is the latest version, which is not compatible with any previous versions
         assert len(versions) == 0
 
+    @pytest.mark.skip_offline
     def test_create_domain(self, es_client, opensearch_create_domain):
         es_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = es_client.list_domain_names(EngineType="Elasticsearch")
         domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
         assert es_domain in domain_names
 
+    @pytest.mark.skip_offline
     def test_create_existing_domain_causes_exception(self, es_client, opensearch_create_domain):
         domain_name = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
 
@@ -115,12 +118,14 @@ class TestElasticsearchProvider:
             es_client.create_elasticsearch_domain(DomainName=domain_name)
         assert exc_info.type.__name__ == "ResourceAlreadyExistsException"
 
+    @pytest.mark.skip_offline
     def test_describe_domains(self, es_client, opensearch_create_domain):
         opensearch_domain = opensearch_create_domain(EngineVersion=ELASTICSEARCH_DEFAULT_VERSION)
         response = es_client.describe_elasticsearch_domains(DomainNames=[opensearch_domain])
         assert len(response["DomainStatusList"]) == 1
         assert response["DomainStatusList"][0]["DomainName"] == opensearch_domain
 
+    @pytest.mark.skip_offline
     def test_domain_version(self, es_client, opensearch_domain, opensearch_create_domain):
         response = es_client.describe_elasticsearch_domain(DomainName=opensearch_domain)
         assert "DomainStatus" in response
@@ -134,6 +139,7 @@ class TestElasticsearchProvider:
         assert "ElasticsearchVersion" in status
         assert status["ElasticsearchVersion"] == "7.10"
 
+    @pytest.mark.potentially_fixed
     def test_path_endpoint_strategy(self, monkeypatch, opensearch_create_domain, es_client):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "path")
         monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -145,6 +145,7 @@ def test_firehose_http(lambda_processor_enabled: bool):
 
 
 class TestFirehoseIntegration:
+    @pytest.mark.skip_offline
     @pytest.mark.parametrize("opensearch_endpoint_strategy", ["domain", "path"])
     def test_kinesis_firehose_elasticsearch_s3_backup(
         self,
@@ -250,6 +251,7 @@ class TestFirehoseIntegration:
             firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
             es_client.delete_elasticsearch_domain(DomainName=domain_name)
 
+    @pytest.mark.skip_offline
     @pytest.mark.parametrize("opensearch_endpoint_strategy", ["domain", "path"])
     def test_kinesis_firehose_opensearch_s3_backup(
         self,

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -76,6 +76,7 @@ def try_cluster_health(cluster_url: str):
     ], "expected cluster state to be in a valid state"
 
 
+@pytest.mark.skip_offline
 class TestOpensearchProvider:
     """
     Because this test reuses the localstack instance for each test, all tests are performed with
@@ -365,6 +366,7 @@ class TestOpensearchProvider:
         )
 
 
+@pytest.mark.skip_offline
 class TestEdgeProxiedOpensearchCluster:
     def test_route_through_edge(self):
         cluster_id = f"domain-{short_uid()}"
@@ -396,8 +398,8 @@ class TestEdgeProxiedOpensearchCluster:
         ), "gave up waiting for cluster to shut down"
 
 
+@pytest.mark.skip_offline
 class TestMultiClusterManager:
-    @pytest.mark.skip_offline
     def test_multi_cluster(self, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "domain")
         monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", True)
@@ -439,8 +441,8 @@ class TestMultiClusterManager:
             call_safe(cluster_1.shutdown)
 
 
+@pytest.mark.skip_offline
 class TestMultiplexingClusterManager:
-    @pytest.mark.skip_offline
     def test_multiplexing_cluster(self, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "domain")
         monkeypatch.setattr(config, "OPENSEARCH_MULTI_CLUSTER", False)
@@ -482,6 +484,7 @@ class TestMultiplexingClusterManager:
             call_safe(cluster_1.shutdown)
 
 
+@pytest.mark.skip_offline
 class TestSingletonClusterManager:
     def test_endpoint_strategy_port_singleton_cluster(self, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "port")
@@ -521,6 +524,7 @@ class TestSingletonClusterManager:
             call_safe(cluster_1.shutdown)
 
 
+@pytest.mark.skip_offline
 class TestCustomBackendManager:
     def test_custom_backend(self, httpserver, monkeypatch):
         monkeypatch.setattr(config, "OPENSEARCH_ENDPOINT_STRATEGY", "domain")

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -1,8 +1,11 @@
+import pytest as pytest
+
 from localstack.constants import LOCALHOST
 from localstack.utils.common import short_uid
 from localstack.utils.net import resolve_hostname
 
 
+@pytest.mark.skip_offline
 def test_resolve_hostname():
     assert "127." in resolve_hostname(LOCALHOST)
     assert resolve_hostname("example.com")


### PR DESCRIPTION
This PR adds the mark "skip_offline" to a set of tests which do need internet access when being executed.
In addition it fixes the check for the `CmdDockerClient` (which raises a `FileNotFoundError` if the binary is not available).