### PR TITLE
remove Werkzeug pin after bugfix release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,8 +89,7 @@ runtime =
     Quart>=0.6.15
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
-    # Pin werkzeug until the issue discussed here is fixed: https://github.com/localstack/localstack/pull/5773
-    Werkzeug>=2.0,<2.1.0
+    Werkzeug>=2.0
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.


### PR DESCRIPTION
A new bugfix release of Werkzeug has just been released: https://github.com/pallets/werkzeug/releases/tag/2.1.2
It fixes the issue with the Transfer-Encoding ([pallets/werkzeug#2375](https://github.com/pallets/werkzeug/issues/2375)) introduced with 2.1.0, which led us to set an upper version boundary to the Werkzeug dependency (#5773).

The new release contains a fix for the issue, which allows us to remove the upper version boundary.