### PR TITLE
fix http path encoding in asgi/wsgi adapter

### DIFF
--- a/tests/unit/http/test_asgi.py
+++ b/tests/unit/http/test_asgi.py
@@ -241,3 +241,17 @@ def test_multipart_post(serve_app):
     response = requests.post(server.url, files={"foo": "bar", "baz": "ed"})
     assert response.ok
     assert response.json() == {"foo": "bar", "baz": "ed"}
+
+
+def test_utf8_path(serve_app):
+    @Request.application
+    def app(request: Request) -> Response:
+        assert request.path == "/foo/Ā0Ä"
+        assert request.environ["PATH_INFO"] == "/foo/Ä\x800Ã\x84"
+
+        return Response("ok", 200)
+
+    server = serve_app(ASGIAdapter(app))
+
+    response = requests.get(server.url + "/foo/Ā0Ä")
+    assert response.ok

--- a/tests/unit/http/test_request.py
+++ b/tests/unit/http/test_request.py
@@ -181,3 +181,10 @@ def test_multipart_parsing():
         result[k] = file_storage.stream.read().decode("utf-8")
 
     assert result == {"foo": "bar", "baz": "ed"}
+
+
+def test_utf8_path():
+    r = Request("GET", "/foo/Ā0Ä")
+
+    assert r.path == "/foo/Ā0Ä"
+    assert r.environ["PATH_INFO"] == "/foo/Ä\x800Ã\x84"  # quoted and latin-1 encoded


### PR DESCRIPTION
This PR fixes an encoding issue that arises from ASGI using normal utf-8 encoding for paths, whereas werkzeug expects latin-1 encoded paths.
This was already implemented for the `dummy_wsgi_environment`, but not for the wsgi/asgi bridge. Added tests for both cases.
