### PR TITLE
Add SES HTML body to match v2 API spec

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -63,6 +63,7 @@ def save_for_retrospection(id: str, region: str, **kwargs: Dict[str, Any]):
     kwargs should consist of following keys related to the email:
     - Body
     - Destinations
+    - HtmlBody
     - RawData
     - Source
     - Subject
@@ -199,6 +200,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
             Destination=destination,
             Subject=message["Subject"].get("Data"),
             Body=message["Body"].get("Text", {}).get("Data"),
+            HtmlBody=message["Body"].get("Html", {}).get("Data"),
         )
 
         return response

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -85,6 +85,9 @@ class TestSES:
                     "Text": {
                         "Data": "A_MESSAGE",
                     },
+                    "Html": {
+                        "Data": "A_HTML",
+                    },
                 },
             },
             Destination={
@@ -101,6 +104,7 @@ class TestSES:
         assert email == contents["Source"]
         assert "A_SUBJECT" == contents["Subject"]
         assert "A_MESSAGE" == contents["Body"]
+        assert "A_HTML" == contents["HtmlBody"]
         assert ["success@example.com"] == contents["Destination"]["ToAddresses"]
 
         emails_url = config.get_edge_url() + INTERNAL_RESOURCE_PATH + EMAILS_ENDPOINT


### PR DESCRIPTION
Presently Localstack only records the body of `Text` emails, and does not support `Html` emails.

In the [AWS SES v2 API spec](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html) HTML formatted emails are sent using this part of the message:
```json
{
   "Content": { 
      "Simple": { 
         "Body": { 
            "Html": { 
               "Charset": "string",
               "Data": "string"
            },
            
            ... rest removed for brevity ....
```

This PR stores anything send in the `Html` part of the body into the JSON files stored in `/ses` in a field called `HtmlBody`.
