### PR TITLE
Kinesis - option for persistence path

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -465,6 +465,9 @@ KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
 # delay in kinesalite response when making changes to streams
 KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
 
+# Delay between data persistence (in seconds)
+KINESIS_MOCK_PERSIST_INTERVAL = os.environ.get("KINESIS_MOCK_PERSIST_INTERVAL", "").strip() or "5s"
+
 # Kinesis provider - either "kinesis-mock" or "kinesalite"
 KINESIS_PROVIDER = os.environ.get("KINESIS_PROVIDER") or "kinesis-mock"
 
@@ -645,6 +648,7 @@ CONFIG_ENV_VARS = [
     "HOSTNAME_FROM_LAMBDA",
     "KINESIS_ERROR_PROBABILITY",
     "KINESIS_INITIALIZE_STREAMS",
+    "KINESIS_MOCK_PERSIST_INTERVAL",
     "LAMBDA_CODE_EXTRACT_TIME",
     "LAMBDA_CONTAINER_REGISTRY",
     "LAMBDA_DOCKER_DNS",

--- a/localstack/services/kinesis/kinesalite_server.py
+++ b/localstack/services/kinesis/kinesalite_server.py
@@ -57,7 +57,7 @@ class KinesaliteServer(Server):
         LOG.info(line.rstrip())
 
 
-def create_kinesalite_server(port=None) -> KinesaliteServer:
+def create_kinesalite_server(port=None, persist_path: Optional[str] = None) -> KinesaliteServer:
     """
     Creates a new Kinesalite server instance. Installs Kinesalite on the host first if necessary.
     Introspects on the host config to determine server configuration:
@@ -67,10 +67,10 @@ def create_kinesalite_server(port=None) -> KinesaliteServer:
     port = port or get_free_tcp_port()
 
     install.install_kinesalite()
-    if config.dirs.data:
-        kinesis_data_dir = "%s/kinesis" % config.dirs.data
-        mkdir(kinesis_data_dir)
-    else:
-        kinesis_data_dir = None
+    persist_path = (
+        f"{config.dirs.data}/dynamodb" if not persist_path and config.dirs.data else persist_path
+    )
+    if persist_path:
+        mkdir(persist_path)
 
-    return KinesaliteServer(port=port, latency=config.KINESIS_LATENCY, data_dir=kinesis_data_dir)
+    return KinesaliteServer(port=port, latency=config.KINESIS_LATENCY, data_dir=persist_path)

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -100,7 +100,7 @@ class KinesisMockServer(Server):
         LOG.info(line.rstrip())
 
 
-def create_kinesis_mock_server(port=None) -> KinesisMockServer:
+def create_kinesis_mock_server(port=None, persist_path: Optional[str] = None) -> KinesisMockServer:
     """
     Creates a new Kinesis Mock server instance. Installs Kinesis Mock on the host first if necessary.
     Introspects on the host config to determine server configuration:
@@ -113,11 +113,11 @@ def create_kinesis_mock_server(port=None) -> KinesisMockServer:
     is_kinesis_mock_installed, kinesis_mock_bin_path = install.get_is_kinesis_mock_installed()
     if not is_kinesis_mock_installed:
         install.install_kinesis_mock(kinesis_mock_bin_path)
-    if config.dirs.data:
-        kinesis_data_dir = "%s/kinesis" % config.dirs.data
-        mkdir(kinesis_data_dir)
-    else:
-        kinesis_data_dir = None
+    persist_path = (
+        f"{config.dirs.data}/kinesis" if not persist_path and config.dirs.data else persist_path
+    )
+    if persist_path:
+        mkdir(persist_path)
 
     if config.LS_LOG:
         if config.LS_LOG == "warning":
@@ -138,6 +138,6 @@ def create_kinesis_mock_server(port=None) -> KinesisMockServer:
         log_level=log_level,
         latency=latency,
         initialize_streams=initialize_streams,
-        data_dir=kinesis_data_dir,
+        data_dir=persist_path,
     )
     return server

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -56,7 +56,10 @@ class KinesisMockServer(Server):
         helper method for creating kinesis mock invocation command
         """
         if self._data_dir:
-            kinesis_data_dir_param = "SHOULD_PERSIST_DATA=true PERSIST_PATH=%s" % self._data_dir
+            kinesis_data_dir_param = (
+                f"SHOULD_PERSIST_DATA=true PERSIST_PATH={self._data_dir} "
+                f"PERSIST_INTERVAL={config.KINESIS_MOCK_PERSIST_INTERVAL}"
+            )
         else:
             kinesis_data_dir_param = ""
         log_level_param = "LOG_LEVEL=%s" % self._log_level

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Dict, List, Optional, Tuple
 
 from localstack import config
 from localstack.services import install
@@ -39,11 +39,12 @@ class KinesisMockServer(Server):
         super().__init__(port, host)
 
     def do_start_thread(self) -> FuncThread:
-        cmd = self._create_shell_command()
-        LOG.debug("starting kinesis process %s", cmd)
+        cmd, env_vars = self._create_shell_command()
+        LOG.debug("starting kinesis process %s with env vars %s", cmd, env_vars)
         t = ShellCommandThread(
             cmd,
             strip_color=True,
+            env_vars=env_vars,
             log_listener=self._log_listener,
             auto_restart=True,
         )
@@ -51,53 +52,42 @@ class KinesisMockServer(Server):
         t.start()
         return t
 
-    def _create_shell_command(self) -> str:
+    def _create_shell_command(self) -> Tuple[List, Dict]:
         """
-        helper method for creating kinesis mock invocation command
+        Helper method for creating kinesis mock invocation command
+        :return: returns a tuple containing the command list and a dictionary with the environment variables
         """
+        env_vars = {"KINESIS_MOCK_PLAIN_PORT": self.port, "SHARD_LIMIT": config.KINESIS_SHARD_LIMIT}
+
+        latency_params = [
+            "CREATE_STREAM_DURATION",
+            "DELETE_STREAM_DURATION",
+            "REGISTER_STREAM_CONSUMER_DURATION",
+            "START_STREAM_ENCRYPTION_DURATION",
+            "STOP_STREAM_ENCRYPTION_DURATION",
+            "DEREGISTER_STREAM_CONSUMER_DURATION",
+            "MERGE_SHARDS_DURATION",
+            "SPLIT_SHARD_DURATION",
+            "UPDATE_SHARD_COUNT_DURATION",
+        ]
+        for param in latency_params:
+            env_vars[param] = self._latency
+
         if self._data_dir:
-            kinesis_data_dir_param = (
-                f"SHOULD_PERSIST_DATA=true PERSIST_PATH={self._data_dir} "
-                f"PERSIST_INTERVAL={config.KINESIS_MOCK_PERSIST_INTERVAL}"
-            )
-        else:
-            kinesis_data_dir_param = ""
-        log_level_param = "LOG_LEVEL=%s" % self._log_level
-        latency_param = (
-            "CREATE_STREAM_DURATION={l} DELETE_STREAM_DURATION={l} REGISTER_STREAM_CONSUMER_DURATION={l} "
-            "START_STREAM_ENCRYPTION_DURATION={l} STOP_STREAM_ENCRYPTION_DURATION={l} "
-            "DEREGISTER_STREAM_CONSUMER_DURATION={l} MERGE_SHARDS_DURATION={l} SPLIT_SHARD_DURATION={l} "
-            "UPDATE_SHARD_COUNT_DURATION={l}"
-        ).format(l=self._latency)
-        init_streams_param = (
-            "INITIALIZE_STREAMS=%s" % self._initialize_streams if self._initialize_streams else ""
-        )
+            env_vars["SHOULD_PERSIST_DATA"] = "true"
+            env_vars["PERSIST_PATH"] = self._data_dir
+            env_vars["PERSIST_INTERVAL"] = config.KINESIS_MOCK_PERSIST_INTERVAL
+
+        env_vars["LOG_LEVEL"] = self._log_level
+        if self._initialize_streams:
+            env_vars["INITIALIZE_STREAMS"] = self._initialize_streams
 
         if self._bin_path.endswith(".jar"):
-            cmd = (
-                "KINESIS_MOCK_PLAIN_PORT=%s SHARD_LIMIT=%s %s %s %s %s java -XX:+UseG1GC -jar %s"
-                % (
-                    self.port,
-                    config.KINESIS_SHARD_LIMIT,
-                    latency_param,
-                    kinesis_data_dir_param,
-                    log_level_param,
-                    init_streams_param,
-                    self._bin_path,
-                )
-            )
+            cmd = ["java", "-XX:+UseG1GC", "-jar", self._bin_path]
         else:
             chmod_r(self._bin_path, 0o777)
-            cmd = "KINESIS_MOCK_PLAIN_PORT=%s SHARD_LIMIT=%s %s %s %s %s %s --gc=G1" % (
-                self.port,
-                config.KINESIS_SHARD_LIMIT,
-                latency_param,
-                kinesis_data_dir_param,
-                log_level_param,
-                init_streams_param,
-                self._bin_path,
-            )
-        return cmd
+            cmd = [self._bin_path, "--gc=G1"]
+        return cmd, env_vars
 
     def _log_listener(self, line, **_kwargs):
         LOG.info(line.rstrip())


### PR DESCRIPTION
Similar to https://github.com/localstack/localstack/pull/6135, added ax explicit argument to set the persistence path for Kinesis. In addition, added a new config variable to set the persistence interval (mostly to speed up testing).