### PR TITLE
minor fix to include request parameters while importing openapi

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -673,9 +673,9 @@ def import_api_from_openapi_spec(
         for method, method_schema in resolved_schema["paths"].get(path, {}).items():
             method = method.upper()
 
-            method_resource = create_method_resource(resource, method, method_schema)
-
             method_integration = method_schema.get("x-amazon-apigateway-integration", {})
+            method_resource = create_method_resource(resource, method, method_schema)
+            method_resource["requestParameters"] = method_integration.get("requestParameters")
             responses = method_schema.get("responses", {})
             for status_code in responses:
                 response_model = None

--- a/tests/integration/files/swagger.yaml
+++ b/tests/integration/files/swagger.yaml
@@ -27,6 +27,8 @@ paths:
             statusCode: '200'
             responseParameters:
               method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestParameters:
+          integration.request.header.X-Amz-Invocation-Type: "'Event'"
         requestTemplates:
           application/json: '{"statusCode": 200}'
         passthroughBehavior: when_no_match

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1165,6 +1165,10 @@ class TestAPIGateway:
 
         resource = [res for res in rs["items"] if res["path"] == "/test"][0]
         assert "GET" in resource["resourceMethods"]
+        assert "requestParameters" in resource["resourceMethods"]["GET"]
+        assert {"integration.request.header.X-Amz-Invocation-Type": "'Event'"} == resource[
+            "resourceMethods"
+        ]["GET"]["requestParameters"]
 
         url = path_based_url(api_id=rest_api_id, stage_name="dev", path="/test")
         response = requests.get(url)


### PR DESCRIPTION
This PR will make sure `requestParameters` included in the openapi document, are included in the method resource model.