### PR TITLE
fix: unexistent roles and policies in sam translator

### DIFF
--- a/localstack/utils/cloudformation/template_preparer.py
+++ b/localstack/utils/cloudformation/template_preparer.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 import boto3
 import moto.cloudformation.utils
 import yaml
+from moto.iam.models import aws_managed_policies_data_parsed
 from requests.structures import CaseInsensitiveDict
 from samtranslator.translator.transform import transform as transform_sam
 
@@ -39,6 +40,10 @@ def transform_template(req_data) -> Optional[str]:
             "dummy": "entry"
             # 'AWSLambdaBasicExecutionRole': 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
         }
+
+        policy_map.update(
+            dict([(name, d.Arn) for name, d in aws_managed_policies_data_parsed.items()])
+        )
 
         class MockPolicyLoader:
             def load(self):


### PR DESCRIPTION
Load all policies from moto to avoid this kind of errors in policies/roles not listed in sam transalator.

https://docs.aws.amazon.com/es_es/lambda/latest/dg/lambda-intro-execution-role.html#permissions-executionrole-features

```
iam_backend.attach_role_policy(policy_arn, role_name)
File "/opt/code/localstack/.venv/lib/python3.8/site-packages/moto/iam/models.py", line 1534, in attach_role_policy
policy = arns[policy_arn]
KeyError: 'AWSLambdaSQSQueueExecutionRole'
```

**Please refer to the contribution guidelines in the README when submitting PRs.**
