### PR TITLE
[minor] Fix text/html Content-Type for local CloudFormation UI

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -145,10 +145,7 @@ class CloudFormationUi:
         for key, value in params.items():
             deploy_html = deploy_html.replace(f"<{key}>", value)
 
-        response = Response()
-        response.data = deploy_html
-        response.headers["content-type"] = "text/html"
-        return response
+        return Response(deploy_html, mimetype="text/html")
 
 
 class DiagnoseResource:

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -144,7 +144,11 @@ class CloudFormationUi:
         # using simple string replacement here, for simplicity (could be replaced with, e.g., jinja)
         for key, value in params.items():
             deploy_html = deploy_html.replace(f"<{key}>", value)
-        return deploy_html
+
+        response = Response()
+        response.data = deploy_html
+        response.headers["content-type"] = "text/html"
+        return response
 
 
 class DiagnoseResource:

--- a/tests/unit/services/test_internal.py
+++ b/tests/unit/services/test_internal.py
@@ -87,6 +87,7 @@ class TestLocalstackResourceHandlerIntegration:
             response = requests.get(f"{url}/_localstack/cloudformation/deploy")
             assert response.ok
             assert "</html>" in response.text, "deploy UI did not render HTML"
+            assert "text/html" in response.headers.get("content-type", "")
 
     def test_fallthrough(self):
         class RaiseError(ProxyListener):


### PR DESCRIPTION
Minor fix: Return `text/html` Content-Type for local CloudFormation UI (http://localhost:4566/_localstack/cloudformation/deploy), to ensure it gets properly rendered by browsers.