### PR TITLE
Bump Kinesis Mock to 0.2.4

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -100,7 +100,7 @@ URL_ASPECTJWEAVER = f"{MAVEN_REPO}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
 # kinesis-mock version
-KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.2"
+KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.4"
 KINESIS_MOCK_RELEASE_URL = (
     "https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/" + KINESIS_MOCK_VERSION
 )


### PR DESCRIPTION
https://github.com/etspaceman/kinesis-mock/releases/tag/0.2.4

https://github.com/etspaceman/kinesis-mock/releases/tag/0.2.3

Primary updates between 0.2.2 and 0.2.4 are the following changes:

https://github.com/etspaceman/kinesis-mock/pull/287
https://github.com/etspaceman/kinesis-mock/pull/307