### PR TITLE
pin opensearch-py to version 1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ runtime =
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=0.14.3
     moto-ext[all]==3.1.10
-    opensearch-py>=1.0.0
+    opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl>=21.0.0
     Quart>=0.6.15


### PR DESCRIPTION
Pins the opensearch-py version to 1.1.0, as the lastest version 2.0.0 was just released and seem to have some breaking changes. 
