### PR TITLE
add workaround for s3 virtual host addressing

### DIFF
--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -9,7 +9,6 @@ from werkzeug.exceptions import NotFound
 from werkzeug.routing import Map, MapAdapter, PathConverter, Rule
 
 from localstack.http import Request
-from localstack.http.request import get_raw_path
 
 
 class GreedyPathConverter(PathConverter):
@@ -279,7 +278,7 @@ class RestServiceOperationRouter:
         matcher: MapAdapter = self._map.bind(request.host)
 
         # perform the matching
-        rule, args = matcher.match(get_raw_path(request), method=request.method, return_rule=True)
+        rule, args = matcher.match(request.path, method=request.method, return_rule=True)
 
         # if the found rule is a _RequestMatchingRule, the multi rule matching needs to be invoked to perform the
         # fine-grained matching based on the whole request

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -990,7 +990,7 @@ class S3RequestParser(RestXMLRequestParser):
 
     def _revert_virtual_host_style(self, request: HttpRequest):
         # extract the bucket name from the host part of the request
-        bucket_name = request.host.split(".")[0]
+        bucket_name, host = request.host.split(".", maxsplit=1)
         # split the url and put the bucket name at the front
         parts = urlsplit(request.url)
         path_parts = parts.path.split("/")
@@ -998,9 +998,31 @@ class S3RequestParser(RestXMLRequestParser):
         path_parts = [part for part in path_parts if part]
         path = "/" + "/".join(path_parts) or "/"
         # set the path with the bucket name in the front at the request
-        # TODO directly modifying the request can cause issues with our handler chain, instead clone the HTTP request
+
+        # TODO directly modifying the request has become extremely difficult since
+        #  https://github.com/localstack/localstack/pull/5876. werkzeug requests are designed to be, for the most
+        #  part, immutable after entering the app. we need to either have a different approach to parsing virtual
+        #  host-based S3 requests, or add code to make it easy to copy requests with modified attributes.
         request.path = path
-        request.raw_path = path
+        request.headers["Host"] = host
+
+        try:
+            # delete the werkzeug request property cache that depends on path, but make sure all of them are initialized
+            # first, otherwise `del` will raise a key error
+            request.host = None  # noqa
+            request.url = None  # noqa
+            request.base_url = None  # noqa
+            request.full_path = None  # noqa
+            request.host_url = None  # noqa
+            request.root_url = None  # noqa
+            del request.host  # noqa
+            del request.url  # noqa
+            del request.base_url  # noqa
+            del request.full_path  # noqa
+            del request.host_url  # noqa
+            del request.root_url  # noqa
+        except AttributeError:
+            pass
 
 
 def create_parser(service: ServiceModel) -> RequestParser:

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -955,10 +955,20 @@ def test_restxml_header_date_parsing():
 
 
 def test_s3_virtual_host_addressing():
-    """Test the parsing of a map with the location trait 'headers'."""
+    """Test the parsing of an S3 bucket request using the bucket encoded in the domain."""
     request = HttpRequest(
         method="PUT", headers={"host": s3_utils.get_bucket_hostname("test-bucket")}
     )
+    parser = create_parser(load_service("s3"))
+    parsed_operation_model, parsed_request = parser.parse(request)
+    assert parsed_operation_model.name == "CreateBucket"
+    assert "Bucket" in parsed_request
+    assert parsed_request["Bucket"] == "test-bucket"
+
+
+def test_s3_path_addressing():
+    """Test the parsing of an S3 bucket request using the bucket encoded in the path."""
+    request = HttpRequest(method="PUT", path="/test-bucket")
     parser = create_parser(load_service("s3"))
     parsed_operation_model, parsed_request = parser.parse(request)
     assert parsed_operation_model.name == "CreateBucket"


### PR DESCRIPTION
This PR fixes an issue where S3 virtual host addressing would not work correctly, because werkzeug caches properties (like various variants of the URL and path) based on the `path` attribute. Simply setting it doesn't work reliably, we also have to delete the related cached properties. This is an unfortunate limitation of #5876.

For now I see this a workaround. Moving forward we need to answer the question whether we really want incoming requests to be mutable.