### PR TITLE
refactor initial set of s3 tests

### DIFF
--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -20,7 +20,7 @@ from localstack.utils.functions import run_safe
 from localstack.utils.generic.wait_utils import wait_until
 from localstack.utils.testutil import start_http_server
 from tests.integration.cloudformation.utils import render_template, template_path
-from tests.integration.util import get_lambda_logs, is_aws_cloud
+from tests.integration.util import get_lambda_logs
 
 if TYPE_CHECKING:
     from mypy_boto3_acm import ACMClient
@@ -270,7 +270,7 @@ def dynamodb_create_table(dynamodb_client):
 
 
 @pytest.fixture
-def s3_create_bucket(s3_client):
+def s3_create_bucket(s3_client, s3_resource):
     buckets = []
 
     def factory(**kwargs) -> str:
@@ -286,15 +286,10 @@ def s3_create_bucket(s3_client):
     # cleanup
     for bucket in buckets:
         try:
-            # TODO we should also delete content of bucket, as the delete_bucket will fail if the bucket is not empty
-            # suggested way is using resource model: https://github.com/boto/boto3/issues/1189#issuecomment-317858880
-            # but this does not work against Localstack (InvalidAccessKeyId) -> xfail: test_delete_bucket_with_content
-            if is_aws_cloud():
-                bucket = boto3.resource("s3").Bucket(bucket)
-                bucket.objects.all().delete()
-                bucket.delete()
-            else:
-                s3_client.delete_bucket(Bucket=bucket)
+            bucket = s3_resource.Bucket(bucket)
+            bucket.objects.all().delete()
+            bucket.object_versions.all().delete()
+            bucket.delete()
         except Exception as e:
             LOG.debug("error cleaning up bucket %s: %s", bucket, e)
 
@@ -371,6 +366,57 @@ def sns_create_topic(sns_client):
 def sns_topic(sns_client, sns_create_topic) -> "GetTopicAttributesResponseTypeDef":
     topic_arn = sns_create_topic()["TopicArn"]
     return sns_client.get_topic_attributes(TopicArn=topic_arn)
+
+
+@pytest.fixture
+def sns_create_sqs_subscription(sns_client, sqs_client):
+    subscriptions = []
+
+    def _factory(topic_arn: str, queue_url: str) -> Dict[str, str]:
+        queue_arn = sqs_client.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+
+        # connect sns topic to sqs
+        subscription = sns_client.subscribe(
+            TopicArn=topic_arn,
+            Protocol="sqs",
+            Endpoint=queue_arn,
+        )
+        subscription_arn = subscription["SubscriptionArn"]
+
+        # allow topic to write to sqs queue
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": json.dumps(
+                    {
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Principal": {"Service": "sns.amazonaws.com"},
+                                "Action": "sqs:SendMessage",
+                                "Resource": queue_arn,
+                                "Condition": {"ArnEquals": {"aws:SourceArn": topic_arn}},
+                            }
+                        ]
+                    }
+                )
+            },
+        )
+
+        subscriptions.append(subscription_arn)
+        return sns_client.get_subscription_attributes(SubscriptionArn=subscription_arn)[
+            "Attributes"
+        ]
+
+    yield _factory
+
+    for arn in subscriptions:
+        try:
+            sns_client.unsubscribe(SubscriptionArn=arn)
+        except Exception as e:
+            LOG.error("error cleaning up subscription %s: %s", arn, e)
 
 
 @pytest.fixture

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -135,7 +135,7 @@ class TestS3PresignedUrl:
             assert not response.text
             # AWS does not send a content-length header at all, legacy localstack sends a 0 length header
             assert response.headers.get("content-length") in [
-                0,
+                "0",
                 None,
             ], f"Unexpected content-length in headers {response.headers}"
 

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1,0 +1,215 @@
+import pytest
+import requests
+from boto3.s3.transfer import KB, TransferConfig
+from botocore.exceptions import ClientError
+
+from localstack.utils.strings import short_uid
+
+
+class TestS3:
+    @pytest.mark.aws_validated
+    def test_region_header_exists(self, s3_client, s3_create_bucket):
+        bucket_name = s3_create_bucket(
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+        )
+
+        response = s3_client.head_bucket(Bucket=bucket_name)
+        assert response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == "eu-west-1"
+
+        response = s3_client.list_objects_v2(Bucket=bucket_name)
+        assert response["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == "eu-west-1"
+
+    @pytest.mark.aws_validated
+    def test_delete_bucket_with_content(self, s3_client, s3_resource, s3_bucket):
+        bucket_name = s3_bucket
+
+        for i in range(0, 10, 1):
+            body = "test-" + str(i)
+            key = "test-key-" + str(i)
+            s3_client.put_object(Bucket=bucket_name, Key=key, Body=body)
+
+        resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=100)
+        assert 10 == len(resp["Contents"])
+
+        bucket = s3_resource.Bucket(bucket_name)
+        bucket.objects.all().delete()
+        bucket.delete()
+
+        resp = s3_client.list_buckets()
+        assert bucket_name not in [b["Name"] for b in resp["Buckets"]]
+
+    @pytest.mark.aws_validated
+    def test_put_and_get_object_with_utf8_key(self, s3_client, s3_bucket):
+        response = s3_client.put_object(Bucket=s3_bucket, Key="Ā0Ä", Body=b"abc123")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        response = s3_client.get_object(Bucket=s3_bucket, Key="Ā0Ä")
+        assert response["Body"].read() == b"abc123"
+
+    @pytest.mark.aws_validated
+    def test_resource_object_with_slashes_in_key(self, s3_resource, s3_bucket):
+        s3_resource.Object(s3_bucket, "/foo").put(Body="foobar")
+        s3_resource.Object(s3_bucket, "bar").put(Body="barfoo")
+
+        with pytest.raises(ClientError) as e:
+            s3_resource.Object(s3_bucket, "foo").get()
+        e.match("NoSuchKey")
+
+        with pytest.raises(ClientError) as e:
+            s3_resource.Object(s3_bucket, "/bar").get()
+        e.match("NoSuchKey")
+
+        response = s3_resource.Object(s3_bucket, "/foo").get()
+        assert response["Body"].read() == b"foobar"
+        response = s3_resource.Object(s3_bucket, "bar").get()
+        assert response["Body"].read() == b"barfoo"
+
+    @pytest.mark.aws_validated
+    def test_metadata_header_character_decoding(self, s3_client, s3_bucket):
+        # Object metadata keys should accept keys with underscores
+        # https://github.com/localstack/localstack/issues/1790
+        # put object
+        object_key = "key-with-metadata"
+        metadata = {"TEST_META_1": "foo", "__meta_2": "bar"}
+        s3_client.put_object(Bucket=s3_bucket, Key=object_key, Metadata=metadata, Body="foo")
+        metadata_saved = s3_client.head_object(Bucket=s3_bucket, Key=object_key)["Metadata"]
+
+        # note that casing is removed (since headers are case-insensitive)
+        assert metadata_saved == {"test_meta_1": "foo", "__meta_2": "bar"}
+
+    @pytest.mark.aws_validated
+    def test_upload_file_multipart(self, s3_client, s3_bucket, tmpdir):
+        key = "my-key"
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#multipart-transfers
+        config = TransferConfig(multipart_threshold=5 * KB, multipart_chunksize=1 * KB)
+
+        file = tmpdir / "test-file.bin"
+        data = b"1" * (6 * KB)  # create 6 kilobytes of ones
+        file.write(data=data, mode="w")
+        s3_client.upload_file(
+            Bucket=s3_bucket, Key=key, Filename=str(file.realpath()), Config=config
+        )
+
+        obj = s3_client.get_object(Bucket=s3_bucket, Key=key)
+        assert obj["Body"].read() == data, f"body did not contain expected data {obj}"
+
+
+class TestS3PresignedUrl:
+    """
+    These tests pertain to S3's presigned URL feature.
+    """
+
+    @pytest.mark.aws_validated
+    def test_put_object(self, s3_client, s3_bucket):
+        key = "my-key"
+
+        url = s3_client.generate_presigned_url(
+            "put_object", Params={"Bucket": s3_bucket, "Key": key}
+        )
+        requests.put(url, data="something", verify=False)
+
+        response = s3_client.get_object(Bucket=s3_bucket, Key=key)
+        assert response["Body"].read() == b"something"
+
+    @pytest.mark.aws_validated
+    def test_delete_has_empty_content_length_header(self, s3_client, s3_bucket):
+        for encoding in None, "gzip":
+            # put object
+            object_key = "key-by-hostname"
+            s3_client.put_object(
+                Bucket=s3_bucket,
+                Key=object_key,
+                Body="something",
+                ContentType="text/html; charset=utf-8",
+            )
+            url = s3_client.generate_presigned_url(
+                "delete_object", Params={"Bucket": s3_bucket, "Key": object_key}
+            )
+
+            # get object and assert headers
+            headers = {}
+            if encoding:
+                headers["Accept-Encoding"] = encoding
+            response = requests.delete(url, headers=headers, verify=False)
+
+            assert response.status_code == 204
+            assert not response.text
+            # AWS does not send a content-length header at all, legacy localstack sends a 0 length header
+            assert response.headers.get("content-length") in [
+                0,
+                None,
+            ], f"Unexpected content-length in headers {response.headers}"
+
+    @pytest.mark.aws_validated
+    def test_head_has_correct_content_length_header(self, s3_client, s3_bucket):
+        body = "something body \n \n\r"
+        # put object
+        object_key = "key-by-hostname"
+        s3_client.put_object(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Body=body,
+            ContentType="text/html; charset=utf-8",
+        )
+        url = s3_client.generate_presigned_url(
+            "head_object", Params={"Bucket": s3_bucket, "Key": object_key}
+        )
+        # get object and assert headers
+        response = requests.head(url, verify=False)
+        assert response.headers.get("content-length") == str(len(body))
+
+    @pytest.mark.aws_validated
+    def test_put_url_metadata(self, s3_client, s3_bucket):
+        # Object metadata should be passed as query params via presigned URL
+        # https://github.com/localstack/localstack/issues/544
+        metadata = {"foo": "bar"}
+        object_key = "key-by-hostname"
+
+        # put object via presigned URL
+        url = s3_client.generate_presigned_url(
+            "put_object",
+            Params={"Bucket": s3_bucket, "Key": object_key, "Metadata": metadata},
+        )
+        assert "x-amz-meta-foo=bar" in url
+
+        response = requests.put(url, data="content 123", verify=False)
+        assert response.ok, f"response returned {response.status_code}: {response.text}"
+        # response body should be empty, see https://github.com/localstack/localstack/issues/1317
+        assert not response.text
+
+        # assert metadata is present
+        response = s3_client.head_object(Bucket=s3_bucket, Key=object_key)
+        assert response.get("Metadata", {}).get("foo") == "bar"
+
+
+class TestS3DeepArchive:
+    """
+    Test to cover DEEP_ARCHIVE Storage Class functionality.
+    """
+
+    @pytest.mark.aws_validated
+    def test_storage_class_deep_archive(self, s3_client, s3_resource, s3_bucket, tmpdir):
+        key = "my-key"
+
+        config = TransferConfig(multipart_threshold=5 * KB, multipart_chunksize=1 * KB)
+
+        def upload_file(size_in_kb: int):
+            file = tmpdir / f"test-file-{short_uid()}.bin"
+            data = b"1" * (size_in_kb * KB)
+            file.write(data=data, mode="w")
+            s3_client.upload_file(
+                Bucket=s3_bucket,
+                Key=key,
+                Filename=str(file.realpath()),
+                ExtraArgs={"StorageClass": "DEEP_ARCHIVE"},
+                Config=config,
+            )
+
+        upload_file(1)
+        upload_file(9)
+        upload_file(15)
+
+        objects = s3_resource.Bucket(s3_bucket).objects.all()
+        keys = []
+        for obj in objects:
+            keys.append(obj.key)
+            assert obj.storage_class == "DEEP_ARCHIVE"

--- a/tests/integration/s3/test_s3_notifications_lambda.py
+++ b/tests/integration/s3/test_s3_notifications_lambda.py
@@ -1,0 +1,71 @@
+import os
+import time
+
+from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
+from localstack.utils import testutil
+from localstack.utils.aws import aws_stack
+from localstack.utils.common import retry, short_uid
+
+THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
+TEST_LAMBDA_PYTHON_TRIGGERED_S3 = os.path.join(
+    THIS_FOLDER, "../awslambda", "functions", "lambda_triggered_by_s3.py"
+)
+
+
+class TestS3NotificationsToLambda:
+    def test_create_object_put_via_dynamodb(
+        self, s3_client, lambda_client, dynamodb_client, s3_create_bucket
+    ):
+        # TODO: inline lambda function
+        bucket_name = s3_create_bucket()
+        function_name = "func-%s" % short_uid()
+        table_name = "table-%s" % short_uid()
+
+        testutil.create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_TRIGGERED_S3,
+            func_name=function_name,
+            runtime=LAMBDA_RUNTIME_PYTHON36,
+            client=lambda_client,
+        )
+
+        # this test uses dynamodb as an intermediary to get the notifications from the lambda back to the test
+        aws_stack.create_dynamodb_table(
+            table_name=table_name, partition_key="uuid", client=dynamodb_client
+        )
+
+        try:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration={
+                    "LambdaFunctionConfigurations": [
+                        {
+                            "LambdaFunctionArn": aws_stack.lambda_function_arn(function_name),
+                            "Events": ["s3:ObjectCreated:*"],
+                        }
+                    ]
+                },
+            )
+
+            # put an object
+            obj = s3_client.put_object(Bucket=bucket_name, Key=table_name, Body="something..")
+            etag = obj["ETag"]
+            time.sleep(2)
+
+            table = aws_stack.connect_to_resource("dynamodb").Table(table_name)
+
+            def check_table():
+                rs = table.scan()
+                assert len(rs["Items"]) == 1
+                return rs
+
+            rs = retry(check_table, retries=4, sleep=3)
+
+            event = rs["Items"][0]["data"]
+            assert event["eventSource"] == "aws:s3"
+            assert event["eventName"] == "ObjectCreated:Put"
+            assert event["s3"]["bucket"]["name"] == bucket_name
+            assert event["s3"]["object"]["eTag"] == etag
+        finally:
+            # clean up
+            lambda_client.delete_function(FunctionName=function_name)
+            dynamodb_client.delete_table(TableName=table_name)

--- a/tests/integration/s3/test_s3_notifications_sns.py
+++ b/tests/integration/s3/test_s3_notifications_sns.py
@@ -1,0 +1,153 @@
+import json
+import logging
+from typing import TYPE_CHECKING, Dict, List
+
+import pytest
+
+from localstack.utils.aws import aws_stack
+from localstack.utils.sync import poll_condition
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_s3.literals import EventType
+    from mypy_boto3_sns import SNSClient
+    from mypy_boto3_sqs import SQSClient
+
+LOG = logging.getLogger(__name__)
+
+
+def create_sns_bucket_notification(
+    s3_client: "S3Client",
+    sns_client: "SNSClient",
+    bucket_name: str,
+    topic_arn: str,
+    events: List["EventType"],
+):
+    """A NotificationFactory."""
+    bucket_arn = aws_stack.s3_bucket_arn(bucket_name)
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "sns:Publish",
+                "Resource": topic_arn,
+                "Condition": {"ArnEquals": {"aws:SourceArn": bucket_arn}},
+            }
+        ],
+    }
+    sns_client.set_topic_attributes(
+        TopicArn=topic_arn, AttributeName="Policy", AttributeValue=json.dumps(policy)
+    )
+
+    s3_client.put_bucket_notification_configuration(
+        Bucket=bucket_name,
+        NotificationConfiguration=dict(
+            TopicConfigurations=[
+                dict(
+                    TopicArn=topic_arn,
+                    Events=events,
+                )
+            ]
+        ),
+    )
+
+
+def sqs_collect_sns_messages(
+    sqs_client: "SQSClient", queue_url: str, min_messages: int, timeout: int = 10
+) -> List[Dict]:
+    """
+    Polls the given queue for the given amount of time and extracts the received SQS messages all SNS messages (messages that have a "TopicArn" field).
+
+    :param sqs_client: the boto3 client to use
+    :param queue_url: the queue URL connected to the topic
+    :param min_messages: the minimum number of messages to wait for
+    :param timeout: the number of seconds to wait before raising an assert error
+    :return: a list with the deserialized SNS messages
+    """
+
+    collected_messages = []
+
+    def collect_events() -> int:
+        _response = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=timeout, MaxNumberOfMessages=1
+        )
+        messages = _response.get("Messages", [])
+        if not messages:
+            LOG.info("no messages received from %s after %d seconds", queue_url, timeout)
+
+        for m in messages:
+            body = m["Body"]
+            # see https://www.mikulskibartosz.name/what-is-s3-test-event/
+            if "s3:TestEvent" in body:
+                continue
+
+            doc = json.loads(body)
+            assert "TopicArn" in doc, f"unexpected event in message {m}"
+            collected_messages.append(doc)
+
+        return len(collected_messages)
+
+    assert poll_condition(lambda: collect_events() >= min_messages, timeout=timeout)
+
+    return collected_messages
+
+
+class TestS3NotificationsToSns:
+    @pytest.mark.aws_validated
+    def test_object_created_put(
+        self,
+        s3_client,
+        sqs_client,
+        sns_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription,
+    ):
+        bucket_name = s3_create_bucket()
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        key_name = "bucket-key"
+
+        # connect topic to queue
+        sns_create_sqs_subscription(topic_arn, queue_url)
+        create_sns_bucket_notification(
+            s3_client, sns_client, bucket_name, topic_arn, ["s3:ObjectCreated:*"]
+        )
+
+        # trigger the events
+        s3_client.put_object(Bucket=bucket_name, Key=key_name, Body="first event")
+        s3_client.put_object(Bucket=bucket_name, Key=key_name, Body="second event")
+
+        # collect messages
+        messages = sqs_collect_sns_messages(sqs_client, queue_url, 2)
+
+        # asserts
+        # first event
+        message = messages[0]
+        assert message["Type"] == "Notification"
+        assert message["TopicArn"] == topic_arn
+        assert message["Subject"] == "Amazon S3 Notification"
+
+        event = json.loads(message["Message"])["Records"][0]
+        assert event["eventSource"] == "aws:s3"
+        assert event["eventName"] == "ObjectCreated:Put"
+        assert event["s3"]["bucket"]["name"] == bucket_name
+        assert event["s3"]["object"]["key"] == key_name
+        assert event["s3"]["object"]["size"] == len("first event")
+
+        # second event
+        message = messages[1]
+        assert message["Type"] == "Notification"
+        assert message["TopicArn"] == topic_arn
+        assert message["Subject"] == "Amazon S3 Notification"
+
+        event = json.loads(message["Message"])["Records"][0]
+        assert event["eventSource"] == "aws:s3"
+        assert event["eventName"] == "ObjectCreated:Put"
+        assert event["s3"]["bucket"]["name"] == bucket_name
+        assert event["s3"]["object"]["key"] == key_name
+        assert event["s3"]["object"]["size"] == len("second event")

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -1,0 +1,410 @@
+import json
+import logging
+from typing import TYPE_CHECKING, Dict, List, Protocol
+
+import pytest
+import requests
+from boto3.s3.transfer import KB, TransferConfig
+
+from localstack.utils.aws import aws_stack
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import poll_condition
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_s3.literals import EventType
+    from mypy_boto3_sqs import SQSClient
+
+LOG = logging.getLogger(__name__)
+
+
+class NotificationFactory(Protocol):
+    """
+    A protocol for connecting a bucket to a queue with a notification configurations and the necessary policies.
+    """
+
+    def __call__(self, bucket_name: str, queue_url: str, events: List["EventType"]) -> None:
+        """
+        Creates a new notification configuration and respective policies.
+
+        :param bucket_name: the source bucket
+        :param queue_url: the target SQS queue
+        :param events: the type of S3 events to trigger the notification
+        :return: None
+        """
+        raise NotImplementedError
+
+
+def get_queue_arn(sqs_client, queue_url: str) -> str:
+    """
+    Returns the given Queue's ARN. Expects the Queue to exist.
+
+    :param sqs_client: the boto3 client
+    :param queue_url: the queue URL
+    :return: the QueueARN
+    """
+    response = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])
+    return response["Attributes"]["QueueArn"]
+
+
+def create_sqs_bucket_notification(
+    s3_client: "S3Client",
+    sqs_client: "SQSClient",
+    bucket_name: str,
+    queue_url: str,
+    events: List["EventType"],
+):
+    """A NotificationFactory."""
+    queue_arn = get_queue_arn(sqs_client, queue_url)
+    assert queue_arn
+    bucket_arn = aws_stack.s3_bucket_arn(bucket_name)
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "sqs:SendMessage",
+                "Resource": queue_arn,
+                "Condition": {"ArnEquals": {"aws:SourceArn": bucket_arn}},
+            }
+        ],
+    }
+    sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)})
+
+    s3_client.put_bucket_notification_configuration(
+        Bucket=bucket_name,
+        NotificationConfiguration=dict(
+            QueueConfigurations=[
+                dict(
+                    QueueArn=queue_arn,
+                    Events=events,
+                )
+            ]
+        ),
+    )
+
+
+@pytest.fixture
+def s3_create_sqs_bucket_notification(s3_client, sqs_client) -> NotificationFactory:
+    """
+    A factory fixture for creating sqs bucket notifications.
+
+    :param s3_client:
+    :param sqs_client:
+    :return:
+    """
+
+    def factory(bucket_name: str, queue_url: str, events: List["EventType"]):
+        return create_sqs_bucket_notification(s3_client, sqs_client, bucket_name, queue_url, events)
+
+    return factory
+
+
+def sqs_collect_s3_events(
+    sqs_client: "SQSClient", queue_url: str, min_events: int, timeout: int = 10
+) -> List[Dict]:
+    """
+    Polls the given queue for the given amount of time and extracts and flattens from the received messages all
+    events (messages that have a "Records" field in their body, and where the records can be json-deserialized).
+
+    :param sqs_client: the boto3 client to use
+    :param queue_url: the queue URL to listen from
+    :param min_events: the minimum number of events to receive to wait for
+    :param timeout: the number of seconds to wait before raising an assert error
+    :return: a list with the deserialized records from the SQS messages
+    """
+
+    events = []
+
+    def collect_events() -> int:
+        _response = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=timeout, MaxNumberOfMessages=1
+        )
+        messages = _response.get("Messages", [])
+        if not messages:
+            LOG.info("no messages received from %s after %d seconds", queue_url, timeout)
+
+        for m in messages:
+            body = m["Body"]
+            # see https://www.mikulskibartosz.name/what-is-s3-test-event/
+            if "s3:TestEvent" in body:
+                continue
+
+            assert "Records" in body, "Unexpected event received"
+
+            doc = json.loads(body)
+            events.extend(doc["Records"])
+
+        return len(events)
+
+    assert poll_condition(lambda: collect_events() >= min_events, timeout=timeout)
+
+    return events
+
+
+class TestS3NotificationsToSQS:
+    @pytest.mark.aws_validated
+    def test_object_created_put(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+    ):
+        # setup fixture
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectCreated:Put"])
+
+        s3_client.put_bucket_versioning(
+            Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"}
+        )
+
+        obj0 = s3_client.put_object(Bucket=bucket_name, Key="my_key_0", Body="something")
+        obj1 = s3_client.put_object(Bucket=bucket_name, Key="my_key_1", Body="something else")
+
+        # collect s3 events from SQS queue
+        events = sqs_collect_s3_events(sqs_client, queue_url, min_events=2)
+
+        assert len(events) == 2, f"unexpected number of events in {events}"
+
+        # assert
+        assert events[0]["eventSource"] == "aws:s3"
+        assert events[0]["eventName"] == "ObjectCreated:Put"
+        assert events[0]["s3"]["bucket"]["name"] == bucket_name
+        assert events[0]["s3"]["object"]["key"] == "my_key_0"
+        assert events[0]["s3"]["object"]["size"] == 9
+        assert events[0]["s3"]["object"]["versionId"]
+        assert obj0["VersionId"] == events[0]["s3"]["object"]["versionId"]
+
+        assert events[1]["eventSource"] == "aws:s3"
+        assert events[0]["eventName"] == "ObjectCreated:Put"
+        assert events[1]["s3"]["bucket"]["name"] == bucket_name
+        assert events[1]["s3"]["object"]["key"] == "my_key_1"
+        assert events[1]["s3"]["object"]["size"] == 14
+        assert events[1]["s3"]["object"]["versionId"]
+        assert obj1["VersionId"] == events[1]["s3"]["object"]["versionId"]
+
+    @pytest.mark.aws_validated
+    def test_object_created_copy(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+    ):
+        # setup fixture
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectCreated:Copy"])
+
+        src_key = "src-dest-%s" % short_uid()
+        dest_key = "key-dest-%s" % short_uid()
+
+        s3_client.put_object(Bucket=bucket_name, Key=src_key, Body="something")
+
+        assert not sqs_collect_s3_events(
+            sqs_client, queue_url, 0, timeout=1
+        ), "unexpected event triggered for put_object"
+
+        s3_client.copy_object(
+            Bucket=bucket_name,
+            CopySource={"Bucket": bucket_name, "Key": src_key},
+            Key=dest_key,
+        )
+
+        events = sqs_collect_s3_events(sqs_client, queue_url, 1)
+        assert len(events) == 1, f"unexpected number of events in {events}"
+
+        assert events[0]["eventSource"] == "aws:s3"
+        assert events[0]["eventName"] == "ObjectCreated:Copy"
+        assert events[0]["s3"]["bucket"]["name"] == bucket_name
+        assert events[0]["s3"]["object"]["key"] == dest_key
+
+    @pytest.mark.aws_validated
+    def test_object_created_and_object_removed(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+    ):
+        # setup fixture
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        s3_create_sqs_bucket_notification(
+            bucket_name, queue_url, ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
+        )
+
+        src_key = "src-dest-%s" % short_uid()
+        dest_key = "key-dest-%s" % short_uid()
+
+        # event0 = PutObject
+        s3_client.put_object(Bucket=bucket_name, Key=src_key, Body="something")
+        # event1 = CopyObject
+        s3_client.copy_object(
+            Bucket=bucket_name,
+            CopySource={"Bucket": bucket_name, "Key": src_key},
+            Key=dest_key,
+        )
+        # event3 = DeleteObject
+        s3_client.delete_object(Bucket=bucket_name, Key=src_key)
+
+        # collect events
+        events = sqs_collect_s3_events(sqs_client, queue_url, 3)
+        assert len(events) == 3, f"unexpected number of events in {events}"
+
+        assert events[0]["eventName"] == "ObjectCreated:Put"
+        assert events[0]["s3"]["bucket"]["name"] == bucket_name
+        assert events[0]["s3"]["object"]["key"] == src_key
+
+        assert events[1]["eventName"] == "ObjectCreated:Copy"
+        assert events[1]["s3"]["bucket"]["name"] == bucket_name
+        assert events[1]["s3"]["object"]["key"] == dest_key
+
+        assert events[2]["eventName"] == "ObjectRemoved:Delete"
+        assert events[2]["s3"]["bucket"]["name"] == bucket_name
+        assert events[2]["s3"]["object"]["key"] == src_key
+
+    @pytest.mark.aws_validated
+    def test_object_created_complete_multipart_upload(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+        tmpdir,
+    ):
+        # setup fixture
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        key = "test-key"
+
+        s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectCreated:*"])
+
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3.html#multipart-transfers
+        config = TransferConfig(multipart_threshold=5 * KB, multipart_chunksize=1 * KB)
+
+        file = tmpdir / "test-file.bin"
+        data = b"1" * (6 * KB)  # create 6 kilobytes of ones
+        file.write(data=data, mode="w")
+        s3_client.upload_file(
+            Bucket=bucket_name, Key=key, Filename=str(file.realpath()), Config=config
+        )
+
+        events = sqs_collect_s3_events(sqs_client, queue_url, 1)
+
+        assert events[0]["eventName"] == "ObjectCreated:CompleteMultipartUpload"
+        assert events[0]["s3"]["bucket"]["name"] == bucket_name
+        assert events[0]["s3"]["object"]["key"] == key
+        assert events[0]["s3"]["object"]["size"] == file.size()
+
+    @pytest.mark.aws_validated
+    def test_key_encoding(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+    ):
+        # test for https://github.com/localstack/localstack/issues/2741
+
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectCreated:*"])
+
+        key = "a@b"
+        key_encoded = "a%40b"
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body="something")
+
+        events = sqs_collect_s3_events(sqs_client, queue_url, min_events=1)
+
+        assert events[0]["eventName"] == "ObjectCreated:Put"
+        assert events[0]["s3"]["object"]["key"] == key_encoded
+
+    @pytest.mark.aws_validated
+    def test_object_created_put_with_presigned_url_upload(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+    ):
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        key = "key-by-hostname"
+
+        s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectCreated:*"])
+        url = s3_client.generate_presigned_url(
+            "put_object", Params={"Bucket": bucket_name, "Key": key}
+        )
+        requests.put(url, data="something", verify=False)
+
+        events = sqs_collect_s3_events(sqs_client, queue_url, 1)
+        assert events[0]["eventName"] == "ObjectCreated:Put"
+        assert events[0]["s3"]["object"]["key"] == key
+
+    @pytest.mark.aws_validated
+    def test_xray_header(
+        self,
+        s3_client,
+        sqs_client,
+        s3_create_bucket,
+        sqs_create_queue,
+        s3_create_sqs_bucket_notification,
+        cleanups,
+    ):
+        # test for https://github.com/localstack/localstack/issues/3686
+
+        # add boto hook
+        def add_xray_header(request, **kwargs):
+            request.headers[
+                "X-Amzn-Trace-Id"
+            ] = "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+
+        s3_client.meta.events.register("before-send.s3.*", add_xray_header)
+        # make sure the hook gets cleaned up after the test
+        cleanups.append(
+            lambda: s3_client.meta.events.unregister("before-send.s3.*", add_xray_header)
+        )
+
+        key = "test-data"
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+
+        s3_create_sqs_bucket_notification(bucket_name, queue_url, ["s3:ObjectCreated:*"])
+
+        # put an object where the bucket_name is in the path
+        s3_client.put_object(Bucket=bucket_name, Key=key, Body="something")
+
+        messages = []
+
+        def get_messages():
+            resp = sqs_client.receive_message(
+                QueueUrl=queue_url,
+                AttributeNames=["AWSTraceHeader"],
+                MessageAttributeNames=["All"],
+                VisibilityTimeout=0,
+            )
+            for m in resp["Messages"]:
+                if "s3:TestEvent" in m["Body"]:
+                    continue
+                messages.append(m)
+
+            return len(messages)
+
+        assert poll_condition(lambda: get_messages() >= 1, timeout=10)
+
+        assert "AWSTraceHeader" in messages[0]["Attributes"]
+        assert (
+            messages[0]["Attributes"]["AWSTraceHeader"]
+            == "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+        )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,3 +1,5 @@
+# TODO: migrate tests to tests/integration/s3/
+#  DO NOT ADD ADDITIONAL TESTS HERE. USE PYTEST AND RUN TESTS AGAINST AWS!
 import base64
 import datetime
 import gzip
@@ -43,9 +45,7 @@ from localstack.utils.common import (
     get_service_protocol,
     load_file,
     new_tmp_dir,
-    new_tmp_file,
     retry,
-    rm_rf,
     run,
     safe_requests,
     short_uid,
@@ -168,160 +168,6 @@ class TestS3(unittest.TestCase):
         ]
         self.assertEqual(policy, json.loads(saved_policy))
 
-    def test_s3_put_object_notification(self):
-        bucket_name = "notif-%s" % short_uid()
-        key_by_path = "key-by-hostname"
-        key_by_host = "key-by-host"
-        queue_url, queue_attributes = self._create_test_queue()
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-        self.s3_client.put_bucket_versioning(
-            Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"}
-        )
-
-        # put an object where the bucket_name is in the path
-        obj = self.s3_client.put_object(Bucket=bucket_name, Key=key_by_path, Body="something")
-
-        # put an object where the bucket_name is in the host
-        headers = aws_stack.mock_aws_request_headers("s3")
-        headers["Host"] = s3_utils.get_bucket_hostname(bucket_name)
-        url = f"{config.service_url('s3')}/{key_by_host}"
-        # verify=False must be set as this test fails on travis because of an SSL error non-existent locally
-        response = requests.put(url, data="something else", headers=headers, verify=False)
-        self.assertTrue(response.ok)
-
-        self.assertEqual("2", self._get_test_queue_message_count(queue_url))
-
-        response = self.sqs_client.receive_message(QueueUrl=queue_url)
-        messages = [json.loads(to_str(m["Body"])) for m in response["Messages"]]
-        record = messages[0]["Records"][0]
-        self.assertIsNotNone(record["s3"]["object"]["versionId"])
-        self.assertEqual(obj["VersionId"], record["s3"]["object"]["versionId"])
-
-        # clean up
-        self.s3_client.put_bucket_versioning(
-            Bucket=bucket_name, VersioningConfiguration={"Status": "Disabled"}
-        )
-        self.sqs_client.delete_queue(QueueUrl=queue_url)
-        self._delete_bucket(bucket_name, [key_by_path, key_by_host])
-
-    def test_s3_put_object_notification_extra_xmlns(self):
-        """Test that request payloads with excessive xmlns attributes are
-        correctly handled.
-
-        This happens with the AWS Rust SDK.
-        See: https://github.com/awslabs/aws-sdk-rust/issues/301
-        """
-        bucket_name = "notif-%s" % short_uid()
-        s3_listener.handle_put_bucket_notification(
-            bucket_name,
-            """
-                <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                    <QueueConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                        <Id xmlns="http://s3.amazonaws.com/doc/2006-03-01/">queueid</Id>
-                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Put</Event>
-                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Post</Event>
-                        <Queue xmlns="http://s3.amazonaws.com/doc/2006-03-01/">queue</Queue>
-                        <Filter xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                            <S3Key xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                                <FilterRule xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                                    <Name xmlns="http://s3.amazonaws.com/doc/2006-03-01/">prefix</Name>
-                                    <Value xmlns="http://s3.amazonaws.com/doc/2006-03-01/">img/</Value>
-                                </FilterRule>
-                            </S3Key>
-                        </Filter>
-                    </QueueConfiguration>
-                    <TopicConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                        <Id xmlns="http://s3.amazonaws.com/doc/2006-03-01/">topicid</Id>
-                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Put</Event>
-                        <Event xmlns="http://s3.amazonaws.com/doc/2006-03-01/">s3:ObjectCreated:Post</Event>
-                        <Topic xmlns="http://s3.amazonaws.com/doc/2006-03-01/">topic</Topic>
-                        <Filter xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                            <S3Key xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                                <FilterRule xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                                    <Name xmlns="http://s3.amazonaws.com/doc/2006-03-01/">prefix</Name>
-                                    <Value xmlns="http://s3.amazonaws.com/doc/2006-03-01/">img/</Value>
-                                </FilterRule>
-                            </S3Key>
-                        </Filter>
-                    </TopicConfiguration>
-                </NotificationConfiguration>
-            """,
-        )
-        self.assertEqual(
-            s3_listener.S3_NOTIFICATIONS[bucket_name],
-            [
-                {
-                    "Id": "queueid",
-                    "Event": ["s3:ObjectCreated:Put", "s3:ObjectCreated:Post"],
-                    "Queue": "queue",
-                    "Filter": {"S3Key": {"FilterRule": [{"Name": "Prefix", "Value": "img/"}]}},
-                },
-                {
-                    "Id": "topicid",
-                    "Event": ["s3:ObjectCreated:Put", "s3:ObjectCreated:Post"],
-                    "Topic": "topic",
-                    "Filter": {"S3Key": {"FilterRule": [{"Name": "Prefix", "Value": "img/"}]}},
-                },
-            ],
-        )
-
-    def test_s3_upload_fileobj_with_large_file_notification(self):
-        bucket_name = "notif-large-%s" % short_uid()
-        queue_url, queue_attributes = self._create_test_queue()
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-
-        # has to be larger than 64MB to be broken up into a multipart upload
-        file_size = 75000000
-        large_file = self.generate_large_file(file_size)
-        download_file = new_tmp_file()
-        try:
-            self.s3_client.upload_file(
-                Bucket=bucket_name, Key=large_file.name, Filename=large_file.name
-            )
-
-            self.assertEqual("1", self._get_test_queue_message_count(queue_url))
-
-            # ensure that the first message's eventName is ObjectCreated:CompleteMultipartUpload
-            messages = self.sqs_client.receive_message(QueueUrl=queue_url, AttributeNames=["All"])
-            message = json.loads(messages["Messages"][0]["Body"])
-            self.assertEqual(
-                "ObjectCreated:CompleteMultipartUpload",
-                message["Records"][0]["eventName"],
-            )
-
-            # download the file, check file size
-            self.s3_client.download_file(
-                Bucket=bucket_name, Key=large_file.name, Filename=download_file
-            )
-            self.assertEqual(file_size, os.path.getsize(download_file))
-
-            # clean up
-            self.sqs_client.delete_queue(QueueUrl=queue_url)
-            self._delete_bucket(bucket_name, large_file.name)
-        finally:
-            # clean up large files
-            large_file.close()
-            rm_rf(large_file.name)
-            rm_rf(download_file)
-
-    def test_s3_multipart_upload_with_small_single_part(self):
-        # In a multipart upload "Each part must be at least 5 MB in size, except the last part."
-        # https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadComplete.html
-
-        bucket_name = "notif-large-%s" % short_uid()
-        key_by_path = "key-by-hostname"
-        queue_url, queue_attributes = self._create_test_queue()
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-
-        # perform upload
-        self._perform_multipart_upload(bucket=bucket_name, key=key_by_path, zip=True)
-
-        self.assertEqual("1", self._get_test_queue_message_count(queue_url))
-
-        # clean up
-        self.sqs_client.delete_queue(QueueUrl=queue_url)
-        self._delete_bucket(bucket_name, [key_by_path])
-
     def test_invalid_range_error(self):
         bucket_name = "range-%s" % short_uid()
         self.s3_client.create_bucket(Bucket=bucket_name)
@@ -387,20 +233,6 @@ class TestS3(unittest.TestCase):
         self._perform_multipart_upload(bucket=bucket_name, key="acl-key2", acl="public-read-write")
         check_permissions("acl-key2", 2)
 
-    def test_s3_presigned_url_upload(self):
-        key_by_path = "key-by-hostname"
-        bucket_name = "notif-large-%s" % short_uid()
-        queue_url, queue_attributes = self._create_test_queue()
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-
-        self._perform_presigned_url_upload(bucket=bucket_name, key=key_by_path)
-
-        self.assertEqual("1", self._get_test_queue_message_count(queue_url))
-
-        # clean up
-        self.sqs_client.delete_queue(QueueUrl=queue_url)
-        self._delete_bucket(bucket_name, [key_by_path])
-
     def test_s3_get_response_default_content_type_and_headers(self):
         # When no content type is provided by a PUT request
         # 'binary/octet-stream' should be used
@@ -431,52 +263,6 @@ class TestS3(unittest.TestCase):
                 self.assertIn(expected_etag, header_names)
         finally:
             http2_server.RETURN_CASE_SENSITIVE_HEADERS = case_sensitive_before
-
-        # clean up
-        self._delete_bucket(bucket_name, [object_key])
-
-    def test_s3_put_presigned_url_metadata(self):
-        # Object metadata should be passed as query params via presigned URL
-        # https://github.com/localstack/localstack/issues/544
-        bucket_name = "test-bucket-%s" % short_uid()
-        client = self._get_test_client()
-        client.create_bucket(Bucket=bucket_name)
-
-        metadata = {"foo": "bar"}
-
-        # put object
-        object_key = "key-by-hostname"
-        url = client.generate_presigned_url(
-            "put_object",
-            Params={"Bucket": bucket_name, "Key": object_key, "Metadata": metadata},
-        )
-        # append metadata manually to URL (this is not easily possible with boto3, as "Metadata" cannot
-        # be passed to generate_presigned_url, and generate_presigned_post works differently)
-        url += "&x-amz-meta-foo=bar"
-
-        # get object and assert metadata is present
-        response = requests.put(url, data="content 123", verify=False)
-        self.assertLess(response.status_code, 400)
-        # response body should be empty, see https://github.com/localstack/localstack/issues/1317
-        self.assertEqual("", to_str(response.content))
-        response = client.head_object(Bucket=bucket_name, Key=object_key)
-        self.assertEqual("bar", response.get("Metadata", {}).get("foo"))
-
-        # clean up
-        self._delete_bucket(bucket_name, [object_key])
-
-    def test_s3_put_metadata_underscores(self):
-        # Object metadata keys should accept keys with underscores
-        # https://github.com/localstack/localstack/issues/1790
-        bucket_name = "test-%s" % short_uid()
-        self.s3_client.create_bucket(Bucket=bucket_name)
-
-        # put object
-        object_key = "key-with-metadata"
-        metadata = {"test_meta_1": "foo", "__meta_2": "bar"}
-        self.s3_client.put_object(Bucket=bucket_name, Key=object_key, Metadata=metadata, Body="foo")
-        metadata_saved = self.s3_client.head_object(Bucket=bucket_name, Key=object_key)["Metadata"]
-        self.assertEqual(metadata, metadata_saved)
 
         # clean up
         self._delete_bucket(bucket_name, [object_key])
@@ -706,28 +492,6 @@ class TestS3(unittest.TestCase):
         # clean up
         self._delete_bucket(bucket_name, [object_key])
 
-    def test_s3_head_response_content_length_same_as_upload(self):
-        bucket_name = "test-bucket-%s" % short_uid()
-        client = self._get_test_client()
-        client.create_bucket(Bucket=bucket_name)
-        body = "something body \n \n\r"
-        # put object
-        object_key = "key-by-hostname"
-        client.put_object(
-            Bucket=bucket_name,
-            Key=object_key,
-            Body=body,
-            ContentType="text/html; charset=utf-8",
-        )
-        url = client.generate_presigned_url(
-            "head_object", Params={"Bucket": bucket_name, "Key": object_key}
-        )
-        # get object and assert headers
-        response = requests.head(url, verify=False)
-        self.assertEqual(str(len(body)), response.headers["content-length"])
-        # clean up
-        self._delete_bucket(bucket_name, [object_key])
-
     def test_s3_put_object_chunked_newlines(self):
         # Test for https://github.com/localstack/localstack/issues/1571
         bucket_name = "test-bucket-%s" % short_uid()
@@ -879,39 +643,6 @@ class TestS3(unittest.TestCase):
 
         # clean up
         self._delete_bucket(bucket_name)
-
-    def test_s3_delete_response_content_length_zero(self):
-        bucket_name = "test-bucket-%s" % short_uid()
-        client = self._get_test_client()
-        client.create_bucket(Bucket=bucket_name)
-
-        for encoding in None, "gzip":
-            # put object
-            object_key = "key-by-hostname"
-            client.put_object(
-                Bucket=bucket_name,
-                Key=object_key,
-                Body="something",
-                ContentType="text/html; charset=utf-8",
-            )
-            url = client.generate_presigned_url(
-                "delete_object", Params={"Bucket": bucket_name, "Key": object_key}
-            )
-
-            # get object and assert headers
-            headers = {}
-            if encoding:
-                headers["Accept-Encoding"] = encoding
-            response = requests.delete(url, headers=headers, verify=False)
-
-            self.assertEqual(
-                "0",
-                response.headers["content-length"],
-                f"Unexpected response Content-Length for encoding {encoding}",
-            )
-
-        # clean up
-        self._delete_bucket(bucket_name, [object_key])
 
     def test_delete_object_tagging(self):
         bucket_name = "test-%s" % short_uid()
@@ -1378,38 +1109,6 @@ class TestS3(unittest.TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual("index", response.text)
 
-    def test_s3_event_notification_with_sqs(self):
-        key_by_path = "aws/bucket=2020/test1.txt"
-        bucket_name = "notif-sqs-%s" % short_uid()
-
-        queue_url, queue_attributes = self._create_test_queue()
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-        self.s3_client.put_bucket_versioning(
-            Bucket=bucket_name, VersioningConfiguration={"Status": "Enabled"}
-        )
-
-        body = "Lorem ipsum dolor sit amet, ... " * 30
-
-        # put an object
-        self.s3_client.put_object(Bucket=bucket_name, Key=key_by_path, Body=body)
-
-        self.assertEqual("1", self._get_test_queue_message_count(queue_url))
-
-        rs = self.sqs_client.receive_message(QueueUrl=queue_url)
-        record = [json.loads(to_str(m["Body"])) for m in rs["Messages"]][0]["Records"][0]
-
-        download_file = new_tmp_file()
-        self.s3_client.download_file(Bucket=bucket_name, Key=key_by_path, Filename=download_file)
-
-        self.assertEqual(record["s3"]["object"]["size"], os.path.getsize(download_file))
-
-        # clean up
-        self.s3_client.put_bucket_versioning(
-            Bucket=bucket_name, VersioningConfiguration={"Status": "Disabled"}
-        )
-        self.sqs_client.delete_queue(QueueUrl=queue_url)
-        self._delete_bucket(bucket_name, [key_by_path])
-
     def test_s3_delete_object_with_version_id(self):
         test_1st_key = "aws/s3/testkey1.txt"
         test_2nd_key = "aws/s3/testkey2.txt"
@@ -1596,146 +1295,6 @@ class TestS3(unittest.TestCase):
         self.assertEqual(200, response["ResponseMetadata"]["HTTPStatusCode"])
         self.s3_client.delete_bucket(Bucket=bucket_name)
 
-    def test_s3_multipart_upload_file(self):
-        def upload(size_in_mb, bucket):
-            file_name = "{}.tmp".format(short_uid())
-            path = "{}".format(file_name)
-            with open(path, "wb") as f:
-                f.seek(int(size_in_mb * 1e6))
-                f.write(b"\0")
-                f.flush()
-                self.s3_client.upload_file(
-                    path,
-                    bucket,
-                    f"{file_name}",
-                    ExtraArgs={"StorageClass": "DEEP_ARCHIVE"},
-                )
-
-            os.remove(path)
-
-        bucket_name = "bucket-%s" % short_uid()
-        self.s3_client.create_bucket(Bucket=bucket_name)
-
-        upload(1, bucket_name)
-        upload(9, bucket_name)
-        upload(15, bucket_name)
-
-        s3_resource = aws_stack.connect_to_resource("s3")
-        objects = s3_resource.Bucket(bucket_name).objects.all()
-        keys = []
-        for obj in objects:
-            keys.append(obj.key)
-            self.assertEqual("DEEP_ARCHIVE", obj.storage_class)
-
-        self._delete_bucket(bucket_name, keys)
-
-    def test_s3_put_object_notification_with_lambda(self):
-        bucket_name = "bucket-%s" % short_uid()
-        function_name = "func-%s" % short_uid()
-        table_name = "table-%s" % short_uid()
-
-        self.s3_client.create_bucket(Bucket=bucket_name)
-
-        testutil.create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON_TRIGGERED_S3,
-            func_name=function_name,
-            runtime=LAMBDA_RUNTIME_PYTHON36,
-        )
-
-        aws_stack.create_dynamodb_table(table_name=table_name, partition_key="uuid")
-
-        self.s3_client.put_bucket_notification_configuration(
-            Bucket=bucket_name,
-            NotificationConfiguration={
-                "LambdaFunctionConfigurations": [
-                    {
-                        "LambdaFunctionArn": aws_stack.lambda_function_arn(function_name),
-                        "Events": ["s3:ObjectCreated:*"],
-                    }
-                ]
-            },
-        )
-
-        # put an object
-        obj = self.s3_client.put_object(Bucket=bucket_name, Key=table_name, Body="something..")
-        etag = obj["ETag"]
-        time.sleep(2)
-
-        table = aws_stack.connect_to_resource("dynamodb").Table(table_name)
-
-        def check_table():
-            rs = table.scan()
-            self.assertEqual(1, len(rs["Items"]))
-            return rs
-
-        rs = retry(check_table, retries=4, sleep=3)
-
-        record = rs["Items"][0]
-        self.assertEqual(bucket_name, record["data"]["s3"]["bucket"]["name"])
-        self.assertEqual(etag, record["data"]["s3"]["object"]["eTag"])
-
-        # clean up
-        self._delete_bucket(bucket_name, [table_name])
-
-        lambda_client = aws_stack.create_external_boto_client("lambda")
-        lambda_client.delete_function(FunctionName=function_name)
-
-        dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
-        dynamodb_client.delete_table(TableName=table_name)
-
-    def test_s3_put_object_notification_with_sns_topic(self):
-        bucket_name = "bucket-%s" % short_uid()
-        topic_name = "topic-%s" % short_uid()
-        queue_name = "queue-%s" % short_uid()
-        key_name = "bucket-key-%s" % short_uid()
-
-        sns_client = aws_stack.create_external_boto_client("sns")
-
-        self.s3_client.create_bucket(Bucket=bucket_name)
-        queue_url = self.sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-
-        topic_arn = sns_client.create_topic(Name=topic_name)["TopicArn"]
-
-        sns_client.subscribe(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=aws_stack.sqs_queue_arn(queue_name),
-        )
-
-        self.s3_client.put_bucket_notification_configuration(
-            Bucket=bucket_name,
-            NotificationConfiguration={
-                "TopicConfigurations": [{"TopicArn": topic_arn, "Events": ["s3:ObjectCreated:*"]}]
-            },
-        )
-
-        # Put an object
-        # This will trigger an event to sns topic, sqs queue will get a message since it's a subscriber of topic
-        self.s3_client.put_object(Bucket=bucket_name, Key=key_name, Body="body content...")
-        time.sleep(2)
-
-        def get_message(q_url):
-            resp = self.sqs_client.receive_message(QueueUrl=q_url)
-            m = resp["Messages"][0]
-            self.sqs_client.delete_message(QueueUrl=q_url, ReceiptHandle=m["ReceiptHandle"])
-            return json.loads(m["Body"])
-
-        message = retry(get_message, retries=3, sleep=2, q_url=queue_url)
-        # We got a notification message in sqs queue (from s3 source)
-        self.assertEqual("Notification", message["Type"])
-        self.assertEqual(topic_arn, message["TopicArn"])
-        self.assertEqual("Amazon S3 Notification", message["Subject"])
-
-        r = json.loads(message["Message"])["Records"][0]
-        self.assertEqual("aws:s3", r["eventSource"])
-        self.assertEqual(bucket_name, r["s3"]["bucket"]["name"])
-        self.assertEqual(key_name, r["s3"]["object"]["key"])
-
-        # clean up
-        self._delete_bucket(bucket_name, [key_name])
-        self.sqs_client.delete_queue(QueueUrl=queue_url)
-        sns_client.delete_topic(TopicArn=topic_arn)
-
     def test_s3_get_deep_archive_object(self):
         bucket_name = "bucket-%s" % short_uid()
         object_key = "key-%s" % short_uid()
@@ -1794,89 +1353,6 @@ class TestS3(unittest.TestCase):
 
         # clean up
         self._delete_bucket(bucket_name, [object_key])
-
-    def test_encoding_notification_messages(self):
-        key = "a@b"
-        bucket_name = "notif-enc-%s" % short_uid()
-        queue_url = self.sqs_client.create_queue(QueueName="testQueue")["QueueUrl"]
-        queue_attributes = self.sqs_client.get_queue_attributes(
-            QueueUrl=queue_url, AttributeNames=["QueueArn"]
-        )
-
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-
-        # put an object where the bucket_name is in the path
-        self.s3_client.put_object(Bucket=bucket_name, Key=key, Body="something")
-
-        response = self.sqs_client.receive_message(QueueUrl=queue_url)
-        self.assertEqual(
-            "a%40b",
-            json.loads(response["Messages"][0]["Body"])["Records"][0]["s3"]["object"]["key"],
-        )
-        # clean up
-        self.s3_client.delete_objects(Bucket=bucket_name, Delete={"Objects": [{"Key": key}]})
-
-    def test_s3_notification_copy_event(self):
-        bucket_name = "notif-event-%s" % short_uid()
-        src_key = "key-src-%s" % short_uid()
-        queue_url, queue_attributes = self._create_test_queue()
-        self._create_test_notification_bucket(
-            queue_attributes, bucket_name=bucket_name, event_name="ObjectCreated:Copy"
-        )
-
-        self.s3_client.put_object(Bucket=bucket_name, Key=src_key, Body="something")
-
-        self.assertEqual("0", self._get_test_queue_message_count(queue_url))
-
-        dest_key = "key-dest-%s" % short_uid()
-        self.s3_client.copy_object(
-            Bucket=bucket_name,
-            CopySource={"Bucket": bucket_name, "Key": src_key},
-            Key=dest_key,
-        )
-
-        self.assertEqual("1", self._get_test_queue_message_count(queue_url))
-
-        # clean up
-        self.sqs_client.delete_queue(QueueUrl=queue_url)
-        self._delete_bucket(bucket_name, [src_key, dest_key])
-
-    def add_xray_header(self, request, **kwargs):
-        request.headers[
-            "X-Amzn-Trace-Id"
-        ] = "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
-
-    def test_xray_header_to_sqs(self):
-        key = "test-data"
-        bucket_name = "bucket-%s" % short_uid()
-        self.s3_client.meta.events.register("before-send.s3.*", self.add_xray_header)
-        queue_url = self.sqs_client.create_queue(QueueName="testQueueNew")["QueueUrl"]
-        queue_attributes = self.sqs_client.get_queue_attributes(
-            QueueUrl=queue_url, AttributeNames=["QueueArn"]
-        )
-
-        self._create_test_notification_bucket(queue_attributes, bucket_name=bucket_name)
-
-        # put an object where the bucket_name is in the path
-        self.s3_client.put_object(Bucket=bucket_name, Key=key, Body="something")
-
-        def get_message(queue_url):
-            resp = self.sqs_client.receive_message(
-                QueueUrl=queue_url,
-                AttributeNames=["AWSTraceHeader"],
-                MessageAttributeNames=["All"],
-                VisibilityTimeout=0,
-            )
-
-            self.assertEqual(
-                "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1",
-                resp["Messages"][0]["Attributes"]["AWSTraceHeader"],
-            )
-
-        retry(get_message, retries=3, sleep=10, queue_url=queue_url)
-
-        # clean up
-        self.s3_client.delete_objects(Bucket=bucket_name, Delete={"Objects": [{"Key": key}]})
 
     def test_s3_batch_delete_objects_using_requests(self):
         bucket_name = "bucket-%s" % short_uid()
@@ -2672,66 +2148,6 @@ class TestS3(unittest.TestCase):
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
             region_name=region_name,
         )
-
-
-class TestS3New:
-    def test_region_header_exists(self, s3_client, s3_create_bucket):
-        bucket_name = s3_create_bucket(
-            CreateBucketConfiguration={"LocationConstraint": TEST_REGION_1},
-        )
-        bucket_head = s3_client.head_bucket(Bucket=bucket_name)
-        buckets = s3_client.list_objects_v2(Bucket=bucket_name)
-        assert (
-            bucket_head["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == TEST_REGION_1
-        )
-        assert buckets["ResponseMetadata"]["HTTPHeaders"]["x-amz-bucket-region"] == TEST_REGION_1
-
-    @pytest.mark.xfail(
-        reason="Deleting content of bucket with objects.all().delete() not working (InvalidAccessKeyId)"
-    )
-    def test_delete_bucket_with_content(self, s3_client, s3_create_bucket):
-        bucket_name = s3_create_bucket()
-        for i in range(0, 10, 1):
-            body = "test-" + str(i)
-            key = "test-key-" + str(i)
-            s3_client.put_object(Bucket=bucket_name, Key=key, Body=body)
-
-        resp = s3_client.list_objects(Bucket=bucket_name, MaxKeys=100)
-        assert 10 == len(resp["Contents"])
-
-        bucket = boto3.resource("s3").Bucket(bucket_name)
-        bucket.objects.all().delete()
-        bucket.delete()
-
-        resp = s3_client.list_buckets()
-        assert len(resp["Buckets"]) == 0
-
-    @pytest.mark.aws_validated
-    def test_put_and_get_object_with_utf8_key(self, s3_client, s3_create_bucket):
-        bucket = s3_create_bucket()
-        response = s3_client.put_object(Bucket=bucket, Key="Ā0Ä", Body=b"abc123")
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        response = s3_client.get_object(Bucket=bucket, Key="Ā0Ä")
-        assert response["Body"].read() == b"abc123"
-
-    @pytest.mark.aws_validated
-    def test_s3_resource_object_slashes_in_key(self, s3_resource, s3_create_bucket):
-        bucket = s3_create_bucket()
-        s3_resource.Object(bucket, "/foo").put(Body="foobar")
-        s3_resource.Object(bucket, "bar").put(Body="barfoo")
-
-        with pytest.raises(ClientError) as e:
-            s3_resource.Object(bucket, "foo").get()
-        e.match("NoSuchKey")
-
-        with pytest.raises(ClientError) as e:
-            s3_resource.Object(bucket, "/bar").get()
-        e.match("NoSuchKey")
-
-        response = s3_resource.Object(bucket, "/foo").get()
-        assert response["Body"].read() == b"foobar"
-        response = s3_resource.Object(bucket, "bar").get()
-        assert response["Body"].read() == b"barfoo"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is an initial effort to refactor the s3 tests.

Rough rundown of changes:
* move s3 tests into separate package (`tests/integration/s3`)
* separate tests that have integrations with other services (in this PR: s3 notifications), may be interesting for the case @viren-nadkarni ran in to related to s3->eventbridge notifications
* completely revamped the notification tests using polling mechanisms (to make them work against AWS)
* use pytest and factory fixture pattern correctly
* -> allowed me to run all refactored tests against AWS (except the lambda notification test, i was too lazy to create the policies ;-))
* removed a few redundant tests

I did not refactor all of them, it was just too much work for one pass. But I hope this can give a template for how to proceed.