### PR TITLE
Fix CFN Events create rule without targets

### DIFF
--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -144,8 +144,10 @@ class EventsRule(GenericBaseModel):
             rule_name = props["Name"]
             event_bus_name = props.get("EventBusName")
             targets = props.get("Targets") or []
-            if len(targets) > 0:
+            if len(targets) > 0 and event_bus_name:
                 events.put_targets(Rule=rule_name, EventBusName=event_bus_name, Targets=targets)
+            elif len(targets) > 0:
+                events.put_targets(Rule=rule_name, Targets=targets)
 
         return {
             "create": [

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -1,7 +1,6 @@
 import json
 
 from localstack.services.cloudformation.deployment_utils import (
-    PLACEHOLDER_RESOURCE_NAME,
     generate_default_name,
     select_parameters,
 )
@@ -138,17 +137,20 @@ class EventsRule(GenericBaseModel):
                 events.remove_targets(Rule=rule_name, Ids=target_ids, Force=True)
             events.delete_rule(Name=rule_name)
 
+        def _put_targets(resource_id, resources, *args, **kwargs):
+            events = aws_stack.connect_to_service("events")
+            resource = resources[resource_id]
+            props = resource["Properties"]
+            rule_name = props["Name"]
+            event_bus_name = props.get("EventBusName")
+            targets = props.get("Targets") or []
+            if len(targets) > 0:
+                events.put_targets(Rule=rule_name, EventBusName=event_bus_name, Targets=targets)
+
         return {
             "create": [
                 {"function": "put_rule", "parameters": events_put_rule_params},
-                {
-                    "function": "put_targets",
-                    "parameters": {
-                        "Rule": PLACEHOLDER_RESOURCE_NAME,
-                        "EventBusName": "EventBusName",
-                        "Targets": "Targets",
-                    },
-                },
+                {"function": _put_targets},
             ],
             "delete": {"function": _delete_rule},
         }

--- a/tests/integration/cloudformation/test_cloudformation_events.py
+++ b/tests/integration/cloudformation/test_cloudformation_events.py
@@ -223,14 +223,14 @@ def test_event_rule_to_logs(
         cleanup_stacks([stack_id])
 
 
-def test_event_rule_creation_without_target(
-    cfn_client, cleanup_stacks, is_stack_created, deploy_cfn_template
-):
+def test_event_rule_creation_without_target(cfn_client, deploy_cfn_template):
     event_rule_name = f"event-rule-{short_uid()}"
     deployed = deploy_cfn_template(
-        template_file_name="events_rule_without_targets.yaml",
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../templates/events_rule_without_targets.yaml"
+        ),
         parameters={"EventRuleName": event_rule_name},
-    )  # see now below re: parameters
+    )
     stack_name = deployed.stack_name
 
     assert (

--- a/tests/integration/cloudformation/test_cloudformation_events.py
+++ b/tests/integration/cloudformation/test_cloudformation_events.py
@@ -221,3 +221,29 @@ def test_event_rule_to_logs(
     finally:
         cleanup_changesets([change_set_id])
         cleanup_stacks([stack_id])
+
+
+def test_event_rule_creation_without_target(
+    cfn_client,
+    events_client,
+    cleanup_stacks,
+    is_stack_created,
+):
+    stack_name = f"stack-{short_uid()}"
+    event_rule_name = f"event-rule-{short_uid()}"
+
+    template_rendered = jinja2.Template(
+        load_template_raw("events_rule_without_targets.yaml")
+    ).render(
+        event_rule_name=event_rule_name,
+    )
+
+    response = cfn_client.create_stack(StackName=stack_name, TemplateBody=template_rendered)
+    stack_id = response["StackId"]
+
+    wait_until(is_stack_created(stack_id))
+    assert (
+        cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["StackStatus"]
+        == "CREATE_COMPLETE"
+    )
+    cleanup_stacks([stack_id])

--- a/tests/integration/templates/events_rule_without_targets.yaml
+++ b/tests/integration/templates/events_rule_without_targets.yaml
@@ -1,0 +1,6 @@
+Resources:
+  TestRule99A50909:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: {{ event_rule_name }}
+      ScheduleExpression: 'cron(0 1 * * * *)'

--- a/tests/integration/templates/events_rule_without_targets.yaml
+++ b/tests/integration/templates/events_rule_without_targets.yaml
@@ -1,6 +1,11 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  EventRuleName:
+    Type: String
 Resources:
   TestRule99A50909:
     Type: AWS::Events::Rule
     Properties:
-      Name: {{ event_rule_name }}
+      Name: 
+        Ref: EventRuleName
       ScheduleExpression: 'cron(0 1 * * * *)'


### PR DESCRIPTION
This PR addresses issue #6033, where is shown that LocalStack CFN throws an error when trying to create a Rule that was defined without Targets. When testing against AWS, shows that it should work without problems. 

Changes:
- CFN Events Rule put_targets function is optional now.
- Test to validate changes.
- Template of a Rule without Targets.
