### PR TITLE
fix Transfer-Encoding "chunked" on empty responses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
           environment:
             DEBUG: 1
             LAMBDA_EXECUTOR: "docker"
+            USE_SSL: 1
             TEST_ERROR_INJECTION: 1
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='lambda-docker'"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ jobs:
           environment:
             DEBUG: 1
             LAMBDA_EXECUTOR: "docker"
-            USE_SSL: 1
             TEST_ERROR_INJECTION: 1
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='lambda-docker'"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Pull lambda runtimes
+          name: Pull Lambda runtimes
           command: |
             sudo useradd localstack -s /bin/bash
             docker pull -q lambci/lambda:20191117-nodejs8.10
@@ -92,7 +92,7 @@ jobs:
           name: Initialize Test Libraries
           command: make init-testlibs
       - run:
-          name: Test docker client
+          name: Test Docker client
           environment:
             DEBUG: 1
             TEST_PATH: "tests/integration/docker_utils"
@@ -101,7 +101,7 @@ jobs:
             COVERAGE_ARGS: "-p"
           command: make test-coverage
       - run:
-          name: Test docker lambda executor
+          name: Test 'docker' Lambda executor
           environment:
             DEBUG: 1
             LAMBDA_EXECUTOR: "docker"
@@ -112,7 +112,7 @@ jobs:
             COVERAGE_ARGS: "-p"
           command: make test-coverage
       - run:
-          name: Test docker-reuse lambda executor
+          name: Test 'docker-reuse' Lambda executor
           environment:
             DEBUG: 1
             LAMBDA_EXECUTOR: "docker-reuse"
@@ -139,7 +139,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Test elasticmq SQS provider
+          name: Test ElasticMQ SQS provider
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Pull Lambda runtimes
+          name: Pull lambda runtimes
           command: |
             sudo useradd localstack -s /bin/bash
             docker pull -q lambci/lambda:20191117-nodejs8.10
@@ -92,7 +92,7 @@ jobs:
           name: Initialize Test Libraries
           command: make init-testlibs
       - run:
-          name: Test Docker client
+          name: Test docker client
           environment:
             DEBUG: 1
             TEST_PATH: "tests/integration/docker_utils"
@@ -101,7 +101,7 @@ jobs:
             COVERAGE_ARGS: "-p"
           command: make test-coverage
       - run:
-          name: Test 'docker' Lambda executor
+          name: Test docker lambda executor
           environment:
             DEBUG: 1
             LAMBDA_EXECUTOR: "docker"
@@ -110,18 +110,16 @@ jobs:
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='lambda-docker'"
             COVERAGE_ARGS: "-p"
-          # TODO: re-enable the tests below!
-          command: make test-coverage || true
+          command: make test-coverage
       - run:
-          name: Test 'docker-reuse' Lambda executor
+          name: Test docker-reuse lambda executor
           environment:
             DEBUG: 1
             LAMBDA_EXECUTOR: "docker-reuse"
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker-reuse.xml -o junit_suite_name='lambda-docker-reuse'"
             COVERAGE_ARGS: "-p"
-          # TODO: re-enable the tests below!
-          command: make test-coverage || true
+          command: make test-coverage
       - run:
           name: Store coverage results
           command: mv .coverage.* target/coverage/
@@ -141,7 +139,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: Test ElasticMQ SQS provider
+          name: Test elasticmq SQS provider
           environment:
             DEBUG: 1
             SQS_PROVIDER: "elasticmq"

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -203,12 +203,10 @@ def run_server(
                 if async_gen:
                     return async_gen
                 # prepare and return regular response
+                is_chunked = uses_chunked_encoding(result)
                 result_content = result.content or ""
                 response = await make_response(result_content)
                 response.status_code = result.status_code
-                if response.status_code == 204:
-                    result.headers.pop("Transfer-Encoding", None)
-                is_chunked = uses_chunked_encoding(result)
                 if is_chunked:
                     response.headers.pop("Content-Length", None)
                 result.headers.pop("Server", None)

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -203,10 +203,12 @@ def run_server(
                 if async_gen:
                     return async_gen
                 # prepare and return regular response
-                is_chunked = uses_chunked_encoding(result)
                 result_content = result.content or ""
                 response = await make_response(result_content)
                 response.status_code = result.status_code
+                if response.status_code == 204:
+                    result.headers.pop("Transfer-Encoding", None)
+                is_chunked = uses_chunked_encoding(result)
                 if is_chunked:
                     response.headers.pop("Content-Length", None)
                 result.headers.pop("Server", None)

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,14 +85,11 @@ runtime =
     moto-ext[all]==3.1.2
     opensearch-py>=1.0.0
     pproxy>=2.7.0
-    #pympler>=0.6
     pyopenssl>=21.0.0
     Quart>=0.6.15
-    # Pin Jinja2 (transitive dep of Quart) until this bug is fixed: https://github.com/pgjones/quart/issues/141
-    Jinja2<=3.0.3
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
-    #sasl>=0.2.1
+    # Pin werkzeug until the issue discussed here is fixed: https://github.com/localstack/localstack/pull/5773
     Werkzeug>=2.0,<2.1.0
     xmltodict>=0.11.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ runtime =
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
     #sasl>=0.2.1
-    Werkzeug>=2.0
+    Werkzeug>=2.0,<2.1.0
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.


### PR DESCRIPTION
Avoid returning `Transfer-Encoding` headers for HTTP 204 responses. Should fix the currently failing build on `master`.

Currently seeing connection/protocol errors like below:
```
            except (HTTPException, SocketError) as e:
                # This includes IncompleteRead.
>               raise ProtocolError("Connection broken: %r" % e, e)
E               urllib3.exceptions.ProtocolError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))

.venv/lib/python3.8/site-packages/urllib3/response.py:458: ProtocolError
```

The issue is that `Transfer-Encoding` is being returned from some of the Flask APIs (Lambda DELETE operations that return a 204 status), which newer versions of `urllib3` cannot handle.

Was doing a quick search across recent changes in `urllib3`/`flask`/`hypercorn` to find out where this new behavior got introduced, but couldn't pinpoint the change so far.
 
The change to remove `Transfer-Encoding` seems safe in the general case, as 204 HTTP responses expect no content to be sent along with the response.