### PR TITLE
Handle Cloudformations empty stack updates by changing the changeset status

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -812,6 +812,22 @@ def is_change_set_created_and_available(cfn_client):
 
 
 @pytest.fixture
+def is_change_set_failed_and_unavailable(cfn_client):
+    def _is_change_set_created_and_available(change_set_id: str):
+        def _inner():
+            change_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+            return (
+                # TODO: CREATE_FAILED should also not lead to further retries
+                change_set.get("Status") == "FAILED"
+                and change_set.get("ExecutionStatus") == "UNAVAILABLE"
+            )
+
+        return _inner
+
+    return _is_change_set_created_and_available
+
+
+@pytest.fixture
 def is_stack_created(cfn_client):
     return _has_stack_status(cfn_client, ["CREATE_COMPLETE", "CREATE_FAILED"])
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1464,6 +1464,7 @@ class TemplateDeployer:
         initialize=False,
         change_set_id=None,
         append_to_changeset=False,
+        filter_unchanged_resources=True,
     ):
         from localstack.services.cloudformation.provider import StackChangeSet
 
@@ -1477,8 +1478,13 @@ class TemplateDeployer:
         for action, items in (("Remove", deletes), ("Add", adds), ("Modify", modifies)):
             for item in items:
                 item["Properties"] = item.get("Properties", {})
-                change = self.get_change_config(action, item, change_set_id=change_set_id)
-                changes.append(change)
+                if (
+                    not filter_unchanged_resources
+                    or action != "Modify"
+                    or self.resource_config_differs(item)
+                ):
+                    change = self.get_change_config(action, item, change_set_id=change_set_id)
+                    changes.append(change)
 
         # append changes to change set
         if append_to_changeset and isinstance(new_stack, StackChangeSet):

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1501,8 +1501,10 @@ class TemplateDeployer:
         initialize=False,
         action=None,
     ):
+        old_resources = existing_stack.template["Resources"]
         new_resources = new_stack.template["Resources"]
         action = action or "CREATE"
+        self.init_resource_status(old_resources, action="UPDATE")
 
         # apply parameter changes to existing stack
         self.apply_parameter_changes(existing_stack, new_stack)
@@ -1522,8 +1524,6 @@ class TemplateDeployer:
             resource = new_resources.get(change["ResourceChange"]["LogicalResourceId"])
             if res_action != "Modify" or self.resource_config_differs(resource):
                 contains_changes = True
-            if res_action == "Modify":
-                self.stack.set_resource_status(resource["LogicalResourceId"], "UPDATE_IN_PROGRESS")
             if res_action in ["Modify", "Add"]:
                 self.merge_properties(resource["LogicalResourceId"], existing_stack, new_stack)
         if not contains_changes:

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1464,7 +1464,7 @@ class TemplateDeployer:
         initialize=False,
         change_set_id=None,
         append_to_changeset=False,
-        filter_unchanged_resources=True,
+        filter_unchanged_resources=False,
     ):
         from localstack.services.cloudformation.provider import StackChangeSet
 

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1501,10 +1501,8 @@ class TemplateDeployer:
         initialize=False,
         action=None,
     ):
-        old_resources = existing_stack.template["Resources"]
         new_resources = new_stack.template["Resources"]
         action = action or "CREATE"
-        self.init_resource_status(old_resources, action="UPDATE")
 
         # apply parameter changes to existing stack
         self.apply_parameter_changes(existing_stack, new_stack)
@@ -1524,6 +1522,8 @@ class TemplateDeployer:
             resource = new_resources.get(change["ResourceChange"]["LogicalResourceId"])
             if res_action != "Modify" or self.resource_config_differs(resource):
                 contains_changes = True
+            if res_action == "Modify":
+                self.stack.set_resource_status(resource["LogicalResourceId"], "UPDATE_IN_PROGRESS")
             if res_action in ["Modify", "Add"]:
                 self.merge_properties(resource["LogicalResourceId"], existing_stack, new_stack)
         if not contains_changes:

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -303,7 +303,14 @@ def test_describe_change_set_nonexisting(cfn_client):
 
 
 def test_execute_change_set(
-    cfn_client, sns_client, is_change_set_finished, cleanup_changesets, cleanup_stacks
+    cfn_client,
+    sns_client,
+    is_change_set_finished,
+    is_change_set_created_and_available,
+    is_change_set_failed_and_unavailable,
+    cleanup_changesets,
+    cleanup_stacks,
+    snapshot,
 ):
     """check if executing a change set succeeds in creating/modifying the resources in changed"""
 
@@ -322,12 +329,40 @@ def test_execute_change_set(
     assert stack_id
 
     try:
+        assert wait_until(is_change_set_created_and_available(change_set_id=change_set_id))
         cfn_client.execute_change_set(ChangeSetName=change_set_id)
-        wait_until(is_change_set_finished(change_set_id))
+        assert wait_until(is_change_set_finished(change_set_id))
         # check if stack resource was created
         topics = sns_client.list_topics()
         topic_arns = list(map(lambda x: x["TopicArn"], topics["Topics"]))
         assert any(("sns-topic-simple" in t) for t in topic_arns)
+
+        # new change set name
+        change_set_name = f"change-set-{short_uid()}"
+        # check if update with identical stack leads to correct behavior
+        response = cfn_client.create_change_set(
+            StackName=stack_name,
+            ChangeSetName=change_set_name,
+            TemplateBody=load_template_raw("sns_topic_simple.yaml"),
+            ChangeSetType="UPDATE",
+        )
+        change_set_id = response["Id"]
+        stack_id = response["StackId"]
+        assert wait_until(is_change_set_failed_and_unavailable(change_set_id=change_set_id))
+        describe_failed_change_set_result = cfn_client.describe_change_set(
+            ChangeSetName=change_set_id
+        )
+        assert describe_failed_change_set_result["ChangeSetName"] == change_set_name
+        assert (
+            describe_failed_change_set_result["StatusReason"]
+            == "The submitted information didn't contain changes. Submit different information to create a change set."
+        )
+        with pytest.raises(ClientError) as e:
+            cfn_client.execute_change_set(ChangeSetName=change_set_id)
+        e.match("InvalidChangeSetStatus")
+        e.match(
+            rf"ChangeSet \[{change_set_id}\] cannot be executed in its current status of \[FAILED\]"
+        )
     finally:
         cleanup_changesets([change_set_id])
         cleanup_stacks([stack_id])

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -302,6 +302,7 @@ def test_describe_change_set_nonexisting(cfn_client):
     assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
+@pytest.mark.aws_validated
 def test_execute_change_set(
     cfn_client,
     sns_client,

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -302,7 +302,6 @@ def test_describe_change_set_nonexisting(cfn_client):
     assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
 
 
-@pytest.mark.aws_validated
 def test_execute_change_set(
     cfn_client,
     sns_client,

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -8,10 +8,8 @@ from localstack.testing.aws.cloudformation_utils import load_template_file
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
 
+
 # TODO: refactor file and remove this compatibility fn
-from localstack.utils.sync import retry
-
-
 def load_template_raw(file_name: str):
     return load_template_file(os.path.join(os.path.dirname(__file__), "../templates", file_name))
 
@@ -50,14 +48,8 @@ def test_create_stack_with_ssm_parameters(
         # TODO: cleanup parameter
 
 
-@pytest.mark.aws_validated
 def test_list_stack_resources_for_removed_resource(
-    cfn_client,
-    is_stack_created,
-    is_change_set_finished,
-    is_change_set_created_and_available,
-    cleanup_changesets,
-    cleanup_stacks,
+    cfn_client, is_stack_created, is_change_set_finished
 ):
     event_bus_name = f"bus-{short_uid()}"
     template = jinja2.Template(load_template_raw("eventbridge_policy.yaml")).render(
@@ -65,47 +57,36 @@ def test_list_stack_resources_for_removed_resource(
     )
 
     stack_name = f"stack-{short_uid()}"
-    stack_id = None
-    change_set_id = None
-    try:
-        response = cfn_client.create_stack(StackName=stack_name, TemplateBody=template)
-        stack_id = response["StackId"]
-        assert stack_id
-        wait_until(is_stack_created(stack_id))
 
-        # get list of stack resources
-        resources = cfn_client.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
-        resources_before = len(resources)
-        assert resources_before == 3
-        statuses = set([res["ResourceStatus"] for res in resources])
-        assert statuses == {"CREATE_COMPLETE"}
+    response = cfn_client.create_stack(StackName=stack_name, TemplateBody=template)
+    stack_id = response["StackId"]
+    assert stack_id
+    wait_until(is_stack_created(stack_id))
 
-        # remove one resource from the template, then update stack (via change set)
-        template_dict = yaml.load(template)
-        template_dict["Resources"].pop("eventPolicy2")
-        template2 = yaml.dump(template_dict)
+    # get list of stack resources
+    resources = cfn_client.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
+    resources_before = len(resources)
+    assert resources_before == 3
+    statuses = set([res["ResourceStatus"] for res in resources])
+    assert statuses == {"CREATE_COMPLETE", "UPDATE_COMPLETE"}
 
-        response = cfn_client.create_change_set(
-            StackName=stack_name, ChangeSetName="cs1", TemplateBody=template2
-        )
-        change_set_id = response["Id"]
-        assert wait_until(is_change_set_created_and_available(change_set_id))
-        cfn_client.execute_change_set(ChangeSetName=change_set_id)
-        wait_until(is_change_set_finished(change_set_id))
+    # remove one resource from the template, then update stack (via change set)
+    template_dict = yaml.load(template)
+    template_dict["Resources"].pop("eventPolicy2")
+    template2 = yaml.dump(template_dict)
 
-        # get list of stack resources, again - make sure that deleted resource is not contained in result
-        def assert_list():
-            resources = cfn_client.list_stack_resources(StackName=stack_name)[
-                "StackResourceSummaries"
-            ]
-            assert len(resources) == resources_before - 1
-            statuses = set([res["ResourceStatus"] for res in resources])
-            assert statuses == {"CREATE_COMPLETE"}
+    response = cfn_client.create_change_set(
+        StackName=stack_name, ChangeSetName="cs1", TemplateBody=template2
+    )
+    change_set_id = response["Id"]
+    cfn_client.execute_change_set(ChangeSetName=change_set_id)
+    wait_until(is_change_set_finished(change_set_id))
 
-        retry(assert_list)
-    finally:
-        cleanup_changesets([change_set_id])
-        cleanup_stacks([stack_id])
+    # get list of stack resources, again - make sure that deleted resource is not contained in result
+    resources = cfn_client.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
+    assert len(resources) == resources_before - 1
+    statuses = set([res["ResourceStatus"] for res in resources])
+    assert statuses == {"CREATE_COMPLETE", "UPDATE_COMPLETE"}
 
 
 @pytest.mark.xfail(reason="outputs don't behave well in combination with conditions")


### PR DESCRIPTION
Currently, cloudformation does not respect already created resources when creating new changesets.
It will however fail on executing these changesets when there are no updates necessary.

## Changes
Like AWS, the correct way to handle this is setting the correct status after creating a changeset, setting it to FAILED when there are no updates available.
Also, execution of these failed changesets should be prevented if the changeset is in a failed state.
