### PR TITLE
Fix ApiGW: accept yaml format for openapi(swagger) import

### DIFF
--- a/localstack/services/apigateway/apigateway_listener.py
+++ b/localstack/services/apigateway/apigateway_listener.py
@@ -71,6 +71,7 @@ from localstack.utils.common import camel_to_snake_case, json_safe, long_uid, to
 
 # set up logger
 from localstack.utils.http import add_query_params_to_url
+from localstack.utils.json import parse_json_or_yaml
 
 LOG = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class ProxyListenerApiGateway(ProxyListener):
             if result is not None:
                 return result
 
-        data = data and json.loads(to_str(data))
+        data = parse_json_or_yaml(to_str(data or b""))
 
         if re.match(PATH_REGEX_AUTHORIZERS, path):
             return handle_authorizers(method, path, data, headers)

--- a/localstack/services/apigateway/apigateway_starter.py
+++ b/localstack/services/apigateway/apigateway_starter.py
@@ -18,6 +18,7 @@ from localstack.services.apigateway.helpers import (
 )
 from localstack.services.infra import start_moto_server
 from localstack.utils.common import DelSafeDict, short_uid, str_to_bool, to_str
+from localstack.utils.json import parse_json_or_yaml
 
 LOG = logging.getLogger(__name__)
 
@@ -148,7 +149,7 @@ def apply_patches():
 
         # handle import rest_api via swagger file
         if self.method == "PUT":
-            body = json.loads(to_str(self.body))
+            body = parse_json_or_yaml(to_str(self.body))
             rest_api = self.backend.put_rest_api(function_id, body, self.querystring)
             return 200, {}, json.dumps(rest_api.to_dict())
 
@@ -487,7 +488,7 @@ def apply_patches():
             return status, _, rest_api
 
         function_id = json.loads(rest_api)["id"]
-        body = json.loads(request.data.decode("utf-8"))
+        body = parse_json_or_yaml(request.data.decode("utf-8"))
         self.backend.put_rest_api(function_id, body, parsed_qs)
 
         return 200, {}, rest_api

--- a/tests/integration/files/swagger.yaml
+++ b/tests/integration/files/swagger.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.1
+info:
+  title: test
+  version: '2020-07-23T23:02:57Z'
+servers:
+- url: https://rei6t36l9d.execute-api.us-east-1.amazonaws.com/{basePath}
+  variables:
+    basePath:
+      default: "/test"
+paths:
+  "/test":
+    get:
+      responses:
+        '200':
+          description: 200 response
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Empty"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+            responseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: when_no_match
+        type: mock
+    options:
+      responses:
+        '200':
+          description: 200 response
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Empty"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: '200'
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: when_no_match
+        type: mock
+components:
+  schemas:
+    Empty:
+      title: Empty Schema
+      type: object

--- a/tests/integration/test_api_gateway.py
+++ b/tests/integration/test_api_gateway.py
@@ -49,7 +49,8 @@ from .awslambda.test_lambda import (
 )
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
-TEST_SWAGGER_FILE = os.path.join(THIS_FOLDER, "files", "swagger.json")
+TEST_SWAGGER_FILE_JSON = os.path.join(THIS_FOLDER, "files", "swagger.json")
+TEST_SWAGGER_FILE_YAML = os.path.join(THIS_FOLDER, "files", "swagger.yaml")
 TEST_IMPORT_REST_API_FILE = os.path.join(THIS_FOLDER, "files", "pets.json")
 
 ApiGatewayLambdaProxyIntegrationTestResult = namedtuple(
@@ -1131,7 +1132,11 @@ class TestAPIGateway(unittest.TestCase):
         client = aws_stack.create_external_boto_client("apigateway")
         rest_api_id = client.create_rest_api(name=rest_api_name)["id"]
 
-        spec_file = load_file(TEST_SWAGGER_FILE)
+        spec_file = load_file(TEST_SWAGGER_FILE_JSON)
+        rs = client.put_rest_api(restApiId=rest_api_id, body=spec_file, mode="overwrite")
+        self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
+
+        spec_file = load_file(TEST_SWAGGER_FILE_YAML)
         rs = client.put_rest_api(restApiId=rest_api_id, body=spec_file, mode="overwrite")
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
 


### PR DESCRIPTION
This PR addresses #5852. 

Changes: 
- ApiGW now accepts yaml files for api definitions.
- Test extension to validate change.