### PR TITLE
fix SQS ReceiveMessage blocking behavior when MaxNumberOfMessages is set

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -318,6 +318,10 @@ class SqsQueue:
     def visibility_timeout(self) -> int:
         return int(self.attributes[QueueAttributeName.VisibilityTimeout])
 
+    @property
+    def wait_time_seconds(self) -> int:
+        return int(self.attributes[QueueAttributeName.ReceiveMessageWaitTimeSeconds])
+
     def validate_receipt_handle(self, receipt_handle: str):
         if self.arn != decode_receipt_handle(receipt_handle):
             raise ReceiptHandleIsInvalid(
@@ -1061,8 +1065,11 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
     ) -> ReceiveMessageResult:
         queue = self._resolve_queue(context, queue_url=queue_url)
 
+        if wait_time_seconds is None:
+            wait_time_seconds = queue.wait_time_seconds
+
         num = max_number_of_messages or 1
-        block = wait_time_seconds is not None
+        block = True if wait_time_seconds else False
         # collect messages
         messages = []
 

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -102,6 +102,7 @@ def handle_request(request: Request, region: str) -> Response:
 
     try:
         response, operation = try_call_sqs(request, region)
+        del response["ResponseMetadata"]
         return serializer.serialize_to_response(response, operation)
     except UnknownOperationException:
         return Response("<UnknownOperationException/>", 404)

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+from threading import Timer
 from urllib.parse import urlencode
 
 import pytest
@@ -69,6 +70,20 @@ def get_queue_arn(sqs_client, queue_url: str) -> str:
     """
     response = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])
     return response["Attributes"]["QueueArn"]
+
+
+def get_qsize(sqs_client, queue_url: str) -> int:
+    """
+    Returns the integer value of the ApproximateNumberOfMessages queue attribute.
+
+    :param sqs_client: the boto3 client
+    :param queue_url: the queue URL
+    :return: the ApproximateNumberOfMessages converted to int
+    """
+    response = sqs_client.get_queue_attributes(
+        QueueUrl=queue_url, AttributeNames=["ApproximateNumberOfMessages"]
+    )
+    return int(response["Attributes"]["ApproximateNumberOfMessages"])
 
 
 class TestSqsProvider:
@@ -314,6 +329,41 @@ class TestSqsProvider:
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
 
         assert sqs_create_queue(QueueName=queue_name, Attributes=attributes) == queue_url
+
+    @pytest.mark.aws_validated
+    def test_receive_message_wait_time_seconds_and_max_number_of_messages_does_not_block(
+        self, sqs_client, sqs_queue
+    ):
+        """
+        this test makes sure that `WaitTimeSeconds` does not block when messages are in the queue, even when
+        `MaxNumberOfMessages` is provided.
+        """
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foobar1")
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foobar2")
+
+        # wait for the two messages to be in the queue
+        assert poll_condition(lambda: get_qsize(sqs_client, sqs_queue) == 2)
+
+        then = time.time()
+        response = sqs_client.receive_message(
+            QueueUrl=sqs_queue, MaxNumberOfMessages=3, WaitTimeSeconds=5
+        )
+        took = time.time() - then
+        assert took < 2  # should take much less than 5 seconds
+
+        assert len(response["Messages"]) >= 1, f"unexpected number of messages in {response}"
+
+    @pytest.mark.aws_validated
+    def test_wait_time_in_seconds_waits_correctly(self, sqs_client, sqs_queue):
+        def _send_message():
+            sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foobared")
+
+        Timer(1, _send_message).start()  # send message asynchronously after 1 second
+        response = sqs_client.receive_message(QueueUrl=sqs_queue, WaitTimeSeconds=10)
+
+        assert (
+            len(response["Messages"]) == 1
+        ), f"unexpected number of messages in response {response}"
 
     @pytest.mark.aws_validated
     @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/5938")


### PR DESCRIPTION
This PR fixes an issue in the ReceiveMessage long-polling behavior. Previously we would potentially wait several cycles of `WaitTimeSeconds` when it was specified together with `MaxNumberOfMessages`, and `MaxNumberOfMessages > qsize`. This lead to pretty severe slowdowns of message receiving when these values were set together.

We now only wait (correctly) at most one get-cycle, and then turn the blocking behavior off.
Moreover, we now respect the queue's default `ReceiveMessageWaitTimeSeconds` attribute value.

Issues that are potentially fixed:
* #5824
* #6093 
* #5178