### PR TITLE
add task scheduler utility

### DIFF
--- a/localstack/utils/scheduler.py
+++ b/localstack/utils/scheduler.py
@@ -1,0 +1,184 @@
+import queue
+import threading
+import time
+from concurrent.futures import Executor
+from typing import Any, Callable, List, Mapping, Optional, Tuple, Union
+
+
+class ScheduledTask:
+    """
+    Internal representation of a task (a callable) and its scheduling parameters.
+    """
+
+    def __init__(
+        self,
+        task: Callable,
+        period: Optional[float] = None,
+        fixed_rate: bool = True,
+        start: Optional[float] = None,
+        on_error: Callable[[Exception], None] = None,
+        args: Optional[Union[tuple, list]] = None,
+        kwargs: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self.task = task
+        self.fixed_rate = fixed_rate
+        self.period = period
+        self.start = start
+        self.on_error = on_error
+        self.args = args or tuple()
+        self.kwargs = kwargs or dict()
+
+        self.deadline = None
+        self.error = None
+        self._cancelled = False
+
+    @property
+    def is_periodic(self) -> bool:
+        return self.period is not None
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancelled
+
+    def set_next_deadline(self):
+        if not self.deadline:
+            raise ValueError("Deadline was not initialized")
+
+        if self.fixed_rate:
+            self.deadline = self.deadline + self.period
+        else:
+            self.deadline = time.time() + self.period
+
+    def cancel(self):
+        self._cancelled = True
+
+    def run(self):
+        """
+
+        :return:
+        """
+        try:
+            self.task(*self.args, **self.kwargs)
+        except Exception as e:
+            if self.on_error:
+                self.on_error(e)
+
+
+class Scheduler:
+    """
+    An event-loop based task scheduler that can be parallelized with an executor.
+    """
+
+    POISON = (-1, "__POISON__")
+
+    def __init__(self, executor: Optional[Executor] = None) -> None:
+        """
+        Creates a new Scheduler. If an executor is passed, then that executor will be used to run the scheduled tasks
+        asynchronously, otherwise they will be executed synchronously inside the event loop.
+
+        :param executor: an optional executor that tasks will be submitted to.
+        """
+        super().__init__()
+        self.executor = executor
+
+        self._queue = queue.PriorityQueue()
+        self._condition = threading.Condition()
+
+    def schedule(
+        self,
+        func: Callable,
+        period: Optional[float] = None,
+        fixed_rate: bool = True,
+        start: Optional[float] = None,
+        on_error: Callable[[Exception], None] = None,
+        args: Optional[Union[Tuple, List[Any]]] = None,
+        kwargs: Optional[Mapping[str, Any]] = None,
+    ) -> ScheduledTask:
+        """
+        Schedules a given task (function call).
+
+        :param func: the task to schedule
+        :param period: the period in which to run the task (in seconds). if not set, task will run once
+        :param fixed_rate: whether the to run at a fixed rate (neglecting execution duration of the task)
+        :param start: start time
+        :param on_error: error callback
+        :param args: additional positional arguments to pass to the function
+        :param kwargs: additional keyword arguments to pass to the function
+        :return a ScheduledTask instance
+        """
+        st = ScheduledTask(
+            func,
+            period=period,
+            fixed_rate=fixed_rate,
+            start=start,
+            on_error=on_error,
+            args=args,
+            kwargs=kwargs,
+        )
+        self.schedule_task(st)
+        return st
+
+    def schedule_task(self, task: ScheduledTask) -> None:
+        task.deadline = max(task.start or 0, time.time())
+        self.add(task)
+
+    def add(self, task: ScheduledTask) -> None:
+        if task.deadline is None:
+            raise ValueError
+
+        task._cancelled = False
+
+        with self._condition:
+            self._queue.put((task.deadline, task))
+            self._condition.notify()
+
+    def close(self) -> None:
+        """
+        Termintes the run loop.
+        """
+        with self._condition:
+            self._queue.put(self.POISON)
+            self._condition.notify()
+
+    def run(self):
+        q = self._queue
+        cond = self._condition
+        executor = self.executor
+        poison = self.POISON
+
+        task: ScheduledTask
+        while True:
+            deadline, task = q.get()
+
+            if (deadline, task) == poison:
+                break
+
+            if task.is_cancelled:
+                continue
+
+            w = max(0, deadline - time.time())
+            if w > 0:
+                with cond:
+                    interrupted = cond.wait(timeout=w)
+                    if interrupted:
+                        # something with a potentially earlier deadline has arrived
+                        # the naive thing is to requeue and retry
+                        # could optimize by checking the deadline of the added element(s), but that would be fairly
+                        # involved. the assumption is that schedule is not invoked frequently
+                        q.put((task.deadline, task))
+                        continue
+
+            if task.is_periodic:
+                try:
+                    task.set_next_deadline()
+                except ValueError:
+                    # task deadline couldn't be set because it was cancelled
+                    return
+                q.put((task.deadline, task))
+
+            if not task.is_cancelled:
+                if executor:
+                    executor.submit(task.run)
+                else:
+                    task.run()

--- a/tests/unit/utils/test_scheduler.py
+++ b/tests/unit/utils/test_scheduler.py
@@ -65,9 +65,9 @@ class TestScheduler:
 
         assert task.invocations[0][1] == pytest.approx(invocation_time, 0.1)
 
-    def test_period_run_nonfixed(self, dispatcher):
+    def test_period_run_nonfixed(self):
         task = DummyTask()
-        scheduler, thread = self.create_and_start(dispatcher)
+        scheduler, thread = self.create_and_start(None)
 
         scheduler.schedule(task, period=0.1, fixed_rate=False)
         scheduler.schedule(scheduler.close, start=time.time() + 0.5)
@@ -77,10 +77,10 @@ class TestScheduler:
         assert task.invocations[2][1] + 0.1 == pytest.approx(task.invocations[3][1], 0.05)
         assert task.invocations[3][1] + 0.1 == pytest.approx(task.invocations[4][1], 0.05)
 
-    def test_periodic_run_fixed_with_longer_task(self, dispatcher):
+    def test_periodic_run_fixed_with_longer_task(self):
         task = DummyTask(fn=lambda: time.sleep(1))
 
-        scheduler, thread = self.create_and_start(dispatcher)
+        scheduler, thread = self.create_and_start(None)
 
         scheduler.schedule(task, period=0.5, fixed_rate=True)
         scheduler.schedule(scheduler.close, start=time.time() + 1.25)

--- a/tests/unit/utils/test_scheduler.py
+++ b/tests/unit/utils/test_scheduler.py
@@ -1,0 +1,184 @@
+import threading
+import time
+from concurrent.futures.thread import ThreadPoolExecutor
+from typing import Tuple
+
+import pytest
+
+from localstack.utils.scheduler import ScheduledTask, Scheduler
+from localstack.utils.sync import poll_condition
+
+
+class DummyTask:
+    def __init__(self, fn=None) -> None:
+        super().__init__()
+        self.i = 0
+        self.invocations = list()
+        self.completions = list()
+        self.fn = fn
+
+    def __call__(self, *args, **kwargs):
+        self.invoke(*args, **kwargs)
+
+    def invoke(self, *args, **kwargs):
+        self.i += 1
+        invoked = time.time()
+        self.invocations.append((self.i, invoked, args, kwargs))
+
+        if self.fn:
+            self.fn(*args, **kwargs)
+
+        self.completions.append((self.i, time.time(), args, kwargs))
+
+
+@pytest.fixture
+def dispatcher():
+    executor = ThreadPoolExecutor(4)
+    yield executor
+    executor.shutdown()
+
+
+class TestScheduler:
+    @staticmethod
+    def create_and_start(dispatcher) -> Tuple[Scheduler, threading.Thread]:
+        scheduler = Scheduler(executor=dispatcher)
+        thread = threading.Thread(target=scheduler.run)
+        thread.start()
+
+        return scheduler, thread
+
+    def test_single_scheduled_run(self, dispatcher):
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        task = DummyTask()
+        invocation_time = time.time() + 0.2
+
+        scheduler.schedule(task, start=invocation_time)
+
+        assert poll_condition(lambda: len(task.invocations) >= 1, timeout=5)
+
+        scheduler.close()
+        thread.join(5)
+
+        assert len(task.invocations) == 1
+        assert task.invocations[0][0] == 1
+
+        assert task.invocations[0][1] == pytest.approx(invocation_time, 0.1)
+
+    def test_period_run_nonfixed(self, dispatcher):
+        task = DummyTask()
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        scheduler.schedule(task, period=0.1, fixed_rate=False)
+        scheduler.schedule(scheduler.close, start=time.time() + 0.5)
+        thread.join(5)
+
+        assert task.invocations[1][1] + 0.1 == pytest.approx(task.invocations[2][1], 0.05)
+        assert task.invocations[2][1] + 0.1 == pytest.approx(task.invocations[3][1], 0.05)
+        assert task.invocations[3][1] + 0.1 == pytest.approx(task.invocations[4][1], 0.05)
+
+    def test_periodic_run_fixed_with_longer_task(self, dispatcher):
+        task = DummyTask(fn=lambda: time.sleep(1))
+
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        scheduler.schedule(task, period=0.5, fixed_rate=True)
+        scheduler.schedule(scheduler.close, start=time.time() + 1.25)
+
+        thread.join(5)
+
+        assert len(task.invocations) == 3
+
+        first = task.invocations[0][1]
+        assert first + 0.5 == pytest.approx(task.invocations[1][1], 0.1)
+        assert first + 1 == pytest.approx(task.invocations[2][1], 0.1)
+
+        assert poll_condition(lambda: len(task.completions) >= 3, timeout=5)
+
+    def test_periodic_change_period(self, dispatcher):
+        task = DummyTask()
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        stask = scheduler.schedule(task, period=1, fixed_rate=True)
+
+        def change_period(t: ScheduledTask, period: float):
+            t.period = period
+
+        scheduler.schedule(change_period, start=time.time() + 1.25, args=(stask, 0.5))
+        scheduler.schedule(scheduler.close, start=time.time() + 3)
+
+        thread.join(5)
+
+        first = task.invocations[0][1]
+        second = task.invocations[1][1]
+        third = task.invocations[2][1]
+        fourth = task.invocations[3][1]
+        assert first + 1 == pytest.approx(second, 0.1)
+        assert second + 1 == pytest.approx(third, 0.1)
+        # changed to 0.5
+        assert third + 0.5 == pytest.approx(fourth, 0.1)
+
+    def test_cancel_task(self, dispatcher):
+        task1 = DummyTask()
+        task2 = DummyTask()
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        scheduler.schedule(task2.invoke, period=0.5)
+        stask = scheduler.schedule(task1.invoke, period=0.5)
+
+        scheduler.schedule(stask.cancel, start=time.time() + 0.75)
+        scheduler.schedule(scheduler.close, start=time.time() + 1.5)
+
+        thread.join(5)
+
+        assert len(task1.invocations) == 2
+        assert len(task2.invocations) == 4
+
+    def test_error_handler(self):
+        scheduler = Scheduler()
+
+        event = threading.Event()
+
+        def invoke():
+            raise ValueError("unittest")
+
+        def on_error(e):
+            event.set()
+
+        scheduler.schedule(invoke, on_error=on_error)
+        scheduler.schedule(scheduler.close)
+
+        scheduler.run()
+
+        assert event.wait(5)
+
+    def test_scheduling_reordering(self, dispatcher):
+        task = DummyTask()
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        t = time.time()
+        scheduler.schedule(task, args=("task2",), start=t + 1)  # task two gets scheduled first
+        time.sleep(0.25)
+        scheduler.schedule(
+            task, args=("task1",), start=t + 0.5
+        )  # but task one has the shorter deadline
+
+        scheduler.schedule(scheduler.close, start=t + 1.5)
+
+        thread.join(5)
+
+        assert len(task.invocations) == 2
+        assert task.invocations[0][2][0] == "task1"
+        assert task.invocations[1][2][0] == "task2"
+
+    def test_close_interrupts_waiting_tasks(self, dispatcher):
+        task = DummyTask()
+        scheduler, thread = self.create_and_start(dispatcher)
+
+        scheduler.schedule(task, start=time.time() + 1)
+        time.sleep(0.25)
+        scheduler.close()
+
+        thread.join(5)
+
+        assert len(task.invocations) == 0


### PR DESCRIPTION
This PR adds a scheduler utility that can be used to schedule tasks in an event-loop based manner, potentially without threads, which can be helpful to implement things like alarm evaluations in cloudwatch.