### PR TITLE
fix dynamodb index query validation

### DIFF
--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -312,11 +312,12 @@ class ProxyListenerDynamoDB(ProxyListener):
             ProxyListenerDynamoDB.thread_local.unprocessed_delete_items = unprocessed_delete_items
 
         elif action == "Query":
-            if data.get("IndexName"):
-                if not is_index_query_valid(to_str(data["TableName"]), data.get("Select")):
+            index_name = data.get("IndexName")
+            if index_name:
+                if not is_index_query_valid(data):
                     return error_response(
                         message="One or more parameter values were invalid: Select type ALL_ATTRIBUTES "
-                        "is not supported for global secondary index id-index because its projection "
+                        f"is not supported for global secondary index {index_name} because its projection "
                         "type is not ALL",
                         error_type="ValidationException",
                         code=400,
@@ -1020,12 +1021,21 @@ def update_global_table(data):
 # ---
 
 
-def is_index_query_valid(table_name: str, index_query_type: str) -> bool:
+def get_global_secondary_index(table_name, index_name):
     schema = SchemaExtractor.get_table_schema(table_name)
     for index in schema["Table"].get("GlobalSecondaryIndexes", []):
-        index_projection_type = index.get("Projection").get("ProjectionType")
-        if index_query_type == "ALL_ATTRIBUTES" and index_projection_type != "ALL":
-            return False
+        if index["IndexName"] == index_name:
+            return index
+
+
+def is_index_query_valid(query_data: dict) -> bool:
+    table_name = to_str(query_data["TableName"])
+    index_name = to_str(query_data["IndexName"])
+    index_query_type = query_data.get('Select')
+    index = get_global_secondary_index(table_name, index_name)
+    index_projection_type = index.get("Projection").get("ProjectionType")
+    if index_query_type == "ALL_ATTRIBUTES" and index_projection_type != "ALL":
+        return False
     return True
 
 

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -1031,7 +1031,7 @@ def get_global_secondary_index(table_name, index_name):
 def is_index_query_valid(query_data: dict) -> bool:
     table_name = to_str(query_data["TableName"])
     index_name = to_str(query_data["IndexName"])
-    index_query_type = query_data.get('Select')
+    index_query_type = query_data.get("Select")
     index = get_global_secondary_index(table_name, index_name)
     index_projection_type = index.get("Projection").get("ProjectionType")
     if index_query_type == "ALL_ATTRIBUTES" and index_projection_type != "ALL":

--- a/localstack/services/dynamodb/dynamodb_listener.py
+++ b/localstack/services/dynamodb/dynamodb_listener.py
@@ -1026,6 +1026,7 @@ def get_global_secondary_index(table_name, index_name):
     for index in schema["Table"].get("GlobalSecondaryIndexes", []):
         if index["IndexName"] == index_name:
             return index
+    raise Exception("Index not found")  # TODO: add proper exception handling
 
 
 def is_index_query_valid(query_data: dict) -> bool:

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -38,7 +38,6 @@ def dynamodb():
 
 class TestDynamoDB:
     def test_non_ascii_chars(self, dynamodb):
-        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
         # write some items containing non-ASCII characters
@@ -257,6 +256,79 @@ class TestDynamoDB:
                 Select="ALL_ATTRIBUTES",
             )
         assert ctx.match("ValidationException")
+
+    def test_invalid_query_index(self, dynamodb):
+        """Raises an exception when a query requests ALL_ATTRIBUTES,
+        but the index does not have a ProjectionType of ALL"""
+        table_name = f"test-table-{short_uid()}"
+        table = dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "id", "AttributeType": "S"},
+                {"AttributeName": "field_a", "AttributeType": "S"},
+            ],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            Tags=TEST_DDB_TAGS,
+            GlobalSecondaryIndexes=[{
+                "IndexName": "field_a_index",
+                "KeySchema": [{"AttributeName": "field_a", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": 1,
+                    "WriteCapacityUnits": 1,
+                },
+            }]
+        )
+
+        with pytest.raises(Exception) as ctx:
+            table.query(
+                TableName=table_name,
+                IndexName="field_a_index",
+                KeyConditionExpression=Key("field_a").eq("xyz"),
+                Select="ALL_ATTRIBUTES",
+            )
+        assert ctx.match("ValidationException")
+
+    def test_valid_query_index(self, dynamodb):
+        """Query requests ALL_ATTRIBUTES and the named index has a ProjectionType of ALL,
+        no exception is should be raised."""
+        table_name = f"test-table-{short_uid()}"
+        table = dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "id", "AttributeType": "S"},
+                {"AttributeName": "field_a", "AttributeType": "S"},
+                {"AttributeName": "field_b", "AttributeType": "S"},
+            ],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            Tags=TEST_DDB_TAGS,
+            GlobalSecondaryIndexes=[{
+                "IndexName": "field_a_index",
+                "KeySchema": [{"AttributeName": "field_a", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "KEYS_ONLY"},
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": 1,
+                    "WriteCapacityUnits": 1,
+                },
+            }, {
+                "IndexName": "field_b_index",
+                "KeySchema": [{"AttributeName": "field_b", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": 1,
+                    "WriteCapacityUnits": 1,
+                },
+            }]
+        )
+
+        table.query(
+            TableName=table_name,
+            IndexName="field_b_index",
+            KeyConditionExpression=Key("field_b").eq("xyz"),
+            Select="ALL_ATTRIBUTES",
+        )
 
     def test_return_values_in_put_item(self, dynamodb):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -271,15 +271,17 @@ class TestDynamoDB:
             ],
             ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
             Tags=TEST_DDB_TAGS,
-            GlobalSecondaryIndexes=[{
-                "IndexName": "field_a_index",
-                "KeySchema": [{"AttributeName": "field_a", "KeyType": "HASH"}],
-                "Projection": {"ProjectionType": "KEYS_ONLY"},
-                "ProvisionedThroughput": {
-                    "ReadCapacityUnits": 1,
-                    "WriteCapacityUnits": 1,
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "field_a_index",
+                    "KeySchema": [{"AttributeName": "field_a", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 1,
+                        "WriteCapacityUnits": 1,
+                    },
                 },
-            }]
+            ],
         )
 
         with pytest.raises(Exception) as ctx:
@@ -305,23 +307,26 @@ class TestDynamoDB:
             ],
             ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
             Tags=TEST_DDB_TAGS,
-            GlobalSecondaryIndexes=[{
-                "IndexName": "field_a_index",
-                "KeySchema": [{"AttributeName": "field_a", "KeyType": "HASH"}],
-                "Projection": {"ProjectionType": "KEYS_ONLY"},
-                "ProvisionedThroughput": {
-                    "ReadCapacityUnits": 1,
-                    "WriteCapacityUnits": 1,
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "field_a_index",
+                    "KeySchema": [{"AttributeName": "field_a", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "KEYS_ONLY"},
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 1,
+                        "WriteCapacityUnits": 1,
+                    },
                 },
-            }, {
-                "IndexName": "field_b_index",
-                "KeySchema": [{"AttributeName": "field_b", "KeyType": "HASH"}],
-                "Projection": {"ProjectionType": "ALL"},
-                "ProvisionedThroughput": {
-                    "ReadCapacityUnits": 1,
-                    "WriteCapacityUnits": 1,
+                {
+                    "IndexName": "field_b_index",
+                    "KeySchema": [{"AttributeName": "field_b", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 1,
+                        "WriteCapacityUnits": 1,
+                    },
                 },
-            }]
+            ],
         )
 
         table.query(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -38,6 +38,7 @@ def dynamodb():
 
 class TestDynamoDB:
     def test_non_ascii_chars(self, dynamodb):
+        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
         # write some items containing non-ASCII characters
@@ -292,7 +293,7 @@ class TestDynamoDB:
 
     def test_valid_query_index(self, dynamodb):
         """Query requests ALL_ATTRIBUTES and the named index has a ProjectionType of ALL,
-        no exception is should be raised."""
+        no exception should be raised."""
         table_name = f"test-table-{short_uid()}"
         table = dynamodb.create_table(
             TableName=table_name,

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -293,6 +293,9 @@ class TestDynamoDB:
             )
         assert ctx.match("ValidationException")
 
+        # clean up
+        delete_table(table_name)
+
     def test_valid_query_index(self, dynamodb):
         """Query requests ALL_ATTRIBUTES and the named index has a ProjectionType of ALL,
         no exception should be raised."""
@@ -335,6 +338,9 @@ class TestDynamoDB:
             KeyConditionExpression=Key("field_b").eq("xyz"),
             Select="ALL_ATTRIBUTES",
         )
+
+        # clean up
+        delete_table(table_name)
 
     def test_return_values_in_put_item(self, dynamodb):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)


### PR DESCRIPTION
Fixes an issue where the following exception was being thrown for a valid query:
```
One or more parameter values were invalid: Select type ALL_ATTRIBUTES is not supported for 
global secondary index id-index because its projection type is not ALL
```

The exception is thrown if the table has additional global secondary indexes (besides the one being queried) that do not have a projection type of ALL.
