### PR TITLE
Fix SNS URL construction of ConfirmSubscription and Unsubscribe operation

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -300,17 +300,18 @@ def determine_aws_service_name(
 
     # 5. check the query / form-data
     values = request.values
-    if "Action" in values and "Version" in values:
+    if "Action" in values:
         # query / ec2 protocol requests always have an action and a version (the action is more significant)
         query_candidates = services.by_operation(values["Action"])
         if len(query_candidates) == 1:
             return query_candidates[0]
 
-        for service in list(query_candidates):
-            service_model = services.get(service)
-            if values["Version"] != service_model.api_version:
-                # the combination of Version and Action is not unique, add matches to the candidates
-                query_candidates.remove(service)
+        if "Version" in values:
+            for service in list(query_candidates):
+                service_model = services.get(service)
+                if values["Version"] != service_model.api_version:
+                    # the combination of Version and Action is not unique, add matches to the candidates
+                    query_candidates.remove(service)
 
         if len(query_candidates) == 1:
             return query_candidates[0]

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -300,18 +300,17 @@ def determine_aws_service_name(
 
     # 5. check the query / form-data
     values = request.values
-    if "Action" in values:
+    if "Action" in values and "Version" in values:
         # query / ec2 protocol requests always have an action and a version (the action is more significant)
         query_candidates = services.by_operation(values["Action"])
         if len(query_candidates) == 1:
             return query_candidates[0]
 
-        if "Version" in values:
-            for service in list(query_candidates):
-                service_model = services.get(service)
-                if values["Version"] != service_model.api_version:
-                    # the combination of Version and Action is not unique, add matches to the candidates
-                    query_candidates.remove(service)
+        for service in list(query_candidates):
+            service_model = services.get(service)
+            if values["Version"] != service_model.api_version:
+                # the combination of Version and Action is not unique, add matches to the candidates
+                query_candidates.remove(service)
 
         if len(query_candidates) == 1:
             return query_candidates[0]

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -466,11 +466,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 external_url = external_service_url("sns")
                 token = short_uid()
                 message_id = long_uid()
-                # subscription_url = "%s/?Action=ConfirmSubscription&SubscriptionArn=%s&Token=%s" % (
-                #     external_url,
-                #     target_subscription_arn,
-                #     token,
-                # )
                 subscription_url = create_subscribe_url(
                     external_url, target_subscription_arn, token
                 )

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -144,6 +144,9 @@ class TestSNSProvider:
             f"{external_service_url('sns')}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
         )
 
+        confirm_subscribe_request = requests.get(subscribe_url)
+        assert "<ConfirmSubscriptionResult />" in confirm_subscribe_request.text
+
     def test_subscribe_with_invalid_protocol(self, sns_client, sns_create_topic, sns_subscription):
         topic_arn = sns_create_topic()["TopicArn"]
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -13,7 +13,7 @@ from localstack import config
 from localstack.config import external_service_url
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.install import SQS_BACKEND_IMPL
-from localstack.services.sns.provider import SNSBackend
+from localstack.services.sns.provider import SNSBackend, SnsProvider
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
@@ -141,7 +141,8 @@ class TestSNSProvider:
         token = payload["Token"]
         subscribe_url = payload["SubscribeURL"]
         assert subscribe_url == (
-            f"{external_service_url('sns')}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+            f"{external_service_url('sns')}/?"
+            f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}&Version={SnsProvider.version}"
         )
 
         confirm_subscribe_request = requests.get(subscribe_url)


### PR DESCRIPTION
`"Version"` was missing from the URL to ConfirmSubscription and Unsubscribe operations. This would in turn fail to get recognized through the service name parser for query-protocol, as the `"Version"` needs to be there.
https://github.com/localstack/localstack/blob/d7b10447c6a57d477867a314ea4b2310b7433430/localstack/aws/protocol/service_router.py#L301-L304

https://docs.aws.amazon.com/sns/latest/api/API_ConfirmSubscription.html
https://docs.aws.amazon.com/sns/latest/api/API_Unsubscribe.html

_fixes #6227_