### PR TITLE
fix off-by-one error for nextToken generation

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -76,7 +76,7 @@ class PaginatedList(list):
         except StopIteration:
             pass
 
-        if start_idx + page_size <= len(result_list):
+        if start_idx + page_size < len(result_list):
             next_token = token_generator(result_list[start_idx + page_size])
         else:
             next_token = None


### PR DESCRIPTION
Example: len(list) = 2, pagesize = 1
First run: start_index = 0, nextToken = token_generator( list[ start_index + pagesize = 0 + 1])
Second run: start_index = 1, nextToken = token_generator( list[ start_index + pagesize = 1 + 1]) -> list[2], -> out of bounds