### PR TITLE
Ensure eventID is contained in DDB stream records

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -223,7 +223,6 @@ class EventForwarder:
         # StreamViewType determines what information is written to the stream for the table
         # When an item in the table is inserted, updated or deleted
         for record in records:
-            record.pop("eventID", None)
             ddb_record = record["dynamodb"]
             stream_type = ddb_record.get("StreamViewType")
             if not stream_type:

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -667,6 +667,9 @@ class TestDynamoDB:
         assert len(records) == 6
         events = [rec["eventName"] for rec in records]
         assert events == ["INSERT", "MODIFY", "REMOVE"] * 2
+        # assert that all records contain proper event IDs
+        event_ids = [rec.get("eventID") for rec in records]
+        assert all(event_ids)
 
         # assert that updates have been received from regular table operations and PartiQL query operations
         for idx, record in enumerate(records):


### PR DESCRIPTION
Ensure that `eventID` is contained in DynamoDB stream records - addresses #5957 , fixes a regression that was likely introduced in the DynamoDB ASF migration in #5796