### PR TITLE
fix SQS ApproximateFirstReceiveTimestamp type

### DIFF
--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -56,7 +56,9 @@ def _wrap_with_fallthrough(
             # implemented, we try to fall back to forwarding the request to the backend
             return handler(context, req)
         except NotImplementedError:
-            return fallthrough_handler(context, req)
+            pass
+
+        return fallthrough_handler(context, req)
 
     return _call
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -444,7 +444,7 @@ class SqsQueue:
             ] = str(standard_message.receive_times)
             copied_message.message["Attributes"][
                 MessageSystemAttributeName.ApproximateFirstReceiveTimestamp
-            ] = str(int(standard_message.first_received))
+            ] = str(int(standard_message.first_received * 1000))
             copied_message.message["ReceiptHandle"] = receipt_handle
 
             return copied_message
@@ -1289,7 +1289,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
     ) -> Dict[MessageSystemAttributeName, str]:
         result: Dict[MessageSystemAttributeName, str] = {
             MessageSystemAttributeName.SenderId: context.account_id,  # not the account ID in AWS
-            MessageSystemAttributeName.SentTimestamp: str(now()),
+            MessageSystemAttributeName.SentTimestamp: str(now(millis=True)),
         }
 
         if message_system_attributes is not None:

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -161,6 +161,8 @@ class SqsMessage:
     visibility_timeout: int
     receive_times: int
     receipt_handles: Set[str]
+    last_received: Optional[float]
+    first_received: Optional[float]
     deleted: bool
     priority: float
     message_deduplication_id: str
@@ -442,7 +444,7 @@ class SqsQueue:
             ] = str(standard_message.receive_times)
             copied_message.message["Attributes"][
                 MessageSystemAttributeName.ApproximateFirstReceiveTimestamp
-            ] = standard_message.first_received
+            ] = str(int(standard_message.first_received))
             copied_message.message["ReceiptHandle"] = receipt_handle
 
             return copied_message

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -174,6 +174,21 @@ class TestSqsProvider:
         assert message["MessageId"] == send_result["MessageId"]
         assert message["MD5OfBody"] == send_result["MD5OfMessageBody"]
 
+    @pytest.mark.aws_validated
+    def test_receive_message_attributes_timestamp_types(self, sqs_client, sqs_queue):
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="message")
+
+        r0 = sqs_client.receive_message(
+            QueueUrl=sqs_queue, VisibilityTimeout=0, AttributeNames=["All"]
+        )
+        attrs = r0["Messages"][0]["Attributes"]
+        assert float(attrs["ApproximateFirstReceiveTimestamp"]).is_integer()
+        assert float(attrs["SentTimestamp"]).is_integer()
+
+        assert float(attrs["SentTimestamp"]) == pytest.approx(
+            float(attrs["ApproximateFirstReceiveTimestamp"]), 2
+        )
+
     def test_send_receive_message_multiple_queues(self, sqs_client, sqs_create_queue):
         queue0 = sqs_create_queue()
         queue1 = sqs_create_queue()


### PR DESCRIPTION
Fixes #6146 (simply does a rounding the timestamp before adding it as string to the attributes that are returned)

also sneakily added a change to `localstack.aws.forwarder` to avoid nested (and unnecessary) exceptions stack traces. /cc @whummer 