### PR TITLE
Add error handling for localstack container startup in CLI

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -492,26 +492,35 @@ class LocalstackContainer:
         client = CmdDockerClient()
         client.default_run_outfile = self.logfile
 
-        return client.run_container(
-            image_name=self.image_name,
-            stdin=self.stdin,
-            name=self.name,
-            entrypoint=self.entrypoint or None,
-            remove=self.remove,
-            interactive=self.interactive,
-            tty=self.tty,
-            detach=self.detach,
-            command=self.command or None,
-            mount_volumes=self._get_mount_volumes(),
-            ports=self.ports,
-            env_vars=self.env_vars,
-            user=self.user,
-            cap_add=self.cap_add,
-            network=self.network,
-            dns=self.dns,
-            additional_flags=" ".join(self.additional_flags),
-            workdir=self.workdir,
-        )
+        try:
+            return client.run_container(
+                image_name=self.image_name,
+                stdin=self.stdin,
+                name=self.name,
+                entrypoint=self.entrypoint or None,
+                remove=self.remove,
+                interactive=self.interactive,
+                tty=self.tty,
+                detach=self.detach,
+                command=self.command or None,
+                mount_volumes=self._get_mount_volumes(),
+                ports=self.ports,
+                env_vars=self.env_vars,
+                user=self.user,
+                cap_add=self.cap_add,
+                network=self.network,
+                dns=self.dns,
+                additional_flags=" ".join(self.additional_flags),
+                workdir=self.workdir,
+            )
+        except ContainerException as e:
+            if LOG.isEnabledFor(logging.DEBUG):
+                LOG.exception("Error while starting LocalStack container")
+            else:
+                LOG.error(
+                    "Error while starting LocalStack container: %s\n%s", e.message, to_str(e.stderr)
+                )
+            raise
 
     def truncate_log(self):
         with open(self.logfile, "wb") as fd:

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -96,7 +96,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def pause_container(self, container_name: str) -> None:
         cmd = self._docker_cmd()
@@ -110,7 +110,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def unpause_container(self, container_name: str) -> None:
         cmd = self._docker_cmd()
@@ -124,7 +124,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def remove_image(self, image: str, force: bool = True) -> None:
         cmd = self._docker_cmd()
@@ -140,7 +140,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def commit(
         self,
@@ -161,7 +161,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def remove_container(self, container_name: str, force=True, check_existence=False) -> None:
         if check_existence and container_name not in self.get_running_container_names():
@@ -179,7 +179,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def list_containers(self, filter: Union[List[str], str, None] = None, all=True) -> List[dict]:
         filter = [filter] if isinstance(filter, str) else filter
@@ -198,7 +198,7 @@ class CmdDockerClient(ContainerClient):
         except subprocess.CalledProcessError as e:
             raise ContainerException(
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-            )
+            ) from e
         container_list = []
         if cmd_result:
             container_list = [json.loads(line) for line in cmd_result.splitlines()]
@@ -228,7 +228,7 @@ class CmdDockerClient(ContainerClient):
                 raise NoSuchContainer(container_name)
             raise ContainerException(
                 f"Docker process returned with errorcode {e.returncode}", e.stdout, e.stderr
-            )
+            ) from e
 
     def copy_from_container(
         self, container_name: str, local_path: str, container_path: str
@@ -243,7 +243,7 @@ class CmdDockerClient(ContainerClient):
                 raise NoSuchContainer(container_name)
             raise ContainerException(
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-            )
+            ) from e
 
     def pull_image(self, docker_image: str) -> None:
         cmd = self._docker_cmd()
@@ -256,7 +256,7 @@ class CmdDockerClient(ContainerClient):
                 raise NoSuchImage(docker_image)
             raise ContainerException(
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-            )
+            ) from e
 
     def push_image(self, docker_image: str) -> None:
         cmd = self._docker_cmd()
@@ -329,7 +329,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def stream_container_logs(self, container_name_or_id: str) -> CancellableStream:
         self.inspect_container(container_name_or_id)  # guard to check whether container is there
@@ -354,7 +354,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
         image_data = json.loads(cmd_result.strip())
         return image_data
 
@@ -404,7 +404,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def disconnect_container_from_network(
         self, network_name: str, container_name_or_id: str
@@ -424,7 +424,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def get_container_ip(self, container_name_or_id: str) -> str:
         cmd = self._docker_cmd()
@@ -443,7 +443,7 @@ class CmdDockerClient(ContainerClient):
             else:
                 raise ContainerException(
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-                )
+                ) from e
 
     def has_docker(self) -> bool:
         try:
@@ -465,7 +465,7 @@ class CmdDockerClient(ContainerClient):
                 raise NoSuchImage(image_name, stdout=e.stdout, stderr=e.stderr)
             raise ContainerException(
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-            )
+            ) from e
         finally:
             Util.rm_env_vars_file(env_file)
 
@@ -558,7 +558,7 @@ class CmdDockerClient(ContainerClient):
                 raise NoSuchContainer(container_name, stdout=e.stdout, stderr=e.stderr)
             raise ContainerException(
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
-            )
+            ) from e
 
     def _build_run_create_cmd(
         self,


### PR DESCRIPTION
## Background
Currently, if something unexpected goes wrong with the docker run command when starting localstack, we get no feedback to the user what exactly went wrong, the CLI will just terminate.

## Fix
Unexpected failures will now return the error message as returned from the docker daemon, instead of silently exiting.
Also, I added explicit exception chaining for the CmdDockerClient.