### PR TITLE
add cloudformation support for s3 bucket versioning

### DIFF
--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -143,6 +143,20 @@ class S3Bucket(GenericBaseModel):
             if len(tags) > 0:
                 s3.put_bucket_tagging(Bucket=bucket_name, Tagging={"TagSet": tags})
 
+        def _put_bucket_versioning(resource_id, resources, resource_type, func, stack_name):
+            s3_client = aws_stack.connect_to_service("s3")
+            resource = resources[resource_id]
+            props = resource["Properties"]
+            bucket_name = props.get("BucketName")
+            versioning_config = props.get("VersioningConfiguration")
+            if versioning_config:
+                s3_client.put_bucket_versioning(
+                    Bucket=bucket_name,
+                    VersioningConfiguration={
+                        "Status": versioning_config.get("Status", "Disabled"),
+                    },
+                )
+
         result = {
             "create": [
                 {
@@ -159,6 +173,7 @@ class S3Bucket(GenericBaseModel):
                     "function": "put_bucket_notification_configuration",
                     "parameters": s3_bucket_notification_config,
                 },
+                {"function": _put_bucket_versioning},
                 {"function": _add_bucket_tags},
             ],
             "delete": [

--- a/tests/integration/cloudformation/test_cloudformation_s3.py
+++ b/tests/integration/cloudformation/test_cloudformation_s3.py
@@ -34,3 +34,11 @@ def test_bucket_autoname(cfn_client, deploy_cfn_template):
     output = descr_response["Stacks"][0]["Outputs"][0]
     assert output["OutputKey"] == "BucketNameOutput"
     assert result.stack_name.lower() in output["OutputValue"]
+
+
+def test_bucket_versioning(cfn_client, deploy_cfn_template, s3_client):
+    result = deploy_cfn_template(template_file_name="s3_versioned_bucket.yaml")
+    assert "BucketName" in result.outputs
+    bucket_name = result.outputs["BucketName"]
+    bucket_version = s3_client.get_bucket_versioning(Bucket=bucket_name)
+    assert bucket_version["Status"] == "Enabled"

--- a/tests/integration/templates/s3_versioned_bucket.yaml
+++ b/tests/integration/templates/s3_versioned_bucket.yaml
@@ -1,0 +1,17 @@
+Resources:
+  Bucket83908E77:
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+Outputs:
+  BucketName:
+    Value:
+      Ref: Bucket83908E77


### PR DESCRIPTION
Adds support for bucket versioning to the AWS::S3::Bucket CloudFormation model.

e.g.

```yaml
Resources:
  Bucket83908E77:
    Type: AWS::S3::Bucket
    Properties:
      VersioningConfiguration:
        Status: Enabled
```