### PR TITLE
fix path url-encoding for generic proxy's modify_and_forward

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -262,6 +262,7 @@ def do_forward_request_inmem(api, method, path, data, headers, port=None):
 def do_forward_request_network(port, method, path, data, headers, target_url=None):
     # TODO: enable per-service endpoints, to allow deploying in distributed settings
     target_url = target_url or f"{config.get_protocol()}://{LOCALHOST}:{port}"
+    # the path here needs to be already url-encoded, otherwise parts might not be sent (f.e. if it contains a #)
     url = f"{target_url}{path}"
     return requests.request(
         method,

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -52,6 +52,7 @@ from localstack.utils.server import http2_server
 from localstack.utils.serving import Server
 from localstack.utils.strings import to_bytes, to_str
 from localstack.utils.threads import start_thread
+from localstack.utils.urls import path_from_url
 
 # set up logger
 LOG = logging.getLogger(__name__)
@@ -965,7 +966,9 @@ def start_proxy_server(
 
     def handler(request, data):
         parsed_url = urlparse(request.url)
-        path_with_params = request.full_path.strip("?")
+        # make sure to use the url-encoded path here, the decoding is not reversible and some listeners depend on it
+        # (f.e. for the ProxyListenerEdge's forwarding functionality)
+        path_with_params = path_from_url(request.url)
         method = request.method
         headers = request.headers
         headers[HEADER_LOCALSTACK_REQUEST_URL] = str(request.url)


### PR DESCRIPTION
This PR fixes another encoding issue which has been introduced with https://github.com/localstack/localstack/pull/5734.
Instead of using the request's `full_path` (which is already url-decoded) it reverts to the "old" variant of extracting the path and query params from the URL.

It is necessary to use the encoded path, because the encoding is non-reversible (f.e. `/foo/bar%2Fbaz` cannot be decoded and encoded again) and the edge proxy forwarding (when the edge proxy is spawned on port 443 to forward requests to 4566) needs to use the encoded URL for the forwarding (see the comment in the changed `edge.py`).

A lot of the encoding and decoding has changed recently with the new HTTP request object and ongoing refactorings, therefore I'm happy for any input (if this violates current assumptions somewhere else).