### PR TITLE
fix get_raw_path to unify wsgi/asgi specs

### DIFF
--- a/localstack/http/request.py
+++ b/localstack/http/request.py
@@ -59,6 +59,8 @@ def dummy_wsgi_environment(
         environ["QUERY_STRING"] = query_string
 
     if raw_uri:
+        if query_string:
+            raw_uri += "?" + query_string
         environ["RAW_URI"] = raw_uri
         environ["REQUEST_URI"] = environ["RAW_URI"]
 
@@ -152,19 +154,19 @@ class Request(WerkzeugRequest):
 
 def get_raw_path(request) -> str:
     """
-    Returns the raw_path inside the request. The request can either be a Quart Request object (that
-    encodes the raw path in request.scope['raw_path']) or a Werkzeug WSGi request (that encodes the
-    raw path in request.environ['RAW_URI']).
+    Returns the raw_path inside the request without the query string. The request can either be a Quart Request
+    object (that encodes the raw path in request.scope['raw_path']) or a Werkzeug WSGi request (that encodes the raw
+    path in request.environ['RAW_URI']).
 
     :param request: the request object
     :return: the raw path if any
     """
     if hasattr(request, "environ"):
-        # werkzeug/flask request (already a string)
-        return request.environ.get("RAW_URI", request.path)
+        # werkzeug/flask request (already a string, and contains the query part)
+        return request.environ.get("RAW_URI", request.path).split("?")[0]
 
     if hasattr(request, "scope"):
-        # quart request raw_path comes as bytes
+        # quart request raw_path comes as bytes, and without the query part
         return request.scope.get("raw_path", request.path).decode("utf-8")
 
     raise ValueError("cannot extract raw path from request object %s" % request)

--- a/tests/unit/http/test_request.py
+++ b/tests/unit/http/test_request.py
@@ -120,4 +120,14 @@ def test_get_custom_headers():
 def test_get_raw_path():
     request = Request("GET", "/foo/bar/ed", raw_path="/foo%2Fbar/ed")
 
+    assert request.path == "/foo/bar/ed"
+    assert request.environ["RAW_URI"] == "/foo%2Fbar/ed"
+    assert get_raw_path(request) == "/foo%2Fbar/ed"
+
+
+def test_get_raw_path_with_query():
+    request = Request("GET", "/foo/bar/ed", raw_path="/foo%2Fbar/ed?fizz=buzz")
+
+    assert request.path == "/foo/bar/ed"
+    assert request.environ["RAW_URI"] == "/foo%2Fbar/ed?fizz=buzz"
     assert get_raw_path(request) == "/foo%2Fbar/ed"


### PR DESCRIPTION
This PR fixes two issues:

* `get_raw_path` would return different results depending on whether it is a WSGI or an ASGI request. This would lead to inconsistent behavior and rules not matching when using the asgi->wsgi bridge here:
https://github.com/localstack/localstack/blob/01cb58478ee3a2329b86b0d88fbb12695ce1c3a6/localstack/aws/protocol/op_router.py#L252-L253

* the dummy WSGI environment now correctly adds the query string to the `RAW_URI` environment (which seems redundant since we're removing it in `get_raw_path` now, but this is to conform to the spec.

## Validation of spec

Here's what the relevant parts of the underlying environ/scope look like for "GET /foo/b r?bar=ze 69"

wsgi environ (via werkzeug)
```python
{
  'PATH_INFO': '/foo/b r'
  'QUERY_STRING': 'bar=ze%2069'
  'REQUEST_URI': '/foo/b%20r?bar=ze%2069'
  'RAW_URI': '/foo/b%20r?bar=ze%2069'
}
```

asgi scope (via hypercorn)
```python
{
  'path': '/foo/b r',
  'raw_path': b'/foo/b%20r',
  'query_string': b'bar=ze%2069'
}
```