### PR TITLE
add pluggable response handler for asf handler chain

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -56,6 +56,7 @@ class LocalstackAwsGateway(Gateway):
         # response post-processing
         self.response_handlers.extend(
             [
+                handlers.run_custom_response_handlers,
                 handlers.add_cors_response_headers,
                 handlers.log_response,
                 handlers.pop_request_context,

--- a/localstack/aws/chain.py
+++ b/localstack/aws/chain.py
@@ -147,12 +147,28 @@ class CompositeHandler(Handler):
 
     handlers: List[Handler]
 
-    def __init__(self) -> None:
+    def __init__(self, return_on_stop=True) -> None:
+        """
+        Creates a new composite handler with an empty handler list.
+
+        TODO: build a proper chain nesting mechanism.
+
+        :param return_on_stop: whether to respect chain.stopped
+        """
         super().__init__()
-        self.handlers = list()
+        self.handlers = []
+        self.return_on_stop = return_on_stop
 
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
         for handler in self.handlers:
             handler(chain, context, response)
-            if chain.stopped or chain.terminated:
+
+            if chain.terminated:
                 return
+            if chain.stopped and self.return_on_stop:
+                return
+
+
+class CompositeResponseHandler(CompositeHandler):
+    def __init__(self) -> None:
+        super().__init__(return_on_stop=False)

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -17,6 +17,7 @@ handle_service_exception = service.ServiceExceptionSerializer()
 handle_internal_failure = fallback.InternalFailureHandler()
 serve_custom_service_request_handlers = chain.CompositeHandler()
 serve_localstack_resources = internal.LocalstackResourceHandler()
+run_custom_response_handlers = chain.CompositeResponseHandler()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()
 serve_default_listeners = legacy.DefaultListenerHandler()

--- a/tests/unit/aws/test_chain.py
+++ b/tests/unit/aws/test_chain.py
@@ -32,6 +32,58 @@ class TestCompositeHandler:
         inner2.assert_not_called()
         response1.assert_called_once()
 
+    def test_composite_handler_terminates_handler_chain(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            _chain.terminate()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler()
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_not_called()
+        response1.assert_not_called()
+
+    def test_composite_handler_with_not_return_on_stop(self):
+        def inner1(_chain: HandlerChain, request: RequestContext, response: Response):
+            _chain.stop()
+
+        inner2 = mock.MagicMock()
+        outer1 = mock.MagicMock()
+        outer2 = mock.MagicMock()
+        response1 = mock.MagicMock()
+
+        chain = HandlerChain()
+
+        composite = CompositeHandler(return_on_stop=False)
+        composite.handlers.append(inner1)
+        composite.handlers.append(inner2)
+
+        chain.request_handlers.append(outer1)
+        chain.request_handlers.append(composite)
+        chain.request_handlers.append(outer2)
+        chain.response_handlers.append(response1)
+
+        chain.handle(RequestContext(), Response())
+        outer1.assert_called_once()
+        outer2.assert_not_called()
+        inner2.assert_called_once()
+        response1.assert_called_once()
+
     def test_composite_handler_continues_handler_chain(self):
         inner1 = mock.MagicMock()
         inner2 = mock.MagicMock()


### PR DESCRIPTION
Building on #6240, this PR adds a similar mechanism for response handlers (also a compromise until we have a well-defined nested handler chain mechanism).

It is used in localstack-ext to plug in response handlers (like the state serializers) into the response handler chain.