### PR TITLE
fix op router when matching keys with slashes

### DIFF
--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -6,10 +6,14 @@ from urllib.parse import parse_qs, unquote
 from botocore.model import OperationModel, ServiceModel, StructureShape
 from werkzeug.datastructures import Headers, MultiDict
 from werkzeug.exceptions import NotFound
-from werkzeug.routing import Map, MapAdapter, Rule
+from werkzeug.routing import Map, MapAdapter, PathConverter, Rule
 
 from localstack.http import Request
 from localstack.http.request import get_raw_path
+
+
+class GreedyPathConverter(PathConverter):
+    regex = ".*?"
 
 
 class _HttpOperation(NamedTuple):
@@ -223,7 +227,7 @@ def _create_service_map(service: ServiceModel) -> Map:
             # a custom rule - which can use additional request metadata - needs to be used
             rules.append(_RequestMatchingRule(rule_string, methods=[method], operations=ops))
 
-    return Map(rules=rules)
+    return Map(rules=rules, merge_slashes=False, converters={"path": GreedyPathConverter})
 
 
 class RestServiceOperationRouter:

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from mypy_boto3_redshift import RedshiftClient
     from mypy_boto3_resourcegroupstaggingapi import ResourceGroupsTaggingAPIClient
     from mypy_boto3_route53 import Route53Client
-    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_s3 import S3Client, S3ServiceResource
     from mypy_boto3_s3control import S3ControlClient
     from mypy_boto3_secretsmanager import SecretsManagerClient
     from mypy_boto3_ses import SESClient
@@ -111,6 +111,11 @@ def iam_client() -> "IAMClient":
 @pytest.fixture(scope="class")
 def s3_client() -> "S3Client":
     return _client("s3")
+
+
+@pytest.fixture(scope="class")
+def s3_resource() -> "S3ServiceResource":
+    return _resource("s3")
 
 
 @pytest.fixture(scope="class")

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -900,6 +900,27 @@ def test_s3_operation_detection():
     )
 
 
+def test_s3_put_object_keys_with_slashes():
+    _botocore_parser_integration_test(
+        service="s3",
+        action="PutObject",
+        Bucket="test-bucket",
+        Key="/test-key",
+        ContentLength=6,
+        Body=b"foobar",
+        Metadata={},
+    )
+
+
+def test_s3_get_object_keys_with_slashes():
+    _botocore_parser_integration_test(
+        service="s3",
+        action="GetObject",
+        Bucket="test-bucket",
+        Key="/test-key",
+    )
+
+
 def test_restxml_headers_parsing():
     """Test the parsing of a map with the location trait 'headers'."""
     _botocore_parser_integration_test(


### PR DESCRIPTION
This PR changes the way path rules of requestUri patterns, e.g., `{Key+}`, are matched. It adds tests for the behavior at multiple levels.

Background: S3 keys can contain slashes, which are encoded in the path, and the slashes should be matched by the path rule.

    /test-bucket-5a51ca7e//foo/bar
     -------------------^ -------^
     bucket                key

The default `path` rule regex is `[^/].*?`, I changed that to `.*?`, so it matches slashes as well.

This will work even when matching paths where there is a static suffix. For example, these rules exist and will work:

* workspaces-web GetTrustStoreCertificate: `/trustStores/{trustStoreArn+}/certificate`

Moreover, when the routing Map has `merge_slashes=True` set, werkzeug detects multiple consecutive slashes and then attempts to redirect. So we disable that too.

... didn't let me sleep this one ;-)