### PR TITLE
ASF protocol cleanup / small enhancements

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -257,7 +257,12 @@ class RequestParser(abc.ABC):
 
         fn_name = "_parse_%s" % shape.type_name
         handler = getattr(self, fn_name, self._noop_parser)
-        return handler(request, shape, payload, uri_params) if payload is not None else None
+        try:
+            return handler(request, shape, payload, uri_params) if payload is not None else None
+        except (TypeError, ValueError, AttributeError) as e:
+            raise ProtocolParserError(
+                f"Invalid type when parsing {shape.name}: '{payload}' cannot be parsed to int."
+            ) from e
 
     # The parsing functions for primitive types, lists, and timestamps are shared among subclasses.
 

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -557,7 +557,7 @@ class BaseXMLResponseSerializer(ResponseSerializer):
         self._add_error_tags(code, error, error_tag, sender_fault)
         request_id = ETree.SubElement(root, "RequestId")
         request_id.text = gen_amzn_requestid_long()
-        response.data = self._encode_payload(self._xml_to_string(root))
+        response.set_response(self._encode_payload(self._xml_to_string(root)))
 
     def _add_error_tags(
         self, code: str, error: ServiceException, error_tag: ETree.Element, sender_fault: bool
@@ -747,7 +747,7 @@ class BaseXMLResponseSerializer(ResponseSerializer):
         response.headers["Content-Type"] = "text/xml"
         return response
 
-    def _xml_to_string(self, root: Optional[ETree.ElementTree]) -> Optional[str]:
+    def _xml_to_string(self, root: Optional[ETree.Element]) -> Optional[str]:
         """Generates the string representation of the given XML element."""
         if root is not None:
             return ETree.tostring(
@@ -809,20 +809,24 @@ class BaseRestResponseSerializer(ResponseSerializer, ABC):
             # If it's streaming, then the body is just the value of the payload.
             body_payload = parameters.get(payload_member, b"")
             body_payload = self._encode_payload(body_payload)
-            response.data = body_payload
+            response.set_response(body_payload)
         elif payload_member is not None:
             # If there's a payload member, we serialized that member to the body.
             body_params = parameters.get(payload_member)
             if body_params is not None:
-                response.data = self._encode_payload(
-                    self._serialize_body_params(
-                        body_params, shape_members[payload_member], operation_model
+                response.set_response(
+                    self._encode_payload(
+                        self._serialize_body_params(
+                            body_params, shape_members[payload_member], operation_model
+                        )
                     )
                 )
         else:
             # Otherwise, we use the "traditional" way of serializing the whole parameters dict recursively.
-            response.data = self._encode_payload(
-                self._serialize_body_params(parameters, shape, operation_model)
+            response.set_response(
+                self._encode_payload(
+                    self._serialize_body_params(parameters, shape, operation_model)
+                )
             )
 
     def _serialize_content_type(self, serialized: HttpResponse, shape: Shape, shape_members: dict):
@@ -950,7 +954,7 @@ class RestXMLResponseSerializer(BaseRestResponseSerializer, BaseXMLResponseSeria
             self._add_error_tags(code, error, root, sender_fault)
             request_id = ETree.SubElement(root, "RequestId")
             request_id.text = gen_amzn_requestid_long()
-            response.data = self._encode_payload(self._xml_to_string(root))
+            response.set_response(self._encode_payload(self._xml_to_string(root)))
         else:
             super()._serialize_error(error, code, sender_fault, response, shape, operation_model)
 
@@ -983,8 +987,8 @@ class QueryResponseSerializer(BaseXMLResponseSerializer):
         :param operation_model: The specification of the operation of which the response is serialized here
         :return: None - the given `serialized` dict is modified
         """
-        response.data = self._encode_payload(
-            self._serialize_body_params(parameters, shape, operation_model)
+        response.set_response(
+            self._encode_payload(self._serialize_body_params(parameters, shape, operation_model))
         )
 
     def _serialize_body_params_to_xml(
@@ -1057,7 +1061,7 @@ class EC2ResponseSerializer(QueryResponseSerializer):
         self._add_error_tags(code, error, error_tag, sender_fault)
         request_id = ETree.SubElement(root, "RequestID")
         request_id.text = gen_amzn_requestid_long()
-        response.data = self._encode_payload(self._xml_to_string(root))
+        response.set_response(self._encode_payload(self._xml_to_string(root)))
 
     def _prepare_additional_traits_in_xml(self, root: Optional[ETree.Element]):
         # The EC2 protocol does not use the root output shape, therefore we need to remove the hierarchy level
@@ -1113,7 +1117,7 @@ class JSONResponseSerializer(ResponseSerializer):
         json_version = operation_model.metadata.get("jsonVersion")
         if json_version is not None:
             response.headers["Content-Type"] = "application/x-amz-json-%s" % json_version
-        response.data = self._serialize_body_params(parameters, shape, operation_model)
+        response.set_response(self._serialize_body_params(parameters, shape, operation_model))
 
     def _serialize_body_params(
         self, params: dict, shape: Shape, operation_model: OperationModel

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -187,7 +187,7 @@ def legacy_rules(request: Request) -> Optional[str]:
 
     # S3 delete object requests
     if method == "POST" and "delete" in values:
-        data_bytes = to_bytes(request.get_data())
+        data_bytes = to_bytes(request.data)
         if b"<Delete" in data_bytes and b"<Key>" in data_bytes:
             return "s3"
 

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -309,8 +309,6 @@ def determine_aws_service_name(
     if legacy_match:
         return legacy_match
 
-    LOG.warning("could not uniquely determine service from request, candidates=%s", candidates)
-
     if signing_name:
         return signing_name
     if candidates:

--- a/localstack/http/response.py
+++ b/localstack/http/response.py
@@ -20,6 +20,14 @@ class Response(WerkzeugResponse):
         self.data = json.dumps(doc, cls=CustomEncoder)
         self.mimetype = "application/json"
 
+    def set_response(self, response):
+        if response is None:
+            self.response = []
+        elif isinstance(response, (str, bytes, bytearray)):
+            self.data = response
+        else:
+            self.response = response
+
     def to_readonly_response_dict(self) -> Dict:
         """
         Returns a read-only version of a response dictionary as it is often expected by other libraries like boto.

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -11,6 +11,7 @@ from typing import Dict
 from requests.models import Response
 
 from localstack import config
+from localstack.aws.protocol.service_router import determine_aws_service_name
 from localstack.constants import (
     HEADER_LOCALSTACK_EDGE_URL,
     HEADER_LOCALSTACK_REQUEST_URL,
@@ -94,7 +95,6 @@ class ProxyListenerEdge(ProxyListener):
 
         # re-create an HTTP request from the given parts
         request = create_request_from_parts(method, path, data, headers)
-        from localstack.aws.protocol.service_router import determine_aws_service_name
 
         api = determine_aws_service_name(request)
         port = None

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -135,6 +135,7 @@ def try_call_sqs(request: Request, region: str) -> Tuple[Dict, OperationModel]:
     body = urlencode(params)
 
     try:
+        request.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
         operation, service_request = parser.parse(
             Request("POST", "/", headers=request.headers, body=body)
         )

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 
 from botocore.exceptions import ClientError
 from botocore.model import OperationModel
+from werkzeug.datastructures import Headers
 
 from localstack import config
 from localstack.aws.api import CommonServiceException
@@ -135,10 +136,9 @@ def try_call_sqs(request: Request, region: str) -> Tuple[Dict, OperationModel]:
     body = urlencode(params)
 
     try:
-        request.headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
-        operation, service_request = parser.parse(
-            Request("POST", "/", headers=request.headers, body=body)
-        )
+        headers = Headers(request.headers)
+        headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
+        operation, service_request = parser.parse(Request("POST", "/", headers=headers, body=body))
         validate_request(operation, service_request).raise_first()
     except OperationNotFoundParserError:
         raise InvalidAction(action)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -881,7 +881,7 @@ def mock_aws_request_headers(service="dynamodb", region_name=None, access_key=No
     ctype = APPLICATION_AMZ_JSON_1_0
     if service == "kinesis":
         ctype = APPLICATION_AMZ_JSON_1_1
-    elif service in ["sns", "sqs"]:
+    elif service in ["sns", "sqs", "sts", "cloudformation"]:
         ctype = APPLICATION_X_WWW_FORM_URLENCODED
 
     # TODO: consider adding an internal=False flag, to use INTERNAL_AWS_ACCESS_KEY_ID for internal calls here

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -97,7 +97,7 @@ class TestCSRF:
         assert "<ListTopicsResponse" in to_str(response.content)
 
         monkeypatch.setattr(config, "DISABLE_CORS_HEADERS", True)
-        response = requests.get(url, headers=headers, data=data)
+        response = requests.post(url, headers=headers, data=data)
         assert response.status_code == 200
         assert "<ListTopicsResponse" in to_str(response.content)
         assert not response.headers.get("access-control-allow-headers")

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1306,7 +1306,11 @@ class TestSqsProvider:
             "X-Amz-Signature": signer.signature(string_to_sign, req),
         }
 
-        response = requests.post(url=base_url, data=urlencode(payload))
+        response = requests.post(
+            url=base_url,
+            data=urlencode(payload),
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
         assert response.status_code == 200
         assert b"<ListQueuesResponse" in response.content
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -30,7 +30,7 @@ def test_query_parser():
             "DelaySeconds=2"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     operation, params = parser.parse(request)
@@ -57,6 +57,7 @@ def test_sqs_parse_tag_map_with_member_name_as_location():
         "Tag.1.Value=local&"
         "Tag.2.Key=returnly%3Acreator&"
         "Tag.2.Value=rma-api-svc",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
 
     operation, params = parser.parse(request)
@@ -78,6 +79,7 @@ def test_sqs_parse_tag_map_with_member_name_as_location():
         "Tags.1.Value=local&"
         "Tags.2.Key=returnly%3Acreator&"
         "Tags.2.Value=rma-api-svc",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
 
     operation, params = parser.parse(request)
@@ -100,7 +102,6 @@ def test_query_parser_uri():
         "MessageBody=%7B%22foo%22%3A+%22bared%22%7D&"
         "DelaySeconds=2",
         method="POST",
-        headers={},
         path="",
     )
     operation, params = parser.parse(request)
@@ -132,7 +133,7 @@ def test_query_parser_flattened_map():
             "Attribute.6.Name=VisibilityTimeout&Attribute.6.Value=60"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     operation, params = parser.parse(request)
@@ -163,7 +164,7 @@ def test_query_parser_non_flattened_map():
             "AUTHPARAMS"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     operation, params = parser.parse(request)
@@ -195,7 +196,7 @@ def test_query_parser_non_flattened_list_structure():
             "X-Amz-Signature=[Signature]"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     operation, params = parser.parse(request)
@@ -228,7 +229,7 @@ def test_query_parser_non_flattened_list_structure_changed_name():
             "AUTHPARAMS"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     operation, params = parser.parse(request)
@@ -260,7 +261,7 @@ def test_query_parser_flattened_list_structure():
             "DeleteMessageBatchRequestEntry.2.ReceiptHandle=foo"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     operation, params = parser.parse(request)
@@ -1060,7 +1061,7 @@ def test_query_parser_error_on_protocol_error():
             "DelaySeconds=2"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
     with pytest.raises(ProtocolParserError):
@@ -1091,7 +1092,7 @@ def test_parser_error_on_unknown_error():
             "DelaySeconds=2"
         ),
         method="POST",
-        headers={},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         path="",
     )
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -272,9 +272,6 @@ def test_query_parser_flattened_list_structure():
     }
 
 
-@pytest.mark.xfail(
-    reason="types are currently not checked in the parser so this will raise an UnknownParserError"
-)
 def test_query_parser_pass_str_as_int_raises_error():
     """Test to make sure that invalid types correctly raise a ProtocolParserError."""
     parser = QueryRequestParser(load_service("sts"))
@@ -286,6 +283,7 @@ def test_query_parser_pass_str_as_int_raises_error():
             "DurationSeconds=abcd"  # illegal argument (should be an int)
         ),
         method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
 
     with pytest.raises(ProtocolParserError):

--- a/tests/unit/aws/protocol/test_parser_validate.py
+++ b/tests/unit/aws/protocol/test_parser_validate.py
@@ -43,6 +43,7 @@ class TestExceptions:
                     "Action=SendMessage&Version=2012-11-05&"
                     "QueueUrl=http%3A%2F%2Flocalhost%3A4566%2F000000000000%2Ftf-acc-test-queue&"
                 ),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
         )
 
@@ -89,6 +90,7 @@ class TestExceptions:
                         "DurationSeconds": "100",
                     }
                 ),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
         )
 
@@ -111,6 +113,7 @@ class TestExceptions:
                         "RoleSessionName": "foobared",
                     }
                 ),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
             )
         )
 

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -1309,8 +1309,8 @@ def test_no_mutation_of_parameters():
     assert parameters == expected
 
 
-def test_serializer_error_on_protocol_error():
-    """Test that the serializer raises a ProtocolSerializerError in case of invalid data to serialize."""
+def test_serializer_error_on_protocol_error_invalid_exception():
+    """Test that the serializer raises a ProtocolSerializerError in case of invalid exception to serialize."""
     service = load_service("sqs")
     operation_model = service.operation_model("SendMessage")
     serializer = QueryResponseSerializer()
@@ -1318,6 +1318,17 @@ def test_serializer_error_on_protocol_error():
         # a known protocol error would be if we try to serialize an exception which is not a CommonServiceException and
         # also not a generated exception
         serializer.serialize_error_to_response(NotImplementedError(), operation_model)
+
+
+def test_serializer_error_on_protocol_error_invalid_data():
+    """Test that the serializer raises a ProtocolSerializerError in case of invalid data to serialize."""
+    service = load_service("dynamodbstreams")
+    operation_model = service.operation_model("DescribeStream")
+    serializer = QueryResponseSerializer()
+    with pytest.raises(ProtocolSerializerError):
+        serializer.serialize_to_response(
+            {"StreamDescription": {"CreationRequestDateTime": "invalid_timestamp"}}, operation_model
+        )
 
 
 def test_serializer_error_on_unknown_error():


### PR DESCRIPTION
This PR contains the following changes (each encapsulated in a different commit):
- https://github.com/localstack/localstack/commit/c5ae9212613f849713588ca0d80befdbecc3955d Removes the warning in the ASF service router in case no service could be detected (the warning caused lots of false-positives)
- https://github.com/localstack/localstack/commit/75ecc7d7c934bf269b28a8b0b6caa829d7a3fde8 Moves the service-router import to the top-level imports (as discussed in https://github.com/localstack/localstack/pull/5734#discussion_r859524921 /cc @whummer)
- https://github.com/localstack/localstack/commit/f430c5314bf2e4e5b1dde2831bf87bffa96f0564 Adjusts the parser and serializer to use the features of Werkzeug's request class.
- https://github.com/localstack/localstack/commit/ccff61db809bbfa3458bc93d83c629bda920f9e5 Adjusts the error handling in the parser and serializer that certain exceptions caused by invalid input raises a protocol-error instead of an "unknown" error.