### PR TITLE
Use asyncio run_in_executor to prevent is_ssl_socket check from blocking

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import functools
 import json
 import logging
@@ -42,6 +41,7 @@ from localstack.http.request import get_full_raw_path
 from localstack.services.messages import Headers, MessagePayload
 from localstack.services.messages import Request as RoutingRequest
 from localstack.services.messages import Response as RoutingResponse
+from localstack.utils.asyncio import run_sync
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import LambdaResponse, calculate_crc32
 from localstack.utils.aws.aws_stack import is_internal_call_context
@@ -936,8 +936,7 @@ class FakeEndpointProxyServer(Server):
 
 
 async def _accept_connection2(self, protocol_factory, conn, extra, sslcontext, *args, **kwargs):
-    loop = asyncio.get_event_loop()
-    is_ssl_socket = await loop.run_in_executor(None, DuplexSocket.is_ssl_socket, conn)
+    is_ssl_socket = await run_sync(DuplexSocket.is_ssl_socket, conn)
     if is_ssl_socket is False:
         sslcontext = None
     result = await _accept_connection2_orig(

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import functools
 import json
 import logging
@@ -935,7 +936,8 @@ class FakeEndpointProxyServer(Server):
 
 
 async def _accept_connection2(self, protocol_factory, conn, extra, sslcontext, *args, **kwargs):
-    is_ssl_socket = DuplexSocket.is_ssl_socket(conn)
+    loop = asyncio.get_event_loop()
+    is_ssl_socket = await loop.run_in_executor(None, DuplexSocket.is_ssl_socket, conn)
     if is_ssl_socket is False:
         sslcontext = None
     result = await _accept_connection2_orig(


### PR DESCRIPTION
This PR aims to fix blocking of the whole event loop for the lookahead for the SSL duplex socket.
Currently, the method is_ssl_socket will block until the first 5 bytes can be read - if the client does not provide these bytes, the eventloop will block and refuse any connections for the time being.

This PR fixes this by executing the method in an executor, and waiting for the result in the eventloop, therefore keeping it responsive.

Thanks @thrau for the tip!
Should fix #5499 .