### PR TITLE
Apigateway OpenAPI import support for authorizers

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -604,6 +604,13 @@ def import_api_from_openapi_spec(
     # Remove default root, then add paths from API spec
     rest_api.resources = {}
 
+    def create_authorizer(path_payload: dict, body: dict):
+        if security_schemes := path_payload.get("security"):
+            for security_scheme in security_schemes:
+                for security_scheme_name, scopes in security_scheme.items():
+                    print(security_scheme_name)
+
+
     def get_or_create_path(path):
         parts = path.rstrip("/").replace("//", "/").split("/")
         parent_id = ""
@@ -611,11 +618,7 @@ def import_api_from_openapi_spec(
             parent_path = "/".join(parts[:-1])
             parent = get_or_create_path(parent_path)
             parent_id = parent.id
-        if existing := [
-            r
-            for r in rest_api.resources.values()
-            if r.path_part == (parts[-1] or "/") and (r.parent_id or "") == (parent_id or "")
-        ]:
+        if existing := [r for r in rest_api.resources.values() if r.path_part == (parts[-1] or "/") and (r.parent_id or "") == (parent_id or "")]:
             return existing[0]
         return add_path(path, parts, parent_id=parent_id)
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -628,7 +628,7 @@ def import_api_from_openapi_spec(
                             "authorizerCredentials"
                         ),
                         identity_source=aws_apigateway_authorizer.get("identitySource"),
-                        identiy_validation_expression=None,
+                        identiy_validation_expression=aws_apigateway_authorizer.get("identityValidationExpression"),
                         authorizer_result_ttl=300,
                     )
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -628,8 +628,13 @@ def import_api_from_openapi_spec(
                             "authorizerCredentials"
                         ),
                         identity_source=aws_apigateway_authorizer.get("identitySource"),
-                        identiy_validation_expression=aws_apigateway_authorizer.get("identityValidationExpression"),
-                        authorizer_result_ttl=300,
+                        identiy_validation_expression=aws_apigateway_authorizer.get(
+                            "identityValidationExpression"
+                        ),
+                        authorizer_result_ttl=aws_apigateway_authorizer.get(
+                            "authorizerResultTtlInSeconds"
+                        )
+                        or 300,
                     )
 
     def get_or_create_path(path):

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -76,7 +76,7 @@ class VelocityUtil:
         except Exception:
             primitive_types = (str, int, bool, float, type(None))
             s = s if isinstance(s, primitive_types) else str(s)
-        if str(s).strip() in ["true", "false"]:
+        if str(s).strip() in {"true", "false"}:
             s = bool(s)
         elif s not in [True, False] and is_number(s):
             s = to_number(s)

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -162,7 +162,9 @@ def validate_api_key(api_key: str, stage: str):
     usage_plans = client.get_usage_plans()
     for item in usage_plans.get("items", []):
         api_stages = item.get("apiStages", [])
-        usage_plan_ids.extend(item.get("id") for api_stage in api_stages if api_stage.get("stage") == stage)
+        usage_plan_ids.extend(
+            item.get("id") for api_stage in api_stages if api_stage.get("stage") == stage
+        )
 
     for usage_plan_id in usage_plan_ids:
         usage_plan_keys = client.get_usage_plan_keys(usagePlanId=usage_plan_id)

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -162,9 +162,7 @@ def validate_api_key(api_key: str, stage: str):
     usage_plans = client.get_usage_plans()
     for item in usage_plans.get("items", []):
         api_stages = item.get("apiStages", [])
-        for api_stage in api_stages:
-            if api_stage.get("stage") == stage:
-                usage_plan_ids.append(item.get("id"))
+        usage_plan_ids.extend(item.get("id") for api_stage in api_stages if api_stage.get("stage") == stage)
 
     for usage_plan_id in usage_plan_ids:
         usage_plan_keys = client.get_usage_plan_keys(usagePlanId=usage_plan_id)

--- a/tests/integration/files/swagger.json
+++ b/tests/integration/files/swagger.json
@@ -17,6 +17,11 @@
   "paths": {
     "/test": {
       "get": {
+        "security": [
+          {
+            "myapi-authorizer-0": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "200 response",
@@ -53,6 +58,11 @@
         }
       },
       "options": {
+        "security": [
+          {
+            "myapi-authorizer-0": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "200 response",
@@ -108,6 +118,20 @@
         "title": "Empty Schema",
         "type": "object"
       }
+    }
+  },
+  "securityDefinitions": {
+    "myapi-authorizer-0": {
+      "in": "query",
+      "name": "auth",
+      "type": "apiKey",
+      "x-amazon-apigateway-authorizer": {
+        "authorizerCredentials": "arn:aws:iam::000000000000:role/myapi-authorizer-0-authorizer-role-3bd761a",
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:myapi-authorizer-0-22ad13b/invocations",
+        "identitySource": "method.request.querystring.auth",
+        "type": "request"
+      },
+      "x-amazon-apigateway-authtype": "custom"
     }
   }
 }

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1145,7 +1145,7 @@ class TestAPIGateway(unittest.TestCase):
             self.assertEqual(200, response.status_code)
 
     def test_import_rest_api(self):
-        rest_api_name = "restapi-%s" % short_uid()
+        rest_api_name = f"restapi-{short_uid()}"
 
         client = aws_stack.create_external_boto_client("apigateway")
         rest_api_id = client.create_rest_api(name=rest_api_name)["id"]

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1154,6 +1154,12 @@ class TestAPIGateway(unittest.TestCase):
         rs = client.put_rest_api(restApiId=rest_api_id, body=spec_file, mode="overwrite")
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
 
+        resources = client.get_resources(restApiId=rest_api_id)
+        for rv in resources.get("items"):
+            for method in rv.get("resourceMethods", {}).values():
+                assert method.get("authorizationType") == "request"
+                assert method.get("authorizerId") is not None
+
         spec_file = load_file(TEST_SWAGGER_FILE_YAML)
         rs = client.put_rest_api(restApiId=rest_api_id, body=spec_file, mode="overwrite")
         self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -305,7 +305,7 @@ def test_integration_response(apigateway_client):
     response = apigateway_client.get_method(restApiId=api_id, resourceId=root_id, httpMethod="GET")
     assert response["methodIntegration"]["integrationResponses"] == {}
 
-    # adding a new method and perfomring put intergration with contentHandling as CONVERT_TO_BINARY
+    # adding a new method and performing put integration with contentHandling as CONVERT_TO_BINARY
     apigateway_client.put_method(
         restApiId=api_id, resourceId=root_id, httpMethod="PUT", authorizationType="none"
     )


### PR DESCRIPTION
This PR adds support for authorisers included in the OpenAPI specification. The method needs to be refactored further into a class that handles different versions of the spec and makes it easy to add new functionality not supported in the current implementation.


