### PR TITLE
Add CFn support for remaining EC2::Subnet properties

### DIFF
--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -1,8 +1,12 @@
+import json
+from typing import Callable
+
 from moto.ec2.utils import generate_route_id
 
 from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
+from localstack.utils.strings import str_to_bool
 
 
 class EC2RouteTable(GenericBaseModel):
@@ -34,9 +38,7 @@ class EC2RouteTable(GenericBaseModel):
                 "function": "create_route_table",
                 "parameters": {
                     "VpcId": "VpcId",
-                    "TagSpecifications": lambda params, **kwargs: [
-                        {"ResourceType": "route-table", "Tags": params.get("Tags")}
-                    ],
+                    "TagSpecifications": get_tags_param("route-table"),
                 },
             },
             "delete": {
@@ -86,19 +88,11 @@ class EC2Route(GenericBaseModel):
         return {
             "create": {
                 "function": "create_route",
-                "parameters": {
-                    "DestinationCidrBlock": "DestinationCidrBlock",
-                    "DestinationIpv6CidrBlock": "DestinationIpv6CidrBlock",
-                    "RouteTableId": "RouteTableId",
-                },
+                "parameters": ["DestinationCidrBlock", "DestinationIpv6CidrBlock", "RouteTableId"],
             },
             "delete": {
                 "function": "delete_route",
-                "parameters": {
-                    "DestinationCidrBlock": "DestinationCidrBlock",
-                    "DestinationIpv6CidrBlock": "DestinationIpv6CidrBlock",
-                    "RouteTableId": "RouteTableId",
-                },
+                "parameters": ["DestinationCidrBlock", "DestinationIpv6CidrBlock", "RouteTableId"],
             },
         }
 
@@ -120,17 +114,10 @@ class EC2InternetGateway(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _create_params(params, **kwargs):
-            return {
-                "TagSpecifications": [
-                    {"ResourceType": "internet-gateway", "Tags": params.get("Tags", [])}
-                ]
-            }
-
         return {
             "create": {
                 "function": "create_internet_gateway",
-                "parameters": _create_params,
+                "parameters": get_tags_param("internet-gateway"),
             }
         }
 
@@ -293,20 +280,59 @@ class EC2Subnet(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         return self.props.get("SubnetId")
 
-    @staticmethod
-    def get_deploy_templates():
+    @classmethod
+    def get_deploy_templates(cls):
+        def _post_create(resource_id, resources, resource_type, func, stack_name):
+            client = aws_stack.connect_to_service("ec2")
+            resource = cls(resources[resource_id])
+            props = resource.props
+
+            bool_attrs = [
+                "AssignIpv6AddressOnCreation",
+                "EnableDns64",
+                "MapPublicIpOnLaunch",
+            ]
+            custom_attrs = bool_attrs + ["PrivateDnsNameOptionsOnLaunch"]
+            if not any(attr in props for attr in custom_attrs):
+                return
+
+            state = resource.fetch_state(stack_name, resources)
+            subnet_id = state.get("SubnetId")
+
+            # update boolean attributes
+            for attr in bool_attrs:
+                if attr in props:
+                    kwargs = {attr: {"Value": str_to_bool(props[attr])}}
+                    client.modify_subnet_attribute(SubnetId=subnet_id, **kwargs)
+
+            # determine DNS hostname type on launch
+            dns_options = props.get("PrivateDnsNameOptionsOnLaunch")
+            if dns_options:
+                if isinstance(dns_options, str):
+                    dns_options = json.loads(dns_options)
+                if dns_options.get("HostnameType"):
+                    client.modify_subnet_attribute(
+                        SubnetId=subnet_id,
+                        PrivateDnsHostnameTypeOnLaunch=dns_options.get("HostnameType"),
+                    )
+
         return {
-            "create": {
-                "function": "create_subnet",
-                "parameters": {
-                    "VpcId": "VpcId",
-                    "CidrBlock": "CidrBlock",
-                    "OutpostArn": "OutpostArn",
-                    "Ipv6CidrBlock": "Ipv6CidrBlock",
-                    "AvailabilityZone": "AvailabilityZone"
-                    # TODO: add TagSpecifications
+            "create": [
+                {
+                    "function": "create_subnet",
+                    "parameters": [
+                        "AvailabilityZone",
+                        "AvailabilityZoneId",
+                        "CidrBlock",
+                        "Ipv6CidrBlock",
+                        "Ipv6Native",
+                        "OutpostArn",
+                        {"TagSpecifications": get_tags_param("subnet")},
+                        "VpcId",
+                    ],
                 },
-            },
+                {"function": _post_create},
+            ],
             "delete": {
                 "function": "delete_subnet",
                 "parameters": {"SubnetId": "PhysicalResourceId"},
@@ -355,7 +381,7 @@ class EC2VPC(GenericBaseModel):
 
     @classmethod
     def get_deploy_templates(cls):
-        def _pre_delete(resource_id, resources, resource_type, func, stack_name):
+        def _pre_delete(resource_id, resources, *args, **kwargs):
             res = cls(resources[resource_id])
             vpc_id = res.state.get("VpcId")
             if vpc_id:
@@ -381,8 +407,8 @@ class EC2VPC(GenericBaseModel):
                 "function": "create_vpc",
                 "parameters": {
                     "CidrBlock": "CidrBlock",
-                    "InstanceTenancy": "InstanceTenancy"
-                    # TODO: add TagSpecifications
+                    "InstanceTenancy": "InstanceTenancy",
+                    "TagSpecifications": get_tags_param("vpc"),
                 },
             },
             "delete": [
@@ -426,8 +452,8 @@ class EC2NatGateway(GenericBaseModel):
                 "function": "create_nat_gateway",
                 "parameters": {
                     "SubnetId": "SubnetId",
-                    "AllocationId": "AllocationId"
-                    # TODO: add TagSpecifications
+                    "AllocationId": "AllocationId",
+                    "TagSpecifications": get_tags_param("natgateway"),
                 },
             },
             "delete": {
@@ -514,3 +540,16 @@ class EC2Instance(GenericBaseModel):
                 },
             },
         }
+
+
+def get_tags_param(resource_type: str) -> Callable:
+    """Return a tag parameters creation function for the given resource type"""
+
+    def _param(params, **kwargs):
+        tags = params.get("Tags")
+        if not tags:
+            return None
+
+        return [{"ResourceType": resource_type, "Tags": tags}]
+
+    return _param

--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -1,8 +1,11 @@
 from abc import ABC
 from datetime import datetime, timezone
 
+from botocore.parsers import ResponseParserError
+from moto.core.utils import camelcase_to_underscores, underscores_to_camelcase
 from moto.ec2 import ec2_backends
 from moto.ec2.exceptions import InvalidVpcEndPointIdError
+from moto.ec2.models import SubnetBackend
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.ec2 import (
@@ -15,8 +18,11 @@ from localstack.aws.api.ec2 import (
     DescribeReservedInstancesOfferingsResult,
     DescribeReservedInstancesRequest,
     DescribeReservedInstancesResult,
+    DescribeSubnetsRequest,
+    DescribeSubnetsResult,
     Ec2Api,
     InstanceType,
+    ModifySubnetAttributeRequest,
     ModifyVpcEndpointResult,
     OfferingClassType,
     OfferingTypeValues,
@@ -40,7 +46,11 @@ from localstack.aws.api.ec2 import (
     scope,
 )
 from localstack.services.moto import call_moto
-from localstack.utils.strings import long_uid
+from localstack.utils.patch import patch
+from localstack.utils.strings import first_char_to_upper, long_uid
+
+# additional subnet attributes not yet supported upstream
+ADDITIONAL_SUBNET_ATTRS = ("private_dns_name_options_on_launch", "enable_dns64")
 
 
 class Ec2Provider(Ec2Api, ABC):
@@ -188,6 +198,28 @@ class Ec2Provider(Ec2Api, ABC):
 
         return ModifyVpcEndpointResult(Return=True)
 
+    @handler("ModifySubnetAttribute", expand=False)
+    def modify_subnet_attribute(
+        self, context: RequestContext, request: ModifySubnetAttributeRequest
+    ) -> None:
+        try:
+            return call_moto(context)
+        except Exception as e:
+            if not isinstance(e, ResponseParserError) and not "InvalidParameterValue" in str(e):
+                raise
+            # fix setting subnet attributes currently not supported upstream
+            backend = ec2_backends[context.region]
+            subnet_id = request["SubnetId"]
+            host_type = request.get("PrivateDnsHostnameTypeOnLaunch")
+            if host_type:
+                attr_name = camelcase_to_underscores("PrivateDnsNameOptionsOnLaunch")
+                value = {"HostnameType": host_type}
+                backend.modify_subnet_attribute(subnet_id, attr_name, value)
+            enable_dns64 = request.get("EnableDns64")
+            if enable_dns64:
+                attr_name = camelcase_to_underscores("EnableDns64")
+                backend.modify_subnet_attribute(subnet_id, attr_name, enable_dns64)
+
     @handler("RevokeSecurityGroupEgress", expand=False)
     def revoke_security_group_egress(
         self,
@@ -204,3 +236,30 @@ class Ec2Provider(Ec2Api, ABC):
                 if group and not group.egress_rules:
                     return RevokeSecurityGroupEgressResult(Return=True)
             raise
+
+    @handler("DescribeSubnets", expand=False)
+    def describe_subnets(
+        self,
+        context: RequestContext,
+        request: DescribeSubnetsRequest,
+    ) -> DescribeSubnetsResult:
+        result = call_moto(context)
+        backend = ec2_backends[context.region]
+        # add additional/missing attributes in subnet responses
+        for subnet in result.get("Subnets", []):
+            subnet_obj = backend.subnets[subnet["AvailabilityZone"]][subnet["SubnetId"]]
+            for attr in ADDITIONAL_SUBNET_ATTRS:
+                if hasattr(subnet_obj, attr):
+                    attr_name = first_char_to_upper(underscores_to_camelcase(attr))
+                    if attr_name not in subnet:
+                        subnet[attr_name] = getattr(subnet_obj, attr)
+        return result
+
+
+@patch(SubnetBackend.modify_subnet_attribute)
+def modify_subnet_attribute(fn, self, subnet_id, attr_name, attr_value):
+    subnet = self.get_subnet(subnet_id)
+    if attr_name in ADDITIONAL_SUBNET_ATTRS:
+        setattr(subnet, attr_name, attr_value)
+        return
+    return fn(self, subnet_id, attr_name, attr_value)

--- a/tests/integration/templates/template37.yaml
+++ b/tests/integration/templates/template37.yaml
@@ -28,6 +28,9 @@ Resources:
       CidrBlock: "100.0.0.0/24"
       VpcId:
         Ref: VPC
+      AssignIpv6AddressOnCreation: True
+      EnableDns64: True
+      MapPublicIpOnLaunch: True
 
   SubnetB:
     Type: AWS::EC2::Subnet
@@ -40,6 +43,8 @@ Resources:
       CidrBlock: "100.0.2.0/24"
       VpcId:
         Ref: VPC
+      PrivateDnsNameOptionsOnLaunch:
+        HostnameType: ip-name
 
   RouteTableAssociationA:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
@@ -65,8 +70,10 @@ Resources:
       - SubnetB
       - RouteTable
 
-
 Outputs:
   RouteTable:
     Value:
       Ref: RouteTable
+  VpcId:
+    Value:
+      Ref: VPC

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1780,6 +1780,17 @@ class TestCloudFormation:
         # CloudFormation will create more than one route table 2 in template + default
         assert len(route_table["Associations"]) == 3
 
+        # assert subnet attributes are present
+        vpc_id = stack.outputs["VpcId"]
+        response = ec2_client.describe_subnets(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
+        subnets = response["Subnets"]
+        subnet1 = [sub for sub in subnets if sub["CidrBlock"] == "100.0.0.0/24"][0]
+        subnet2 = [sub for sub in subnets if sub["CidrBlock"] == "100.0.2.0/24"][0]
+        assert subnet1["AssignIpv6AddressOnCreation"] is True
+        assert subnet1["EnableDns64"] is True
+        assert subnet1["MapPublicIpOnLaunch"] is True
+        assert subnet2["PrivateDnsNameOptionsOnLaunch"]["HostnameType"] == "ip-name"
+
     def test_resolve_transitive_placeholders_in_strings(self, sqs_client, deploy_cfn_template):
         queue_name = f"q-{short_uid()}"
         stack_name = f"stack-{short_uid()}"


### PR DESCRIPTION
Add CloudFormation support for remaining (currently unsupported) properties for `EC2::Subnet` resources (`AssignIpv6AddressOnCreation`, `EnableDns64`, `MapPublicIpOnLaunch`, `PrivateDnsNameOptionsOnLaunch`). Addresses https://github.com/localstack/aws-cdk-local/issues/69

* extend the deploy templates for the `EC2Subnet` resource model class
* add missing logic in `modify_subnet_attribute(..)` and `describe_subnets(..)` in EC2 provider, to enable setting the new attributes
* refactor logic around `TagSpecifications` and use common `get_tags_param(..)` utility to add tags for different EC2 resource types
* slight refactoring in some model classes - replacing dict-format with list-format for properties with identical mapped names
* add additional test assertions to cover the new properties