### PR TITLE
Fix ResourceNotFoundException for BatchGetItem operation

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -19,6 +19,8 @@ from localstack.aws.api import (
     handler,
 )
 from localstack.aws.api.dynamodb import (
+    BatchGetItemOutput,
+    BatchGetRequestMap,
     BatchWriteItemInput,
     BatchWriteItemOutput,
     CreateGlobalTableOutput,
@@ -56,6 +58,7 @@ from localstack.aws.api.dynamodb import (
     ResourceArnString,
     ResourceInUseException,
     ResourceNotFoundException,
+    ReturnConsumedCapacity,
     ScanInput,
     ScanOutput,
     StreamArn,
@@ -709,6 +712,15 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                     del unprocessed[key]
 
         return result
+
+    @handler("BatchGetItem")
+    def batch_get_item(
+        self,
+        context: RequestContext,
+        request_items: BatchGetRequestMap,
+        return_consumed_capacity: ReturnConsumedCapacity = None,
+    ) -> BatchGetItemOutput:
+        return self.forward_request(context)
 
     @handler("TransactWriteItems", expand=False)
     def transact_write_items(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -977,6 +977,28 @@ class TestDynamoDB:
 
         delete_table(table_name)
 
+    def test_dynamodb_get_batch_items(self):
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
+        table_name = "ddb-table-%s" % short_uid()
+
+        dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "PK", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "PK", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1}
+        )
+
+        result = dynamodb.batch_get_item(
+            RequestItems={
+                table_name: {
+                    "Keys": [
+                        {"PK": {"S": "test-key"}}
+                    ]
+                }
+            }
+        )
+        assert list(result["Responses"])[0] == table_name
+
 
 def delete_table(name):
     dynamodb_client = aws_stack.create_external_boto_client("dynamodb")

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -985,17 +985,11 @@ class TestDynamoDB:
             TableName=table_name,
             KeySchema=[{"AttributeName": "PK", "KeyType": "HASH"}],
             AttributeDefinitions=[{"AttributeName": "PK", "AttributeType": "S"}],
-            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1}
+            ProvisionedThroughput={"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
         )
 
         result = dynamodb.batch_get_item(
-            RequestItems={
-                table_name: {
-                    "Keys": [
-                        {"PK": {"S": "test-key"}}
-                    ]
-                }
-            }
+            RequestItems={table_name: {"Keys": [{"PK": {"S": "test-key"}}]}}
         )
         assert list(result["Responses"])[0] == table_name
 


### PR DESCRIPTION
The error was probably due to different access keys used across different requests.
Should fix #5843 