### PR TITLE
Enable signal handlers per default for LocalStack inside a docker container

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -36,7 +36,7 @@ source <(
 )
 
 # Setup trap handler(s)
-if [ "$SET_TERM_HANDLER" != "" ]; then
+if [ "$DISABLE_TERM_HANDLER" == "" ]; then
   # Catch all the main
   trap 'kill -1 ${!}; term_handler 1' SIGHUP
   trap 'kill -2 ${!}; term_handler 2' SIGINT
@@ -71,7 +71,7 @@ function run_startup_scripts {
 run_startup_scripts &
 
 # Run tail on the localstack log files forever until we are told to terminate
-if [ "$SET_TERM_HANDLER" != "" ]; then
+if [ "$DISABLE_TERM_HANDLER" == "" ]; then
   while true; do
     tail -qF /tmp/localstack_infra.log /tmp/localstack_infra.err & wait ${!}
   done

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -649,7 +649,7 @@ def configure_container(container: LocalstackContainer):
     container.env_vars["DOCKER_HOST"] = f"unix://{config.DOCKER_SOCK}"
     container.env_vars["HOST_TMP_FOLDER"] = config.dirs.functions  # TODO: rename env var
 
-    # TODO discuss if this should be the default?
+    # TODO this is default now, remove once a considerate time is passed
     # to activate proper signal handling
     container.env_vars["SET_TERM_HANDLER"] = "1"
 


### PR DESCRIPTION
Currently, passing signals from the LS docker container init process (= docker-entrypoint.sh) to supervisord (which will in turn pass it to the LocalStack process itself), is disabled per default, unless you set `SET_TERM_HANDLER=1`.
This results in long shutdown times for docker-compose, as well as leftover containers started by LS (like lambda containers etc.), since docker-compose will kill containers after 10s if they do not end themselves in that timeframe.
This behavior is not seen in LS CLI, since we set the term handler variable explicitely there.

This PR inverts this behavior, signal handling is enabled per default, unless `DISABLE_TERM_HANDLER=1` is set, for users who, for any reason, would like to use the "old" behavior.

The `SET_TERM_HANDLER` variable setting in CLI is still in there for now, in order to prevent bricking instances where a new CLI meets an older docker image (should be removed after a considerate amount of time).

This PR results in way faster stop times in docker-compose (<2s instead of >10s), as well as a possible cleanup of resources, and possibilities for persistence.