### PR TITLE
don't suppress stage variables from lambda event

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -349,8 +349,6 @@ def process_apigateway_invocation(
 ):
     if path_params is None:
         path_params = {}
-    if stage_variables is None:
-        stage_variables = {}
     if request_context is None:
         request_context = {}
     try:
@@ -363,8 +361,7 @@ def process_apigateway_invocation(
         event["pathParameters"] = path_params
         event["resource"] = resource_path
         event["requestContext"] = request_context
-        if stage_variables:
-            event["stageVariables"] = stage_variables
+        event["stageVariables"] = stage_variables
         LOG.debug(
             "Running Lambda function %s from API Gateway invocation: %s %s",
             func_arn,


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/6022

The lambda failed to source `stageVariables` from the event because it was being suppressed by the event construction. 
