### PR TITLE
ignore GET and HEAD request body for rest-xml protocol

### DIFF
--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -180,6 +180,21 @@ class TestS3PresignedUrl:
         response = s3_client.head_object(Bucket=s3_bucket, Key=object_key)
         assert response.get("Metadata", {}).get("foo") == "bar"
 
+    @pytest.mark.aws_validated
+    def test_get_object_ignores_request_body(self, s3_client, s3_bucket):
+        key = "foo-key"
+        body = "foobar"
+
+        s3_client.put_object(Bucket=s3_bucket, Key=key, Body=body)
+
+        url = s3_client.generate_presigned_url(
+            "get_object", Params={"Bucket": s3_bucket, "Key": key}
+        )
+
+        response = requests.get(url, data=b"get body is ignored by AWS")
+        assert response.status_code == 200
+        assert response.text == body
+
 
 class TestS3DeepArchive:
     """


### PR DESCRIPTION
This PR fixes an issue where the parser would raise ProtocolErrors when receiving GET requests with a body. This was uncovered while running S3 tests that send GET bodies that are by default ignored by AWS (I verified it against AWS).
Basically we try body parsing, but if fails and it is a `GET` or `HEAD` request, we ignore the error. I also introduced a flag to control it so we can disable it for rest-json and enable it for rest-xml (which seems to be the behavior in AWS), or specific service protocols should we come across different behavior.

## HTTP Spec 
Whether sending a body with a GET request is allowed in HTTP is debated here: https://stackoverflow.com/a/983458/804840. TL;DR, the spec says
> the message-body SHOULD be ignored when handling the request.

AWS does things differently of course.

## Behavior in AWS

AWS has as of now three operations that ignore the spec (these are all `rest-json`), and where our parsers should parse the body regardless.

* quicksight GET ListIAMPolicyAssignments (member: AssignmentStatus)
* sesv2 GET ListContacts (member: Filter)
* sesv2 GET ListImportJobs (member: ImportDestinationType)

At the same time, some services, like S3, ignore GET request bodies completely, which means you can send GET requests to rest-xml services that are ignored, even if they are invalid.

## Limitations

rest-json services behave a bit differently, and i think the behavior is partly service-specific. the opensearch GET may send you something like `400, '{"Message": null}'` if you send "foobar", but pass normally when you pass `{}`. A POST request with "foobar" as body will also yield `400, '{"Message": null}'`, but with a valid JSON but illegal request it will return something like: `400, {"message":"1 validation error detected: Value null at 'domainName' failed to satisfy constraint: Member must not be null"}`

Implementing that particular behavior seems out of scope of this fix, but it's also not clear to me how to distinguish the different `ProtocolParserErrors` :shrug: .

Here's a script demonstrating the behavior:

```python
import boto3
import requests
from botocore.auth import SigV4Auth
from botocore.awsrequest import AWSRequest


def main():
    session = boto3.Session(profile_name="sandbox")
    credentials = session.get_credentials()
    creds = credentials.get_frozen_credentials()

    def signed_request(method, url, data=None, params=None, headers=None):
        request = AWSRequest(method=method, url=url, data=data, params=params, headers=headers)
        # "service_name" is generally "execute-api" for signing API Gateway requests
        SigV4Auth(creds, "es", "us-east-1").add_auth(request)
        return requests.request(method=method, url=url, headers=dict(request.headers), data=data)

    response = signed_request(
        method='GET',
        url="https://es.us-east-1.amazonaws.com/2021-01-01/domain",
        data=b"fooobar",
        headers={}
    )
    print(response.status_code, response.text)  # prints 400, '{"Message": null}'

    response = signed_request(
        method='GET',
        url="https://es.us-east-1.amazonaws.com/2021-01-01/domain",
        data=b"{}",
        headers={}
    )
    print(response.status_code, response.text)  # 200 {"DomainNames":[]}

    response = signed_request(
        method='POST',
        url="https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/domain",
        data=b"{}",
        headers={}
    )
    print(response.status_code, response.text)  # prints 400, {"message":"1 validation error detected: Value null at 'domainName' failed to satisfy constraint: Member must not be null"}

    response = signed_request(
        method='POST',
        url="https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/domain",
        data=b"foo",
        headers={}
    )
    print(response.status_code, response.text)  # prints 400, '{"Message": null}'


if __name__ == '__main__':
    main()
```
