### PR TITLE
fix apigateway delete_rest_api method

### DIFF
--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -142,6 +142,15 @@ class TestAPIGateway:
     }
     TEST_API_GATEWAY_AUTHORIZER_OPS = [{"op": "replace", "path": "/name", "value": "test1"}]
 
+    @pytest.mark.aws_validated
+    def test_delete_rest_api_with_invalid_id(self, apigateway_client):
+        with pytest.raises(ClientError) as e:
+            apigateway_client.delete_rest_api(restApiId="foobar")
+
+        assert e.value.response["Error"]["Code"] == "NotFoundException"
+        assert "Invalid API identifier specified" in e.value.response["Error"]["Message"]
+        assert "foobar" in e.value.response["Error"]["Message"]
+
     def test_create_rest_api_with_custom_id(self):
         client = aws_stack.create_external_boto_client("apigateway")
         apigw_name = "gw-%s" % short_uid()


### PR DESCRIPTION
This PR fixes the `delete_rest_api` method, which would previously raise internal errors (propagating moto `KeyError` from here: https://github.com/spulec/moto/blob/34a98d2c205ed311a867083b3ee17c18fb8ebb48/moto/apigateway/models.py#L1368-L1370).

I noticed these errors when running the CloudFormation tests which were trying to retry apparently already deleted rest apis. Should maybe investigate this more.