### PR TITLE
get_handler_file_from_name when path contains periods

### DIFF
--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -139,7 +139,7 @@ def format_name_to_path(handler_name: str, delimiter: str, extension: str):
     if file_path.startswith(f".{os.path.sep}"):
         file_path = file_path[2:]
 
-    return "%s%s" % (file_path, extension)
+    return f"{file_path}{extension}"
 
 
 def get_handler_file_from_name(handler_name: str, runtime: str = None):

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -136,7 +136,7 @@ def format_name_to_path(handler_name: str, delimiter: str, extension: str):
     if os.path.sep not in file_path:
         file_path = file_path.replace(".", os.path.sep)
 
-    if file_path.startswith(".%s" % os.path.sep):
+    if file_path.startswith(f".{os.path.sep}"):
         file_path = file_path[2:]
 
     return "%s%s" % (file_path, extension)

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -128,24 +128,35 @@ def is_provided_runtime(runtime_details: Union[LambdaFunction, str]) -> bool:
     return runtime.startswith("provided")
 
 
+def format_name_to_path(handler_name: str, delimiter: str, extension: str):
+    file_path = handler_name.rpartition(delimiter)[0]
+    if delimiter == ":":
+        file_path = file_path.split(delimiter)[0]
+
+    if os.path.sep not in file_path:
+        file_path = file_path.replace(".", os.path.sep)
+
+    if file_path.startswith(".%s" % os.path.sep):
+        file_path = file_path[2:]
+
+    return "%s%s" % (file_path, extension)
+
+
 def get_handler_file_from_name(handler_name: str, runtime: str = None):
     runtime = runtime or LAMBDA_DEFAULT_RUNTIME
+
     if runtime.startswith(LAMBDA_RUNTIME_PROVIDED):
         return "bootstrap"
-    delimiter = "."
     if runtime.startswith(LAMBDA_RUNTIME_NODEJS):
-        file_ext = ".js"
-    elif runtime.startswith(LAMBDA_RUNTIME_GOLANG):
-        file_ext = ""
-    elif runtime.startswith(tuple(DOTNET_LAMBDA_RUNTIMES)):
-        file_ext = ".dll"
-        delimiter = ":"
-    elif runtime.startswith(LAMBDA_RUNTIME_RUBY):
-        file_ext = ".rb"
-    else:
-        handler_name = handler_name.rpartition(delimiter)[0].replace(delimiter, os.path.sep)
-        file_ext = ".py"
-    return "%s%s" % (handler_name.split(delimiter)[0], file_ext)
+        return format_name_to_path(handler_name, ".", ".js")
+    if runtime.startswith(LAMBDA_RUNTIME_GOLANG):
+        return format_name_to_path(handler_name, ".", "")
+    if runtime.startswith(tuple(DOTNET_LAMBDA_RUNTIMES)):
+        return format_name_to_path(handler_name, ":", ".dll")
+    if runtime.startswith(LAMBDA_RUNTIME_RUBY):
+        return format_name_to_path(handler_name, ".", ".rb")
+
+    return format_name_to_path(handler_name, ".", ".py")
 
 
 def is_java_lambda(lambda_details):

--- a/tests/unit/services/awslambda/test_lambda_utils.py
+++ b/tests/unit/services/awslambda/test_lambda_utils.py
@@ -1,0 +1,43 @@
+from localstack.services.awslambda.lambda_utils import (
+    LAMBDA_RUNTIME_DOTNETCORE31,
+    LAMBDA_RUNTIME_GOLANG,
+    LAMBDA_RUNTIME_NODEJS,
+    LAMBDA_RUNTIME_PROVIDED,
+    LAMBDA_RUNTIME_RUBY,
+    format_name_to_path,
+    get_handler_file_from_name,
+)
+
+
+class TestLambdaUtils:
+    def test_format_name_to_path(self):
+        assert ".build/handler.js" == format_name_to_path(".build/handler.execute", ".", ".js")
+        assert "handler" == format_name_to_path("handler.execute", ".", "")
+        assert "CSharpHandlers.dll" == format_name_to_path(
+            "./CSharpHandlers::AwsDotnetCsharp.Handler::CreateProfileAsync",
+            ":",
+            ".dll",
+        )
+        assert "test/handler.rb" == format_name_to_path("test.handler.execute", ".", ".rb")
+        assert "test.handler.py" == format_name_to_path("./test.handler.execute", ".", ".py")
+        assert "../handler.js" == format_name_to_path("../handler.execute", ".", ".js")
+
+    def test_get_handler_file_from_name(self):
+        assert ".build/handler.js" == get_handler_file_from_name(
+            ".build/handler.execute", LAMBDA_RUNTIME_NODEJS
+        )
+        assert ".build/handler" == get_handler_file_from_name(
+            "./.build/handler.execute", LAMBDA_RUNTIME_GOLANG
+        )
+        assert "CSharpHandlers.dll" == get_handler_file_from_name(
+            "./CSharpHandlers::AwsDotnetCsharp.Handler::CreateProfileAsync",
+            LAMBDA_RUNTIME_DOTNETCORE31,
+        )
+        assert "test/handler.rb" == get_handler_file_from_name(
+            "test.handler.execute", LAMBDA_RUNTIME_RUBY
+        )
+        assert "test.handler" == get_handler_file_from_name(
+            "./test.handler.execute", LAMBDA_RUNTIME_GOLANG
+        )
+        assert "../handler.py" == get_handler_file_from_name("../handler.execute")
+        assert "bootstrap" == get_handler_file_from_name("", LAMBDA_RUNTIME_PROVIDED)


### PR DESCRIPTION
Fixes for get_handler_file_from_name, fixing incorrectly returning '.js' from '.build/handler.execute' (Typescript).

Revisiting #1774 / #1775
Also appears related to both #5485 and #3969 with '.webpack/service/first.hello'
This appears to have either regressed or not been fixed, due to `handler_name.split(delimiter)[0]` will return '.js' from '.build/handler.execute' instead of '.build/handler.js'

Have added in a few tests to with my assumptions on how it's currently working.
Please do let me know if any of these assumptions are incorrect, or anything else for that matter and I'll update the PR.

Thanks,
Matt