### PR TITLE
Add localstack update command

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -420,12 +420,12 @@ class ContainerClient(metaclass=ABCMeta):
 
     @abstractmethod
     def pull_image(self, docker_image: str) -> None:
-        """Pulls a image with a given name from a Docker registry"""
+        """Pulls an image with a given name from a Docker registry"""
         pass
 
     @abstractmethod
     def push_image(self, docker_image: str) -> None:
-        """Pushes a image with a given name to a Docker registry"""
+        """Pushes an image with a given name to a Docker registry"""
         pass
 
     @abstractmethod

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -377,6 +377,8 @@ class SdkDockerClient(ContainerClient):
         except ImageNotFound:
             if not force:
                 raise NoSuchImage(image)
+        except APIError:
+            raise ContainerException()
 
     def commit(
         self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages=find:
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
     boto3>=1.20
-    click>=8.1
+    click>=7.0
     cachetools>=3.1.1,<4.0.0
     # dataclasses needed for python3.6 compat
     dataclasses; python_version < '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages=find:
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
     boto3>=1.20
-    click>=7.0
+    click>=8.1
     cachetools>=3.1.1,<4.0.0
     # dataclasses needed for python3.6 compat
     dataclasses; python_version < '3.7'
@@ -40,7 +40,7 @@ install_requires =
     psutil>=5.4.8,<6.0.0
     python-dotenv>=0.19.1
     pyyaml>=5.1
-    rich>=10.7.0
+    rich>=12.3.0
     requests>=2.20.0,<2.26
     semver>=2.10
     stevedore>=3.4.0


### PR DESCRIPTION
## Summary
This PR adds a `localstack update` command, which provides a convenient way to update LocalStack components.

## Implemented commands
`localstack update all`: Updates all components, in essence execute all the commands below
`localstack update localstack-cli`: Update the LocalStack cli packages, in essence `localstack` and `localstack-ext`.
`localstack update docker-images`: Update all LocalStack-used container images (main image, lambda images, bigdata)

## Implementation specifics
We look at the images by prefix. So basically, all images currently available to the daemon will be listed, then filtered by prefix (currently `localstack/`, `lambci/lambda:`, `mlupin/docker-lambda:`), and afterwards we will try pulling each image, and checking if it has updated to be displayed on the UI side.
This means, no image will be pulled if it is not present already. The responsibility for the necessary images to be pulled in the first place, is on the side of LocalStack itself. Specifically, if localstack was never installed on the machine, or all images are deleted, the docker-images CLI part will do nothing.

## Current UI state
During run:
![image](https://user-images.githubusercontent.com/16599060/165930651-cf5e15df-d885-4799-af05-19c47a37eb63.png)
Finished:
![image](https://user-images.githubusercontent.com/16599060/165930784-ddb695fc-f8ac-414a-985b-1c0f62d69f1d.png)

## Discussion
Short call for discussion: How should the commands be separated in the end? We can leave it like this, but it also would be nearly no work to split the docker-images part into one for bigdata images, one for the "core" localstack images, and one for lambda images, for example. Or maybe a completely different split?
Are there any parts missing? Should we display a warning for updates, regarding persistence supports etc