### PR TITLE
Reintroduce log output str casting

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -647,7 +647,7 @@ class LambdaExecutorContainers(LambdaExecutor):
             result = to_str(result).strip()
         except Exception:
             pass
-
+        log_output = to_str(log_output).strip()
         # Note: The user's code may have been logging to stderr, in which case the logs
         # will be part of the "result" variable here. Hence, make sure that we extract
         # only the *last* line of "result" and consider anything above that as log output.


### PR DESCRIPTION
This PR fixes a regression which happened with #5391 

removing the line which converts log outputs to string causes an error when concatenating in L662