### PR TITLE
Fix #5821 - ElasticMQ always downloaded due to incorrect cache path in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,7 @@ ARG DYNAMODB_ZIP_URL=https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_
 RUN mkdir -p /opt/code/localstack/localstack/infra/dynamodb && \
       curl -L -o /tmp/localstack.ddb.zip ${DYNAMODB_ZIP_URL} && \
       (cd localstack/infra/dynamodb && unzip -q /tmp/localstack.ddb.zip && rm /tmp/localstack.ddb.zip) && \
+    mkdir -p /opt/code/localstack/localstack/infra/elasticmq && \
     curl -L -o /opt/code/localstack/localstack/infra/elasticmq/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ ARG DYNAMODB_ZIP_URL=https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_
 RUN mkdir -p /opt/code/localstack/localstack/infra/dynamodb && \
       curl -L -o /tmp/localstack.ddb.zip ${DYNAMODB_ZIP_URL} && \
       (cd localstack/infra/dynamodb && unzip -q /tmp/localstack.ddb.zip && rm /tmp/localstack.ddb.zip) && \
-    curl -L -o /opt/code/localstack/localstack/infra/elasticmq-server.jar \
+    curl -L -o /opt/code/localstack/localstack/infra/elasticmq/elasticmq-server.jar \
         https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar
 
 # upgrade python build tools


### PR DESCRIPTION
Pretty self-explanatory, see bug #5821