### PR TITLE
fix secretsmanager to use ASF instead of moto exceptions

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -9,11 +9,10 @@ from typing import Dict, Final, Optional, Union
 from moto.awslambda.models import LambdaFunction
 from moto.iam.policy_validation import IAMPolicyDocumentValidator
 from moto.secretsmanager import models as secretsmanager_models
-from moto.secretsmanager.exceptions import SecretNotFoundException, ValidationException
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend, secretsmanager_backends
 from moto.secretsmanager.responses import SecretsManagerResponse
 
-from localstack.aws.api import RequestContext, ServiceResponse, handler
+from localstack.aws.api import CommonServiceException, RequestContext, ServiceResponse, handler
 from localstack.aws.api.secretsmanager import (
     CancelRotateSecretRequest,
     CancelRotateSecretResponse,
@@ -76,6 +75,16 @@ LOG = logging.getLogger(__name__)
 
 # Maps key names to ARNs.
 SECRET_ARN_STORAGE = {}
+
+
+class ValidationException(CommonServiceException):
+    def __init__(self, message: str):
+        super().__init__("ValidationException", message, 400, True)
+
+
+class SecretNotFoundException(CommonServiceException):
+    def __init__(self, message: str):
+        super().__init__("SecretNotFoundException", message, 404, True)
 
 
 class SecretsmanagerProvider(SecretsmanagerApi):

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -35,8 +35,8 @@ TEST_LAMBDA_ROTATE_SECRET = os.path.join(THIS_FOLDER, "functions", "lambda_rotat
 
 class TestSecretsManager:
     @pytest.fixture
-    def sm_client(self):
-        return aws_stack.create_external_boto_client("secretsmanager")
+    def sm_client(self, secretsmanager_client):
+        return secretsmanager_client
 
     @pytest.mark.parametrize(
         "secret_name, is_valid_partial_arn",
@@ -408,6 +408,7 @@ class TestSecretsManager:
     @pytest.mark.parametrize(
         "secret_name", ["Inv Name", " Inv Name", " Inv*Name? ", " Inv *?!]Name\\-"]
     )
+    @pytest.mark.aws_validated
     def test_invalid_secret_name(self, sm_client, secret_name: str):
         def check_validation_exception(exc_info: ExceptionInfo):
             error = exc_info.value.response["Error"]


### PR DESCRIPTION
This PR fixes an issue where the ASF gateway would not serialize boto exceptions correctly, because it doesn't know about moto exceptions. Because the tests were using the custom `sm_client` fixture, and i was too lazy to refactor the tests, i simply wrapped the fixture with our `secretsmanager_client` to run the affected test against AWS.