### PR TITLE
Fix references to AWS managed policies in SAM templates

### DIFF
--- a/tests/integration/cloudformation/test_cloudformation_sam.py
+++ b/tests/integration/cloudformation/test_cloudformation_sam.py
@@ -1,0 +1,16 @@
+import os.path
+
+import pytest
+
+
+@pytest.mark.aws_validated
+def test_sam_policies(deploy_cfn_template, cfn_client, iam_client):
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../templates/sam_function-policies.yaml"
+        )
+    )
+    role_name = stack.outputs["HelloWorldFunctionIamRoleName"]
+
+    roles = iam_client.list_attached_role_policies(RoleName=role_name)
+    assert "AmazonSNSFullAccess" in [p["PolicyName"] for p in roles["AttachedPolicies"]]

--- a/tests/integration/templates/sam_function-policies.yaml
+++ b/tests/integration/templates/sam_function-policies.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |+
+        import json
+
+        def handler(event, context):
+              return {
+                  "statusCode": 200,
+                  "body": json.dumps({
+                      "message": "hello world",
+                  }),
+              }
+
+      Runtime: python3.9
+      Handler: index.handler
+      Architectures:
+        - x86_64
+      Policies:
+        - AmazonSNSFullAccess
+      Events:
+        HelloWorld:
+          Type: Api
+          Properties:
+            Path: /hello
+            Method: get
+Outputs:
+  HelloWorldFunctionIamRoleArn:
+    Value: !GetAtt HelloWorldFunctionRole.Arn
+  HelloWorldFunctionIamRoleName:
+    Value: !Ref HelloWorldFunctionRole


### PR DESCRIPTION
Fixes the initial problem encountered in #6143 which turned out to be a bit of a rabbit hole.

The SAM translator now properly loads a map of all managed policies (Name => ARN) since cloudformation expects full policy ARNs while SAM allows specifying only the policy name. I've introduced a SAM template & a corresponding test to validate this.

@whummer Note this also reverts the changes introduced in cedc908e7cd1d13037c8d09c098ee09d0f348c5c since they were breaking parity with AWS (e.g. in `iam_client.list_policies` calls that would always return `aws-us-gov` ARNs besides regular ones which broke loading policies via the samtranslator). There were no tests introduced in the linked commit so I'm not sure if this is breaking something. Technically the partition rewriter should take care of this for users in `aws-us-gov` anyway.