### PR TITLE
fix request encoding in generic proxy listener chain and forwarding

### DIFF
--- a/localstack/http/request.py
+++ b/localstack/http/request.py
@@ -177,3 +177,14 @@ def get_raw_path(request) -> str:
         return request.scope.get("raw_path", request.path).decode("utf-8")
 
     raise ValueError("cannot extract raw path from request object %s" % request)
+
+
+def get_full_raw_path(request) -> str:
+    """
+    Returns the full raw request path (with original URL encoding), including the query string.
+    This is _not_ equal to request.url, since there the path section would be url-encoded while the query part will be
+    (partly) url-decoded.
+    """
+    query_str = f"?{strings.to_str(request.query_string)}" if request.query_string else ""
+    raw_path = f"{get_raw_path(request)}{query_str}"
+    return raw_path

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -37,6 +37,7 @@ from localstack.constants import (
     HEADER_LOCALSTACK_AUTHORIZATION,
     HEADER_LOCALSTACK_REQUEST_URL,
 )
+from localstack.http.request import get_full_raw_path
 from localstack.services.messages import Headers, MessagePayload
 from localstack.services.messages import Request as RoutingRequest
 from localstack.services.messages import Response as RoutingResponse
@@ -964,7 +965,7 @@ def start_proxy_server(
 
     def handler(request, data):
         parsed_url = urlparse(request.url)
-        path_with_params = request.full_path.strip("?")
+        path_with_params = get_full_raw_path(request)
         method = request.method
         headers = request.headers
         headers[HEADER_LOCALSTACK_REQUEST_URL] = str(request.url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ from _pytest.config.argparsing import Parser
 
 os.environ["LOCALSTACK_INTERNAL_TEST_RUN"] = "1"
 
+pytest_plugins = [
+    "localstack.testing.pytest.fixtures",
+    "localstack.testing.pytest.snapshot",
+]
+
 
 @pytest.hookimpl
 def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,11 +31,6 @@ startup_monitor_event = mp.Event()  # event that can be triggered to start local
 # collection of functions that should be executed to initialize tests
 test_init_functions = set()
 
-pytest_plugins = [
-    "localstack.testing.pytest.fixtures",
-    "localstack.testing.pytest.snapshot",
-]
-
 
 @pytest.hookimpl()
 def pytest_configure(config):

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -174,15 +174,21 @@ class TestEdgeAPI:
 
         # Create a relay proxy which forwards request to the HTTP echo server
         port_relay_proxy = get_free_tcp_port()
-        forward_url = f"https://localhost:{port_http_server}/foo/bar%23baz"
+        forward_url = f"https://localhost:{port_http_server}"
         relay_proxy = start_proxy_server(port_relay_proxy, forward_url=forward_url, use_ssl=True)
 
         # Contact the relay proxy
-        url = f"https://localhost:{port_relay_proxy}/foo/bar%23baz"
+        query = "%2B=%3B%2C%2F%3F%3A%40%26%3D%2B%24%21%2A%27%28%29%23"
+        path = f"/foo/bar%3B%2C%2F%3F%3A%40%26%3D%2B%24%21%2A%27%28%29%23baz?{query}"
+        url = f"https://localhost:{port_relay_proxy}{path}"
         response = requests.post(url, verify=False)
 
         # Expect the response from the HTTP echo server
-        expected = {"method": "POST", "path": "/foo/bar%23baz", "data": ""}
+        expected = {
+            "method": "POST",
+            "path": path,
+            "data": "",
+        }
         assert json.loads(to_str(response.content)) == expected
 
         http_server.stop()

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -11,7 +11,7 @@ from requests.models import Request as RequestsRequest
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL, TEST_AWS_ACCOUNT_ID
-from localstack.services.edge import ProxyListenerEdge
+from localstack.http.request import get_full_raw_path
 from localstack.services.generic_proxy import (
     MessageModifyingProxyListener,
     ProxyListener,
@@ -160,6 +160,34 @@ class TestEdgeAPI:
         assert json.loads(to_str(response.content)) == expected
         proxy.stop()
 
+    def test_http2_relay_traffic(self):
+        """Tests if HTTP2 traffic can correctly be forwarded (including url-encoded characters)."""
+
+        # Create a simple HTTP echo server
+        class MyListener(ProxyListener):
+            def forward_request(self, method, path, data, headers):
+                return {"method": method, "path": path, "data": data}
+
+        listener = MyListener()
+        port_http_server = get_free_tcp_port()
+        http_server = start_proxy_server(port_http_server, update_listener=listener, use_ssl=True)
+
+        # Create a relay proxy which forwards request to the HTTP echo server
+        port_relay_proxy = get_free_tcp_port()
+        forward_url = f"https://localhost:{port_http_server}/foo/bar%23baz"
+        relay_proxy = start_proxy_server(port_relay_proxy, forward_url=forward_url, use_ssl=True)
+
+        # Contact the relay proxy
+        url = f"https://localhost:{port_relay_proxy}/foo/bar%23baz"
+        response = requests.post(url, verify=False)
+
+        # Expect the response from the HTTP echo server
+        expected = {"method": "POST", "path": "/foo/bar%23baz", "data": ""}
+        assert json.loads(to_str(response.content)) == expected
+
+        http_server.stop()
+        relay_proxy.stop()
+
     def test_invoke_sns_sqs_integration_using_edge_port(
         self, sqs_create_queue, sqs_client, sns_client, sns_create_topic, sns_subscription
     ):
@@ -303,7 +331,7 @@ class TestEdgeAPI:
     def test_forward_raw_path(self, monkeypatch):
         class MyListener(ProxyListener):
             def forward_request(self, method, path, data, headers):
-                _path = ProxyListenerEdge.get_full_raw_path(quart_request)
+                _path = get_full_raw_path(quart_request)
                 return {"method": method, "path": _path}
 
         # start listener and configure EDGE_FORWARD_URL


### PR DESCRIPTION
This PR fixes an issue initially addressed with https://github.com/localstack/localstack/pull/6059 (which was later closed in favor of https://github.com/localstack/localstack/pull/6065).
Unfortunately, https://github.com/localstack/localstack/pull/6065 does not fix the issue described in https://github.com/localstack/localstack/pull/6059.
This PR contains the following changes:
- It changes the path and query parameter handling for the handler chain such that the generic proxy uses the url-encoded path and query parameters within its proxy handler chain.
- It partly reverts https://github.com/localstack/localstack/pull/6065, since the proxy listener gets the encoded path and query parts now. /cc @whummer 
- Fixes a small issue with the pytest plugin config (moves pytest plugins to the root conftest, since it's not allowed anywhere else anymore).

The special handling with `get_full_raw_path` was necessary due to a specific peculiarity in Werkzeug's url property handling.
Here's a short scratch to illustrate the issue:
```
from werkzeug.sansio.utils import get_current_url

# Werkzeug (and with that the Quart request wrapper) internally uses get_current_url on request.url:
# > werkzeug.sansio.Request#L212:
# @cached_property
# def url(self) -> str:
#     """The full request URL with the scheme, host, root path, path,
#     and query string."""
#     return get_current_url(
#         self.scheme, self.host, self.root_path, self.path, self.query_string
#     )

# get_current_url is weird, because it _encodes_ the path segment, while it _decodes_ (some) characters in the query segment
url = get_current_url(scheme="https", root_path="root", path="pa#th", host="host", query_string=b"query-string%2Basdf")
print(url)
assert url == "https://hostroot/pa%23th?query-string+asdf" # <- mind the encoded # (%23) and the decoded %2B (+)!
```