### PR TITLE
improve SQS receipt handle error parity

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -85,15 +85,6 @@ FIFO_MSG_REGEX = "^[0-9a-zA-z!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~-]*$"
 DEDUPLICATION_INTERVAL_IN_SEC = 5 * 60
 
 
-def generate_message_id():
-    return long_uid()
-
-
-def generate_receipt_handle():
-    # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/ImportantIdentifiers.html#ImportantIdentifiers-receipt-handles
-    return "".join(random.choices(string.ascii_letters + string.digits, k=172)) + "="
-
-
 class InvalidParameterValue(CommonServiceException):
     def __init__(self, message):
         super().__init__("InvalidParameterValue", message, 400, True)
@@ -107,6 +98,10 @@ class InvalidAttributeValue(CommonServiceException):
 class MissingParameter(CommonServiceException):
     def __init__(self, message):
         super().__init__("MissingParameter", message, 400, True)
+
+
+def generate_message_id():
+    return long_uid()
 
 
 def assert_queue_name(queue_name: str, fifo: bool = False):
@@ -131,6 +126,27 @@ def check_message_content(message_body: str):
 
     if not re.match(MSG_CONTENT_REGEX, message_body):
         raise InvalidMessageContents(error)
+
+
+def generate_receipt_handle(queue_arn, message: "SqsMessage") -> str:
+    # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/ImportantIdentifiers.html#ImportantIdentifiers-receipt-handles
+    # encode the queue arn in the receipt handle, so we can later check if it belongs to the queue
+    # but also add some randomness s.t. the generated receipt handles look like the ones from AWS
+    handle = f"{long_uid()} {queue_arn} {message.message.get('MessageId')} {message.last_received}"
+    encoded = base64.b64encode(handle.encode("utf-8"))
+    return encoded.decode("utf-8")
+
+
+def decode_receipt_handle(receipt_handle: str) -> str:
+    try:
+        handle = base64.b64decode(receipt_handle).decode("utf-8")
+        _, queue_arn, message_id, last_received = handle.split(" ")
+        parse_arn(queue_arn)  # raises a ValueError if it is not an arn
+        return queue_arn
+    except (IndexError, ValueError):
+        raise ReceiptHandleIsInvalid(
+            f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
+        )
 
 
 class Permission(NamedTuple):
@@ -302,12 +318,22 @@ class SqsQueue:
     def visibility_timeout(self) -> int:
         return int(self.attributes[QueueAttributeName.VisibilityTimeout])
 
+    def validate_receipt_handle(self, receipt_handle: str):
+        if self.arn != decode_receipt_handle(receipt_handle):
+            raise ReceiptHandleIsInvalid(
+                f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
+            )
+
     def update_visibility_timeout(self, receipt_handle: str, visibility_timeout: int):
         with self.mutex:
+            self.validate_receipt_handle(receipt_handle)
+
             if receipt_handle not in self.receipts:
-                raise ReceiptHandleIsInvalid(
-                    f'The input receipt handle "{receipt_handle}" is not a valid receipt handle.'
+                raise InvalidParameterValue(
+                    f"Value {receipt_handle} for parameter ReceiptHandle is invalid. Reason: Message does not exist "
+                    f"or is not available for visibility timeout change."
                 )
+
             standard_message = self.receipts[receipt_handle]
 
             if standard_message not in self.inflight:
@@ -327,6 +353,8 @@ class SqsQueue:
 
     def remove(self, receipt_handle: str):
         with self.mutex:
+            self.validate_receipt_handle(receipt_handle)
+
             if receipt_handle not in self.receipts:
                 LOG.debug(
                     "no in-flight message found for receipt handle %s in queue %s",
@@ -394,7 +422,7 @@ class SqsQueue:
                     standard_message.first_received = standard_message.last_received
 
                 # create and manage receipt handle
-                receipt_handle = generate_receipt_handle()
+                receipt_handle = self.generate_receipt_handle(standard_message)
                 standard_message.receipt_handles.add(receipt_handle)
                 self.receipts[receipt_handle] = standard_message
 
@@ -414,6 +442,9 @@ class SqsQueue:
             copied_message.message["ReceiptHandle"] = receipt_handle
 
             return copied_message
+
+    def generate_receipt_handle(self, message: SqsMessage) -> str:
+        return generate_receipt_handle(self.arn, message)
 
     def requeue_inflight_messages(self):
         if not self.inflight:

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -128,7 +128,7 @@ def check_message_content(message_body: str):
         raise InvalidMessageContents(error)
 
 
-def generate_receipt_handle(queue_arn, message: "SqsMessage") -> str:
+def encode_receipt_handle(queue_arn, message: "SqsMessage") -> str:
     # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/ImportantIdentifiers.html#ImportantIdentifiers-receipt-handles
     # encode the queue arn in the receipt handle, so we can later check if it belongs to the queue
     # but also add some randomness s.t. the generated receipt handles look like the ones from AWS
@@ -422,7 +422,7 @@ class SqsQueue:
                     standard_message.first_received = standard_message.last_received
 
                 # create and manage receipt handle
-                receipt_handle = self.generate_receipt_handle(standard_message)
+                receipt_handle = self.create_receipt_handle(standard_message)
                 standard_message.receipt_handles.add(receipt_handle)
                 self.receipts[receipt_handle] = standard_message
 
@@ -443,8 +443,8 @@ class SqsQueue:
 
             return copied_message
 
-    def generate_receipt_handle(self, message: SqsMessage) -> str:
-        return generate_receipt_handle(self.arn, message)
+    def create_receipt_handle(self, message: SqsMessage) -> str:
+        return encode_receipt_handle(self.arn, message)
 
     def requeue_inflight_messages(self):
         if not self.inflight:

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1847,7 +1847,7 @@ class TestSqsProvider:
 
         # check that it works as expected
         sqs_client.change_message_visibility(
-            QueueUrl=sqs_queue, ReceiptHandle=handle, VisibilityTimeout=5
+            QueueUrl=sqs_queue, ReceiptHandle=handle, VisibilityTimeout=42
         )
 
         # delete the message, the handle becomes invalid

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1836,6 +1836,56 @@ class TestSqsProvider:
         response = receive_message(["SenderId", "SequenceNumber"])
         assert snapshot.match("multiple_attributes", response)
 
+    @pytest.mark.aws_validated
+    def test_change_visibility_on_deleted_message_raises_invalid_parameter_value(
+        self, sqs_client, sqs_queue
+    ):
+        # prepare the fixture
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foo")
+        response = sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=5)
+        handle = response["Messages"][0]["ReceiptHandle"]
+
+        # check that it works as expected
+        sqs_client.change_message_visibility(
+            QueueUrl=sqs_queue, ReceiptHandle=handle, VisibilityTimeout=5
+        )
+
+        # delete the message, the handle becomes invalid
+        sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+
+        with pytest.raises(ClientError) as e:
+            sqs_client.change_message_visibility(
+                QueueUrl=sqs_queue, ReceiptHandle=handle, VisibilityTimeout=42
+            )
+
+        err = e.value.response["Error"]
+        assert err["Code"] == "InvalidParameterValue"
+        assert (
+            err["Message"]
+            == f"Value {handle} for parameter ReceiptHandle is invalid. Reason: Message does not exist or is not "
+            f"available for visibility timeout change."
+        )
+
+    @pytest.mark.aws_validated
+    def test_delete_message_with_illegal_receipt_handle(self, sqs_client, sqs_queue):
+        with pytest.raises(ClientError) as e:
+            sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle="garbage")
+
+        err = e.value.response["Error"]
+        assert err["Code"] == "ReceiptHandleIsInvalid"
+        assert err["Message"] == 'The input receipt handle "garbage" is not a valid receipt handle.'
+
+    @pytest.mark.aws_validated
+    def test_delete_message_with_deleted_receipt_handle(self, sqs_client, sqs_queue):
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foo")
+        response = sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=5)
+        handle = response["Messages"][0]["ReceiptHandle"]
+
+        # does not raise errors even after successive calls
+        sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+        sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+        sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
+
 
 def get_region():
     return os.environ.get("AWS_DEFAULT_REGION") or TEST_REGION


### PR DESCRIPTION
This PR fixes #5293 by raising the correct error messages when using an SQS receipt handle to either delete a message, or change the visibility of a message.
AWS raises `InvalidParameterValue` if a receipt handle is used that was previously issued but is no longer valid for the given queue. Previously we were raising `ReceiptHandleIsInvalid` which seems to happen only when receipt handles have a value that is not a real receipt handle. This seems to indicate some kind of internal format that receipt handles have. Since they seem to be base64 encoded values of some sort.

We now encode the queue ARN into the receipt handle (as well as some randomness to make it look like a random base64 encoded string), and base64 encode that. That allows us to later check whether a) the receipt handle is a real receipt handle (to raise `ReceiptHandleIsInvalid`), or b) the receipt handle is not valid for this queue because it is not currently associated with any message of the queue (to raise `InvalidParameterValue`).