### PR TITLE
Minor fixes for data types handling in CloudFormation deployer

### DIFF
--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -262,7 +262,10 @@ def get_zip_bytes(function_code):
             s3_client.download_fileobj(function_code["S3Bucket"], function_code["S3Key"], bytes_io)
             zip_file_content = bytes_io.getvalue()
         except Exception as e:
-            raise ClientError("Unable to fetch Lambda archive from S3: %s" % e, 404)
+            s3_url = (
+                f's3://{function_code["S3Bucket"]}/{function_code.get("S3Key", "").lstrip("/")}'
+            )
+            raise ClientError(f"Unable to fetch Lambda archive from {s3_url}: {e}", 404)
     elif "ZipFile" in function_code:
         zip_file_content = function_code["ZipFile"]
         zip_file_content = base64.b64decode(zip_file_content)

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -262,9 +262,8 @@ def get_zip_bytes(function_code):
             s3_client.download_fileobj(function_code["S3Bucket"], function_code["S3Key"], bytes_io)
             zip_file_content = bytes_io.getvalue()
         except Exception as e:
-            s3_url = (
-                f's3://{function_code["S3Bucket"]}/{function_code.get("S3Key", "").lstrip("/")}'
-            )
+            s3_key = str(function_code.get("S3Key") or "")
+            s3_url = f's3://{function_code["S3Bucket"]}{s3_key if s3_key.startswith("/") else f"/{s3_key}"}'
             raise ClientError(f"Unable to fetch Lambda archive from {s3_url}: {e}", 404)
     elif "ZipFile" in function_code:
         zip_file_content = function_code["ZipFile"]

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -6,7 +6,8 @@ from localstack.config import dirs
 from localstack.utils import common
 from localstack.utils.common import select_attributes, short_uid
 
-# URL to "cfn-response" module which is required in some CF Lambdas
+# URL to "cfn-response" module which is required in some CF Lambdas. The purpose of cfn-response is to make it easier
+# to write "inline" code for custom resources. TODO: consider copying code into our repo instead of downloading it
 CFN_RESPONSE_MODULE_URL = (
     "https://raw.githubusercontent.com/LukeMizuhashi/cfn-response/master/index.js"
 )

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -4,10 +4,9 @@ from typing import Callable
 
 from localstack.config import dirs
 from localstack.utils import common
-
-# URL to "cfn-response" module which is required in some CF Lambdas
 from localstack.utils.common import select_attributes, short_uid
 
+# URL to "cfn-response" module which is required in some CF Lambdas
 CFN_RESPONSE_MODULE_URL = (
     "https://raw.githubusercontent.com/LukeMizuhashi/cfn-response/master/index.js"
 )

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -480,6 +480,11 @@ class GatewayUsagePlan(GenericBaseModel):
                     "throttle": lambda_keys_to_lower("Throttle"),
                     "tags": params_list_to_dict("Tags"),
                 },
+                "types": {
+                    "limit": int,
+                    "burstLimit": int,
+                    "rateLimit": float,
+                },
             }
         }
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -712,6 +712,8 @@ def resolve_placeholders_in_string(result, stack):
                 )
             # make sure we resolve any functions/placeholders in the extracted string
             result = resolve_refs_recursively(stack, result)
+            # make sure we convert the result to string
+            result = "" if result is None else str(result)
             return result
         # TODO raise exception here?
         return match.group(0)
@@ -807,8 +809,8 @@ def convert_data_types(func_details, params):
             if isinstance(_obj, bool):
                 return str(_obj).lower()
             return str(_obj)
-        if _type == int:
-            return int(_obj)
+        if _type in (int, float):
+            return _type(_obj)
         return _obj
 
     def fix_types(o, **kwargs):

--- a/tests/integration/templates/apigateway_integration.json
+++ b/tests/integration/templates/apigateway_integration.json
@@ -152,13 +152,17 @@
     "ApiGatewayUsagePlan": {
       "Type": "AWS::ApiGateway::UsagePlan",
       "Properties": {
-        "Quota": {"Limit" : 123},
+        "Quota": {"Limit" : "123"},
         "ApiStages": [
           {
             "ApiId": {"Ref": "ApiGatewayRestApi"},
             "Stage": {"Ref": "ApiGWStage"}
           }
-        ]
+        ],
+        "Throttle": {
+          "BurstLimit": "500",
+          "RateLimit": "1000"
+        }
       }
     },
     "ApiGatewayUsagePlanKey": {


### PR DESCRIPTION
Minor fixes for data types handling in CloudFormation deployer - surfaced when working on changes for #5674

* fix request types for ApiGateway::UsagePlan parameters
* fix logic for using `!Sub` with numeric substitution values (ensure we return `str` for the regex replacer)