### PR TITLE
Increment kinesis-mock version to 0.2.4 for validation fix

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -100,7 +100,7 @@ URL_ASPECTJWEAVER = f"{MAVEN_REPO}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
 # kinesis-mock version
-KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.2"
+KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.4"
 KINESIS_MOCK_RELEASE_URL = (
     "https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/" + KINESIS_MOCK_VERSION
 )


### PR DESCRIPTION
Upgrade kinesis-mock to [0.2.4](https://github.com/etspaceman/kinesis-mock/releases/tag/0.2.4) to fix tag validation excluding characters
