### PR TITLE
fix ASF operation routing (empty query args, deprecated ops)

### DIFF
--- a/localstack/aws/protocol/router.py
+++ b/localstack/aws/protocol/router.py
@@ -79,8 +79,14 @@ class _HttpOperation(NamedTuple):
         # requestUris can contain mandatory query args (f.e. /apikeys?mode=import)
         path_query = uri.split("?")
         path = path_query[0]
-        query_args: Dict[str, List[str]] = parse_qs(path_query[1]) if len(path_query) > 1 else {}
         header_args = []
+        query_args: Dict[str, List[str]] = {}
+
+        if len(path_query) > 1:
+            # parse the query args of the request URI (they are mandatory)
+            query_args: Dict[str, List[str]] = parse_qs(path_query[1], keep_blank_values=True)
+            # for mandatory keys without values, keep an empty list (instead of [''] - the result of parse_qs)
+            query_args = {k: filter(None, v) for k, v in query_args.items()}
 
         # find the required header and query parameters of the input shape
         input_shape = op.input_shape

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -778,6 +778,41 @@ def test_restjson_operation_detection_with_query_suffix_in_requesturi():
     _botocore_parser_integration_test(service="apigateway", action="ImportRestApi", body=b"Test")
 
 
+def test_restxml_operation_detection_with_query_suffix_without_value_in_requesturi():
+    # Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
+    # parameter without a specific value, f.e. CloudFront's CreateDistributionWithTags:
+    # "/2020-05-31/distribution?WithTags"
+    _botocore_parser_integration_test(
+        service="cloudfront",
+        action="CreateDistributionWithTags",
+        DistributionConfigWithTags={
+            "DistributionConfig": {
+                "CallerReference": "string",
+                "Origins": {
+                    "Quantity": 1,
+                    "Items": [
+                        {
+                            "Id": "string",
+                            "DomainName": "string",
+                        }
+                    ],
+                },
+                "Comment": "string",
+                "Enabled": True,
+                "DefaultCacheBehavior": {
+                    "TargetOriginId": "string",
+                    "ViewerProtocolPolicy": "allow-all",
+                },
+            },
+            "Tags": {
+                "Items": [
+                    {"Key": "string", "Value": "string"},
+                ]
+            },
+        },
+    )
+
+
 def test_restjson_operation_detection_with_length_prio():
     """
     Tests if the correct operation is detected if the requestURI patterns are conflicting and the length of the

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -727,6 +727,21 @@ def test_parse_appconfig_non_json_blob_payload():
     )
 
 
+def test_parse_appconfig_deprecated_operation():
+    """
+    Tests if the parsing works correctly if the request targets a deprecated operation (without alternative, i.e.
+    another function having the same signature).
+    """
+    _botocore_parser_integration_test(
+        service="appconfig",
+        action="GetConfiguration",
+        Application="test-application",
+        Environment="test-environment",
+        Configuration="test-configuration",
+        ClientId="test-client-id",
+    )
+
+
 def test_parse_s3_with_extended_uri_pattern():
     """
     Tests if the parsing works for operations where the operation defines a request URI with a "+" in the variable name,


### PR DESCRIPTION
With the introduction of the `RestServiceOperationRouter` in ASF (https://github.com/localstack/localstack/pull/5827), we introduced a small regression.
The operation detection did not work correctly anymore for mandatory query parameters - defined in the requestUri of the operation specification - without a value.

For example, the operation detection did not work for CloudFront's `CreateDistributionWithTags` (where it mistakenly detects `CreateDistribution`):
- CreateDistributionWithTags: `/2020-05-31/distribution?WithTags`
- CreateDistribution: `/2014-05-31/distribution`

This PR contains a fix which ensures that an empty query arg in the requestUri is still considered for the operation detection.