### PR TITLE
NaiveBackend for region-neutral providers

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -391,6 +391,34 @@ class RegionBackend:
         return cls.regions()
 
 
+U = TypeVar("U", bound="NaiveBackend")
+
+
+class NaiveBackend:
+    """Base class for the region-naive backends.
+
+    Certain service providers handle region-resolution themselves. The NaiveBackend
+    is suited for such providers. It aims to provide persistence support for
+    these region-neutral global providers."""
+
+    BACKEND: U
+
+    @classmethod
+    def get(cls: Type[U]) -> U:
+        if not hasattr(cls, 'BACKEND'):
+            cls.BACKEND = cls()
+        return cls.BACKEND
+
+    @classmethod
+    def set(cls: Type[U], state: U):
+        cls.BACKEND = state
+
+    @classmethod
+    def reset(cls):
+        cls.BACKEND = cls()
+        return cls.BACKEND
+
+
 # ---------------------
 # PROXY LISTENER UTILS
 # ---------------------

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -276,18 +276,6 @@ def sns():
 
 @aws_provider()
 def sqs():
-    from localstack.services.sqs import sqs_listener, sqs_starter
-
-    return Service(
-        "sqs",
-        listener=sqs_listener.UPDATE_SQS,
-        start=sqs_starter.start_sqs,
-        check=sqs_starter.check_sqs,
-    )
-
-
-@aws_provider(api="sqs", name="asf")
-def sqs_asf():
     from localstack.aws.proxy import AwsApiListener
     from localstack.services.sqs.provider import SqsProvider
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -13,7 +13,6 @@ import time
 from queue import Empty, PriorityQueue
 from typing import Dict, List, NamedTuple, Optional, Set
 
-from localstack.services.generic_proxy import NaiveBackend
 from moto.sqs.models import BINARY_TYPE_FIELD_INDEX, STRING_TYPE_FIELD_INDEX
 from moto.sqs.models import Message as MotoMessage
 
@@ -69,7 +68,6 @@ from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws.aws_stack import parse_arn
 from localstack.utils.common import long_uid, md5, now, start_thread
 from localstack.utils.run import FuncThread
-from services.base import setup_and_restore_persistence
 
 LOG = logging.getLogger(__name__)
 
@@ -638,15 +636,6 @@ def check_fifo_id(fifo_id):
         )
 
 
-class SqsBackend(NaiveBackend):
-    queues: Dict[QueueKey, SqsQueue]
-
-    def __init__(self):
-        super(SqsBackend, self).__init__()
-
-        self.queues = {}
-
-
 class SqsProvider(SqsApi, ServiceLifecycleHook):
     """
     LocalStack SQS Provider.
@@ -659,6 +648,11 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
     queues: Dict[QueueKey, SqsQueue]
 
+    def __init__(self, *args, **kwargs):
+        super(SqsProvider).__init__(*args, **kwargs)
+
+        self.queues = {}
+
     def start(self):
         self._inflight_worker.start()
 
@@ -666,10 +660,6 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         self._inflight_worker.stop()
 
     def on_after_init(self):
-        setup_and_restore_persistence("sqs", naive_backend=SqsBackend)
-
-        self.queues = SqsBackend.get().queues
-
         self._mutex = threading.RLock()
         self._inflight_worker = InflightUpdateWorker(self.queues)
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -648,9 +648,8 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
     queues: Dict[QueueKey, SqsQueue]
 
-    def __init__(self, *args, **kwargs):
-        super(SqsProvider).__init__(*args, **kwargs)
-
+    def __init__(self) -> None:
+        super().__init__()
         self.queues = {}
 
     def start(self):


### PR DESCRIPTION
### Summary

NaiveBackend is a provider backend for services that do no have the concept of regions or handle region resolution themselves.
It uses the existing persistence/pickling mechanism, storing the serialised dumps in the `global` subdirectory:
```
.
.
├── api_states
│   └── 00000069
│       ├── ec2
│       │   └── us-east-1
│       │       └── backend_state
│       └── sqs
│           ├── global
│           │   └── region_state
│           └── static
│               └── shared_state
├── recorded_api_calls.json
└── startup_info.json

```
For now, this backend will be used by SQS pro provider.