### PR TITLE
APIGW Lambda integration validations

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -201,11 +201,9 @@ class LambdaProxyIntegration(BackendIntegration):
             parsed_result = common.json_safe(parsed_result)
             parsed_result = {} if parsed_result is None else parsed_result
 
-            keys =  parsed_result.keys()
+            keys = parsed_result.keys()
 
-            if not (
-                "statusCode" in keys and "body" in keys
-            ):
+            if not ("statusCode" in keys and "body" in keys):
                 LOG.warning(
                     'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}'
                 )
@@ -213,7 +211,7 @@ class LambdaProxyIntegration(BackendIntegration):
                 response.headers.update({"content-type": "application/json"})
                 response._content = json.dumps({"message": "Internal server error"})
                 return response
-            
+
             response.status_code = int(parsed_result.get("statusCode", 200))
             parsed_headers = parsed_result.get("headers", {})
             if parsed_headers is not None:

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -200,6 +200,20 @@ class LambdaProxyIntegration(BackendIntegration):
             parsed_result = result if isinstance(result, dict) else json.loads(str(result or "{}"))
             parsed_result = common.json_safe(parsed_result)
             parsed_result = {} if parsed_result is None else parsed_result
+
+            keys =  parsed_result.keys()
+
+            if not (
+                "statusCode" in keys and "body" in keys
+            ):
+                LOG.warning(
+                    'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}'
+                )
+                response.status_code = 502
+                response.headers.update({"content-type": "application/json"})
+                response._content = json.dumps({"message": "Internal server error"})
+                return response
+            
             response.status_code = int(parsed_result.get("statusCode", 200))
             parsed_headers = parsed_result.get("headers", {})
             if parsed_headers is not None:

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -382,6 +382,8 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
                 response = result
             else:
                 response = LambdaResponse()
+                response.headers.update({"content-type": "application/json"})
+
                 parsed_result = (
                     result if isinstance(result, dict) else json.loads(str(result or "{}"))
                 )

--- a/tests/integration/awslambda/functions/apigw_502.js
+++ b/tests/integration/awslambda/functions/apigw_502.js
@@ -1,4 +1,4 @@
-exports.handler =  async function(event, context) {
-  let body = {"message": "completed"}
+exports.handler = async function (event, context) {
+  let body = { "message": "completed" }
   return body
 }

--- a/tests/integration/awslambda/functions/apigw_502.js
+++ b/tests/integration/awslambda/functions/apigw_502.js
@@ -1,0 +1,4 @@
+exports.handler =  async function(event, context) {
+  let body = {"message": "completed"}
+  return body
+}

--- a/tests/integration/awslambda/functions/apigw_integration.js
+++ b/tests/integration/awslambda/functions/apigw_integration.js
@@ -1,8 +1,9 @@
-exports.handler = function(event, context) {
+exports.handler = async function (event, context) {
   console.log("FUNCTION HAS RUN")
   return {
-    "isBase64Encoded": false,
-    "statusCode": 200,
-    "headers": { "content-type": "application/xml"},
-    "body": "<message>completed</message>"
-}}
+    isBase64Encoded: false,
+    statusCode: 300,
+    headers: { "content-type": "application/xml" },
+    body: "<message>completed</message>"
+  }
+}

--- a/tests/integration/awslambda/functions/apigw_integration.js
+++ b/tests/integration/awslambda/functions/apigw_integration.js
@@ -1,0 +1,8 @@
+exports.handler = function(event, context) {
+  console.log("FUNCTION HAS RUN")
+  return {
+    "isBase64Encoded": false,
+    "statusCode": 200,
+    "headers": { "content-type": "application/xml"},
+    "body": "<message>completed</message>"
+}}

--- a/tests/integration/awslambda/functions/lambda_handler.js
+++ b/tests/integration/awslambda/functions/lambda_handler.js
@@ -2,6 +2,8 @@ exports.handler = async (event) => {
    console.log(JSON.stringify(event))
    return {
      statusCode: 200,
-     body: JSON.stringify(`response from localstack lambda: ${JSON.stringify(event)}`)
+     body: JSON.stringify(`response from localstack lambda: ${JSON.stringify(event)}`),
+     isBase64Encoded: false,
+     headers: {}
    }
 }

--- a/tests/integration/awslambda/functions/lambda_integration.py
+++ b/tests/integration/awslambda/functions/lambda_integration.py
@@ -70,7 +70,7 @@ def handler(event, context):
         body["headers"] = event.get("headers")
         body["isBase64Encoded"] = event.get("isBase64Encoded")
         if body["httpMethod"] == "DELETE":
-            return {"statusCode": 204}
+            return {"statusCode": 204, "body": ""}
 
         # This parameter is often just completely excluded from the response.
         base64_response = {}

--- a/tests/integration/awslambda/functions/lambda_integration.py
+++ b/tests/integration/awslambda/functions/lambda_integration.py
@@ -85,6 +85,7 @@ def handler(event, context):
         return {
             "body": body,
             "statusCode": status_code,
+            "isBase64Encoded": is_base_64_encoded,
             "headers": headers,
             "multiValueHeaders": {"set-cookie": ["language=en-US", "theme=blue moon"]},
             **base64_response,

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -112,6 +112,9 @@ TEST_LAMBDA_FUNCTION_PREFIX = "lambda-function"
 
 TEST_GOLANG_LAMBDA_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-runtime/releases/download/v{version}/example-handler-{os}-{arch}.tar.gz"
 
+TEST_LAMBDA_JS_APIGW_INTEGRATION = os.path.join(THIS_FOLDER, "functions/apigw_integration.js")
+TEST_LAMBDA_JS_APIGW_502 = os.path.join(THIS_FOLDER, "functions/apigw_502.js")
+
 TEST_LAMBDA_LIBS = [
     "requests",
     "psutil",

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -83,6 +83,8 @@ TEST_LAMBDA_INTEGRATION_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_int
 TEST_LAMBDA_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_handler.js")
 TEST_LAMBDA_NODEJS_ES6 = os.path.join(THIS_FOLDER, "functions/lambda_handler_es6.mjs")
 TEST_LAMBDA_HELLO_WORLD = os.path.join(THIS_FOLDER, "functions/lambda_hello_world.py")
+TEST_LAMBDA_NODEJS_APIGW_INTEGRATION = os.path.join(THIS_FOLDER, "functions/apigw_integration.js")
+TEST_LAMBDA_NODEJS_APIGW_502 = os.path.join(THIS_FOLDER, "functions/apigw_502.js")
 TEST_LAMBDA_GOLANG_ZIP = os.path.join(THIS_FOLDER, "functions/golang/handler.zip")
 TEST_LAMBDA_RUBY = os.path.join(THIS_FOLDER, "functions/lambda_integration.rb")
 TEST_LAMBDA_DOTNETCORE2 = os.path.join(THIS_FOLDER, "functions/dotnetcore2/dotnetcore2.zip")
@@ -112,8 +114,6 @@ TEST_LAMBDA_FUNCTION_PREFIX = "lambda-function"
 
 TEST_GOLANG_LAMBDA_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-runtime/releases/download/v{version}/example-handler-{os}-{arch}.tar.gz"
 
-TEST_LAMBDA_JS_APIGW_INTEGRATION = os.path.join(THIS_FOLDER, "functions/apigw_integration.js")
-TEST_LAMBDA_JS_APIGW_502 = os.path.join(THIS_FOLDER, "functions/apigw_502.js")
 
 TEST_LAMBDA_LIBS = [
     "requests",

--- a/tests/integration/awslambda/test_lambda_integration.py
+++ b/tests/integration/awslambda/test_lambda_integration.py
@@ -3,9 +3,9 @@ import json
 import os
 import time
 from unittest.mock import patch
-import xmltodict
 
 import pytest
+import xmltodict
 from botocore.exceptions import ClientError
 
 from localstack import config
@@ -15,9 +15,9 @@ from localstack.services.awslambda.lambda_api import (
     INVALID_PARAMETER_VALUE_EXCEPTION,
 )
 from localstack.services.awslambda.lambda_utils import (
+    LAMBDA_RUNTIME_NODEJS14X,
     LAMBDA_RUNTIME_PYTHON36,
     LAMBDA_RUNTIME_PYTHON37,
-    LAMBDA_RUNTIME_NODEJS14X,
 )
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -29,13 +29,11 @@ from localstack.utils.testutil import check_expected_lambda_log_events_length, g
 from .functions import lambda_integration
 from .test_lambda import (
     TEST_LAMBDA_LIBS,
+    TEST_LAMBDA_NODEJS_APIGW_502,
+    TEST_LAMBDA_NODEJS_APIGW_INTEGRATION,
     TEST_LAMBDA_PYTHON,
     TEST_LAMBDA_PYTHON_ECHO,
     TEST_LAMBDA_PYTHON_UNHANDLED_ERROR,
-    TEST_LAMBDA_NODEJS_APIGW_502,
-    TEST_LAMBDA_NODEJS_APIGW_INTEGRATION,
-    TEST_LAMBDA_NODEJS,
-    read_streams
 )
 
 TEST_STAGE_NAME = "testing"
@@ -459,17 +457,17 @@ class TestLambdaHttpInvocation:
         assert lambda_resource == content["resource"]
         assert lambda_request_context_path == content["requestContext"]["path"]
         assert lambda_request_context_resource_path == content["requestContext"]["resourcePath"]
-        
+
     def test_response_headers_invocation_with_apigw(self, create_lambda_function, lambda_client):
         lambda_name = f"test_lambda_{short_uid()}"
         lambda_resource = "/api/v1/{proxy+}"
         lambda_path = "/api/v1/hello/world"
-        lambda_request_context_path = "/" + TEST_STAGE_NAME + lambda_path
-        lambda_request_context_resource_path = lambda_resource
 
         create_lambda_function(
             func_name=lambda_name,
-            zip_file=testutil.create_zip_file(TEST_LAMBDA_NODEJS_APIGW_INTEGRATION, get_content=True ),
+            zip_file=testutil.create_zip_file(
+                TEST_LAMBDA_NODEJS_APIGW_INTEGRATION, get_content=True
+            ),
             runtime=LAMBDA_RUNTIME_NODEJS14X,
             handler="apigw_integration.handler",
         )
@@ -487,20 +485,18 @@ class TestLambdaHttpInvocation:
         result = safe_requests.get(url)
 
         assert result.status_code == 300
-        assert result.headers["Content-Type"] == 'application/xml'
+        assert result.headers["Content-Type"] == "application/xml"
         body = xmltodict.parse(result.content)
         assert body.get("message") == "completed"
-    
+
     def test_malformed_response_apigw_invocation(self, create_lambda_function, lambda_client):
         lambda_name = f"test_lambda_{short_uid()}"
         lambda_resource = "/api/v1/{proxy+}"
         lambda_path = "/api/v1/hello/world"
-        lambda_request_context_path = "/" + TEST_STAGE_NAME + lambda_path
-        lambda_request_context_resource_path = lambda_resource
 
         create_lambda_function(
             func_name=lambda_name,
-            zip_file=testutil.create_zip_file(TEST_LAMBDA_NODEJS_APIGW_502, get_content=True ),
+            zip_file=testutil.create_zip_file(TEST_LAMBDA_NODEJS_APIGW_502, get_content=True),
             runtime=LAMBDA_RUNTIME_NODEJS14X,
             handler="apigw_502.handler",
         )


### PR DESCRIPTION
This PR addresses issue #6134, where an user mentions that the ApiGW-Lambda integration returns `content-type: text/html` regardless of what the Lambda returns, which is not the case, but another user mentioned that the integration by default should return `content-type: application/json`. While triaging this, I also discovered that AWS does a validation on the lambda response and returns a 502 if it doesn't follow a [format](https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway).

Changes:
- Add a test to make sure that APIGW-Lambda integration returns the headers correctly.
- The validation for the Lambda response and return a 502 error if it doesn't pass.
- Test of the integration 502 error.
- The integration by default returns a `content-type: application/json`