### PR TITLE
Fix shutdown error in pytest by waiting for LS to finish correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,5 @@ markers = [
 ]
 log_cli = true
 log_level = "DEBUG"
-log_cli_format = "%(asctime)s.%(msecs)03d:%(levelname)s:%(threadName)s:%(name)s: %(message)s"
+log_cli_format = "%(asctime)s.%(msecs)03d:%(levelname)s:%(name)s: %(message)s"
 log_cli_date_format = "%Y-%m-%dT%H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,5 @@ markers = [
 ]
 log_cli = true
 log_level = "DEBUG"
+log_cli_format = "%(asctime)s.%(msecs)03d:%(levelname)s:%(threadName)s:%(name)s: %(message)s"
+log_cli_date_format = "%Y-%m-%dT%H:%M:%S"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -77,6 +77,9 @@ def pytest_runtestloop(session):
 def pytest_unconfigure(config):
     # last pytest lifecycle hook (before pytest exits)
     _trigger_stop()
+    # wait for localstack to stop. We do not want to exit immediately, otherwise new threads during shutdown will fail
+    if not localstack_stopped.wait(timeout=10):
+        logger.warning("LocalStack did not exit in time!")
 
 
 def _start_monitor():
@@ -105,6 +108,7 @@ def startup_monitor() -> None:
     if is_env_true("TEST_SKIP_LOCALSTACK_START") or os.environ.get("TEST_TARGET") == "AWS_CLOUD":
         logger.info("TEST_SKIP_LOCALSTACK_START is set, not starting localstack")
         localstack_started.set()
+        localstack_stopped.set()
         return
 
     logger.info("running localstack")


### PR DESCRIPTION
## Background
Currently, in test runs, after pytest exits an error message will show, namely `RuntimeError: cannot schedule new futures after interpreter shutdown`. This is due to the main thread of pytest exiting without waiting for LocalStack to finish, and LocalStack needing new futures for shutdown.
## Fix
We now wait (for 10 seconds) for LocalStack to terminate correctly. If it does, no error will be shown. If it takes longer, we will print an error message (regarding LocalStack not yet shut down), and exit nevertheless. The tests will still be a success and exit code of pytest will still be 0 in this case (to minimize flaky test runs due to this change).
## Other changes
I introduced timestamps for logging in tests, to debug performance issues, hung threads etc better.