### PR TITLE
update localstack wait command to use docker logs stream

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -5,6 +5,7 @@ import re
 import shlex
 import signal
 import threading
+import time
 import warnings
 from functools import wraps
 from typing import Dict, Iterable, List, Optional, Set
@@ -764,6 +765,7 @@ def start_infra_in_docker_detached(console):
 def wait_container_is_ready(timeout: Optional[float] = None):
     """Blocks until the localstack main container is running and the ready marker has been printed."""
     container_name = config.MAIN_CONTAINER_NAME
+    started = time.time()
 
     def is_container_running():
         return DOCKER_CLIENT.is_container_running(container_name)
@@ -771,29 +773,32 @@ def wait_container_is_ready(timeout: Optional[float] = None):
     if not poll_condition(is_container_running, timeout=timeout):
         return False
 
-    logfile = LocalstackContainer(container_name).logfile
+    stream = DOCKER_CLIENT.stream_container_logs(container_name)
 
-    ready = threading.Event()
-
-    def set_ready_if_marker_found(_line: str):
-        if _line == constants.READY_MARKER_OUTPUT:
-            ready.set()
-
-    # start a tail on the logfile
-    listener = FileListener(logfile, set_ready_if_marker_found)
-    listener.start()
+    # create a timer that will terminate the log stream after the remaining timeout
+    timer = None
+    if timeout:
+        waited = time.time() - started
+        remaining = timeout - waited
+        # check the rare case that the timeout has already been reached
+        if remaining <= 0:
+            stream.close()
+            return False
+        timer = threading.Timer(remaining, stream.close)
+        timer.start()
 
     try:
-        # but also check the existing log in case the container has been running longer
-        with open(logfile, "r") as fd:
-            for line in fd:
-                if constants.READY_MARKER_OUTPUT == line.strip():
-                    return True
+        for line in stream:
+            line = line.decode("utf-8").strip()
+            if line == constants.READY_MARKER_OUTPUT:
+                return True
 
-        # TODO: calculate remaining timeout
-        return ready.wait(timeout)
+        # EOF was reached or the stream was closed
+        return False
     finally:
-        listener.close()
+        if timer:
+            # make sure the timer is stopped (does nothing if it has already run)
+            timer.cancel()
 
 
 # ---------------

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -23,6 +23,7 @@ from localstack.utils.container_utils.container_client import (
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cache_dir, chmod_r, mkdir
+from localstack.utils.functions import call_safe
 from localstack.utils.run import run, to_str
 from localstack.utils.serving import Server
 from localstack.utils.sync import poll_condition
@@ -796,6 +797,7 @@ def wait_container_is_ready(timeout: Optional[float] = None):
         # EOF was reached or the stream was closed
         return False
     finally:
+        call_safe(stream.close)
         if timer:
             # make sure the timer is stopped (does nothing if it has already run)
             timer.cancel()

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional, Tuple, Union
 from localstack import config
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
+    CancellableStream,
     ContainerClient,
     ContainerException,
     DockerContainerStatus,
@@ -26,6 +27,26 @@ from localstack.utils.run import run
 from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
+
+
+class CancellableProcessStream(CancellableStream):
+    process: subprocess.Popen
+
+    def __init__(self, process: subprocess.Popen) -> None:
+        super().__init__()
+        self.process = process
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = self.process.stdout.readline()
+        if not line:
+            raise StopIteration
+        return line
+
+    def close(self):
+        return self.process.terminate()
 
 
 class CmdDockerClient(ContainerClient):
@@ -309,6 +330,18 @@ class CmdDockerClient(ContainerClient):
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
                 )
+
+    def stream_container_logs(self, container_name_or_id: str) -> CancellableStream:
+        self._inspect_object(container_name_or_id)  # guard to check whether container is there
+
+        cmd = self._docker_cmd()
+        cmd += ["logs", container_name_or_id, "--follow"]
+
+        process: subprocess.Popen = run(
+            cmd, asynchronous=True, outfile=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        return CancellableProcessStream(process)
 
     def _inspect_object(self, object_name_or_id: str) -> Dict[str, Union[Dict, str]]:
         cmd = self._docker_cmd()

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -332,7 +332,7 @@ class CmdDockerClient(ContainerClient):
                 )
 
     def stream_container_logs(self, container_name_or_id: str) -> CancellableStream:
-        self._inspect_object(container_name_or_id)  # guard to check whether container is there
+        self.inspect_container(container_name_or_id)  # guard to check whether container is there
 
         cmd = self._docker_cmd()
         cmd += ["logs", container_name_or_id, "--follow"]

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -13,6 +13,7 @@ from docker.utils.socket import STDERR, STDOUT, frames_iter
 
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
+    CancellableStream,
     ContainerClient,
     ContainerException,
     DockerContainerStatus,
@@ -277,6 +278,15 @@ class SdkDockerClient(ContainerClient):
         except APIError:
             if safe:
                 return ""
+            raise ContainerException()
+
+    def stream_container_logs(self, container_name_or_id: str) -> CancellableStream:
+        try:
+            container = self.client().containers.get(container_name_or_id)
+            return container.logs(stream=True, follow=True)
+        except NotFound:
+            raise NoSuchContainer(container_name_or_id)
+        except APIError:
             raise ContainerException()
 
     def inspect_container(self, container_name_or_id: str) -> Dict[str, Union[Dict, str]]:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -729,6 +729,52 @@ class TestDockerClient:
             "container_hopefully_does_not_exist", safe=True
         )
 
+    def test_get_logs(self, docker_client: ContainerClient):
+        container_name = _random_container_name()
+        try:
+            docker_client.run_container(
+                "alpine",
+                name=container_name,
+                detach=True,
+                command=["env"],
+            )
+
+            logs = docker_client.get_container_logs(container_name)
+            assert "PATH=" in logs
+            assert "HOSTNAME=" in logs
+            assert "HOME=/root" in logs
+
+        finally:
+            docker_client.remove_container(container_name)
+
+    def test_stream_logs_non_existent_container(self, docker_client: ContainerClient):
+        with pytest.raises(NoSuchContainer):
+            docker_client.get_container_logs("container_hopefully_does_not_exist", safe=False)
+
+        assert "" == docker_client.get_container_logs(
+            "container_hopefully_does_not_exist", safe=True
+        )
+
+    def test_stream_logs(self, docker_client: ContainerClient):
+        container_name = _random_container_name()
+        try:
+            docker_client.run_container(
+                "alpine",
+                name=container_name,
+                detach=True,
+                command=["env"],
+            )
+
+            stream = docker_client.stream_container_logs(container_name)
+            for line in stream:
+                line = line.decode("utf-8")
+                assert line.split("=")[0] in ["HOME", "PATH", "HOSTNAME"]
+
+            stream.close()
+
+        finally:
+            docker_client.remove_container(container_name)
+
     @pytest.mark.skip_offline
     def test_pull_docker_image(self, docker_client: ContainerClient):
         try:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -749,11 +749,7 @@ class TestDockerClient:
 
     def test_stream_logs_non_existent_container(self, docker_client: ContainerClient):
         with pytest.raises(NoSuchContainer):
-            docker_client.get_container_logs("container_hopefully_does_not_exist", safe=False)
-
-        assert "" == docker_client.get_container_logs(
-            "container_hopefully_does_not_exist", safe=True
-        )
+            docker_client.stream_container_logs("container_hopefully_does_not_exist")
 
     def test_stream_logs(self, docker_client: ContainerClient):
         container_name = _random_container_name()


### PR DESCRIPTION
This PR changes the `localstack wait` and `localstack logs` command to use the docker logs stream instead of the logfile created by `localstack start`. This allows `wait` and `logs` to be used when localstack was started with docker or docker-compose manually. it also allows invocations like `MAIN_CONTAINER_NAME=my_localstack_container localstack wait` which were previously not possible.

To that end, we needed a way to stream docker logs (`docker logs --follow`). The `CancellableStream` is inspired by what the docker SDK client returns.

Example code: listen and print the log stream for 5 seconds then close the stream. This would look pretty much the same with the docker python SDK, just had to make it work for the `CmdDockerClient` (wrapping `Popen`)

```python
docker = SdkDockerClient()
stream = docker.stream_container_logs("localstack_main")

threading.Timer(5, stream.close).start()

for line in stream: # blocks until stream.close is called, or EOF is reached
    print(">", line)

print("bye!")
```
