### PR TITLE
fix ASF error serialization for shapes w/ members

### DIFF
--- a/localstack/aws/api/acm/__init__.py
+++ b/localstack/aws/api/acm/__init__.py
@@ -150,112 +150,96 @@ class AccessDeniedException(ServiceException):
     code: str = "AccessDeniedException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ServiceErrorMessage]
 
 
 class ConflictException(ServiceException):
     code: str = "ConflictException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidArgsException(ServiceException):
     code: str = "InvalidArgsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidArnException(ServiceException):
     code: str = "InvalidArnException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidDomainValidationOptionsException(ServiceException):
     code: str = "InvalidDomainValidationOptionsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidParameterException(ServiceException):
     code: str = "InvalidParameterException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidStateException(ServiceException):
     code: str = "InvalidStateException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidTagException(ServiceException):
     code: str = "InvalidTagException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class RequestInProgressException(ServiceException):
     code: str = "RequestInProgressException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class TagPolicyException(ServiceException):
     code: str = "TagPolicyException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ThrottlingException(ServiceException):
     code: str = "ThrottlingException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[AvailabilityErrorMessage]
 
 
 class TooManyTagsException(ServiceException):
     code: str = "TooManyTagsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ValidationExceptionMessage]
 
 
 class Tag(TypedDict, total=False):

--- a/localstack/aws/api/apigateway/__init__.py
+++ b/localstack/aws/api/apigateway/__init__.py
@@ -172,14 +172,12 @@ class BadRequestException(ServiceException):
     code: str = "BadRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ConflictException(ServiceException):
     code: str = "ConflictException"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[String]
 
 
 class LimitExceededException(ServiceException):
@@ -187,14 +185,12 @@ class LimitExceededException(ServiceException):
     sender_fault: bool = False
     status_code: int = 429
     retryAfterSeconds: Optional[String]
-    message: Optional[String]
 
 
 class NotFoundException(ServiceException):
     code: str = "NotFoundException"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[String]
 
 
 class ServiceUnavailableException(ServiceException):
@@ -202,7 +198,6 @@ class ServiceUnavailableException(ServiceException):
     sender_fault: bool = False
     status_code: int = 503
     retryAfterSeconds: Optional[String]
-    message: Optional[String]
 
 
 class TooManyRequestsException(ServiceException):
@@ -210,14 +205,12 @@ class TooManyRequestsException(ServiceException):
     sender_fault: bool = False
     status_code: int = 429
     retryAfterSeconds: Optional[String]
-    message: Optional[String]
 
 
 class UnauthorizedException(ServiceException):
     code: str = "UnauthorizedException"
     sender_fault: bool = False
     status_code: int = 401
-    message: Optional[String]
 
 
 class AccessLogSettings(TypedDict, total=False):

--- a/localstack/aws/api/cloudformation/__init__.py
+++ b/localstack/aws/api/cloudformation/__init__.py
@@ -541,7 +541,6 @@ class CFNRegistryException(ServiceException):
     code: str = "CFNRegistryException"
     sender_fault: bool = True
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class ChangeSetNotFoundException(ServiceException):

--- a/localstack/aws/api/cloudwatch/__init__.py
+++ b/localstack/aws/api/cloudwatch/__init__.py
@@ -202,7 +202,6 @@ class DashboardInvalidInputError(ServiceException):
     code: str = "InvalidParameterInput"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[DashboardErrorMessage]
     dashboardValidationMessages: Optional[DashboardValidationMessages]
 
 
@@ -210,42 +209,36 @@ class DashboardNotFoundError(ServiceException):
     code: str = "ResourceNotFound"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[DashboardErrorMessage]
 
 
 class InternalServiceFault(ServiceException):
     code: str = "InternalServiceError"
     sender_fault: bool = False
     status_code: int = 500
-    Message: Optional[FaultDescription]
 
 
 class InvalidFormatFault(ServiceException):
     code: str = "InvalidFormat"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidNextToken(ServiceException):
     code: str = "InvalidNextToken"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidParameterCombinationException(ServiceException):
     code: str = "InvalidParameterCombination"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[AwsQueryErrorMessage]
 
 
 class InvalidParameterValueException(ServiceException):
     code: str = "InvalidParameterValue"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[AwsQueryErrorMessage]
 
 
 class LimitExceededException(ServiceException):
@@ -258,21 +251,18 @@ class LimitExceededFault(ServiceException):
     code: str = "LimitExceeded"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class MissingRequiredParameterException(ServiceException):
     code: str = "MissingParameter"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[AwsQueryErrorMessage]
 
 
 class ResourceNotFound(ServiceException):
     code: str = "ResourceNotFound"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):

--- a/localstack/aws/api/config/__init__.py
+++ b/localstack/aws/api/config/__init__.py
@@ -699,7 +699,6 @@ class ResourceConcurrentModificationException(ServiceException):
     code: str = "ResourceConcurrentModificationException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceInUseException(ServiceException):

--- a/localstack/aws/api/dynamodb/__init__.py
+++ b/localstack/aws/api/dynamodb/__init__.py
@@ -313,182 +313,156 @@ class BackupInUseException(ServiceException):
     code: str = "BackupInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class BackupNotFoundException(ServiceException):
     code: str = "BackupNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ConditionalCheckFailedException(ServiceException):
     code: str = "ConditionalCheckFailedException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ContinuousBackupsUnavailableException(ServiceException):
     code: str = "ContinuousBackupsUnavailableException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DuplicateItemException(ServiceException):
     code: str = "DuplicateItemException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ExportConflictException(ServiceException):
     code: str = "ExportConflictException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ExportNotFoundException(ServiceException):
     code: str = "ExportNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class GlobalTableAlreadyExistsException(ServiceException):
     code: str = "GlobalTableAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class GlobalTableNotFoundException(ServiceException):
     code: str = "GlobalTableNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class IdempotentParameterMismatchException(ServiceException):
     code: str = "IdempotentParameterMismatchException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class IndexNotFoundException(ServiceException):
     code: str = "IndexNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InternalServerError(ServiceException):
     code: str = "InternalServerError"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidExportTimeException(ServiceException):
     code: str = "InvalidExportTimeException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidRestoreTimeException(ServiceException):
     code: str = "InvalidRestoreTimeException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ItemCollectionSizeLimitExceededException(ServiceException):
     code: str = "ItemCollectionSizeLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class PointInTimeRecoveryUnavailableException(ServiceException):
     code: str = "PointInTimeRecoveryUnavailableException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ProvisionedThroughputExceededException(ServiceException):
     code: str = "ProvisionedThroughputExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ReplicaAlreadyExistsException(ServiceException):
     code: str = "ReplicaAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ReplicaNotFoundException(ServiceException):
     code: str = "ReplicaNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class RequestLimitExceeded(ServiceException):
     code: str = "RequestLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TableAlreadyExistsException(ServiceException):
     code: str = "TableAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TableInUseException(ServiceException):
     code: str = "TableInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TableNotFoundException(ServiceException):
     code: str = "TableNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AttributeValue(TypedDict, total=False):
@@ -526,7 +500,6 @@ class TransactionCanceledException(ServiceException):
     code: str = "TransactionCanceledException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
     CancellationReasons: Optional[CancellationReasonList]
 
 
@@ -534,14 +507,12 @@ class TransactionConflictException(ServiceException):
     code: str = "TransactionConflictException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TransactionInProgressException(ServiceException):
     code: str = "TransactionInProgressException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 Date = datetime

--- a/localstack/aws/api/dynamodbstreams/__init__.py
+++ b/localstack/aws/api/dynamodbstreams/__init__.py
@@ -61,35 +61,30 @@ class ExpiredIteratorException(ServiceException):
     code: str = "ExpiredIteratorException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InternalServerError(ServiceException):
     code: str = "InternalServerError"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TrimmedDataAccessException(ServiceException):
     code: str = "TrimmedDataAccessException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AttributeValue(TypedDict, total=False):

--- a/localstack/aws/api/es/__init__.py
+++ b/localstack/aws/api/es/__init__.py
@@ -304,7 +304,6 @@ class BaseException(ServiceException):
     code: str = "BaseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ConflictException(ServiceException):

--- a/localstack/aws/api/firehose/__init__.py
+++ b/localstack/aws/api/firehose/__init__.py
@@ -235,50 +235,42 @@ class ConcurrentModificationException(ServiceException):
     code: str = "ConcurrentModificationException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidArgumentException(ServiceException):
     code: str = "InvalidArgumentException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidKMSResourceException(ServiceException):
     code: str = "InvalidKMSResourceException"
     sender_fault: bool = False
     status_code: int = 400
-    code: Optional[ErrorCode]
-    message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ServiceUnavailableException(ServiceException):
     code: str = "ServiceUnavailableException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AmazonopensearchserviceBufferingHints(TypedDict, total=False):

--- a/localstack/aws/api/iam/__init__.py
+++ b/localstack/aws/api/iam/__init__.py
@@ -266,189 +266,162 @@ class ConcurrentModificationException(ServiceException):
     code: str = "ConcurrentModification"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[ConcurrentModificationMessage]
 
 
 class CredentialReportExpiredException(ServiceException):
     code: str = "ReportExpired"
     sender_fault: bool = True
     status_code: int = 410
-    message: Optional[credentialReportExpiredExceptionMessage]
 
 
 class CredentialReportNotPresentException(ServiceException):
     code: str = "ReportNotPresent"
     sender_fault: bool = True
     status_code: int = 410
-    message: Optional[credentialReportNotPresentExceptionMessage]
 
 
 class CredentialReportNotReadyException(ServiceException):
     code: str = "ReportInProgress"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[credentialReportNotReadyExceptionMessage]
 
 
 class DeleteConflictException(ServiceException):
     code: str = "DeleteConflict"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[deleteConflictMessage]
 
 
 class DuplicateCertificateException(ServiceException):
     code: str = "DuplicateCertificate"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[duplicateCertificateMessage]
 
 
 class DuplicateSSHPublicKeyException(ServiceException):
     code: str = "DuplicateSSHPublicKey"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[duplicateSSHPublicKeyMessage]
 
 
 class EntityAlreadyExistsException(ServiceException):
     code: str = "EntityAlreadyExists"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[entityAlreadyExistsMessage]
 
 
 class EntityTemporarilyUnmodifiableException(ServiceException):
     code: str = "EntityTemporarilyUnmodifiable"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[entityTemporarilyUnmodifiableMessage]
 
 
 class InvalidAuthenticationCodeException(ServiceException):
     code: str = "InvalidAuthenticationCode"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[invalidAuthenticationCodeMessage]
 
 
 class InvalidCertificateException(ServiceException):
     code: str = "InvalidCertificate"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[invalidCertificateMessage]
 
 
 class InvalidInputException(ServiceException):
     code: str = "InvalidInput"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[invalidInputMessage]
 
 
 class InvalidPublicKeyException(ServiceException):
     code: str = "InvalidPublicKey"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[invalidPublicKeyMessage]
 
 
 class InvalidUserTypeException(ServiceException):
     code: str = "InvalidUserType"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[invalidUserTypeMessage]
 
 
 class KeyPairMismatchException(ServiceException):
     code: str = "KeyPairMismatch"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[keyPairMismatchMessage]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceeded"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[limitExceededMessage]
 
 
 class MalformedCertificateException(ServiceException):
     code: str = "MalformedCertificate"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[malformedCertificateMessage]
 
 
 class MalformedPolicyDocumentException(ServiceException):
     code: str = "MalformedPolicyDocument"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[malformedPolicyDocumentMessage]
 
 
 class NoSuchEntityException(ServiceException):
     code: str = "NoSuchEntity"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[noSuchEntityMessage]
 
 
 class PasswordPolicyViolationException(ServiceException):
     code: str = "PasswordPolicyViolation"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[passwordPolicyViolationMessage]
 
 
 class PolicyEvaluationException(ServiceException):
     code: str = "PolicyEvaluation"
     sender_fault: bool = False
     status_code: int = 500
-    message: Optional[policyEvaluationErrorMessage]
 
 
 class PolicyNotAttachableException(ServiceException):
     code: str = "PolicyNotAttachable"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[policyNotAttachableMessage]
 
 
 class ReportGenerationLimitExceededException(ServiceException):
     code: str = "ReportGenerationLimitExceeded"
     sender_fault: bool = True
     status_code: int = 409
-    message: Optional[reportGenerationLimitExceededMessage]
 
 
 class ServiceFailureException(ServiceException):
     code: str = "ServiceFailure"
     sender_fault: bool = False
     status_code: int = 500
-    message: Optional[serviceFailureExceptionMessage]
 
 
 class ServiceNotSupportedException(ServiceException):
     code: str = "NotSupportedService"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[serviceNotSupportedMessage]
 
 
 class UnmodifiableEntityException(ServiceException):
     code: str = "UnmodifiableEntity"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[unmodifiableEntityMessage]
 
 
 class UnrecognizedPublicKeyEncodingException(ServiceException):
     code: str = "UnrecognizedPublicKeyEncoding"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[unrecognizedPublicKeyEncodingMessage]
 
 
 dateType = datetime

--- a/localstack/aws/api/kms/__init__.py
+++ b/localstack/aws/api/kms/__init__.py
@@ -205,238 +205,204 @@ class AlreadyExistsException(ServiceException):
     code: str = "AlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterInUseException(ServiceException):
     code: str = "CloudHsmClusterInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterInvalidConfigurationException(ServiceException):
     code: str = "CloudHsmClusterInvalidConfigurationException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterNotActiveException(ServiceException):
     code: str = "CloudHsmClusterNotActiveException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterNotFoundException(ServiceException):
     code: str = "CloudHsmClusterNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterNotRelatedException(ServiceException):
     code: str = "CloudHsmClusterNotRelatedException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreHasCMKsException(ServiceException):
     code: str = "CustomKeyStoreHasCMKsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreInvalidStateException(ServiceException):
     code: str = "CustomKeyStoreInvalidStateException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreNameInUseException(ServiceException):
     code: str = "CustomKeyStoreNameInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreNotFoundException(ServiceException):
     code: str = "CustomKeyStoreNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class DependencyTimeoutException(ServiceException):
     code: str = "DependencyTimeoutException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class DisabledException(ServiceException):
     code: str = "DisabledException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class ExpiredImportTokenException(ServiceException):
     code: str = "ExpiredImportTokenException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class IncorrectKeyException(ServiceException):
     code: str = "IncorrectKeyException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class IncorrectKeyMaterialException(ServiceException):
     code: str = "IncorrectKeyMaterialException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class IncorrectTrustAnchorException(ServiceException):
     code: str = "IncorrectTrustAnchorException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidAliasNameException(ServiceException):
     code: str = "InvalidAliasNameException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidArnException(ServiceException):
     code: str = "InvalidArnException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidCiphertextException(ServiceException):
     code: str = "InvalidCiphertextException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidGrantIdException(ServiceException):
     code: str = "InvalidGrantIdException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidGrantTokenException(ServiceException):
     code: str = "InvalidGrantTokenException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidImportTokenException(ServiceException):
     code: str = "InvalidImportTokenException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidKeyUsageException(ServiceException):
     code: str = "InvalidKeyUsageException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class InvalidMarkerException(ServiceException):
     code: str = "InvalidMarkerException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class KMSInternalException(ServiceException):
     code: str = "KMSInternalException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class KMSInvalidMacException(ServiceException):
     code: str = "KMSInvalidMacException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class KMSInvalidSignatureException(ServiceException):
     code: str = "KMSInvalidSignatureException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class KMSInvalidStateException(ServiceException):
     code: str = "KMSInvalidStateException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class KeyUnavailableException(ServiceException):
     code: str = "KeyUnavailableException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class MalformedPolicyDocumentException(ServiceException):
     code: str = "MalformedPolicyDocumentException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class NotFoundException(ServiceException):
     code: str = "NotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class TagException(ServiceException):
     code: str = "TagException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 class UnsupportedOperationException(ServiceException):
     code: str = "UnsupportedOperationException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessageType]
 
 
 DateType = datetime

--- a/localstack/aws/api/lambda_/__init__.py
+++ b/localstack/aws/api/lambda_/__init__.py
@@ -256,48 +256,36 @@ class CodeSigningConfigNotFoundException(ServiceException):
     code: str = "CodeSigningConfigNotFoundException"
     sender_fault: bool = False
     status_code: int = 404
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class CodeStorageExceededException(ServiceException):
     code: str = "CodeStorageExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class CodeVerificationFailedException(ServiceException):
     code: str = "CodeVerificationFailedException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class EC2AccessDeniedException(ServiceException):
     code: str = "EC2AccessDeniedException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class EC2ThrottledException(ServiceException):
     code: str = "EC2ThrottledException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class EC2UnexpectedException(ServiceException):
     code: str = "EC2UnexpectedException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
     EC2ErrorCode: Optional[String]
 
 
@@ -305,208 +293,156 @@ class EFSIOException(ServiceException):
     code: str = "EFSIOException"
     sender_fault: bool = False
     status_code: int = 410
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class EFSMountConnectivityException(ServiceException):
     code: str = "EFSMountConnectivityException"
     sender_fault: bool = False
     status_code: int = 408
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class EFSMountFailureException(ServiceException):
     code: str = "EFSMountFailureException"
     sender_fault: bool = False
     status_code: int = 403
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class EFSMountTimeoutException(ServiceException):
     code: str = "EFSMountTimeoutException"
     sender_fault: bool = False
     status_code: int = 408
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class ENILimitReachedException(ServiceException):
     code: str = "ENILimitReachedException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class InvalidCodeSignatureException(ServiceException):
     code: str = "InvalidCodeSignatureException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class InvalidParameterValueException(ServiceException):
     code: str = "InvalidParameterValueException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class InvalidRequestContentException(ServiceException):
     code: str = "InvalidRequestContentException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class InvalidRuntimeException(ServiceException):
     code: str = "InvalidRuntimeException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class InvalidSecurityGroupIDException(ServiceException):
     code: str = "InvalidSecurityGroupIDException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class InvalidSubnetIDException(ServiceException):
     code: str = "InvalidSubnetIDException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class InvalidZipFileException(ServiceException):
     code: str = "InvalidZipFileException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class KMSAccessDeniedException(ServiceException):
     code: str = "KMSAccessDeniedException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class KMSDisabledException(ServiceException):
     code: str = "KMSDisabledException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class KMSInvalidStateException(ServiceException):
     code: str = "KMSInvalidStateException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class KMSNotFoundException(ServiceException):
     code: str = "KMSNotFoundException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class PolicyLengthExceededException(ServiceException):
     code: str = "PolicyLengthExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class PreconditionFailedException(ServiceException):
     code: str = "PreconditionFailedException"
     sender_fault: bool = False
     status_code: int = 412
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class ProvisionedConcurrencyConfigNotFoundException(ServiceException):
     code: str = "ProvisionedConcurrencyConfigNotFoundException"
     sender_fault: bool = False
     status_code: int = 404
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class RequestTooLargeException(ServiceException):
     code: str = "RequestTooLargeException"
     sender_fault: bool = False
     status_code: int = 413
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class ResourceConflictException(ServiceException):
     code: str = "ResourceConflictException"
     sender_fault: bool = False
     status_code: int = 409
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 404
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class ResourceNotReadyException(ServiceException):
     code: str = "ResourceNotReadyException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    message: Optional[String]
 
 
 class ServiceException(ServiceException):
     code: str = "ServiceException"
     sender_fault: bool = False
     status_code: int = 500
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class SubnetIPAddressLimitReachedException(ServiceException):
     code: str = "SubnetIPAddressLimitReachedException"
     sender_fault: bool = False
     status_code: int = 502
-    Type: Optional[String]
-    Message: Optional[String]
 
 
 class TooManyRequestsException(ServiceException):
@@ -514,8 +450,6 @@ class TooManyRequestsException(ServiceException):
     sender_fault: bool = False
     status_code: int = 429
     retryAfterSeconds: Optional[String]
-    Type: Optional[String]
-    message: Optional[String]
     Reason: Optional[ThrottleReason]
 
 
@@ -523,8 +457,6 @@ class UnsupportedMediaTypeException(ServiceException):
     code: str = "UnsupportedMediaTypeException"
     sender_fault: bool = False
     status_code: int = 415
-    Type: Optional[String]
-    message: Optional[String]
 
 
 Long = int

--- a/localstack/aws/api/opensearch/__init__.py
+++ b/localstack/aws/api/opensearch/__init__.py
@@ -346,7 +346,6 @@ class BaseException(ServiceException):
     code: str = "BaseException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ConflictException(ServiceException):

--- a/localstack/aws/api/resource_groups/__init__.py
+++ b/localstack/aws/api/resource_groups/__init__.py
@@ -63,49 +63,42 @@ class BadRequestException(ServiceException):
     code: str = "BadRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class ForbiddenException(ServiceException):
     code: str = "ForbiddenException"
     sender_fault: bool = False
     status_code: int = 403
-    Message: Optional[ErrorMessage]
 
 
 class InternalServerErrorException(ServiceException):
     code: str = "InternalServerErrorException"
     sender_fault: bool = False
     status_code: int = 500
-    Message: Optional[ErrorMessage]
 
 
 class MethodNotAllowedException(ServiceException):
     code: str = "MethodNotAllowedException"
     sender_fault: bool = False
     status_code: int = 405
-    Message: Optional[ErrorMessage]
 
 
 class NotFoundException(ServiceException):
     code: str = "NotFoundException"
     sender_fault: bool = False
     status_code: int = 404
-    Message: Optional[ErrorMessage]
 
 
 class TooManyRequestsException(ServiceException):
     code: str = "TooManyRequestsException"
     sender_fault: bool = False
     status_code: int = 429
-    Message: Optional[ErrorMessage]
 
 
 class UnauthorizedException(ServiceException):
     code: str = "UnauthorizedException"
     sender_fault: bool = False
     status_code: int = 401
-    Message: Optional[ErrorMessage]
 
 
 GroupConfigurationParameterValueList = List[GroupConfigurationParameterValue]

--- a/localstack/aws/api/resourcegroupstaggingapi/__init__.py
+++ b/localstack/aws/api/resourcegroupstaggingapi/__init__.py
@@ -51,42 +51,36 @@ class ConcurrentModificationException(ServiceException):
     code: str = "ConcurrentModificationException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class ConstraintViolationException(ServiceException):
     code: str = "ConstraintViolationException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InternalServiceException(ServiceException):
     code: str = "InternalServiceException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InvalidParameterException(ServiceException):
     code: str = "InvalidParameterException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class PaginationTokenExpiredException(ServiceException):
     code: str = "PaginationTokenExpiredException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class ThrottledException(ServiceException):
     code: str = "ThrottledException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 TagKeyList = List[TagKey]

--- a/localstack/aws/api/route53/__init__.py
+++ b/localstack/aws/api/route53/__init__.py
@@ -301,168 +301,144 @@ class CidrBlockInUseException(ServiceException):
     code: str = "CidrBlockInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class CidrCollectionAlreadyExistsException(ServiceException):
     code: str = "CidrCollectionAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class CidrCollectionInUseException(ServiceException):
     code: str = "CidrCollectionInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class CidrCollectionVersionMismatchException(ServiceException):
     code: str = "CidrCollectionVersionMismatchException"
     sender_fault: bool = False
     status_code: int = 409
-    Message: Optional[ErrorMessage]
 
 
 class ConcurrentModification(ServiceException):
     code: str = "ConcurrentModification"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ConflictingDomainExists(ServiceException):
     code: str = "ConflictingDomainExists"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ConflictingTypes(ServiceException):
     code: str = "ConflictingTypes"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DNSSECNotFound(ServiceException):
     code: str = "DNSSECNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DelegationSetAlreadyCreated(ServiceException):
     code: str = "DelegationSetAlreadyCreated"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DelegationSetAlreadyReusable(ServiceException):
     code: str = "DelegationSetAlreadyReusable"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DelegationSetInUse(ServiceException):
     code: str = "DelegationSetInUse"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DelegationSetNotAvailable(ServiceException):
     code: str = "DelegationSetNotAvailable"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DelegationSetNotReusable(ServiceException):
     code: str = "DelegationSetNotReusable"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class HealthCheckAlreadyExists(ServiceException):
     code: str = "HealthCheckAlreadyExists"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class HealthCheckInUse(ServiceException):
     code: str = "HealthCheckInUse"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class HealthCheckVersionMismatch(ServiceException):
     code: str = "HealthCheckVersionMismatch"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class HostedZoneAlreadyExists(ServiceException):
     code: str = "HostedZoneAlreadyExists"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class HostedZoneNotEmpty(ServiceException):
     code: str = "HostedZoneNotEmpty"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class HostedZoneNotFound(ServiceException):
     code: str = "HostedZoneNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class HostedZoneNotPrivate(ServiceException):
     code: str = "HostedZoneNotPrivate"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class HostedZonePartiallyDelegated(ServiceException):
     code: str = "HostedZonePartiallyDelegated"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class IncompatibleVersion(ServiceException):
     code: str = "IncompatibleVersion"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InsufficientCloudWatchLogsResourcePolicy(ServiceException):
     code: str = "InsufficientCloudWatchLogsResourcePolicy"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidArgument(ServiceException):
     code: str = "InvalidArgument"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 ErrorMessages = List[ErrorMessage]
@@ -473,315 +449,270 @@ class InvalidChangeBatch(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     messages: Optional[ErrorMessages]
-    message: Optional[ErrorMessage]
 
 
 class InvalidDomainName(ServiceException):
     code: str = "InvalidDomainName"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidInput(ServiceException):
     code: str = "InvalidInput"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidKMSArn(ServiceException):
     code: str = "InvalidKMSArn"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidKeySigningKeyName(ServiceException):
     code: str = "InvalidKeySigningKeyName"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidKeySigningKeyStatus(ServiceException):
     code: str = "InvalidKeySigningKeyStatus"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidPaginationToken(ServiceException):
     code: str = "InvalidPaginationToken"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidSigningStatus(ServiceException):
     code: str = "InvalidSigningStatus"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidTrafficPolicyDocument(ServiceException):
     code: str = "InvalidTrafficPolicyDocument"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidVPCId(ServiceException):
     code: str = "InvalidVPCId"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class KeySigningKeyAlreadyExists(ServiceException):
     code: str = "KeySigningKeyAlreadyExists"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class KeySigningKeyInParentDSRecord(ServiceException):
     code: str = "KeySigningKeyInParentDSRecord"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class KeySigningKeyInUse(ServiceException):
     code: str = "KeySigningKeyInUse"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class KeySigningKeyWithActiveStatusNotFound(ServiceException):
     code: str = "KeySigningKeyWithActiveStatusNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class LastVPCAssociation(ServiceException):
     code: str = "LastVPCAssociation"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class LimitsExceeded(ServiceException):
     code: str = "LimitsExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class NoSuchChange(ServiceException):
     code: str = "NoSuchChange"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchCidrCollectionException(ServiceException):
     code: str = "NoSuchCidrCollectionException"
     sender_fault: bool = False
     status_code: int = 404
-    Message: Optional[ErrorMessage]
 
 
 class NoSuchCidrLocationException(ServiceException):
     code: str = "NoSuchCidrLocationException"
     sender_fault: bool = False
     status_code: int = 404
-    Message: Optional[ErrorMessage]
 
 
 class NoSuchCloudWatchLogsLogGroup(ServiceException):
     code: str = "NoSuchCloudWatchLogsLogGroup"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchDelegationSet(ServiceException):
     code: str = "NoSuchDelegationSet"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class NoSuchGeoLocation(ServiceException):
     code: str = "NoSuchGeoLocation"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchHealthCheck(ServiceException):
     code: str = "NoSuchHealthCheck"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchHostedZone(ServiceException):
     code: str = "NoSuchHostedZone"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchKeySigningKey(ServiceException):
     code: str = "NoSuchKeySigningKey"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchQueryLoggingConfig(ServiceException):
     code: str = "NoSuchQueryLoggingConfig"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchTrafficPolicy(ServiceException):
     code: str = "NoSuchTrafficPolicy"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NoSuchTrafficPolicyInstance(ServiceException):
     code: str = "NoSuchTrafficPolicyInstance"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class NotAuthorizedException(ServiceException):
     code: str = "NotAuthorizedException"
     sender_fault: bool = False
     status_code: int = 401
-    message: Optional[ErrorMessage]
 
 
 class PriorRequestNotComplete(ServiceException):
     code: str = "PriorRequestNotComplete"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class PublicZoneVPCAssociation(ServiceException):
     code: str = "PublicZoneVPCAssociation"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class QueryLoggingConfigAlreadyExists(ServiceException):
     code: str = "QueryLoggingConfigAlreadyExists"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class ThrottlingException(ServiceException):
     code: str = "ThrottlingException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyHealthChecks(ServiceException):
     code: str = "TooManyHealthChecks"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyHostedZones(ServiceException):
     code: str = "TooManyHostedZones"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyKeySigningKeys(ServiceException):
     code: str = "TooManyKeySigningKeys"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyTrafficPolicies(ServiceException):
     code: str = "TooManyTrafficPolicies"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyTrafficPolicyInstances(ServiceException):
     code: str = "TooManyTrafficPolicyInstances"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyTrafficPolicyVersionsForCurrentPolicy(ServiceException):
     code: str = "TooManyTrafficPolicyVersionsForCurrentPolicy"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyVPCAssociationAuthorizations(ServiceException):
     code: str = "TooManyVPCAssociationAuthorizations"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TrafficPolicyAlreadyExists(ServiceException):
     code: str = "TrafficPolicyAlreadyExists"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class TrafficPolicyInUse(ServiceException):
     code: str = "TrafficPolicyInUse"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TrafficPolicyInstanceAlreadyExists(ServiceException):
     code: str = "TrafficPolicyInstanceAlreadyExists"
     sender_fault: bool = False
     status_code: int = 409
-    message: Optional[ErrorMessage]
 
 
 class VPCAssociationAuthorizationNotFound(ServiceException):
     code: str = "VPCAssociationAuthorizationNotFound"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 class VPCAssociationNotFound(ServiceException):
     code: str = "VPCAssociationNotFound"
     sender_fault: bool = False
     status_code: int = 404
-    message: Optional[ErrorMessage]
 
 
 LimitValue = int

--- a/localstack/aws/api/route53resolver/__init__.py
+++ b/localstack/aws/api/route53resolver/__init__.py
@@ -214,35 +214,30 @@ class AccessDeniedException(ServiceException):
     code: str = "AccessDeniedException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class ConflictException(ServiceException):
     code: str = "ConflictException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InternalServiceErrorException(ServiceException):
     code: str = "InternalServiceErrorException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InvalidNextTokenException(ServiceException):
     code: str = "InvalidNextTokenException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidParameterException(ServiceException):
     code: str = "InvalidParameterException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: ExceptionMessage
     FieldName: Optional[String]
 
 
@@ -250,28 +245,24 @@ class InvalidPolicyDocument(ServiceException):
     code: str = "InvalidPolicyDocument"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InvalidRequestException(ServiceException):
     code: str = "InvalidRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InvalidTagException(ServiceException):
     code: str = "InvalidTagException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     ResourceType: Optional[String]
 
 
@@ -279,7 +270,6 @@ class ResourceExistsException(ServiceException):
     code: str = "ResourceExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     ResourceType: Optional[String]
 
 
@@ -287,7 +277,6 @@ class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     ResourceType: Optional[String]
 
 
@@ -295,7 +284,6 @@ class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     ResourceType: Optional[String]
 
 
@@ -303,7 +291,6 @@ class ResourceUnavailableException(ServiceException):
     code: str = "ResourceUnavailableException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     ResourceType: Optional[String]
 
 
@@ -311,21 +298,18 @@ class ThrottlingException(ServiceException):
     code: str = "ThrottlingException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class UnknownResourceException(ServiceException):
     code: str = "UnknownResourceException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class Tag(TypedDict, total=False):

--- a/localstack/aws/api/s3control/__init__.py
+++ b/localstack/aws/api/s3control/__init__.py
@@ -297,7 +297,6 @@ class BadRequestException(ServiceException):
     code: str = "BadRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class BucketAlreadyExists(ServiceException):
@@ -316,63 +315,54 @@ class IdempotencyException(ServiceException):
     code: str = "IdempotencyException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InternalServiceException(ServiceException):
     code: str = "InternalServiceException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InvalidNextTokenException(ServiceException):
     code: str = "InvalidNextTokenException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class InvalidRequestException(ServiceException):
     code: str = "InvalidRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class JobStatusException(ServiceException):
     code: str = "JobStatusException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class NoSuchPublicAccessBlockConfiguration(ServiceException):
     code: str = "NoSuchPublicAccessBlockConfiguration"
     sender_fault: bool = False
     status_code: int = 404
-    Message: Optional[NoSuchPublicAccessBlockConfigurationMessage]
 
 
 class NotFoundException(ServiceException):
     code: str = "NotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class TooManyRequestsException(ServiceException):
     code: str = "TooManyRequestsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class TooManyTagsException(ServiceException):
     code: str = "TooManyTagsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ExceptionMessage]
 
 
 class AbortIncompleteMultipartUpload(TypedDict, total=False):

--- a/localstack/aws/api/secretsmanager/__init__.py
+++ b/localstack/aws/api/secretsmanager/__init__.py
@@ -68,84 +68,72 @@ class DecryptionFailure(ServiceException):
     code: str = "DecryptionFailure"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class EncryptionFailure(ServiceException):
     code: str = "EncryptionFailure"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class InternalServiceError(ServiceException):
     code: str = "InternalServiceError"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class InvalidNextTokenException(ServiceException):
     code: str = "InvalidNextTokenException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class InvalidParameterException(ServiceException):
     code: str = "InvalidParameterException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class InvalidRequestException(ServiceException):
     code: str = "InvalidRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
     code: str = "LimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class MalformedPolicyDocumentException(ServiceException):
     code: str = "MalformedPolicyDocumentException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class PreconditionNotMetException(ServiceException):
     code: str = "PreconditionNotMetException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class PublicPolicyException(ServiceException):
     code: str = "PublicPolicyException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class ResourceExistsException(ServiceException):
     code: str = "ResourceExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[ErrorMessage]
 
 
 class ReplicaRegionType(TypedDict, total=False):

--- a/localstack/aws/api/sns/__init__.py
+++ b/localstack/aws/api/sns/__init__.py
@@ -78,224 +78,192 @@ class AuthorizationErrorException(ServiceException):
     code: str = "AuthorizationError"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[string]
 
 
 class BatchEntryIdsNotDistinctException(ServiceException):
     code: str = "BatchEntryIdsNotDistinct"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class BatchRequestTooLongException(ServiceException):
     code: str = "BatchRequestTooLong"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class ConcurrentAccessException(ServiceException):
     code: str = "ConcurrentAccess"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class EmptyBatchRequestException(ServiceException):
     code: str = "EmptyBatchRequest"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class EndpointDisabledException(ServiceException):
     code: str = "EndpointDisabled"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class FilterPolicyLimitExceededException(ServiceException):
     code: str = "FilterPolicyLimitExceeded"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[string]
 
 
 class InternalErrorException(ServiceException):
     code: str = "InternalError"
     sender_fault: bool = False
     status_code: int = 500
-    message: Optional[string]
 
 
 class InvalidBatchEntryIdException(ServiceException):
     code: str = "InvalidBatchEntryId"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class InvalidParameterException(ServiceException):
     code: str = "InvalidParameter"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class InvalidParameterValueException(ServiceException):
     code: str = "ParameterValueInvalid"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class InvalidSecurityException(ServiceException):
     code: str = "InvalidSecurity"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[string]
 
 
 class KMSAccessDeniedException(ServiceException):
     code: str = "KMSAccessDenied"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class KMSDisabledException(ServiceException):
     code: str = "KMSDisabled"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class KMSInvalidStateException(ServiceException):
     code: str = "KMSInvalidState"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class KMSNotFoundException(ServiceException):
     code: str = "KMSNotFound"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class KMSOptInRequired(ServiceException):
     code: str = "KMSOptInRequired"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[string]
 
 
 class KMSThrottlingException(ServiceException):
     code: str = "KMSThrottling"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class NotFoundException(ServiceException):
     code: str = "NotFound"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[string]
 
 
 class OptedOutException(ServiceException):
     code: str = "OptedOut"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class PlatformApplicationDisabledException(ServiceException):
     code: str = "PlatformApplicationDisabled"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFound"
     sender_fault: bool = True
     status_code: int = 404
-    message: Optional[string]
 
 
 class StaleTagException(ServiceException):
     code: str = "StaleTag"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class SubscriptionLimitExceededException(ServiceException):
     code: str = "SubscriptionLimitExceeded"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[string]
 
 
 class TagLimitExceededException(ServiceException):
     code: str = "TagLimitExceeded"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class TagPolicyException(ServiceException):
     code: str = "TagPolicy"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class ThrottledException(ServiceException):
     code: str = "Throttled"
     sender_fault: bool = True
     status_code: int = 429
-    message: Optional[string]
 
 
 class TooManyEntriesInBatchRequestException(ServiceException):
     code: str = "TooManyEntriesInBatchRequest"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class TopicLimitExceededException(ServiceException):
     code: str = "TopicLimitExceeded"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[string]
 
 
 class UserErrorException(ServiceException):
     code: str = "UserError"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[string]
 
 
 class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = True
     status_code: int = 400
-    Message: string
 
 
 class VerificationException(ServiceException):
     code: str = "VerificationException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: string
     Status: string
 
 

--- a/localstack/aws/api/ssm/__init__.py
+++ b/localstack/aws/api/ssm/__init__.py
@@ -997,7 +997,6 @@ class AlreadyExistsException(ServiceException):
     code: str = "AlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AssociatedInstances(ServiceException):
@@ -1016,14 +1015,12 @@ class AssociationDoesNotExist(ServiceException):
     code: str = "AssociationDoesNotExist"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AssociationExecutionDoesNotExist(ServiceException):
     code: str = "AssociationExecutionDoesNotExist"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AssociationLimitExceeded(ServiceException):
@@ -1036,112 +1033,96 @@ class AssociationVersionLimitExceeded(ServiceException):
     code: str = "AssociationVersionLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AutomationDefinitionNotApprovedException(ServiceException):
     code: str = "AutomationDefinitionNotApprovedException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AutomationDefinitionNotFoundException(ServiceException):
     code: str = "AutomationDefinitionNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AutomationDefinitionVersionNotFoundException(ServiceException):
     code: str = "AutomationDefinitionVersionNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AutomationExecutionLimitExceededException(ServiceException):
     code: str = "AutomationExecutionLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AutomationExecutionNotFoundException(ServiceException):
     code: str = "AutomationExecutionNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class AutomationStepNotFoundException(ServiceException):
     code: str = "AutomationStepNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class ComplianceTypeCountLimitExceededException(ServiceException):
     code: str = "ComplianceTypeCountLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class CustomSchemaCountLimitExceededException(ServiceException):
     code: str = "CustomSchemaCountLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DocumentAlreadyExists(ServiceException):
     code: str = "DocumentAlreadyExists"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DocumentLimitExceeded(ServiceException):
     code: str = "DocumentLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DocumentPermissionLimit(ServiceException):
     code: str = "DocumentPermissionLimit"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DocumentVersionLimitExceeded(ServiceException):
     code: str = "DocumentVersionLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DoesNotExistException(ServiceException):
     code: str = "DoesNotExistException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DuplicateDocumentContent(ServiceException):
     code: str = "DuplicateDocumentContent"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DuplicateDocumentVersionName(ServiceException):
     code: str = "DuplicateDocumentVersionName"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class DuplicateInstanceId(ServiceException):
@@ -1154,105 +1135,90 @@ class FeatureNotAvailableException(ServiceException):
     code: str = "FeatureNotAvailableException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class HierarchyLevelLimitExceededException(ServiceException):
     code: str = "HierarchyLevelLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class HierarchyTypeMismatchException(ServiceException):
     code: str = "HierarchyTypeMismatchException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class IdempotentParameterMismatch(ServiceException):
     code: str = "IdempotentParameterMismatch"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class IncompatiblePolicyException(ServiceException):
     code: str = "IncompatiblePolicyException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InternalServerError(ServiceException):
     code: str = "InternalServerError"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidActivation(ServiceException):
     code: str = "InvalidActivation"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidActivationId(ServiceException):
     code: str = "InvalidActivationId"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidAggregatorException(ServiceException):
     code: str = "InvalidAggregatorException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidAllowedPatternException(ServiceException):
     code: str = "InvalidAllowedPatternException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidAssociation(ServiceException):
     code: str = "InvalidAssociation"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidAssociationVersion(ServiceException):
     code: str = "InvalidAssociationVersion"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidAutomationExecutionParametersException(ServiceException):
     code: str = "InvalidAutomationExecutionParametersException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidAutomationSignalException(ServiceException):
     code: str = "InvalidAutomationSignalException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidAutomationStatusUpdateException(ServiceException):
     code: str = "InvalidAutomationStatusUpdateException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidCommandId(ServiceException):
@@ -1265,63 +1231,54 @@ class InvalidDeleteInventoryParametersException(ServiceException):
     code: str = "InvalidDeleteInventoryParametersException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDeletionIdException(ServiceException):
     code: str = "InvalidDeletionIdException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDocument(ServiceException):
     code: str = "InvalidDocument"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDocumentContent(ServiceException):
     code: str = "InvalidDocumentContent"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDocumentOperation(ServiceException):
     code: str = "InvalidDocumentOperation"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDocumentSchemaVersion(ServiceException):
     code: str = "InvalidDocumentSchemaVersion"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDocumentType(ServiceException):
     code: str = "InvalidDocumentType"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidDocumentVersion(ServiceException):
     code: str = "InvalidDocumentVersion"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidFilter(ServiceException):
     code: str = "InvalidFilter"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidFilterKey(ServiceException):
@@ -1334,49 +1291,42 @@ class InvalidFilterOption(ServiceException):
     code: str = "InvalidFilterOption"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidFilterValue(ServiceException):
     code: str = "InvalidFilterValue"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidInstanceId(ServiceException):
     code: str = "InvalidInstanceId"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidInstanceInformationFilterValue(ServiceException):
     code: str = "InvalidInstanceInformationFilterValue"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidInventoryGroupException(ServiceException):
     code: str = "InvalidInventoryGroupException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidInventoryItemContextException(ServiceException):
     code: str = "InvalidInventoryItemContextException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidInventoryRequestException(ServiceException):
     code: str = "InvalidInventoryRequestException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidItemContentException(ServiceException):
@@ -1384,35 +1334,30 @@ class InvalidItemContentException(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
-    Message: Optional[String]
 
 
 class InvalidKeyId(ServiceException):
     code: str = "InvalidKeyId"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidNextToken(ServiceException):
     code: str = "InvalidNextToken"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidNotificationConfig(ServiceException):
     code: str = "InvalidNotificationConfig"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidOptionException(ServiceException):
     code: str = "InvalidOptionException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidOutputFolder(ServiceException):
@@ -1431,14 +1376,12 @@ class InvalidParameters(ServiceException):
     code: str = "InvalidParameters"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidPermissionType(ServiceException):
     code: str = "InvalidPermissionType"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidPluginName(ServiceException):
@@ -1451,14 +1394,12 @@ class InvalidPolicyAttributeException(ServiceException):
     code: str = "InvalidPolicyAttributeException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidPolicyTypeException(ServiceException):
     code: str = "InvalidPolicyTypeException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class InvalidResourceId(ServiceException):
@@ -1477,49 +1418,42 @@ class InvalidResultAttributeException(ServiceException):
     code: str = "InvalidResultAttributeException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidRole(ServiceException):
     code: str = "InvalidRole"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidSchedule(ServiceException):
     code: str = "InvalidSchedule"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidTarget(ServiceException):
     code: str = "InvalidTarget"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidTargetMaps(ServiceException):
     code: str = "InvalidTargetMaps"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidTypeNameException(ServiceException):
     code: str = "InvalidTypeNameException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvalidUpdate(ServiceException):
     code: str = "InvalidUpdate"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class InvocationDoesNotExist(ServiceException):
@@ -1533,7 +1467,6 @@ class ItemContentMismatchException(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
-    Message: Optional[String]
 
 
 class ItemSizeLimitExceededException(ServiceException):
@@ -1541,21 +1474,18 @@ class ItemSizeLimitExceededException(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
-    Message: Optional[String]
 
 
 class MaxDocumentSizeExceeded(ServiceException):
     code: str = "MaxDocumentSizeExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class OpsItemAlreadyExistsException(ServiceException):
     code: str = "OpsItemAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     OpsItemId: Optional[String]
 
 
@@ -1567,7 +1497,6 @@ class OpsItemInvalidParameterException(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     ParameterNames: Optional[OpsItemParameterNamesList]
-    Message: Optional[String]
 
 
 class OpsItemLimitExceededException(ServiceException):
@@ -1577,21 +1506,18 @@ class OpsItemLimitExceededException(ServiceException):
     ResourceTypes: Optional[OpsItemParameterNamesList]
     Limit: Optional[Integer]
     LimitType: Optional[String]
-    Message: Optional[String]
 
 
 class OpsItemNotFoundException(ServiceException):
     code: str = "OpsItemNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class OpsItemRelatedItemAlreadyExistsException(ServiceException):
     code: str = "OpsItemRelatedItemAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
     ResourceUri: Optional[OpsItemRelatedItemAssociationResourceUri]
     OpsItemId: Optional[OpsItemId]
 
@@ -1600,105 +1526,90 @@ class OpsItemRelatedItemAssociationNotFoundException(ServiceException):
     code: str = "OpsItemRelatedItemAssociationNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class OpsMetadataAlreadyExistsException(ServiceException):
     code: str = "OpsMetadataAlreadyExistsException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class OpsMetadataInvalidArgumentException(ServiceException):
     code: str = "OpsMetadataInvalidArgumentException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class OpsMetadataKeyLimitExceededException(ServiceException):
     code: str = "OpsMetadataKeyLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class OpsMetadataLimitExceededException(ServiceException):
     code: str = "OpsMetadataLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class OpsMetadataNotFoundException(ServiceException):
     code: str = "OpsMetadataNotFoundException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class OpsMetadataTooManyUpdatesException(ServiceException):
     code: str = "OpsMetadataTooManyUpdatesException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterAlreadyExists(ServiceException):
     code: str = "ParameterAlreadyExists"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterLimitExceeded(ServiceException):
     code: str = "ParameterLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterMaxVersionLimitExceeded(ServiceException):
     code: str = "ParameterMaxVersionLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterNotFound(ServiceException):
     code: str = "ParameterNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterPatternMismatchException(ServiceException):
     code: str = "ParameterPatternMismatchException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterVersionLabelLimitExceeded(ServiceException):
     code: str = "ParameterVersionLabelLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ParameterVersionNotFound(ServiceException):
     code: str = "ParameterVersionNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class PoliciesLimitExceededException(ServiceException):
     code: str = "PoliciesLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class ResourceDataSyncAlreadyExistsException(ServiceException):
@@ -1712,21 +1623,18 @@ class ResourceDataSyncConflictException(ServiceException):
     code: str = "ResourceDataSyncConflictException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class ResourceDataSyncCountExceededException(ServiceException):
     code: str = "ResourceDataSyncCountExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class ResourceDataSyncInvalidConfigurationException(ServiceException):
     code: str = "ResourceDataSyncInvalidConfigurationException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class ResourceDataSyncNotFoundException(ServiceException):
@@ -1735,28 +1643,24 @@ class ResourceDataSyncNotFoundException(ServiceException):
     status_code: int = 400
     SyncName: Optional[ResourceDataSyncName]
     SyncType: Optional[ResourceDataSyncType]
-    Message: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class ResourceLimitExceededException(ServiceException):
     code: str = "ResourceLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class ServiceSettingNotFound(ServiceException):
     code: str = "ServiceSettingNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class StatusUnchanged(ServiceException):
@@ -1769,21 +1673,18 @@ class SubTypeCountLimitExceededException(ServiceException):
     code: str = "SubTypeCountLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class TargetInUseException(ServiceException):
     code: str = "TargetInUseException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class TargetNotConnected(ServiceException):
     code: str = "TargetNotConnected"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class TooManyTagsError(ServiceException):
@@ -1796,28 +1697,24 @@ class TooManyUpdates(ServiceException):
     code: str = "TooManyUpdates"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class TotalSizeLimitExceededException(ServiceException):
     code: str = "TotalSizeLimitExceededException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class UnsupportedCalendarException(ServiceException):
     code: str = "UnsupportedCalendarException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class UnsupportedFeatureRequiredException(ServiceException):
     code: str = "UnsupportedFeatureRequiredException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class UnsupportedInventoryItemContextException(ServiceException):
@@ -1825,35 +1722,30 @@ class UnsupportedInventoryItemContextException(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
-    Message: Optional[String]
 
 
 class UnsupportedInventorySchemaVersionException(ServiceException):
     code: str = "UnsupportedInventorySchemaVersionException"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class UnsupportedOperatingSystem(ServiceException):
     code: str = "UnsupportedOperatingSystem"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 class UnsupportedParameterType(ServiceException):
     code: str = "UnsupportedParameterType"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[String]
 
 
 class UnsupportedPlatformType(ServiceException):
     code: str = "UnsupportedPlatformType"
     sender_fault: bool = False
     status_code: int = 400
-    Message: Optional[String]
 
 
 AccountIdList = List[AccountId]

--- a/localstack/aws/api/stepfunctions/__init__.py
+++ b/localstack/aws/api/stepfunctions/__init__.py
@@ -128,112 +128,96 @@ class ActivityDoesNotExist(ServiceException):
     code: str = "ActivityDoesNotExist"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ActivityLimitExceeded(ServiceException):
     code: str = "ActivityLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ActivityWorkerLimitExceeded(ServiceException):
     code: str = "ActivityWorkerLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ExecutionAlreadyExists(ServiceException):
     code: str = "ExecutionAlreadyExists"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ExecutionDoesNotExist(ServiceException):
     code: str = "ExecutionDoesNotExist"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ExecutionLimitExceeded(ServiceException):
     code: str = "ExecutionLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidArn(ServiceException):
     code: str = "InvalidArn"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidDefinition(ServiceException):
     code: str = "InvalidDefinition"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidExecutionInput(ServiceException):
     code: str = "InvalidExecutionInput"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidLoggingConfiguration(ServiceException):
     code: str = "InvalidLoggingConfiguration"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidName(ServiceException):
     code: str = "InvalidName"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidOutput(ServiceException):
     code: str = "InvalidOutput"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidToken(ServiceException):
     code: str = "InvalidToken"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InvalidTracingConfiguration(ServiceException):
     code: str = "InvalidTracingConfiguration"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class MissingRequiredParameter(ServiceException):
     code: str = "MissingRequiredParameter"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ResourceNotFound(ServiceException):
     code: str = "ResourceNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
     resourceName: Optional[Arn]
 
 
@@ -241,56 +225,48 @@ class StateMachineAlreadyExists(ServiceException):
     code: str = "StateMachineAlreadyExists"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class StateMachineDeleting(ServiceException):
     code: str = "StateMachineDeleting"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class StateMachineDoesNotExist(ServiceException):
     code: str = "StateMachineDoesNotExist"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class StateMachineLimitExceeded(ServiceException):
     code: str = "StateMachineLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class StateMachineTypeNotSupported(ServiceException):
     code: str = "StateMachineTypeNotSupported"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TaskDoesNotExist(ServiceException):
     code: str = "TaskDoesNotExist"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TaskTimedOut(ServiceException):
     code: str = "TaskTimedOut"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyTags(ServiceException):
     code: str = "TooManyTags"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
     resourceName: Optional[Arn]
 
 

--- a/localstack/aws/api/sts/__init__.py
+++ b/localstack/aws/api/sts/__init__.py
@@ -54,56 +54,48 @@ class ExpiredTokenException(ServiceException):
     code: str = "ExpiredTokenException"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[expiredIdentityTokenMessage]
 
 
 class IDPCommunicationErrorException(ServiceException):
     code: str = "IDPCommunicationError"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[idpCommunicationErrorMessage]
 
 
 class IDPRejectedClaimException(ServiceException):
     code: str = "IDPRejectedClaim"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[idpRejectedClaimMessage]
 
 
 class InvalidAuthorizationMessageException(ServiceException):
     code: str = "InvalidAuthorizationMessageException"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[invalidAuthorizationMessage]
 
 
 class InvalidIdentityTokenException(ServiceException):
     code: str = "InvalidIdentityToken"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[invalidIdentityTokenMessage]
 
 
 class MalformedPolicyDocumentException(ServiceException):
     code: str = "MalformedPolicyDocument"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[malformedPolicyDocumentMessage]
 
 
 class PackedPolicyTooLargeException(ServiceException):
     code: str = "PackedPolicyTooLarge"
     sender_fault: bool = True
     status_code: int = 400
-    message: Optional[packedPolicyTooLargeMessage]
 
 
 class RegionDisabledException(ServiceException):
     code: str = "RegionDisabledException"
     sender_fault: bool = True
     status_code: int = 403
-    message: Optional[regionDisabledMessage]
 
 
 tagKeyListType = List[tagKeyType]

--- a/localstack/aws/api/support/__init__.py
+++ b/localstack/aws/api/support/__init__.py
@@ -47,63 +47,54 @@ class AttachmentIdNotFound(ServiceException):
     code: str = "AttachmentIdNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AttachmentLimitExceeded(ServiceException):
     code: str = "AttachmentLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AttachmentSetExpired(ServiceException):
     code: str = "AttachmentSetExpired"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AttachmentSetIdNotFound(ServiceException):
     code: str = "AttachmentSetIdNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class AttachmentSetSizeLimitExceeded(ServiceException):
     code: str = "AttachmentSetSizeLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class CaseCreationLimitExceeded(ServiceException):
     code: str = "CaseCreationLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class CaseIdNotFound(ServiceException):
     code: str = "CaseIdNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DescribeAttachmentLimitExceeded(ServiceException):
     code: str = "DescribeAttachmentLimitExceeded"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class InternalServerError(ServiceException):
     code: str = "InternalServerError"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 Data = bytes

--- a/localstack/aws/api/swf/__init__.py
+++ b/localstack/aws/api/swf/__init__.py
@@ -291,70 +291,60 @@ class DefaultUndefinedFault(ServiceException):
     code: str = "DefaultUndefinedFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DomainAlreadyExistsFault(ServiceException):
     code: str = "DomainAlreadyExistsFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class DomainDeprecatedFault(ServiceException):
     code: str = "DomainDeprecatedFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class LimitExceededFault(ServiceException):
     code: str = "LimitExceededFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class OperationNotPermittedFault(ServiceException):
     code: str = "OperationNotPermittedFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TooManyTagsFault(ServiceException):
     code: str = "TooManyTagsFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TypeAlreadyExistsFault(ServiceException):
     code: str = "TypeAlreadyExistsFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class TypeDeprecatedFault(ServiceException):
     code: str = "TypeDeprecatedFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class UnknownResourceFault(ServiceException):
     code: str = "UnknownResourceFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class WorkflowExecutionAlreadyStartedFault(ServiceException):
     code: str = "WorkflowExecutionAlreadyStartedFault"
     sender_fault: bool = False
     status_code: int = 400
-    message: Optional[ErrorMessage]
 
 
 class ActivityType(TypedDict, total=False):

--- a/localstack/aws/client.py
+++ b/localstack/aws/client.py
@@ -1,13 +1,14 @@
 """Utils to process AWS requests as a client."""
 import io
 import logging
-from typing import Iterable
+from typing import Dict, Iterable, Optional
 
 from botocore.model import OperationModel
+from botocore.parsers import ResponseParser
 from botocore.parsers import create_parser as create_response_parser
 from werkzeug import Response
 
-from localstack.aws.api import ServiceResponse
+from localstack.aws.api import CommonServiceException, ServiceException, ServiceResponse
 
 LOG = logging.getLogger(__name__)
 
@@ -62,13 +63,38 @@ class _RawStream:
         pass
 
 
-def parse_response(operation: OperationModel, response: Response) -> ServiceResponse:
+def _add_modeled_error_fields(
+    response_dict: Dict,
+    parsed_response: Dict,
+    operation_model: OperationModel,
+    parser: ResponseParser,
+):
+    """
+    This function adds additional error shape members (other than message, code, and type) to an already parsed error
+    response dict.
+    Port of botocore's Endpoint#_add_modeled_error_fields.
+    """
+    error_code = parsed_response.get("Error", {}).get("Code")
+    if error_code is None:
+        return
+    service_model = operation_model.service_model
+    error_shape = service_model.shape_for_error_code(error_code)
+    if error_shape is None:
+        return
+    modeled_parse = parser.parse(response_dict, error_shape)
+    parsed_response.update(modeled_parse)
+
+
+def parse_response(
+    operation: OperationModel, response: Response, include_response_metadata: bool = True
+) -> ServiceResponse:
     """
     Parses an HTTP Response object into an AWS response object using botocore. It does this by adapting the
     procedure of ``botocore.endpoint.convert_to_response_dict`` to work with Werkzeug's server-side response object.
 
     :param operation: the operation of the original request
     :param response: the HTTP response object containing the response of the operation
+    :param include_response_metadata: True if the ResponseMetadata (typical for boto response dicts) should be included
     :return: a parsed dictionary as it is returned by botocore
     """
     # this is what botocore.endpoint.convert_to_response_dict normally does
@@ -80,7 +106,7 @@ def parse_response(operation: OperationModel, response: Response) -> ServiceResp
         },
     }
 
-    if response_dict["status_code"] >= 300:
+    if response_dict["status_code"] >= 301:
         response_dict["body"] = response.data
     elif operation.has_event_stream_output:
         # TODO test this
@@ -92,4 +118,51 @@ def parse_response(operation: OperationModel, response: Response) -> ServiceResp
         response_dict["body"] = response.data
 
     parser = create_response_parser(operation.service_model.protocol)
-    return parser.parse(response_dict, operation.output_shape)
+    parsed_response = parser.parse(response_dict, operation.output_shape)
+
+    if response.status_code >= 301:
+        # Add possible additional error shape members
+        _add_modeled_error_fields(response_dict, parsed_response, operation, parser)
+
+    if not include_response_metadata:
+        parsed_response.pop("ResponseMetadata", None)
+
+    return parsed_response
+
+
+def parse_service_exception(
+    response: Response, parsed_response: Dict
+) -> Optional[ServiceException]:
+    """
+    Creates a ServiceException from a parsed response (one that botocore would return).
+    It does not automatically raise the exception (see #raise_service_exception).
+    :param response: Un-parsed response
+    :param parsed_response: Parsed response
+    :return: ServiceException or None (if it's not an error response)
+    """
+    if response.status_code < 301 or "Error" not in parsed_response:
+        return None
+    error = parsed_response["Error"]
+    service_exception = CommonServiceException(
+        code=error.get("Code", f"'{response.status_code}'"),
+        status_code=response.status_code,
+        message=error.get("Message", ""),
+        sender_fault=error.get("Type") == "Sender",
+    )
+    # Add all additional fields in the parsed response as members of the exception
+    for key, value in parsed_response.items():
+        if key.lower() not in ["code", "message", "type"] and not hasattr(service_exception, key):
+            setattr(service_exception, key, value)
+    return service_exception
+
+
+def raise_service_exception(response: Response, parsed_response: Dict) -> None:
+    """
+    Creates and raises a ServiceException from a parsed response (one that botocore would return).
+    :param response: Un-parsed response
+    :param parsed_response: Parsed response
+    :raise ServiceException: If the response is an error response
+    :return: None if the response is not an error response
+    """
+    if service_exception := parse_service_exception(response, parsed_response):
+        raise service_exception

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -74,7 +74,7 @@ def get_request_forwarder_http(forward_url_getter: Callable[[], str]) -> Service
                 parameters=service_request,
                 region=context.region,
             )
-            local_context.request.headers.extend(context.request.headers)
+            local_context.request.headers.update(context.request.headers)
             context = local_context
         return forward_request(context, forward_url_getter)
 

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -2,30 +2,27 @@
 This module contains utilities to call a backend (e.g., an external service process like
 DynamoDBLocal) from a service provider.
 """
-from typing import Any, Callable, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Mapping, Optional
 from urllib.parse import urlsplit
 
-import requests
 from botocore.awsrequest import AWSPreparedRequest
 from werkzeug.datastructures import Headers
 
 from localstack import config
 from localstack.aws.api.core import (
-    CommonServiceException,
     Request,
     RequestContext,
     ServiceRequest,
     ServiceRequestHandler,
     ServiceResponse,
 )
-from localstack.aws.client import parse_response
+from localstack.aws.client import parse_response, raise_service_exception
 from localstack.aws.skeleton import DispatchTable, create_dispatch_table
 from localstack.aws.spec import load_service
 from localstack.http import Response
+from localstack.http.proxy import forward
 from localstack.utils.aws import aws_stack
 from localstack.utils.strings import to_str
-
-HttpBackendResponse = Tuple[int, dict, Union[str, bytes]]
 
 
 def ForwardingFallbackDispatcher(
@@ -87,15 +84,15 @@ def get_request_forwarder_http(forward_url_getter: Callable[[], str]) -> Service
 def forward_request(
     context: RequestContext, forward_url_getter: Callable[[], str]
 ) -> ServiceResponse:
-    def _call_http_backend(context: RequestContext) -> HttpBackendResponse:
-        return call_http_backend(context, forward_url=forward_url_getter())
+    def _call_http_backend(context: RequestContext) -> Response:
+        return forward(context.request, forward_url_getter())
 
     return dispatch_to_backend(context, _call_http_backend)
 
 
 def dispatch_to_backend(
     context: RequestContext,
-    http_request_dispatcher: Callable[[RequestContext], HttpBackendResponse],
+    http_request_dispatcher: Callable[[RequestContext], Response],
     include_response_metadata=False,
 ) -> ServiceResponse:
     """
@@ -104,35 +101,13 @@ def dispatch_to_backend(
     :param context: the request context
     :param http_request_dispatcher: dispatcher that performs the request and returns an HTTP response
     :param include_response_metadata: whether to include boto3 response metadata in the response
-    :return:
+    :return: parsed service response
+    :raises ServiceException: if the dispatcher returned an error response
     """
-    status, headers, content = http_request_dispatcher(context)
-
-    response = parse_response(context.operation, Response(content, status, dict(headers)))
-
-    if status >= 301:
-        error = response["Error"]
-        raise CommonServiceException(
-            code=error.get("Code", "UnknownError"),
-            status_code=status,
-            message=error.get("Message", ""),
-            sender_fault=("Type" in error),
-        )
-
-    if not include_response_metadata:
-        response.pop("ResponseMetadata", None)
-
-    return response
-
-
-def call_http_backend(context: RequestContext, forward_url: str) -> HttpBackendResponse:
-    response = requests.request(
-        method=context.request.method,
-        url=forward_url,
-        headers=context.request.headers,
-        data=context.request.data,
-    )
-    return response.status_code, response.headers, response.content
+    http_response = http_request_dispatcher(context)
+    parsed_response = parse_response(context.operation, http_response, include_response_metadata)
+    raise_service_exception(http_response, parsed_response)
+    return parsed_response
 
 
 def create_aws_request_context(

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -219,9 +219,7 @@ class ResponseSerializer(abc.ABC):
             # Therefore, service implementations can also throw a "CommonServiceException" to raise arbitrary /
             # non-specified exceptions (where the developer needs to define the data which would usually be taken from
             # the specification, like the "Code").
-            code = error.code
-            sender_fault = error.sender_fault
-            status_code = error.status_code
+            # These exceptions cannot have additional members (due to the missing spec).
             shape = None
         else:
             # It's not a CommonServiceException, the exception is being serialized based on the specification
@@ -237,28 +235,15 @@ class ResponseSerializer(abc.ABC):
                         f"shape."
                     )
             except NoShapeFoundError as e:
+
                 raise ProtocolSerializerError(
                     f"Error to serialize ({error_shape_name}) neither is a CommonServiceException, nor is its error "
                     f"shape contained in the service's specification ({operation_model.service_model.service_name})."
                 ) from e
 
-            error_spec = shape.metadata.get("error", {})
-            status_code = error_spec.get("httpStatusCode")
+        serialized_response.status_code = error.status_code
 
-            # If the code is not explicitly set, it's typically the shape's name
-            code = error_spec.get("code", shape.name)
-
-            # The senderFault is only set if the "senderFault" is true
-            # (there are no examples which show otherwise)
-            sender_fault = error_spec.get("senderFault")
-
-        # Some specifications do not contain the httpStatusCode field.
-        # These errors typically have the http status code 400.
-        serialized_response.status_code = status_code or 400
-
-        self._serialize_error(
-            error, code, sender_fault, serialized_response, shape, operation_model
-        )
+        self._serialize_error(error, serialized_response, shape, operation_model)
         serialized_response = self._prepare_additional_traits_in_response(
             serialized_response, operation_model
         )
@@ -290,10 +275,8 @@ class ResponseSerializer(abc.ABC):
     def _serialize_error(
         self,
         error: ServiceException,
-        code: str,
-        sender_fault: bool,
         response: HttpResponse,
-        shape: Shape,
+        shape: StructureShape,
         operation_model: OperationModel,
     ) -> None:
         raise NotImplementedError
@@ -539,13 +522,10 @@ class BaseXMLResponseSerializer(ResponseSerializer):
     def _serialize_error(
         self,
         error: ServiceException,
-        code: str,
-        sender_fault: bool,
         response: HttpResponse,
-        shape: Shape,
+        shape: StructureShape,
         operation_model: OperationModel,
     ) -> None:
-        # TODO handle error shapes with members
         # Check if we need to add a namespace
         attr = (
             {"xmlns": operation_model.metadata.get("xmlNamespace")}
@@ -553,21 +533,43 @@ class BaseXMLResponseSerializer(ResponseSerializer):
             else {}
         )
         root = ETree.Element("ErrorResponse", attr)
+
         error_tag = ETree.SubElement(root, "Error")
-        self._add_error_tags(code, error, error_tag, sender_fault)
+        self._add_error_tags(error, error_tag)
         request_id = ETree.SubElement(root, "RequestId")
         request_id.text = gen_amzn_requestid_long()
+
+        if shape:
+            params = {}
+            for member in shape.members:
+                if hasattr(error, member):
+                    params[member] = getattr(error, member)
+                elif member.lower() in ["code", "message", "type"] and hasattr(
+                    error, member.lower()
+                ):
+                    # Default error message fields can sometimes have different casing in the specs
+                    params[member] = getattr(error, member.lower())
+
+            # If there is an error shape with members which should be set, they need to be added to the node
+            if params:
+                # Serialize the remaining params
+                root_name = shape.serialization.get("name", shape.name)
+                pseudo_root = ETree.Element("")
+                self._serialize(shape, params, pseudo_root, root_name)
+                real_root = list(pseudo_root)[0]
+                # Add the child elements to the already created root error element
+                for child in list(real_root):
+                    root.append(child)
+
         response.set_response(self._encode_payload(self._xml_to_string(root)))
 
-    def _add_error_tags(
-        self, code: str, error: ServiceException, error_tag: ETree.Element, sender_fault: bool
-    ) -> None:
+    def _add_error_tags(self, error: ServiceException, error_tag: ETree.Element) -> None:
         code_tag = ETree.SubElement(error_tag, "Code")
-        code_tag.text = code
+        code_tag.text = error.code
         message = self._get_error_message(error)
         if message:
             self._default_serialize(error_tag, message, None, "Message")
-        if sender_fault:
+        if error.sender_fault:
             # The sender fault is either not set or "Sender"
             self._default_serialize(error_tag, "Sender", None, "Type")
 
@@ -941,10 +943,8 @@ class RestXMLResponseSerializer(BaseRestResponseSerializer, BaseXMLResponseSeria
     def _serialize_error(
         self,
         error: ServiceException,
-        code: str,
-        sender_fault: bool,
         response: HttpResponse,
-        shape: Shape,
+        shape: StructureShape,
         operation_model: OperationModel,
     ) -> None:
         # It wouldn't be a spec if there wouldn't be any exceptions.
@@ -956,12 +956,12 @@ class RestXMLResponseSerializer(BaseRestResponseSerializer, BaseXMLResponseSeria
                 else None
             )
             root = ETree.Element("Error", attr)
-            self._add_error_tags(code, error, root, sender_fault)
+            self._add_error_tags(error, root)
             request_id = ETree.SubElement(root, "RequestId")
             request_id.text = gen_amzn_requestid_long()
             response.set_response(self._encode_payload(self._xml_to_string(root)))
         else:
-            super()._serialize_error(error, code, sender_fault, response, shape, operation_model)
+            super()._serialize_error(error, response, shape, operation_model)
 
 
 class QueryResponseSerializer(BaseXMLResponseSerializer):
@@ -1038,10 +1038,8 @@ class EC2ResponseSerializer(QueryResponseSerializer):
     def _serialize_error(
         self,
         error: ServiceException,
-        code: str,
-        sender_fault: bool,
         response: HttpResponse,
-        shape: Shape,
+        shape: StructureShape,
         operation_model: OperationModel,
     ) -> None:
         # EC2 errors look like:
@@ -1063,7 +1061,7 @@ class EC2ResponseSerializer(QueryResponseSerializer):
         )
         root = ETree.Element("Errors", attr)
         error_tag = ETree.SubElement(root, "Error")
-        self._add_error_tags(code, error, error_tag, sender_fault)
+        self._add_error_tags(error, error_tag)
         request_id = ETree.SubElement(root, "RequestID")
         request_id.text = gen_amzn_requestid_long()
         response.set_response(self._encode_payload(self._xml_to_string(root)))
@@ -1098,22 +1096,32 @@ class JSONResponseSerializer(ResponseSerializer):
     def _serialize_error(
         self,
         error: ServiceException,
-        code: str,
-        sender_fault: bool,
         response: HttpResponse,
-        shape: Shape,
+        shape: StructureShape,
         operation_model: OperationModel,
     ) -> None:
-        # TODO handle error shapes with members
         # TODO implement different service-specific serializer configurations
         #   - currently we set both, the `__type` member as well as the `X-Amzn-Errortype` header
         #   - the specification defines that it's either the __type field OR the header
         #     (https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#operation-error-serialization)
-        body = {"__type": code}
-        response.headers["X-Amzn-Errortype"] = code
+        body = {"__type": error.code}
+        response.headers["X-Amzn-Errortype"] = error.code
         message = self._get_error_message(error)
         if message is not None:
             body["message"] = message
+
+        if shape:
+            remaining_params = {}
+            for member in shape.members:
+                if hasattr(error, member):
+                    remaining_params[member] = getattr(error, member)
+                elif member.lower() in ["code", "message", "type"] and hasattr(
+                    error, member.lower()
+                ):
+                    # Default error message fields can sometimes have different casing in the specs
+                    remaining_params[member] = getattr(error, member.lower())
+            self._serialize(body, remaining_params, shape)
+
         response.set_json(body)
 
     def _serialize_response(

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -146,7 +146,17 @@ class ShapeNode:
         elif not self.shape.members:
             output.write("    pass\n")
 
-        for k, v in self.shape.members.items():
+        # Avoid generating members for the common error members:
+        # - The message will always be the exception message (first argument of the exception class init)
+        # - The code is already set above
+        # - The type is the sender_fault which is already set above
+        remaining_members = {
+            k: v
+            for k, v in self.shape.members.items()
+            if not self.is_exception or k.lower() not in ["message", "code", "type"]
+        }
+
+        for k, v in remaining_members.items():
             if k in self.shape.required_members:
                 if v.serialization.get("eventstream"):
                     output.write(f"    {k}: Iterator[{q}{to_valid_python_name(v.name)}{q}]\n")

--- a/localstack/aws/spec.py
+++ b/localstack/aws/spec.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
 from functools import cached_property
-from typing import Dict, List, Optional
+from typing import Dict, Generator, List, Optional, Tuple
 
 from botocore.loaders import create_loader
-from botocore.model import ServiceModel
+from botocore.model import OperationModel, ServiceModel
 
 loader = create_loader()
 
@@ -20,6 +20,18 @@ def load_service(service: ServiceName, version: str = None, model_type="service-
     """
     service_description = loader.load_service_model(service, model_type, version)
     return ServiceModel(service_description, service)
+
+
+def iterate_service_operations() -> Generator[Tuple[ServiceModel, OperationModel], None, None]:
+    """
+    Returns one record per operation in the AWS service spec, where the first item is the service model the operation
+    belongs to, and the second is the operation model.
+
+    :return: an iterable
+    """
+    for service in list_services():
+        for op_name in service.operation_names:
+            yield service, service.operation_model(op_name)
 
 
 class ServiceCatalog:

--- a/localstack/http/proxy.py
+++ b/localstack/http/proxy.py
@@ -6,7 +6,7 @@ from werkzeug.datastructures import Headers
 from werkzeug.test import EnvironBuilder
 
 from .client import HttpClient, SimpleRequestsClient
-from .request import restore_payload
+from .request import restore_payload, set_environment_headers
 
 
 def forward(
@@ -40,7 +40,7 @@ class Proxy:
         request: Request,
         forward_path: str = None,
         headers: Union[Headers, Mapping[str, str]] = None,
-    ):
+    ) -> Response:
         """
         Uses the client to forward the given request according to the proxy's configuration.
 
@@ -113,6 +113,8 @@ def _copy_request(
     :param headers: optional headers to overwrite
     :return: a new request with slightly modified underlying environment but the same data stream
     """
+    # ensure that the headers in the env are set on the environment
+    set_environment_headers(request.environ, request.headers)
     builder = EnvironBuilder.from_environ(request.environ)
 
     if base_url:

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -760,7 +760,7 @@ def _call_moto(context: RequestContext, operation_name: str, parameters: Service
         region=context.region,
     )
 
-    local_context.request.headers.extend(context.request.headers)
+    local_context.request.headers.update(context.request.headers)
     return call_moto(local_context)
 
 

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -67,7 +67,7 @@ def call_moto_with_request(
         region=context.region,
     )
 
-    local_context.request.headers.extend(context.request.headers)
+    local_context.request.headers.update(context.request.headers)
 
     return call_moto(local_context)
 

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -17,22 +17,16 @@ from localstack import config
 from localstack.aws.api import (
     CommonServiceException,
     HttpRequest,
-    HttpResponse,
     RequestContext,
     ServiceRequest,
     ServiceResponse,
 )
-from localstack.aws.client import parse_response
-from localstack.aws.forwarder import (
-    ForwardingFallbackDispatcher,
-    HttpBackendResponse,
-    create_aws_request_context,
-)
+from localstack.aws.client import parse_response, raise_service_exception
+from localstack.aws.forwarder import ForwardingFallbackDispatcher, create_aws_request_context
 from localstack.aws.skeleton import DispatchTable
 from localstack.http import Response
 
-MotoResponse = HttpBackendResponse
-MotoDispatcher = Callable[[HttpRequest, str, dict], MotoResponse]
+MotoDispatcher = Callable[[HttpRequest, str, dict], Response]
 
 user_agent = f"Localstack/{localstack_version} Python/{sys.version.split(' ')[0]}"
 
@@ -43,24 +37,15 @@ def call_moto(context: RequestContext, include_response_metadata=False) -> Servi
 
     :param context: the request context
     :param include_response_metadata: whether to include botocore's "ResponseMetadata" attribute
-    :return: a serialized AWS ServiceResponse (same as boto3 would return)
+    :return: an AWS ServiceResponse (same as a service provider would return)
+    :raises ServiceException: if moto returned an error response
     """
     status, headers, content = dispatch_to_moto(context)
+    response = Response(content, status, headers)
+    parsed_response = parse_response(context.operation, response, include_response_metadata)
+    raise_service_exception(response, parsed_response)
 
-    response = parse_response(context.operation, Response(content, status, headers))
-
-    if status >= 301:
-        error = response["Error"]
-        raise CommonServiceException(
-            code=error.get("Code", "UnknownError"),
-            status_code=status,
-            message=error.get("Message", ""),
-        )
-
-    if not include_response_metadata:
-        response.pop("ResponseMetadata", None)
-
-    return response
+    return parsed_response
 
 
 def call_moto_with_request(
@@ -73,7 +58,7 @@ def call_moto_with_request(
 
     :param context: the original request context
     :param service_request: the dictionary containing the service request parameters
-    :return: a serialized AWS ServiceResponse (same as boto3 would return)
+    :return: an ASF ServiceResponse (same as a service provider would return)
     """
     local_context = create_aws_request_context(
         service_name=context.service.service_name,
@@ -87,18 +72,18 @@ def call_moto_with_request(
     return call_moto(local_context)
 
 
-def proxy_moto(context: RequestContext, service_request: ServiceRequest = None) -> HttpResponse:
+def proxy_moto(context: RequestContext, service_request: ServiceRequest = None) -> Response:
     """
     Similar to ``call``, only that ``proxy`` does not parse the HTTP response into a ServiceResponse, but instead
     returns directly the HTTP response. This can be useful to pass through moto's response directly to the client.
 
     :param context: the request context
     :param service_request: currently not being used, added to satisfy ServiceRequestHandler contract
-    :return: the HttpResponse from moto
+    :return: the Response from moto
     """
     status, headers, content = dispatch_to_moto(context)
 
-    return HttpResponse(response=content, status=status, headers=headers)
+    return Response(response=content, status=status, headers=headers)
 
 
 def MotoFallbackDispatcher(provider: object) -> DispatchTable:
@@ -113,7 +98,7 @@ def MotoFallbackDispatcher(provider: object) -> DispatchTable:
     return ForwardingFallbackDispatcher(provider, proxy_moto)
 
 
-def dispatch_to_moto(context: RequestContext) -> MotoResponse:
+def dispatch_to_moto(context: RequestContext) -> Response:
     """
     Internal method to dispatch the request to moto without changing moto's dispatcher output.
     :param context: the request context


### PR DESCRIPTION
This PR implements the error serialization for error shapes which contain additional members (f.e. `TransactionCancelledException` of dynamodb).

This PR has been separated into three commits:
- 3187413108675a86f45ee60f2743a0b9596020c1 contains the necessary changes in the serializer and the scaffold to support the serialization of additional members in exceptions (i.e. other than "code", "message", and "type").
- 3c3a237c745914770f495e56894efbd7d9cdb7c1 updates all generated APIs (after the scaffold has been changed in the first commit).
- 8b4872d8b1455f4d4ae0bf6bdfae00dd323b7d23 finally adjusts the proxy mechanisms (mainly `forwarder.py` and `proxy.py` to correctly handle additional members in errors). This commit also contains some cleanup (the forwarder uses the proxy now).

Fixes #5860