### PR TITLE
extend s3 virtual host addressing rules exemptions

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -975,7 +975,6 @@ class EC2RequestParser(QueryRequestParser):
 
 
 class S3RequestParser(RestXMLRequestParser):
-
     @_handle_exceptions
     def parse(self, request: HttpRequest) -> Tuple[OperationModel, Any]:
         """Handle virtual-host-addressing for S3."""

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -975,13 +975,6 @@ class EC2RequestParser(QueryRequestParser):
 
 
 class S3RequestParser(RestXMLRequestParser):
-    def __init__(self, service_model: ServiceModel):
-        super().__init__(service_model)
-
-        # hack to make sure we only call import lib once and not on every request
-        from localstack.services.s3.s3_utils import uses_host_addressing
-
-        self._is_vhost_address_by_headers = uses_host_addressing
 
     @_handle_exceptions
     def parse(self, request: HttpRequest) -> Tuple[OperationModel, Any]:
@@ -992,11 +985,9 @@ class S3RequestParser(RestXMLRequestParser):
         return super().parse(request)
 
     def _is_vhost_address(self, request: HttpRequest) -> bool:
-        # TODO implement properly here
-        return self._is_vhost_address_by_headers(request.headers)
+        from localstack.services.s3.s3_utils import uses_host_addressing
 
-    def _is_vhost_address_by_headers(self, request: HttpRequest) -> bool:
-        return False
+        return uses_host_addressing(request.headers)
 
     def _revert_virtual_host_style(self, request: HttpRequest):
         # extract the bucket name from the host part of the request

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -980,7 +980,9 @@ class S3RequestParser(RestXMLRequestParser):
         """Handle virtual-host-addressing for S3."""
         if (
             # TODO implement a more sophisticated determination if the host contains S3 virtual host addressing
-            not request.host.startswith("s3.")
+            not request.host == "localhost"
+            and not request.host.startswith("localhost:")
+            and not request.host.startswith("s3.")
             and not request.host.startswith("localhost.")
             and not request.host.startswith("127.0.0.1")
         ):

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -924,7 +924,7 @@ def test_s3_virtual_host_addressing():
 
 
 def test_s3_list_buckets_with_localhost():
-    # this is the canonical request of `awslocal s3 ls`
+    # this is the canonical request of `awslocal s3 ls` when running on a standard port
     request = HttpRequest("GET", "/", headers={"host": "localhost"})
     parser = create_parser(load_service("s3"))
     parsed_operation_model, parsed_request = parser.parse(request)

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -923,6 +923,22 @@ def test_s3_virtual_host_addressing():
     assert parsed_request["Bucket"] == "test-bucket"
 
 
+def test_s3_list_buckets_with_localhost():
+    # this is the canonical request of `awslocal s3 ls`
+    request = HttpRequest("GET", "/", headers={"host": "localhost"})
+    parser = create_parser(load_service("s3"))
+    parsed_operation_model, parsed_request = parser.parse(request)
+    assert parsed_operation_model.name == "ListBuckets"
+
+
+def test_s3_list_buckets_with_localhost_and_port():
+    # this is the canonical request of `awslocal s3 ls`
+    request = HttpRequest("GET", "/", headers={"host": "localhost:4566"})
+    parser = create_parser(load_service("s3"))
+    parsed_operation_model, parsed_request = parser.parse(request)
+    assert parsed_operation_model.name == "ListBuckets"
+
+
 def test_parser_error_on_protocol_error():
     """Test that the parser raises a ProtocolParserError in case of invalid data to parse."""
     parser = QueryRequestParser(load_service("sqs"))


### PR DESCRIPTION
This fixes an issue where invoking `awslocal s3 ls` would incorrectly create an s3 `ListObjects` command with the bucket name `localhost:4566` (instead of `ListBuckets`) and subsequently setting the `path` of the request object to `/localhost:4566`.
