### PR TITLE
move import_rest_api patch into ASF handler

### DIFF
--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -2,7 +2,7 @@ import json
 import re
 from copy import deepcopy
 
-from localstack.aws.api import RequestContext, handler, ServiceRequest
+from localstack.aws.api import RequestContext, ServiceRequest, handler
 from localstack.aws.api.apigateway import (
     Account,
     ApigatewayApi,
@@ -56,7 +56,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.collections import ensure_list
 from localstack.utils.json import parse_json_or_yaml
-from localstack.utils.strings import short_uid, to_str, str_to_bool
+from localstack.utils.strings import short_uid, str_to_bool, to_str
 from localstack.utils.time import now_utc
 
 
@@ -657,12 +657,14 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         )
 
         return _call_moto(
-            context, "PutRestApi", PutRestApiRequest(
+            context,
+            "PutRestApi",
+            PutRestApiRequest(
                 restApiId=response.get("id"),
                 failOnWarnings=str_to_bool(fail_on_warnings) or False,
                 parameters=parameters or {},
-                body=body
-            )
+                body=body,
+            ),
         )
 
 

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1,6 +1,7 @@
 import json
 import re
 from copy import deepcopy
+from typing import Any, Mapping
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.apigateway import (
@@ -10,6 +11,7 @@ from localstack.aws.api.apigateway import (
     Authorizers,
     BasePathMapping,
     BasePathMappings,
+    Blob,
     Boolean,
     ClientCertificate,
     ClientCertificates,
@@ -24,6 +26,7 @@ from localstack.aws.api.apigateway import (
     MapOfStringToString,
     NotFoundException,
     NullableInteger,
+    PutRestApiRequest,
     RequestValidator,
     RequestValidators,
     RestApi,
@@ -32,6 +35,7 @@ from localstack.aws.api.apigateway import (
     VpcLink,
     VpcLinks,
 )
+from localstack.aws.forwarder import create_aws_request_context
 from localstack.aws.proxy import AwsApiListener
 from localstack.constants import HEADER_LOCALSTACK_EDGE_URL
 from localstack.services.apigateway import helpers
@@ -638,10 +642,41 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         for key in tag_keys:
             resource_tags.pop(key, None)
 
+    def import_rest_api(
+        self,
+        context: RequestContext,
+        body: Blob,
+        fail_on_warnings: Boolean = None,
+        parameters: MapOfStringToString = None,
+    ) -> RestApi:
+
+        openapi_spec = parse_json_or_yaml(body)
+        response = _call_moto(
+            context,
+            "CreateRestApi",
+            CreateRestApiRequest(name=openapi_spec.get("info").get("title")),
+        )
+
+        return _call_moto(
+            context, "PutRestApi", PutRestApiRequest(restApiId=response.get("id"), body=body)
+        )
+
 
 # ---------------
 # UTIL FUNCTIONS
 # ---------------
+
+
+def _call_moto(context: RequestContext, operation_name: str, parameters: Mapping[str, Any]):
+    local_context = create_aws_request_context(
+        service_name=context.service.service_name,
+        action=operation_name,
+        parameters=parameters,
+        region=context.region,
+    )
+
+    local_context.request.headers.extend(context.request.headers)
+    return call_moto(local_context)
 
 
 def normalize_authorizer(data):

--- a/localstack/utils/strings.py
+++ b/localstack/utils/strings.py
@@ -106,8 +106,8 @@ def first_char_to_upper(s: str) -> str:
 
 def str_to_bool(value):
     """Return the boolean value of the given string, or the verbatim value if it is not a string"""
-    true_strings = ["true", "True"]
     if isinstance(value, str):
+        true_strings = ["true", "True"]
         return value in true_strings
     return value
 

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1181,7 +1181,7 @@ class TestAPIGateway(unittest.TestCase):
 
         spec_file = load_file(TEST_IMPORT_REST_API_FILE)
         rs = client.import_rest_api(body=spec_file)
-        self.assertEqual(200, rs["ResponseMetadata"]["HTTPStatusCode"])
+        self.assertEqual(201, rs["ResponseMetadata"]["HTTPStatusCode"])
 
         rest_api_id = rs["id"]
 


### PR DESCRIPTION
Small PR to move the `import_rest_api` operation to the ASF handler. Doing that, we can remove our internal monkey patching.
