### PR TITLE
Fix CLI usage with python 3.7

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -3,19 +3,14 @@ dicts, list, sets). """
 
 import logging
 import re
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sized,
-    Tuple,
-    Type,
-    TypedDict,
-    TypeVar,
-    Union,
-)
+import sys
+from typing import Any, Callable, Dict, List, Optional, Sized, Tuple, Type, TypeVar, Union
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/utils/container_networking.py
+++ b/localstack/utils/container_networking.py
@@ -10,7 +10,7 @@ from localstack.utils.docker_utils import DOCKER_CLIENT
 LOG = logging.getLogger(__name__)
 
 
-@lru_cache
+@lru_cache()
 def get_main_container_network() -> Optional[str]:
     """
     Gets the main network of the LocalStack container (if we run in one, bridge otherwise)
@@ -32,7 +32,7 @@ def get_main_container_network() -> Optional[str]:
     return main_container_network
 
 
-@lru_cache
+@lru_cache()
 def get_endpoint_for_network(network: Optional[str] = None) -> str:
     """
     Get the LocalStack endpoint (= IP address) on the given network.
@@ -90,7 +90,7 @@ def get_main_container_id():
         return None
 
 
-@lru_cache
+@lru_cache()
 def get_main_container_name():
     """
     Returns the container name of the LocalStack container

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -5,12 +5,18 @@ import logging
 import os
 import re
 import shlex
+import sys
 import tarfile
 import tempfile
 from abc import ABCMeta, abstractmethod
 from enum import Enum, unique
 from pathlib import Path
-from typing import Dict, List, Optional, Protocol, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 from localstack import config
 from localstack.utils.collections import HashableList


### PR DESCRIPTION
Types not available in python3.7 without typing_extensions: TypedDict, Protocol

These types will now be imported depending on the current runtime version, either from typing or typing extensions (as done in other places in the code).

Also, lru_cache takes a userfunction as argument since 3.8, so for 3.7 compatibility we need to call it as function for the default parameters to work.

Fixes #6083