### PR TITLE
fix CLA assistant allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,4 +26,4 @@ jobs:
           path-to-signatures: "etc/cla-signatures/signatures.json"
           path-to-document: "https://github.com/localstack/localstack/blob/master/.github/CLA.md"
           branch: "cla-signatures"
-          allowlist: "localstack-bot,renovate"
+          allowlist: "localstack-bot,renovate-bot"


### PR DESCRIPTION
The new CLA assistant's allowlist does not work for the RenovateBot PRs (as you can see in https://github.com/localstack/localstack/pull/6029).
This PR changes the allowlist entry from "renovate" to "renovate-bot" (which is the GitHub username used for the commit - https://github.com/localstack/localstack/pull/6029/commits/ec615f88106c3628f5881715aa1ee5f041480d7d).