### PR TITLE
add apigateway restapi dispatcher to edge router

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -151,6 +151,7 @@ def legacy_rules(request: Request) -> Optional[str]:
     host = hostname_from_url(request.host)
 
     # API Gateway invocation URLs
+    # TODO: deprecated with #6040, where API GW user routes are served through the gateway directly
     if ("/%s/" % PATH_USER_REQUEST) in request.path or (
         host.endswith(LOCALHOST_HOSTNAME) and "execute-api" in host
     ):

--- a/localstack/services/apigateway/provider_asf.py
+++ b/localstack/services/apigateway/provider_asf.py
@@ -1,0 +1,216 @@
+"""A version of the API Gateway provider that uses ASF constructs to dispatch user routes."""
+import json
+import re
+from collections import defaultdict
+from typing import Dict, List
+
+from requests.structures import CaseInsensitiveDict
+from werkzeug.datastructures import Headers
+from werkzeug.exceptions import NotFound
+from werkzeug.routing import Rule
+
+from localstack.aws.api import RequestContext, handler
+from localstack.aws.api.apigateway import (
+    CreateRestApiRequest,
+    RestApi,
+    String,
+    TestInvokeMethodRequest,
+    TestInvokeMethodResponse,
+)
+from localstack.aws.protocol.op_router import RestServiceOperationRouter
+from localstack.aws.proxy import AwsApiListener
+from localstack.aws.spec import load_service
+from localstack.http import Request, Response, Router
+from localstack.http.dispatcher import Handler
+from localstack.services.apigateway.context import ApiInvocationContext
+from localstack.services.apigateway.helpers import API_REGIONS
+from localstack.services.apigateway.invocations import invoke_rest_api_from_request
+from localstack.services.apigateway.provider import ApigatewayProvider
+from localstack.services.edge import ROUTER
+from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_responses import LambdaResponse, requests_response
+from localstack.utils.json import parse_json_or_yaml
+from localstack.utils.strings import to_str
+
+
+class AsfApigatewayApiListener(AwsApiListener):
+    def return_response(self, method, path, data, headers, response):
+        # TODO: clean up logic below!
+
+        # fix backend issue (missing support for API documentation)
+        if (
+            re.match(r"/restapis/[^/]+/documentation/versions", path)
+            and response.status_code == 404
+        ):
+            return requests_response({"position": "1", "items": []})
+
+        # keep track of API regions for faster lookup later on
+        # TODO - to be removed - see comment for API_REGIONS variable
+        if method == "POST" and path == "/restapis":
+            content = json.loads(to_str(response.content))
+            api_id = content["id"]
+            region = aws_stack.extract_region_from_auth_header(headers)
+            API_REGIONS[api_id] = region
+
+
+def to_invocation_context(request: Request) -> ApiInvocationContext:
+    """
+    Converts an HTTP Request object into an ApiInvocationContext.
+
+    :param request: the original request
+    :return: the ApiInvocationContext
+    """
+    # FIXME: ApiInvocationContext should be refactored to use werkzeug request object correctly
+    method = request.method
+    path = request.full_path if request.query_string else request.path
+    data = request.get_data(cache=True) or b""
+    headers = Headers(request.headers)
+
+    if "X-Forwarded-For" in headers:
+        headers["X-Forwarded-For"] = headers["X-Forwarded-For"] + ", " + request.server[0]
+    else:
+        headers["X-Forwarded-For"] = request.remote_addr + ", " + request.server[0]
+
+    # this is for compatibility with the lower layers of apigw and lambda that make assumptions about header casing
+    headers = CaseInsensitiveDict(
+        {k.title(): ", ".join(headers.getlist(k)) for k in set(headers.keys())}
+    )
+
+    return ApiInvocationContext(
+        method,
+        path,
+        data,
+        headers,
+    )
+
+
+class ApigatewayRouter:
+    """
+    Simple implementation around a Router to manage dynamic restapi routes (routes added by a user through the
+    apigateway API).
+    """
+
+    router: Router[Handler]
+
+    def __init__(self, router: Router[Handler]):
+        self.op_router = RestServiceOperationRouter(load_service("apigateway"))
+        self.router_rules: Dict[str, List[Rule]] = defaultdict(list)
+        self.router = router
+
+    def add_rest_api(self, rest_api: RestApi) -> None:
+        """
+        Adds a route for the given RestApi.
+        :param rest_api: the RestApi to add
+        """
+        # TODO: probably it is better to have a parameterized handler and only one rule, rather than creating a new
+        #  rule for every rest API. the more rules there are, the slower the routing will be. on the other hand,
+        #  regex matching could be just as slow. need to check!
+        api_id = rest_api["id"]
+
+        # add the canonical execute-api handler
+        self.router_rules[api_id].append(
+            self.router.add(
+                "/",
+                host=f"{api_id}.execute-api.<regex('.*'):server>",
+                endpoint=self._restapis_host_handler,
+            )
+        )
+        self.router_rules[api_id].append(
+            self.router.add(
+                "/<path:path>",
+                host=f"{api_id}.execute-api.<regex('.*'):server>",
+                endpoint=self._restapis_host_handler,
+            )
+        )
+
+        # add the localstack-specific _user_request_ handler
+        self.router_rules[api_id].append(
+            self.router.add(
+                f"/restapis/{api_id}/<stage>/_user_request_",
+                endpoint=self._restapis_user_request_handler,
+            )
+        )
+        self.router_rules[api_id].append(
+            self.router.add(
+                f"/restapis/{api_id}/<stage>/_user_request_/<path:path>",
+                endpoint=self._restapis_user_request_handler,
+            )
+        )
+
+    def remove_rest_api(self, rest_api_id: str) -> None:
+        """
+        Removes the given rest api.
+        :param rest_api_id: the rest api to remove
+        """
+        rules = self.router_rules.pop(rest_api_id, [])
+        for rule in rules:
+            self.router.remove_rule(rule)
+
+    def _restapis_handler(self, request: Request, path=None) -> Response:
+        invocation_context = to_invocation_context(request)
+
+        result = invoke_rest_api_from_request(invocation_context)
+        if result is not None:
+            if isinstance(result, LambdaResponse):
+                headers = Headers(dict(result.headers))
+                for k, values in result.multi_value_headers.items():
+                    for value in values:
+                        headers.add(k, value)
+            else:
+                headers = dict(result.headers)
+            return Response(
+                response=result.content,
+                status=result.status_code,
+                headers=headers,
+            )
+
+        raise NotFound()
+
+    def _restapis_user_request_handler(self, request: Request, stage=None, path=None):
+        return self._restapis_handler(request, path)
+
+    def _restapis_host_handler(self, request: Request, path=None, server=None) -> Response:
+        return self._restapis_handler(request)
+
+
+class AsfApigatewayProvider(ApigatewayProvider):
+    """Modern ASF provider that uses an ApigatewayRouter to dispatch requests to user routes."""
+
+    router: ApigatewayRouter
+
+    def __init__(self, router: ApigatewayRouter = None):
+        self.router = router or ApigatewayRouter(router=ROUTER)
+
+    def create_rest_api(self, context: RequestContext, request: CreateRestApiRequest) -> RestApi:
+        result = super().create_rest_api(context, request)
+        self.router.add_rest_api(result)
+        return result
+
+    def delete_rest_api(self, context: RequestContext, rest_api_id: String) -> None:
+        super().delete_rest_api(context, rest_api_id)
+        self.router.remove_rest_api(rest_api_id)
+
+    @handler("TestInvokeMethod", expand=False)
+    def test_invoke_method(
+        self, context: RequestContext, request: TestInvokeMethodRequest
+    ) -> TestInvokeMethodResponse:
+
+        invocation_context = to_invocation_context(context.request)
+        invocation_context.method = request["httpMethod"]
+
+        if data := parse_json_or_yaml(to_str(invocation_context.data or b"")):
+            orig_data = data
+            path_with_query_string = orig_data.get("pathWithQueryString", None)
+            if path_with_query_string:
+                invocation_context.path_with_query_string = path_with_query_string
+            invocation_context.data = data.get("body")
+            invocation_context.headers = orig_data.get("headers", {})
+
+        result = invoke_rest_api_from_request(invocation_context)
+
+        # FIXME: there are also multi-value-headers, log, and latency
+        return TestInvokeMethodResponse(
+            status=result.status_code,
+            headers=dict(result.headers),
+            body=to_str(result.content),
+        )

--- a/localstack/services/apigateway/provider_asf.py
+++ b/localstack/services/apigateway/provider_asf.py
@@ -178,8 +178,7 @@ class AsfApigatewayProvider(ApigatewayProvider):
 
         if data := parse_json_or_yaml(to_str(invocation_context.data or b"")):
             orig_data = data
-            path_with_query_string = orig_data.get("pathWithQueryString", None)
-            if path_with_query_string:
+            if path_with_query_string := orig_data.get("pathWithQueryString"):
                 invocation_context.path_with_query_string = path_with_query_string
             invocation_context.data = data.get("body")
             invocation_context.headers = orig_data.get("headers", {})

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -14,12 +14,25 @@ def acm():
     return Service("acm", listener=AwsApiListener("acm", MotoFallbackDispatcher(provider)))
 
 
-@aws_provider()
-def apigateway():
+@aws_provider(api="apigateway", name="legacy")
+def apigateway_legacy():
     from localstack.services.apigateway.provider import ApigatewayApiListener, ApigatewayProvider
 
     provider = ApigatewayProvider()
     listener = ApigatewayApiListener("apigateway", MotoFallbackDispatcher(provider))
+
+    return Service("apigateway", listener=listener, lifecycle_hook=provider)
+
+
+@aws_provider(api="apigateway", name="default")
+def apigateway_asf():
+    from localstack.services.apigateway.provider_asf import (
+        AsfApigatewayApiListener,
+        AsfApigatewayProvider,
+    )
+
+    provider = AsfApigatewayProvider()
+    listener = AsfApigatewayApiListener("apigateway", MotoFallbackDispatcher(provider))
 
     return Service("apigateway", listener=listener, lifecycle_hook=provider)
 

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -14,7 +14,7 @@ def acm():
     return Service("acm", listener=AwsApiListener("acm", MotoFallbackDispatcher(provider)))
 
 
-@aws_provider(api="apigateway", name="default")
+@aws_provider(api="apigateway", name="legacy")
 def apigateway_legacy():
     from localstack.services.apigateway.provider import ApigatewayApiListener, ApigatewayProvider
 
@@ -24,15 +24,12 @@ def apigateway_legacy():
     return Service("apigateway", listener=listener, lifecycle_hook=provider)
 
 
-@aws_provider(api="apigateway", name="asf")
+@aws_provider(api="apigateway", name="default")
 def apigateway_asf():
-    from localstack.services.apigateway.provider_asf import (
-        AsfApigatewayApiListener,
-        AsfApigatewayProvider,
-    )
+    from localstack.services.apigateway.provider_asf import AsfApigatewayProvider
 
     provider = AsfApigatewayProvider()
-    listener = AsfApigatewayApiListener("apigateway", MotoFallbackDispatcher(provider))
+    listener = AwsApiListener("apigateway", MotoFallbackDispatcher(provider))
 
     return Service("apigateway", listener=listener, lifecycle_hook=provider)
 

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -14,7 +14,7 @@ def acm():
     return Service("acm", listener=AwsApiListener("acm", MotoFallbackDispatcher(provider)))
 
 
-@aws_provider(api="apigateway", name="legacy")
+@aws_provider(api="apigateway", name="default")
 def apigateway_legacy():
     from localstack.services.apigateway.provider import ApigatewayApiListener, ApigatewayProvider
 
@@ -24,7 +24,7 @@ def apigateway_legacy():
     return Service("apigateway", listener=listener, lifecycle_hook=provider)
 
 
-@aws_provider(api="apigateway", name="default")
+@aws_provider(api="apigateway", name="asf")
 def apigateway_asf():
     from localstack.services.apigateway.provider_asf import AsfApigatewayProvider
 

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -14,7 +14,7 @@ def acm():
     return Service("acm", listener=AwsApiListener("acm", MotoFallbackDispatcher(provider)))
 
 
-@aws_provider(api="apigateway", name="legacy")
+@aws_provider(api="apigateway", name="default")
 def apigateway_legacy():
     from localstack.services.apigateway.provider import ApigatewayApiListener, ApigatewayProvider
 
@@ -24,7 +24,7 @@ def apigateway_legacy():
     return Service("apigateway", listener=listener, lifecycle_hook=provider)
 
 
-@aws_provider(api="apigateway", name="default")
+@aws_provider(api="apigateway", name="asf")
 def apigateway_asf():
     from localstack.services.apigateway.provider_asf import (
         AsfApigatewayApiListener,

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -5,7 +5,6 @@ import os
 import re
 from collections import namedtuple
 from typing import Callable, Optional
-from unittest.mock import patch
 
 import pytest
 import xmltodict
@@ -269,12 +268,10 @@ class TestAPIGateway:
         assert 1 == len(messages)
         assert test_data == json.loads(base64.b64decode(messages[0]["Body"]))
 
-    def test_api_gateway_http_integrations(self):
-        self.run_api_gateway_http_integration("custom")
-        self.run_api_gateway_http_integration("proxy")
+    @pytest.mark.parametrize("int_type", ["custom", "proxy"])
+    def test_api_gateway_http_integrations(self, int_type, monkeypatch):
+        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)
 
-    @patch.object(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)
-    def run_api_gateway_http_integration(self, int_type):
         test_port = get_free_tcp_port()
         backend_url = "http://localhost:%s%s" % (test_port, self.API_PATH_HTTP_BACKEND)
 


### PR DESCRIPTION
This PR implements apigateway's execute-api functionality through the edge router mechanism, which makes the custom proxy listener obsolete and unblocks the complete migration to the ASF gateway.

Note that this is only a first version for the community version. We will need to do some unification for our pro extensions and add routing for custom domains. Maybe it would be useful to consolidate some of the `UrlParts` code into the `ApigatewayRouter`. In any case this is a second step.

The major change are:
* introducing the `ApigatewayRouter`, which registers, for each newly added rest API, routing rules into the underlying `Router` (which currently is the `edge.ROUTER` singleton, but can now easily be exchanged). Beyond that it uses the familiar `invoke_rest_api_from_request` abstraction.
* The TestInvokeMethod logic was moved to it's respective API method.
* removed the `/documentation/versions` hack in the response handler, since we seem to have no tests for it. There are API methods that should be parity-tested and then implemented (`create_documentation_version`, ...).
* moved caching the rest API regions

Currently the provider is the default provider, but we should consider switching it back before merging and flipping the switch when merging the ASF gateway for v1.