### PR TITLE
add SQS feature flag to raise QueueDeletedRecently errors

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -493,6 +493,9 @@ DYNAMODB_HEAP_SIZE = os.environ.get("DYNAMODB_HEAP_SIZE", "").strip() or "256m"
 # single DB instance across multiple credentials are regions
 DYNAMODB_SHARE_DB = int(os.environ.get("DYNAMODB_SHARE_DB") or 0)
 
+# Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it
+SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
+
 # expose SQS on a specific port externally
 SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
 
@@ -670,6 +673,7 @@ CONFIG_ENV_VARS = [
     "SERVICES",
     "SKIP_INFRA_DOWNLOADS",
     "SKIP_SSL_CERT_DOWNLOAD",
+    "SQS_DELAY_RECENTLY_DELETED",
     "SQS_ENDPOINT_STRATEGY",
     "SQS_PORT_EXTERNAL",
     "STEPFUNCTIONS_LAMBDA_ENDPOINT",

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -85,6 +85,10 @@ FIFO_MSG_REGEX = "^[0-9a-zA-z!\"#$%&'()*+,./:;<=>?@[\\]^_`{|}~-]*$"
 
 DEDUPLICATION_INTERVAL_IN_SEC = 5 * 60
 
+# When you delete a queue, you must wait at least 60 seconds before creating a queue with the same name.
+# see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html
+RECENTLY_DELETED_TIMEOUT = 60
+
 
 class InvalidParameterValue(CommonServiceException):
     def __init__(self, message):
@@ -715,6 +719,11 @@ class SqsBackend(RegionBackend):
         self.queues = {}
         self.deleted = {}
 
+    def expire_deleted(self):
+        for k in list(self.deleted.keys()):
+            if self.deleted[k] <= (time.time() - RECENTLY_DELETED_TIMEOUT):
+                del self.deleted[k]
+
 
 class SqsProvider(SqsApi, ServiceLifecycleHook):
     """
@@ -796,31 +805,31 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
 
         backend = SqsBackend.get(context.region)
 
-        if queue_name in backend.queues:
-            # FIXME #5938: should raise `QueueNameExists` if queue exists with different attributes
-            queue = backend.queues[queue_name]
-            return CreateQueueResult(QueueUrl=queue.url(context))
-
-        # When you delete a queue, you must wait at least 60 seconds before creating a queue with the same name.
-        # see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html
-        if queue_name in backend.deleted and config.SQS_DELAY_RECENTLY_DELETED:
-            deleted = backend.deleted[queue_name]
-            if deleted > (time.time() - 60):
-                raise QueueDeletedRecently(
-                    "You must wait 60 seconds after deleting a queue before you can create another with the same name."
-                )
-            else:
-                del backend.deleted[queue_name]
-
-        # create the appropriate queue
-        if fifo:
-            queue = FifoQueue(queue_name, context.region, context.account_id, attributes, tags)
-        else:
-            queue = StandardQueue(queue_name, context.region, context.account_id, attributes, tags)
-
-        LOG.debug("creating queue key=%s attributes=%s tags=%s", queue_name, attributes, tags)
-
         with self._mutex:
+            if queue_name in backend.queues:
+                # FIXME #5938: should raise `QueueNameExists` if queue exists with different attributes
+                queue = backend.queues[queue_name]
+                return CreateQueueResult(QueueUrl=queue.url(context))
+
+            if config.SQS_DELAY_RECENTLY_DELETED:
+                deleted = backend.deleted.get(queue_name)
+                if deleted and deleted > (time.time() - RECENTLY_DELETED_TIMEOUT):
+                    raise QueueDeletedRecently(
+                        "You must wait 60 seconds after deleting a queue before you can create "
+                        "another with the same name."
+                    )
+            backend.expire_deleted()
+
+            # create the appropriate queue
+            if fifo:
+                queue = FifoQueue(queue_name, context.region, context.account_id, attributes, tags)
+            else:
+                queue = StandardQueue(
+                    queue_name, context.region, context.account_id, attributes, tags
+                )
+
+            LOG.debug("creating queue key=%s attributes=%s tags=%s", queue_name, attributes, tags)
+
             backend.queues[queue_name] = queue
 
         return CreateQueueResult(QueueUrl=queue.url(context))

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -174,6 +174,31 @@ class TestSqsProvider:
         )
 
     @pytest.mark.only_localstack
+    def test_create_queue_recently_deleted_cache(self, sqs_client, sqs_create_queue, monkeypatch):
+        # this is a white-box test for the QueueDeletedRecently timeout behavior
+        from localstack.services.sqs import provider
+
+        monkeypatch.setattr(config, "SQS_DELAY_RECENTLY_DELETED", True)
+        monkeypatch.setattr(provider, "RECENTLY_DELETED_TIMEOUT", 1)
+
+        name = f"test-queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=name)
+        sqs_client.delete_queue(QueueUrl=queue_url)
+
+        with pytest.raises(ClientError) as e:
+            sqs_create_queue(QueueName=name)
+
+        e.match("QueueDeletedRecently")
+        e.match(
+            "You must wait 60 seconds after deleting a queue before you can create another with the same name."
+        )
+
+        time.sleep(1.5)
+        assert name in provider.SqsBackend.get().deleted
+        assert queue_url == sqs_create_queue(QueueName=name)
+        assert name not in provider.SqsBackend.get().deleted
+
+    @pytest.mark.only_localstack
     def test_create_queue_recently_deleted_can_be_disabled(
         self, sqs_client, sqs_create_queue, monkeypatch
     ):


### PR DESCRIPTION
This PR adds a feature flag for enabling the behavior requested in
-  #5801

AWS does not allow creating a queue with the same name for 60 seconds after it was deleted. See the [`DeleteQueue` API Reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteQueue.html). By starting localstack with `SQS_DELAY_RECENTLY_DELETED=1`, localstack will behave in the same way, but it is turned off by default.

The reason for adding the feature flag was that, localstack is often used in testing scenarios where test suites may depend on having a queue with the same name be deleted and created frequently.