### PR TITLE
fix broken transitive imports of quart from jinja

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,8 @@ runtime =
     #pympler>=0.6
     pyopenssl>=21.0.0
     Quart>=0.6.15
+    # Pin Jinja2 (transitive dep of Quart) until this bug is fixed: https://github.com/pgjones/quart/issues/141
+    Jinja2<=3.0.3
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
     #sasl>=0.2.1


### PR DESCRIPTION
Our test pipelines recently broke due to the following error:
```
Traceback:
/usr/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/unit/test_apigateway.py:10: in <module>
    from localstack.services.apigateway import apigateway_listener
localstack/services/apigateway/apigateway_listener.py:24: in <module>
    from localstack.services.apigateway import helpers
localstack/services/apigateway/helpers.py:22: in <module>
    from localstack.services.generic_proxy import RegionBackend
localstack/services/generic_proxy.py:48: in <module>
    from localstack.utils.server import http2_server
localstack/utils/server/http2_server.py:16: in <module>
    from quart import Quart
.venv/lib/python3.8/site-packages/quart/__init__.py:3: in <module>
    from jinja2 import escape, Markup
E   ImportError: cannot import name 'escape' from 'jinja2' (/tmp/workspace/repo/.venv/lib/python3.8/site-packages/jinja2/__init__.py)
```

This issue is caused by an update of [Jinja2 (3.1.0)](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0) which removes deprecated code.
This causes issues with Quart (of which Jinja is a transitive dependency): https://github.com/pgjones/quart/issues/141

This PR limits the version of Jinja2 to the latest working version (3.0.3). This workaround can be removed as soon as the issue in Quart is fixed and released.