### PR TITLE
Fixed issue with spaces in Windows user names

### DIFF
--- a/bin/localstack.bat
+++ b/bin/localstack.bat
@@ -1,1 +1,1 @@
-python %~dp0\localstack %*
+python "%~dp0\localstack" %*


### PR DESCRIPTION
Fixed an issue with running localstack on Windows when the primary user name has a space in it.

I ran into this issue myself, and decided to fix it.