### PR TITLE
add test cases for ASF op router

### DIFF
--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -1,0 +1,26 @@
+import pytest
+from werkzeug.exceptions import NotFound
+
+from localstack.aws.protocol.op_router import RestServiceOperationRouter
+from localstack.aws.spec import list_services, load_service
+from localstack.http import Request
+
+
+def _collect_services():
+    for service in list_services():
+        if service.protocol.startswith("rest"):
+            yield service.service_name
+
+
+@pytest.mark.parametrize(
+    "service",
+    _collect_services(),
+)
+@pytest.mark.param
+def test_create_op_router_works_for_every_service(service):
+    router = RestServiceOperationRouter(load_service(service))
+
+    try:
+        router.match(Request("GET", "/"))
+    except NotFound:
+        pass

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -800,15 +800,30 @@ def test_parse_restjson_querystring_list_parsing():
 
 
 def test_restjson_operation_detection_with_query_suffix_in_requesturi():
-    # Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
-    # parameter, f.e. API Gateway's ImportRestApi: "/restapis?mode=import"
+    """
+    Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
+    parameter, f.e. API Gateway's ImportRestApi: "/restapis?mode=import
+    """
     _botocore_parser_integration_test(service="apigateway", action="ImportRestApi", body=b"Test")
 
 
+def test_rest_url_parameter_with_dashes():
+    """
+    Test if requestUri parameters with dashes in them (e.g., "/v2/tags/{resource-arn}") are parsed correctly.
+    """
+    _botocore_parser_integration_test(
+        service="apigatewayv2",
+        action="GetTags",
+        ResourceArn="arn:aws:apigatewayv2:us-east-1:000000000000:foobar",
+    )
+
+
 def test_restxml_operation_detection_with_query_suffix_without_value_in_requesturi():
-    # Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
-    # parameter without a specific value, f.e. CloudFront's CreateDistributionWithTags:
-    # "/2020-05-31/distribution?WithTags"
+    """
+    Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
+    parameter without a specific value, f.e. CloudFront's CreateDistributionWithTags:
+    "/2020-05-31/distribution?WithTags"
+    """
     _botocore_parser_integration_test(
         service="cloudfront",
         action="CreateDistributionWithTags",


### PR DESCRIPTION
This demonstrates the behavior of #5944. It also adds a test that identifies the affected services.

@alexrashed feel free to close this one and pull the tests into your own PR :-)