### PR TITLE
fix invalid characters in asf rest-protocol operation router

### DIFF
--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -1,0 +1,26 @@
+import pytest
+from werkzeug.exceptions import NotFound
+
+from localstack.aws.protocol.op_router import RestServiceOperationRouter
+from localstack.aws.spec import list_services, load_service
+from localstack.http import Request
+
+
+def _collect_services():
+    for service in list_services():
+        if service.protocol.startswith("rest"):
+            yield service.service_name
+
+
+@pytest.mark.parametrize(
+    "service",
+    _collect_services(),
+)
+@pytest.mark.param
+def test_create_op_router_works_for_every_service(service):
+    router = RestServiceOperationRouter(load_service(service))
+
+    try:
+        router.match(Request("GET", "/"))
+    except NotFound:
+        pass

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -800,15 +800,30 @@ def test_parse_restjson_querystring_list_parsing():
 
 
 def test_restjson_operation_detection_with_query_suffix_in_requesturi():
-    # Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
-    # parameter, f.e. API Gateway's ImportRestApi: "/restapis?mode=import"
+    """
+    Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
+    parameter, f.e. API Gateway's ImportRestApi: "/restapis?mode=import
+    """
     _botocore_parser_integration_test(service="apigateway", action="ImportRestApi", body=b"Test")
 
 
+def test_rest_url_parameter_with_dashes():
+    """
+    Test if requestUri parameters with dashes in them (e.g., "/v2/tags/{resource-arn}") are parsed correctly.
+    """
+    _botocore_parser_integration_test(
+        service="apigatewayv2",
+        action="GetTags",
+        ResourceArn="arn:aws:apigatewayv2:us-east-1:000000000000:foobar",
+    )
+
+
 def test_restxml_operation_detection_with_query_suffix_without_value_in_requesturi():
-    # Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
-    # parameter without a specific value, f.e. CloudFront's CreateDistributionWithTags:
-    # "/2020-05-31/distribution?WithTags"
+    """
+    Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
+    parameter without a specific value, f.e. CloudFront's CreateDistributionWithTags:
+    "/2020-05-31/distribution?WithTags"
+    """
     _botocore_parser_integration_test(
         service="cloudfront",
         action="CreateDistributionWithTags",


### PR DESCRIPTION
This PR fixes the `RestServiceOperationRouter` for operations which contain request URI path params with dashes (`-`).
The issue has been described in #5944.
I cherry-picked the tests from #5945 (in order to have @thrau as a reviewer - which wouldn't be possible when continuing on the existing PR).

This fix introduces a temporary replacement of forbidden characters with a substitution, as well as the reverse operation after the matching has been done. This is necessary since - after a match has been found - the parser assumes the arg keys to be equal to the path params in the request URI of the specs.

I did not introduce a state machine as suggested in https://github.com/localstack/localstack/issues/5944#issuecomment-1111450334, since the regex replacement function seems quite elegant. It nicely encapsulates the transformation of a single request URI path parameter to a Werkzeug rule variable. But I'm open to any suggestions / discussions / feedback (not only on that specific topic 😉).

Closes #5945
Fixes #5944