### PR TITLE
Fix flaky tests: test_dynamodb_stream_records_with_update_item, test_rotate_secret_with_lambda_2

### DIFF
--- a/tests/integration/secretsmanager/functions/lambda_rotate_secret.py
+++ b/tests/integration/secretsmanager/functions/lambda_rotate_secret.py
@@ -49,7 +49,10 @@ def handler(event, context):
     edge_port = os.environ.get("EDGE_PORT") or 4566
     protocol = "https" if os.environ.get("USE_SSL") else "http"
     endpoint_url = f"{protocol}://{os.environ['LOCALSTACK_HOSTNAME']}:{edge_port}"
-    service_client = boto3.client("secretsmanager", endpoint_url=endpoint_url, verify=False)
+    region = os.environ["AWS_REGION"]
+    service_client = boto3.client(
+        "secretsmanager", endpoint_url=endpoint_url, verify=False, region_name=region
+    )
 
     arn = event["SecretId"]
     token = event["ClientRequestToken"]


### PR DESCRIPTION
This PR fixes two flaky tests:
* `test_rotate_secret_with_lambda_2` sporadically failed on a feature branch with message `Error executing Lambda function {"errorType": "NoRegionError", "errorMessage": "You must specify a region."`

* `test_dynamodb_stream_records_with_update_item`flaky on several branches: added a retry, as it seems like the second record might not be ready
