### PR TITLE
fix and clean up sns tests to use httpserver fixture

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2,31 +2,23 @@
 import json
 import queue
 import random
-import time
 
 import pytest
 import requests
 from botocore.exceptions import ClientError
+from pytest_httpserver import HTTPServer
+from werkzeug import Response
 
 from localstack import config
 from localstack.config import external_service_url
 from localstack.constants import TEST_AWS_ACCOUNT_ID
-from localstack.http import Request
-from localstack.services.generic_proxy import ProxyListener
-from localstack.services.infra import start_proxy
 from localstack.services.install import SQS_BACKEND_IMPL
 from localstack.services.sns.provider import SNSBackend
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import (
-    get_free_tcp_port,
-    get_service_protocol,
-    poll_condition,
-    retry,
-    short_uid,
-    to_str,
-    wait_for_port_open,
-)
+from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.strings import short_uid, to_str
+from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
 from .awslambda.functions import lambda_integration
@@ -37,11 +29,6 @@ from .awslambda.test_lambda import (
     TEST_LAMBDA_PYTHON,
     TEST_LAMBDA_PYTHON_ECHO,
 )
-
-TEST_TOPIC_NAME = "TestTopic_snsTest"
-TEST_QUEUE_NAME = "TestQueue_snsTest"
-TEST_QUEUE_DLQ_NAME = "TestQueue_DLQ_snsTest"
-TEST_TOPIC_NAME_2 = "topic-test-2"
 
 PUBLICATION_TIMEOUT = 0.500
 PUBLICATION_RETRIES = 4
@@ -129,41 +116,36 @@ class TestSNSProvider:
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
-    def test_subscribe_http_endpoint(self, sns_client, sns_create_topic, sns_subscription):
+    def test_subscribe_http_endpoint(
+        self, sns_client, sns_create_topic, sns_subscription, httpserver: HTTPServer
+    ):
         topic_arn = sns_create_topic()["TopicArn"]
 
         # create HTTP endpoint and connect it to SNS topic
-        class MyUpdateListener(ProxyListener):
-            def forward_request(self, method, path, data, headers):
-                records.append((json.loads(to_str(data)), headers))
-                return 200
+        httpserver.expect_request("/").respond_with_data(status=200)
+        endpoint_url = httpserver.url_for("/")
+        wait_for_port_open(endpoint_url)
 
-        records = []
-        local_port = get_free_tcp_port()
-        proxy = start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
-        wait_for_port_open(local_port)
-        queue_arn = "%s://localhost:%s" % (get_service_protocol(), local_port)
-        sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=queue_arn)
+        sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=endpoint_url)
 
-        def received():
-            assert records[0][0]["Type"] == "SubscriptionConfirmation"
-            assert records[0][1]["x-amz-sns-message-type"] == "SubscriptionConfirmation"
+        assert poll_condition(lambda: len(httpserver.log) >= 1)
 
-            token = records[0][0]["Token"]
-            subscribe_url = records[0][0]["SubscribeURL"]
+        request, response = httpserver.log[0]
+        payload = request.get_json(True)
 
-            assert subscribe_url == (
-                f"{external_service_url('sns')}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
-            )
+        assert payload["Type"] == "SubscriptionConfirmation"
+        assert request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
+        assert "Signature" in payload
+        assert "SigningCertURL" in payload
 
-            assert "Signature" in records[0][0]
-            assert "SigningCertURL" in records[0][0]
-
-        retry(received, retries=5, sleep=1)
-        proxy.stop()
+        token = payload["Token"]
+        subscribe_url = payload["SubscribeURL"]
+        assert subscribe_url == (
+            f"{external_service_url('sns')}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+        )
 
     def test_subscribe_with_invalid_protocol(self, sns_client, sns_create_topic, sns_subscription):
-        topic_arn = sns_create_topic(Name=TEST_TOPIC_NAME_2)["TopicArn"]
+        topic_arn = sns_create_topic()["TopicArn"]
 
         with pytest.raises(ClientError) as e:
             sns_subscription(
@@ -358,7 +340,7 @@ class TestSNSProvider:
         retry(check_message2, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
         # test with exist operator set to false.
-        queue_arn = aws_stack.sqs_queue_arn(TEST_QUEUE_NAME)
+        queue_arn = aws_stack.sqs_queue_arn(queue_name)
         filter_policy = {"store": [{"exists": False}]}
         do_subscribe(filter_policy, queue_arn)
         # get number of messages
@@ -651,27 +633,22 @@ class TestSNSProvider:
         topic_arn = sns_create_topic()["TopicArn"]
 
         # create HTTP endpoint and connect it to SNS topic
-        class MyUpdateListener(ProxyListener):
-            def forward_request(self, method, path, data, headers):
-                records.append((json.loads(to_str(data)), headers))
-                return 200
+        with HTTPServer() as server:
+            http_endpoint = server.url_for("/")
 
-        records = []
-        local_port = get_free_tcp_port()
-        proxy = start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
-        wait_for_port_open(local_port)
-        http_endpoint = f"{get_service_protocol()}://localhost:{local_port}"
+            wait_for_port_open(http_endpoint)
+            server.expect_request("/").respond_with_data(b"", 200)
 
-        subscription = sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint)
-        sns_client.set_subscription_attributes(
-            SubscriptionArn=subscription["SubscriptionArn"],
-            AttributeName="RedrivePolicy",
-            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
-        )
+            subscription = sns_subscription(
+                TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint
+            )
+            sns_client.set_subscription_attributes(
+                SubscriptionArn=subscription["SubscriptionArn"],
+                AttributeName="RedrivePolicy",
+                AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+            )
 
-        proxy.stop()
-        # for some reason, it takes a long time to stop the proxy thread -> TODO investigate
-        time.sleep(5)
+        wait_for_port_closed(http_endpoint)
 
         sns_client.publish(
             TopicArn=topic_arn,
@@ -953,9 +930,7 @@ class TestSNSProvider:
         message = f"test message {short_uid()}"
         topic_arn = sns_create_topic(Name=topic_name)["TopicArn"]
 
-        base_url = (
-            f"{get_service_protocol()}://{config.LOCALSTACK_HOSTNAME}:{config.service_port('sns')}"
-        )
+        base_url = config.get_edge_url()
         path = "Action=Publish&Version=2010-03-31&TopicArn={}&Message={}".format(topic_arn, message)
 
         queue_url = sqs_create_queue(QueueName=queue_name)
@@ -991,22 +966,22 @@ class TestSNSProvider:
         _requests = queue.Queue()
 
         # create HTTP endpoint and connect it to SNS topic
-        class MyUpdateListener(ProxyListener):
-            def forward_request(self, method, path, data, headers):
-                _requests.put(Request(method, path, headers=headers, body=data))
-                return 429
+        def handler(request):
+            _requests.put(request)
+            return Response(status=429)
 
         number_of_endpoints = 4
 
-        proxies = []
+        servers = []
 
         for _ in range(number_of_endpoints):
-            local_port = get_free_tcp_port()
-            proxies.append(
-                start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
-            )
-            wait_for_port_open(local_port)
-            http_endpoint = f"{get_service_protocol()}://localhost:{local_port}"
+            server = HTTPServer()
+            server.start()
+            servers.append(server)
+            server.expect_request("/").respond_with_handler(handler)
+            http_endpoint = server.url_for("/")
+            wait_for_port_open(http_endpoint)
+
             sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint)
 
         # fetch subscription information
@@ -1024,8 +999,8 @@ class TestSNSProvider:
             # make sure only four requests are received
             _requests.get(timeout=1)
 
-        for proxy in proxies:
-            proxy.stop()
+        for server in servers:
+            server.stop()
 
     def test_publish_sms_endpoint(self, sns_client, sns_create_topic, sns_subscription):
         list_of_contacts = [


### PR DESCRIPTION
This PR replaces the use of the generic proxy for testing sns HTTP subscriptions, and instead uses [pytest-httpserver](https://github.com/csernazs/pytest-httpserver).

Background: I've seen `test_redrive_policy_http_subscription` flake several times, blocking the build pipeline, [here](https://app.circleci.com/pipelines/github/localstack/localstack/6610/workflows/4e390dbb-ce6f-4c57-a699-c1e800c0539f/jobs/39121) for example, which seems to happen when the proxy server does not shut down in the expected time window, and the sns message arrives anyway. Replacing `time.sleep(5)` with `wait_for_port_closed` would have probably been enough, but I took the opportunity to clean up the tests a bit and start removing dependency to the generic proxy.