### PR TITLE
Fix DynamoDB error injection and re-enable tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,6 @@ jobs:
           environment:
             LAMBDA_EXECUTOR: "docker"
             USE_SSL: 1
-            TEST_ERROR_INJECTION: 1
             TEST_PATH: "tests/integration/awslambda/ tests/integration/test_integration.py tests/integration/test_apigateway.py"
             PYTEST_ARGS: "--reruns 2 --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='lambda-docker'"
             COVERAGE_ARGS: "-p"

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -283,18 +283,6 @@ class DynamoDBApiListener(AwsApiListener):
         self.provider = provider
         super().__init__("dynamodb", HttpFallbackDispatcher(provider, provider.get_forward_url))
 
-    def forward_request(self, method, path, data, headers):
-        action = headers.get("X-Amz-Target", "")
-        action = action.replace(ACTION_PREFIX, "")
-        if self.provider.should_throttle(action):
-            message = (
-                "The level of configured provisioned throughput for the table was exceeded. "
-                + "Consider increasing your provisioning level with the UpdateTable API"
-            )
-            raise ProvisionedThroughputExceededException(message)
-
-        return super().forward_request(method, path, data, headers)
-
     def return_response(self, method, path, data, headers, response):
         if response._content:
             # fix the table and latest stream ARNs (DynamoDBLocal hardcodes "ddblocal" as the region)
@@ -334,6 +322,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def forward_request(
         self, context: RequestContext, service_request: ServiceRequest = None
     ) -> ServiceResponse:
+        # check rate limiting for this request and raise an error, if provisioned throughput is exceeded
+        self.check_provisioned_throughput(context.operation.name)
+
         # note: modifying headers in-place here before forwarding the request
         self.prepare_request_headers(context.request.headers)
         return self.request_forwarder(context, service_request)
@@ -1244,6 +1235,14 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             "eventSource": "aws:dynamodb",
         }
 
+    def check_provisioned_throughput(self, action):
+        if self.should_throttle(action):
+            message = (
+                "The level of configured provisioned throughput for the table was exceeded. "
+                + "Consider increasing your provisioning level with the UpdateTable API"
+            )
+            raise ProvisionedThroughputExceededException(message)
+
     def action_should_throttle(self, action, actions):
         throttled = [f"{ACTION_PREFIX}{a}" for a in actions]
         return (action in throttled) or (action in actions)
@@ -1262,8 +1261,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             action, THROTTLED_ACTIONS
         ):
             return True
-        else:
-            return False
+        return False
 
 
 # ---

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -1010,7 +1010,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         if not self.table_exists(table_name):
             raise ResourceNotFoundException("Cannot do operations on a non-existent table")
 
-        table_def = DynamoDBRegion.get().table_definitions.get(table_name)
+        table_def = DynamoDBRegion.get().table_definitions.get(table_name) or {}
 
         stream_destinations = table_def.get("KinesisDataStreamDestinations") or []
         return DescribeKinesisStreamingDestinationOutput(

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -272,6 +272,8 @@ def connect_to_resource(
         env=env,
         region_name=region_name,
         endpoint_url=endpoint_url,
+        *args,
+        **kwargs,
     )
 
 

--- a/tests/integration/test_error_injection.py
+++ b/tests/integration/test_error_injection.py
@@ -1,114 +1,109 @@
-import unittest
-
 import pytest
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 
-from .awslambda.functions import lambda_integration
-from .test_integration import PARTITION_KEY, TEST_TABLE_NAME
-
-TEST_STREAM_NAME = lambda_integration.KINESIS_STREAM_NAME
+from .test_integration import PARTITION_KEY
 
 
-def should_run():
-    return config.is_env_true("TEST_ERROR_INJECTION")
+class TestErrorInjection:
+    @pytest.mark.only_localstack
+    def test_kinesis_error_injection(self, monkeypatch, kinesis_client, wait_for_stream_ready):
+        kinesis = aws_stack.create_external_boto_client("kinesis", config=self.retry_config())
+        stream_name = f"stream-{short_uid()}"
+        aws_stack.create_kinesis_stream(stream_name)
+        wait_for_stream_ready(stream_name)
 
+        try:
+            records = [{"Data": "0", "ExplicitHashKey": "0", "PartitionKey": "0"}]
 
-class TestErrorInjection(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        if not should_run():
-            pytest.skip("skipping TestErrorInjection (TEST_ERROR_INJECTION not set or false)")
+            # by default, no errors
+            test_no_errors = kinesis.put_records(StreamName=stream_name, Records=records)
+            assert test_no_errors["FailedRecordCount"] == 0
 
-    def test_kinesis_error_injection(self):
-        kinesis = aws_stack.create_external_boto_client("kinesis")
-        aws_stack.create_kinesis_stream(TEST_STREAM_NAME)
+            # with a probability of 1, always throw errors
+            monkeypatch.setattr(config, "KINESIS_ERROR_PROBABILITY", 1.0)
+            test_all_errors = kinesis.put_records(StreamName=stream_name, Records=records)
+            assert test_all_errors["FailedRecordCount"] == 1
+        finally:
+            kinesis_client.delete_stream(StreamName=stream_name)
 
-        records = [{"Data": "0", "ExplicitHashKey": "0", "PartitionKey": "0"}]
+    @pytest.mark.only_localstack
+    def test_dynamodb_error_injection(self, monkeypatch):
+        table = self.get_dynamodb_table()
 
-        # by default, no errors
-        test_no_errors = kinesis.put_records(StreamName=TEST_STREAM_NAME, Records=records)
-        assert test_no_errors["FailedRecordCount"] == 0
+        try:
+            partition_key = short_uid()
+            self.assert_zero_probability_read_error_injection(table, partition_key)
 
-        # with a probability of 1, always throw errors
-        config.KINESIS_ERROR_PROBABILITY = 1.0
-        test_all_errors = kinesis.put_records(StreamName=TEST_STREAM_NAME, Records=records)
-        assert test_all_errors["FailedRecordCount"] == 1
+            # with a probability of 1, always throw errors
+            monkeypatch.setattr(config, "DYNAMODB_ERROR_PROBABILITY", 1.0)
+            with pytest.raises(ClientError) as exc:
+                table.get_item(Key={PARTITION_KEY: partition_key})
+            exc.match("ProvisionedThroughputExceededException")
+        finally:
+            table.delete()
 
-        # reset probability to zero
-        config.KINESIS_ERROR_PROBABILITY = 0.0
+    @pytest.mark.only_localstack
+    def test_dynamodb_read_error_injection(self, monkeypatch):
+        table = self.get_dynamodb_table()
+
+        try:
+            partition_key = short_uid()
+            self.assert_zero_probability_read_error_injection(table, partition_key)
+
+            # with a probability of 1, always throw errors
+            monkeypatch.setattr(config, "DYNAMODB_READ_ERROR_PROBABILITY", 1.0)
+            with pytest.raises(ClientError) as exc:
+                table.get_item(Key={PARTITION_KEY: partition_key})
+            exc.match("ProvisionedThroughputExceededException")
+        finally:
+            table.delete()
+
+    @pytest.mark.only_localstack
+    def test_dynamodb_write_error_injection(self, monkeypatch):
+        table = self.get_dynamodb_table()
+
+        try:
+            # by default, no errors
+            test_no_errors = table.put_item(Item={PARTITION_KEY: short_uid(), "data": "foobar123"})
+            assert test_no_errors["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            # with a probability of 1, always throw errors
+            monkeypatch.setattr(config, "DYNAMODB_WRITE_ERROR_PROBABILITY", 1.0)
+            with pytest.raises(ClientError) as exc:
+                table.put_item(Item={PARTITION_KEY: short_uid(), "data": "foobar123"})
+            exc.match("ProvisionedThroughputExceededException")
+
+            # BatchWriteItem throws ProvisionedThroughputExceededException if ALL items in Batch are Throttled
+            with pytest.raises(ClientError) as exc:
+                with table.batch_writer() as batch:
+                    for _ in range(3):
+                        batch.put_item(
+                            Item={
+                                PARTITION_KEY: short_uid(),
+                                "data": "foobar123",
+                            }
+                        )
+            exc.match("ProvisionedThroughputExceededException")
+        finally:
+            table.delete()
 
     def get_dynamodb_table(self):
-        dynamodb = aws_stack.connect_to_resource("dynamodb")
-        # create table with stream forwarding config
-        aws_stack.create_dynamodb_table(TEST_TABLE_NAME, partition_key=PARTITION_KEY)
-        return dynamodb.Table(TEST_TABLE_NAME)
+        # set max_attempts=1 to speed up the test execution
+        dynamodb = aws_stack.connect_to_resource("dynamodb", config=self.retry_config())
+        table_name = f"table-{short_uid()}"
+        aws_stack.create_dynamodb_table(table_name, partition_key=PARTITION_KEY)
+        return dynamodb.Table(table_name)
+
+    def retry_config(self):
+        # set max_attempts=1 to speed up the test execution
+        return Config(retries={"max_attempts": 1})
 
     def assert_zero_probability_read_error_injection(self, table, partition_key):
         # by default, no errors
         test_no_errors = table.get_item(Key={PARTITION_KEY: partition_key})
         assert test_no_errors["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-    def test_dynamodb_error_injection(self):
-
-        table = self.get_dynamodb_table()
-
-        partition_key = short_uid()
-        self.assert_zero_probability_read_error_injection(table, partition_key)
-
-        # with a probability of 1, always throw errors
-        config.DYNAMODB_ERROR_PROBABILITY = 1.0
-        with self.assertRaises(ClientError):
-            table.get_item(Key={PARTITION_KEY: partition_key})
-
-        # reset probability to zero
-        config.DYNAMODB_ERROR_PROBABILITY = 0.0
-
-    def test_dynamodb_read_error_injection(self):
-        table = self.get_dynamodb_table()
-
-        partition_key = short_uid()
-        self.assert_zero_probability_read_error_injection(table, partition_key)
-
-        # with a probability of 1, always throw errors
-        config.DYNAMODB_READ_ERROR_PROBABILITY = 1.0
-        with self.assertRaises(ClientError):
-            table.get_item(Key={PARTITION_KEY: partition_key})
-
-        # reset probability to zero
-        config.DYNAMODB_READ_ERROR_PROBABILITY = 0.0
-
-    def test_dynamodb_write_error_injection(self):
-        table = self.get_dynamodb_table()
-
-        # by default, no errors
-        test_no_errors = table.put_item(Item={PARTITION_KEY: short_uid(), "data": "foobar123"})
-        self.assertEqual(200, test_no_errors["ResponseMetadata"]["HTTPStatusCode"])
-
-        # with a probability of 1, always throw errors
-        config.DYNAMODB_WRITE_ERROR_PROBABILITY = 1.0
-        with self.assertRaises(ClientError):
-            table.put_item(Item={PARTITION_KEY: short_uid(), "data": "foobar123"})
-
-        # BatchWriteItem throws ProvisionedThroughputExceededException if ALL items in Batch are Throttled
-        with self.assertRaises(ClientError):
-            table.batch_write_item(
-                RequestItems={
-                    table: [
-                        {
-                            "PutRequest": {
-                                "Item": {
-                                    PARTITION_KEY: short_uid(),
-                                    "data": "foobar123",
-                                }
-                            }
-                        }
-                    ]
-                }
-            )
-
-        # reset probability to zero
-        config.DYNAMODB_WRITE_ERROR_PROBABILITY = 0.0


### PR DESCRIPTION
* Fix DynamoDB error injection - return proper `ProvisionedThroughputExceededException` error message to the client, instead of a 500 error. This was an oversight in the DynamoDB ASF migration. Addresses #6056
This change also enables us to remove the custom `forward_request(..)` logic in the DynamoDB listener.

* Refactor and re-enable the error injection tests - they are now executed by default as part of the integration test suite. (disabling botocore retries ensures that the tests are executing fast)

* The PR also contains a tiny fix to avoid `AttributeError` in `describe_kinesis_streaming_destination(..)` - addresses #6031