### PR TITLE
Allow multiple bind addresses to be passed to hypercorn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
       - run:
           name: Unit tests
           environment:
+            DEBUG: 1
             TEST_PATH: "tests/unit"
             PYTEST_ARGS: "--junitxml=target/reports/unit-tests.xml -o junit_suite_name=unit-tests"
             COVERAGE_ARGS: "-p"

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -942,7 +942,7 @@ def get_cert_pem_file_path():
 
 def start_proxy_server(
     port,
-    bind_address=None,
+    bind_address: Union[str, List[str]] = None,
     forward_url=None,
     use_ssl=None,
     update_listener: Optional[Union[ProxyListener, List[ProxyListener]]] = None,
@@ -953,7 +953,10 @@ def start_proxy_server(
     max_content_length: int = None,
     send_timeout: int = None,
 ):
-    bind_address = bind_address if bind_address else BIND_HOST
+    if bind_address:
+        bind_addresses = bind_address if isinstance(bind_address, List) else [bind_address]
+    else:
+        bind_addresses = [BIND_HOST]
 
     if update_listener is None:
         listeners = []
@@ -988,7 +991,7 @@ def start_proxy_server(
 
     result = http2_server.run_server(
         port,
-        bind_address,
+        bind_addresses=bind_addresses,
         handler=handler,
         asynchronous=asynchronous,
         ssl_creds=ssl_creds,

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -45,7 +45,9 @@ def is_port_open(
     nw_protocols += [socket.SOCK_STREAM] if "tcp" in protocols else []
     nw_protocols += [socket.SOCK_DGRAM] if "udp" in protocols else []
     for nw_protocol in nw_protocols:
-        with closing(socket.socket(socket.AF_INET, nw_protocol)) as sock:
+        with closing(
+            socket.socket(socket.AF_INET if ":" not in host else socket.AF_INET6, nw_protocol)
+        ) as sock:
             sock.settimeout(1)
             if nw_protocol == socket.SOCK_DGRAM:
                 try:
@@ -74,7 +76,8 @@ def is_port_open(
                     return False
     if "tcp" not in protocols or not http_path:
         return True
-    url = "%s://%s:%s%s" % (protocol, host, port, http_path)
+    host = f"[{host}]" if ":" in host else host
+    url = f"{protocol}://{host}:{port}{http_path}"
     try:
         response = safe_requests.get(url, verify=False)
         return not expect_success or response.status_code < 400

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -5,7 +5,7 @@ import os
 import ssl
 import threading
 import traceback
-from typing import Callable, Tuple
+from typing import Callable, List, Tuple
 
 import h11
 from hypercorn import utils as hypercorn_utils
@@ -151,7 +151,7 @@ def get_async_generator_result(result):
 
 def run_server(
     port: int,
-    bind_address: str,
+    bind_addresses: List[str],
     handler: Callable = None,
     asynchronous: bool = True,
     ssl_creds: Tuple[str, str] = None,
@@ -161,7 +161,7 @@ def run_server(
     """
     Run an HTTP2-capable Web server on the given port, processing incoming requests via a `handler` function.
     :param port: port to bind to
-    :param bind_address: address to bind to
+    :param bind_addresses: addresses to bind to
     :param handler: callable that receives the request and returns a response
     :param asynchronous: whether to start the server asynchronously in the background
     :param ssl_creds: optional tuple with SSL cert file names (cert file, key file)
@@ -242,7 +242,8 @@ def run_server(
             kwargs["keyfile"] = key_file_name
             config.keyfile = key_file_name
         setup_quart_logging()
-        config.bind = [f"{bind_address}:{port}"]
+        config.bind = [f"{bind_address}:{port}" for bind_address in bind_addresses]
+        config.workers = len(bind_addresses)
         loop = loop or ensure_event_loop()
         run_kwargs = {}
         if shutdown_event:

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -663,7 +663,7 @@ def http_server(handler, host="127.0.0.1", port=None) -> str:
     """
     from localstack.utils.server.http2_server import run_server
 
-    host = host
+    host = [host]
     port = port or get_free_tcp_port()
     thread = run_server(port, host, handler=handler, asynchronous=True)
     url = f"http://{host}:{port}"

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -663,9 +663,9 @@ def http_server(handler, host="127.0.0.1", port=None) -> str:
     """
     from localstack.utils.server.http2_server import run_server
 
-    host = [host]
+    host = host
     port = port or get_free_tcp_port()
-    thread = run_server(port, host, handler=handler, asynchronous=True)
+    thread = run_server(port, [host], handler=handler, asynchronous=True)
     url = f"http://{host}:{port}"
     assert poll_condition(
         lambda: is_port_open(port), timeout=5

--- a/tests/unit/utils/test_http2_server.py
+++ b/tests/unit/utils/test_http2_server.py
@@ -16,20 +16,20 @@ class TestHttp2Server:
     def test_run_and_stop_server(self):
         port = get_free_tcp_port()
         host = "127.0.0.1"
-        host_ipv6 = "[::1]"
+        host_2 = "127.0.0.2"
 
         LOG.info("%.2f starting server on port %d", time.time(), port)
-        thread = run_server(port=port, bind_addresses=[host, host_ipv6], asynchronous=True)
+        thread = run_server(port=port, bind_addresses=[host, host_2], asynchronous=True)
         try:
             url = f"http://{host}:{port}"
-            url_ipv6 = f"http://{host_ipv6}:{port}"
+            url_2 = f"http://{host_2}:{port}"
             assert poll_condition(
                 lambda: is_port_open(url, http_path="/"), timeout=15
             ), f"gave up waiting for port {port}"
             assert poll_condition(
-                lambda: is_port_open(url_ipv6, http_path="/"), timeout=15
+                lambda: is_port_open(url_2, http_path="/"), timeout=15
             ), f"gave up waiting for port {port}"
-            assert not is_port_open(f"http://127.0.0.2:{port}", http_path="/")
+            assert not is_port_open(f"http://127.0.0.3:{port}", http_path="/")
         finally:
             LOG.info("%.2f stopping server on port %d", time.time(), port)
             thread.stop()

--- a/tests/unit/utils/test_http2_server.py
+++ b/tests/unit/utils/test_http2_server.py
@@ -16,14 +16,20 @@ class TestHttp2Server:
     def test_run_and_stop_server(self):
         port = get_free_tcp_port()
         host = "127.0.0.1"
+        host_ipv6 = "[::1]"
 
         LOG.info("%.2f starting server on port %d", time.time(), port)
-        thread = run_server(port=port, bind_address=host, asynchronous=True)
+        thread = run_server(port=port, bind_addresses=[host, host_ipv6], asynchronous=True)
         try:
             url = f"http://{host}:{port}"
+            url_ipv6 = f"http://{host_ipv6}:{port}"
             assert poll_condition(
                 lambda: is_port_open(url, http_path="/"), timeout=15
             ), f"gave up waiting for port {port}"
+            assert poll_condition(
+                lambda: is_port_open(url_ipv6, http_path="/"), timeout=15
+            ), f"gave up waiting for port {port}"
+            assert not is_port_open(f"http://127.0.0.2:{port}", http_path="/")
         finally:
             LOG.info("%.2f stopping server on port %d", time.time(), port)
             thread.stop()
@@ -38,7 +44,7 @@ class TestHttp2Server:
         host = "127.0.0.1"
 
         LOG.info("%.2f starting server on port %d", time.time(), port)
-        thread = run_server(port=port, bind_address=host, asynchronous=True)
+        thread = run_server(port=port, bind_addresses=[host], asynchronous=True)
 
         try:
             url = f"http://{host}:{port}"
@@ -61,7 +67,7 @@ class TestHttp2Server:
         host = "127.0.0.1"
         thread = run_server(
             port=port,
-            bind_address=host,
+            bind_addresses=[host],
             asynchronous=True,
             max_content_length=max_length,
             handler=lambda *args: None,


### PR DESCRIPTION
As seen here (https://pgjones.gitlab.io/hypercorn/how_to_guides/binds.html#multiple-binds), hypercorn supports multiple binds for a single server.
Our current tooling, however, does not allow passing multiple bind_addresses.
This PR introduces the possibility to allow multiple addresses in start_proxy_server and in run_server, to be passed to hypercorn.
To minimize the impact, a single string will still be accepted in start_proxy_server (run_server does not seem to be called from anything but tests and this method), however we should move towards using lists to specify them.

This should help with different problems regarding ipv6 support in host mode (for starting in docker we need to modify the default values in docker-compose and localstack cli as well - separate PR).
It is necessary to provide support for binding to ipv4 and ipv6, since some systems begin to resolve "localhost" to "[::1]" already, which can lead to problems otherwise.