### PR TITLE
add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ localstack/infra/
 package-lock.json
 /nosetests.xml
 
+.env
 venv
 /.venv*
 /.coverage


### PR DESCRIPTION
This PR adds .env to .gitignore.

Allows to use .env file for easily configuring test environments (local vs aws) without credentials leaking into the repo.
 