### PR TITLE
Fix event message parameters priority

### DIFF
--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -295,6 +295,7 @@ def add_api_destination_authorization(destination, headers, event):
 def add_target_http_parameters(http_parameters: Dict, endpoint: str, headers: Dict, body):
     endpoint = add_path_parameters_to_url(endpoint, http_parameters.get("PathParameterValues", []))
 
+    # The request should prioritze connection header/query parameters over target params if there is an overlap
     query_params = http_parameters.get("QueryStringParameters", {})
     prev_query_params = extract_query_string_params(endpoint)[1]
     query_params.update(prev_query_params)

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 
 from moto.events.models import events_backends as moto_events_backends
 
+from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.services.awslambda.lambda_executors import InvocationException, InvocationResult
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.aws.aws_stack import (
@@ -247,7 +248,7 @@ def send_event_to_api_destination(target_arn, event, http_parameters: Optional[D
 
     endpoint = add_api_destination_authorization(destination, headers, event)
     if http_parameters:
-        endpoint = add_http_parameters(http_parameters, endpoint, headers, event)
+        endpoint = add_target_http_parameters(http_parameters, endpoint, headers, event)
 
     result = requests.request(
         method=method, url=endpoint, data=json.dumps(event or {}), headers=headers
@@ -291,8 +292,17 @@ def add_api_destination_authorization(destination, headers, event):
     return endpoint
 
 
-def add_http_parameters(http_parameters: Dict, endpoint: str, headers: Dict, body):
-    headers.update(http_parameters.get("HeaderParameters", {}))
+def add_target_http_parameters(http_parameters: Dict, endpoint: str, headers: Dict, body):
     endpoint = add_path_parameters_to_url(endpoint, http_parameters.get("PathParameterValues", []))
-    endpoint = add_query_params_to_url(endpoint, http_parameters.get("QueryStringParameters", {}))
+
+    query_params = http_parameters.get("QueryStringParameters", {})
+    prev_query_params = extract_query_string_params(endpoint)[1]
+    query_params.update(prev_query_params)
+    endpoint = add_query_params_to_url(endpoint, query_params)
+
+    target_headers = http_parameters.get("HeaderParameters", {})
+    for target_header in target_headers.keys():
+        if target_header not in headers:
+            headers.update({target_header: target_headers.get(target_header)})
+
     return endpoint

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Tuple
 import pytest
 
 from localstack import config
+from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.events.provider import _get_events_tmp_dir
 from localstack.services.generic_proxy import ProxyListener
@@ -604,21 +605,23 @@ class TestEvents:
         stepfunctions_client.delete_state_machine(stateMachineArn=state_machine_arn)
 
     def test_api_destinations(self, events_client):
-
         token = short_uid()
         bearer = "Bearer %s" % token
 
         class HttpEndpointListener(ProxyListener):
             def forward_request(self, method, path, data, headers):
                 event = json.loads(to_str(data))
-                events.append(event)
-                paths_list.append(path)
-                auth = headers.get("Api") or headers.get("Authorization")
-                if auth not in headers_list:
-                    headers_list.append(auth)
+                data_received.update(event)
 
-                if headers.get("target_header"):
-                    headers_list.append(headers.get("target_header"))
+                request_split = extract_query_string_params(path)
+                paths_list.append(request_split[0])
+                query_params_received.update(request_split[1])
+
+                auth = headers.get("Authorization", "")
+                if "Bearer" in auth and "Authorization" in headers_received:
+                    headers.pop("Authorization")
+                    headers.update({"Oauth_token": auth})
+                headers_received.update(headers)
 
                 if "client_id" in event:
                     oauth_data.update(
@@ -639,9 +642,10 @@ class TestEvents:
                     }
                 )
 
-        events = []
+        data_received = {}
+        query_params_received = {}
         paths_list = []
-        headers_list = []
+        headers_received = {}
         oauth_data = {}
 
         local_port = get_free_tcp_port()
@@ -685,13 +689,23 @@ class TestEvents:
                     auth.get("key"): auth.get("parameters"),
                     "InvocationHttpParameters": {
                         "BodyParameters": [
-                            {"Key": "key", "Value": "value", "IsValueSecret": False}
+                            {"Key": "key", "Value": "value", "IsValueSecret": False},
                         ],
                         "HeaderParameters": [
-                            {"Key": "key", "Value": "value", "IsValueSecret": False}
+                            {"Key": "key", "Value": "value", "IsValueSecret": False},
+                            {
+                                "Key": "overwrited_header",
+                                "Value": "original",
+                                "IsValueSecret": False,
+                            },
                         ],
                         "QueryStringParameters": [
-                            {"Key": "key", "Value": "value", "IsValueSecret": False}
+                            {"Key": "key", "Value": "value", "IsValueSecret": False},
+                            {
+                                "Key": "overwrited_query",
+                                "Value": "original",
+                                "IsValueSecret": False,
+                            },
                         ],
                     },
                 },
@@ -720,8 +734,14 @@ class TestEvents:
                         "Input": '{"target_value":"value"}',
                         "HttpParameters": {
                             "PathParameterValues": ["target_path"],
-                            "HeaderParameters": {"target_header": "target_header_value"},
-                            "QueryStringParameters": {"target_query": "t_query"},
+                            "HeaderParameters": {
+                                "target_header": "target_header_value",
+                                "overwrited_header": "changed",
+                            },
+                            "QueryStringParameters": {
+                                "target_query": "t_query",
+                                "overwrited_query": "changed",
+                            },
                         },
                     }
                 ],
@@ -742,27 +762,27 @@ class TestEvents:
             self.cleanup(rule_name=rule_name, target_ids=target_id)
 
         # assert that all events have been received in the HTTP server listener
+        user_pass = to_str(base64.b64encode(b"user:pass"))
 
         def check():
-            assert len(events) >= len(auth_types)
-            assert "key" in paths_list[0] and "value" in paths_list[0]
-            assert "target_query" in paths_list[0] and "t_query" in paths_list[0]
-            assert "target_path" in paths_list[0]
-            assert events[0].get("key") == "value"
-            assert events[0].get("target_value") == "value"
+            assert data_received.get("key") == "value"
+            assert data_received.get("target_value") == "value"
+            assert "/target_path" in paths_list
 
             assert oauth_data.get("client_id") == "id"
             assert oauth_data.get("client_secret") == "password"
             assert oauth_data.get("header_value") == "value2"
             assert oauth_data.get("body_value") == "value1"
-            assert "oauthquery" in oauth_data.get("path")
-            assert "value3" in oauth_data.get("path")
+            assert "oauthquery=value3" in oauth_data.get("path")
 
-            user_pass = to_str(base64.b64encode(b"user:pass"))
-            assert f"Basic {user_pass}" in headers_list
-            assert "apikey_secret" in headers_list
-            assert bearer in headers_list
-            assert "target_header_value" in headers_list
+            assert headers_received.get("Api") == "apikey_secret"
+            assert headers_received.get("Authorization") == f"Basic {user_pass}"
+            assert headers_received.get("Oauth_token") == bearer
+            assert headers_received.get("Target_Header") == "target_header_value"
+
+            # overwrite test
+            assert headers_received.get("Overwrited_Header") == "original"
+            assert query_params_received.get("overwrited_query") == "original"
 
         retry(check, sleep=0.5, retries=5)
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -694,7 +694,7 @@ class TestEvents:
                         "HeaderParameters": [
                             {"Key": "key", "Value": "value", "IsValueSecret": False},
                             {
-                                "Key": "overwrited_header",
+                                "Key": "overwritten_header",
                                 "Value": "original",
                                 "IsValueSecret": False,
                             },
@@ -702,7 +702,7 @@ class TestEvents:
                         "QueryStringParameters": [
                             {"Key": "key", "Value": "value", "IsValueSecret": False},
                             {
-                                "Key": "overwrited_query",
+                                "Key": "overwritten_query",
                                 "Value": "original",
                                 "IsValueSecret": False,
                             },
@@ -736,11 +736,11 @@ class TestEvents:
                             "PathParameterValues": ["target_path"],
                             "HeaderParameters": {
                                 "target_header": "target_header_value",
-                                "overwrited_header": "changed",
+                                "overwritten_header": "changed",
                             },
                             "QueryStringParameters": {
                                 "target_query": "t_query",
-                                "overwrited_query": "changed",
+                                "overwritten_query": "changed",
                             },
                         },
                     }
@@ -781,8 +781,8 @@ class TestEvents:
             assert headers_received.get("Target_Header") == "target_header_value"
 
             # overwrite test
-            assert headers_received.get("Overwrited_Header") == "original"
-            assert query_params_received.get("overwrited_query") == "original"
+            assert headers_received.get("Overwritten_Header") == "original"
+            assert query_params_received.get("overwritten_query") == "original"
 
         retry(check, sleep=0.5, retries=5)
 


### PR DESCRIPTION
This PR addresses issue #5878, where is shown that the Connection query parameters and header parameters have a higher priority than the Target query and header parameters.

Changes:
- Fixing of error.
- Test extended and refactored.
