### PR TITLE
Fixes zone-name filter bug in describe-availability-zones

### DIFF
--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -58,29 +58,19 @@ class Ec2Provider(Ec2Api, ABC):
             for zone in zone_names:
                 zone_detail = backend.get_zone_by_name(zone)
                 if zone_detail:
-                    _zone_data = AvailabilityZone(
-                        State="available",
-                        Messages=[],
-                        RegionName=zone_detail.region_name,
-                        ZoneName=zone_detail.name,
-                        ZoneId=zone_detail.zone_id,
+                    availability_zones.append(
+                        AvailabilityZone(
+                            State="available",
+                            Messages=[],
+                            RegionName=zone_detail.region_name,
+                            ZoneName=zone_detail.name,
+                            ZoneId=zone_detail.zone_id,
+                        )
                     )
-                    availability_zones.append(_zone_data)
 
             return DescribeAvailabilityZonesResult(AvailabilityZones=availability_zones)
-        else:
-            all_zones_detail = backend.describe_availability_zones()
-            for zone_detail in all_zones_detail:
-                _zone_data = AvailabilityZone(
-                    State="available",
-                    Messages=[],
-                    RegionName=zone_detail.region_name,
-                    ZoneName=zone_detail.name,
-                    ZoneId=zone_detail.zone_id,
-                )
-                availability_zones.append(_zone_data)
 
-            return DescribeAvailabilityZonesResult(AvailabilityZones=availability_zones)
+        return call_moto(context)
 
     @handler("DescribeReservedInstancesOfferings", expand=False)
     def describe_reserved_instances_offerings(

--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -6,9 +6,8 @@ from moto.ec2.exceptions import InvalidVpcEndPointIdError
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.ec2 import (
-    Boolean,
     AvailabilityZone,
-    AvailabilityZones,
+    Boolean,
     CurrencyCodeValues,
     DescribeAvailabilityZonesRequest,
     DescribeAvailabilityZonesResult,
@@ -45,7 +44,6 @@ from localstack.utils.strings import long_uid
 
 
 class Ec2Provider(Ec2Api, ABC):
-
     @handler("DescribeAvailabilityZones", expand=False)
     def describe_availability_zones(
         self,
@@ -65,13 +63,11 @@ class Ec2Provider(Ec2Api, ABC):
                         Messages=[],
                         RegionName=zone_detail.region_name,
                         ZoneName=zone_detail.name,
-                        ZoneId=zone_detail.zone_id
+                        ZoneId=zone_detail.zone_id,
                     )
                     availability_zones.append(_zone_data)
 
-        return DescribeAvailabilityZonesResult(
-            AvailabilityZones=availability_zones
-        )
+        return DescribeAvailabilityZonesResult(AvailabilityZones=availability_zones)
 
     @handler("DescribeReservedInstancesOfferings", expand=False)
     def describe_reserved_instances_offerings(

--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -67,7 +67,20 @@ class Ec2Provider(Ec2Api, ABC):
                     )
                     availability_zones.append(_zone_data)
 
-        return DescribeAvailabilityZonesResult(AvailabilityZones=availability_zones)
+            return DescribeAvailabilityZonesResult(AvailabilityZones=availability_zones)
+        else:
+            all_zones_detail = backend.describe_availability_zones()
+            for zone_detail in all_zones_detail:
+                _zone_data = AvailabilityZone(
+                    State="available",
+                    Messages=[],
+                    RegionName=zone_detail.region_name,
+                    ZoneName=zone_detail.name,
+                    ZoneId=zone_detail.zone_id,
+                )
+                availability_zones.append(_zone_data)
+
+            return DescribeAvailabilityZonesResult(AvailabilityZones=availability_zones)
 
     @handler("DescribeReservedInstancesOfferings", expand=False)
     def describe_reserved_instances_offerings(


### PR DESCRIPTION
Fixes issue [#4715](https://github.com/localstack/localstack/issues/4715). Now, `--zone-name` filters `AvailabilityZones` data in `ec2 describe-availability-zones` response.