### PR TITLE
Revert "add workaround for s3 virtual host addressing (#6026)"

### DIFF
--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -9,6 +9,7 @@ from werkzeug.exceptions import NotFound
 from werkzeug.routing import Map, MapAdapter, PathConverter, Rule
 
 from localstack.http import Request
+from localstack.http.request import get_raw_path
 
 
 class GreedyPathConverter(PathConverter):
@@ -278,7 +279,7 @@ class RestServiceOperationRouter:
         matcher: MapAdapter = self._map.bind(request.host)
 
         # perform the matching
-        rule, args = matcher.match(request.path, method=request.method, return_rule=True)
+        rule, args = matcher.match(get_raw_path(request), method=request.method, return_rule=True)
 
         # if the found rule is a _RequestMatchingRule, the multi rule matching needs to be invoked to perform the
         # fine-grained matching based on the whole request

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -956,20 +956,10 @@ def test_restxml_header_date_parsing():
 
 
 def test_s3_virtual_host_addressing():
-    """Test the parsing of an S3 bucket request using the bucket encoded in the domain."""
+    """Test the parsing of a map with the location trait 'headers'."""
     request = HttpRequest(
         method="PUT", headers={"host": s3_utils.get_bucket_hostname("test-bucket")}
     )
-    parser = create_parser(load_service("s3"))
-    parsed_operation_model, parsed_request = parser.parse(request)
-    assert parsed_operation_model.name == "CreateBucket"
-    assert "Bucket" in parsed_request
-    assert parsed_request["Bucket"] == "test-bucket"
-
-
-def test_s3_path_addressing():
-    """Test the parsing of an S3 bucket request using the bucket encoded in the path."""
-    request = HttpRequest(method="PUT", path="/test-bucket")
     parser = create_parser(load_service("s3"))
     parsed_operation_model, parsed_request = parser.parse(request)
     assert parsed_operation_model.name == "CreateBucket"


### PR DESCRIPTION
This reverts commit 67298f40f776b9f6c7de9b03cfa22a29fb3acf79.

This PR currently breaks a lot of -ext services (amplify, apigateway, ...)
This is due to the replacement of get_raw_path with direct access to .path.
According to @thrau , the rest of the PR does not really make sense without this change, so this is an immediate fix by reverting. Proper fix incoming once ready.