### PR TITLE
Update python to 3.8.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG IMAGE_TYPE=full
 
 # java-builder: Stage to build a custom JRE (with jlink)
-FROM python:3.8.12-slim-buster@sha256:26ab58f6b8936fe59303b0ca0e915d5f9e071ef8b9bf7b3d716b4068f11443dc as java-builder
+FROM python:3.8.13-slim-buster@sha256:be6b8111e837bd2fd9149a60348cbaebba4ccd61ca1b40d6f973bd5996d3a47a as java-builder
 ARG TARGETARCH
 
 # install OpenJDK 11
@@ -34,7 +34,7 @@ jdk.localedata --include-locales en,th \
 
 
 # base: Stage which installs necessary runtime dependencies (OS packages, java, maven,...)
-FROM python:3.8.12-slim-buster@sha256:26ab58f6b8936fe59303b0ca0e915d5f9e071ef8b9bf7b3d716b4068f11443dc as base
+FROM python:3.8.13-slim-buster@sha256:be6b8111e837bd2fd9149a60348cbaebba4ccd61ca1b40d6f973bd5996d3a47a as base
 ARG TARGETARCH
 
 # Install runtime OS package dependencies


### PR DESCRIPTION
## PR reason
Currently, using curl with cipher `AEAD-CHACHA20-POLY1305-SHA256` (only available in LibreSSL versions on Mac at this time) to connect to an endpoint on LocalStack, like this:
```
curl --ciphers AEAD-CHACHA20-POLY1305-SHA256 https://localhost.localstack.cloud:4566/health
```
will cause LocalStack to segfault and restart.
This seems to be fixed in the latest python docker image.

## Fix
Update to python 3.8.13. You can see, in the changelogs (https://www.python.org/downloads/release/python-3813/) that openssl is updated (only mention for installers, but it seems to be the case in the docker images as well).
Output of `openssl version` in the 3.8.13 container:
```
OpenSSL 1.1.1n  15 Mar 2022
```
vs 3.8.12:
```
OpenSSL 1.1.1n  15 Mar 2022 (Library: OpenSSL 1.1.1d  10 Sep 2019)
```
This update (while done for security reasons) seems to also have fixed the segfault when using the cipher.

Unlike #5632 , this should not have any ill effects regarding the circleCI pipeline, so should be a quick fix for #5749 .