### PR TITLE
fix HypercornServer API and test to allow multiple instances

### DIFF
--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -306,6 +306,9 @@ class ASGIAdapter:
     Adapter to expose a WSGIApplication as an ASGI3Application. This allows you to serve synchronous WSGI applications
     through ASGI servers (e.g., Hypercorn).
 
+    IMPORTANT: The ASGIAdapter needs to use the same event loop as the underlying server. If you pass a new event
+    loop to the server, you need to also pass it to the ASGIAdapter.
+
     https://asgi.readthedocs.io/en/latest/specs/main.html
     """
 

--- a/tests/unit/http_/test_dispatcher.py
+++ b/tests/unit/http_/test_dispatcher.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
+
 import pytest
-from werkzeug.exceptions import MethodNotAllowed
+from werkzeug.exceptions import MethodNotAllowed, NotFound
 
 from localstack.http import Request, Response, Router
-from localstack.http.dispatcher import resource_dispatcher
+from localstack.http.dispatcher import handler_dispatcher, resource_dispatcher
 
 
 class TestResourceDispatcher:
@@ -58,3 +60,63 @@ class TestResourceDispatcher:
         router.add("/health", TestResource())
         assert router.dispatch(Request("GET", "/health")).json == {"message": "GET/OK"}
         assert router.dispatch(Request("POST", "/health")).get_data(True) == "POST/OK"
+
+
+class TestHandlerDispatcher:
+    def test_handler_dispatcher(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler_foo(_request: Request) -> Response:
+            return Response("ok")
+
+        def handler_bar(_request: Request, bar, baz) -> Dict[str, any]:
+            response = Response()
+            response.set_json({"bar": bar, "baz": baz})
+            return response
+
+        router.add("/foo", handler_foo)
+        router.add("/bar/<int:bar>/<baz>", handler_bar)
+
+        assert router.dispatch(Request("GET", "/foo")).data == b"ok"
+        assert router.dispatch(Request("GET", "/bar/420/ed")).json == {"bar": 420, "baz": "ed"}
+
+        with pytest.raises(NotFound):
+            assert router.dispatch(Request("GET", "/bar/asfg/ed"))
+
+    def test_handler_dispatcher_invalid_signature(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, arg1) -> Response:  # invalid signature
+            return Response("ok")
+
+        router.add("/foo/<arg1>/<arg2>", handler)
+
+        with pytest.raises(TypeError):
+            router.dispatch(Request("GET", "/foo/a/b"))
+
+    def test_handler_dispatcher_with_dict_return(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, arg1) -> Dict[str, Any]:
+            return {"arg1": arg1, "hello": "there"}
+
+        router.add("/foo/<arg1>", handler)
+        assert router.dispatch(Request("GET", "/foo/a")).json == {"arg1": "a", "hello": "there"}
+
+    def test_handler_dispatcher_with_text_return(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request, arg1) -> str:
+            return f"hello: {arg1}"
+
+        router.add("/<arg1>", handler)
+        assert router.dispatch(Request("GET", "/world")).data == b"hello: world"
+
+    def test_handler_dispatcher_with_none_return(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        def handler(_request: Request):
+            return None
+
+        router.add("/", handler)
+        assert router.dispatch(Request("GET", "/")).status_code == 200


### PR DESCRIPTION
This PR fixes the HypercornServer to allow multiple instances of the server. It's mostly a documentation change, and i also adapted the tests to show it it has to be used together with the ASGI adapter.

I also added a few tests to increase the coverage of the handler dispatcher of the router API. 