### PR TITLE
fix ARN rewriting for incoming requests, fix lambda arn creation

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -239,9 +239,6 @@ class ArnPartitionRewriteListener(MessageModifyingProxyListener):
     def forward_request(
         self, method: str, path: str, data: MessagePayload, headers: Headers
     ) -> Optional[RoutingRequest]:
-        # Only handle requests for calls from external clients
-        if is_internal_call_context(headers):
-            return None
         return RoutingRequest(
             method=method,
             path=self._adjust_partition_in_path(path, self.DEFAULT_INBOUND_PARTITION),

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -708,7 +708,7 @@ def lambda_function_or_layer_arn(
 
     account_id = get_account_id(account_id)
     region_name = region_name or get_region()
-    result = f"arn:aws:lambda:{region_name}:{account_id}:function:{entity_name}"
+    result = f"arn:aws:lambda:{region_name}:{account_id}:{type}:{entity_name}"
     if version:
         result = f"{result}:{version}"
     return result

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -691,7 +691,7 @@ def lambda_layer_arn(layer_name, version=None, account_id=None):
 def lambda_function_or_layer_arn(
     type, entity_name, version=None, account_id=None, region_name=None
 ):
-    pattern = "arn:aws:lambda:.*:.*:(function|layer):.*"
+    pattern = "arn:([a-z-]+):lambda:.*:.*:(function|layer):.*"
     if re.match(pattern, entity_name):
         return entity_name
     if ":" in entity_name:
@@ -702,16 +702,15 @@ def lambda_function_or_layer_arn(
             version = alias_response["FunctionVersion"]
 
         except Exception as e:
-            msg = "Alias %s of %s not found" % (alias, entity_name)
+            msg = f"Alias {alias} of {entity_name} not found"
             LOG.info(f"{msg}: {e}")
             raise Exception(msg)
 
     account_id = get_account_id(account_id)
     region_name = region_name or get_region()
-    pattern = re.sub(r"\([^\|]+\|.+\)", type, pattern)
-    result = pattern.replace(".*", "%s") % (region_name, account_id, entity_name)
+    result = f"arn:aws:lambda:{region_name}:{account_id}:function:{entity_name}"
     if version:
-        result = "%s:%s" % (result, version)
+        result = f"{result}:{version}"
     return result
 
 

--- a/tests/unit/test_generic_proxy.py
+++ b/tests/unit/test_generic_proxy.py
@@ -3,7 +3,9 @@ import json
 import pytest
 from requests.models import Response
 
+from localstack.constants import INTERNAL_AWS_ACCESS_KEY_ID
 from localstack.services.generic_proxy import ArnPartitionRewriteListener
+from localstack.utils.aws.aws_stack import mock_aws_request_headers
 from localstack.utils.common import to_bytes, to_str
 
 # Define the callables used to convert the payload to the appropriate encoding for the tests
@@ -28,9 +30,10 @@ def test_no_arn_partition_rewriting_in_request(encoding):
     assert result.headers == {"some-header-without-arn": "nothing to see here"}
 
 
+@pytest.mark.parametrize("internal_call", [True, False])
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
 @pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
-def test_arn_partition_rewriting_in_request(encoding, origin_partition):
+def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_partition):
     listener = ArnPartitionRewriteListener()
     data = encoding(
         json.dumps(
@@ -39,9 +42,20 @@ def test_arn_partition_rewriting_in_request(encoding, origin_partition):
             }
         )
     )
-    headers = {
-        "some-header-with-arn": f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
-    }
+
+    # if this test is parameterized to be an internal call, set the internal auth
+    # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
+    if internal_call:
+        headers = mock_aws_request_headers(
+            region_name=origin_partition, access_key=INTERNAL_AWS_ACCESS_KEY_ID
+        )
+    else:
+        headers = {}
+
+    headers[
+        "some-header-with-arn"
+    ] = f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+
     result = listener.forward_request(
         method="POST",
         path=f"/?arn=arn%3A{origin_partition}%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path%2F%2A&"
@@ -60,9 +74,10 @@ def test_arn_partition_rewriting_in_request(encoding, origin_partition):
             {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
         )
     )
-    assert result.headers == {
-        "some-header-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
-    }
+    assert (
+        result.headers["some-header-with-arn"]
+        == "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    )
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
@@ -122,6 +137,32 @@ def test_arn_partition_rewriting_in_response(encoding):
             }
         )
     )
+
+
+def test_no_arn_partition_rewriting_in_internal_response():
+    """Partitions should not be rewritten for _responses_ of _internal_ requests."""
+    listener = ArnPartitionRewriteListener()
+    response = Response()
+    body_content = json.dumps(
+        {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+    )
+    response._content = body_content
+    response._status_code = 200
+    response_header_content = {
+        "some-header-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+    }
+    response.headers = response_header_content
+
+    # mimic an internal request
+    request_headers = mock_aws_request_headers(
+        region_name="us-gov-west-1", access_key=INTERNAL_AWS_ACCESS_KEY_ID
+    )
+
+    result = listener.return_response(
+        method="POST", path="/", data="ignored", headers=request_headers, response=response
+    )
+
+    assert result is None
 
 
 @pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])


### PR DESCRIPTION
This PR contains the following changes:
- Fix the ARN partition rewriting for incoming requests (https://github.com/localstack/localstack/pull/6075 excluded the incoming internal requests from being rewritten - which cased a regression).
- Cleanup of `lambda_function_or_layer_arn` and making it partition-agnostic.