### PR TITLE
GCM support for SNS

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -165,9 +165,7 @@ def publish_message(
 
         message_structure = req_data.get('MessageStructure',[None])[0]
         LOG.debug("Publishing message to Endpoint: %s | Message: %s", target_arn, message)
-        start_thread(
-            lambda _: message_to_endpoint(target_arn, message, message_structure)
-        )
+        message_to_endpoint(target_arn, message, message_structure)
         return message_id
 
     LOG.debug("Publishing message to TopicArn: %s | Message: %s", topic_arn, message)
@@ -738,6 +736,7 @@ def message_to_endpoint(
     app_name = target_arn.split('/')[-2]
     platform = target_arn.split("/")[-3]
     platform_apps = sns_client.list_platform_applications()['PlatformApplications']
+    
     app = [x for x in platform_apps if app_name in x['PlatformApplicationArn']][0]
 
     if structure == 'json':
@@ -753,7 +752,6 @@ def message_to_endpoint(
         prev_responses = sns_backend.platform_endpoint_responses.get(target_arn, [])
         prev_responses.append(response)
         sns_backend.platform_endpoint_responses.update({target_arn: prev_responses})
-    
 
 
 def send_message_to_GCM(app_attributes, endpoint_attributes, message):

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -7,7 +7,6 @@ import logging
 import time
 import traceback
 import uuid
-from platform import platform
 from typing import Dict, List
 
 import requests as requests
@@ -93,7 +92,6 @@ from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import RegionBackend
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils import server
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import create_sqs_system_attributes, parse_urlencoded_data
@@ -194,7 +192,7 @@ def message_to_endpoint(
     sns_client = aws_stack.connect_to_service("sns")
     endpoint_attributes = sns_client.get_endpoint_attributes(EndpointArn=target_arn)["Attributes"]
     app_name = target_arn.split("/")[-2]
-    platform = target_arn.split("/")[-3]
+    platform_name = target_arn.split("/")[-3]
     platform_apps = sns_client.list_platform_applications()["PlatformApplications"]
     app = [x for x in platform_apps if app_name in x["PlatformApplicationArn"]][0]
 
@@ -202,7 +200,7 @@ def message_to_endpoint(
         message = json.loads(message)
 
     response = None
-    if platform == "GCM":
+    if platform_name == "GCM":
         response = send_message_to_GCM(app["Attributes"], endpoint_attributes, message["GCM"])
     # TODO: Add support for other platforms
 

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -206,9 +206,10 @@ def message_to_endpoint(
 
     if response:
         sns_backend = SNSBackend.get()
-        prev_responses = sns_backend.platform_endpoint_responses.get(target_arn, [])
-        prev_responses.append({"status_code": response.status_code, "body": response.content})
-        sns_backend.platform_endpoint_responses[target_arn] = prev_responses
+        cache = sns_backend.platform_endpoint_responses[target_arn] = (
+            sns_backend.platform_endpoint_responses.get(target_arn) or []
+        )
+        cache.append({"status_code": response.status_code, "body": response.content})
 
 
 def send_message_to_GCM(app_attributes, endpoint_attributes, message):
@@ -219,11 +220,12 @@ def send_message_to_GCM(app_attributes, endpoint_attributes, message):
     data["to"] = token
     headers = {"Authorization": f"key={server_key}", "Content-type": "application/json"}
 
-    return requests.post(
+    response = requests.post(
         GCM_URL,
         headers=headers,
         data=json.dumps(data),
     )
+    return response
 
 
 class SnsProvider(SnsApi, ServiceLifecycleHook):

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -204,7 +204,7 @@ def message_to_endpoint(
         response = send_message_to_GCM(app["Attributes"], endpoint_attributes, message["GCM"])
     # TODO: Add support for other platforms
 
-    if response:
+    if response is not None:
         sns_backend = SNSBackend.get()
         cache = sns_backend.platform_endpoint_responses[target_arn] = (
             sns_backend.platform_endpoint_responses.get(target_arn) or []

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1820,10 +1820,8 @@ class TestSNSProvider:
 
         def check_responses():
             responses = sns_backend.platform_endpoint_responses[endpoint_arn]
-            assert responses[0]['status_code'] == "401"
+            assert responses[0]["status_code"] == 401
 
         retry(check_responses, sleep=1)
-        # print(sns_backend.platform_endpoint_messages)
-        print(sns_backend.platform_endpoint_responses)
         sns_client.delete_endpoint(EndpointArn=endpoint_arn)
         sns_client.delete_platform_application(PlatformApplicationArn=platform_app_arn)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1820,9 +1820,10 @@ class TestSNSProvider:
 
         def check_responses():
             responses = sns_backend.platform_endpoint_responses[endpoint_arn]
-            assert responses[0].status_code == "200"
+            assert responses[0]['status_code'] == "401"
 
-        # retry(check_responses, sleep=1)
-        print(sns_backend.platform_endpoint_responses.keys())
+        retry(check_responses, sleep=1)
+        # print(sns_backend.platform_endpoint_messages)
+        print(sns_backend.platform_endpoint_responses)
         sns_client.delete_endpoint(EndpointArn=endpoint_arn)
         sns_client.delete_platform_application(PlatformApplicationArn=platform_app_arn)


### PR DESCRIPTION
This PR addresses issue #6238. With these changes if a message is published to an Endpoint for a GCM Platform Application, LocalStack will use the [GCM Http protocol](https://firebase.google.com/docs/cloud-messaging/http-server-ref?hl=en) to send the message.

Changes:
- Integration of GCM protocol.
- Test that validates that LocalStack is trying to use the protocol.

Note:
- For the test to expect a response with `status_code == 200` it will need a real service key and a token. 
