### PR TITLE
fix message attribute filter for SQS ReceiveMessage

### DIFF
--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -1,0 +1,214 @@
+{
+  "tests/integration/test_sqs.py::TestSqsProvider::test_receive_message_message_attribute_names_filters": {
+    "send_message_response": {
+      "MD5OfMessageBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+      "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+      "MessageId": "<uuid>",
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "empty_filter": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg"
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "all_name": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg",
+          "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+          "MessageAttributes": {
+            "General": {
+              "StringValue": "Kenobi",
+              "DataType": "String"
+            },
+            "Hello": {
+              "StringValue": "There",
+              "DataType": "String"
+            },
+            "Help.Me": {
+              "StringValue": "Me",
+              "DataType": "String"
+            }
+          }
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "all_wildcard": {
+      "MessageId": "<uuid>",
+      "ReceiptHandle": "",
+      "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+      "Body": "msg",
+      "MD5OfMessageAttributes": "4c360f3fdafd970e05fae2f149d997f5",
+      "MessageAttributes": {
+        "General": {
+          "StringValue": "Kenobi",
+          "DataType": "String"
+        },
+        "Hello": {
+          "StringValue": "There",
+          "DataType": "String"
+        },
+        "Help.Me": {
+          "StringValue": "Me",
+          "DataType": "String"
+        }
+      }
+    },
+    "only_non_existing_names": {
+      "MessageId": "<uuid>",
+      "ReceiptHandle": "",
+      "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+      "Body": "msg"
+    },
+    "only_existing": {
+      "MessageId": "<uuid>",
+      "ReceiptHandle": "",
+      "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+      "Body": "msg",
+      "MD5OfMessageAttributes": "fca026605781cb4126a1e9044df24232",
+      "MessageAttributes": {
+        "General": {
+          "StringValue": "Kenobi",
+          "DataType": "String"
+        },
+        "Hello": {
+          "StringValue": "There",
+          "DataType": "String"
+        }
+      }
+    },
+    "existing_and_non_existing": {
+      "MessageId": "<uuid>",
+      "ReceiptHandle": "",
+      "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+      "Body": "msg",
+      "MD5OfMessageAttributes": "a311262e065454b75da111d535b8dacd",
+      "MessageAttributes": {
+        "Hello": {
+          "StringValue": "There",
+          "DataType": "String"
+        }
+      }
+    },
+    "prefix_filter": {
+      "MessageId": "<uuid>",
+      "ReceiptHandle": "",
+      "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+      "Body": "msg",
+      "MD5OfMessageAttributes": "83fee93c1bcd8b9a5a923ffacdc636c7",
+      "MessageAttributes": {
+        "Hello": {
+          "StringValue": "There",
+          "DataType": "String"
+        },
+        "Help.Me": {
+          "StringValue": "Me",
+          "DataType": "String"
+        }
+      }
+    },
+    "illegal_name_1": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg"
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "illegal_name_2": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg"
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_receive_message_attribute_names_filters": {
+    "all_attributes": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg",
+          "Attributes": {
+            "SenderId": "",
+            "ApproximateFirstReceiveTimestamp": "<timestamp>",
+            "ApproximateReceiveCount": "1",
+            "SentTimestamp": "<timestamp>"
+          }
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "all_system_and_message_attributes": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg",
+          "Attributes": {
+            "SenderId": "",
+            "ApproximateFirstReceiveTimestamp": "<timestamp>",
+            "ApproximateReceiveCount": "2",
+            "SentTimestamp": "<timestamp>"
+          },
+          "MD5OfMessageAttributes": "ae7155c6026991b6d54b11589678bf9c",
+          "MessageAttributes": {
+            "Foo": {
+              "StringValue": "Bar",
+              "DataType": "String"
+            }
+          }
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "single_attribute": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg",
+          "Attributes": {
+            "SenderId": ""
+          }
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    },
+    "multiple_attributes": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "",
+          "MD5OfBody": "6e2baaf3b97dbeef01c0043275f9a0e7",
+          "Body": "msg",
+          "Attributes": {
+            "SenderId": ""
+          }
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    }
+  }
+}

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -347,6 +347,12 @@ def test_query_serializer_sqs_flattened_list_map_with_botocore():
                 "ReceiptHandle": "AQEBZ14sCjWJuot0T8G2Eg3S8C+sJGg+QRKYCJjfd8iiOsrPfUzbXSjlQquT9NZP1Mxxkcud3HcaxvS7I1gxoM9MSjbpenKgkti8TPCc7nQBUk9y6xXYWlhysjgAi9YjExUIxO2ozYZuwyksOvIxS4NZs2aBctyR74N3XjOO/t8GByAz2u7KR5vYJu418Y9apAuYB1n6ZZ6aE1NrjIK9mjGCKSqE3YxN5SNkKXf1zRwTUjq8cE73F7cK7DBXNFWBTZSYkLLnFg/QuqKh0dfwGgLseeKhHUxw2KiP9qH4kvXBn2UdeI8jkFMbPERiSf2KMrGKyMCtz3jL+YVRYkB4BB0hx15Brrgo/zhePXHbT692VxKF98MIMQc/v+dc6aewQZldjuq6ANrp4RM+LdjlTPg7ow==",
                 "MD5OfBody": "13c0c73bbf11056450c43bf3159b3585",
                 "Body": '{"foo": "bared"}',
+                "Attributes": {"SenderId": "000000000000", "SentTimestamp": "1652963711"},
+                "MD5OfMessageAttributes": "fca026605781cb4126a1e9044df24232",
+                "MessageAttributes": {
+                    "Hello": {"StringValue": "There", "DataType": "String"},
+                    "General": {"StringValue": "Kenobi", "DataType": "String"},
+                },
             }
         ]
     }


### PR DESCRIPTION
This PR properly implements the `MessageAttributeNames` and `MessageAttributes` filter for the `ReceiveMessage` operation. The behavior is described here: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html#SQS.Client.receive_message

* moved the filtering of both user message attributes and system message attributes into their own functions
* added snapshot tests for both for different cases
* extended the serializer test (i initially thought it was a serializer error, but our implementation just wasn't correct)

should potentially fix #5248