### PR TITLE
Handling TableClass in DynamoDB

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -421,6 +421,10 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         if "StreamSpecification" in table_definitions:
             create_dynamodb_stream(table_definitions, table_description.get("LatestStreamLabel"))
 
+        if "TableClass" in table_description:
+            table_class = table_description.pop("TableClass")
+            table_description["TableClassSummary"] = {"TableClass": table_class}
+
         tags = table_definitions.pop("Tags", [])
         if tags:
             table_arn = table_description["TableArn"]

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -501,7 +501,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             is_no_update_error = (
                 e.code == "ValidationException" and "Nothing to update" in e.message
             )
-            if is_no_update_error and not list(
+            if not is_no_update_error or not list(
                 {"TableClass", "ReplicaUpdates"} & set(update_table_input.keys())
             ):
                 raise

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -422,7 +422,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             create_dynamodb_stream(table_definitions, table_description.get("LatestStreamLabel"))
 
         if "TableClass" in table_definitions:
-            table_class = table_description.pop("TableClass", None) or table_definitions.pop("TableClass")
+            table_class = table_description.pop("TableClass", None) or table_definitions.pop(
+                "TableClass"
+            )
             table_description["TableClassSummary"] = {"TableClass": table_class}
 
         tags = table_definitions.pop("Tags", [])
@@ -482,7 +484,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 if table_definitions.get(key):
                     result.get("Table", {})[key] = table_definitions[key]
             if "TableClass" in table_definitions:
-                result.get("Table", {})["TableClassSummary"] = {"TableClass": table_definitions["TableClass"]}
+                result.get("Table", {})["TableClassSummary"] = {
+                    "TableClass": table_definitions["TableClass"]
+                }
 
         return result
 
@@ -497,7 +501,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             is_no_update_error = (
                 e.code == "ValidationException" and "Nothing to update" in e.message
             )
-            if is_no_update_error and not list({"TableClass", "ReplicaUpdates"} & set(update_table_input.keys())):
+            if is_no_update_error and not list(
+                {"TableClass", "ReplicaUpdates"} & set(update_table_input.keys())
+            ):
                 raise
 
             table_name = update_table_input.get("TableName")

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -509,7 +509,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             table_name = update_table_input.get("TableName")
 
             if update_table_input.get("TableClass"):
-                table_definitions = DynamoDBRegion.get().table_definitions.get(table_name)
+                table_definitions = DynamoDBRegion.get().table_definitions.setdefault(
+                    table_name, {}
+                )
                 table_definitions["TableClass"] = update_table_input.get("TableClass")
 
             if update_table_input.get("ReplicaUpdates"):

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -506,6 +506,20 @@ class TestDynamoDB:
         )
         assert "ShardIterator" in response
 
+    def test_dynamodb_create_table_with_class(self, dynamodb_client):
+        table_name = "table_with_class_%s" % short_uid()
+        # create table
+        result = dynamodb_client.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            TableClass="STANDARD",
+        )
+        assert result["TableDescription"]["TableClassSummary"]["TableClass"] == "STANDARD"
+        # clean resources
+        dynamodb_client.delete_table(TableName=table_name)
+
     def test_dynamodb_execute_transaction(self, dynamodb_client):
         table_name = "table_%s" % short_uid()
         dynamodb_client.create_table(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -517,6 +517,15 @@ class TestDynamoDB:
             TableClass="STANDARD",
         )
         assert result["TableDescription"]["TableClassSummary"]["TableClass"] == "STANDARD"
+        result = dynamodb_client.describe_table(TableName=table_name)
+        assert result["Table"]["TableClassSummary"]["TableClass"] == "STANDARD"
+        result = dynamodb_client.update_table(
+            TableName=table_name,
+            TableClass="STANDARD_INFREQUENT_ACCESS"
+        )
+        assert result["TableDescription"]["TableClassSummary"]["TableClass"] == "STANDARD_INFREQUENT_ACCESS"
+        result = dynamodb_client.describe_table(TableName=table_name)
+        assert result["Table"]["TableClassSummary"]["TableClass"] == "STANDARD_INFREQUENT_ACCESS"
         # clean resources
         dynamodb_client.delete_table(TableName=table_name)
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -520,10 +520,12 @@ class TestDynamoDB:
         result = dynamodb_client.describe_table(TableName=table_name)
         assert result["Table"]["TableClassSummary"]["TableClass"] == "STANDARD"
         result = dynamodb_client.update_table(
-            TableName=table_name,
-            TableClass="STANDARD_INFREQUENT_ACCESS"
+            TableName=table_name, TableClass="STANDARD_INFREQUENT_ACCESS"
         )
-        assert result["TableDescription"]["TableClassSummary"]["TableClass"] == "STANDARD_INFREQUENT_ACCESS"
+        assert (
+            result["TableDescription"]["TableClassSummary"]["TableClass"]
+            == "STANDARD_INFREQUENT_ACCESS"
+        )
         result = dynamodb_client.describe_table(TableName=table_name)
         assert result["Table"]["TableClassSummary"]["TableClass"] == "STANDARD_INFREQUENT_ACCESS"
         # clean resources


### PR DESCRIPTION
`TableClass` was not managed for the CRUD operations in DynamoDB. This PR should fix #5916 