### PR TITLE
fix test_cloudwatch.py mock patches

### DIFF
--- a/localstack/utils/patch.py
+++ b/localstack/utils/patch.py
@@ -120,7 +120,6 @@ class Patches:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.undo()
-        return self
 
     def add(self, patch: Patch):
         self.patches.append(patch)

--- a/tests/unit/test_cloudwatch.py
+++ b/tests/unit/test_cloudwatch.py
@@ -211,14 +211,17 @@ def run_and_assert_calculate_alarm_state(
             Patch.function(
                 alarm_scheduler.get_metric_alarm_details_for_alarm_arn,
                 mock_metric_alarm_details,
+                pass_target=False,
             ),
             Patch.function(
                 alarm_scheduler.get_cloudwatch_client_for_region_of_alarm,
                 mock_cloudwatch_client,
+                pass_target=False,
             ),
             Patch.function(
                 alarm_scheduler.collect_metric_data,
                 mock_collect_metric_data,
+                pass_target=False,
             ),
         ]
     )


### PR DESCRIPTION
This fixes a regression that I introduced (sorry!) with the patch utility. The `Patch.function` expects the method signatures by default to take as first argument the method that is patched. The method signature of `mock_metric_alarm_details`, etc, were not updated correctly. The `alarm_scheduler.calculate_alarm_state("helloworld")` call would then raise a TypeError, which i was only able to uncover by wrapping a try/except block:
![image](https://user-images.githubusercontent.com/3996682/166307887-35989f00-5931-4c85-a787-41aa5c5af10e.png)

No idea where the exception is lost, but potentially worth looking into at some point.
