### PR TITLE
Fix `KMS_PROVIDER=kms-local` back to `local-kms`

### DIFF
--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -140,7 +140,7 @@ def kinesis():
 
 @aws_provider()
 def kms():
-    if config.KMS_PROVIDER == "kms-local":
+    if config.KMS_PROVIDER == "local-kms":
         from localstack.services.kms import kms_starter
 
         return Service("kms", start=kms_starter.start_kms_local)


### PR DESCRIPTION
70958beb42bbf3d686dbf4453618618b6705879a swapped `local-kms` for `kms-local` as the expected `KMS_PROVIDER` environment variable value.

This commit puts that back.

Fixes #5792.

Hat tip to mathi in Slack for [noticing this](https://localstack-community.slack.com/archives/CLRFWBFC3/p1648835936348719).