### PR TITLE
fix queries for local secondary index on dynamodb

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -1225,9 +1225,19 @@ def get_global_secondary_index(table_name, index_name):
     raise ResourceNotFoundException("Index not found")
 
 
+def is_local_secondary_index(table_name, index_name) -> bool:
+    schema = SchemaExtractor.get_table_schema(table_name)
+    for index in schema["Table"].get("LocalSecondaryIndexes", []):
+        if index["IndexName"] == index_name:
+            return True
+    return False
+
+
 def is_index_query_valid(query_data: dict) -> bool:
     table_name = to_str(query_data["TableName"])
     index_name = to_str(query_data["IndexName"])
+    if is_local_secondary_index(table_name, index_name):
+        return True
     index_query_type = query_data.get("Select")
     index = get_global_secondary_index(table_name, index_name)
     index_projection_type = index.get("Projection").get("ProjectionType")


### PR DESCRIPTION
This is a fix for https://github.com/localstack/localstack/issues/5831:

Recently, we added a fix for Global Secondary Index usage https://github.com/localstack/localstack/pull/5799, which would raise an Exception if the index is not found in the `GlobalSecondaryIndexes`.

However, the index might be in `LocalSecondaryIndexes`. For this we should not require an additional check for the projection type, as [it states in the docs](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#API_Query_RequestSyntax):

> If you query or scan a local secondary index and request only attributes that are projected into that index, the operation will read only the index and not the table. If any of the requested attributes are not projected into the local secondary index, DynamoDB fetches each of these attributes from the parent table. This extra fetching incurs additional throughput cost and latency.

Which is different from the global index:
> If you query or scan a global secondary index, you can only request attributes that are projected into the index. Global secondary index queries cannot fetch attributes from the parent table.
