### PR TITLE
Minor: Bump version of awscli for compabilibity with poetry

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ runtime =
     amazon_kclpy-ext==1.5.1
     # amazon-kclpy==1.5.1
     aws-sam-translator>=1.15.1
-    awscli>=1.14.18
+    awscli>=1.22.90
     boto>=2.49.0
     botocore>=1.12.13
     cbor2>=5.2.0


### PR DESCRIPTION
Minor: Bump version of awscli for compabilibity with poetry - should fix https://github.com/localstack/localstack/issues/5520

Was able to replicate locally. With the following `pyproject.toml` config:
```
[tool.poetry]
name = "test"
version = "0.1"
description = "test"
authors = []

[tool.poetry.dependencies]
python=">=3.7,<4.0"
```
... the following command installs the runtime dependencies successfully:
```
poetry add "localstack[runtime]"
```