### PR TITLE
add metric-alarm evaluation to Cloudwatch

### DIFF
--- a/localstack/services/cloudwatch/alarm_schedule_util.py
+++ b/localstack/services/cloudwatch/alarm_schedule_util.py
@@ -1,0 +1,248 @@
+import logging
+import math
+import threading
+import traceback
+from datetime import datetime, timedelta, timezone
+
+from localstack.utils.aws import aws_stack
+from localstack.utils.scheduler import Scheduler
+
+LOG = logging.getLogger(__name__)
+
+# TODO used for anomaly detection models:
+# LessThanLowerOrGreaterThanUpperThreshold
+# LessThanLowerThreshold
+# GreaterThanUpperThreshold
+COMPARISON_OPS = {
+    "GreaterThanOrEqualToThreshold": (lambda value, threshold: value >= threshold),
+    "GreaterThanThreshold": (lambda value, threshold: value > threshold),
+    "LessThanThreshold": (lambda value, threshold: value < threshold),
+    "LessThanOrEqualToThreshold": (lambda value, threshold: value <= threshold),
+}
+
+STATE_ALARM = "ALARM"
+STATE_OK = "OK"
+STATE_INSUFFICIENT_DATA = "INSUFFICIENT_DATA"
+REASON = "Alarm Evaluation"  # TODO
+
+
+class AlarmScheduler:
+    def __init__(self) -> None:
+        super().__init__()
+        self.scheduler = Scheduler()
+        self.thread = threading.Thread(target=self.scheduler.run)
+        self.thread.start()
+        self.scheduled_alarms = {}
+
+    def shutdown_scheduler(self):
+        self.scheduler.close()
+        self.thread.join(5)
+
+    def schedule_metric_alarm(self, alarm_arn):
+        """(Re-)schedules the alarm, if the alarm is re-scheduled, the running alarm scheduler will be cancelled before
+        starting a new one"""
+        alarm_details = get_metric_alarm_details_for_alarm_arn(alarm_arn)
+        task = self.scheduled_alarms.get(alarm_arn)
+        if task:
+            task.cancel()
+
+        period = alarm_details["Period"]
+        evaluation_periods = alarm_details["EvaluationPeriods"]
+        schedule_period = evaluation_periods * period
+
+        def on_error(e):
+            LOG.error(f"Error executing scheduled alarm: {e}")
+            LOG.error(traceback.format_exc())
+
+        task = self.scheduler.schedule(
+            func=calculate_alarm_state, period=schedule_period, args=[alarm_arn], on_error=on_error
+        )
+
+        self.scheduled_alarms[alarm_arn] = task
+
+
+def get_metric_alarm_details_for_alarm_arn(alarm_arn):
+    alarm_name = aws_stack.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
+    client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
+    return client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"][0]
+
+
+def get_cloudwatch_client_for_region_of_alarm(alarm_arn):
+    region = aws_stack.extract_region_from_arn(alarm_arn)
+    return aws_stack.connect_to_service("cloudwatch", region_name=region)
+
+
+def generate_metric_query(alarm_details):
+    """Creates the dict with the required data for MetricDataQueries when calling client.get_metric_data"""
+    return {
+        "Id": alarm_details["AlarmName"],
+        "MetricStat": {
+            "Metric": {
+                "Namespace": alarm_details["Namespace"],
+                "MetricName": alarm_details["MetricName"],
+                "Dimensions": alarm_details["Dimensions"],
+            },
+            "Period": alarm_details["Period"],
+            "Stat": alarm_details["Statistic"],
+        },
+        # TODO other fields might be required
+    }
+
+
+def is_threshold_exceeded(metric_values, alarm_details):
+    """Evaluates if the threshold is exceeded for the configured alarm and given metric values
+
+    :param metric_values: values to compare against threshold
+    :param alarm_details: Alarm Description, as returned from describe_alarms
+
+    :return: True if threshold is exceeded, else False
+    """
+    threshold = alarm_details["Threshold"]
+    comparison_operator = alarm_details["ComparisonOperator"]
+    treat_missing_data = alarm_details["TreatMissingData"]
+    datapoints_to_alarm = alarm_details.get("DatapointsToAlarm", 1)
+    evaluated_datapoints = []
+    for value in metric_values:
+        if not value:
+            if treat_missing_data == "breaching":
+                evaluated_datapoints.append(True)
+            elif treat_missing_data == "notBreaching":
+                evaluated_datapoints.append(False)
+            # else we can ignore the data
+        else:
+            evaluated_datapoints.append(COMPARISON_OPS.get(comparison_operator)(value, threshold))
+
+    sum_breaching = evaluated_datapoints.count(True)
+    if sum_breaching >= datapoints_to_alarm:
+        return True
+    return False
+
+
+def is_triggering_premature_alarm(metric_values, alarm_details):
+    """
+    Checks if a premature alarm should be triggered.
+    https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#CloudWatch-alarms-avoiding-premature-transition:
+
+    [...] alarms are designed to always go into ALARM state when the oldest available breaching datapoint during the Evaluation
+    Periods number of data points is at least as old as the value of Datapoints to Alarm, and all other more recent data
+    points are breaching or missing. In this case, the alarm goes into ALARM state even if the total number of datapoints
+    available is lower than M (Datapoints to Alarm).
+    This alarm logic applies to M out of N alarms as well.
+    """
+    treat_missing_data = alarm_details["TreatMissingData"]
+    if treat_missing_data not in ("missing", "ignore"):
+        return False
+
+    datapoints_to_alarm = alarm_details.get("DatapointsToAlarm", 1)
+    if datapoints_to_alarm > 1:
+        comparison_operator = alarm_details["ComparisonOperator"]
+        threshold = alarm_details["Threshold"]
+        oldest_datapoints = metric_values[:-datapoints_to_alarm]
+        if oldest_datapoints.count(None) == len(oldest_datapoints):
+            if metric_values[-datapoints_to_alarm] and COMPARISON_OPS.get(comparison_operator)(
+                metric_values[-datapoints_to_alarm], threshold
+            ):
+                values = list(filter(None, metric_values[len(oldest_datapoints) :]))
+                if all(
+                    COMPARISON_OPS.get(comparison_operator)(value, threshold) for value in values
+                ):
+                    return True
+    return False
+
+
+def collect_metric_data(alarm_details, client):
+    """
+    Collects the metric data for the evaluation interval.
+
+    :param alarm_details: the alarm details as returned by describe_alarms
+    :param client: the cloudwatch client
+    :return: list with data points
+    """
+    metric_values = []
+    evaluation_periods = alarm_details["EvaluationPeriods"]
+    period = alarm_details["Period"]
+
+    # From the docs: "Whenever an alarm evaluates whether to change state, CloudWatch attempts to retrieve a higher number of data
+    # points than the number specified as Evaluation Periods."
+    # No other indication, try to calculate a reasonable value:
+    magic_number = max(math.floor(evaluation_periods / 3), 2)
+
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    metric_query = generate_metric_query(alarm_details)
+    collected_periods = evaluation_periods + magic_number
+
+    # get_metric_data needs to be run in a loop, so we also collect empty data points on the right position
+    for i in range(0, collected_periods):
+        start_time = now - timedelta(seconds=period)
+        end_time = now
+        metric_data = client.get_metric_data(
+            MetricDataQueries=[metric_query], StartTime=start_time, EndTime=end_time
+        )["MetricDataResults"][0]
+        val = metric_data["Values"]
+        metric_values.append(val[0] if val else None)
+        now = start_time
+    return metric_values
+
+
+def update_alarm_state(client, alarm_name, current_state, desired_state):
+    """Updates the alarm state, if the current_state is different than the desired_state
+
+    :param client: the cloudwatch client
+    :param alarm_name: the name of the alarm
+    :param current_state: the state the alarm is currently in
+    :param desired_state: the state the alarm should have after updating
+    """
+    if current_state == desired_state:
+        return
+    client.set_alarm_state(AlarmName=alarm_name, StateValue=desired_state, StateReason=REASON)
+
+
+def calculate_alarm_state(alarm_arn):
+    """
+    Calculates and updates the state of the alarm
+
+    :param alarm_arn: the arn of the alarm to be evaluated
+    """
+    alarm_details = get_metric_alarm_details_for_alarm_arn(alarm_arn)
+    client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
+
+    metric_values = collect_metric_data(alarm_details, client)
+
+    alarm_name = alarm_details["AlarmName"]
+    alarm_state = alarm_details["StateValue"]
+    treat_missing_data = alarm_details["TreatMissingData"]
+
+    empty_datapoints = metric_values.count(None)
+    if empty_datapoints == len(metric_values):
+        if treat_missing_data == "missing":
+            update_alarm_state(client, alarm_name, alarm_state, STATE_INSUFFICIENT_DATA)
+        elif treat_missing_data == "breaching":
+            update_alarm_state(client, alarm_name, alarm_state, STATE_ALARM)
+        elif treat_missing_data == "notBreaching":
+            update_alarm_state(client, alarm_name, alarm_state, STATE_OK)
+        # 'ignore': keep the same state
+        return
+
+    if is_triggering_premature_alarm(metric_values, alarm_details):
+        if treat_missing_data == "missing":
+            update_alarm_state(client, alarm_name, alarm_state, STATE_ALARM)
+        # for 'ignore' the state should be retained
+        return
+
+    # collect all non-empty datapoints from the evaluation interval
+    collected_datapoints = [val for val in reversed(metric_values) if val]
+
+    # adding empty data points until amount of data points == "evaluation periods"
+    evaluation_periods = alarm_details["EvaluationPeriods"]
+    while len(collected_datapoints) < evaluation_periods and treat_missing_data in (
+        "breaching",
+        "notBreaching",
+    ):
+        # breaching/non-breaching datapoints will be evaluated
+        # ignore/missing are not relevant
+        collected_datapoints.append(None)
+
+    if is_threshold_exceeded(collected_datapoints, alarm_details):
+        update_alarm_state(client, alarm_name, alarm_state, STATE_ALARM)
+    else:
+        update_alarm_state(client, alarm_name, alarm_state, STATE_OK)

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -86,7 +86,7 @@ class AlarmScheduler:
 
         :param alarm_arn: the arn of the alarm to be removed
         """
-        task = self.scheduled_alarms.get(alarm_arn)
+        task = self.scheduled_alarms.pop(alarm_arn, None)
         if task:
             task.cancel()
 

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import threading
-import traceback
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, List
 
@@ -69,8 +68,7 @@ class AlarmScheduler:
         schedule_period = evaluation_periods * period
 
         def on_error(e):
-            LOG.error(f"Error executing scheduled alarm: {e}")
-            LOG.error(traceback.format_exc())
+            LOG.exception("Error executing scheduled alarm", exc_info=e)
 
         task = self.scheduler.schedule(
             func=calculate_alarm_state,

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -5,7 +5,7 @@ from xml.sax.saxutils import escape
 from moto.cloudwatch import cloudwatch_backends
 from moto.cloudwatch.models import CloudWatchBackend, FakeAlarm
 
-from localstack.aws.api import RequestContext, handler
+from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudwatch import (
     AmazonResourceName,
     CloudwatchApi,
@@ -19,6 +19,7 @@ from localstack.aws.api.cloudwatch import (
 )
 from localstack.http import Request
 from localstack.services import moto
+from localstack.services.cloudwatch.alarm_schedule_util import AlarmScheduler
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import aws_stack
@@ -168,6 +169,11 @@ def create_message_response_update_state(alarm, old_state):
     return json.dumps(response)
 
 
+class ValidationError(CommonServiceException):
+    def __init__(self, message: str):
+        super().__init__("ValidationError", message, 400, True)
+
+
 class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     """
     Cloudwatch provider.
@@ -178,9 +184,19 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
 
     def __init__(self):
         self.tags = TaggingService()
+        self.alarm_scheduler = None
 
     def on_after_init(self):
         ROUTER.add(PATH_GET_RAW_METRICS, self.get_raw_metrics)
+        self.alarm_scheduler = AlarmScheduler()  # TODO start in new thread
+        # TODO init scheduler
+        # TODO restart -> persistence -> from all regions??
+
+    def on_before_stop(self):
+        # TODO shutdown scheduler
+        self.alarm_scheduler.shutdown_scheduler()
+
+    # TODO delete scheduler on delete_alarm
 
     def get_raw_metrics(self, request: Request):
         region = aws_stack.extract_region_from_auth_header(request.headers)
@@ -226,11 +242,37 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         context: RequestContext,
         request: PutMetricAlarmInput,
     ) -> None:
-        moto.call_moto(context)
+
+        # Supported values are [breaching, notBreaching, ignore, missing]
+        if not request.get("TreatMissingData"):
+            # missing is the default
+            # TODO test with AWS
+            request["TreatMissingData"] = "missing"
+            moto.call_moto_with_request(context, request)
+        else:
+            # validate "TreatMissingData" input
+            if not request.get("TreatMissingData") in [
+                "breaching",
+                "notBreaching",
+                "ignore",
+                "missing",
+            ]:
+                raise ValidationError(
+                    f"The value {request['TreatMissingData']} is not supported for TreatMissingData parameter. Supported values are [breaching, notBreaching, ignore, missing]."
+                )
+            # TODO verification of parameters
+            # period: Valid values are 10, 30, and any multiple of 60.
+            # statistic: possible values: SampleCount, Average, Sum, Minimum, Maximum; either Statistics or ExtendedStatics can be set -> not both!
+            # ExtendedStatistics:
+            # Unit: list of possible values
+            # EvaluationPeriod: number multiplied by period, must not be greater than 86,400
+            # datapoints-to-alarm
+            moto.call_moto(context)
 
         name = request.get("AlarmName")
         arn = aws_stack.cloudwatch_alarm_arn(name)
         self.tags.tag_resource(arn, request.get("Tags"))
+        self.alarm_scheduler.schedule_metric_alarm(arn)
 
     @handler("PutCompositeAlarm", expand=False)
     def put_composite_alarm(
@@ -238,7 +280,6 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         context: RequestContext,
         request: PutCompositeAlarmInput,
     ) -> None:
-        pass
         backend = cloudwatch_backends[context.region]
         backend.put_metric_alarm(
             name=request.get("AlarmName"),

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -259,7 +259,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             raise ValidationError(
                 f"The value {request['TreatMissingData']} is not supported for TreatMissingData parameter. Supported values are [breaching, notBreaching, ignore, missing]."
             )
-        # TODO verification of parameters
+        # do some sanity checks:
         if request.get("Period"):
             # Valid values are 10, 30, and any multiple of 60.
             value = request.get("Period")
@@ -277,10 +277,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
                 raise ValidationError(
                     f"Value '{request.get('Statistic')}' at 'statistic' failed to satisfy constraint: Member must satisfy enum value set: [Maximum, SampleCount, Sum, Minimum, Average]"
                 )
-            # ExtendedStatistics:
-            # Unit: list of possible values
-            # EvaluationPeriod: number multiplied by period, must not be greater than 86,400
-            # datapoints-to-alarm
+
         moto.call_moto(context)
 
         name = request.get("AlarmName")
@@ -319,4 +316,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             threshold_metric_id=None,
             rule=request.get("AlarmRule"),
             tags=request.get("Tags", []),
+        )
+        LOG.warning(
+            "Composite Alarms configuration is not yet supported, alarm state will not be evaluated"
         )

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -571,6 +571,13 @@ def extract_service_from_arn(arn: str) -> Optional[str]:
         return None
 
 
+def extract_resource_from_arn(arn: str) -> Optional[str]:
+    try:
+        return parse_arn(arn).get("resource")
+    except InvalidArnException:
+        return None
+
+
 def get_account_id(account_id=None, env=None):
     if account_id:
         return account_id

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -89,6 +89,13 @@ def get_valid_regions():
     return valid_regions
 
 
+def get_valid_regions_for_service(service_name):
+    regions = list(boto3.Session().get_available_regions(service_name))
+    regions.extend(boto3.Session().get_available_regions("cloudwatch", partition_name="aws-us-gov"))
+    regions.extend(boto3.Session().get_available_regions("cloudwatch", partition_name="aws-cn"))
+    return regions
+
+
 class Environment:
     def __init__(self, region=None, prefix=None):
         # target is the runtime environment to use, e.g.,

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from flask import Response
@@ -37,7 +37,7 @@ def publish_lambda_metric(metric, value, kwargs):
                 {
                     "MetricName": metric,
                     "Dimensions": dimension_lambda(kwargs),
-                    "Timestamp": datetime.now(),
+                    "Timestamp": datetime.utcnow().replace(tzinfo=timezone.utc),
                     "Value": value,
                 }
             ],

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -1,6 +1,6 @@
 import gzip
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from urllib.request import Request, urlopen
 
 import requests
@@ -429,6 +429,88 @@ class TestCloudwatch:
             # cleanup
             sns_client.unsubscribe(SubscriptionArn=subscription_alarm["SubscriptionArn"])
             sns_client.unsubscribe(SubscriptionArn=subscription_ok["SubscriptionArn"])
+            cloudwatch_client.delete_alarms(AlarmNames=[alarm_name])
+
+    def test_put_metric_alarm(
+        self, sns_client, cloudwatch_client, sqs_client, sns_create_topic, sqs_create_queue
+    ):
+        sns_topic_alarm = sns_create_topic()
+        topic_arn_alarm = sns_topic_alarm["TopicArn"]
+
+        sqs_queue = sqs_create_queue()
+        arn_queue = sqs_client.get_queue_attributes(
+            QueueUrl=sqs_queue, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+        # required for AWS:
+        sqs_client.set_queue_attributes(
+            QueueUrl=sqs_queue,
+            Attributes={"Policy": get_sqs_policy(arn_queue, topic_arn_alarm)},
+        )
+        metric_name = "my-metric1"
+        dimension = [{"Name": "InstanceId", "Value": "abc"}]
+        namespace = "test/nsp"
+        alarm_name = f"test-alarm-{short_uid()}"
+
+        try:
+            subscription = sns_client.subscribe(
+                TopicArn=topic_arn_alarm, Protocol="sqs", Endpoint=arn_queue
+            )
+            data = [
+                {
+                    "MetricName": metric_name,
+                    "Dimensions": dimension,
+                    "Value": 21,
+                    "Timestamp": datetime.utcnow().replace(tzinfo=timezone.utc),
+                    "Unit": "Seconds",
+                },
+                {
+                    "MetricName": metric_name,
+                    "Dimensions": dimension,
+                    "Value": 22,
+                    "Timestamp": datetime.utcnow().replace(tzinfo=timezone.utc),
+                    "Unit": "Seconds",
+                },
+            ]
+            cloudwatch_client.put_metric_data(Namespace=namespace, MetricData=data)
+
+            # create alarm with action for "ALARM"
+            cloudwatch_client.put_metric_alarm(
+                AlarmName=alarm_name,
+                AlarmDescription="testing cloudwatch alarms",
+                MetricName=metric_name,
+                Namespace=namespace,
+                ActionsEnabled=True,
+                Period=30,
+                Threshold=2,
+                Dimensions=dimension,
+                Unit="Seconds",
+                Statistic="Average",
+                OKActions=[topic_arn_alarm],
+                AlarmActions=[topic_arn_alarm],
+                EvaluationPeriods=1,
+                ComparisonOperator="GreaterThanThreshold",
+                TreatMissingData="notBreaching",
+            )
+
+            def check_alarm_triggered(expected_state):
+                result = sqs_client.receive_message(QueueUrl=sqs_queue, VisibilityTimeout=0)
+
+                msg = result["Messages"][0]
+                receipt_handle = msg["ReceiptHandle"]
+                sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=receipt_handle)
+
+                body = json.loads(msg["Body"])
+                message = json.loads(body["Message"])
+                assert message["NewStateValue"] == expected_state
+
+            retry(check_alarm_triggered, retries=60, sleep=3.0, expected_state="ALARM")
+
+            # missing are treated as not breaching, so we should reach OK state again
+            retry(
+                check_alarm_triggered, retries=60, sleep=3.0, sleep_before=25, expected_state="OK"
+            )
+        finally:
+            sns_client.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
             cloudwatch_client.delete_alarms(AlarmNames=[alarm_name])
 
 

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -496,12 +496,13 @@ class TestCloudwatch:
                 result = sqs_client.receive_message(QueueUrl=sqs_queue, VisibilityTimeout=0)
 
                 msg = result["Messages"][0]
-                receipt_handle = msg["ReceiptHandle"]
-                sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=receipt_handle)
 
                 body = json.loads(msg["Body"])
                 message = json.loads(body["Message"])
                 assert message["NewStateValue"] == expected_state
+
+                receipt_handle = msg["ReceiptHandle"]
+                sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=receipt_handle)
 
             retry(check_alarm_triggered, retries=60, sleep=3.0, expected_state="ALARM")
 

--- a/tests/unit/test_cloudwatch.py
+++ b/tests/unit/test_cloudwatch.py
@@ -1,0 +1,237 @@
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from localstack.services.cloudwatch.alarm_schedule_util import (
+    COMPARISON_OPS,
+    REASON,
+    calculate_alarm_state,
+)
+
+
+class TestAlarmScheduler:
+    TEST_1_DATA = "'0 - X - X'"
+    TEST_2_DATA = "'0 - - - -'"
+    TEST_3_DATA = "'- - - - -'"
+    TEST_4_DATA = "'0 X X - X'"
+    TEST_5_DATA = "'- - X - -'"
+
+    TEST_1_M_OF_N = "'0 - X - X'"
+    TEST_2_M_OF_N = "'0 0 X 0 X'"
+    TEST_3_M_OF_N = "'0 - X - - '"
+    TEST_4_M_OF_N = "'- - - - 0'"
+    TEST_5_M_OF_N = "'- - - X -'"
+
+    def test_comparison_operation_mapping(self):
+
+        a = 3
+        b = 4
+
+        assert not COMPARISON_OPS.get("GreaterThanOrEqualToThreshold")(a, b)
+        assert COMPARISON_OPS.get("GreaterThanOrEqualToThreshold")(a, a)
+        assert COMPARISON_OPS.get("GreaterThanOrEqualToThreshold")(b, a)
+
+        assert not COMPARISON_OPS.get("GreaterThanThreshold")(a, b)
+        assert not COMPARISON_OPS.get("GreaterThanThreshold")(a, a)
+        assert COMPARISON_OPS.get("GreaterThanThreshold")(b, a)
+
+        assert COMPARISON_OPS.get("LessThanThreshold")(a, b)
+        assert not COMPARISON_OPS.get("LessThanThreshold")(a, a)
+        assert not COMPARISON_OPS.get("LessThanThreshold")(b, a)
+
+        assert COMPARISON_OPS.get("LessThanOrEqualToThreshold")(a, b)
+        assert COMPARISON_OPS.get("LessThanOrEqualToThreshold")(a, a)
+        assert not COMPARISON_OPS.get("LessThanOrEqualToThreshold")(b, a)
+
+    @pytest.mark.parametrize(
+        "initial_state,expected_state,expected_calls,treat_missing,metric_data",
+        [
+            # 0 - X - X
+            ("ALARM", "OK", 1, "missing", TEST_1_DATA),
+            ("ALARM", "OK", 1, "ignore", TEST_1_DATA),
+            ("ALARM", "OK", 1, "breaching", TEST_1_DATA),
+            ("ALARM", "OK", 1, "notBreaching", TEST_1_DATA),
+            # 0 - - - -
+            ("ALARM", "OK", 1, "missing", TEST_2_DATA),
+            ("ALARM", "OK", 1, "ignore", TEST_2_DATA),
+            ("ALARM", "OK", 1, "breaching", TEST_2_DATA),
+            ("ALARM", "OK", 1, "notBreaching", TEST_2_DATA),
+            # - - - - -
+            ("OK", "INSUFFICIENT_DATA", 1, "missing", TEST_3_DATA),
+            ("OK", "OK", 0, "ignore", TEST_3_DATA),
+            ("OK", "ALARM", 1, "breaching", TEST_3_DATA),
+            ("OK", "OK", 0, "notBreaching", TEST_3_DATA),
+            # 0 X X - X
+            ("OK", "ALARM", 1, "missing", TEST_4_DATA),
+            ("OK", "ALARM", 1, "ignore", TEST_4_DATA),
+            ("OK", "ALARM", 1, "breaching", TEST_4_DATA),
+            ("OK", "ALARM", 1, "notBreaching", TEST_4_DATA),
+            # - - X - -
+            ("INSUFFICIENT_DATA", "ALARM", 1, "missing", TEST_5_DATA),
+            ("INSUFFICIENT_DATA", "INSUFFICIENT_DATA", 0, "ignore", TEST_5_DATA),
+            ("INSUFFICIENT_DATA", "ALARM", 1, "breaching", TEST_5_DATA),
+            ("INSUFFICIENT_DATA", "OK", 1, "notBreaching", TEST_5_DATA),
+        ],
+    )
+    def test_calculate_alarm_state_3_out_of_3(
+        self, initial_state, expected_state, expected_calls, treat_missing, metric_data
+    ):
+        """
+        Tests Table 1 depicted in the docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+        Datapoints to Alarm and Evaluation Periods are both 3.
+        Cloudwatch uses 5 latest datapoints for evaluation:
+        0 = ok
+        X = breaking threshold
+        - = no data available
+        |Test   | Data points  | MISSING          | IGNORE      | BREACHING | NOT BREACHING | # missing datapoints |
+        |-------|--------------|------------------|-------------|-----------|---------------| ---------------------|
+        |TEST_1 | 0 - X - X    | OK               | OK          | OK        | OK            | 0                    |
+        |TEST_2 | 0 - - - -    | OK               | OK          | OK        | OK            | 2                    |
+        |TEST_3 | - - - - -    | INSUFFICIENT_DATA| Retain state| ALARM     | OK            | 3                    |
+        |TEST_4 | 0 X X - X    | ALARM            | ALARM       | ALARM     | ALARM         | 0                    |
+        |TEST_5 | - - X - -    | ALARM            | Retain state| ALARM     | OK            | 2 -> Premature alarm |
+        """
+
+        def mock_metric_alarm_details(alarm_arn):
+            details = {
+                "AlarmName": "test-alarm",
+                "StateValue": initial_state,
+                "TreatMissingData": treat_missing,
+                "DatapointsToAlarm": 3,
+                "EvaluationPeriods": 3,
+                "Period": 5,
+                "ComparisonOperator": "LessThanThreshold",
+                "Threshold": 2,
+            }
+            return details
+
+        def mock_collect_metric_data(alarm_details, client):
+            if metric_data == self.TEST_1_DATA:
+                return [2.5, None, 1, None, 1.7]
+            if metric_data == self.TEST_2_DATA:
+                return [3.0, None, None, None, None]
+            if metric_data == self.TEST_3_DATA:
+                return [None, None, None, None, None]
+            if metric_data == self.TEST_4_DATA:
+                return [3.0, 1.5, 1.0, None, 1.5]
+            if metric_data == self.TEST_5_DATA:
+                return [None, None, 1.0, None, None]
+            return metric_data
+
+        run_and_assert_calculate_alarm_state(
+            mock_metric_alarm_details, mock_collect_metric_data, expected_calls, expected_state
+        )
+
+    @pytest.mark.parametrize(
+        "initial_state,expected_state,expected_calls,treat_missing,metric_data",
+        [
+            # 0 - X - X
+            ("OK", "ALARM", 1, "missing", TEST_1_M_OF_N),
+            ("OK", "ALARM", 1, "ignore", TEST_1_M_OF_N),
+            ("OK", "ALARM", 1, "breaching", TEST_1_M_OF_N),
+            ("OK", "ALARM", 1, "notBreaching", TEST_1_M_OF_N),
+            # 0 0 X 0 X
+            ("OK", "ALARM", 1, "missing", TEST_2_M_OF_N),
+            ("OK", "ALARM", 1, "ignore", TEST_2_M_OF_N),
+            ("OK", "ALARM", 1, "breaching", TEST_2_M_OF_N),
+            ("OK", "ALARM", 1, "notBreaching", TEST_2_M_OF_N),
+            # 0 - X - -
+            ("INSUFFICIENT_DATA", "OK", 1, "missing", TEST_3_M_OF_N),
+            ("INSUFFICIENT_DATA", "OK", 1, "ignore", TEST_3_M_OF_N),
+            ("INSUFFICIENT_DATA", "ALARM", 1, "breaching", TEST_3_M_OF_N),
+            ("INSUFFICIENT_DATA", "OK", 1, "notBreaching", TEST_3_M_OF_N),
+            # - - - - 0
+            ("INSUFFICIENT_DATA", "OK", 1, "missing", TEST_4_M_OF_N),
+            ("INSUFFICIENT_DATA", "OK", 1, "ignore", TEST_4_M_OF_N),
+            ("INSUFFICIENT_DATA", "ALARM", 1, "breaching", TEST_4_M_OF_N),
+            ("INSUFFICIENT_DATA", "OK", 1, "notBreaching", TEST_4_M_OF_N),
+            # - - - X -
+            ("INSUFFICIENT_DATA", "ALARM", 1, "missing", TEST_5_M_OF_N),
+            ("INSUFFICIENT_DATA", "INSUFFICIENT_DATA", 0, "ignore", TEST_5_M_OF_N),
+            ("INSUFFICIENT_DATA", "ALARM", 1, "breaching", TEST_5_M_OF_N),
+            ("INSUFFICIENT_DATA", "OK", 1, "notBreaching", TEST_5_M_OF_N),
+        ],
+    )
+    def test_calculate_alarm_state_2_out_of_3(
+        self, initial_state, expected_state, expected_calls, treat_missing, metric_data
+    ):
+        """
+        Tests Table 2 depicted in the docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+        Datapoints to Alarm = 2 and Evaluation Periods = 3
+        Cloudwatch uses 5 latest datapoints for evaluation:
+        0 = ok
+        X = breaking threshold
+        - = no data available
+        |Test          | Data points  | MISSING          | IGNORE      | BREACHING | NOT BREACHING | # missing datapoints |
+        |--------------|--------------|------------------|-------------|-----------|---------------| ---------------------|
+        |TEST_1_M_OF_N | 0 - X - X    | ALARM            | ALARM       | ALARM     | ALARM         | 0                    |
+        |TEST_2_M_OF_N | 0 0 X 0 X    | ALARM            | ALARM       | ALARM     | ALARM         | 0                    |
+        |TEST_3_M_OF_N | 0 - X - -    | OK               | OK          | ALARM     | OK            | 1                    |
+        |TEST_4_M_OF_N | - - - - 0    | OK               | OK          | ALARM     | OK            | 2                    |
+        |TEST_5_M_OF_N | - - - X -    | ALARM            | Retain state| ALARM     | OK            | 2 -> Premature alarm |
+        """
+        mock_client = Mock()
+
+        def mock_metric_alarm_details(alarm_arn):
+            details = {
+                "AlarmName": "test-alarm",
+                "StateValue": initial_state,
+                "TreatMissingData": treat_missing,
+                "DatapointsToAlarm": 2,
+                "EvaluationPeriods": 3,
+                "Period": 5,
+                "ComparisonOperator": "LessThanThreshold",
+                "Threshold": 2,
+            }
+            return details
+
+        def mock_cloudwatch_client(alarm_arn):
+            return mock_client
+
+        def mock_collect_metric_data(alarm_details, client):
+            if metric_data == self.TEST_1_DATA:
+                return [2.5, None, 1, None, 1.7]
+            if metric_data == self.TEST_2_M_OF_N:
+                return [3.0, 4.0, 1.0, 3.5, 1.5]
+            if metric_data == self.TEST_3_M_OF_N:
+                return [4.0, None, 1.2, None, None]
+            if metric_data == self.TEST_4_M_OF_N:
+                return [None, None, None, None, 8]
+            if metric_data == self.TEST_5_M_OF_N:
+                return [None, None, None, 1.0, None]
+            return metric_data
+
+        run_and_assert_calculate_alarm_state(
+            mock_metric_alarm_details, mock_collect_metric_data, expected_calls, expected_state
+        )
+
+
+def run_and_assert_calculate_alarm_state(
+    mock_metric_alarm_details, mock_collect_metric_data, expected_calls, expected_state
+):
+    mock_client = Mock()
+
+    def mock_cloudwatch_client(alarm_arn):
+        return mock_client
+
+    with patch(
+        "localstack.services.cloudwatch.alarm_schedule_util.get_metric_alarm_details_for_alarm_arn",
+        mock_metric_alarm_details,
+    ):
+        with patch(
+            "localstack.services.cloudwatch.alarm_schedule_util.get_cloudwatch_client_for_region_of_alarm",
+            mock_cloudwatch_client,
+        ):
+            with patch(
+                "localstack.services.cloudwatch.alarm_schedule_util.collect_metric_data",
+                mock_collect_metric_data,
+            ):
+                calculate_alarm_state("helloworld")
+                assert len(mock_client.mock_calls) == expected_calls
+                if expected_calls != 0:
+                    expected_calls = [
+                        call.set_alarm_state(
+                            AlarmName="test-alarm", StateValue=expected_state, StateReason=REASON
+                        )
+                    ]
+                    mock_client.assert_has_calls(expected_calls)

--- a/tests/unit/test_cloudwatch.py
+++ b/tests/unit/test_cloudwatch.py
@@ -112,7 +112,6 @@ class TestAlarmScheduler:
                 return [3.0, 1.5, 1.0, None, 1.5]
             if metric_data == self.TEST_5_DATA:
                 return [None, None, 1.0, None, None]
-            return metric_data
 
         run_and_assert_calculate_alarm_state(
             mock_metric_alarm_details, mock_collect_metric_data, expected_calls, expected_state
@@ -166,7 +165,6 @@ class TestAlarmScheduler:
         |TEST_4_M_OF_N | - - - - 0    | OK               | OK          | ALARM     | OK            | 2                    |
         |TEST_5_M_OF_N | - - - X -    | ALARM            | Retain state| ALARM     | OK            | 2 -> Premature alarm |
         """
-        mock_client = Mock()
 
         def mock_metric_alarm_details(alarm_arn):
             details = {
@@ -181,11 +179,8 @@ class TestAlarmScheduler:
             }
             return details
 
-        def mock_cloudwatch_client(alarm_arn):
-            return mock_client
-
         def mock_collect_metric_data(alarm_details, client):
-            if metric_data == self.TEST_1_DATA:
+            if metric_data == self.TEST_1_M_OF_N:
                 return [2.5, None, 1, None, 1.7]
             if metric_data == self.TEST_2_M_OF_N:
                 return [3.0, 4.0, 1.0, 3.5, 1.5]
@@ -195,7 +190,6 @@ class TestAlarmScheduler:
                 return [None, None, None, None, 8]
             if metric_data == self.TEST_5_M_OF_N:
                 return [None, None, None, 1.0, None]
-            return metric_data
 
         run_and_assert_calculate_alarm_state(
             mock_metric_alarm_details, mock_collect_metric_data, expected_calls, expected_state

--- a/tests/unit/test_cloudwatch.py
+++ b/tests/unit/test_cloudwatch.py
@@ -1,12 +1,8 @@
-from unittest.mock import Mock, call, patch
+from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 
-from localstack.services.cloudwatch.alarm_schedule_util import (
-    COMPARISON_OPS,
-    REASON,
-    calculate_alarm_state,
-)
+from localstack.services.cloudwatch.alarm_scheduler import COMPARISON_OPS, calculate_alarm_state
 
 
 class TestAlarmScheduler:
@@ -214,16 +210,17 @@ def run_and_assert_calculate_alarm_state(
     def mock_cloudwatch_client(alarm_arn):
         return mock_client
 
+    alarm_scheduler_pckg = "localstack.services.cloudwatch.alarm_scheduler"
     with patch(
-        "localstack.services.cloudwatch.alarm_schedule_util.get_metric_alarm_details_for_alarm_arn",
+        f"{alarm_scheduler_pckg}.get_metric_alarm_details_for_alarm_arn",
         mock_metric_alarm_details,
     ):
         with patch(
-            "localstack.services.cloudwatch.alarm_schedule_util.get_cloudwatch_client_for_region_of_alarm",
+            f"{alarm_scheduler_pckg}.get_cloudwatch_client_for_region_of_alarm",
             mock_cloudwatch_client,
         ):
             with patch(
-                "localstack.services.cloudwatch.alarm_schedule_util.collect_metric_data",
+                f"{alarm_scheduler_pckg}.collect_metric_data",
                 mock_collect_metric_data,
             ):
                 calculate_alarm_state("helloworld")
@@ -231,7 +228,7 @@ def run_and_assert_calculate_alarm_state(
                 if expected_calls != 0:
                     expected_calls = [
                         call.set_alarm_state(
-                            AlarmName="test-alarm", StateValue=expected_state, StateReason=REASON
+                            AlarmName="test-alarm", StateValue=expected_state, StateReason=ANY
                         )
                     ]
                     mock_client.assert_has_calls(expected_calls)


### PR DESCRIPTION
This PR refers to https://github.com/localstack/localstack/issues/5446 and implements basic cloudwatch metric-alarm evaluation:

supports metric-alarm with the following characteristics:
- "Statistic": Maximum, SampleCount, Sum, Minimum, Average
- "ComparisonOperator": GreaterThanOrEqualToThreshold, GreaterThanThreshold, LessThanThreshold, LessThanOrEqualToThreshold
- "[Alarm|OK|InsufficentData]Actions": SNS Topic

Note: in order to correctly filter for Dimensions, [this PR in Moto](https://github.com/spulec/moto/pull/5041) is required.