### PR TITLE
Added explicit check for a bucket when deploying a stack

### DIFF
--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from localstack.constants import AWS_REGION_US_EAST_1, S3_VIRTUAL_HOSTNAME
+from localstack.constants import S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
     dump_json_params,
@@ -111,10 +111,8 @@ class S3Bucket(GenericBaseModel):
             }
             return result
 
-        def get_bucket_location_config(**kwargs):
+        def get_bucket_location_config():
             region = aws_stack.get_region()
-            if region == AWS_REGION_US_EAST_1:
-                return None
             return {"LocationConstraint": region}
 
         def _pre_delete(resource_id, resources, resource_type, func, stack_name):
@@ -157,18 +155,26 @@ class S3Bucket(GenericBaseModel):
                     },
                 )
 
+        def _create_bucket(resource_id, resources, resource_type, func, stack_name):
+            s3_client = aws_stack.connect_to_service("s3")
+            resource = resources[resource_id]
+            props = resource["Properties"]
+            bucket_name = props.get("BucketName")
+            try:
+                s3_client.head_bucket(Bucket=bucket_name)
+            except Exception:
+                # bucket not found; we create one
+                props = resource["Properties"]
+                bucket_name = props.get("BucketName")
+                s3_client.create_bucket(
+                    Bucket=bucket_name,
+                    ACL=convert_acl_cf_to_s3(props.get("AccessControl", "PublicRead")),
+                    CreateBucketConfiguration=get_bucket_location_config(),
+                )
+
         result = {
             "create": [
-                {
-                    "function": "create_bucket",
-                    "parameters": {
-                        "Bucket": ["BucketName", PLACEHOLDER_RESOURCE_NAME],
-                        "ACL": lambda params, **kwargs: convert_acl_cf_to_s3(
-                            params.get("AccessControl", "PublicRead")
-                        ),
-                        "CreateBucketConfiguration": lambda params, **kwargs: get_bucket_location_config(),
-                    },
-                },
+                {"function": _create_bucket},
                 {
                     "function": "put_bucket_notification_configuration",
                     "parameters": s3_bucket_notification_config,

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import time
+from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 
 import boto3
@@ -79,6 +80,14 @@ def _client(service, region_name=None):
         else None
     )
     return aws_stack.create_external_boto_client(service, config=config, region_name=region_name)
+
+
+@pytest.fixture(scope="class")
+def patch_region(monkeypatch, request):
+    region = request.param if hasattr(request, "param") else "us-east-1"
+    monkeypatch.setattr(
+        "localstack.testing.pytest.fixtures._client", partial(_client, region_name=region)
+    )
 
 
 def _resource(service):

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import time
-from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 
 import boto3
@@ -80,14 +79,6 @@ def _client(service, region_name=None):
         else None
     )
     return aws_stack.create_external_boto_client(service, config=config, region_name=region_name)
-
-
-@pytest.fixture(scope="class")
-def patch_region(monkeypatch, request):
-    region = request.param if hasattr(request, "param") else "us-east-1"
-    monkeypatch.setattr(
-        "localstack.testing.pytest.fixtures._client", partial(_client, region_name=region)
-    )
 
 
 def _resource(service):

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -997,10 +997,26 @@ class TestCloudFormation:
         rs = events_client.list_rules()
         assert rule["Name"] not in [r["Name"] for r in rs["Rules"]]
 
-    def test_cfn_handle_s3_notification_configuration(self, s3_client, deploy_cfn_template):
+    @pytest.mark.parametrize(
+        "create_bucket_first, patch_region",
+        [(True, "eu-west-1"), (False, "us-east-1")],
+        indirect=["patch_region"],
+    )
+    def test_cfn_handle_s3_notification_configuration(
+        self,
+        patch_region,
+        s3_client,
+        deploy_cfn_template,
+        create_bucket_first,
+    ):
         bucket_name = f"target-{short_uid()}"
         queue_name = f"queue-{short_uid()}"
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = aws_stack.sqs_queue_arn(queue_name, region_name=s3_client.meta.region_name)
+        if create_bucket_first:
+            s3_client.create_bucket(
+                Bucket=bucket_name,
+                CreateBucketConfiguration={"LocationConstraint": s3_client.meta.region_name},
+            )
         stack = deploy_cfn_template(
             template=TEST_TEMPLATE_17 % (queue_name, bucket_name, queue_arn),
         )

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -998,17 +998,16 @@ class TestCloudFormation:
         assert rule["Name"] not in [r["Name"] for r in rs["Rules"]]
 
     @pytest.mark.parametrize(
-        "create_bucket_first, patch_region",
-        [(True, "eu-west-1"), (False, "us-east-1")],
-        indirect=["patch_region"],
+        "create_bucket_first, region", [(True, "eu-west-1"), (False, "us-east-1")]
     )
     def test_cfn_handle_s3_notification_configuration(
         self,
-        patch_region,
-        s3_client,
+        region,
+        create_boto_client,
         deploy_cfn_template,
         create_bucket_first,
     ):
+        s3_client = create_boto_client("s3", region_name=region)
         bucket_name = f"target-{short_uid()}"
         queue_name = f"queue-{short_uid()}"
         queue_arn = aws_stack.sqs_queue_arn(queue_name, region_name=s3_client.meta.region_name)


### PR DESCRIPTION
Issue coming from support. 
The problem came from the fact that we consider a resource as not created if it does not have notification configs attached. 
This causes a `BucketAlreadyOwnedByYou` error outside `us-east-1`. 
I changed the deploy template with a function that explicitly checks if the bucket exists and, if not, proceeds to create it.
Feedback are welcome, quite a newbie here on CloudFormation.