### PR TITLE
Rework Lambda Integration tests to work against AWS as well as LocalStack

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -45,7 +45,7 @@ def add_dynamodb_stream(
             ),
             "TableName": table_name,
             "StreamLabel": latest_stream_label,
-            "StreamStatus": "ENABLED",
+            "StreamStatus": "ENABLING",
             "KeySchema": [],
             "Shards": [],
             "StreamViewType": view_type,

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -267,6 +267,27 @@ def connect_to_resource(
     )
 
 
+def connect_to_resource_external(
+    service_name,
+    env=None,
+    region_name=None,
+    endpoint_url=None,
+    config: botocore.config.Config = None,
+    **kwargs,
+):
+    """
+    Generic method to obtain an AWS service resource using boto3, based on environment, region, or custom endpoint_url.
+    """
+    return create_external_boto_client(
+        service_name,
+        client=False,
+        env=env,
+        region_name=region_name,
+        endpoint_url=endpoint_url,
+        config=config,
+    )
+
+
 def connect_to_service(
     service_name,
     client=True,

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -569,8 +569,12 @@ def get_lambda_log_group_name(function_name):
     return "/aws/lambda/{}".format(function_name)
 
 
-def check_expected_lambda_log_events_length(expected_length, function_name, regex_filter=None):
-    events = get_lambda_log_events(function_name, regex_filter=regex_filter)
+def check_expected_lambda_log_events_length(
+    expected_length, function_name, regex_filter=None, logs_client=None
+):
+    events = get_lambda_log_events(
+        function_name, regex_filter=regex_filter, logs_client=logs_client
+    )
     events = [line for line in events if line not in ["\x1b[0m", "\\x1b[0m"]]
     if len(events) != expected_length:
         print(

--- a/tests/integration/awslambda/functions/lambda_integration.py
+++ b/tests/integration/awslambda/functions/lambda_integration.py
@@ -185,7 +185,11 @@ def forward_event_to_target_stream(record, stream_name):
 
 
 def create_external_boto_client(service):
-    endpoint_url = f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ.get('EDGE_PORT', 4566)}"
+    endpoint_url = None
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        endpoint_url = (
+            f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ.get('EDGE_PORT', 4566)}"
+        )
     region_name = (
         os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-east-1"
     )

--- a/tests/integration/awslambda/functions/lambda_put_item.py
+++ b/tests/integration/awslambda/functions/lambda_put_item.py
@@ -8,8 +8,10 @@ EDGE_PORT = 4566
 
 
 def handler(event, context):
-    protocol = "https" if os.environ.get("USE_SSL") else "http"
-    endpoint_url = "{}://{}:{}".format(protocol, os.environ["LOCALSTACK_HOSTNAME"], EDGE_PORT)
+    endpoint_url = None
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        protocol = "https" if os.environ.get("USE_SSL") else "http"
+        endpoint_url = "{}://{}:{}".format(protocol, os.environ["LOCALSTACK_HOSTNAME"], EDGE_PORT)
     ddb = boto3.resource(
         "dynamodb",
         endpoint_url=endpoint_url,

--- a/tests/integration/awslambda/functions/lambda_send_message.py
+++ b/tests/integration/awslambda/functions/lambda_send_message.py
@@ -6,8 +6,10 @@ EDGE_PORT = 4566
 
 
 def handler(event, context):
-    protocol = "https" if os.environ.get("USE_SSL") else "http"
-    endpoint_url = "{}://{}:{}".format(protocol, os.environ["LOCALSTACK_HOSTNAME"], EDGE_PORT)
+    endpoint_url = None
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        protocol = "https" if os.environ.get("USE_SSL") else "http"
+        endpoint_url = "{}://{}:{}".format(protocol, os.environ["LOCALSTACK_HOSTNAME"], EDGE_PORT)
     sqs = boto3.client(
         "sqs", endpoint_url=endpoint_url, region_name=event["region_name"], verify=False
     )

--- a/tests/integration/awslambda/functions/lambda_start_execution.py
+++ b/tests/integration/awslambda/functions/lambda_start_execution.py
@@ -9,8 +9,10 @@ EDGE_PORT = 4566
 
 
 def handler(event, context):
-    protocol = "https" if os.environ.get("USE_SSL") else "http"
-    endpoint_url = "{}://{}:{}".format(protocol, os.environ["LOCALSTACK_HOSTNAME"], EDGE_PORT)
+    endpoint_url = None
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        protocol = "https" if os.environ.get("USE_SSL") else "http"
+        endpoint_url = "{}://{}:{}".format(protocol, os.environ["LOCALSTACK_HOSTNAME"], EDGE_PORT)
     sf = boto3.client(
         "stepfunctions",
         endpoint_url=endpoint_url,

--- a/tests/integration/awslambda/test_lambda_integration.py
+++ b/tests/integration/awslambda/test_lambda_integration.py
@@ -19,6 +19,7 @@ from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import retry, safe_requests, short_uid
 from localstack.utils.kinesis import kinesis_connector
+from localstack.utils.sync import poll_condition
 from localstack.utils.testutil import check_expected_lambda_log_events_length, get_lambda_log_events
 
 from .test_lambda import (
@@ -37,7 +38,15 @@ TEST_LAMBDA_PARALLEL_FILE = os.path.join(THIS_FOLDER, "functions", "lambda_paral
 
 class TestLambdaEventSourceMappings:
     def test_event_source_mapping_default_batch_size(
-        self, create_lambda_function, lambda_client, sqs_client
+        self,
+        create_lambda_function,
+        lambda_client,
+        sqs_client,
+        sqs_create_queue,
+        sqs_queue_arn,
+        dynamodb_client,
+        dynamodb_create_table,
+        lambda_su_role,
     ):
         function_name = f"lambda_func-{short_uid()}"
         queue_name_1 = f"queue-{short_uid()}-1"
@@ -48,16 +57,22 @@ class TestLambdaEventSourceMappings:
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             runtime=LAMBDA_RUNTIME_PYTHON36,
+            role=lambda_su_role,
         )
 
-        queue_url_1 = sqs_client.create_queue(QueueName=queue_name_1)["QueueUrl"]
-        queue_arn_1 = aws_stack.sqs_queue_arn(queue_name_1)
+        queue_url_1 = sqs_create_queue(QueueName=queue_name_1)
+        queue_arn_1 = sqs_queue_arn(queue_url_1)
 
         rs = lambda_client.create_event_source_mapping(
             EventSourceArn=queue_arn_1, FunctionName=function_name
         )
         assert BATCH_SIZE_RANGES["sqs"][0] == rs["BatchSize"]
         uuid = rs["UUID"]
+
+        def wait_for_event_source_mapping():
+            return lambda_client.get_event_source_mapping(UUID=uuid)["State"] == "Enabled"
+
+        assert poll_condition(wait_for_event_source_mapping, timeout=30)
 
         with pytest.raises(ClientError) as e:
             # Update batch size with invalid value
@@ -68,8 +83,8 @@ class TestLambdaEventSourceMappings:
             )
         e.match(INVALID_PARAMETER_VALUE_EXCEPTION)
 
-        queue_url_2 = sqs_client.create_queue(QueueName=queue_name_2)["QueueUrl"]
-        queue_arn_2 = aws_stack.sqs_queue_arn(queue_name_2)
+        queue_url_2 = sqs_create_queue(QueueName=queue_name_2)
+        queue_arn_2 = sqs_queue_arn(queue_url_2)
 
         with pytest.raises(ClientError) as e:
             # Create event source mapping with invalid batch size value
@@ -80,22 +95,40 @@ class TestLambdaEventSourceMappings:
             )
         e.match(INVALID_PARAMETER_VALUE_EXCEPTION)
 
-        table_arn = aws_stack.create_dynamodb_table(ddb_table, partition_key="id")[
-            "TableDescription"
-        ]["TableArn"]
+        table_description = dynamodb_create_table(
+            table_name=ddb_table,
+            partition_key="id",
+            stream_view_type="NEW_IMAGE",
+        )["TableDescription"]
+
+        # table ARNs are not sufficient as event source, needs to be a dynamodb stream arn
+        with pytest.raises(ClientError) as e:
+            lambda_client.create_event_source_mapping(
+                EventSourceArn=table_description["TableArn"],
+                FunctionName=function_name,
+                StartingPosition="LATEST",
+            )
+        e.match(INVALID_PARAMETER_VALUE_EXCEPTION)
+
+        # check if event source mapping can be created with latest stream ARN
         rs = lambda_client.create_event_source_mapping(
-            EventSourceArn=table_arn, FunctionName=function_name
+            EventSourceArn=table_description["LatestStreamArn"],
+            FunctionName=function_name,
+            StartingPosition="LATEST",
         )
+
         assert BATCH_SIZE_RANGES["dynamodb"][0] == rs["BatchSize"]
 
-        # clean up
-        dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
-        dynamodb_client.delete_table(TableName=ddb_table)
-        sqs_client.delete_queue(QueueUrl=queue_url_1)
-        sqs_client.delete_queue(QueueUrl=queue_url_2)
-
     def test_disabled_event_source_mapping_with_dynamodb(
-        self, create_lambda_function, lambda_client
+        self,
+        create_lambda_function,
+        lambda_client,
+        dynamodb_resource,
+        dynamodb_client,
+        dynamodb_create_table,
+        logs_client,
+        dynamodbstreams_client,
+        lambda_su_role,
     ):
         function_name = f"lambda_func-{short_uid()}"
         ddb_table = f"ddb_table-{short_uid()}"
@@ -104,19 +137,40 @@ class TestLambdaEventSourceMappings:
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             runtime=LAMBDA_RUNTIME_PYTHON36,
+            role=lambda_su_role,
         )
 
-        table_arn = aws_stack.create_dynamodb_table(ddb_table, partition_key="id")[
-            "TableDescription"
-        ]["TableArn"]
+        latest_stream_arn = dynamodb_create_table(
+            table_name=ddb_table, partition_key="id", stream_view_type="NEW_IMAGE"
+        )["TableDescription"]["LatestStreamArn"]
 
         rs = lambda_client.create_event_source_mapping(
-            FunctionName=function_name, EventSourceArn=table_arn
+            FunctionName=function_name,
+            EventSourceArn=latest_stream_arn,
+            StartingPosition="TRIM_HORIZON",
+            MaximumBatchingWindowInSeconds=1,
         )
         uuid = rs["UUID"]
 
-        dynamodb = aws_stack.connect_to_resource("dynamodb")
-        table = dynamodb.Table(ddb_table)
+        def wait_for_table_created():
+            return (
+                dynamodb_client.describe_table(TableName=ddb_table)["Table"]["TableStatus"]
+                == "ACTIVE"
+            )
+
+        assert poll_condition(wait_for_table_created, timeout=30)
+
+        def wait_for_stream_created():
+            return (
+                dynamodbstreams_client.describe_stream(StreamArn=latest_stream_arn)[
+                    "StreamDescription"
+                ]["StreamStatus"]
+                == "ENABLED"
+            )
+
+        assert poll_condition(wait_for_stream_created, timeout=30)
+
+        table = dynamodb_resource.Table(ddb_table)
 
         items = [
             {"id": short_uid(), "data": "data1"},
@@ -124,26 +178,28 @@ class TestLambdaEventSourceMappings:
         ]
 
         table.put_item(Item=items[0])
-        events = get_lambda_log_events(function_name)
 
-        # lambda was invoked 1 time
-        assert 1 == len(events[0]["Records"])
+        def assert_events():
+            events = get_lambda_log_events(function_name, logs_client=logs_client)
+
+            # lambda was invoked 1 time
+            assert 1 == len(events[0]["Records"])
+
+        # might take some time against AWS
+        retry(assert_events, sleep=3, retries=10)
 
         # disable event source mapping
         lambda_client.update_event_source_mapping(UUID=uuid, Enabled=False)
 
         table.put_item(Item=items[1])
-        events = get_lambda_log_events(function_name)
+        events = get_lambda_log_events(function_name, logs_client=logs_client)
 
         # lambda no longer invoked, still have 1 event
         assert 1 == len(events[0]["Records"])
 
-        # clean up
-        dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
-        dynamodb_client.delete_table(TableName=ddb_table)
-
+    # TODO invalid test against AWS, this behavior just is not correct
     def test_deletion_event_source_mapping_with_dynamodb(
-        self, create_lambda_function, lambda_client
+        self, create_lambda_function, lambda_client, dynamodb_client, lambda_su_role
     ):
         function_name = f"lambda_func-{short_uid()}"
         ddb_table = f"ddb_table-{short_uid()}"
@@ -168,7 +224,16 @@ class TestLambdaEventSourceMappings:
         result = lambda_client.list_event_source_mappings(EventSourceArn=table_arn)
         assert 0 == len(result["EventSourceMappings"])
 
-    def test_event_source_mapping_with_sqs(self, create_lambda_function, lambda_client, sqs_client):
+    def test_event_source_mapping_with_sqs(
+        self,
+        create_lambda_function,
+        lambda_client,
+        sqs_client,
+        sqs_create_queue,
+        sqs_queue_arn,
+        logs_client,
+        lambda_su_role,
+    ):
         function_name = f"lambda_func-{short_uid()}"
         queue_name_1 = f"queue-{short_uid()}-1"
 
@@ -176,27 +241,38 @@ class TestLambdaEventSourceMappings:
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             runtime=LAMBDA_RUNTIME_PYTHON36,
+            role=lambda_su_role,
         )
 
-        queue_url_1 = sqs_client.create_queue(QueueName=queue_name_1)["QueueUrl"]
-        queue_arn_1 = aws_stack.sqs_queue_arn(queue_name_1)
+        queue_url_1 = sqs_create_queue(QueueName=queue_name_1)
+        queue_arn_1 = sqs_queue_arn(queue_url_1)
 
         lambda_client.create_event_source_mapping(
-            EventSourceArn=queue_arn_1, FunctionName=function_name
+            EventSourceArn=queue_arn_1, FunctionName=function_name, MaximumBatchingWindowInSeconds=1
         )
 
         sqs_client.send_message(QueueUrl=queue_url_1, MessageBody=json.dumps({"foo": "bar"}))
-        events = retry(get_lambda_log_events, sleep_before=3, function_name=function_name)
 
-        # lambda was invoked 1 time
-        assert 1 == len(events[0]["Records"])
+        def assert_lambda_log_events():
+            events = get_lambda_log_events(function_name=function_name, logs_client=logs_client)
+            # lambda was invoked 1 time
+            assert 1 == len(events[0]["Records"])
+
+        retry(assert_lambda_log_events, sleep_before=3, retries=30)
+
         rs = sqs_client.receive_message(QueueUrl=queue_url_1)
         assert rs.get("Messages") is None
 
-        # clean up
-        sqs_client.delete_queue(QueueUrl=queue_url_1)
-
-    def test_create_kinesis_event_source_mapping(self, create_lambda_function, lambda_client):
+    def test_create_kinesis_event_source_mapping(
+        self,
+        create_lambda_function,
+        lambda_client,
+        kinesis_client,
+        kinesis_create_stream,
+        lambda_su_role,
+        wait_for_stream_ready,
+        logs_client,
+    ):
         function_name = f"lambda_func-{short_uid()}"
         stream_name = f"test-foobar-{short_uid()}"
 
@@ -204,33 +280,40 @@ class TestLambdaEventSourceMappings:
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             runtime=LAMBDA_RUNTIME_PYTHON36,
+            role=lambda_su_role,
         )
 
-        arn = aws_stack.kinesis_stream_arn(stream_name, account_id="000000000000")
-        lambda_client.create_event_source_mapping(EventSourceArn=arn, FunctionName=function_name)
+        kinesis_create_stream(StreamName=stream_name, ShardCount=1)
 
-        def process_records(record):
-            assert record
+        stream_arn = kinesis_client.describe_stream(StreamName=stream_name)["StreamDescription"][
+            "StreamARN"
+        ]
+        # with pytest.raises(ClientError) as e:
+        #     lambda_client.create_event_source_mapping(EventSourceArn=stream_arn, FunctionName=function_name)
+        # e.match(INVALID_PARAMETER_VALUE_EXCEPTION)
 
-        aws_stack.create_kinesis_stream(stream_name, delete=True)
-        kinesis_connector.listen_to_kinesis(
-            stream_name=stream_name,
-            listener_func=process_records,
-            wait_until_started=True,
+        wait_for_stream_ready(stream_name=stream_name)
+
+        lambda_client.create_event_source_mapping(
+            EventSourceArn=stream_arn, FunctionName=function_name, StartingPosition="TRIM_HORIZON"
         )
 
-        kinesis = aws_stack.create_external_boto_client("kinesis")
-        stream_summary = kinesis.describe_stream_summary(StreamName=stream_name)
+        stream_summary = kinesis_client.describe_stream_summary(StreamName=stream_name)
         assert 1 == stream_summary["StreamDescriptionSummary"]["OpenShardCount"]
         num_events_kinesis = 10
-        kinesis.put_records(
+        kinesis_client.put_records(
             Records=[
                 {"Data": "{}", "PartitionKey": f"test_{i}"} for i in range(0, num_events_kinesis)
             ],
             StreamName=stream_name,
         )
 
-        events = get_lambda_log_events(function_name)
+        def get_lambda_events():
+            events = get_lambda_log_events(function_name, logs_client=logs_client)
+            assert events
+            return events
+
+        events = retry(get_lambda_events, retries=30)
         assert 10 == len(events[0]["Records"])
 
         assert "eventID" in events[0]["Records"][0]
@@ -242,18 +325,19 @@ class TestLambdaEventSourceMappings:
         assert "awsRegion" in events[0]["Records"][0]
         assert "kinesis" in events[0]["Records"][0]
 
-    def test_python_lambda_subscribe_sns_topic(self, create_lambda_function):
-        sns_client = aws_stack.create_external_boto_client("sns")
+    def test_python_lambda_subscribe_sns_topic(
+        self, create_lambda_function, sns_client, lambda_su_role, sns_topic, logs_client
+    ):
         function_name = f"{TEST_LAMBDA_FUNCTION_PREFIX}-{short_uid()}"
 
         create_lambda_function(
             func_name=function_name,
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             runtime=LAMBDA_RUNTIME_PYTHON36,
+            role=lambda_su_role,
         )
 
-        topic = sns_client.create_topic(Name=TEST_SNS_TOPIC_NAME)
-        topic_arn = topic["TopicArn"]
+        topic_arn = sns_topic["Attributes"]["TopicArn"]
 
         sns_client.subscribe(
             TopicArn=topic_arn,
@@ -272,6 +356,7 @@ class TestLambdaEventSourceMappings:
             function_name=function_name,
             expected_length=1,
             regex_filter="Records.*Sns",
+            logs_client=logs_client,
         )
         notification = events[0]["Records"][0]["Sns"]
 

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -267,21 +267,6 @@ class TestKinesis:
 
 
 @pytest.fixture
-def wait_for_stream_ready(kinesis_client):
-    def _wait_for_stream_ready(stream_name: str):
-        def is_stream_ready():
-            describe_stream_response = kinesis_client.describe_stream(StreamName=stream_name)
-            return describe_stream_response["StreamDescription"]["StreamStatus"] in [
-                "ACTIVE",
-                "UPDATING",
-            ]
-
-        poll_condition(is_stream_ready)
-
-    return _wait_for_stream_ready
-
-
-@pytest.fixture
 def wait_for_consumer_ready(kinesis_client):
     def _wait_for_consumer_ready(consumer_arn: str):
         def is_consumer_ready():


### PR DESCRIPTION
Tests against Lambda should be able to run against AWS too, to prevent many false assertions.
This refactoring will do that, by fixing wrong assertions and adding permissions as well as retries.

This is a preparation work for better and more complete lambda tests.