### PR TITLE
fix op router for new HTTP gateway requests with slashes

### DIFF
--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -9,6 +9,7 @@ from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import Map, MapAdapter, PathConverter, Rule
 
 from localstack.http import Request
+from localstack.http.request import get_raw_path
 
 
 class GreedyPathConverter(PathConverter):
@@ -283,7 +284,7 @@ class RestServiceOperationRouter:
             # specified. the specs do _not_ contain any operations on OPTIONS methods at all.
             # avoid matching issues for preflight requests by matching against a similar GET request instead.
             method = request.method if request.method != "OPTIONS" else "GET"
-            rule, args = matcher.match(request.path, method=method, return_rule=True)
+            rule, args = matcher.match(get_raw_path(request), method=method, return_rule=True)
         except MethodNotAllowed as e:
             # MethodNotAllowed (405) exception is raised if a path is matching, but the method does not.
             # Our router handles this as a 404.

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import unquote, urlencode, urlsplit
 
 import pytest
 from botocore.awsrequest import prepare_request_dict
@@ -317,7 +317,7 @@ def _botocore_parser_integration_test(
     parsed_operation_model, parsed_request = parser.parse(
         HttpRequest(
             method=serialized_request.get("method") or "GET",
-            path=path,
+            path=unquote(path),
             query_string=to_str(query_string),
             headers=headers,
             body=body,
@@ -881,6 +881,15 @@ def test_rest_url_parameter_with_dashes():
         service="apigatewayv2",
         action="GetTags",
         ResourceArn="arn:aws:apigatewayv2:us-east-1:000000000000:foobar",
+    )
+
+
+def test_rest_url_parameter_with_slashes():
+    """Test if the parsing works for requests with (encoded) slashes in a parameter."""
+    _botocore_parser_integration_test(
+        service="backup",
+        action="ListRecoveryPointsByResource",
+        ResourceArn="arn:aws:dynamodb:us-east-1:000000000000:table/table-104f455b",
     )
 
 


### PR DESCRIPTION
This PR fixes an issue in the operation router when using the new ASF gateway (https://github.com/localstack/localstack/pull/5243).
In contrast to the `generic_proxy`, the `request.path` received by the new HTTP gateway is already URL decoded.
This can cause an issue for path parameters which can contain slashes (since these slashes need to be URL encoded for the route matching).
This PR contains the following changes:
- Adjusts the unit tests such that the `path` of the request is url-decoded.
- Fixes the issue in the op router (always use the raw path for matching).
- Adds a test for the operation `ListRecoveryPointsByResource` of the `backup` API with the following request URI: `/resources/{resourceArn}/recovery-points/`