### PR TITLE
LocationConstraint should be None for us-east-1

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -630,19 +630,6 @@ def append_metadata_headers(method, query_map, headers):
                 headers[key] = value[0]
 
 
-def fix_location_constraint(response):
-    """Make sure we return a valid non-empty LocationConstraint, as this otherwise breaks Serverless."""
-    try:
-        content = to_str(response.content or "") or ""
-    except Exception:
-        content = ""
-    if "LocationConstraint" in content:
-        pattern = r"<LocationConstraint([^>]*)>\s*</LocationConstraint>"
-        replace = r"<LocationConstraint\1>%s</LocationConstraint>" % aws_stack.get_region()
-        response._content = re.sub(pattern, replace, content)
-        remove_xml_preamble(response)
-
-
 def fix_range_content_type(bucket_name, path, headers, response):
     # Fix content type for Range requests - https://github.com/localstack/localstack/issues/1259
     if "Range" not in headers:

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -1491,7 +1491,6 @@ class ProxyListenerS3(PersistingProxyListener):
             )
             append_last_modified_headers(response=response)
             append_list_objects_marker(method, path, data, response)
-            fix_location_constraint(response)
             fix_range_content_type(bucket_name, path, headers, response)
             fix_delete_objects_response(bucket_name, method, parsed, data, headers, response)
             fix_metadata_key_underscores(response=response)

--- a/tests/integration/serverless/serverless.yml
+++ b/tests/integration/serverless/serverless.yml
@@ -120,6 +120,11 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: "${self:service}-${opt:stage}-CreateBackupQueue"
+    
+    TestBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: 'testing-bucket'
 
 functions:
   tests:

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -170,3 +170,10 @@ class TestServerless(unittest.TestCase):
                 aws_stack.lambda_function_arn(function_name),
                 resource_method["methodIntegration"]["uri"],
             )
+
+    @pytest.mark.skip_offline
+    def test_s3_bucket_deployed(self):
+        s3_client = aws_stack.create_external_boto_client("s3")
+        bucket_name = "testing-bucket"
+        response = s3_client.head_bucket(Bucket=bucket_name)
+        self.assertEqual(response["ResponseMetadata"]["HTTPStatusCode"], 200)


### PR DESCRIPTION
This PR addresses issue #5748. Even thought I didn't found any official documentation, it's common knowledge that `LocationConstraint` should be `None` when is set to us-east-1. And the fix put in place to avoid return None, returns the requests region, instead of Null or the correct one.

Changes:
- Removing of **get-bucket-location** response fixing.
- Test to validate the correct responses in both cases: default and non-default
