### PR TITLE
Add support for #return macros in VTL templates

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -130,6 +130,7 @@ class VelocityInput:
         return "$input"
 
 
+# TODO: move generic VTL logic to utils/aws/templating.py
 class VtlTemplate:
     def render_vtl(self, template, variables: dict, as_json=False):
         if variables is None:

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -1,28 +1,24 @@
 import base64
-import copy
 import json
 import logging
-import re
+from abc import ABC
+from typing import Any, Dict
 from urllib.parse import quote_plus, unquote_plus
-
-import airspeed
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.templating import VtlTemplate
 from localstack.utils.common import make_http_request, to_str
 from localstack.utils.json import extract_jsonpath, json_safe
 from localstack.utils.numbers import is_number, to_number
-from localstack.utils.objects import recurse_object
 
 LOG = logging.getLogger(__name__)
 
 
-class BackendIntegration:
-    """
-    Backend integration
-    """
+class BackendIntegration(ABC):
+    """Abstract base class representing a backend integration"""
 
 
 class SnsIntegration(BackendIntegration):
@@ -130,78 +126,18 @@ class VelocityInput:
         return "$input"
 
 
-# TODO: move generic VTL logic to utils/aws/templating.py
-class VtlTemplate:
-    def render_vtl(self, template, variables: dict, as_json=False):
-        if variables is None:
-            variables = {}
+class ApiGatewayVtlTemplate(VtlTemplate):
+    """Util class for rendering VTL templates with API Gateway specific extensions"""
 
-        if not template:
-            return template
-
-        # fix "#set" commands
-        template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
-
-        # enable syntax like "test#${foo.bar}"
-        empty_placeholder = " __pLaCe-HoLdEr__ "
-        template = re.sub(
-            r"([^\s]+)#\$({)?(.*)",
-            r"\1#%s$\2\3" % empty_placeholder,
-            template,
-            re.MULTILINE,
-        )
-
-        # add extensions for common string functions below
-
-        class ExtendedString(str):
-            def trim(self, *args, **kwargs):
-                return ExtendedString(self.strip(*args, **kwargs))
-
-            def toLowerCase(self, *args, **kwargs):
-                return ExtendedString(self.lower(*args, **kwargs))
-
-            def toUpperCase(self, *args, **kwargs):
-                return ExtendedString(self.upper(*args, **kwargs))
-
-        def apply(obj, **kwargs):
-            if isinstance(obj, dict):
-                for k, v in obj.items():
-                    if isinstance(v, str):
-                        obj[k] = ExtendedString(v)
-            return obj
-
-        # loop through the variables and enable certain additional util functions (e.g.,
-        # string utils)
-        variables = copy.deepcopy(variables or {})
-        recurse_object(variables, apply)
-
-        # prepare and render template
-        context_var = variables.get("context") or {}
+    def prepare_namespace(self, variables) -> Dict[str, Any]:
+        namespace = super().prepare_namespace(variables)
         input_var = variables.get("input") or {}
-        stage_var = variables.get("stage_variables") or {}
-        t = airspeed.Template(template)
-        namespace = {
+        variables = {
             "input": VelocityInput(input_var.get("body"), input_var.get("params")),
             "util": VelocityUtil(),
-            "context": context_var,
-            "stageVariables": stage_var,
         }
-
-        # this steps prepares the namespace for object traversal,
-        # e.g, foo.bar.trim().toLowerCase().replace
-        dict_pack = input_var.get("body")
-        if isinstance(dict_pack, dict):
-            for k, v in dict_pack.items():
-                namespace.update({k: v})
-
-        rendered_template = t.merge(namespace)
-
-        # revert temporary changes from the fixes above
-        rendered_template = rendered_template.replace(empty_placeholder, "")
-
-        if as_json:
-            rendered_template = json.loads(rendered_template)
-        return rendered_template
+        namespace.update(variables)
+        return namespace
 
 
 class Templates:

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -144,7 +144,7 @@ class Templates:
     __slots__ = ["vtl"]
 
     def __init__(self):
-        self.vtl = VtlTemplate()
+        self.vtl = ApiGatewayVtlTemplate()
 
     def render(self, api_context: ApiInvocationContext):
         pass

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -1,91 +1,100 @@
-import base64
+import copy
 import json
 import re
-from urllib.parse import quote_plus, unquote_plus
+from typing import Dict
 
 import airspeed
 
-from localstack import config
-from localstack.utils.json import extract_jsonpath, json_safe
-from localstack.utils.numbers import is_number, to_number
 from localstack.utils.objects import recurse_object
 from localstack.utils.patch import patch
-from localstack.utils.strings import short_uid
-
-# remove all the code below after removing references in:
-# - invocations.py
-# - graphql_executor.py
 
 
-class VelocityInput:
-    """Simple class to mimick the behavior of variable '$input' in AWS API Gateway integration
-    velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
+class VtlTemplate:
+    """Utility class for rendering velocity templates"""
 
-    def __init__(self, value):
-        self.value = value
+    def render_vtl(self, template, variables: dict, as_json=False):
+        if variables is None:
+            variables = {}
 
-    def path(self, path):
-        if not self.value:
-            return {}
-        value = self.value if isinstance(self.value, dict) else json.loads(self.value)
-        return extract_jsonpath(value, path)
+        if not template:
+            return template
 
-    def json(self, path):
-        path = path or "$"
-        matching = self.path(path)
-        if isinstance(matching, (list, dict)):
-            matching = json_safe(matching)
-        return json.dumps(matching)
+        # fix "#set" commands
+        template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
 
-    def __getattr__(self, name):
-        return self.value.get(name)
+        # enable syntax like "test#${foo.bar}"
+        empty_placeholder = " __pLaCe-HoLdEr__ "
+        template = re.sub(
+            r"([^\s]+)#\$({)?(.*)",
+            r"\1#%s$\2\3" % empty_placeholder,
+            template,
+            re.MULTILINE,
+        )
 
-    def __repr__(self):
-        return "$input"
+        # add extensions for common string functions below
+
+        class ExtendedString(str):
+            def trim(self, *args, **kwargs):
+                return ExtendedString(self.strip(*args, **kwargs))
+
+            def toLowerCase(self, *_, **__):
+                return ExtendedString(self.lower())
+
+            def toUpperCase(self, *_, **__):
+                return ExtendedString(self.upper())
+
+        def apply(obj, **_):
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    if isinstance(v, str):
+                        obj[k] = ExtendedString(v)
+            return obj
+
+        # loop through the variables and enable certain additional util
+        # functions (e.g., string utils)
+        variables = copy.deepcopy(variables or {})
+        recurse_object(variables, apply)
+
+        # prepare and render template
+        t = airspeed.Template(template)
+        namespace = self.prepare_namespace(variables)
+
+        # this steps prepares the namespace for object traversal,
+        # e.g, foo.bar.trim().toLowerCase().replace
+        input_var = variables.get("input") or {}
+        dict_pack = input_var.get("body")
+        if isinstance(dict_pack, dict):
+            for k, v in dict_pack.items():
+                namespace.update({k: v})
+
+        rendered_template = t.merge(namespace)
+
+        # revert temporary changes from the fixes above
+        rendered_template = rendered_template.replace(empty_placeholder, "")
+
+        if as_json:
+            rendered_template = json.loads(rendered_template)
+        return rendered_template
+
+    def prepare_namespace(self, variables) -> Dict:
+        context_var = variables.get("context") or {}
+        stage_var = variables.get("stage_variables") or {}
+        namespace = {
+            "context": context_var,
+            "stageVariables": stage_var,
+        }
+        return namespace
 
 
-class VelocityUtil:
-    """Simple class to mimick the behavior of variable '$util' in AWS API Gateway integration
-    velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html"""
-
-    def base64Encode(self, s):
-        if not isinstance(s, str):
-            s = json.dumps(s)
-        encoded_str = s.encode(config.DEFAULT_ENCODING)
-        encoded_b64_str = base64.b64encode(encoded_str)
-        return encoded_b64_str.decode(config.DEFAULT_ENCODING)
-
-    def base64Decode(self, s):
-        if not isinstance(s, str):
-            s = json.dumps(s)
-        return base64.b64decode(s)
-
-    def toJson(self, obj):
-        return obj and json.dumps(obj)
-
-    def urlEncode(self, s):
-        return quote_plus(s)
-
-    def urlDecode(self, s):
-        return unquote_plus(s)
-
-    def escapeJavaScript(self, s):
-        try:
-            return json.dumps(json.loads(s))
-        except Exception:
-            primitive_types = (str, int, bool, float, type(None))
-            s = s if isinstance(s, primitive_types) else str(s)
-        if str(s).strip() in ["true", "false"]:
-            s = bool(s)
-        elif s not in [True, False] and is_number(s):
-            s = to_number(s)
-        return json.dumps(s)
+# TODO: clean up this function, once all references have been removed (difference between context/variables unclear)
+def render_velocity_template(template, context, variables=None, as_json=False):
+    context = context or {}
+    context.update(variables or {})
+    return VtlTemplate().render_vtl(template, context, as_json=as_json)
 
 
 # START of patches for airspeed
-# TODO: contribute these patches upstream, if possible
+# TODO: contribute these patches upstream!
 
 
 airspeed.MacroDefinition.RESERVED_NAMES = airspeed.MacroDefinition.RESERVED_NAMES + ("return",)
@@ -150,65 +159,3 @@ def parse(self):
 
 
 # END of patches for airspeed
-
-
-def render_velocity_template(template, context, variables=None, as_json=False):
-    if variables is None:
-        variables = {}
-
-    if not template:
-        return template
-
-    # fix "#set" commands
-    template = re.sub(r"(^|\n)#\s+set(.*)", r"\1#set\2", template, re.MULTILINE)
-
-    # enable syntax like "test#${foo.bar}"
-    empty_placeholder = " __pLaCe-HoLdEr__ "
-    template = re.sub(
-        r"([^\s]+)#\$({)?(.*)",
-        r"\1#%s$\2\3" % empty_placeholder,
-        template,
-        re.MULTILINE,
-    )
-
-    # add extensions for common string functions below
-
-    class ExtendedString(str):
-        def trim(self, *args, **kwargs):
-            return ExtendedString(self.strip(*args, **kwargs))
-
-        def toLowerCase(self, *args, **kwargs):
-            return ExtendedString(self.lower(*args, **kwargs))
-
-        def toUpperCase(self, *args, **kwargs):
-            return ExtendedString(self.upper(*args, **kwargs))
-
-    def apply(obj, **kwargs):
-        if isinstance(obj, dict):
-            for k, v in obj.items():
-                if isinstance(v, str):
-                    obj[k] = ExtendedString(v)
-        return obj
-
-    # loop through the variables and enable certain additional util functions (e.g., string utils)
-    variables = variables or {}
-    recurse_object(variables, apply)
-
-    # prepare and render template
-    context_var = variables.get("context") or {}
-    context_var.setdefault("requestId", short_uid())
-    t = airspeed.Template(template)
-    var_map = {
-        "input": VelocityInput(context),
-        "util": VelocityUtil(),
-        "context": context_var,
-    }
-    var_map.update(variables or {})
-    replaced = t.merge(var_map)
-
-    # revert temporary changes from the fixes above
-    replaced = replaced.replace(empty_placeholder, "")
-
-    if as_json:
-        replaced = json.loads(replaced)
-    return replaced

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -1,11 +1,7 @@
-import base64
 import json
 
-import pytest
-
-from localstack.services.apigateway.integration import VtlTemplate
+from localstack.services.apigateway.integration import ApiGatewayVtlTemplate
 from localstack.utils.aws.templating import render_velocity_template
-from localstack.utils.common import to_str
 
 # template used to transform incoming requests at the API Gateway (forward to Kinesis)
 APIGW_TEMPLATE_TRANSFORM_KINESIS = """{
@@ -20,7 +16,7 @@ APIGW_TEMPLATE_TRANSFORM_KINESIS = """{
         {
             "Data": "$elemJsonB64",
             "PartitionKey": #if( $elem.partitionKey != '')"$elem.partitionKey"
-                            #else"$elemJsonB64.length()"#end
+                            #else"$elemJsonB64"#end
         }#if($foreach.hasNext),#end
         #end
         #end
@@ -84,92 +80,8 @@ APIGW_TEMPLATE_CUSTOM_BODY = """
 """
 
 
-@pytest.fixture
-def velocity_template():
-    return VtlTemplate()
-
-
-class TestMessageTransformation:
-    def test_array_size(self, velocity_template):
-        template = "#set($list = $input.path('$.records')) $list.size()"
-        body = {"records": [{"data": {"foo": "bar1"}}, {"data": {"foo": "bar2"}}]}
-        variables = {
-            "input": {
-                "body": body,
-            },
-        }
-
-        result = velocity_template.render_vtl(template, variables)
-        assert result == " 2"
-
-    def test_message_transformation(self, velocity_template):
-        template = APIGW_TEMPLATE_TRANSFORM_KINESIS
-        records = [
-            {"data": {"foo": "foo1", "bar": "bar2"}},
-            {"data": {"foo": "foo1", "bar": "bar2"}, "partitionKey": "key123"},
-        ]
-        variables = {"input": {"body": {"records": records}}}
-
-        def do_test(variables):
-            result = velocity_template.render_vtl(template, variables, as_json=True)
-            result_decoded = json.loads(to_str(base64.b64decode(result["Records"][0]["Data"])))
-            assert result_decoded == records[0]["data"]
-            # TODO: look into this assertion
-            # assert result["Records"][0]["PartitionKey"] == "$elem.partitionKey"
-            assert result["Records"][1]["PartitionKey"] == "key123"
-
-        # try rendering the template
-        do_test(variables)
-
-        # test with empty array
-        records = []
-        variables = {"input": {"body": {"records": records}}}
-        # try rendering the template
-        result = velocity_template.render_vtl(template, variables, as_json=True)
-        assert result["Records"] == []
-
-    def test_array_in_set_expr(self, velocity_template):
-        template = "#set ($bar = $input.path('$.foo')[1]) \n $bar"
-        variables = {"input": {"body": {"foo": ["e1", "e2", "e3", "e4"]}}}
-        result = velocity_template.render_vtl(template, variables).strip()
-        assert result == "e2"
-
-        template = "#set ($bar = $input.path('$.foo')[1][1][1]) $bar"
-        variables = {"input": {"body": {"foo": [["e1"], ["e2", ["e3", "e4"]]]}}}
-        result = velocity_template.render_vtl(template, variables).strip()
-        assert result == "e4"
-
-    def test_string_methods(self, velocity_template):
-        context = {"foo": {"bar": "BAZ baz"}}
-        variables = {"input": {"body": context}}
-        template1 = "${foo.bar.strip().lower().replace(' ','-')}"
-        template2 = "${foo.bar.trim().toLowerCase().replace(' ','-')}"
-        for template in [template1, template2]:
-            result = velocity_template.render_vtl(template, variables=variables)
-            assert result == "baz-baz"
-
-    def test_render_urlencoded_string_data(self, velocity_template):
-        template = "MessageBody=$util.base64Encode($input.json('$'))"
-        variables = {"input": {"body": {"spam": "eggs"}}}
-        result = velocity_template.render_vtl(template, variables)
-        assert result == "MessageBody=eyJzcGFtIjogImVnZ3MifQ=="
-
-    def test_construct_json_using_define(self, velocity_template):
-        template = APIGW_TEMPLATE_CONSTRUCT_JSON
-        data = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
-        variables = {"input": {"body": data}}
-        result = velocity_template.render_vtl(template, variables).strip()
-        result = json.loads(result)
-        assert result == {"p0": True, **data}
-
-    def test_keyset_functions(self, velocity_template):
-        template = "#set($list = $input.path('$..var1[1]').keySet()) #foreach($e in $list)$e#end"
-        body = {"var1": [{"a": 1}, {"b": 2}]}
-        variables = {"input": {"body": body}}
-        result = velocity_template.render_vtl(template, variables)
-        assert result == " b"
-
-    def test_return_macro(self, velocity_template):
+class TestMessageTransformationBasic:
+    def test_return_macro(self):
         template = """
         #set($v1 = {})
         $v1.put('foo', 'bar')
@@ -178,3 +90,82 @@ class TestMessageTransformation:
         result = render_velocity_template(template, {})
         expected = {"foo": "bar"}
         assert json.loads(result) == expected
+
+
+class TestMessageTransformationApiGateway:
+    def test_construct_json_using_define(self):
+        template = APIGW_TEMPLATE_CONSTRUCT_JSON
+        data = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
+        variables = {"input": {"body": data}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables).strip()
+        result = json.loads(result)
+        assert result == {"p0": True, **data}
+
+    def test_array_size(self):
+        template = "#set($list = $input.path('$.records')) $list.size()"
+        body = {"records": [{"data": {"foo": "bar1"}}, {"data": {"foo": "bar2"}}]}
+        variables = {
+            "input": {
+                "body": body,
+            },
+        }
+
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables)
+        assert result == " 2"
+
+    def test_message_transformation(self):
+        template = APIGW_TEMPLATE_TRANSFORM_KINESIS
+        records = [
+            {"data": {"foo": "foo1", "bar": "bar2"}},
+            {"data": {"foo": "foo1", "bar": "bar2"}, "partitionKey": "key123"},
+        ]
+        variables = {"input": {"body": {"records": records}}}
+
+        def do_test(_vars):
+            res = ApiGatewayVtlTemplate().render_vtl(template, _vars, as_json=True)
+            data_encoded = res["Records"][0]["Data"]
+            assert res["Records"][0]["PartitionKey"] == data_encoded
+            assert res["Records"][1]["PartitionKey"] == "key123"
+
+        # try rendering the template
+        do_test(variables)
+
+        # test with empty array
+        records = []
+        variables = {"input": {"body": {"records": records}}}
+        # try rendering the template
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables, as_json=True)
+        assert result["Records"] == []
+
+    def test_array_in_set_expr(self):
+        template = "#set ($bar = $input.path('$.foo')[1]) \n $bar"
+        variables = {"input": {"body": {"foo": ["e1", "e2", "e3", "e4"]}}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables).strip()
+        assert result == "e2"
+
+        template = "#set ($bar = $input.path('$.foo')[1][1][1]) $bar"
+        variables = {"input": {"body": {"foo": [["e1"], ["e2", ["e3", "e4"]]]}}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables).strip()
+        assert result == "e4"
+
+    def test_string_methods(self):
+        context = {"foo": {"bar": "BAZ baz"}}
+        variables = {"input": {"body": context}}
+        template1 = "${foo.bar.strip().lower().replace(' ','-')}"
+        template2 = "${foo.bar.trim().toLowerCase().replace(' ','-')}"
+        for template in [template1, template2]:
+            result = ApiGatewayVtlTemplate().render_vtl(template, variables=variables)
+            assert result == "baz-baz"
+
+    def test_render_urlencoded_string_data(self):
+        template = "MessageBody=$util.base64Encode($input.json('$'))"
+        variables = {"input": {"body": {"spam": "eggs"}}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables)
+        assert result == "MessageBody=eyJzcGFtIjogImVnZ3MifQ=="
+
+    def test_keyset_functions(self):
+        template = "#set($list = $input.path('$..var1[1]').keySet()) #foreach($e in $list)$e#end"
+        body = {"var1": [{"a": 1}, {"b": 2}]}
+        variables = {"input": {"body": body}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables)
+        assert result == " b"


### PR DESCRIPTION
* Add support for `#return` macros in VTL templates - addresses #5988 . This requires a patch in `airspeed`, which over time we should contribute upstream.
* Clean up and unify templating code. A large portion of of the PR is actually just moving things around, cleaning up duplicate code, etc. The key change is to separate a (somewhat) generic `VtlTemplate` (which can also be used by AppSync and other services), and a derived `ApiGatewayVtlTemplate` which adds extensions that are relevant in an API GW context. Was taking care of backwards compatibility, and should be reasonably well covered by tests.