### PR TITLE
Unify SES logging format

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -63,7 +63,6 @@ def save_for_retrospection(id: str, region: str, **kwargs: Dict[str, Any]):
     kwargs should consist of following keys related to the email:
     - Body
     - Destinations
-    - HtmlBody
     - RawData
     - Source
     - Subject
@@ -193,14 +192,16 @@ class SesProvider(SesApi, ServiceLifecycleHook):
     ) -> SendEmailResponse:
         response = call_moto(context)
 
+        text_part = message["Body"].get("Text", {}).get("Data")
+        html_part = message["Body"].get("Html", {}).get("Data")
+
         save_for_retrospection(
             response["MessageId"],
             context.region,
             Source=source,
             Destination=destination,
             Subject=message["Subject"].get("Data"),
-            Body=message["Body"].get("Text", {}).get("Data"),
-            HtmlBody=message["Body"].get("Html", {}).get("Data"),
+            Body=dict(text_part=text_part, html_part=html_part),
         )
 
         return response

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -103,8 +103,7 @@ class TestSES:
 
         assert email == contents["Source"]
         assert "A_SUBJECT" == contents["Subject"]
-        assert "A_MESSAGE" == contents["Body"]
-        assert "A_HTML" == contents["HtmlBody"]
+        assert {"text_part": "A_MESSAGE", "html_part": "A_HTML"} == contents["Body"]
         assert ["success@example.com"] == contents["Destination"]["ToAddresses"]
 
         emails_url = config.get_edge_url() + INTERNAL_RESOURCE_PATH + EMAILS_ENDPOINT


### PR DESCRIPTION
Localstack has a feature which saves all SES email to memory and filesystem for later inspection. This PR unifies the format for these email and makes it consistent with LocalStack Pro.