### PR TITLE
Minor fix to ensure that /static/ paths are properly served by the proxy

### DIFF
--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -170,7 +170,7 @@ def run_server(
     """
 
     ensure_event_loop()
-    app = Quart(__name__)
+    app = Quart(__name__, static_folder=None)
     app.config["MAX_CONTENT_LENGTH"] = max_content_length or DEFAULT_MAX_CONTENT_LENGTH
     if send_timeout:
         app.config["BODY_TIMEOUT"] = send_timeout

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -130,7 +130,7 @@ def _do_start_ssl_proxy(port: int, target: PortOrUrl, target_ssl=False):
     server = pproxy.Server("secure+tunnel://0.0.0.0:%s" % port)
     target_proto = "ssl+tunnel" if target_ssl else "tunnel"
     remote = pproxy.Connection("%s://%s" % (target_proto, target))
-    args = dict(rserver=[remote], verbose=print)
+    args = dict(rserver=[remote])
 
     # set SSL contexts
     _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert()


### PR DESCRIPTION
Minor fix to ensure that `/static/...` paths are properly served by the proxy. 

Turns out that the Quart HTTP server by default attempts to serve `/static` paths from the local filesystem (see `static_folder="static"` in the [Quart initializer](https://github.com/pgjones/quart/blob/638a8e02493441f6c15cf19266d1ae80a2d984d1/src/quart/app.py#L215)). This was causing 404 errors whenever we were requesting `/static/...` paths through the edge proxy (and other proxy listeners). In this PR we explicitly set `static_folder=None` to disable this behavior.

The PR also contains some minor changes to reduce log verbosity (removing `print` statements) which surfaced during testing.

Part of this may become obsolete with the new Gateway, still good to have it covered by a test for now. /cc @thrau 