### PR TITLE
implement ExclusiveStartShardId for DynamoDB Streams describe_stream

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -58,7 +58,7 @@ def get_stream_for_table(table_arn: str) -> dict:
     return region.ddb_streams.get(table_name)
 
 
-def forward_events(records: dict) -> None:
+def forward_events(records: Dict) -> None:
     kinesis = aws_stack.connect_to_service("kinesis")
     for record in records:
         table_arn = record.pop("eventSourceARN", "")
@@ -112,8 +112,8 @@ def kinesis_shard_id(dynamodbstream_shard_id: str) -> str:
     return f"{shard_params[0]}-{shard_params[-1]}"
 
 
-def get_shard_id(stream: dict, kinesis_shard_id: str) -> str:
-    ddb_stream_shard_id = stream["shards_id_map"].get(kinesis_shard_id)
+def get_shard_id(stream: Dict, kinesis_shard_id: str) -> str:
+    ddb_stream_shard_id = stream.get("shards_id_map", {}).get(kinesis_shard_id)
     if not ddb_stream_shard_id:
         ddb_stream_shard_id = shard_id(kinesis_shard_id)
         stream["shards_id_map"][kinesis_shard_id] = ddb_stream_shard_id

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -117,8 +117,8 @@ def kinesis_shard_id(dynamodbstream_shard_id):
 def get_shard_id(stream_arn, kinesis_shard_id):
     region = DynamoDBStreamsBackend.get()
     stream_shards = region.ddb_streams_shards.get(stream_arn)
-    if stream_shards and (stream_shard_id := stream_shards.get(kinesis_shard_id)):
-        return stream_shard_id
+    if stream_shards and kinesis_shard_id in stream_shards:
+        return stream_shards[kinesis_shard_id]
 
     if not stream_shards:
         region.ddb_streams_shards[stream_arn] = {}

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -22,8 +22,8 @@ from localstack.aws.api.dynamodbstreams import (
 from localstack.services.dynamodbstreams.dynamodbstreams_api import (
     DynamoDBStreamsBackend,
     get_kinesis_stream_name,
+    get_shard_id,
     kinesis_shard_id,
-    shard_id,
     stream_name_from_stream_arn,
     table_name_from_stream_arn,
 )
@@ -70,9 +70,19 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
                 # Replace Kinesis ShardIDs with ones that mimic actual
                 # DynamoDBStream ShardIDs.
                 stream_shards = copy.deepcopy(stream_details["StreamDescription"]["Shards"])
-                for shard in stream_shards:
-                    shard["ShardId"] = shard_id(shard["ShardId"])
+                start_index = 0
+                for index, shard in enumerate(stream_shards):
+                    shard["ShardId"] = get_shard_id(stream_arn, shard["ShardId"])
                     shard.pop("HashKeyRange", None)
+                    # we want to ignore the shards before exclusive_start_shard_id parameters
+                    # we store the index where we encounter then slice the shards
+                    if exclusive_start_shard_id and exclusive_start_shard_id == shard["ShardId"]:
+                        start_index = index
+
+                if exclusive_start_shard_id:
+                    # slicing the resulting shards after the exclusive_start_shard_id parameters
+                    stream_shards = stream_shards[start_index + 1 :]
+
                 stream["Shards"] = stream_shards
                 return DescribeStreamOutput(**result)
         if not result:

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -17,6 +17,7 @@ from localstack.aws.api.dynamodbstreams import (
     ShardId,
     ShardIteratorType,
     StreamArn,
+    StreamStatus,
     TableName,
 )
 from localstack.services.dynamodbstreams.dynamodbstreams_api import (
@@ -35,10 +36,10 @@ from localstack.utils.common import to_str
 LOG = logging.getLogger(__name__)
 
 STREAM_STATUS_MAP = {
-    "ACTIVE": "ENABLED",
-    "CREATING": "ENABLING",
-    "DELETING": "DISABLING",
-    "UPDATING": "ENABLING",
+    "ACTIVE": StreamStatus.ENABLED,
+    "CREATING": StreamStatus.ENABLING,
+    "DELETING": StreamStatus.DISABLING,
+    "UPDATING": StreamStatus.ENABLING,
 }
 
 

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -55,7 +55,6 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
     ) -> DescribeStreamOutput:
         region = DynamoDBStreamsBackend.get()
         kinesis = aws_stack.connect_to_service("kinesis")
-        result = {}
         for stream in region.ddb_streams.values():
             if stream["StreamArn"] == stream_arn:
                 # get stream details
@@ -88,8 +87,8 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
                 stream["Shards"] = stream_shards
                 stream_description = select_from_typed_dict(StreamDescription, stream)
                 return DescribeStreamOutput(StreamDescription=stream_description)
-        if not result:
-            raise ResourceNotFoundException(f"Stream {stream_arn} was not found.")
+
+        raise ResourceNotFoundException(f"Stream {stream_arn} was not found.")
 
     @handler("GetRecords", expand=False)
     def get_records(self, context: RequestContext, payload: GetRecordsInput) -> GetRecordsOutput:

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -22,7 +22,6 @@ from localstack.testing.aws.cloudformation_utils import load_template_file, rend
 from localstack.testing.aws.util import get_lambda_logs
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import create_dynamodb_table
 from localstack.utils.aws.client import SigningHttpClient
 from localstack.utils.common import ensure_list, poll_condition, retry
 from localstack.utils.common import safe_requests as requests
@@ -323,17 +322,11 @@ def dynamodb_create_table(dynamodb_client):
     tables = []
 
     def factory(**kwargs):
-        kwargs["client"] = dynamodb_client
-        if "table_name" not in kwargs:
-            kwargs["table_name"] = "test-table-%s" % short_uid()
-        if "partition_key" not in kwargs:
-            kwargs["partition_key"] = "id"
+        if "TableName" not in kwargs:
+            kwargs["TableName"] = "test-table-%s" % short_uid()
 
-        kwargs["sleep_after"] = 0
-
-        tables.append(kwargs["table_name"])
-
-        return create_dynamodb_table(**kwargs)
+        tables.append(kwargs["TableName"])
+        return dynamodb_client.create_table(**kwargs)
 
     yield factory
 


### PR DESCRIPTION
This PR implements (or start using) the ExclusiveStartShardId parameter for DynamoDB streams `describe_stream` operation. 

### Issue

#6158 very well described and gave a detailed explanation of ExclusiveStartShardId not being used.
AWS docs for DescribeStream operation:
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_DescribeStream.html
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_StreamDescription.html

### Solution

The `shardId`s coming from Kinesis were formatted to look like DynamoDB streams, auto generated with a timestamp every time the function was called. We had to implement a way to store those DynamoDB `shardId`s to be able to filter them if the function was called a second time. (Otherwise the shardId always looked "recent").
Kinesis returns the shards in stream description in ascending order, so we ignore everything before/including the `shardId` passed as parameter. 
_Note: this could be implement as a filter instead, I am not sure which solution is best._

_fix #6158_