### PR TITLE
Error message for PAY_PER_REQUEST billing mode

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -388,10 +388,8 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         if self.table_exists(table_name):
             raise ResourceInUseException("Cannot create preexisting table")
         billing_mode = create_table_input.get("BillingMode")
-        if (
-            billing_mode == BillingMode.PAY_PER_REQUEST
-            and create_table_input.get("ProvisionedThroughput", None) is not None
-        ):
+        provisioned_throughput = create_table_input.get("ProvisionedThroughput")
+        if billing_mode == BillingMode.PAY_PER_REQUEST and provisioned_throughput is not None:
             raise ValidationException(
                 "One or more parameter values were invalid: Neither ReadCapacityUnits nor WriteCapacityUnits can be "
                 "specified when BillingMode is PAY_PER_REQUEST"

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -387,7 +387,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         table_name = create_table_input["TableName"]
         if self.table_exists(table_name):
             raise ResourceInUseException("Cannot create preexisting table")
-        billing_mode = create_table_input.get("BillingMode", None)
+        billing_mode = create_table_input.get("BillingMode")
         if (
             billing_mode == BillingMode.PAY_PER_REQUEST
             and create_table_input.get("ProvisionedThroughput", None) is not None

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -978,6 +978,20 @@ class TestDynamoDB:
 
         assert result.get("UnprocessedItems") == {}
 
+    def test_dynamodb_pay_per_request(self):
+        dynamodb = aws_stack.create_external_boto_client("dynamodb")
+        table_name = "ddb-table-%s" % short_uid()
+
+        with pytest.raises(Exception) as e:
+            dynamodb.create_table(
+                TableName=table_name,
+                KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+                AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+                ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+                BillingMode="PAY_PER_REQUEST",
+            )
+        assert "One or more parameter values were invalid" in str(e.value)
+
     def test_dynamodb_create_table_with_sse_specification(self):
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
         table_name = "ddb-table-%s" % short_uid()

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -990,7 +990,7 @@ class TestDynamoDB:
                 ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
                 BillingMode="PAY_PER_REQUEST",
             )
-        assert "One or more parameter values were invalid" in str(e.value)
+        assert e.match("ValidationException")
 
     def test_dynamodb_create_table_with_sse_specification(self):
         dynamodb = aws_stack.create_external_boto_client("dynamodb")


### PR DESCRIPTION
As reported in #4982, when a table is created with `PAY_PER_REQUEST` billing mode and a provisioned throughput is specified as well, we should return a `ValidationException`. 

