### PR TITLE
Add snapshot tests for s3 and cloudformation iam

### DIFF
--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -215,7 +215,11 @@ class SnapshotSession:
             tmp = sr(tmp)
 
         assert tmp
-        tmp = json.loads(tmp)
+        try:
+            tmp = json.loads(tmp)
+        except JSONDecodeError:
+            LOG.error(f"could not decode json-string:\n{tmp}")
+            return {}
 
         return tmp
 

--- a/localstack/testing/snapshots/transformer.py
+++ b/localstack/testing/snapshots/transformer.py
@@ -79,10 +79,13 @@ class ResponseMetaDataTransformer:
             if k == "ResponseMetadata":
                 metadata = v
                 http_headers = metadata.get("HTTPHeaders")
+                # TODO "x-amz-bucket-region"
+                # TestS3.test_region_header_exists -> verifies bucket-region
+                headers_to_collect = ["content_type"]
                 simplified_headers = {}
-                if http_headers.get("content_type"):
-                    simplified_headers = {"content-type": http_headers["content-type"]}
-
+                for h in headers_to_collect:
+                    if http_headers.get(h):
+                        simplified_headers[h] = http_headers[h]
                 simplified_metadata = {
                     "HTTPHeaders": simplified_headers,
                 }

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -134,7 +134,27 @@ class TransformerUtility:
             TransformerUtility.jsonpath(
                 jsonpath="$..Owner.ID", value_replacement="<owner-id>", reference_replacement=False
             ),
-            # TransformerUtility.key_value("ETag"), TODO might not required, as the tag is calculated from the file content
+            # for s3 notifications:
+            TransformerUtility.jsonpath(
+                "$..responseElements.x-amz-id-2", "amz-id", reference_replacement=False
+            ),
+            TransformerUtility.jsonpath(
+                "$..responseElements.x-amz-request-id",
+                "amz-request-id",
+                reference_replacement=False,
+            ),
+            TransformerUtility.jsonpath("$..s3.configurationId", "config-id"),
+            TransformerUtility.jsonpath(
+                "$..s3.object.sequencer", "sequencer", reference_replacement=False
+            ),
+            TransformerUtility.jsonpath("$..s3.bucket.ownerIdentity.principalId", "principal-id"),
+            TransformerUtility.jsonpath("$..userIdentity.principalId", "principal-id"),
+            TransformerUtility.jsonpath("$..requestParameters.sourceIPAddress", "ip-address"),
+            TransformerUtility.jsonpath(
+                "$..s3.object.versionId",
+                "version-id",
+                reference_replacement=False,
+            ),
         ]
 
     @staticmethod

--- a/tests/integration/cloudformation/test_cloudformation_sam.py
+++ b/tests/integration/cloudformation/test_cloudformation_sam.py
@@ -4,7 +4,9 @@ import pytest
 
 
 @pytest.mark.aws_validated
-def test_sam_policies(deploy_cfn_template, cfn_client, iam_client):
+def test_sam_policies(deploy_cfn_template, cfn_client, iam_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.iam_api())
     stack = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../templates/sam_function-policies.yaml"
@@ -14,3 +16,4 @@ def test_sam_policies(deploy_cfn_template, cfn_client, iam_client):
 
     roles = iam_client.list_attached_role_policies(RoleName=role_name)
     assert "AmazonSNSFullAccess" in [p["PolicyName"] for p in roles["AttachedPolicies"]]
+    snapshot.match("list_attached_role_policies", roles)

--- a/tests/integration/cloudformation/test_cloudformation_sam.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_sam.snapshot.json
@@ -1,0 +1,24 @@
+{
+  "tests/integration/cloudformation/test_cloudformation_sam.py::test_sam_policies": {
+    "recorded-date": "02-06-2022, 13:13:20",
+    "recorded-content": {
+      "list_attached_role_policies": {
+        "AttachedPolicies": [
+          {
+            "PolicyName": "AWSLambdaBasicExecutionRole",
+            "PolicyArn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          },
+          {
+            "PolicyName": "AmazonSNSFullAccess",
+            "PolicyArn": "arn:aws:iam::aws:policy/AmazonSNSFullAccess"
+          }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_utf8_key": {
-    "recorded-date": "31-05-2022, 09:37:20",
+    "recorded-date": "02-06-2022, 11:43:43",
     "recorded-content": {
       "put-object": {
         "ResponseMetadata": {
@@ -8,6 +8,19 @@
           "HTTPHeaders": {}
         },
         "ETag": "\"e99a18c428cb38d5f260853678922e03\""
+      },
+      "get-object": {
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        },
+        "AcceptRanges": "bytes",
+        "LastModified": "datetime",
+        "ContentLength": 6,
+        "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": ""
       }
     }
   },
@@ -156,6 +169,84 @@
         "Owner": {
           "DisplayName": "<display-name>",
           "ID": "<owner-id>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_region_header_exists": {
+    "recorded-date": "02-06-2022, 11:23:16",
+    "recorded-content": {
+      "head_bucket": {
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        }
+      },
+      "list_objects_v2": {
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        },
+        "IsTruncated": false,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "MaxKeys": 1000,
+        "EncodingType": "url",
+        "KeyCount": 0
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_upload_file_multipart": {
+    "recorded-date": "02-06-2022, 11:52:47",
+    "recorded-content": {
+      "get_object": {
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        },
+        "AcceptRanges": "bytes",
+        "LastModified": "datetime",
+        "ContentLength": 6144,
+        "ETag": "\"8eabe9d6b43316e840b079170916c079-1\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": ""
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object": {
+    "recorded-date": "02-06-2022, 11:55:55",
+    "recorded-content": {
+      "get_object": {
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        },
+        "AcceptRanges": "bytes",
+        "LastModified": "datetime",
+        "ContentLength": 9,
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {},
+        "Body": ""
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_url_metadata": {
+    "recorded-date": "02-06-2022, 12:05:29",
+    "recorded-content": {
+      "head_object": {
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        },
+        "AcceptRanges": "bytes",
+        "LastModified": "datetime",
+        "ContentLength": 11,
+        "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+        "ContentType": "binary/octet-stream",
+        "Metadata": {
+          "foo": "bar"
         }
       }
     }

--- a/tests/integration/s3/test_s3_notifications_sns.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sns.snapshot.json
@@ -1,0 +1,109 @@
+{
+  "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_object_created_put": {
+    "recorded-date": "07-06-2022, 16:15:43",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "Type": "Notification",
+            "MessageId": "<uuid:1>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+            "Subject": "Amazon S3 Notification",
+            "Message": {
+              "Records": [
+                {
+                  "eventVersion": "2.1",
+                  "eventSource": "aws:s3",
+                  "awsRegion": "<region>",
+                  "eventTime": "date",
+                  "eventName": "ObjectCreated:Put",
+                  "userIdentity": {
+                    "principalId": "<principal-id:2>"
+                  },
+                  "requestParameters": {
+                    "sourceIPAddress": "<ip-address:1>"
+                  },
+                  "responseElements": {
+                    "x-amz-request-id": "amz-request-id",
+                    "x-amz-id-2": "amz-id"
+                  },
+                  "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "configurationId": "<config-id:1>",
+                    "bucket": {
+                      "name": "<resource:2>",
+                      "ownerIdentity": {
+                        "principalId": "<principal-id:1>"
+                      },
+                      "arn": "arn:aws:s3:::<resource:2>"
+                    },
+                    "object": {
+                      "key": "bucket-key",
+                      "size": 11,
+                      "eTag": "c8e3a3027a133355210f85cfbb1acc35",
+                      "sequencer": "sequencer"
+                    }
+                  }
+                }
+              ]
+            },
+            "Timestamp": "date",
+            "SignatureVersion": "1",
+            "Signature": "signature",
+            "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
+            "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>"
+          },
+          {
+            "Type": "Notification",
+            "MessageId": "<uuid:2>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+            "Subject": "Amazon S3 Notification",
+            "Message": {
+              "Records": [
+                {
+                  "eventVersion": "2.1",
+                  "eventSource": "aws:s3",
+                  "awsRegion": "<region>",
+                  "eventTime": "date",
+                  "eventName": "ObjectCreated:Put",
+                  "userIdentity": {
+                    "principalId": "<principal-id:2>"
+                  },
+                  "requestParameters": {
+                    "sourceIPAddress": "<ip-address:1>"
+                  },
+                  "responseElements": {
+                    "x-amz-request-id": "amz-request-id",
+                    "x-amz-id-2": "amz-id"
+                  },
+                  "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "configurationId": "<config-id:1>",
+                    "bucket": {
+                      "name": "<resource:2>",
+                      "ownerIdentity": {
+                        "principalId": "<principal-id:1>"
+                      },
+                      "arn": "arn:aws:s3:::<resource:2>"
+                    },
+                    "object": {
+                      "key": "bucket-key",
+                      "size": 12,
+                      "eTag": "05c7c1b96e20928f6e55a881b5ca1c45",
+                      "sequencer": "sequencer"
+                    }
+                  }
+                }
+              ]
+            },
+            "Timestamp": "date",
+            "SignatureVersion": "1",
+            "Signature": "signature",
+            "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
+            "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -1,0 +1,499 @@
+{
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put": {
+    "recorded-date": "07-06-2022, 17:28:41",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "my_key_0",
+                "size": 9,
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "versionId": "version-id",
+                "sequencer": "sequencer"
+              }
+            }
+          },
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "my_key_1",
+                "size": 14,
+                "eTag": "6c7ba9c5a141421e1c03cb9807c97c74",
+                "versionId": "version-id",
+                "sequencer": "sequencer"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_copy": {
+    "recorded-date": "07-06-2022, 17:28:48",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Copy",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "<object-key:1>",
+                "size": 9,
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "sequencer": "sequencer"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_and_object_removed": {
+    "recorded-date": "07-06-2022, 17:28:55",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Copy",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "<object-key:1>",
+                "size": 9,
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "sequencer": "sequencer"
+              }
+            }
+          },
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "<object-key:2>",
+                "size": 9,
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "sequencer": "sequencer"
+              }
+            }
+          },
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectRemoved:Delete",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "<object-key:2>",
+                "sequencer": "sequencer"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_complete_multipart_upload": {
+    "recorded-date": "07-06-2022, 17:29:02",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:CompleteMultipartUpload",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "test-key",
+                "size": 6144,
+                "eTag": "8eabe9d6b43316e840b079170916c079-1",
+                "sequencer": "sequencer"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_key_encoding": {
+    "recorded-date": "07-06-2022, 17:29:07",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "a%40b",
+                "size": 9,
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "sequencer": "sequencer"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_created_put_with_presigned_url_upload": {
+    "recorded-date": "07-06-2022, 17:29:13",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.1",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "key-by-hostname",
+                "size": 9,
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "sequencer": "sequencer"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_tagging_put_event": {
+    "recorded-date": "07-06-2022, 17:29:18",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.3",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectTagging:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "<object-key:1>",
+                "eTag": "f3e6da48d914f3f04f6bd9cb092c044d"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_tagging_delete_event": {
+    "recorded-date": "07-06-2022, 17:29:25",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "eventVersion": "2.3",
+            "eventSource": "aws:s3",
+            "awsRegion": "<region>",
+            "eventTime": "date",
+            "eventName": "ObjectTagging:Delete",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            },
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-request-id": "amz-request-id",
+              "x-amz-id-2": "amz-id"
+            },
+            "s3": {
+              "s3SchemaVersion": "1.0",
+              "configurationId": "<config-id:1>",
+              "bucket": {
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                },
+                "arn": "arn:aws:s3:::<resource:1>"
+              },
+              "object": {
+                "key": "<object-key:1>",
+                "eTag": "f3e6da48d914f3f04f6bd9cb092c044d"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_xray_header": {
+    "recorded-date": "07-06-2022, 17:29:32",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>",
+            "MD5OfBody": "m-d5-of-body",
+            "Body": {
+              "Records": [
+                {
+                  "eventVersion": "2.1",
+                  "eventSource": "aws:s3",
+                  "awsRegion": "<region>",
+                  "eventTime": "date",
+                  "eventName": "ObjectCreated:Put",
+                  "userIdentity": {
+                    "principalId": "<principal-id:2>"
+                  },
+                  "requestParameters": {
+                    "sourceIPAddress": "<ip-address:1>"
+                  },
+                  "responseElements": {
+                    "x-amz-request-id": "amz-request-id",
+                    "x-amz-id-2": "amz-id"
+                  },
+                  "s3": {
+                    "s3SchemaVersion": "1.0",
+                    "configurationId": "<config-id:1>",
+                    "bucket": {
+                      "name": "<resource:1>",
+                      "ownerIdentity": {
+                        "principalId": "<principal-id:1>"
+                      },
+                      "arn": "arn:aws:s3:::<resource:1>"
+                    },
+                    "object": {
+                      "key": "test-data",
+                      "size": 9,
+                      "eTag": "437b930db84b8079c2dd804a71936b5f",
+                      "sequencer": "sequencer"
+                    }
+                  }
+                }
+              ]
+            },
+            "Attributes": {
+              "AWSTraceHeader": "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -188,6 +188,7 @@ class TestCloudWatchLogs:
                     else None
                 ),
                 replacement="event_id",
+                replace_reference=False,
             ),
         )
 

--- a/tests/integration/test_logs.snapshot.json
+++ b/tests/integration/test_logs.snapshot.json
@@ -1,11 +1,11 @@
 {
   "tests/integration/test_logs.py::TestCloudWatchLogs::test_put_subscription_filter_lambda": {
-    "recorded-date": "03-06-2022, 20:06:22",
+    "recorded-date": "08-06-2022, 11:51:14",
     "recorded-content": {
       "add_permission": {
         "ResponseMetadata": {
-          "HTTPStatusCode": 201,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         },
         "Statement": {
           "Sid": "<resource:1>",
@@ -27,8 +27,8 @@
       },
       "put_subscription_filter": {
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "describe_subscription_filter": {
@@ -43,8 +43,8 @@
           }
         ],
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "list_all_log_events": [
@@ -53,14 +53,14 @@
           "timestamp": "timestamp",
           "message": "test",
           "ingestionTime": "timestamp",
-          "eventId": "<event_id:1>"
+          "eventId": "event_id"
         },
         {
           "logStreamName": "<log-stream-name:1>",
           "timestamp": "timestamp",
           "message": "test 2",
           "ingestionTime": "timestamp",
-          "eventId": "<event_id:2>"
+          "eventId": "event_id"
         }
       ]
     }


### PR DESCRIPTION
Use snapshot verification for more s3 and cloudformation tests, that have already been marked as `aws_validated`
