### PR TITLE
rework localstack.http.Request object to use a dummy WSGi environment

### DIFF
--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -131,9 +131,6 @@ def dispatch_to_moto(context: RequestContext) -> MotoResponse:
     service = context.service
     request = context.request
 
-    # hack to avoid call to request.form (see moto's BaseResponse.dispatch)
-    request.body = request.data
-
     # this is where we skip the HTTP roundtrip between the moto server and the boto client
     dispatch = get_dispatcher(service.service_name, request.path)
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -5,7 +5,6 @@ import pytest
 from botocore.awsrequest import prepare_request_dict
 from botocore.serialize import create_serializer
 
-from localstack.aws.api import HttpRequest
 from localstack.aws.protocol.parser import (
     OperationNotFoundParserError,
     ProtocolParserError,
@@ -14,6 +13,7 @@ from localstack.aws.protocol.parser import (
     create_parser,
 )
 from localstack.aws.spec import load_service
+from localstack.http import Request as HttpRequest
 from localstack.services.s3 import s3_utils
 from localstack.utils.common import to_bytes, to_str
 

--- a/tests/unit/http/test_request.py
+++ b/tests/unit/http/test_request.py
@@ -1,8 +1,9 @@
-from json import JSONDecodeError
+import wsgiref.validate
 
 import pytest
+from werkzeug.exceptions import BadRequest
 
-from localstack.http.request import Request
+from localstack.http.request import Request, dummy_wsgi_environment
 
 
 def test_get_json():
@@ -23,7 +24,7 @@ def test_get_json_force():
 def test_get_json_invalid():
     r = Request("POST", "/", body=b'{"foo": "')
 
-    with pytest.raises(JSONDecodeError):
+    with pytest.raises(BadRequest):
         assert r.get_json(force=True)
 
     assert r.get_json(force=True, silent=True) is None
@@ -43,3 +44,59 @@ def test_get_stream():
     r = Request("GET", "/", body=b"foobar")
     assert r.stream.read(3) == b"foo"
     assert r.stream.read(3) == b"bar"
+
+
+def test_args():
+    r = Request("GET", "/", query_string="foo=420&bar=69")
+    assert len(r.args) == 2
+    assert r.args["foo"] == "420"
+    assert r.args["bar"] == "69"
+
+
+def test_values():
+    r = Request("GET", "/", query_string="foo=420&bar=69")
+    assert len(r.values) == 2
+    assert r.values["foo"] == "420"
+    assert r.values["bar"] == "69"
+
+
+def test_form_empty():
+    r = Request("POST", "/")
+    assert len(r.form) == 0
+
+
+def test_post_form_urlencoded_and_query():
+    # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST#example
+    r = Request(
+        "POST",
+        "/form",
+        query_string="query1=foo&query2=bar",
+        body=b"field1=value1&field2=value2",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert len(r.form) == 2
+    assert r.form["field1"] == "value1"
+    assert r.form["field2"] == "value2"
+
+    assert len(r.args) == 2
+    assert r.args["query1"] == "foo"
+    assert r.args["query2"] == "bar"
+
+    assert len(r.values) == 4
+    assert r.values["field1"] == "value1"
+    assert r.values["field2"] == "value2"
+    assert r.args["query1"] == "foo"
+    assert r.args["query2"] == "bar"
+
+
+def test_validate_dummy_environment():
+    def validate(*args, **kwargs):
+        assert wsgiref.validate.check_environ(dummy_wsgi_environment(*args, **kwargs)) is None
+
+    validate(path="/foo/bar", body="foo")
+    validate(path="/foo/bar", query_string="foo=420&bar=69")
+    validate(server=("localstack.cloud", 4566))
+    validate(server=("localstack.cloud", None))
+    validate(remote_addr="127.0.0.1")
+    validate(headers={"Content-Type": "text/xml"}, body=b"")


### PR DESCRIPTION
This PR reworks our HTTP Request object to better re-use werkzeug's Request object. Instead of replicating the methods and mocking out IO, we now create a fake `WSGIEnvironment`, which is what underlies a werkzeug Request. This way we can re-use all of werkzeug's request parsing methods (e.g., parsing form data).
What needs to be in the `WSGIEnvironment` dictionary was determined partly from [the wsgi docs](https://wsgi.readthedocs.io/en/latest/definitions.html#standard-environ-keys), partly from the [werkzeug code](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/wrappers/request.py), and partly from inspecting a flask request.

* Supersedes #5875