### PR TITLE
configure pytest to log DEBUG to cli by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
       - run:
           name: Unit tests
           environment:
-            DEBUG: 1
             TEST_PATH: "tests/unit"
             PYTEST_ARGS: "--junitxml=target/reports/unit-tests.xml -o junit_suite_name=unit-tests"
             COVERAGE_ARGS: "-p"
@@ -103,7 +102,6 @@ jobs:
       - run:
           name: Test Docker client
           environment:
-            DEBUG: 1
             TEST_PATH: "tests/integration/docker_utils"
             TEST_SKIP_LOCALSTACK_START: 1
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/docker-client.xml -o junit_suite_name='docker-client'"
@@ -112,7 +110,6 @@ jobs:
       - run:
           name: Test 'docker' Lambda executor
           environment:
-            DEBUG: 1
             LAMBDA_EXECUTOR: "docker"
             USE_SSL: 1
             TEST_ERROR_INJECTION: 1
@@ -123,7 +120,6 @@ jobs:
       - run:
           name: Test 'docker-reuse' Lambda executor
           environment:
-            DEBUG: 1
             LAMBDA_EXECUTOR: "docker-reuse"
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py tests/integration/test_apigateway.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker-reuse.xml -o junit_suite_name='lambda-docker-reuse'"
@@ -149,7 +145,6 @@ jobs:
       - run:
           name: Test ElasticMQ SQS provider
           environment:
-            DEBUG: 1
             SQS_PROVIDER: "elasticmq"
             TEST_PATH: "tests/integration/test_sns.py -k test_publish_sqs_from_sns_with_xray_propagation"
             PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/elasticmq.xml -o junit_suite_name='elasticmq'"
@@ -158,7 +153,6 @@ jobs:
       - run:
           name: Test ASF SQS provider
           environment:
-            DEBUG: 1
             PROVIDER_OVERRIDE_SQS: "asf"
             TEST_PATH: "tests/integration/test_sqs.py"
             PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/sqs_asf.xml -o junit_suite_name='sqs_asf'"
@@ -184,7 +178,6 @@ jobs:
       - run:
           name: Test ASF Lambda provider
           environment:
-            DEBUG: 1
             PROVIDER_OVERRIDE_LAMBDA: "asf"
             TEST_PATH: "tests/integration/awslambda/test_lambda_api.py"
             PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/lambda_asf.xml -o junit_suite_name='lambda_asf'"
@@ -210,7 +203,6 @@ jobs:
       - run:
           name: Run bootstrap tests
           environment:
-            DEBUG: 1
             TEST_PATH: "tests/bootstrap"
             PYTEST_ARGS: "--junitxml=target/reports/bootstrap.xml -o junit_suite_name='bootstrap'"
             COVERAGE_ARGS: "-p"
@@ -305,7 +297,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/integration/**/test_*.py" | circleci tests split --split-by=timings | tr '\n' ' ')
             PYTEST_ARGS="-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
             COVERAGE_FILE="target/coverage/.coverage.<< parameters.platform >>.${CIRCLE_NODE_INDEX}" \
-            TEST_PATH=$TEST_FILES \
+            PYTEST_LOGLEVEL="info" TEST_PATH=$TEST_FILES \
             make docker-run-tests
       - store_test_results:
           path: target/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
             TEST_FILES=$(circleci tests glob "tests/integration/**/test_*.py" | circleci tests split --split-by=timings | tr '\n' ' ')
             PYTEST_ARGS="-o junit_family=legacy --junitxml=target/reports/test-report-<< parameters.platform >>-${CIRCLE_NODE_INDEX}.xml" \
             COVERAGE_FILE="target/coverage/.coverage.<< parameters.platform >>.${CIRCLE_NODE_INDEX}" \
-            PYTEST_LOGLEVEL="info" TEST_PATH=$TEST_FILES \
+            TEST_PATH=$TEST_FILES \
             make docker-run-tests
       - store_test_results:
           path: target/reports/

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VENV_BIN ?= python3 -m venv
 VENV_DIR ?= .venv
 PIP_CMD ?= pip3
 TEST_PATH ?= .
-PYTEST_LOGLEVEL ?= warning
+PYTEST_LOGLEVEL ?=
 MAIN_CONTAINER_NAME ?= localstack_main
 
 MAJOR_VERSION = $(shell echo ${IMAGE_TAG} | cut -d '.' -f1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,5 @@ exclude_lines = [
 markers = [
     "aws_parity: test can be run standalone against AWS and has been validated before",
 ]
+log_cli = true
+log_level = "DEBUG"


### PR DESCRIPTION
This PR sets the default loglevel of pytest to debug, meaning that logs will automatically be output to the CLI. The consequence is that, when running `DEBUG=1 make test`, you will automatically get logs in your terminal.