### PR TITLE
fix localstack.http.Request path encoding

### DIFF
--- a/localstack/http/adapters.py
+++ b/localstack/http/adapters.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import NotFound
 
 from localstack.services.generic_proxy import ProxyListener
 
-from .request import Request
+from .request import Request, get_raw_path
 from .response import Response
 from .router import Router
 
@@ -24,7 +24,7 @@ class ProxyListenerAdapter(ProxyListener):
 
     def forward_request(self, method, path, data, headers):
         split_url = urlsplit(path)
-        raw_path = quart_request.scope.get("raw_path")
+        raw_path = get_raw_path(quart_request)
 
         request = Request(
             method=method,

--- a/localstack/http/request.py
+++ b/localstack/http/request.py
@@ -43,14 +43,13 @@ def dummy_wsgi_environment(
     :param raw_uri: The original path that may contain url encoded path elements.
     :return: A WSGIEnvironment dictionary
     """
-    # prepare the path for the "WSGI decoding dance" done by werkzeug
-    wsgi_encoded_path = unquote(quote(path), "latin-1")
 
     # Standard environ keys
     environ = {
         "REQUEST_METHOD": method,
-        "SCRIPT_NAME": root_path.rstrip("/"),
-        "PATH_INFO": wsgi_encoded_path,
+        # prepare the paths for the "WSGI decoding dance" done by werkzeug
+        "SCRIPT_NAME": unquote(quote(root_path.rstrip("/")), "latin-1"),
+        "PATH_INFO": unquote(quote(path), "latin-1"),
         "SERVER_PROTOCOL": "HTTP/1.1",
     }
 

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -2706,6 +2706,14 @@ class TestS3New:
         resp = s3_client.list_buckets()
         assert len(resp["Buckets"]) == 0
 
+    @pytest.mark.aws_validated
+    def test_put_and_get_object_with_utf8_key(self, s3_client, s3_create_bucket):
+        bucket = s3_create_bucket()
+        response = s3_client.put_object(Bucket=bucket, Key="Ā0Ä", Body=b"abc123")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        response = s3_client.get_object(Bucket=bucket, Key="Ā0Ä")
+        assert response["Body"].read() == b"abc123"
+
 
 @pytest.mark.parametrize(
     "api_version, bucket_name, payload",

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from urllib.parse import unquote, urlencode, urlsplit
+from urllib.parse import urlencode, urlsplit
 
 import pytest
 from botocore.awsrequest import prepare_request_dict
@@ -251,7 +251,7 @@ def _botocore_parser_integration_test(
     parsed_operation_model, parsed_request = parser.parse(
         HttpRequest(
             method=serialized_request.get("method") or "GET",
-            path=unquote(path),
+            path=path,
             query_string=to_str(query_string),
             headers=headers,
             body=body,
@@ -751,6 +751,18 @@ def test_parse_s3_with_extended_uri_pattern():
     """
     _botocore_parser_integration_test(
         service="s3", action="ListParts", Bucket="foo", Key="bar/test", UploadId="test-upload-id"
+    )
+
+
+def test_parse_s3_utf8_url():
+    """Test the parsing of a map with the location trait 'headers'."""
+    _botocore_parser_integration_test(
+        service="s3",
+        action="PutObject",
+        ContentLength=0,
+        Bucket="test-bucket",
+        Key="Ā0",
+        Metadata={"Key": "value", "Key2": "value2"},
     )
 
 


### PR DESCRIPTION
When creating a werkzeug `Request` object from the WSGI environment, werkzeug does the "WSGI decoding dance" [here](https://github.com/pallets/werkzeug/blob/c7ae2fea4fb229ffd71187c2b665874c91b96277/src/werkzeug/wrappers/request.py#L109-L114):
```python
  root_path=_wsgi_decoding_dance(
      environ.get("PATH_INFO") or "", self.charset, self.encoding_errors
  ),
```
where the `_wsgi_decoding_dance` method does this: `return s.encode("latin1").decode('utf-8', errors)`

meaning werkzeug expects the WSGI environment to contain `latin-1` encoded path. so 
* `'/my-testbucket/Ā_'` (quoted as `'/my-testbucket/%C4%80_'`) is expected to be `/my-testbucket/Ä\x80_`  in `environ['PATH_INFO']` so the path can be restored as such from the request. previously we would pass the utf-8 encoded path directly into `PATH_INFO`. which would lead to encoding errors (#5921). now we encode the path according to the WSGI spec.

Fixes #5921