### PR TITLE
add composite handler for asf handler chain

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -36,6 +36,7 @@ class LocalstackAwsGateway(Gateway):
                 handlers.add_region_from_header,
                 handlers.add_default_account_id,
                 handlers.parse_service_request,
+                handlers.serve_custom_service_request_handlers,
                 load_service,  # once we have the service request we can make sure we load the service
                 self.service_request_router,  # once we know the service is loaded we can route the request
                 # if the chain is still running, set an empty response

--- a/localstack/aws/chain.py
+++ b/localstack/aws/chain.py
@@ -138,3 +138,21 @@ class HandlerChain:
                     LOG.exception(msg)
                 else:
                     LOG.warning(msg + ": %s", nested)
+
+
+class CompositeHandler(Handler):
+    """
+    A handler that sequentially invokes a list of Handlers, forming a stripped-down version of a handler chain.
+    """
+
+    handlers: List[Handler]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.handlers = list()
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        for handler in self.handlers:
+            handler(chain, context, response)
+            if chain.stopped or chain.terminated:
+                return

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -1,5 +1,6 @@
 """ A set of common handlers to build an AWS server application."""
 
+from .. import chain
 from . import auth, codec, cors, fallback, internal, legacy, logging, region, service
 
 enforce_cors = cors.CorsEnforcer()
@@ -14,6 +15,7 @@ log_exception = logging.ExceptionLogger()
 log_response = logging.ResponseLogger()
 handle_service_exception = service.ServiceExceptionSerializer()
 handle_internal_failure = fallback.InternalFailureHandler()
+serve_custom_service_request_handlers = chain.CompositeHandler()
 serve_localstack_resources = internal.LocalstackResourceHandler()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()

--- a/tests/unit/aws/test_chain.py
+++ b/tests/unit/aws/test_chain.py
@@ -1,0 +1,87 @@
+from unittest import mock
+
+from localstack.aws.api import RequestContext
+from localstack.aws.chain import CompositeHandler, HandlerChain
+from localstack.http import Response
+
+
+class TestCompositeHandler:
+    def test_composite_handler_stops_handler_chain(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            _chain.stop()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_not_called()
+        response1.assert_called_once()
+
+    def test_composite_handler_continues_handler_chain(self):
+        inner1 = mock.MagicMock()
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_called_once()
+        inner1.assert_called_once()
+        inner2.assert_called_once()
+        response1.assert_called_once()
+
+    def test_composite_handler_exception_calls_outer_exception_handlers(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            raise ValueError()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        exception_handler = mock.MagicMock()
+        response1 = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.exception_handlers.append(exception_handler)
+        chain.response_handlers.append(response1)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_not_called()
+        exception_handler.assert_called_once()
+        response1.assert_called_once()


### PR DESCRIPTION
This PR adds a new type of handler that can contain multiple handlers. It's a simple nested handler chain. One specific instances, the `serve_custom_service_request_handlers`, will be used to hook things like the IAM policy enforcer into the chain without modifying the gateway request handlers directly.


The implementation is a compromise. Building a full nested handler chain is not as straight forward because it's not always clear how the control flow behavior (terminated, stopped, exception handlers, ...) should propagate to the outer handler chain. So i decided to keep it simple for now.

I added some unit tests using mocks that verify that the control flow behavior is executed correctly.
