### PR TITLE
Add map, quiet return functions for VTL template rendering

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -131,15 +131,15 @@ class ApiGatewayVtlTemplate(VtlTemplate):
 
     def prepare_namespace(self, variables) -> Dict[str, Any]:
         namespace = super().prepare_namespace(variables)
+        stage_var = variables.get("stage_variables") or {}
+        if stage_var:
+            namespace["stageVariables"] = stage_var
         input_var = variables.get("input") or {}
         variables = {
             "input": VelocityInput(input_var.get("body"), input_var.get("params")),
             "util": VelocityUtilApiGateway(),
         }
         namespace.update(variables)
-        stage_var = variables.get("stage_variables") or {}
-        if stage_var:
-            namespace["stageVariables"] = stage_var
         return namespace
 
 

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -9,7 +9,7 @@ from localstack import config
 from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.templating import VtlTemplate
+from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
 from localstack.utils.common import make_http_request, to_str
 from localstack.utils.json import extract_jsonpath, json_safe
 from localstack.utils.numbers import is_number, to_number
@@ -42,7 +42,7 @@ class SnsIntegration(BackendIntegration):
         )
 
 
-class VelocityUtil:
+class VelocityUtilApiGateway(VelocityUtil):
     """
     Simple class to mimic the behavior of variable '$util' in AWS API Gateway integration
     velocity templates.
@@ -134,9 +134,12 @@ class ApiGatewayVtlTemplate(VtlTemplate):
         input_var = variables.get("input") or {}
         variables = {
             "input": VelocityInput(input_var.get("body"), input_var.get("params")),
-            "util": VelocityUtil(),
+            "util": VelocityUtilApiGateway(),
         }
         namespace.update(variables)
+        stage_var = variables.get("stage_variables") or {}
+        if stage_var:
+            namespace["stageVariables"] = stage_var
         return namespace
 
 

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -1,7 +1,7 @@
 import copy
 import json
 import re
-from typing import Dict
+from typing import Any, Dict
 
 import airspeed
 
@@ -9,8 +9,24 @@ from localstack.utils.objects import recurse_object
 from localstack.utils.patch import patch
 
 
+class VelocityUtil:
+    """
+    Simple class to mimic the behavior of variable '$util' in AWS velocity templates.
+
+    This class defines basic shared functions, which can be overwritten/extended by
+    subclasses (e.g., for API Gateway, AppSync, etc).
+    """
+
+    def quiet(self, *args, **kwargs):
+        """No-op util function, often used as wrapper around other functions to suppress output"""
+        pass
+
+    def qr(self, *args, **kwargs):
+        self.quiet(*args, **kwargs)
+
+
 class VtlTemplate:
-    """Utility class for rendering velocity templates"""
+    """Utility class for rendering Velocity templates"""
 
     def render_vtl(self, template, variables: dict, as_json=False):
         if variables is None:
@@ -76,13 +92,11 @@ class VtlTemplate:
             rendered_template = json.loads(rendered_template)
         return rendered_template
 
-    def prepare_namespace(self, variables) -> Dict:
-        context_var = variables.get("context") or {}
-        stage_var = variables.get("stage_variables") or {}
-        namespace = {
-            "context": context_var,
-            "stageVariables": stage_var,
-        }
+    def prepare_namespace(self, variables: Dict[str, Any]) -> Dict:
+        namespace = dict(variables or {})
+        namespace.setdefault("context", {})
+        if not namespace.get("util"):
+            namespace["util"] = VelocityUtil()
         return namespace
 
 
@@ -156,6 +170,20 @@ def parse(self):
             )
         except airspeed.NoMatch:
             break
+
+
+def dict_put(self, key, value):
+    existing = self.get(key)
+    self.update({key: value})
+    return existing
+
+
+def dict_put_all(self, values):
+    self.update(values)
+
+
+airspeed.__additional_methods__[dict]["put"] = dict_put
+airspeed.__additional_methods__[dict]["putAll"] = dict_put_all
 
 
 # END of patches for airspeed

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -28,7 +28,7 @@ class VelocityUtil:
 class VtlTemplate:
     """Utility class for rendering Velocity templates"""
 
-    def render_vtl(self, template, variables: dict, as_json=False):
+    def render_vtl(self, template, variables: Dict, as_json=False):
         if variables is None:
             variables = {}
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -18,7 +18,7 @@ from localstack.services.apigateway.helpers import (
 from localstack.services.apigateway.integration import (
     RequestTemplates,
     ResponseTemplates,
-    VelocityUtil,
+    VelocityUtilApiGateway,
 )
 from localstack.services.apigateway.invocations import (
     ApiInvocationContext,
@@ -197,7 +197,7 @@ class ApiGatewayPathsTest(unittest.TestCase):
 
 
 def test_render_template_values():
-    util = VelocityUtil()
+    util = VelocityUtilApiGateway()
 
     encoded = util.urlEncode("x=a+b")
     assert encoded == "x%3Da%2Bb"


### PR DESCRIPTION
Small enhancements for Velocity rendering, continuation of fixes for #5988 :
* add proper support for map functions `put`/`putAll`
* add `quiet`/`qr` util function to suppress output from function results
* minor refactoring, pulling out `VelocityUtil` base functionality into common base class