### PR TITLE
Add `AWS::OpenSearchService::Domain`

### DIFF
--- a/localstack/services/cloudformation/models/__init__.py
+++ b/localstack/services/cloudformation/models/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "ec2",
     "ecr",
     "elasticsearch",
+    "opensearch",
     "events",
     "iam",
     "kinesis",

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -1,3 +1,7 @@
+from localstack.aws.api.opensearch import (
+    OpenSearchPartitionInstanceType,
+    OpenSearchWarmPartitionInstanceType,
+)
 from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
@@ -55,8 +59,12 @@ class OpenSearchDomain(GenericBaseModel):
             cluster_config = result.get("ClusterConfig")
             if isinstance(cluster_config, dict):
                 # set defaults required for boto3 calls
-                cluster_config.setdefault("DedicatedMasterType", "m3.medium.elasticsearch")
-                cluster_config.setdefault("WarmType", "ultrawarm1.medium.elasticsearch")
+                cluster_config.setdefault(
+                    "DedicatedMasterType", OpenSearchPartitionInstanceType.m3_medium_search
+                )
+                cluster_config.setdefault(
+                    "WarmType", OpenSearchWarmPartitionInstanceType.ultrawarm1_medium_search
+                )
             return result
 
         return {

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -1,4 +1,5 @@
 from localstack.aws.api.opensearch import (
+    CreateDomainRequest,
     OpenSearchPartitionInstanceType,
     OpenSearchWarmPartitionInstanceType,
 )
@@ -40,19 +41,11 @@ class OpenSearchDomain(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _create_params(params, **kwargs):
+            # Tags handled outside of creation
             attributes = [
-                "AccessPolicies",
-                "AdvancedOptions",
-                "CognitoOptions",
-                "DomainName",
-                "EBSOptions",
-                "ClusterConfig",
-                "EngineVersion",
-                "EncryptionAtRestOptions",
-                "LogPublishingOptions",
-                "NodeToNodeEncryptionOptions",
-                "SnapshotOptions",
-                "VPCOptions",
+                attribute
+                for attribute in CreateDomainRequest.__annotations__.keys()
+                if "Tag" not in attribute
             ]
             result = select_attributes(params, attributes)
             result = remove_none_values(result)

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -123,6 +123,8 @@ def get_service_name(resource):
         return "cognito-idp"
     if parts[-2] == "Elasticsearch":
         return "es"
+    if parts[-2] == "OpenSearchService":
+        return "opensearch"
     if parts[-2] == "KinesisFirehose":
         return "firehose"
     if parts[-2] == "ResourceGroups":

--- a/tests/integration/templates/opensearch_domain.yaml
+++ b/tests/integration/templates/opensearch_domain.yaml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  OpenSearchDomainName:
+    Type: String
+Resources:
+  OpenSearchServiceDomain:
+    Type: AWS::OpenSearchService::Domain
+    Properties:
+      DomainName:
+        Ref: OpenSearchDomainName

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -389,7 +389,7 @@ class TestOpensearchProvider:
     # testing CloudFormation deployment here to make sure OpenSearch is installed
     def test_cloudformation_deployment(self, deploy_cfn_template, opensearch_client):
         domain_name = f"domain-{short_uid()}"
-        stack = deploy_cfn_template(
+        deploy_cfn_template(
             template_path=os.path.join(
                 os.path.dirname(__file__), "templates/opensearch_domain.yaml"
             ),

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import threading
 
 import botocore.exceptions
@@ -384,6 +385,20 @@ class TestOpensearchProvider:
         assert int(parts[1]) in range(
             config.EXTERNAL_SERVICE_PORTS_START, config.EXTERNAL_SERVICE_PORTS_END
         )
+
+    # testing CloudFormation deployment here to make sure OpenSearch is installed
+    def test_cloudformation_deployment(self, deploy_cfn_template, opensearch_client):
+        domain_name = f"domain-{short_uid()}"
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                os.path.dirname(__file__), "templates/opensearch_domain.yaml"
+            ),
+            parameters={"OpenSearchDomainName": domain_name},
+        )
+
+        response = opensearch_client.list_domain_names(EngineType="OpenSearch")
+        domain_names = [domain["DomainName"] for domain in response["DomainNames"]]
+        assert domain_name in domain_names
 
 
 @pytest.mark.skip_offline


### PR DESCRIPTION
This PR adds the `Domain` resource for OpenSearch in CloudFormation. It functions the same as the Elasticsearch Domain (except some differences in parameters). 

I chose the code duplication because the OpenSearch Resource might diverge in the future.

Fixes #6163