### PR TITLE
Add hosts file to container to fix performance issues in windows container mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,9 @@ RUN pip install --no-cache-dir --upgrade supervisor virtualenv
 # install supervisor config file and entrypoint script
 ADD bin/supervisord.conf /etc/supervisord.conf
 ADD bin/docker-entrypoint.sh /usr/local/bin/
+# add the shipped hosts file to prevent performance degredation in windows container mode on windows
+# (where hosts file is not mounted) See https://github.com/localstack/localstack/issues/5178
+ADD bin/hosts /etc/hosts
 
 # expose default environment
 # Set edge bind host so localstack can be reached by other containers

--- a/bin/hosts
+++ b/bin/hosts
@@ -1,0 +1,3 @@
+# this hosts file should only be present in windows container mode
+127.0.0.1	localhost localhost.localdomain
+::1	    	localhost localhost.localdomain


### PR DESCRIPTION
## Background
We changed to a debian based image from alpine with 0.13. In contrast to alpine, debian based images do not include an /etc/hosts.
This is normally not relevant, since docker will mount its own version of /etc/hosts into the container anyway.
However, this does not happen when executing linux containers in "Windows container mode" of Docker Desktop in Windows.

## Problem
Due to the missing /etc/hosts file, in combination with the Windows container mode, performance massively degrades, noticable in SQS (see #5178). This does only happen in the specific case of windows container mode.

## Solution
Adding a hosts file to the image. This should have no impact on any platforms correctly mounting an /etc/hosts file managed by docker into the container, but should fix the issues in windows container mode, which does not show this behavior.
