### PR TITLE
Return successfully when attempting to delete a non-existent secret

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -268,8 +268,8 @@ class SecretsmanagerProvider(SecretsmanagerApi):
 
 
 @patch(FakeSecret.__init__)
-def fake_secret__init__(fn, self, **kwargs):
-    fn(self, **kwargs)
+def fake_secret__init__(fn, self, *args, **kwargs):
+    fn(self, *args, **kwargs)
 
     # Fix time not including millis.
     time_now = time.time()

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -1701,10 +1701,10 @@ class TestSecretsManager:
 
     def test_delete_non_existent_secret_returns_as_if_secret_exists(self, sm_client):
         """When ForceDeleteWithoutRecovery=True, AWS responds as if the non-existent secret was successfully deleted."""
-        secret_id = 'non-existent-secret'
+        secret_id = "non-existent-secret"
 
         response = sm_client.delete_secret(SecretId=secret_id, ForceDeleteWithoutRecovery=True)
 
-        assert response['Name'] == secret_id
-        assert response['ARN'] is not None
-        assert response['DeletionDate'] is not None
+        assert response["Name"] == secret_id
+        assert response["ARN"] is not None
+        assert response["DeletionDate"] is not None

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -1698,3 +1698,13 @@ class TestSecretsManager:
         self.secretsmanager_http_delete_secret_val_res(
             self.secretsmanager_http_delete_secret(secret_name), secret_name
         )
+
+    def test_delete_non_existent_secret_returns_as_if_secret_exists(self, sm_client):
+        """When ForceDeleteWithoutRecovery=True, aws responds as if the non-existent secret was successfully deleted."""
+        secret_id = 'non-existent-secret'
+
+        response = sm_client.delete_secret(SecretId=secret_id, ForceDeleteWithoutRecovery=True)
+
+        assert response['Name'] == secret_id
+        assert response['ARN'] is not None
+        assert response['DeletionDate'] is not None

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -1700,7 +1700,7 @@ class TestSecretsManager:
         )
 
     def test_delete_non_existent_secret_returns_as_if_secret_exists(self, sm_client):
-        """When ForceDeleteWithoutRecovery=True, aws responds as if the non-existent secret was successfully deleted."""
+        """When ForceDeleteWithoutRecovery=True, AWS responds as if the non-existent secret was successfully deleted."""
         secret_id = 'non-existent-secret'
 
         response = sm_client.delete_secret(SecretId=secret_id, ForceDeleteWithoutRecovery=True)


### PR DESCRIPTION
This resolves bug https://github.com/localstack/localstack/issues/5872

The issue was caused by localstack patching the constructor of motos FakeSecret class, but not passing along the positional arguments. The call to delete_secret then fails here:
https://github.com/spulec/moto/blob/master/moto/secretsmanager/models.py#L701
(See the stack-trace posted on the bug ticket for details)