### PR TITLE
Refactor util to create S3 buckets with location constraints

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -804,7 +804,8 @@ def get_or_create_bucket(bucket_name: str, s3_client=None):
 
 
 def create_s3_bucket(bucket_name: str, s3_client=None):
-    """Creates a bucket in the region that is associated with the current request context"""
+    """Creates a bucket in the region that is associated with the current request
+    context, or with the given boto3 S3 client, if specified."""
     s3_client = s3_client or connect_to_service("s3")
     region = s3_client.meta.region_name
     kwargs = {}

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -25,6 +25,7 @@ from localstack.constants import (
     APPLICATION_AMZ_JSON_1_0,
     APPLICATION_AMZ_JSON_1_1,
     APPLICATION_X_WWW_FORM_URLENCODED,
+    AWS_REGION_US_EAST_1,
     ENV_DEV,
     INTERNAL_AWS_ACCESS_KEY_ID,
     LOCALHOST,
@@ -794,12 +795,22 @@ def get_events_target_attributes(target):
     return pick_attributes(target, EVENT_TARGET_PARAMETERS)
 
 
-def get_or_create_bucket(bucket_name, s3_client=None):
+def get_or_create_bucket(bucket_name: str, s3_client=None):
     s3_client = s3_client or connect_to_service("s3")
     try:
         return s3_client.head_bucket(Bucket=bucket_name)
     except Exception:
-        return s3_client.create_bucket(Bucket=bucket_name)
+        return create_s3_bucket(bucket_name, s3_client=s3_client)
+
+
+def create_s3_bucket(bucket_name: str, s3_client=None):
+    """Creates a bucket in the region that is associated with the current request context"""
+    s3_client = s3_client or connect_to_service("s3")
+    region = s3_client.meta.region_name
+    kwargs = {}
+    if region != AWS_REGION_US_EAST_1:
+        kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
+    return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
 
 
 def create_sqs_queue(queue_name, env=None):

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -26,6 +26,7 @@ from pytz import timezone
 
 from localstack import config, constants
 from localstack.constants import (
+    AWS_REGION_US_EAST_1,
     S3_VIRTUAL_HOSTNAME,
     TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_SECRET_ACCESS_KEY,
@@ -115,7 +116,12 @@ class TestS3(unittest.TestCase):
     OVERWRITTEN_CLIENT = None
 
     def setUp(self):
-        self._s3_client = aws_stack.create_external_boto_client("s3")
+        # Default S3 operations should be happening in us-east-1, hence passing in the region
+        # here (otherwise create_bucket(..) would fail without specifying a location constraint.
+        # Dedicated multi-region tests use specific clients further below.
+        self._s3_client = aws_stack.create_external_boto_client(
+            "s3", region_name=AWS_REGION_US_EAST_1
+        )
         self.sqs_client = aws_stack.create_external_boto_client("sqs")
 
     @property
@@ -2492,6 +2498,15 @@ class TestS3(unittest.TestCase):
         response = client_2.get_bucket_location(Bucket=bucket_2_name)
         self.assertEqual(region_2, response["LocationConstraint"])
 
+        # assert creation fails without location constraint for us-east-2 region
+        with pytest.raises(Exception) as exc:
+            client_2.create_bucket(Bucket=f"bucket-{short_uid()}")
+        exc.match("IllegalLocationConstraintException")
+        bucket_3_name = f"bucket-{short_uid()}"
+        # assert that creation succeeds with utility function that configures the location constraint
+        result = aws_stack.create_s3_bucket(bucket_3_name, s3_client=client_2)
+        assert result.get("Location")
+
         # make raw request, assert that newline is contained after XML preamble: <?xml ...>\n
         url = f"{config.get_edge_url(localstack_hostname=S3_VIRTUAL_HOSTNAME)}/{bucket_2_name}?location="
         response = requests.get(url)
@@ -2500,8 +2515,8 @@ class TestS3(unittest.TestCase):
         assert re.match(r"^<\?xml [^>]+>\n<.*", content, flags=re.MULTILINE)
 
         # clean up
-        self.s3_client.delete_bucket(Bucket=bucket_1_name)
-        self.s3_client.delete_bucket(Bucket=bucket_2_name)
+        for bucket in [bucket_1_name, bucket_2_name, bucket_3_name]:
+            self.s3_client.delete_bucket(Bucket=bucket)
 
     def test_upload_file_with_xml_preamble(self):
         bucket_name = f"bucket-{short_uid()}"


### PR DESCRIPTION
Minor refactoring in utils to create S3 buckets with location constraints. Buckets now need to be created with the correct region / location constraint (for parity with AWS). 

We can use the `create_s3_bucket(..)` util function to simplify this task and streamline creation of buckets across the codebase. Intended to be used in places where we need to create temporary buckets for other services, e.g., in the case of CloudFormation, to avoid these exceptions:

```
localstack_main |     s3_client.create_bucket(Bucket=CUSTOM_RESOURCES_RESULTS_BUCKET)                                                                                                                                                                          
localstack_main |   File "/opt/code/localstack/.venv/lib/python3.8/site-packages/botocore/client.py", line 415, in _api_call                                                                                                                                  
localstack_main |     return self._make_api_call(operation_name, kwargs)                                                                                                                                                                                      
localstack_main |   File "/opt/code/localstack/.venv/lib/python3.8/site-packages/botocore/client.py", line 745, in _make_api_call                                                                                                                              
localstack_main |     raise error_class(parsed_response, operation_name)
localstack_main | botocore.exceptions.ClientError: An error occurred (IllegalLocationConstraintException) when calling the CreateBucket operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent t
```