### PR TITLE
fix extraction of oauth_http_parameters for api destinations

### DIFF
--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -181,11 +181,12 @@ def auth_keys_from_connection(connection: Dict):
 
     if auth_type == AUTH_OAUTH:
         oauth_parameters = auth_parameters.get("OAuthParameters", {})
-
         oauth_method = oauth_parameters.get("HttpMethod")
+
+        oauth_http_parameters = oauth_parameters.get("OAuthHttpParameters", {})
         oauth_endpoint = oauth_parameters.get("AuthorizationEndpoint", "")
         query_object = list_of_parameters_to_object(
-            oauth_parameters.get("QueryStringParameters", [])
+            oauth_http_parameters.get("QueryStringParameters", [])
         )
         oauth_endpoint = add_query_params_to_url(oauth_endpoint, query_object)
 
@@ -193,17 +194,18 @@ def auth_keys_from_connection(connection: Dict):
         client_id = client_parameters.get("ClientID", "")
         client_secret = client_parameters.get("ClientSecret", "")
 
-        oauth_body = list_of_parameters_to_object(oauth_parameters.get("BodyParameters", []))
+        oauth_body = list_of_parameters_to_object(oauth_http_parameters.get("BodyParameters", []))
         oauth_body.update({"client_id": client_id, "client_secret": client_secret})
 
-        oauth_header = list_of_parameters_to_object(oauth_parameters.get("HeaderParameters", []))
+        oauth_header = list_of_parameters_to_object(
+            oauth_http_parameters.get("HeaderParameters", [])
+        )
         oauth_result = requests.request(
             method=oauth_method,
             url=oauth_endpoint,
             data=json.dumps(oauth_body),
             headers=oauth_header,
         )
-
         oauth_data = json.loads(oauth_result.text)
 
         token_type = oauth_data.get("token_type", "")

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 import uuid
-from typing import Dict
+from typing import Dict, Optional
 
 from moto.events.models import events_backends as moto_events_backends
 
@@ -220,7 +220,7 @@ def list_of_parameters_to_object(items):
     return {item.get("Key"): item.get("Value") for item in items}
 
 
-def send_event_to_api_destination(target_arn, event, http_parameters: Dict = None):
+def send_event_to_api_destination(target_arn, event, http_parameters: Optional[Dict] = None):
     """Send an event to an EventBridge API destination
     See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html"""
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -713,7 +713,6 @@ class EventsTest(unittest.TestCase):
             self.events_client.delete_rule(Name=rule_name, Force=True)
 
         # assert that all events have been received in the HTTP server listener
-        user_pass = to_str(base64.b64encode(b"user:pass"))
 
         def check():
             self.assertTrue(len(events) >= len(auth_types))

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -590,6 +590,17 @@ class EventsTest(unittest.TestCase):
                 if headers.get("target_header"):
                     headers_list.append(headers.get("target_header"))
 
+                if "client_id" in event:
+                    oauth_data.update(
+                        {
+                            "client_id": event.get("client_id"),
+                            "client_secret": event.get("client_secret"),
+                            "header_value": headers.get("oauthheader"),
+                            "body_value": event.get("oauthbody"),
+                            "path": path,
+                        }
+                    )
+
                 return requests_response(
                     {
                         "access_token": token,
@@ -601,6 +612,7 @@ class EventsTest(unittest.TestCase):
         events = []
         paths_list = []
         headers_list = []
+        oauth_data = {}
 
         local_port = get_free_tcp_port()
         proxy = start_proxy(local_port, update_listener=HttpEndpointListener())
@@ -626,6 +638,11 @@ class EventsTest(unittest.TestCase):
                     "AuthorizationEndpoint": url,
                     "ClientParameters": {"ClientID": "id", "ClientSecret": "password"},
                     "HttpMethod": "put",
+                    "OAuthHttpParameters": {
+                        "BodyParameters": [{"Key": "oauthbody", "Value": "value1"}],
+                        "HeaderParameters": [{"Key": "oauthheader", "Value": "value2"}],
+                        "QueryStringParameters": [{"Key": "oauthquery", "Value": "value3"}],
+                    },
                 },
             },
         ]
@@ -706,7 +723,17 @@ class EventsTest(unittest.TestCase):
             self.assertTrue(events[0].get("key") == "value")
             self.assertTrue(events[0].get("target_value") == "value")
 
+            # Oauth validation
+            self.assertTrue(oauth_data.get("client_id") == "id")
+            self.assertTrue(oauth_data.get("client_secret") == "password")
+            self.assertTrue(oauth_data.get("header_value") == "value2")
+            self.assertTrue(oauth_data.get("body_value") == "value1")
+            self.assertTrue("oauthquery" in oauth_data.get("path"))
+            self.assertTrue("value3" in oauth_data.get("path"))
+
+            user_pass = to_str(base64.b64encode(b"user:pass"))
             self.assertTrue(f"Basic {user_pass}" in headers_list)
+
             self.assertTrue("apikey_secret" in headers_list)
             self.assertTrue(bearer in headers_list)
             self.assertTrue("target_header_value" in headers_list)


### PR DESCRIPTION
This PR addresses #5729. Where the user reports an error on the extraction of the oauth credentials parameters for an API destination.

Changes:
- Fixing of the OauthHttpParameters values.
- Test extension to validate changes.

Note: The test extension change probably overlaps with the test correction of #5738 so one of the PR should be rebased after the other one is merged.