### PR TITLE
specify content type header with curl PUT request in docker-entrypoint.sh

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -57,7 +57,7 @@ function run_startup_scripts {
     sleep 7
   done
 
-  curl -XPUT -s -d '{"features:initScripts":"initializing"}' "http://localhost:$EDGE_PORT/health" > /dev/null
+  curl -XPUT -s -H "Content-Type: application/json" -d '{"features:initScripts":"initializing"}' "http://localhost:$EDGE_PORT/health" > /dev/null
   for f in $INIT_SCRIPTS_PATH/*; do
     case "$f" in
       *.sh)     echo "$0: running $f"; . "$f" ;;
@@ -65,7 +65,7 @@ function run_startup_scripts {
     esac
     echo
   done
-  curl -XPUT -s -d '{"features:initScripts":"initialized"}' "http://localhost:$EDGE_PORT/health" > /dev/null
+  curl -XPUT -s -H "Content-Type: application/json" -d '{"features:initScripts":"initialized"}' "http://localhost:$EDGE_PORT/health" > /dev/null
 }
 
 run_startup_scripts &


### PR DESCRIPTION
fixes https://github.com/localstack/localstack/issues/5901

`/health` endpoint handler retrieve request data for PUT request from `request.data`.
https://github.com/localstack/localstack/blob/v0.14.2/localstack/services/internal.py#L63

To using `request.data`, the user must specify a content type correctly but the curl command that is executed in `docker-entrypoint.sh` to store feature states does not specify content type header so that `request.data` always becomes empty.