### PR TITLE
CFN Stack timestamps attributes

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -169,6 +169,9 @@ class Stack:
         )
         self.add_stack_event(self.stack_name, self.stack_id, status)
 
+    def set_time_attribute(self, attribute, new_time=None):
+        self.metadata[attribute] = new_time or timestamp_millis()
+
     def add_stack_event(self, resource_id: str, physical_res_id: str, status: str):
         event = {
             "EventId": long_uid(),

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1232,6 +1232,7 @@ class TemplateDeployer:
         self.stack.set_stack_status("UPDATE_IN_PROGRESS")
         # apply changes
         self.apply_changes(self.stack, new_stack, stack_name=self.stack.stack_name, action="UPDATE")
+        self.stack.set_time_attribute("LastUpdatedTime")
 
     def delete_stack(self):
         if not self.stack:
@@ -1249,6 +1250,7 @@ class TemplateDeployer:
                 self.stack.set_resource_status(resource_id, "DELETE_COMPLETE")
         # update status
         self.stack.set_stack_status("DELETE_COMPLETE")
+        self.stack.set_time_attribute("DeletionTime")
 
     # ----------------------------
     # DEPENDENCY RESOLUTION UTILS

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -141,21 +141,24 @@ def test_parameter_usepreviousvalue_behavior(cfn_client, cleanups):
     assert len(stack_describe_response["Outputs"]) == 2
 
 
+@pytest.mark.aws_validated
 def test_stack_time_attributes(cfn_client, deploy_cfn_template):
-    bucket_name = "test"
+    api_name = f"test_{short_uid()}"
+    template_path = os.path.join(os.path.dirname(__file__), "../templates/simple_api.yaml")
+
     deployed = deploy_cfn_template(
-        template_path=os.path.join(os.path.dirname(__file__), "../templates/template5.yaml"),
-        parameters={"LocalParam": bucket_name},
+        template_path=template_path,
+        parameters={"ApiName": api_name},
     )
     stack_name = deployed.stack_name
-    stack_id = deployed.stack_id
-
     assert "CreationTime" in cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]
 
+    api_name = f"test_{short_uid()}"
+    stack_id = deployed.stack_id
     cfn_client.update_stack(
         StackName=stack_name,
-        TemplateBody=load_template_raw("template5.yaml"),
-        Parameters=[{"ParameterKey": "CustomTag", "ParameterValue": bucket_name}],
+        TemplateBody=load_template_file(template_path),
+        Parameters=[{"ParameterKey": "ApiName", "ParameterValue": api_name}],
     )
 
     def wait_stack_done():

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -139,3 +139,35 @@ def test_parameter_usepreviousvalue_behavior(cfn_client, cleanups):
     assert wait_until(wait_stack_done)
     stack_describe_response = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
     assert len(stack_describe_response["Outputs"]) == 2
+
+
+def test_stack_time_attributes(cfn_client, deploy_cfn_template):
+    bucket_name = "test"
+    deployed = deploy_cfn_template(
+        template_path=os.path.join(os.path.dirname(__file__), "../templates/template5.yaml"),
+        parameters={"LocalParam": bucket_name},
+    )
+    stack_name = deployed.stack_name
+    stack_id = deployed.stack_id
+
+    assert "CreationTime" in cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]
+
+    cfn_client.update_stack(
+        StackName=stack_name,
+        TemplateBody=load_template_raw("template5.yaml"),
+        Parameters=[{"ParameterKey": "CustomTag", "ParameterValue": bucket_name}],
+    )
+
+    def wait_stack_done():
+        return cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]["StackStatus"] in [
+            "CREATE_COMPLETE",
+            "UPDATE_COMPLETE",
+        ]
+
+    assert wait_until(wait_stack_done)
+
+    assert "LastUpdatedTime" in cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]
+    cfn_client.delete_stack(
+        StackName=stack_name,
+    )
+    assert "DeletionTime" in cfn_client.describe_stacks(StackName=stack_name)["Stacks"][0]

--- a/tests/integration/templates/simple_api.yaml
+++ b/tests/integration/templates/simple_api.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+  ApiName:
+    Type: String
+
+Resources:
+  Api:
+    Type: 'AWS::ApiGateway::RestApi'
+    Properties:
+      Name:
+        Ref: ApiName


### PR DESCRIPTION
This PR  addresses issue #6038. Due to some difficulties with Commandeer while triaging, I couldn't exactly find out why it still displays a stack with the state "DELETE_COMPLETE", my best guess is that it uses the timestamp attributes `["CreationTime", "DeletionTime", "LastUpdatedTime"]` to determine if the stack should be shown but Localstack does not return the "DeletionTime" or the "LastUpdatedTime".

Changes:
- Set the DeletionTime and LastUpdatedTime attributes accordingly.
- Test to validate the return of the attributes when calling the cfn describe stack function.
