### PR TITLE
Minor fixes in edge forwarder and zip utils for dev/host mode

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -945,7 +945,6 @@ def start_proxy_server(
     use_ssl=None,
     update_listener: Optional[Union[ProxyListener, List[ProxyListener]]] = None,
     quiet=False,
-    params=None,  # TODO: not being used - should be investigated/removed
     asynchronous=True,
     check_port=True,
     max_content_length: int = None,

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -175,10 +175,12 @@ class MotoServerProperties:
 
 
 def start_proxy_for_service(
-    service_name, port, backend_port, update_listener, quiet=False, params=None
+    service_name,
+    port,
+    backend_port,
+    update_listener,
+    quiet=False,
 ):
-    if params is None:
-        params = {}
     # TODO: remove special switch for Elasticsearch (see also note in service_port(...) in config.py)
     if config.FORWARD_EDGE_INMEM and service_name != "elasticsearch":
         if backend_port:
@@ -196,7 +198,6 @@ def start_proxy_for_service(
         backend_url=backend_url,
         update_listener=update_listener,
         quiet=quiet,
-        params=params,
     )
 
 
@@ -205,18 +206,15 @@ def start_proxy(
     backend_url: str = None,
     update_listener=None,
     quiet: bool = False,
-    params: Dict = None,
     use_ssl: bool = None,
 ):
     use_ssl = config.USE_SSL if use_ssl is None else use_ssl
-    params = {} if params is None else params
     proxy_thread = start_proxy_server(
         port=port,
         forward_url=backend_url,
         use_ssl=use_ssl,
         update_listener=update_listener,
         quiet=quiet,
-        params=params,
         check_port=False,
     )
     return proxy_thread

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -1,15 +1,17 @@
 import io
 import json
 import os
-import time
+import urllib
 
 import pytest
 import requests
 import xmltodict
+from quart import request as quart_request
 from requests.models import Request as RequestsRequest
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL, TEST_AWS_ACCOUNT_ID
+from localstack.http.request import get_raw_path
 from localstack.services.generic_proxy import (
     MessageModifyingProxyListener,
     ProxyListener,
@@ -143,18 +145,16 @@ class TestEdgeAPI:
         client.delete_object(Bucket=bucket_name, Key=object_name)
         client.delete_bucket(Bucket=bucket_name)
 
-    def test_http2_traffic(self):
-        port = get_free_tcp_port()
-
+    def test_basic_https_invocation(self):
         class MyListener(ProxyListener):
             def forward_request(self, method, path, data, headers):
                 return {"method": method, "path": path, "data": data}
 
-        url = "https://localhost:%s/foo/bar" % port
+        port = get_free_tcp_port()
+        url = f"https://localhost:{port}/foo/bar"
 
         listener = MyListener()
         proxy = start_proxy_server(port, update_listener=listener, use_ssl=True)
-        time.sleep(1)
         response = requests.post(url, verify=False)
         expected = {"method": "POST", "path": "/foo/bar", "data": ""}
         assert json.loads(to_str(response.content)) == expected
@@ -299,3 +299,24 @@ class TestEdgeAPI:
                 response = requests.get(f"{url}/2015-03-31/functions", headers=headers)
                 assert response
                 assert "Functions" in json.loads(to_str(response.content))
+
+    def test_forward_raw_path(self, monkeypatch):
+        class MyListener(ProxyListener):
+            def forward_request(self, method, path, data, headers):
+                return {"method": method, "path": get_raw_path(quart_request)}
+
+        # start listener and configure EDGE_FORWARD_URL
+        port = get_free_tcp_port()
+        forward_url = f"http://localhost:{port}"
+        listener = MyListener()
+        proxy = start_proxy_server(port, update_listener=listener, use_ssl=True)
+        monkeypatch.setattr(config, "EDGE_FORWARD_URL", forward_url)
+
+        # run test request, assert that raw request path is forwarded
+        test_arn = "arn:aws:test:resource/test"
+        raw_path = f"/test/{urllib.parse.quote(test_arn)}/bar"
+        url = f"{config.get_edge_url()}{raw_path}"
+        response = requests.get(url)
+        expected = {"method": "GET", "path": raw_path}
+        assert json.loads(to_str(response.content)) == expected
+        proxy.stop()

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -32,7 +32,6 @@ class TestProxyServer:
             backend_port,
             update_listener=None,
             quiet=True,
-            params={"protocol_version": "HTTP/1.0"},
         )
 
         assert server


### PR DESCRIPTION
Minor fixes for issues that surfaced during testing in local dev/host mode:
* When using the HTTPS forwarding server on port 443 (using `EDGE_FORWARD_URL`), we need to forward the requests using the raw path of the HTTP request (otherwise request parsing fails downstream, e.g., for URL-encoded ARNs passed in request paths). Issue can be replicated, e.g., with this command (after starting LS in Pro host mode): `awslocal kafka --endpoint-url https://localhost.localstack.cloud get-bootstrap-brokers --cluster-arn arn:aws:kafka:us-east-1:000000000000:cluster/test`. The existing `get_raw_path(..)` http utility comes in handy here. Added a small test for it as well. 

* Prefer using the native `unzip` command (if available) over the built-in Python ` zipfile` utils. Some versions of Node.js / Serverless are generating zip files with invalid/incorrect CRC codes (e.g., [here](https://github.com/archiverjs/node-archiver/issues/491)) - the files extract fine with `unzip` (potentially generating some warnings), but the unzipping fails with Python utils (empty files being created on disk). In future, we could think about introducing a `strict` mode for the `unzip` utils to enforce CRC codes, if needed.

The changes above should not impact the current logic inside the Docker container (only relevant for host mode).

Additionally, the PR contains a few minor cleanups:
* Remove the obsolete/unused `params` argument for the `start_proxy(..)` utility - resolves a `TODO: not being used` comment
* Remove a few instances of unnecessary `time.sleep(..)` calls in the tests