### PR TITLE
fix create_queue to raise QueueAlreadyExists correctly

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -91,6 +91,19 @@ DEDUPLICATION_INTERVAL_IN_SEC = 5 * 60
 # see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html
 RECENTLY_DELETED_TIMEOUT = 60
 
+IMMUTABLE_QUEUE_ATTRIBUTES = [
+    # these attributes cannot be changed by set_queue_attributes and should
+    # therefore be ignored when comparing queue attributes for create_queue
+    QueueAttributeName.ApproximateNumberOfMessages,
+    QueueAttributeName.ApproximateNumberOfMessagesDelayed,
+    QueueAttributeName.ApproximateNumberOfMessagesNotVisible,
+    QueueAttributeName.ContentBasedDeduplication,
+    QueueAttributeName.CreatedTimestamp,
+    QueueAttributeName.FifoQueue,
+    QueueAttributeName.LastModifiedTimestamp,
+    QueueAttributeName.QueueArn,
+]
+
 
 class InvalidParameterValue(CommonServiceException):
     def __init__(self, message):
@@ -696,7 +709,7 @@ class FifoQueue(SqsQueue):
 
         for k in attributes.keys():
             if k not in valid:
-                raise InvalidAttributeName(f"Unknown Attribute {k}")
+                raise InvalidAttributeName(f"Unknown Attribute {k}.")
         # Special Cases
         fifo = attributes.get(QueueAttributeName.FifoQueue)
         if fifo and fifo.lower() != "true":
@@ -1357,6 +1370,8 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         queue.validate_queue_attributes(attributes)
 
         for k, v in attributes.items():
+            if k in IMMUTABLE_QUEUE_ATTRIBUTES:
+                raise InvalidAttributeName(f"Unknown Attribute {k}.")
             queue.attributes[k] = v
 
         # Special cases

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -92,7 +92,7 @@ DEDUPLICATION_INTERVAL_IN_SEC = 5 * 60
 # see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html
 RECENTLY_DELETED_TIMEOUT = 60
 
-IMMUTABLE_QUEUE_ATTRIBUTES = [
+INTERNAL_QUEUE_ATTRIBUTES = [
     # these attributes cannot be changed by set_queue_attributes and should
     # therefore be ignored when comparing queue attributes for create_queue
     QueueAttributeName.ApproximateNumberOfMessages,
@@ -1386,7 +1386,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         queue.validate_queue_attributes(attributes)
 
         for k, v in attributes.items():
-            if k in IMMUTABLE_QUEUE_ATTRIBUTES:
+            if k in INTERNAL_QUEUE_ATTRIBUTES:
                 raise InvalidAttributeName(f"Unknown Attribute {k}.")
             queue.attributes[k] = v
 
@@ -1480,7 +1480,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         valid = [k[1] for k in inspect.getmembers(QueueAttributeName)]
 
         for k in attributes.keys():
-            if k not in valid or k in IMMUTABLE_QUEUE_ATTRIBUTES:
+            if k not in valid or k in INTERNAL_QUEUE_ATTRIBUTES:
                 raise InvalidAttributeName(f"Unknown Attribute {k}.")
 
     def _validate_actions(self, actions: ActionNameList):

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -350,5 +350,12 @@
     "recorded-content": {
       "send_message": "An error occurred (InvalidParameterValue) when calling the SendMessage operation: Value 2 for parameter DelaySeconds is invalid. Reason: The request include parameter that is not valid for this queue type."
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_create_queue_with_different_attributes_raises_exception": {
+    "recorded-date": "04-08-2022, 17:27:47",
+    "recorded-content": {
+      "create_queue_01": "An error occurred (QueueAlreadyExists) when calling the CreateQueue operation: A queue already exists with the same name and a different value for attribute DelaySeconds",
+      "create_queue_02": "An error occurred (QueueAlreadyExists) when calling the CreateQueue operation: A queue already exists with the same name and a different value for attribute DelaySeconds"
+    }
   }
 }


### PR DESCRIPTION
This PR corrects the behavior of `CreateQueue` to correctly raise `QueueAlreadyExists` exceptions when an attempt is made to create the queue with different attributes.

[According to the spec](https://github.com/boto/botocore/blob/f960a8d73c12d16b53e4d9eacdf515224acb08f6/botocore/data/sqs/2012-11-05/service-2.json#L1138), "Amazon SQS returns this error only if the request includes attributes whose values differ from those of the existing queue."

- fixes #5938