### PR TITLE
Add javaagent loader for DynamoDB local process

### DIFF
--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from localstack import config
 from localstack.config import dirs, is_env_true
 from localstack.services import install
+from localstack.services.install import DDB_AGENT_JAR_PATH
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.run import FuncThread
@@ -54,7 +55,8 @@ class DynamodbServer(Server):
         cmd = [
             "java",
             "-Xmx%s" % self.heap_size,
-            "-Djava.library.path=%s" % self.library_path,
+            f"-javaagent:{DDB_AGENT_JAR_PATH}",
+            f"-Djava.library.path={self.library_path}",
             "-jar",
             self.jar_path,
         ]


### PR DESCRIPTION
Add a javaagent loader for DynamoDB local process, leveraging the corresponding class in the [artifacts repo](https://github.com/localstack/localstack-artifacts/tree/master/dynamodb-local-patch). This replaces the previous approach with patched source files, and instead uses a javaagent for custom class loading/transformation at runtime, to leave the original source and binary files untouched.