### PR TITLE
Fix ValidationError for CloudFormation.DescribeStacks

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -529,7 +529,7 @@ class ValidationError(CommonServiceException):
     """General validation error type (defined in the AWS docs, but not part of the botocore spec)"""
 
     def __init__(self, message=None):
-        super().__init__("ValidationError", message=message)
+        super().__init__("ValidationError", message=message, sender_fault=True)
 
 
 class ResourceNotFoundException(CommonServiceException):

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -629,7 +629,7 @@ class CloudformationProvider(CloudformationApi):
         ]
 
         if stack_name and not stacks:
-            raise ValidationError(f"Stack with id {stack_name} does not exist ")
+            raise ValidationError(f"Stack with id {stack_name} does not exist")
 
         return DescribeStacksOutput(Stacks=stacks)
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -629,7 +629,7 @@ class CloudformationProvider(CloudformationApi):
         ]
 
         if stack_name and not stacks:
-            raise ValidationError(f"Stack with id %s does not exist {stack_name}")
+            raise ValidationError(f"Stack with id {stack_name} does not exist ")
 
         return DescribeStacksOutput(Stacks=stacks)
 


### PR DESCRIPTION
Hotfix for a regression that prevented AWS CDK from bootstrapping since the DescribeStacks response couldn't be parsed successfully.

Fixes https://github.com/localstack/aws-cdk-local/issues/68