### PR TITLE
Fix backdoor API provided on health endpoint

### DIFF
--- a/localstack/http/dispatcher.py
+++ b/localstack/http/dispatcher.py
@@ -15,6 +15,9 @@ ResultValue = Union[
 
 
 def _populate_response(response: Response, result: ResultValue):
+    if result is None:
+        return response
+
     if isinstance(result, dict):
         response.set_json(result)
     else:

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -338,7 +338,7 @@ def terminate_all_processes_in_docker():
     print("INFO: Received command to restart all processes ...")
     cmd = (
         'ps aux | grep -v supervisor | grep -v docker-entrypoint.sh | grep -v "bin/localstack" | '
-        "grep -v localstack_infra.log | awk '{print $1}' | grep -v PID"
+        "grep -v localstack_infra.log | awk '{print $2}' | grep -v PID"
     )
     pids = run(cmd).strip()
     pids = re.split(r"\s+", pids)
@@ -352,7 +352,7 @@ def terminate_all_processes_in_docker():
             except Exception:
                 pass
     # kill the process itself
-    sys.exit(0)
+    os.kill(this_pid, signal.SIGKILL)
 
 
 # -------------

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -9,10 +9,10 @@ import requests
 from werkzeug.exceptions import NotFound
 
 from localstack import config, constants
-from localstack.http import Router
+from localstack.http import Request, Response, Router
 from localstack.http.adapters import RouterListener
 from localstack.http.dispatcher import resource_dispatcher
-from localstack.services.infra import terminate_all_processes_in_docker
+from localstack.services.infra import SHUTDOWN_INFRA, terminate_all_processes_in_docker
 from localstack.utils.collections import merge_recursive
 from localstack.utils.files import load_file
 from localstack.utils.functions import call_safe
@@ -35,13 +35,19 @@ class HealthResource:
         self.service_manager = service_manager
         self.state = {}
 
-    def on_post(self, request):
-        data = request.json
+    def on_post(self, request: Request):
+        data = request.get_json(True, True)
+        if not data:
+            return Response("invalid request", 400)
+
         # backdoor API to support restarting the instance
         if data.get("action") in ["kill", "restart"]:
             terminate_all_processes_in_docker()
+            SHUTDOWN_INFRA.set()
 
-    def on_get(self, request):
+        return Response("ok", 200)
+
+    def on_get(self, request: Request):
         path = request.path
 
         reload = "reload" in path
@@ -59,8 +65,8 @@ class HealthResource:
         result["version"] = constants.VERSION
         return result
 
-    def on_put(self, request):
-        data = json.loads(to_str(request.data or "{}"))
+    def on_put(self, request: Request):
+        data = request.get_json(True, True) or {}
 
         # keys like "features:initScripts" should be interpreted as ['features']['initScripts']
         state = defaultdict(dict)

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -36,7 +36,7 @@ class HealthResource:
         self.state = {}
 
     def on_post(self, request):
-        data = request.json()
+        data = request.json
         # backdoor API to support restarting the instance
         if data.get("action") in ["kill", "restart"]:
             terminate_all_processes_in_docker()

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -233,6 +233,7 @@ def setup_logging(log_level=None):
     logging.getLogger("botocore").setLevel(logging.ERROR)
     logging.getLogger("docker").setLevel(logging.WARNING)
     logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+    logging.getLogger("hpack").setLevel(logging.ERROR)
     logging.getLogger("moto").setLevel(logging.WARNING)
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("s3transfer").setLevel(logging.INFO)


### PR DESCRIPTION
fixes #5906 

Currently, backdoor API to restart the process provided on `/health` endpoint does not work.
This patch fixes some errors to work correctly.