### PR TITLE
Fix HTTP status for InvalidObjectState error code

### DIFF
--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -186,7 +186,7 @@ def apply_patches():
     # patch _key_response_get(..)
     # https://github.com/localstack/localstack/issues/2724
     class InvalidObjectState(S3ClientError):
-        code = 400
+        code = 403
 
         def __init__(self, *args, **kwargs):
             super(InvalidObjectState, self).__init__(


### PR DESCRIPTION
This PR fixes a wrong HTTP status on the InvalidObjectState error implementation.

I reported a wrong status code for the InvalidObjectState error on #6242.
The reported error comes from the [moto](https://github.com/spulec/moto) library. However, there is an implementation in the localstack code that needs to be also fixed.