### PR TITLE
Explicit persistence hook argument for a Service

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Callable, Dict, List, Optional, Tuple
 
+from localstack_ext.bootstrap.persistence_lifecycle import PersistenceLifeCycle
 from plugin import Plugin, PluginLifecycleListener, PluginManager, PluginSpec
 from readerwriterlock import rwlock
 from requests.models import Request
@@ -143,6 +144,7 @@ class Service:
         active=False,
         stop=None,
         lifecycle_hook: ServiceLifecycleHook = None,
+        persistence_hook: PersistenceLifeCycle = None,
     ):
         self.plugin_name = name
         self.start_function = start
@@ -151,6 +153,7 @@ class Service:
         self.default_active = active
         self.stop_function = stop
         self.lifecycle_hook = lifecycle_hook or ServiceLifecycleHook()
+        self.persistence_hook = persistence_hook
         call_safe(self.lifecycle_hook.on_after_init)
 
     def start(self, asynchronous):

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -7,7 +7,6 @@ from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Callable, Dict, List, Optional, Tuple
 
-from localstack_ext.bootstrap.persistence_lifecycle import PersistenceLifeCycle
 from plugin import Plugin, PluginLifecycleListener, PluginManager, PluginSpec
 from readerwriterlock import rwlock
 from requests.models import Request
@@ -134,6 +133,14 @@ class ServiceLifecycleHook:
         pass
 
 
+class StateLifecycle:
+    def retrieve_state(self):
+        pass
+
+    def inject_state(self, state):
+        pass
+
+
 class Service:
     def __init__(
         self,
@@ -144,7 +151,7 @@ class Service:
         active=False,
         stop=None,
         lifecycle_hook: ServiceLifecycleHook = None,
-        persistence_hook: PersistenceLifeCycle = None,
+        state_lifecycle: StateLifecycle = None,
     ):
         self.plugin_name = name
         self.start_function = start
@@ -153,7 +160,7 @@ class Service:
         self.default_active = active
         self.stop_function = stop
         self.lifecycle_hook = lifecycle_hook or ServiceLifecycleHook()
-        self.persistence_hook = persistence_hook
+        self.state_lifecycle = state_lifecycle
         call_safe(self.lifecycle_hook.on_after_init)
 
     def start(self, asynchronous):


### PR DESCRIPTION
This comes in handy when trying to access the `PersistenceLifeCycle` while iterating over the active provider for Cloud Pods.