### PR TITLE
Fix SNS format when delivering to a DLQ

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -804,7 +804,7 @@ async def message_to_subscriber(
 
     elif subscriber["Protocol"] == "sqs":
         queue_url = None
-
+        message_body = create_sns_message_body(subscriber, req_data, message_id)
         try:
             endpoint = subscriber["Endpoint"]
 
@@ -813,8 +813,7 @@ async def message_to_subscriber(
             elif "://" in endpoint:
                 queue_url = endpoint
             else:
-                queue_name = endpoint.split(":")[5]
-                queue_url = aws_stack.get_sqs_queue_url(queue_name)
+                queue_url = aws_stack.get_sqs_queue_url(endpoint)
                 subscriber["sqs_queue_url"] = queue_url
 
             message_group_id = req_data.get("MessageGroupId", [""])[0]
@@ -831,7 +830,7 @@ async def message_to_subscriber(
 
             sqs_client.send_message(
                 QueueUrl=queue_url,
-                MessageBody=create_sns_message_body(subscriber, req_data, message_id),
+                MessageBody=message_body,
                 MessageAttributes=create_sqs_message_attributes(subscriber, message_attributes),
                 MessageSystemAttributes=create_sqs_system_attributes(headers),
                 **kwargs,
@@ -840,7 +839,7 @@ async def message_to_subscriber(
         except Exception as exc:
             LOG.info("Unable to forward SNS message to SQS: %s %s", exc, traceback.format_exc())
             store_delivery_log(subscriber, False, message, message_id)
-            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
+            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], message_body, str(exc))
             if "NonExistentQueue" in str(exc):
                 LOG.info(
                     'Removing non-existent queue "%s" subscribed to topic "%s"',
@@ -888,7 +887,8 @@ async def message_to_subscriber(
                 "Unable to run Lambda function on SNS message: %s %s", exc, traceback.format_exc()
             )
             store_delivery_log(subscriber, False, message, message_id)
-            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
+            message_body = create_sns_message_body(subscriber, req_data, message_id)
+            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], message_body, str(exc))
         return
 
     elif subscriber["Protocol"] in ["http", "https"]:
@@ -898,17 +898,24 @@ async def message_to_subscriber(
         except Exception:
             return
         try:
+            headers = {
+                "Content-Type": "text/plain",
+                # AWS headers according to
+                # https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html#http-header
+                "x-amz-sns-message-type": msg_type,
+                "x-amz-sns-topic-arn": subscriber["TopicArn"],
+                "x-amz-sns-subscription-arn": subscriber["SubscriptionArn"],
+                "User-Agent": "Amazon Simple Notification Service Agent",
+            }
+            # When raw message delivery is enabled, x-amz-sns-rawdelivery needs to be set to 'true'
+            # indicating that the message has been published without JSON formatting.
+            # https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
+            if is_raw_message_delivery(subscriber):
+                headers["x-amz-sns-rawdelivery"] = "true"
+
             response = requests.post(
                 subscriber["Endpoint"],
-                headers={
-                    "Content-Type": "text/plain",
-                    # AWS headers according to
-                    # https://docs.aws.amazon.com/sns/latest/dg/sns-message-and-json-formats.html#http-header
-                    "x-amz-sns-message-type": msg_type,
-                    "x-amz-sns-topic-arn": subscriber["TopicArn"],
-                    "x-amz-sns-subscription-arn": subscriber["SubscriptionArn"],
-                    "User-Agent": "Amazon Simple Notification Service Agent",
-                },
+                headers=headers,
                 data=message_body,
                 verify=False,
             )
@@ -925,7 +932,7 @@ async def message_to_subscriber(
                 "Received error on sending SNS message, putting to DLQ (if configured): %s", exc
             )
             store_delivery_log(subscriber, False, message, message_id)
-            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
+            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], message_body, str(exc))
         return
 
     elif subscriber["Protocol"] == "application":
@@ -940,6 +947,7 @@ async def message_to_subscriber(
                 traceback.format_exc(),
             )
             store_delivery_log(subscriber, False, message, message_id)
+            # check AWS format of DLQ message after application delivery failure, maybe format is wrong
             sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], req_data, str(exc))
         return
 
@@ -996,6 +1004,11 @@ def create_sns_message_body(subscriber, req_data, message_id=None):
             message["MessageAttributes"] = attributes
         return message
 
+    external_url = external_service_url("sns")
+    unsubscribe_url = (
+        f"{external_url}/?Action=Unsubscribe&SubscriptionArn={subscriber['SubscriptionArn']}"
+    )
+
     data = {
         "Type": req_data.get("Type", ["Notification"])[0],
         "MessageId": message_id,
@@ -1007,10 +1020,11 @@ def create_sns_message_body(subscriber, req_data, message_id=None):
         # Hardcoded
         "Signature": "EXAMPLEpH+..",
         "SigningCertURL": "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-0000000000000000000000.pem",
+        "UnsubscribeURL": unsubscribe_url,
     }
 
     for key in ["Subject", "SubscribeURL", "Token"]:
-        if req_data.get(key):
+        if key in req_data and req_data[key][0]:
             data[key] = req_data[key][0]
 
     for key in HTTP_SUBSCRIPTION_ATTRIBUTES:

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -2,7 +2,7 @@ import json
 import logging
 import uuid
 from json import JSONDecodeError
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
@@ -32,7 +32,8 @@ def sqs_error_to_dead_letter_queue(queue_arn: str, event: Dict, error):
     return _send_to_dead_letter_queue("SQS", queue_arn, target_arn, event, error)
 
 
-def sns_error_to_dead_letter_queue(sns_subscriber_arn: str, event: Dict, error):
+def sns_error_to_dead_letter_queue(sns_subscriber_arn: str, event: Union[Dict, str], error):
+    # event should be of type str if coming from SNS, as it represents the message body being passed down
     client = aws_stack.connect_to_service("sns")
     attrs = client.get_subscription_attributes(SubscriptionArn=sns_subscriber_arn)
     attrs = attrs.get("Attributes", {})
@@ -49,7 +50,9 @@ def lambda_error_to_dead_letter_queue(func_details: LambdaFunction, event: Dict,
     return _send_to_dead_letter_queue("Lambda", source_arn, dlq_arn, event, error)
 
 
-def _send_to_dead_letter_queue(source_type: str, source_arn: str, dlq_arn: str, event: Dict, error):
+def _send_to_dead_letter_queue(
+    source_type: str, source_arn: str, dlq_arn: str, event: Union[Dict, str], error
+):
     if not dlq_arn:
         return
     LOG.info("Sending failed execution %s to dead letter queue %s", source_arn, dlq_arn)
@@ -87,7 +90,7 @@ def _send_to_dead_letter_queue(source_type: str, source_arn: str, dlq_arn: str, 
     return dlq_arn
 
 
-def _prepare_messages_to_dlq(source_arn: str, event: Dict, error) -> List[Dict]:
+def _prepare_messages_to_dlq(source_arn: str, event: Union[Dict, str], error) -> List[Dict]:
     messages = []
     custom_attrs = {
         "RequestID": {"DataType": "String", "StringValue": str(uuid.uuid4())},
@@ -110,7 +113,7 @@ def _prepare_messages_to_dlq(source_arn: str, event: Dict, error) -> List[Dict]:
         messages.append(
             {
                 "Id": str(uuid.uuid4()),
-                "MessageBody": json.dumps(event),
+                "MessageBody": event,
                 "MessageAttributes": custom_attrs,
             }
         )

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -32,7 +32,7 @@ def sqs_error_to_dead_letter_queue(queue_arn: str, event: Dict, error):
     return _send_to_dead_letter_queue("SQS", queue_arn, target_arn, event, error)
 
 
-def sns_error_to_dead_letter_queue(sns_subscriber_arn: str, event: Union[Dict, str], error):
+def sns_error_to_dead_letter_queue(sns_subscriber_arn: str, event: str, error):
     # event should be of type str if coming from SNS, as it represents the message body being passed down
     client = aws_stack.connect_to_service("sns")
     attrs = client.get_subscription_attributes(SubscriptionArn=sns_subscriber_arn)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -21,6 +21,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
     get_free_tcp_port,
     get_service_protocol,
+    poll_condition,
     retry,
     short_uid,
     to_str,
@@ -44,6 +45,24 @@ TEST_TOPIC_NAME_2 = "topic-test-2"
 
 PUBLICATION_TIMEOUT = 0.500
 PUBLICATION_RETRIES = 4
+
+
+# copy/pasted from test_sqs.py, utility function
+def queue_exists(sqs_client, queue_url: str) -> bool:
+    """
+    Checks whether a queue with the given queue URL exists.
+
+    :param sqs_client: the botocore client
+    :param queue_url: the queue URL
+    :return: true if the queue exists, false otherwise
+    """
+    try:
+        result = sqs_client.get_queue_url(QueueName=queue_url.split("/")[-1])
+        return result.get("QueueUrl") == queue_url
+    except ClientError as e:
+        if "NonExistentQueue" in e.response["Error"]["Code"]:
+            return False
+        raise
 
 
 class TestSNSSubscription:
@@ -677,15 +696,13 @@ class TestSNSProvider:
             Message=json.dumps({"message": "test_redrive_policy"}),
         )
 
-        def receive_dlq():
-            result = sqs_client.receive_message(QueueUrl=dlq_url, MessageAttributeNames=["All"])
-            assert len(result["Messages"]) > 0
-            assert (
-                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"]
-                == "test_redrive_policy"
-            )
-
-        retry(receive_dlq, retries=7, sleep=2.5)
+        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+        message = json.loads(response["Messages"][0]["Body"])
+        assert message["Type"] == "Notification"
+        assert json.loads(message["Message"])["message"] == "test_redrive_policy"
 
     def test_redrive_policy_lambda_subscription(
         self,
@@ -725,15 +742,13 @@ class TestSNSProvider:
             Message=json.dumps({"message": "test_redrive_policy"}),
         )
 
-        def receive_dlq():
-            result = sqs_client.receive_message(QueueUrl=dlq_url, MessageAttributeNames=["All"])
-            assert len(result["Messages"]) > 0
-            assert (
-                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"]
-                == "test_redrive_policy"
-            )
-
-        retry(receive_dlq, retries=10, sleep=2)
+        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+        message = json.loads(response["Messages"][0]["Body"])
+        assert message["Type"] == "Notification"
+        assert json.loads(message["Message"])["message"] == "test_redrive_policy"
 
     def test_redrive_policy_queue_subscription(
         self,
@@ -766,15 +781,13 @@ class TestSNSProvider:
             TopicArn=topic_arn, Message=json.dumps({"message": "test_redrive_policy"})
         )
 
-        def receive_dlq():
-            result = sqs_client.receive_message(QueueUrl=dlq_url, MessageAttributeNames=["All"])
-            assert len(result["Messages"]) > 0
-            assert (
-                json.loads(json.loads(result["Messages"][0]["Body"])["Message"][0])["message"]
-                == "test_redrive_policy"
-            )
-
-        retry(receive_dlq, retries=10, sleep=2)
+        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+        message = json.loads(response["Messages"][0]["Body"])
+        assert message["Type"] == "Notification"
+        assert json.loads(message["Message"])["message"] == "test_redrive_policy"
 
     def test_publish_with_empty_subject(self, sns_client, sns_create_topic):
         topic_arn = sns_create_topic()["TopicArn"]
@@ -1510,3 +1523,77 @@ class TestSNSProvider:
             )["Attributes"]["ApproximateNumberOfMessages"]
             == "0"
         )
+
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    @pytest.mark.aws_validated
+    def test_dead_letter_queue_with_deleted_sqs_queue(
+        self,
+        sns_client,
+        sqs_client,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sns_create_sqs_subscription,
+        raw_message_delivery,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        dlq_url = sqs_create_queue()
+        dlq_arn = sqs_queue_arn(dlq_url)
+
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="RedrivePolicy",
+            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+        )
+
+        if raw_message_delivery:
+            sns_client.set_subscription_attributes(
+                SubscriptionArn=subscription["SubscriptionArn"],
+                AttributeName="RawMessageDelivery",
+                AttributeValue="true",
+            )
+
+        # allow topic to write to the DLQ sqs queue
+        # taken from localstack.testing.pytest.fixtures.sns_create_sqs_subscription#494
+        sqs_client.set_queue_attributes(
+            QueueUrl=dlq_url,
+            Attributes={
+                "Policy": json.dumps(
+                    {
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Principal": {"Service": "sns.amazonaws.com"},
+                                "Action": "sqs:SendMessage",
+                                "Resource": dlq_arn,
+                                "Condition": {"ArnEquals": {"aws:SourceArn": topic_arn}},
+                            }
+                        ]
+                    }
+                )
+            },
+        )
+
+        sqs_client.delete_queue(QueueUrl=queue_url)
+
+        # AWS takes some time to delete the queue, which make the test fails as it delivers the message correctly
+        assert poll_condition(lambda: not queue_exists(sqs_client, queue_url), timeout=5)
+
+        message = "test_dlq_after_sqs_endpoint_deleted"
+        sns_client.publish(TopicArn=topic_arn, Message=message)
+
+        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+
+        if raw_message_delivery:
+            assert response["Messages"][0]["Body"] == message
+        else:
+            received_message = json.loads(response["Messages"][0]["Body"])
+            assert received_message["Type"] == "Notification"
+            assert received_message["Message"] == message

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -1,0 +1,37 @@
+{
+  "tests/integration/test_sns.py::TestSNSProvider::test_dead_letter_queue_with_deleted_sqs_queue[True]": {
+    "raw_message_delivery": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "<receipt-handle>",
+          "MD5OfBody": "2040fa62e6ff90d21d5fe319d5e65443",
+          "Body": "test_dlq_after_sqs_endpoint_deleted"
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_dead_letter_queue_with_deleted_sqs_queue[False]": {
+    "json_encoded_delivery": {
+      "Messages": [
+        {
+          "MessageId": "<uuid>",
+          "ReceiptHandle": "<receipt-handle>",
+          "MD5OfBody": "<md5-hash>",
+          "Body": {
+            "Type": "Notification",
+            "MessageId": "<uuid>",
+            "TopicArn": "<arn>",
+            "Message": "test_dlq_after_sqs_endpoint_deleted",
+            "Timestamp": "<timestamp>",
+            "SignatureVersion": "1",
+            "Signature": "<signature>",
+            "SigningCertURL": "https://<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=<arn>"
+          }
+        }
+      ],
+      "ResponseMetadata": "<response-metadata>"
+    }
+  }
+}

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -43,35 +43,6 @@ TEST_POLICY = """
 TEST_REGION = "us-east-1"
 
 
-def queue_exists(sqs_client, queue_url: str) -> bool:
-    """
-    Checks whether a queue with the given queue URL exists.
-
-    :param sqs_client: the botocore client
-    :param queue_url: the queue URL
-    :return: true if the queue exists, false otherwise
-    """
-    try:
-        result = sqs_client.get_queue_url(QueueName=queue_url.split("/")[-1])
-        return result.get("QueueUrl") == queue_url
-    except ClientError as e:
-        if "NonExistentQueue" in e.response["Error"]["Code"]:
-            return False
-        raise
-
-
-def get_queue_arn(sqs_client, queue_url: str) -> str:
-    """
-    Returns the given Queue's ARN. Expects the Queue to exist.
-
-    :param sqs_client: the boto3 client
-    :param queue_url: the queue URL
-    :return: the QueueARN
-    """
-    response = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])
-    return response["Attributes"]["QueueArn"]
-
-
 def get_qsize(sqs_client, queue_url: str) -> int:
     """
     Returns the integer value of the ApproximateNumberOfMessages queue attribute.
@@ -829,10 +800,10 @@ class TestSqsProvider:
         e.match("InvalidParameterValue")
 
     @pytest.mark.xfail
-    def test_redrive_policy_attribute_validity(self, sqs_create_queue, sqs_client):
+    def test_redrive_policy_attribute_validity(self, sqs_create_queue, sqs_client, sqs_queue_arn):
         dl_queue_name = f"dl-queue-{short_uid()}"
         dl_queue_url = sqs_create_queue(QueueName=dl_queue_name)
-        dl_target_arn = get_queue_arn(sqs_client, dl_queue_url)
+        dl_target_arn = sqs_queue_arn(dl_queue_url)
         queue_name = f"queue-{short_uid()}"
         queue_url = sqs_create_queue(QueueName=queue_name)
         valid_max_receive_count = "42"
@@ -1164,7 +1135,7 @@ class TestSqsProvider:
 
     @pytest.mark.aws_validated
     def test_dead_letter_queue_with_fifo_and_content_based_deduplication(
-        self, sqs_client, sqs_create_queue
+        self, sqs_client, sqs_create_queue, sqs_queue_arn
     ):
         dlq_url = sqs_create_queue(
             QueueName=f"test-dlq-{short_uid()}.fifo",
@@ -1174,7 +1145,7 @@ class TestSqsProvider:
                 "MessageRetentionPeriod": "1209600",
             },
         )
-        dlq_arn = get_queue_arn(sqs_client, dlq_url)
+        dlq_arn = sqs_queue_arn(dlq_url)
 
         queue_url = sqs_create_queue(
             QueueName=f"test-queue-{short_uid()}.fifo",
@@ -2180,7 +2151,9 @@ class TestSqsQueryApi:
         assert "<Message>Unknown Attribute Foobar.</Message>" in response.text
 
     @pytest.mark.aws_validated
-    def test_get_delete_queue(self, sqs_create_queue, sqs_client, sqs_http_client):
+    def test_get_delete_queue(
+        self, sqs_create_queue, sqs_client, sqs_http_client, sqs_queue_exists
+    ):
         queue_url = sqs_create_queue()
 
         response = sqs_http_client.get(
@@ -2192,7 +2165,7 @@ class TestSqsQueryApi:
         assert response.ok
         assert "<DeleteQueueResponse " in response.text
 
-        assert poll_condition(lambda: not queue_exists(sqs_client, queue_url), timeout=5)
+        assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
 
     @pytest.mark.aws_validated
     def test_get_send_and_receive_messages(self, sqs_create_queue, sqs_http_client):
@@ -2235,12 +2208,14 @@ class TestSqsQueryApi:
         assert "<MD5OfBody>" in response.text
 
     @pytest.mark.aws_validated
-    def test_get_on_deleted_queue_fails(self, sqs_client, sqs_create_queue, sqs_http_client):
+    def test_get_on_deleted_queue_fails(
+        self, sqs_client, sqs_create_queue, sqs_http_client, sqs_queue_exists
+    ):
         queue_url = sqs_create_queue()
 
         sqs_client.delete_queue(QueueUrl=queue_url)
 
-        assert poll_condition(lambda: not queue_exists(sqs_client, queue_url), timeout=5)
+        assert poll_condition(lambda: not sqs_queue_exists(queue_url), timeout=5)
 
         response = sqs_http_client.get(
             queue_url,


### PR DESCRIPTION
There was an issue when delivering to a SQS DLQ after failing to deliver an SNS notification. The format wasn't properly handled, and we passed the event directly down to the SQS client.

### Problem
As notified in #5604, the format of the message received from the DLQ after failing to deliver a message with SNS wasn't the same than AWS.
The issue was tracked down to the message formatting of an event to a SNS notification being done in a `try...except` block. When an Exception would rise, we would pass down the raw data to the SQS client, which would then `json.dumps` it directly as a `MessageBody`. 

### Solution
We need to move the creation of the message body outside the `try...except` block, and pass that message down to the SQS client delivering to the DLQ.
A minor issue arising from this fix is a change to the localstack/utils/aws/dead_letter_queue.py file. The utility function `_send_to_dead_letter_queue` expects an event of type `dict`. But in the case of a SNS delivery to a DLQ, the event being passed down is always a `str` (the message body). The event is never used in itself, but passed down all the way to the end to be sent. So I took the liberty to add the type signature to the method, warning that it can be a `str` or a `dict`. (In the past, in case of `RawDelivery` being set, the event passed down was already a `str`).

A small fix I've done is adding a header when `RawDelivery` is `true` in the case of a http endpoint being set for a SNS subscription. While reading the doc, I realised it was missing.
https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html

Thanks to the snapshot utility testing, I realised a field of SNS notifications was missing: `UnsubscribeURL`. It has been added as well.

I changed some tests (the one failing because of the right message format) to use the `WaitTimeSeconds` keyword in `sqs_client.receive_message` instead of retrying, it allows better error messages, often in `retry`, assert errors would give the first `assert` when the second one would be the culprit. It also feels better to use the functionality given by the `receive_messages` function, and it seems better suited to test against AWS.

### Tests
I've pushed a bit further and used the new `snapshot` utility. I added the usage in another commit, as I realise it could complicate navigating my tests as I tried to cover well the format of the received messages. 

_Fixes #5604_