### PR TITLE
fix ARN rewriting for DynamoDB ASF provider

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -285,13 +285,14 @@ class DynamoDBApiListener(AwsApiListener):
 
     def return_response(self, method, path, data, headers, response):
         if response._content:
+            response_content = to_str(response._content)
             # fix the table and latest stream ARNs (DynamoDBLocal hardcodes "ddblocal" as the region)
             content_replaced = re.sub(
-                r'("TableArn"|"LatestStreamArn"|"StreamArn")\s*:\s*"arn:aws:dynamodb:ddblocal:([^"]+)"',
-                rf'\1: "arn:aws:dynamodb:{aws_stack.get_region()}:\2"',
-                to_str(response._content),
+                r'("TableArn"|"LatestStreamArn"|"StreamArn")\s*:\s*"arn:([a-z-]+):dynamodb:ddblocal:([^"]+)"',
+                rf'\1: "arn:\2:dynamodb:{aws_stack.get_region()}:\3"',
+                response_content,
             )
-            if content_replaced != response._content:
+            if content_replaced != response_content:
                 response._content = content_replaced
 
         # set x-amz-crc32 headers required by some client

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from typing import Optional
 
 import pytest
 
@@ -8,7 +9,7 @@ def switch_region():
     """A fixture which allows to easily switch the region in the config within a `with` context."""
 
     @contextmanager
-    def _switch_region(region: str):
+    def _switch_region(region: Optional[str]):
         from localstack import config
 
         previous_region = config.DEFAULT_REGION

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -125,24 +125,27 @@ def test_arn_partition_rewriting_in_response(encoding):
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
-def test_arn_partition_rewriting_in_response_without_region_and_without_default_region(encoding):
-    listener = ArnPartitionRewriteListener()
-    response = Response()
-    response._content = encoding(
-        json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
-    )
-    response._status_code = 200
-    response.headers = {"some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"}
+def test_arn_partition_rewriting_in_response_without_region_and_without_default_region(
+    encoding, switch_region
+):
+    with switch_region(None):
+        listener = ArnPartitionRewriteListener()
+        response = Response()
+        response._content = encoding(
+            json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
+        )
+        response._status_code = 200
+        response.headers = {"some-header-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInHeader"}
 
-    result = listener.return_response(
-        method="POST", path="/", data="ignored", headers={}, response=response
-    )
+        result = listener.return_response(
+            method="POST", path="/", data="ignored", headers={}, response=response
+        )
 
-    assert result.status_code == response.status_code
-    assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
-    assert result.content == encoding(
-        json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
-    )
+        assert result.status_code == response.status_code
+        assert result.headers == {"some-header-with-arn": "arn:aws:iam::123456789012:ArnInHeader"}
+        assert result.content == encoding(
+            json.dumps({"some-data-with-arn": "arn:aws:iam::123456789012:ArnInData"})
+        )
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])


### PR DESCRIPTION
This PR contains the following changes:
- Adjusts the `ArnPartitionRewriteListener` such that it updates potential `Content-Length` and CRC checksum headers.
- Slightly adjusts the DynamoDB ARN rewriting such that it is partition-agnostic.
- Hardens the `ArnPartitionRewriteListener` unit test such that it explicitly sets the default region to `None` (which otherwise could cause issues if the test is executed in an environment where the default region is set).