### PR TITLE
add ASGI to WSGI bridge and hypercorn server abstraction

### DIFF
--- a/localstack/http/__init__.py
+++ b/localstack/http/__init__.py
@@ -2,4 +2,4 @@ from .request import Request
 from .response import Response
 from .router import Router, route
 
-__all__ = ["Router", "route", "Response", "Request"]
+__all__ = ["route", "Router", "Response", "Request"]

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -1,0 +1,381 @@
+"""This module contains code to make ASGI play nice with WSGI."""
+import asyncio
+import io
+import math
+import typing as t
+from asyncio import AbstractEventLoop
+from concurrent.futures import Executor
+from urllib.parse import urlparse
+
+if t.TYPE_CHECKING:
+    from _typeshed import WSGIApplication, WSGIEnvironment
+    from hypercorn.typing import ASGIReceiveCallable, ASGISendCallable, HTTPScope, Scope
+
+
+def populate_wsgi_environment(environ: "WSGIEnvironment", scope: "HTTPScope"):
+    """
+    Adds the non-IO parts (e.g., excluding wsgi.input) from the ASGI HTTPScope to the WSGI Environment.
+
+    :param environ: the WSGI environment to populate
+    :param scope: the ASGI scope as source
+    """
+    environ["REQUEST_METHOD"] = scope["method"]
+    # path/uri info
+    environ["SCRIPT_NAME"] = scope.get("root_path", "").rstrip("/")
+
+    path = scope["path"]
+    path = path if path[0] == "/" else urlparse(path).path
+    environ["PATH_INFO"] = path
+
+    query_string = scope.get("query_string")
+    if query_string:
+        raw_uri = scope["raw_path"] + b"?" + query_string
+        environ["QUERY_STRING"] = query_string.decode("latin1")
+    else:
+        raw_uri = scope["raw_path"]
+
+    environ["RAW_URI"] = environ["REQUEST_URI"] = raw_uri.decode("utf-8")
+
+    # server address / host
+    server = scope.get("server") or ("localhost", 80)
+    environ["SERVER_NAME"] = server[0]
+    environ["SERVER_PORT"] = str(server[1]) if server[1] else "80"
+
+    # http version
+    environ["SERVER_PROTOCOL"] = "HTTP/" + scope["http_version"]
+
+    # client (remote) address
+    client = scope.get("client")
+    if client:
+        environ["REMOTE_ADDR"] = client[0]
+        environ["REMOTE_PORT"] = str(client[1])
+
+    # headers
+    for name, value in scope["headers"]:
+        key = name.decode("latin1").upper().replace("-", "_")
+
+        if key not in ["CONTENT_TYPE", "CONTENT_LENGTH"]:
+            key = f"HTTP_{key}"
+
+        environ[key] = value.decode("latin1")
+
+    # wsgi specific keys
+    environ["wsgi.version"] = (1, 0)
+    environ["wsgi.url_scheme"] = scope.get("scheme", "http")
+    environ["wsgi.errors"] = io.BytesIO()
+    environ["wsgi.multithread"] = True
+    environ["wsgi.multiprocess"] = False
+    environ["wsgi.run_once"] = False
+
+    # custom key to allow downstream applications to circumvent WSGI header processing
+    environ["asgi.headers"] = scope.get("headers")
+
+
+async def to_async_generator(
+    it: t.Iterator,
+    loop: t.Optional[AbstractEventLoop] = None,
+    executor: t.Optional[Executor] = None,
+) -> t.AsyncGenerator:
+    """
+    Wraps a given synchronous Iterator as an async generator, where each invocation to ``next(it)``
+    will be wrapped in a coroutine execution.
+
+    :param it: the iterator to wrap
+    :param loop: the event loop to run the next invocations
+    :param executor: the executor to run the synchronous code
+    :return: an async generator
+    """
+    loop = loop or asyncio.get_event_loop()
+    stop = object()
+
+    def _next_sync():
+        try:
+            # this call may potentially call blocking IO, which is why we call it in an executor
+            return next(it)
+        except StopIteration:
+            return stop
+
+    while True:
+        val = await loop.run_in_executor(executor, _next_sync)
+        if val is stop:
+            return
+        yield val
+
+
+class HTTPRequestEventStreamAdapter:
+    """
+    An adapter to expose an ASGIReceiveCallable coroutine that returns HTTPRequestEvent
+    instances, as a PEP 3333 InputStream for consumption in synchronous WSGI/Werkzeug code.
+    """
+
+    def __init__(
+        self, receive: "ASGIReceiveCallable", event_loop: t.Optional[AbstractEventLoop] = None
+    ) -> None:
+        super().__init__()
+        self.receive = receive
+        self.event_loop = event_loop or asyncio.get_event_loop()
+
+        self._more_body = True
+        self._buffer = bytearray()
+
+    def _read_into(self, buf: bytearray) -> t.Tuple[int, bool]:
+        if not self._more_body:
+            return 0, False
+
+        recv_future = asyncio.run_coroutine_threadsafe(self.receive(), self.event_loop)
+        event = recv_future.result()
+        # TODO: disconnect events
+        body = event["body"]
+        more = event.get("more_body", False)
+        buf.extend(body)
+        self._more_body = more
+        return len(body), more
+
+    def read(self, size: t.Optional[int] = None) -> bytes:
+        """
+        Reads up to ``size`` bytes from the object and returns them. As a convenience, if ``size`` is unspecified or
+        ``-1``, all bytes until EOF are returned. Like RawIOBase specifies, only one system call is ever made (in
+        this case, a call to the ASGI receive callable). Fewer than ``size`` bytes may be returned if the underlying
+        call returns fewer than ``size`` bytes.
+
+        :param size: the number of bytes to read
+        :return:
+        """
+        buf = self._buffer
+
+        if not buf and not self._more_body:
+            return b""
+
+        if size is None or size == -1:
+            while True:
+                read, more = self._read_into(buf)
+                if not more:
+                    break
+
+            arr = bytes(buf)
+            buf.clear()
+            return arr
+
+        if len(buf) < size:
+            self._read_into(buf)
+
+        copy = bytes(buf[:size])
+        self._buffer = buf[size:]
+        return copy
+
+    def readline(self, size: t.Optional[int] = None) -> bytes:
+        buf = self._buffer
+        size = size if size is not None else -1
+
+        while True:
+            i = buf.find(b"\n")  # FIXME: scans the whole buffer every time
+
+            if i >= 0:
+                if 0 < size < i:
+                    break  # no '\n' in range
+                else:
+                    arr = bytes(buf[: (i + 1)])
+                    self._buffer = buf[(i + 1) :]
+                    return arr
+
+            # ensure the buffer has at least `size` bytes (or all)
+            if size > 0:
+                if len(buf) >= size:
+                    break
+            _, more = self._read_into(buf)
+            if not more:
+                break
+
+        if size > 0:
+            arr = bytes(buf[:size])
+            self._buffer = buf[size:]
+            return arr
+        else:
+            arr = bytes(buf)
+            buf.clear()
+            return arr
+
+    def readlines(self, size: t.Optional[int] = None) -> t.List[bytes]:
+        if size is None or size < 0:
+            return [line for line in self]
+
+        lines = []
+        while size > 0:
+            try:
+                line = self.__next__()
+            except StopIteration:
+                return lines
+
+            lines.append(line)
+            size = size - len(line)
+
+        return lines
+
+    def __next__(self):
+        line = self.readline()
+        if line == b"" and not self._more_body:
+            raise StopIteration()
+        return line
+
+    def __iter__(self):
+        return self
+
+
+class WsgiStartResponse:
+    """
+    A wrapper that exposes an async ``ASGISendCallable`` as synchronous a WSGI ``StartResponse`` protocol callable.
+    See this stackoverflow post for a good explanation: https://stackoverflow.com/a/16775731/804840.
+    """
+
+    def __init__(
+        self,
+        send: "ASGISendCallable",
+        event_loop: AbstractEventLoop = None,
+    ):
+        self.send = send
+        self.event_loop = event_loop or asyncio.get_event_loop()
+        self.sent = 0
+        self.content_length = math.inf
+        self.finalized = False
+        self.started = False
+
+    def __call__(
+        self, status: str, headers: t.List[t.Tuple[str, str]], exec_info=None
+    ) -> t.Callable[[bytes], t.Any]:
+        return self.start_response_sync(status, headers, exec_info)
+
+    def start_response_sync(
+        self, status: str, headers: t.List[t.Tuple[str, str]], exec_info=None
+    ) -> t.Callable[[bytes], t.Any]:
+        """
+        The WSGI start_response protocol.
+
+        :param status: the HTTP status (e.g., ``200 OK``) to write
+        :param headers: the HTTP headers to write
+        :param exec_info: ignored
+        :return: a callable that lets you write bytes to the response body
+        """
+        send = self.send
+        loop = self.event_loop
+
+        # start sending response
+        asyncio.run_coroutine_threadsafe(
+            send(
+                {
+                    "type": "http.response.start",
+                    "status": int(status[:3]),
+                    "headers": [(h[0].encode("latin1"), h[1].encode("latin1")) for h in headers],
+                }
+            ),
+            loop,
+        ).result()
+
+        self.started = True
+        # find out content length if set
+        self.content_length = math.inf  # unknown content-length
+        for k, v in headers:
+            if k.lower() == "content-length":
+                self.content_length = int(v)
+                break
+
+        return self.write_sync
+
+    def write_sync(self, data: bytes) -> None:
+        return asyncio.run_coroutine_threadsafe(self.write(data), self.event_loop).result()
+
+    async def write(self, data: bytes) -> None:
+        if not self.started:
+            raise ValueError("not started the response yet")
+        await self.send({"type": "http.response.body", "body": data, "more_body": True})
+        self.sent += len(data)
+        if self.sent >= self.content_length:
+            await self.close()
+
+    async def close(self):
+        if not self.started:
+            raise ValueError("not started the response yet")
+
+        if not self.finalized:
+            self.finalized = True
+            await self.send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+class ASGIAdapter:
+    """
+    Adapter to expose a WSGIApplication as an ASGI3Application. This allows you to serve synchronous WSGI applications
+    through ASGI servers (e.g., Hypercorn).
+
+    https://asgi.readthedocs.io/en/latest/specs/main.html
+    """
+
+    def __init__(
+        self,
+        wsgi_app: "WSGIApplication",
+        event_loop: AbstractEventLoop = None,
+        executor: Executor = None,
+    ):
+        self.wsgi_app = wsgi_app
+        self.event_loop = event_loop or asyncio.get_event_loop()
+        self.executor = executor
+
+    async def __call__(
+        self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ):
+        """
+        The ASGI 3 interface. Can only handle HTTP calls.
+
+        :param scope: the connection scope
+        :param receive: the receive callable
+        :param send: the send callable
+        """
+        if scope["type"] == "http":
+            return await self.handle_http(scope, receive, send)
+
+        raise NotImplementedError("Unhandled protocol %s" % scope["type"])
+
+    def to_wsgi_environment(
+        self,
+        scope: "HTTPScope",
+        receive: "ASGIReceiveCallable",
+    ) -> "WSGIEnvironment":
+        """
+        Creates an IO-ready WSGIEnvironment from the given ASGI HTTP call.
+
+        :param scope: the ASGI HTTP Scope
+        :param receive: the ASGI callable to receive the HTTP request
+        :return: a WSGIEnvironment
+        """
+        environ: "WSGIEnvironment" = {}
+        populate_wsgi_environment(environ, scope)
+        # add IO wrappers
+        environ["wsgi.input"] = HTTPRequestEventStreamAdapter(receive, event_loop=self.event_loop)
+        environ[
+            "wsgi.input_terminated"
+        ] = True  # indicates that the stream is EOF terminated per request
+        return environ
+
+    async def handle_http(
+        self, scope: "HTTPScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ):
+        env = self.to_wsgi_environment(scope, receive)
+
+        response = WsgiStartResponse(send, self.event_loop)
+
+        iterable = await self.event_loop.run_in_executor(
+            self.executor, self.wsgi_app, env, response
+        )
+
+        try:
+            if iterable:
+                # Generators are also Iterators
+                if isinstance(iterable, t.Iterator):
+                    iterable = to_async_generator(iterable)
+
+                if isinstance(iterable, (t.AsyncIterator, t.AsyncIterable)):
+                    async for packet in iterable:
+                        await response.write(packet)
+                else:
+                    for packet in iterable:
+                        await response.write(packet)
+        finally:
+            await response.close()

--- a/localstack/http/dispatcher.py
+++ b/localstack/http/dispatcher.py
@@ -81,7 +81,7 @@ class Handler(Protocol):
         pass
 
 
-def handler_dispatcher() -> Dispatcher:
+def handler_dispatcher() -> Dispatcher[Handler]:
     """
     Creates a Dispatcher that treats endpoints like callables of the Handler Protocol.
 

--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -1,0 +1,60 @@
+import asyncio
+import threading
+from asyncio import AbstractEventLoop
+
+from hypercorn import Config
+from hypercorn.asyncio import serve
+from hypercorn.typing import ASGI3Framework
+
+from localstack.utils.serving import Server
+
+
+class HypercornServer(Server):
+    """
+    A sync wrapper around Hypercorn that implements the ``Server`` interface.
+    """
+
+    def __init__(self, app: ASGI3Framework, config: Config, loop: AbstractEventLoop = None):
+        """
+        Create a new Hypercorn server instance.
+
+        :param app: the ASGI3 app
+        :param config: the hypercorn config
+        :param loop: optionally the event loop, otherwise ``asyncio.get_event_loop`` will be called
+        """
+        self.app = app
+        self.config = config
+        self.loop = loop or asyncio.get_event_loop()
+
+        self._close = asyncio.Event()
+        self._closed = threading.Event()
+
+        parts = config.bind[0].split(":")
+        if len(parts) == 1:
+            # check ssl
+            host = parts[0]
+            port = 443 if config.ssl_enabled else 80
+        else:
+            host, port = parts[0], int(parts[1])
+
+        super().__init__(port, host)
+
+    @property
+    def protocol(self):
+        return "https" if self.config.ssl_enabled else "http"
+
+    def do_run(self):
+        self.loop.run_until_complete(
+            serve(self.app, self.config, shutdown_trigger=self._shutdown_trigger)
+        )
+        self._closed.set()
+
+    def do_shutdown(self):
+        asyncio.run_coroutine_threadsafe(self._set_closed(), self.loop)
+        self._closed.wait(timeout=10)
+
+    async def _set_closed(self):
+        self._close.set()
+
+    async def _shutdown_trigger(self):
+        await self._close.wait()

--- a/tests/unit/http/test_asgi.py
+++ b/tests/unit/http/test_asgi.py
@@ -1,0 +1,194 @@
+import logging
+from typing import List
+
+import pytest
+import requests
+from hypercorn import Config
+from hypercorn.typing import ASGI3Framework
+from werkzeug import Request, Response
+
+from localstack.http.asgi import ASGIAdapter
+from localstack.http.hypercorn import HypercornServer
+from localstack.utils import net
+from localstack.utils.sync import poll_condition
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def serve_app():
+    _servers = []
+
+    def _create(app: ASGI3Framework, config: Config = None) -> HypercornServer:
+        if not config:
+            config = Config()
+            config.bind = f"localhost:{net.get_free_tcp_port()}"
+
+        srv = HypercornServer(app, config)
+        _servers.append(srv)
+        srv.start()
+        assert srv.wait_is_up(timeout=10), "gave up waiting for server to start up"
+        return srv
+
+    yield _create
+
+    for server in _servers:
+        server.shutdown()
+        assert poll_condition(
+            lambda: not server.is_up(), timeout=10
+        ), "gave up waiting for server to shut down"
+
+
+def test_serve_app(serve_app):
+    request_list: List[Request] = []
+
+    @Request.application
+    def app(request: Request) -> Response:
+        request_list.append(request)
+        return Response("ok", 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    response0 = requests.get(server.url + "/foobar?foo=bar", headers={"x-amz-target": "testing"})
+    assert response0.ok
+    assert response0.text == "ok"
+
+    response1 = requests.get(server.url + "/compute", data='{"foo": "bar"}')
+    assert response1.ok
+    assert response1.text == "ok"
+
+    request0 = request_list[0]
+    assert request0.path == "/foobar"
+    assert request0.query_string == b"foo=bar"
+    assert request0.full_path == "/foobar?foo=bar"
+    assert request0.headers["x-amz-target"] == "testing"
+    assert dict(request0.args) == {"foo": "bar"}
+
+    request1 = request_list[1]
+    assert request1.path == "/compute"
+    assert request1.get_data() == b'{"foo": "bar"}'
+
+
+def test_chunked_transfer_encoding_response(serve_app):
+    # this test makes sure that creating a response with a generator automatically creates a
+    # transfer-encoding=chunked response
+
+    @Request.application
+    def app(_request: Request) -> Response:
+        def _gen():
+            yield "foo"
+            yield "bar\n"
+            yield "baz\n"
+
+        return Response(_gen(), 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    response = requests.get(server.url)
+
+    assert response.headers["Transfer-Encoding"] == "chunked"
+
+    it = response.iter_lines()
+
+    assert next(it) == b"foobar"
+    assert next(it) == b"baz"
+
+
+def test_chunked_transfer_encoding_request(serve_app):
+    request_list: List[Request] = []
+
+    @Request.application
+    def app(request: Request) -> Response:
+        request_list.append(request)
+
+        stream = request.stream
+        data = bytearray()
+
+        for i, item in enumerate(stream):
+            data.extend(item)
+
+            if i == 0:
+                assert item == b"foobar\n"
+            if i == 1:
+                assert item == b"baz"
+
+        return Response(data.decode("utf-8"), 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    def gen():
+        yield b"foo"
+        yield b"bar\n"
+        yield b"baz"
+
+    response = requests.post(server.url, gen())
+    assert response.ok
+    assert response.text == "foobar\nbaz"
+
+    assert request_list[0].headers["Transfer-Encoding"].lower() == "chunked"
+
+
+def test_input_stream_methods(serve_app):
+    @Request.application
+    def app(request: Request) -> Response:
+        assert request.stream.read(1) == b"f"
+        assert request.stream.readline(10) == b"ood\n"
+        assert request.stream.readline(3) == b"bar"
+        assert next(request.stream) == b"ber\n"
+        assert request.stream.readlines(3) == [b"fizz\n"]
+        assert request.stream.readline() == b"buzz\n"
+        assert request.stream.read() == b"really\ndone"
+        assert request.stream.read(10) == b""
+
+        return Response("ok", 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    def gen():
+        yield b"fo"
+        yield b"od\n"
+        yield b"barber\n"
+        yield b"fizz\n"
+        yield b"buzz\n"
+        yield b"really\n"
+        yield b"done"
+
+    response = requests.post(server.url, data=gen())
+    assert response.ok
+    assert response.text == "ok"
+
+
+def test_input_stream_readlines(serve_app):
+    @Request.application
+    def app(request: Request) -> Response:
+        assert request.stream.readlines() == [b"fizz\n", b"buzz\n", b"done"]
+        return Response("ok", 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    def gen():
+        yield b"fizz\n"
+        yield b"buzz\n"
+        yield b"done"
+
+    response = requests.post(server.url, data=gen())
+    assert response.ok
+    assert response.text == "ok"
+
+
+def test_input_stream_readlines_with_limit(serve_app):
+    @Request.application
+    def app(request: Request) -> Response:
+        assert request.stream.readlines(1000) == [b"fizz\n", b"buzz\n", b"done"]
+        return Response("ok", 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    def gen():
+        yield b"fizz\n"
+        yield b"buzz\n"
+        yield b"done"
+
+    response = requests.post(server.url, data=gen())
+    assert response.ok
+    assert response.text == "ok"


### PR DESCRIPTION
This PR adds an ASGI to WSGI bridge to serve WSGI applications through ASGI servers like Hypercorn. This serves as a basis for #5243 that is built around werkzeug's `Request` object which wraps and underlying `WSGIEnvironment`. This gives us all the benefits of the ASGI HTTP/2 server, while also maximally re-using Werkzeug's synchronous server code.

## Example usage

Here's an example server highlighting the integration:
```python
import werkzeug
import hypercorn

from localstack.http.asgi import ASGIAdapter
from localstack.http.hypercorn import HypercornServer


@werkzeug.Request.application
def wsgi_app(request: werkzeug.Request) -> werkzeug.Response:
    return werkzeug.Response("ok", 200)


def main():
    config = hypercorn.Config()
    config.bind = "localhost:4566"

    asgi_app = ASGIAdapter(wsgi_app)
    server = HypercornServer(asgi_app, config)

    server.start()
    server.wait_is_up(10)

    try:
        server.join()
    except KeyboardInterrupt:
        pass
    finally:
        server.shutdown()

if __name__ == '__main__':
    main()
```

## Details

The main difference to [Django's asgiref wsgi wrapper](https://github.com/django/asgiref/blob/main/asgiref/wsgi.py) is that it does not [read the entire request into a SpooledTemporaryFile](https://github.com/django/asgiref/blob/12f6355d50c271aab821a37dbf2cde5863cc2643/asgiref/wsgi.py#L38-L39), but instead wraps the async ASGI event `receive` callable and exposes it as a WSGI `InputStream` protocol conform class (the `HTTPRequestEventStreamAdapter`). This allows, in principle, streaming requests to the server.

Also, [in contrast to asgiref](https://github.com/django/asgiref/blob/12f6355d50c271aab821a37dbf2cde5863cc2643/asgiref/wsgi.py#L130-L131), our implementation allows direct passing of a `ThreadPoolExecutor` to the `ASGIAdapter`, making it much easier to multi-thread the server (otherwise blocking IO in a request would also block the server).