### PR TITLE
fix test_get_queue_url_contains_request_host for pro integration

### DIFF
--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -71,7 +71,7 @@ class TestSqsProvider:
         queue_url = sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
         account_id = constants.TEST_AWS_ACCOUNT_ID
 
-        host = f"http://localhost:{config.EDGE_PORT}"
+        host = config.get_edge_url()
         # our current queue pattern looks like this, but may change going forward, or may be configurable
         assert queue_url == f"{host}/{account_id}/{queue_name}"
 


### PR DESCRIPTION
Previously the pro tests would raise an error here because it would not be using the correct port.

```
>       assert queue_url == f"{host}/{account_id}/{queue_name}"
E       AssertionError: assert 'http://local...ueue-aa52fd71' == 'http://local...ueue-aa52fd71'
E         - http://localhost:443/000000000000/test-queue-aa52fd71
E         ?                   ^^
E         + http://localhost:4566/000000000000/test-queue-aa52fd71
E         ?                   ^^^
```