### PR TITLE
Refactor container network connection to reuse it outside of lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,16 +86,19 @@ jobs:
           name: Pull Lambda runtimes
           command: |
             sudo useradd localstack -s /bin/bash
-            docker pull -q lambci/lambda:20191117-nodejs8.10
-            docker pull -q lambci/lambda:20191117-ruby2.5
-            docker pull -q lambci/lambda:20210129-ruby2.7
-            docker pull -q lambci/lambda:20191117-python3.6
-            docker pull -q lambci/lambda:20191117-dotnetcore2.0
+            docker pull -q lambci/lambda:nodejs12.x
+            docker pull -q localstack/lambda-js:nodejs14.x
+            docker pull -q lambci/lambda:ruby2.7
+            docker pull -q lambci/lambda:python3.6
+            docker pull -q lambci/lambda:python3.7
+            docker pull -q lambci/lambda:python3.8
+            docker pull -q mlupin/docker-lambda:python3.9
             docker pull -q lambci/lambda:dotnetcore3.1
             docker pull -q mlupin/docker-lambda:dotnet6
-            docker pull -q lambci/lambda:20191117-provided
+            docker pull -q lambci/lambda:provided
             docker pull -q lambci/lambda:java8
-            docker pull -q lambci/lambda:python3.8
+            docker pull -q lambci/lambda:java8.al2
+            docker pull -q lambci/lambda:java11
       - run:
           name: Initialize Test Libraries
           command: make init-testlibs

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -425,12 +425,8 @@ class DockerStatus(TypedDict, total=False):
 def print_docker_status(format):
     from localstack import config
     from localstack.utils import docker_utils
-    from localstack.utils.bootstrap import (
-        get_docker_image_details,
-        get_main_container_ip,
-        get_main_container_name,
-        get_server_version,
-    )
+    from localstack.utils.bootstrap import get_docker_image_details, get_server_version
+    from localstack.utils.container_networking import get_main_container_ip, get_main_container_name
 
     img = get_docker_image_details()
     cont_name = config.MAIN_CONTAINER_NAME

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -42,7 +42,6 @@ from localstack.services.awslambda.lambda_utils import (
 )
 from localstack.services.generic_proxy import RegionBackend
 from localstack.services.install import INSTALL_DIR_STEPFUNCTIONS, install_go_lambda_runtime
-from localstack.utils import bootstrap
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import CodeSigningConfig, LambdaFunction
@@ -72,6 +71,7 @@ from localstack.utils.common import (
     to_str,
     unzip,
 )
+from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.functions import run_safe
 from localstack.utils.http import canonicalize_headers, parse_chunked_data
@@ -2135,13 +2135,13 @@ def validate_lambda_config():
         config.LAMBDA_DOCKER_NETWORK
         and config.is_in_docker
         and config.LAMBDA_DOCKER_NETWORK
-        not in DOCKER_CLIENT.get_networks(bootstrap.get_main_container_name())
+        not in DOCKER_CLIENT.get_networks(get_main_container_name())
     ):
         LOG.warning(
             "Your specified LAMBDA_DOCKER_NETWORK '%s' is not connected to the main LocalStack container '%s'. "
             "Lambda functionality might be severely limited.",
             config.LAMBDA_DOCKER_NETWORK,
-            bootstrap.get_main_container_name(),
+            get_main_container_name(),
         )
 
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -33,7 +33,6 @@ from localstack.services.awslambda.lambda_utils import (
     store_lambda_logs,
 )
 from localstack.services.install import GO_LAMBDA_RUNTIME, INSTALL_PATH_LOCALSTACK_FAT_JAR
-from localstack.utils import bootstrap
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.aws.dead_letter_queue import (
@@ -66,6 +65,7 @@ from localstack.utils.common import (
     truncate,
     wait_for_port_open,
 )
+from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.container_utils.container_client import (
     ContainerConfiguration,
     ContainerException,
@@ -1171,7 +1171,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
         Returns the prefix of all docker-reuse lambda containers for this LocalStack instance
         :return: Lambda container name prefix
         """
-        return f"{bootstrap.get_main_container_name()}_lambda_"
+        return f"{get_main_container_name()}_lambda_"
 
     def get_container_name(self, func_arn):
         """

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -22,13 +22,8 @@ from localstack.services.plugins import SERVICE_PLUGINS, ServiceDisabled, wait_f
 from localstack.utils import analytics, config_listener, persistence
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws.request_context import patch_moto_request_handling
-from localstack.utils.bootstrap import (
-    canonicalize_api_names,
-    get_main_container_id,
-    in_ci,
-    log_duration,
-    setup_logging,
-)
+from localstack.utils.bootstrap import canonicalize_api_names, in_ci, log_duration, setup_logging
+from localstack.utils.container_networking import get_main_container_id
 from localstack.utils.files import cleanup_tmp_files
 from localstack.utils.net import get_free_tcp_port, is_port_open
 from localstack.utils.patch import patch

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -13,6 +13,7 @@ from typing import Dict, Iterable, List, Optional, Set
 from localstack import config, constants
 from localstack.config import Directories
 from localstack.runtime import hooks
+from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.container_utils.container_client import (
     ContainerException,
     PortMappings,
@@ -104,33 +105,6 @@ def get_docker_image_details(image_name: str = None) -> Dict[str, str]:
         "created": result["Created"].split(".")[0],
     }
     return result
-
-
-def get_main_container_ip():
-    container_name = get_main_container_name()
-    return DOCKER_CLIENT.get_container_ip(container_name)
-
-
-def get_main_container_id():
-    container_name = get_main_container_name()
-    try:
-        return DOCKER_CLIENT.get_container_id(container_name)
-    except ContainerException:
-        return None
-
-
-def get_main_container_name():
-    global MAIN_CONTAINER_NAME_CACHED
-    if MAIN_CONTAINER_NAME_CACHED is None:
-        hostname = os.environ.get("HOSTNAME")
-        if hostname:
-            try:
-                MAIN_CONTAINER_NAME_CACHED = DOCKER_CLIENT.get_container_name(hostname)
-            except ContainerException:
-                MAIN_CONTAINER_NAME_CACHED = config.MAIN_CONTAINER_NAME
-        else:
-            MAIN_CONTAINER_NAME_CACHED = config.MAIN_CONTAINER_NAME
-    return MAIN_CONTAINER_NAME_CACHED
 
 
 def get_image_environment_variable(env_name: str) -> Optional[str]:

--- a/localstack/utils/container_networking.py
+++ b/localstack/utils/container_networking.py
@@ -1,0 +1,107 @@
+import logging
+import os
+from functools import lru_cache
+from typing import Optional
+
+from localstack import config
+from localstack.utils.container_utils.container_client import ContainerException
+from localstack.utils.docker_utils import DOCKER_CLIENT
+
+LOG = logging.getLogger(__name__)
+
+
+@lru_cache
+def get_main_container_network() -> str:
+    """
+    Gets the main network of the LocalStack container (if we run in one, bridge otherwise)
+    If there are multiple networks connected to the LocalStack container, we choose the first as "main" network
+
+    :return: Network name
+    """
+    main_container_network = None
+    try:
+        if config.is_in_docker:
+            networks = DOCKER_CLIENT.get_networks(get_main_container_name())
+            main_container_network = networks[0]
+        else:
+            main_container_network = "bridge"  # use the default bridge network in case of host mode
+        LOG.info("Determined main container network: %s", main_container_network)
+    except Exception as e:
+        container_name = get_main_container_name()
+        LOG.info('Unable to get network name of main container "%s": %s', container_name, e)
+    return main_container_network
+
+
+@lru_cache
+def get_endpoint_for_network(network: Optional[str] = None) -> str:
+    """
+    Get the LocalStack endpoint (= IP address) on the given network.
+    If a network is given, it will return the IP address of LocalStack on that network
+    If omitted, it will return the IP address of the main container network
+    This is a cached call, clear cache if networks might have changed
+
+    :param network: Network to return the endpoint for
+    :return: IP address of LS on the given network
+    """
+    container_name = get_main_container_name()
+    network = network or get_main_container_network()
+    main_container_ip = None
+    try:
+        if config.is_in_docker:
+            main_container_ip = DOCKER_CLIENT.get_container_ipv4_for_network(
+                container_name_or_id=container_name,
+                container_network=network,
+            )
+        else:
+            # default gateway for the network should be the host
+            # (only under Linux - otherwise fall back to DOCKER_HOST_FROM_CONTAINER below)
+            if config.is_in_linux:
+                main_container_ip = DOCKER_CLIENT.inspect_network(network)["IPAM"]["Config"][0][
+                    "Gateway"
+                ]
+        LOG.info("Determined main container target IP: %s", main_container_ip)
+    except Exception as e:
+        LOG.info('Unable to get IP address of main Docker container "%s": %s', container_name, e)
+    # return (1) predefined endpoint host, or (2) main container IP, or (3) Docker host (e.g., bridge IP)
+    return main_container_ip or config.DOCKER_HOST_FROM_CONTAINER
+
+
+def get_main_container_ip():
+    """
+    Get the container IP address of the LocalStack container.
+    Use get_endpoint_for network where possible, as it allows better control about which address to return
+
+    :return: IP address of LocalStack container
+    """
+    container_name = get_main_container_name()
+    return DOCKER_CLIENT.get_container_ip(container_name)
+
+
+def get_main_container_id():
+    """
+    Return the container ID of the LocalStack container
+
+    :return: container ID
+    """
+    container_name = get_main_container_name()
+    try:
+        return DOCKER_CLIENT.get_container_id(container_name)
+    except ContainerException:
+        return None
+
+
+@lru_cache
+def get_main_container_name():
+    """
+    Returns the container name of the LocalStack container
+
+    :return: LocalStack container name
+    """
+    hostname = os.environ.get("HOSTNAME")
+    if hostname:
+        try:
+            return DOCKER_CLIENT.get_container_name(hostname)
+        except ContainerException:
+            return config.MAIN_CONTAINER_NAME
+    else:
+        return config.MAIN_CONTAINER_NAME

--- a/localstack/utils/container_networking.py
+++ b/localstack/utils/container_networking.py
@@ -36,12 +36,12 @@ def get_main_container_network() -> str:
 def get_endpoint_for_network(network: Optional[str] = None) -> str:
     """
     Get the LocalStack endpoint (= IP address) on the given network.
-    If a network is given, it will return the IP address of LocalStack on that network
-    If omitted, it will return the IP address of the main container network
+    If a network is given, it will return the IP address/hostname of LocalStack on that network
+    If omitted, it will return the IP address/hostname of the main container network
     This is a cached call, clear cache if networks might have changed
 
     :param network: Network to return the endpoint for
-    :return: IP address of LS on the given network
+    :return: IP address or hostname of LS on the given network
     """
     container_name = get_main_container_name()
     network = network or get_main_container_network()

--- a/localstack/utils/diagnose.py
+++ b/localstack/utils/diagnose.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Union
 
 from localstack import config
 from localstack.utils import bootstrap
-from localstack.utils.bootstrap import get_main_container_name
+from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.container_utils.container_client import NoSuchImage
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import load_file


### PR DESCRIPTION
## Goal
Currently, the detection of networks and endpoints is very targeted of lambda.
This PR refactors this, to be more generic, and use the generic methods in the lambda methods as well
We need this to reuse the functionality for other services as well (currently f.e. bigdata).

## Changes
* Move all methods regarding inspection of the networking of the localstack container itself to utils/container_networking.py 
* use lru_cache instead of a global variable cache
* use the new methods in lambda methods as well
* update the pull section of circleci to include actually tested images, and remove ancient unused images

While it should continue to work, best to merge it after accompanying pro PR.