### PR TITLE
Fix MessageGroupId for publish batch to SQS fifo queue

### DIFF
--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -532,8 +532,6 @@ async def message_to_subscriber(
                 queue_url = aws_stack.get_sqs_queue_url(queue_name)
                 subscriber["sqs_queue_url"] = queue_url
 
-
-
             message_group_id = (
                 req_data.get("MessageGroupId") if req_data.get("MessageGroupId") else ""
             )

--- a/localstack/services/sns/sns_listener.py
+++ b/localstack/services/sns/sns_listener.py
@@ -532,9 +532,14 @@ async def message_to_subscriber(
                 queue_url = aws_stack.get_sqs_queue_url(queue_name)
                 subscriber["sqs_queue_url"] = queue_url
 
+
+
             message_group_id = (
-                req_data.get("MessageGroupId")[0] if req_data.get("MessageGroupId") else ""
+                req_data.get("MessageGroupId") if req_data.get("MessageGroupId") else ""
             )
+
+            if isinstance(message_group_id, list):
+                message_group_id = message_group_id[0]
 
             message_deduplication_id = (
                 req_data.get("MessageDeduplicationId")[0]

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1086,16 +1086,16 @@ class TestSNS:
         self.sns_client.subscribe(
             TopicArn=topic_arn,
             Protocol="sqs",
-            Endpoint=queue_arn,
+            Endpoint=queue_url,
             Attributes={"RawMessageDelivery": "true"},
         )
-
+        message_group_id = "complexMessageGroupId"
         publish_batch_response = self.sns_client.publish_batch(
             TopicArn=topic_arn,
             PublishBatchRequestEntries=[
                 {
                     "Id": "1",
-                    "MessageGroupId": "1",
+                    "MessageGroupId": message_group_id,
                     "Message": "Test Message with two attributes",
                     "Subject": "Subject",
                     "MessageAttributes": {
@@ -1105,14 +1105,14 @@ class TestSNS:
                 },
                 {
                     "Id": "2",
-                    "MessageGroupId": "1",
+                    "MessageGroupId": message_group_id,
                     "Message": "Test Message with one attribute",
                     "Subject": "Subject",
                     "MessageAttributes": {"attr1": {"DataType": "Number", "StringValue": "19.12"}},
                 },
                 {
                     "Id": "3",
-                    "MessageGroupId": "1",
+                    "MessageGroupId": message_group_id,
                     "Message": "Test Message without attribute",
                     "Subject": "Subject",
                 },
@@ -1128,8 +1128,9 @@ class TestSNS:
 
         def get_messages(queue_url):
             response = self.sqs_client.receive_message(
-                QueueUrl=queue_url, MessageAttributeNames=["All"], MaxNumberOfMessages=10
+                QueueUrl=queue_url, MessageAttributeNames=["All"]
             )
+            print(response)
             assert len(response["Messages"]) == 3
             for message in response["Messages"]:
                 assert "Body" in message

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1081,7 +1081,6 @@ class TestSNS:
         )
 
         queue_url = queue["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
 
         self.sns_client.subscribe(
             TopicArn=topic_arn,
@@ -1128,12 +1127,15 @@ class TestSNS:
 
         def get_messages(queue_url):
             response = self.sqs_client.receive_message(
-                QueueUrl=queue_url, MessageAttributeNames=["All"]
+                QueueUrl=queue_url,
+                MessageAttributeNames=["All"],
+                AttributeNames=["All"],
+                MaxNumberOfMessages=10,
             )
-            print(response)
             assert len(response["Messages"]) == 3
             for message in response["Messages"]:
                 assert "Body" in message
+                assert message["Attributes"]["MessageGroupId"] == message_group_id
 
                 if message["Body"] == "Test Message with two attributes":
                     assert len(message["MessageAttributes"]) == 2


### PR DESCRIPTION
This PR addresses issue #5746. Seems to be that depending on the type of message publication, the SNS client sends the MessageGroupId as a string or a List of strings. 

Changes:
- Code addition that considers the different format.
- Test extension.
