### PR TITLE
Minor fix for CFn deletion of IAM::Role resources

### DIFF
--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -274,21 +274,22 @@ class IAMRole(GenericBaseModel):
         props = resource["Properties"]
         role_name = props["RoleName"]
 
-        # TODO: this should probably only remove the policies that are specified in the stack (verify with AWS)
-        # detach managed policies
-        for policy in iam_client.list_attached_role_policies(RoleName=role_name).get(
-            "AttachedPolicies", []
-        ):
-            iam_client.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])
-        # delete inline policies
-        for inline_policy_name in iam_client.list_role_policies(RoleName=role_name).get(
-            "PolicyNames", []
-        ):
-            iam_client.delete_role_policy(RoleName=role_name, PolicyName=inline_policy_name)
-
-        # TODO: potentially remove this when stack resource deletion order is fixed (check AWS behavior first)
-        # cleanup instance profile
         try:
+            # TODO: this should probably only remove the policies that are specified in the stack (verify with AWS)
+            # detach managed policies
+            for policy in iam_client.list_attached_role_policies(RoleName=role_name).get(
+                "AttachedPolicies", []
+            ):
+                iam_client.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])
+
+            # delete inline policies
+            for inline_policy_name in iam_client.list_role_policies(RoleName=role_name).get(
+                "PolicyNames", []
+            ):
+                iam_client.delete_role_policy(RoleName=role_name, PolicyName=inline_policy_name)
+
+            # TODO: potentially remove this when stack resource deletion order is fixed (check AWS behavior first)
+            # cleanup instance profile
             rs = iam_client.list_instance_profiles_for_role(RoleName=role_name)
             for instance_profile in rs["InstanceProfiles"]:
                 ip_name = instance_profile["InstanceProfileName"]

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -15,6 +15,7 @@ from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.services.iam.provider import SERVICE_LINKED_ROLE_PATH_PREFIX
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import ensure_list
+from localstack.utils.functions import call_safe
 
 LOG = logging.getLogger(__name__)
 
@@ -280,21 +281,28 @@ class IAMRole(GenericBaseModel):
             for policy in iam_client.list_attached_role_policies(RoleName=role_name).get(
                 "AttachedPolicies", []
             ):
-                iam_client.detach_role_policy(RoleName=role_name, PolicyArn=policy["PolicyArn"])
+                call_safe(
+                    iam_client.detach_role_policy,
+                    kwargs={"RoleName": role_name, "PolicyArn": policy["PolicyArn"]},
+                )
 
             # delete inline policies
             for inline_policy_name in iam_client.list_role_policies(RoleName=role_name).get(
                 "PolicyNames", []
             ):
-                iam_client.delete_role_policy(RoleName=role_name, PolicyName=inline_policy_name)
+                call_safe(
+                    iam_client.delete_role_policy,
+                    kwargs={"RoleName": role_name, "PolicyName": inline_policy_name},
+                )
 
             # TODO: potentially remove this when stack resource deletion order is fixed (check AWS behavior first)
             # cleanup instance profile
             rs = iam_client.list_instance_profiles_for_role(RoleName=role_name)
             for instance_profile in rs["InstanceProfiles"]:
                 ip_name = instance_profile["InstanceProfileName"]
-                iam_client.remove_role_from_instance_profile(
-                    InstanceProfileName=ip_name, RoleName=role_name
+                call_safe(
+                    iam_client.remove_role_from_instance_profile,
+                    kwargs={"InstanceProfileName": ip_name, "RoleName": role_name},
                 )
         except Exception as e:
             if "NoSuchEntity" not in str(e):


### PR DESCRIPTION
Minor fix for CFn deletion of `IAM::Role` resources.

Should fix the following issue that can happen on stack teardown:
```
   File "/opt/code/localstack/localstack/utils/cloudformation/template_deployer.py", line 880, in execute_resource_action
     result = func["function"](resource_id, resources, resource_type, func, stack_name)
   File "/opt/code/localstack/localstack/services/cloudformation/models/iam.py", line 279, in _pre_delete
     for policy in iam_client.list_attached_role_policies(RoleName=role_name).get(
   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 508, in _api_call
     return self._make_api_call(operation_name, kwargs)
   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 911, in _make_api_call
     raise error_class(parsed_response, operation_name)
 botocore.errorfactory.NoSuchEntityException: An error occurred (NoSuchEntity) when calling the ListAttachedRolePolicies operation: Role stack-a216383c-DynamoDBRole-b678a24f not found
```

Should be safe to wrap the three calls with try/except, as if one of them fails with `NoSuchEntity`, this would indicate that the role no longer exists and likely the other calls would fail with the same error as well.

Fixes the symptom we're seeing - lmk if you have some ideas on how to add a test for this @dominikschubert . Overall, some of this logic may be revisited/removed once we have proper stack deletion order in place (as indicated in the existing comment).