### PR TITLE
Update redhat image to python 3.10

### DIFF
--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -7,20 +7,25 @@ LABEL authors="LocalStack Contributors"
 LABEL maintainer="LocalStack Team (info@localstack.cloud)"
 LABEL description="LocalStack Docker image"
 
-RUN dnf install -y cyrus-sasl-devel gcc gcc-c++ git iputils make npm openssl-devel procps bzip2-devel sqlite-devel libffi-devel zip \
+RUN dnf install -y cyrus-sasl-devel gcc gcc-c++ git iputils make npm openssl-devel procps zip \
   && dnf clean all \
   && rm -rf /var/cache/yum
-RUN git clone https://github.com/pyenv/pyenv.git $HOME/.pyenv \
-  && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
-  && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
-  && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
-  && source ~/.bashrc \
-  && pyenv install 3.10.4 --verbose \
-  && pyenv global 3.10.4
 
+RUN dnf install -y bzip2-devel sqlite-devel libffi-devel \
+  && curl https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz -o Python-3.10.4.tgz \
+  && tar xzf Python-3.10.4.tgz \
+  && cd Python-3.10.4 \
+  && ./configure \
+  && make -j $(nproc) \
+  && make install \
+  && cd .. \
+  && rm -rf Python-3.10.4 \
+  && rm Python-3.10.4.tgz \
+  && dnf remove -y bzip2-devel sqlite-devel libffi-devel \
+  && dnf clean all \
+  && rm -rf /var/cache/yum
 
-SHELL ["/bin/bash", "-c", "source ~/.bashrc"]
-RUN python3 --version
+RUN python3 -m pip install -U setuptools pip wheel
 
 # Create a localstack user
 RUN useradd -ms /bin/bash localstack

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -7,9 +7,20 @@ LABEL authors="LocalStack Contributors"
 LABEL maintainer="LocalStack Team (info@localstack.cloud)"
 LABEL description="LocalStack Docker image"
 
-RUN dnf install -y cyrus-sasl-devel gcc gcc-c++ git iputils make npm openssl-devel procps python38-devel zip \
+RUN dnf install -y cyrus-sasl-devel gcc gcc-c++ git iputils make npm openssl-devel procps bzip2-devel sqlite-devel libffi-devel zip \
   && dnf clean all \
   && rm -rf /var/cache/yum
+RUN git clone https://github.com/pyenv/pyenv.git $HOME/.pyenv \
+  && echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc \
+  && echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc \
+  && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
+  && source ~/.bashrc \
+  && pyenv install 3.10.4 --verbose \
+  && pyenv global 3.10.4
+
+
+SHELL ["/bin/bash", "-c", "source ~/.bashrc"]
+RUN python3 --version
 
 # Create a localstack user
 RUN useradd -ms /bin/bash localstack


### PR DESCRIPTION
## Background
With the code moving fast to python3.10, the build pipeline for redhat fails under python3.8.

## Changes
Install python3.10 from source to enable python3.10 features in the redhat image. To be removed after redhat publishes an official python3.10 package.

## Decisions
After trying pyenv, it became clear that it is slightly easier to just install the sourcecode itself. Pyenv would not have taken less work to setup, but would need more stages regarding environment variables etc (since we cannot assume .bashrc is sourced, we would need to setup everything manually in the image).
In the end it seemed easier (and smaller regarding image size) to install python directly than use pyenv.