### PR TITLE
adds authorizer object to lambda event

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -555,6 +555,12 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
 
             invocation_context.context = get_event_request_context(invocation_context)
             invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
+            if invocation_context.auth_info.get("authorizer_type"):
+                authorizer_context = {
+                    invocation_context.auth_info["authorizer_type"]: invocation_context.auth_context
+                }
+                invocation_context.context["authorizer"] = authorizer_context
+
             request_templates = RequestTemplates()
             payload = request_templates.render(invocation_context)
 

--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -555,9 +555,9 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
 
             invocation_context.context = get_event_request_context(invocation_context)
             invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
-            if invocation_context.auth_info.get("authorizer_type"):
+            if invocation_context.authorizer_type:
                 authorizer_context = {
-                    invocation_context.auth_info["authorizer_type"]: invocation_context.auth_context
+                    invocation_context.authorizer_type: invocation_context.auth_context
                 }
                 invocation_context.context["authorizer"] = authorizer_context
 

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -132,6 +132,13 @@ class ApiInvocationContext:
                 self.auth_info["identity"] = {}
             return self.auth_info["identity"]
 
+    @property
+    def authorizer_type(self) -> str:
+        if isinstance(self.auth_info, dict):
+            if self.auth_info.get("authorizer_type") is None:
+                self.auth_info["authorizer_type"] = {}
+            return self.auth_info["authorizer_type"]
+
     def is_websocket_request(self):
         upgrade_header = str(self.headers.get("upgrade") or "")
         return upgrade_header.lower() == "websocket"

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -135,9 +135,7 @@ class ApiInvocationContext:
     @property
     def authorizer_type(self) -> str:
         if isinstance(self.auth_info, dict):
-            if self.auth_info.get("authorizer_type") is None:
-                self.auth_info["authorizer_type"] = {}
-            return self.auth_info["authorizer_type"]
+            return self.auth_info.get("authorizer_type") if self.auth_info else None
 
     def is_websocket_request(self):
         upgrade_header = str(self.headers.get("upgrade") or "")


### PR DESCRIPTION
This PR adds the authorizer object to the lambda event and encapsulates a new property into the invocation context to represent the authorization type (lambda, iam, jwt)

Fixes #5130 
