### PR TITLE
Fix Firehose.PutRecord to extended s3

### DIFF
--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -476,7 +476,10 @@ class FirehoseProvider(FirehoseApi):
                     unprocessed_records,
                 )
             if "S3DestinationDescription" in destination:
-                s3_dest_desc = destination["S3DestinationDescription"]
+                s3_dest_desc = (
+                    destination["S3DestinationDescription"]
+                    or destination["ExtendedS3DestinationDescription"]
+                )
                 self._put_records_to_s3_bucket(delivery_stream_name, records, s3_dest_desc)
             if "HttpEndpointDestinationDescription" in destination:
                 http_dest = destination["HttpEndpointDestinationDescription"]


### PR DESCRIPTION
This PR addresses #5936 where is shown that Localstack crashes when trying to store a record in a Firehose stream that is using ExtendedS3DestinationConfiguration.

Changes:
 - Small change to avoid the crashing.
 - Test added.

Note: The test added is exactly the same as the one for the standard S3 configuration, but it could be used in test the other advance parameters when Localstack supports them. 
