### PR TITLE
add initial support for streaming in ASF scaffold and serializer

### DIFF
--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -94,6 +94,11 @@ class ShapeNode:
         return metadata.get("error") or metadata.get("exception")
 
     @property
+    def is_eventstream(self):
+        metadata = self.shape.metadata
+        return metadata.get("eventstream")
+
+    @property
     def is_primitive(self):
         return self.shape.type_name in ["integer", "boolean", "float", "double", "string"]
 
@@ -143,9 +148,15 @@ class ShapeNode:
 
         for k, v in self.shape.members.items():
             if k in self.shape.required_members:
-                output.write(f"    {k}: {q}{to_valid_python_name(v.name)}{q}\n")
+                if v.serialization.get("eventstream"):
+                    output.write(f"    {k}: Iterator[{q}{to_valid_python_name(v.name)}{q}]\n")
+                else:
+                    output.write(f"    {k}: {q}{to_valid_python_name(v.name)}{q}\n")
             else:
-                output.write(f"    {k}: Optional[{q}{to_valid_python_name(v.name)}{q}]\n")
+                if v.serialization.get("eventstream"):
+                    output.write(f"    {k}: Iterator[{q}{to_valid_python_name(v.name)}{q}]\n")
+                else:
+                    output.write(f"    {k}: Optional[{q}{to_valid_python_name(v.name)}{q}]\n")
 
     def _print_as_typed_dict(self, output, doc=True, quote_types=False):
         name = to_valid_python_name(self.shape.name)
@@ -153,9 +164,15 @@ class ShapeNode:
         output.write('%s = TypedDict("%s", {\n' % (name, name))
         for k, v in self.shape.members.items():
             if k in self.shape.required_members:
-                output.write(f'    "{k}": {q}{to_valid_python_name(v.name)}{q},\n')
+                if v.is_eventstream():
+                    output.write(f'    "{k}": Iterator[{q}{to_valid_python_name(v.name)}{q}],\n')
+                else:
+                    output.write(f'    "{k}": {q}{to_valid_python_name(v.name)}{q},\n')
             else:
-                output.write(f'    "{k}": Optional[{q}{to_valid_python_name(v.name)}{q}],\n')
+                if v.is_eventstream():
+                    output.write(f'    "{k}": Iterator[{q}{to_valid_python_name(v.name)}{q}],\n')
+                else:
+                    output.write(f'    "{k}": Optional[{q}{to_valid_python_name(v.name)}{q}],\n')
         output.write("}, total=False)")
 
     def print_shape_doc(self, output, shape):
@@ -234,7 +251,7 @@ class ShapeNode:
 
 def generate_service_types(output, service: ServiceModel, doc=True):
     output.write("import sys\n")
-    output.write("from typing import Dict, List, Optional\n")
+    output.write("from typing import Dict, List, Optional, Iterator\n")
     output.write("from datetime import datetime\n")
     output.write("if sys.version_info >= (3, 8):\n")
     output.write("    from typing import TypedDict\n")

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -94,11 +94,6 @@ class ShapeNode:
         return metadata.get("error") or metadata.get("exception")
 
     @property
-    def is_eventstream(self):
-        metadata = self.shape.metadata
-        return metadata.get("eventstream")
-
-    @property
     def is_primitive(self):
         return self.shape.type_name in ["integer", "boolean", "float", "double", "string"]
 
@@ -164,12 +159,12 @@ class ShapeNode:
         output.write('%s = TypedDict("%s", {\n' % (name, name))
         for k, v in self.shape.members.items():
             if k in self.shape.required_members:
-                if v.is_eventstream():
+                if v.serialization.get("eventstream"):
                     output.write(f'    "{k}": Iterator[{q}{to_valid_python_name(v.name)}{q}],\n')
                 else:
                     output.write(f'    "{k}": {q}{to_valid_python_name(v.name)}{q},\n')
             else:
-                if v.is_eventstream():
+                if v.serialization.get("eventstream"):
                     output.write(f'    "{k}": Iterator[{q}{to_valid_python_name(v.name)}{q}],\n')
                 else:
                     output.write(f'    "{k}": Optional[{q}{to_valid_python_name(v.name)}{q}],\n')

--- a/localstack/http/adapters.py
+++ b/localstack/http/adapters.py
@@ -53,6 +53,9 @@ class ProxyListenerAdapter(ProxyListener):
         return self.to_proxy_response(response)
 
     def to_proxy_response(self, response: Response):
+        if response.is_streamed:
+            return response.response, response.headers
+
         resp = _RequestsResponse()
         resp._content = response.get_data()
         resp.status_code = response.status_code

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -34,8 +34,6 @@ from localstack.utils.strings import (
 
 REGEX_FLAGS = re.MULTILINE | re.DOTALL
 
-AWS_BINARY_DATA_TYPE_STRING = 7
-
 
 class ErrorResponse(Exception):
     def __init__(self, response):
@@ -404,7 +402,13 @@ def calculate_crc32(content):
     return crc32(to_bytes(content)) & 0xFFFFFFFF
 
 
+# TODO Remove this constant with the function below
+AWS_BINARY_DATA_TYPE_STRING = 7
+
+
 def convert_to_binary_event_payload(result, event_type=None, message_type=None):
+    # TODO This encoding has been migrated to the ASF Serializer.
+    #  Remove this function after S3 and Kinesis have been migrated to ASF.
     # e.g.: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html
     # e.g.: https://docs.aws.amazon.com/transcribe/latest/dg/event-stream.html
 
@@ -425,7 +429,10 @@ def convert_to_binary_event_payload(result, event_type=None, message_type=None):
         headers += header_value
 
     # construct body
-    body = bytes(result, DEFAULT_ENCODING)
+    if isinstance(result, str):
+        body = bytes(result, DEFAULT_ENCODING)
+    else:
+        body = result
 
     # calculate lengths
     headers_length = len(headers)

--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -8,7 +8,8 @@ from localstack.aws.scaffold import generate
 
 @pytest.mark.skip_offline
 @pytest.mark.parametrize(
-    "service", ["apigateway", "autoscaling", "cloudformation", "kafka", "dynamodb", "sqs"]
+    "service",
+    ["apigateway", "autoscaling", "cloudformation", "kafka", "dynamodb", "sqs", "kinesis"],
 )
 def test_generated_code_compiles(service):
     runner = CliRunner()


### PR DESCRIPTION
This PR adds initial support for event streaming to the ASF scaffold (for the generated APIs) as well as the serializer based on the HTTP1.1 feature of chunked `Transfer-Encoding`.
The scaffold generates `TypedDicts` with the event member of type `Iterator[<MemberShape>]`.
The serializer in turn serializes these events such that a generator is returned in the serialized `Response`.

This allows fully-typed service implementations for the streaming responses where all the encoding is done transparently in the serializer. Here's a dummy implementation of Kinesis' SubscribeToShard operation using the features introduced in this PR:
```
class KinesisProvider(KinesisApi):
    def subscribe_to_shard(
        self,
        context: RequestContext,
        consumer_arn: ConsumerARN,
        shard_id: ShardId,
        starting_position: StartingPosition,
    ) -> SubscribeToShardOutput:
        def event_generator() -> Iterator[SubscribeToShardEventStream]:
            event = SubscribeToShardEvent(
                Records=[
                    Record(
                        SequenceNumber="1",
                        Data=b"record 1 binary data",
                        PartitionKey="record_1_partition_key",
                    ),
                ],
                ContinuationSequenceNumber="1",
                MillisBehindLatest=1338,
            )
            yield SubscribeToShardEventStream(SubscribeToShardEvent=event)
            event = SubscribeToShardEvent(
                Records=[
                    Record(
                        SequenceNumber="2",
                        Data=b"record 2 binary data",
                        PartitionKey="record_2_partition_key",
                    )
                ],
                ContinuationSequenceNumber="1",
                MillisBehindLatest=1338,
            )
            yield SubscribeToShardEventStream(SubscribeToShardEvent=event)

        return SubscribeToShardOutput(EventStream=event_generator())
```


The support is a bit rudimentary for now, since in current implementations we only use the very basic "happy path" for the event streams. Therefore the error serialization is not yet fully implemented.

This PR is a prerequisite for the upcoming ASF migration of Kinesis (/cc @baermat) as well as of S3.