### PR TITLE
Fix cfn apigw domain tags

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -584,7 +584,18 @@ class GatewayDomain(GenericBaseModel):
         return {
             "create": {
                 "function": "create_domain_name",
-                "parameters": lambda_keys_to_lower(),
+                "parameters": {
+                    "certificateArn": lambda_keys_to_lower("CertificateArn"),
+                    "domainName": lambda_keys_to_lower("DomainName"),
+                    "endpointConfiguration": lambda_keys_to_lower("EndpointConfiguration"),
+                    "mutualTlsAuthentication": lambda_keys_to_lower("MutualTlsAuthentication"),
+                    "ownershipVerificationCertificateArn": lambda_keys_to_lower(
+                        "OwnershipVerificationCertificateArn"
+                    ),
+                    "regionalCertificateArn": lambda_keys_to_lower("RegionalCertificateArn"),
+                    "securityPolicy": lambda_keys_to_lower("SecurityPolicy"),
+                    "tags": params_list_to_dict("Tags"),
+                },
             }
         }
 
@@ -629,7 +640,7 @@ class GatewayBasePathMapping(GenericBaseModel):
         return {"create": {"function": _create_base_path_mapping}}
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("id")
+        return self.props.get("restApiId")
 
 
 class GatewayModel(GenericBaseModel):

--- a/tests/integration/cloudformation/test_cloudformation_apigateway.py
+++ b/tests/integration/cloudformation/test_cloudformation_apigateway.py
@@ -16,7 +16,11 @@ def test_cfn_apigateway_aws_integration(
         template_path=os.path.join(
             os.path.dirname(__file__), "../templates/apigw-awsintegration-request-parameters.yaml"
         ),
-        parameters={"ApiName": api_name, "CustomTagKey": "_custom_id_", "CustomTagValue": custom_id}
+        parameters={
+            "ApiName": api_name,
+            "CustomTagKey": "_custom_id_",
+            "CustomTagValue": custom_id,
+        },
     )
 
     # check resources creation

--- a/tests/integration/cloudformation/test_cloudformation_apigateway.py
+++ b/tests/integration/cloudformation/test_cloudformation_apigateway.py
@@ -10,12 +10,13 @@ def test_cfn_apigateway_aws_integration(
     apigateway_client, s3_client, iam_client, deploy_cfn_template
 ):
     api_name = f"rest-api-{short_uid()}"
+    custom_id = short_uid()
 
     deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../templates/apigw-awsintegration-request-parameters.yaml"
         ),
-        template_mapping={"api_name": api_name},
+        parameters={"ApiName": api_name, "CustomTagKey": "_custom_id_", "CustomTagValue": custom_id}
     )
 
     # check resources creation

--- a/tests/integration/templates/apigw-awsintegration-request-parameters.yaml
+++ b/tests/integration/templates/apigw-awsintegration-request-parameters.yaml
@@ -1,3 +1,11 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ApiName:
+    Type: String
+  CustomTagKey:
+    Type: String
+  CustomTagValue:
+    Type: String
 Resources:
   Bucket83908E77:
     Type: AWS::S3::Bucket
@@ -44,7 +52,13 @@ Resources:
   RestApi0C43BF4B:
     Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: {{ api_name }}
+      Name: 
+        Ref: ApiName
+      Tags:
+      - Key: 
+          Ref: CustomTagKey 
+        Value: 
+          Ref: CustomTagValue
   RestApiCloudWatchRoleE3ED6605:
     Type: AWS::IAM::Role
     Properties:
@@ -124,6 +138,11 @@ Resources:
         Types:
           - REGIONAL
       RegionalCertificateArn: arn:aws:acm:us-east-1:000000000000:certificate/00000000-0000-0000-0000-000000000000
+      Tags:
+      - Key: 
+          Ref: CustomTagKey 
+        Value: 
+          Ref: CustomTagValue
   RestApiCustomDomainMapMyStackLocalRestApiE67E15D45F8B292A:
     Type: AWS::ApiGateway::BasePathMapping
     Properties:

--- a/tests/integration/templates/apigw-awsintegration-request-parameters.yaml
+++ b/tests/integration/templates/apigw-awsintegration-request-parameters.yaml
@@ -75,6 +75,9 @@ Resources:
             - - "arn:"
               - Ref: AWS::Partition
               - :iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+      Tags:
+      - Key: _custom_id_
+        Value: api
   RestApiAccount7C83CF5A:
     Type: AWS::ApiGateway::Account
     Properties:
@@ -90,6 +93,9 @@ Resources:
       RestApiId:
         Ref: RestApi0C43BF4B
       Description: Automatically created by the RestApi construct
+      Tags:
+      - Key: _custom_id_
+        Value: api
     DependsOn:
       - RestApiGET0F59260B
   RestApiDeploymentStageprod3855DE66:


### PR DESCRIPTION
This PR addresses issue #5926. Where is shown that when deploying a CFN template with a APIGW.DomainName that uses Tags, Localstack Crashes.

Changes: 
- CFN APIGW.DomainName model correction.
- Test refactorization.
- The template file now uses parameters and uses tags. 
