### PR TITLE
Remove explicit object inheritance

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -46,7 +46,7 @@ class SnsIntegration(BackendIntegration):
         )
 
 
-class VelocityUtil(object):
+class VelocityUtil:
     """
     Simple class to mimic the behavior of variable '$util' in AWS API Gateway integration
     velocity templates.
@@ -87,7 +87,7 @@ class VelocityUtil(object):
         return json.dumps(s)
 
 
-class VelocityInput(object):
+class VelocityInput:
     """
     Simple class to mimic the behavior of variable '$input' in AWS API Gateway integration
     velocity templates.

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -128,7 +128,7 @@ class InvocationException(Exception):
         self.result = result
 
 
-class LambdaContext(object):
+class LambdaContext:
     DEFAULT_MEMORY_LIMIT = 1536
 
     def __init__(
@@ -377,7 +377,7 @@ class LambdaAsyncLocks:
 LAMBDA_ASYNC_LOCKS = LambdaAsyncLocks()
 
 
-class LambdaExecutor(object):
+class LambdaExecutor:
     """Base class for Lambda executors. Subclasses must overwrite the _execute method"""
 
     def __init__(self):

--- a/localstack/services/cloudformation/cloudformation_api.py
+++ b/localstack/services/cloudformation/cloudformation_api.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 XMLNS_CF = "http://cloudformation.amazonaws.com/doc/2010-05-15/"
 
 
-class StackSet(object):
+class StackSet:
     """A stack set contains multiple stack instances."""
 
     def __init__(self, metadata=None):
@@ -55,7 +55,7 @@ class StackSet(object):
         return self.metadata.get("StackSetName")
 
 
-class StackInstance(object):
+class StackInstance:
     """A stack instance belongs to a stack set and is specific to a region / account ID."""
 
     def __init__(self, metadata=None):
@@ -66,7 +66,7 @@ class StackInstance(object):
         self.stack = None
 
 
-class Stack(object):
+class Stack:
     def __init__(self, metadata=None, template=None):
         if template is None:
             template = {}

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -638,7 +638,7 @@ def start_edge(port=None, use_ssl=True, asynchronous=False):
 
     # process requires privileged port but we're not root -> try running as sudo
 
-    class Terminator(object):
+    class Terminator:
         def stop(self, quiet=True):
             try:
                 url = "http%s://%s:%s" % ("s" if use_ssl else "", LOCALHOST, port)

--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -9,7 +9,7 @@ from localstack.utils.run import FuncThread
 LOG = logging.getLogger(__name__)
 
 
-class Job(object):
+class Job:
     def __init__(self, job_func, schedule, enabled):
         self.job_func = job_func
         self.schedule = schedule
@@ -32,7 +32,7 @@ class Job(object):
         FuncThread(self.job_func).start()
 
 
-class JobScheduler(object):
+class JobScheduler:
 
     _instance = None
 

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -121,7 +121,7 @@ if EXTRA_CORS_ALLOWED_ORIGINS:
     ALLOWED_CORS_ORIGINS += EXTRA_CORS_ALLOWED_ORIGINS.split(",")
 
 
-class ProxyListener(object):
+class ProxyListener:
     # List of `ProxyListener` instances that are enabled by default for all requests.
     # For inbound flows, the default listeners are applied *before* forwarding requests
     # to the backend; for outbound flows, the default listeners are applied *after* the
@@ -351,7 +351,7 @@ class ArnPartitionRewriteListener(MessageModifyingProxyListener):
 T = TypeVar("T", bound="RegionBackend")
 
 
-class RegionBackend(object):
+class RegionBackend:
     """Base class for region-specific backends for the different APIs.
     RegionBackend lookup methods are not thread safe."""
 
@@ -771,7 +771,7 @@ class DuplexSocket(ssl.SSLSocket):
 ssl.SSLContext.sslsocket_class = DuplexSocket
 
 
-class GenericProxy(object):
+class GenericProxy:
     # TODO: move methods to different class?
     @classmethod
     def create_ssl_cert(cls, serial_number=None):

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -133,7 +133,7 @@ class ServiceLifecycleHook:
         pass
 
 
-class Service(object):
+class Service:
     def __init__(
         self,
         name,

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -8,7 +8,7 @@ from localstack.utils.time import timestamp_millis
 LOG = logging.getLogger(__name__)
 
 
-class Component(object):
+class Component:
     def __init__(self, id, env=None):
         self.id = id
         self.env = env

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -444,7 +444,7 @@ def convert_to_binary_event_payload(result, event_type=None, message_type=None):
     return result
 
 
-class LambdaResponse(object):
+class LambdaResponse:
     """Helper class to support multi_value_headers in Lambda responses"""
 
     def __init__(self):
@@ -458,7 +458,7 @@ class LambdaResponse(object):
         return self._content
 
 
-class MessageConversion(object):
+class MessageConversion:
     @staticmethod
     def fix_date_format(response):
         """Normalize date to format '2019-06-13T18:10:09.1234Z'"""

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -89,7 +89,7 @@ def get_valid_regions():
     return valid_regions
 
 
-class Environment(object):
+class Environment:
     def __init__(self, region=None, prefix=None):
         # target is the runtime environment to use, e.g.,
         # 'local' for local mode

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -86,7 +86,7 @@ def get_request_context():
             return req
 
 
-class RequestContextManager(object):
+class RequestContextManager:
     """Context manager which sets the given request context (i.e., region) for the scope of the block."""
 
     def __init__(self, request_context):

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -16,7 +16,7 @@ from localstack.utils.strings import short_uid
 # - graphql_executor.py
 
 
-class VelocityInput(object):
+class VelocityInput:
     """Simple class to mimick the behavior of variable '$input' in AWS API Gateway integration
     velocity templates.
     See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
@@ -44,7 +44,7 @@ class VelocityInput(object):
         return "$input"
 
 
-class VelocityUtil(object):
+class VelocityUtil:
     """Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration
     velocity templates.
     See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1181,7 +1181,7 @@ def add_default_resource_props(
 # -----------------------
 
 
-class TemplateDeployer(object):
+class TemplateDeployer:
     def __init__(self, stack):
         self.stack = stack
 

--- a/localstack/utils/cloudformation/template_preparer.py
+++ b/localstack/utils/cloudformation/template_preparer.py
@@ -40,7 +40,7 @@ def transform_template(req_data) -> Optional[str]:
             # 'AWSLambdaBasicExecutionRole': 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
         }
 
-        class MockPolicyLoader(object):
+        class MockPolicyLoader:
             def load(self):
                 return policy_map
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -90,7 +90,7 @@ class CancellableStream(Protocol):
         raise NotImplementedError
 
 
-class PortMappings(object):
+class PortMappings:
     """Maps source to target port ranges for Docker port mappings."""
 
     def __init__(self, bind_host=None):

--- a/localstack/utils/json.py
+++ b/localstack/utils/json.py
@@ -42,7 +42,7 @@ class CustomEncoder(json.JSONEncoder):
             return None
 
 
-class JsonObject(object):
+class JsonObject:
     """Generic JSON serializable object for simplified subclassing"""
 
     def to_json(self, indent=None):

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -233,7 +233,7 @@ class OutputReaderThread(FuncThread):
                 yield line.replace("\n", "")
 
 
-class KclLogListener(object):
+class KclLogListener:
     def __init__(self, regex=".*"):
         self.regex = regex
 

--- a/localstack/utils/objects.py
+++ b/localstack/utils/objects.py
@@ -28,7 +28,7 @@ class ArbitraryAccessObj:
         return ArbitraryAccessObj()
 
 
-class Mock(object):
+class Mock:
     """Dummy class that can be used for mocking custom attributes."""
 
     pass

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -335,7 +335,7 @@ class ShellCommandThread(FuncThread):
         self.stopped = True
 
 
-class CaptureOutput(object):
+class CaptureOutput:
     """A context manager that captures stdout/stderr of the current thread. Use it as follows:
 
     with CaptureOutput() as c:

--- a/localstack/utils/tagging.py
+++ b/localstack/utils/tagging.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
 
-class TaggingService(object):
+class TaggingService:
     def __init__(self):
         self.tags = {}
 

--- a/tests/integration/awslambda/test_lambda_size_lims.py
+++ b/tests/integration/awslambda/test_lambda_size_lims.py
@@ -25,7 +25,7 @@ def generate_sized_python_str(size):
     return py_str
 
 
-class TestLambdaSizeLimits(object):
+class TestLambdaSizeLimits:
     def test_oversized_lambda(self, lambda_client, s3_client, s3_bucket):
         function_name = f"test_lambda_{short_uid()}"
         bucket_key = "test_lambda.zip"


### PR DESCRIPTION
Cleaning up a bit.
This PR removes explicit object inheritance. Not needed since we dropped Python 2 support quite a long time ago now.