### PR TITLE
fix HTTP HEAD method operation detection in ASF

### DIFF
--- a/tests/unit/aws/protocol/test_op_router.py
+++ b/tests/unit/aws/protocol/test_op_router.py
@@ -47,3 +47,13 @@ def test_greedy_path_converter():
     assert matcher.match("/some-route//foo/bar/bar") == (None, {"p": "/foo/bar"})
     with pytest.raises(NotFound):
         matcher.match("/some-route//foo/baz")
+
+
+def test_s3_head_request():
+    router = RestServiceOperationRouter(load_service("s3"))
+
+    op, _ = router.match(Request("GET", "/my-bucket/my-key/"))
+    assert op.name == "GetObject"
+
+    op, _ = router.match(Request("HEAD", "/my-bucket/my-key/"))
+    assert op.name == "HeadObject"

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -889,7 +889,7 @@ def test_restjson_operation_detection_with_subpath():
         )
 
 
-def test_s3_operation_detection():
+def test_s3_get_operation_detection():
     """
     Test if the S3 operation detection works for ambiguous operations. GetObject is the worst, because it is
     overloaded with the exact same requestURI by another non-deprecated function where the only distinction is the
@@ -897,6 +897,13 @@ def test_s3_operation_detection():
     """
     _botocore_parser_integration_test(
         service="s3", action="GetObject", Bucket="test-bucket", Key="foo/bar/test.json"
+    )
+
+
+def test_s3_head_operation_detection():
+    """Test if the S3 operation detection works for HEAD operations."""
+    _botocore_parser_integration_test(
+        service="s3", action="HeadObject", Bucket="test-bucket", Key="foo/bar/test.json"
     )
 
 


### PR DESCRIPTION
This PR fixes the HTTP HEAD method detection in the ASF operation router for service with a `rest-*` protocol.

A new inheritance layer has been introduced (`_StrictMethodRule`) which reverts assumptions made by Werkzeug's rule, specifically the automatic adding of `HEAD` to the list of methods if the `methods` param contains `GET` ([werkzeug/routing.py#L723-L724](https://github.com/pallets/werkzeug/blob/bb21bf90b0b121e3ed45b9950b823e4b43a81fd8/src/werkzeug/routing.py#L723-L724)).
