### PR TITLE
Slight refactoring to allow customizing DynamoDB server startup

### DIFF
--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -8,6 +8,7 @@ from localstack.services import install
 from localstack.services.install import DDB_AGENT_JAR_PATH
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
+from localstack.utils.files import rm_rf
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 from localstack.utils.sync import retry
@@ -105,6 +106,15 @@ def create_dynamodb_server(port=None) -> DynamodbServer:
 
     if config.dirs.data:
         ddb_data_dir = "%s/dynamodb" % config.dirs.data
+        mkdir(ddb_data_dir)
+        absolute_path = os.path.abspath(ddb_data_dir)
+        server.db_path = absolute_path
+    else:
+        # if DATA_DIR is not set, we need to dump the db somewhere to retrieve it
+        # together with the state (for Cloud Pods). If a db_path is not set, DynamoDBLocal
+        # keeps the db in memory; we could investigate whether is possible to fetch it on fly.
+        ddb_data_dir = "%s/dynamodb" % config.dirs.tmp
+        rm_rf(ddb_data_dir)
         mkdir(ddb_data_dir)
         absolute_path = os.path.abspath(ddb_data_dir)
         server.db_path = absolute_path


### PR DESCRIPTION
DynamoDBLocal can start in [two different modes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html). If a `dbPath` is set, DynamoDB writes its database files in that directory.
If not, it runs in `inMemory`mode with a transient state (which is what we currently do if persistence is not enabled).

Before, we were interested in having files on disk only when `DATA_DIR` was set. However, now that Pods are independent from persistence, we have a similar need. Therefore, we would just set a temporary directory to dump the database files.
As a future optimization we can investigate whether is possible to run start DynamoDBLocal `inMemory` and only ask for its content on the fly.

@whummer this is basically what we briefly discussed before. Could there be any implications that I do not see?