### PR TITLE
Typo API Gateway Provider validateRequestPparameters

### DIFF
--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -568,7 +568,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             "name": name,
             "restApiId": rest_api_id,
             "validateRequestBody": validate_request_body,
-            "validateRequestPparameters": validate_request_parameters,
+            "validateRequestParameters": validate_request_parameters,
         }
         region_details.validators.setdefault(rest_api_id, []).append(entry)
 


### PR DESCRIPTION
Fixes a bug I've been facing when trying to deploy API Gateways with Schema validation in Localstack with Serverless-Localstack

Serverles used with:

plugins:
  - serverless-offline
  - serverless-localstack

