### PR TITLE
Exit pytest when encountering duplicate fixture names by default

### DIFF
--- a/localstack/testing/pytest/fixture_conflicts.py
+++ b/localstack/testing/pytest/fixture_conflicts.py
@@ -1,0 +1,37 @@
+"""
+This pytest plugin makes sure there's only a single fixture definition for each fixture name when executing a test.
+
+The behavior here can be disabled with the option --ignore-fixture-conflicts which will then behave like pytest does by default (i.e. allow multiple defs).
+"""
+
+import logging
+
+import pytest
+from _pytest.config import PytestPluginManager
+from _pytest.config.argparsing import Parser
+from _pytest.nodes import Item
+from _pytest.python import Function
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.hookimpl
+def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
+    parser.addoption(
+        "--ignore-fixture-conflicts",
+        action="store_true",
+        help="When enabled, allows multiple fixture definitions to exist for a single fixture name.",
+    )
+
+
+@pytest.hookimpl
+def pytest_runtest_setup(item: Item):
+    if not item.config.getoption("--ignore-fixture-conflicts", False):
+        if isinstance(item, Function):
+            # unfortunately there don't seem to be proper fixture initialization hooks and
+            # the fixture names only include a single entry even when multiple definitions are found
+            # so we need to check the internal name2fixturedefs dict instead
+            defs = item._fixtureinfo.name2fixturedefs
+            multi_defs = [k for k, v in defs.items() if len(v) > 1]
+            if multi_defs:
+                pytest.exit(f"Aborting. Detected multiple defs for fixtures: {multi_defs}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ pytest_plugins = [
     "localstack.testing.pytest.fixtures",
     "localstack.testing.pytest.snapshot",
     "localstack.testing.pytest.filters",
+    "localstack.testing.pytest.fixture_conflicts",
 ]
 
 

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import time
 from io import BytesIO
-from typing import Dict, List, TypeVar
+from typing import Dict, TypeVar
 
 import pytest
 from botocore.exceptions import ClientError
@@ -42,7 +42,6 @@ from localstack.services.install import (
     TEST_LAMBDA_JAVA,
     download_and_extract,
 )
-from localstack.testing.aws.util import get_lambda_logs
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
@@ -181,23 +180,6 @@ def read_streams(payload: T) -> T:
         else:
             new_payload[k] = v
     return new_payload
-
-
-@pytest.fixture
-def check_lambda_logs(logs_client):
-    def _check_logs(func_name: str, expected_lines: List[str] = None):
-        if not expected_lines:
-            expected_lines = []
-        log_events = get_lambda_logs(func_name, logs_client=logs_client)
-        log_messages = [e["message"] for e in log_events]
-        for line in expected_lines:
-            if ".*" in line:
-                found = [re.match(line, m, flags=re.DOTALL) for m in log_messages]
-                if any(found):
-                    continue
-            assert line in log_messages
-
-    return _check_logs
 
 
 # API only functions (no lambda execution itself)

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -8,16 +8,12 @@ from botocore.exceptions import ClientError
 from localstack.aws.api.iam import Tag
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.iam.provider import ADDITIONAL_MANAGED_POLICIES
-from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 from localstack.utils.kinesis import kinesis_connector
 from localstack.utils.strings import long_uid
 
 
 class TestIAMIntegrations:
-    @pytest.fixture
-    def iam_client(self):
-        return aws_stack.create_external_boto_client("iam")
 
     # TODO what does this test do?
     def test_run_kcl_with_iam_assume_role(self):


### PR DESCRIPTION
I feel it's generally bad design that pytest allows multiple fixture definitons with the same name to exist. In our case this is never used intentionally and only lead to hard to debug issues in the past, so I've blocked this by default now. 

The default behavior can be reverted to by specifying `--ignore-fixture-conflicts`.


cc @baermat 