### PR TITLE
Added utility to filter a dictionary based on a TypedDict keys

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -3,7 +3,19 @@ dicts, list, sets). """
 
 import logging
 import re
-from typing import Any, Callable, Dict, List, Optional, Sized, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Type,
+    TypedDict,
+    TypeVar,
+    Union,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -352,6 +364,6 @@ def is_none_or_empty(obj: Union[Optional[str], Optional[list]]) -> bool:
     )
 
 
-def select_from_typed_dict(typed_dict: "_TypedDict", obj: Dict):
+def select_from_typed_dict(typed_dict: Type[TypedDict], obj: Dict):
     """Select a subset of attributes from a dictionary based on the keys of a given `TypedDict`"""
     return select_attributes(obj, [*typed_dict.__required_keys__, *typed_dict.__optional_keys__])

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -350,3 +350,8 @@ def is_none_or_empty(obj: Union[Optional[str], Optional[list]]) -> bool:
         or (isinstance(obj, str) and obj.strip() == "")
         or (isinstance(obj, Sized) and len(obj) == 0)
     )
+
+
+def select_from_typed_dict(typed_dict: "_TypedDict", obj: Dict):
+    """Select a subset of attributes from a dictionary based on the keys of a given `TypedDict`"""
+    return select_attributes(obj, [*typed_dict.__required_keys__, *typed_dict.__optional_keys__])

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,0 +1,20 @@
+from typing import Optional, TypedDict
+
+from localstack.utils.collections import select_from_typed_dict
+
+
+class MyTypeDict(TypedDict):
+    key_one: str
+    key_optional: Optional[str]
+
+
+def test_select_from_typed_dict():
+    d = {"key_one": "key_one", "key_optional": "key_optional"}
+    result = select_from_typed_dict(typed_dict=MyTypeDict, obj=d)
+    assert result == d
+    d["key_too_much"] = "key_too_much"
+    result = select_from_typed_dict(typed_dict=MyTypeDict, obj=d)
+    assert result == {"key_one": "key_one", "key_optional": "key_optional"}
+    del d["key_one"]
+    result = select_from_typed_dict(typed_dict=MyTypeDict, obj=d)
+    assert result == {"key_optional": "key_optional"}


### PR DESCRIPTION
Added a small utility to filter dictionary based on the keys declared in a given `TypedDict`. 
This could come in handy for many providers when we explicitly lists the needed attribute and was asked by @MEPalma to facilitate the writing of some tests.