### PR TITLE
disable strict slashes for ASF REST operation router

### DIFF
--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -247,7 +247,12 @@ def _create_service_map(service: ServiceModel) -> Map:
             # a custom rule - which can use additional request metadata - needs to be used
             rules.append(_RequestMatchingRule(string=rule_string, method=method, operations=ops))
 
-    return Map(rules=rules, merge_slashes=False, converters={"path": GreedyPathConverter})
+    return Map(
+        rules=rules,
+        strict_slashes=False,
+        merge_slashes=False,
+        converters={"path": GreedyPathConverter},
+    )
 
 
 class RestServiceOperationRouter:
@@ -270,8 +275,8 @@ class RestServiceOperationRouter:
         :raises: Werkzeug's NotFound exception in case the given request does not match any operation
         """
 
-        # bind the map to get the actual matcher (use an empty server_name, since there won't be a hostname matching)
-        matcher: MapAdapter = self._map.bind("")
+        # bind the map to get the actual matcher
+        matcher: MapAdapter = self._map.bind(request.host)
 
         # perform the matching
         rule, args = matcher.match(get_raw_path(request), method=request.method, return_rule=True)

--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -57,3 +57,21 @@ def test_s3_head_request():
 
     op, _ = router.match(Request("HEAD", "/my-bucket/my-key/"))
     assert op.name == "HeadObject"
+
+
+def test_trailing_slashes_are_not_strict():
+    # this is tested against AWS. AWS is not strict about trailing slashes when routing operations.
+
+    router = RestServiceOperationRouter(load_service("lambda"))
+
+    op, _ = router.match(Request("GET", "/2015-03-31/functions"))
+    assert op.name == "ListFunctions"
+
+    op, _ = router.match(Request("GET", "/2015-03-31/functions/"))
+    assert op.name == "ListFunctions"
+
+    op, _ = router.match(Request("POST", "/2015-03-31/functions"))
+    assert op.name == "CreateFunction"
+
+    op, _ = router.match(Request("POST", "/2015-03-31/functions/"))
+    assert op.name == "CreateFunction"


### PR DESCRIPTION
This PR disables strict slash matching (ignore trailing slashes) for the operation router.
I'm 96% confident this change is safe ;-)

I also added the host to the matcher since it helps with debugging when getting redirect errors.
It then prints: `werkzeug.routing.RequestRedirect: 308 Permanent Redirect: http://127.0.0.1/2015-03-31/functions/`

## Background

I ran into the problem when debugging this test: https://github.com/localstack/localstack/blob/abbb7a8866ca3cafb0b3ca2f60ca26acebad3b44/tests/integration/test_edge.py#L290-L301

The test is calling `GET /2015-03-31/functions`, which would not match the `ListFunctions` rule in botocore, whose requestUri is [`/2015-03-31/functions/`](https://github.com/boto/botocore/blob/801faeec62d325a337bd5b39cce8d2c189774e12/botocore/data/lambda/2015-03-31/service-2.json#L704-L709)

### AWS Behavior

I ran a test against AWS, and it seems like indeed AWS is not strict about trailing slashes.
Here's what I executed. (`sandox` is my local profile to test against AWS).
It does not appear to do any 308 redirects.

```python

def main():
    session = boto3.Session(profile_name="sandbox")
    credentials = session.get_credentials()
    creds = credentials.get_frozen_credentials()

    def signed_request(method, url, data=None, params=None, headers=None):
        request = AWSRequest(method=method, url=url, data=data, params=params, headers=headers)
        # "service_name" is generally "execute-api" for signing API Gateway requests
        SigV4Auth(creds, "lambda", "us-east-1").add_auth(request)
        return requests.request(method=method, url=url, headers=dict(request.headers), data=data)

    response = signed_request(
        method='GET',
        url="https://lambda.us-east-1.amazonaws.com/2015-03-31/functions",
        data=b"",
        headers={}
    )
    assert response.status_code == 200


if __name__ == '__main__':
    main()
```

### Werkzeug strict slashes

Here's a code snippet demonstrating the werkzeug behavior:
```python
from werkzeug.routing import Map, Rule


def main():
    router = Map([
        Rule("/2015-03-31/functions/", methods=["GET"], endpoint="get_functions"),
        Rule("/2015-03-31/functions", methods=["POST"], endpoint="create_function"),
    ], strict_slashes=False)

    matcher = router.bind("")

    # with strict-slashes = True, this tries to redirect to http:///2015-03-31/functions/
    print(matcher.match("/2015-03-31/functions", method="GET"))


if __name__ == '__main__':
    main()
```
