### PR TITLE
fix multiple authorizer creation

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -605,6 +605,9 @@ def import_api_from_openapi_spec(
     # Remove default root, then add paths from API spec
     rest_api.resources = {}
 
+    # authorizers map to avoid duplication
+    authorizers = {}
+
     def create_authorizer(path_payload: dict) -> Authorizer:
         if "security" not in path_payload:
             return None
@@ -617,25 +620,30 @@ def import_api_from_openapi_spec(
                     aws_apigateway_authorizer = security_config.get(
                         "x-amazon-apigateway-authorizer"
                     )
-                    return rest_api.create_authorizer(
-                        create_resource_id(),
-                        name=security_scheme_name,
-                        authorizer_type=aws_apigateway_authorizer.get("type"),
-                        provider_arns=None,
-                        auth_type=security_config.get("x-amazon-apigateway-authtype"),
-                        authorizer_uri=aws_apigateway_authorizer.get("authorizerUri"),
-                        authorizer_credentials=aws_apigateway_authorizer.get(
-                            "authorizerCredentials"
-                        ),
-                        identity_source=aws_apigateway_authorizer.get("identitySource"),
-                        identiy_validation_expression=aws_apigateway_authorizer.get(
-                            "identityValidationExpression"
-                        ),
-                        authorizer_result_ttl=aws_apigateway_authorizer.get(
-                            "authorizerResultTtlInSeconds"
+                    if authorizers.get(security_scheme_name):
+                        return authorizers.get(security_scheme_name)
+                    else:
+                        authorizer = rest_api.create_authorizer(
+                            create_resource_id(),
+                            name=security_scheme_name,
+                            authorizer_type=aws_apigateway_authorizer.get("type"),
+                            provider_arns=None,
+                            auth_type=security_config.get("x-amazon-apigateway-authtype"),
+                            authorizer_uri=aws_apigateway_authorizer.get("authorizerUri"),
+                            authorizer_credentials=aws_apigateway_authorizer.get(
+                                "authorizerCredentials"
+                            ),
+                            identity_source=aws_apigateway_authorizer.get("identitySource"),
+                            identiy_validation_expression=aws_apigateway_authorizer.get(
+                                "identityValidationExpression"
+                            ),
+                            authorizer_result_ttl=aws_apigateway_authorizer.get(
+                                "authorizerResultTtlInSeconds"
+                            ) or 300,
                         )
-                        or 300,
-                    )
+                        if authorizer:
+                            authorizers.update({security_scheme_name: authorizer})
+                        return authorizer
 
     def get_or_create_path(path):
         parts = path.rstrip("/").replace("//", "/").split("/")

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -639,7 +639,8 @@ def import_api_from_openapi_spec(
                             ),
                             authorizer_result_ttl=aws_apigateway_authorizer.get(
                                 "authorizerResultTtlInSeconds"
-                            ) or 300,
+                            )
+                            or 300,
                         )
                         if authorizer:
                             authorizers.update({security_scheme_name: authorizer})

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1783,6 +1783,9 @@ def test_import_swagger_api(apigateway_client):
     # assert imported_api.name == api_spec_dict.get("info").get("title")
     assert imported_api.description == api_spec_dict.get("info").get("description")
 
+    # assert that are no multiple authorizers
+    assert len(imported_api.authorizers) == 1
+
     paths = {v.path_part for k, v in imported_api.resources.items()}
     assert paths == {"/", "pets", "{petId}"}
 

--- a/tests/unit/templates/openapi.swagger.json
+++ b/tests/unit/templates/openapi.swagger.json
@@ -32,6 +32,11 @@
             }
           }
         },
+        "security": [
+          {
+            "test-authorizer": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "responses": {
             "default": {
@@ -91,6 +96,11 @@
             }
           }
         },
+        "security": [
+          {
+            "test-authorizer": []
+          }
+        ],
         "x-amazon-apigateway-integration": {
           "responses": {
             "default": {
@@ -315,6 +325,21 @@
           },
           "type": "mock"
         }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "test-authorizer": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header",
+      "x-amazon-apigateway-authtype": "oauth2",
+      "x-amazon-apigateway-authorizer": {
+        "type": "token",
+        "authorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:account-id:function:function-name/invocations",
+        "authorizerCredentials": "arn:aws:iam::account-id:role",
+        "identityValidationExpression": "^x-[a-z]+",
+        "authorizerResultTtlInSeconds": 60
       }
     }
   },


### PR DESCRIPTION
This PR assures that the same authoriser used in the API is not created multiple times.
