### PR TITLE
add support for apigateway lambda asynchronous invocations

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -900,11 +900,12 @@ def create_invocation_headers(invocation_context: ApiInvocationContext) -> Dict[
 
     if request_parameters := integration.get("requestParameters"):
         for req_parameter_key, req_parameter_value in request_parameters.items():
-            if header_name := list(
-                filter(None, req_parameter_key.split("integration.request.header."))
+            if (
+                header_name := req_parameter_key.lstrip("integration.request.header.")
+                if "integration.request.header." in req_parameter_key
+                else None
             ):
-                headers.update({header_name[0]: req_parameter_value})
-
+                headers.update({header_name: req_parameter_value})
     return headers
 
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -12,8 +12,7 @@ from apispec import APISpec
 from botocore.utils import InvalidArnException
 from jsonpatch import apply_patch
 from jsonpointer import JsonPointerException
-from moto.apigateway import models as apigateway_models
-from moto.apigateway.models import Authorizer
+from moto.apigateway.models import Authorizer, Integration, Resource, RestAPI, apigateway_backends
 from moto.apigateway.utils import create_id as create_resource_id
 from requests.models import Response
 
@@ -218,9 +217,7 @@ def get_stage_variables(context: ApiInvocationContext) -> Optional[Dict[str, str
         return {}
 
     region_name = [
-        name
-        for name, region in apigateway_models.apigateway_backends.items()
-        if context.api_id in region.apis
+        name for name, region in apigateway_backends.items() if context.api_id in region.apis
     ][0]
     api_gateway_client = aws_stack.connect_to_service("apigateway", region_name=region_name)
     try:
@@ -397,7 +394,7 @@ def extract_path_params(path: str, extracted_path: str) -> Dict[str, str]:
     return path_params
 
 
-def extract_query_string_params(path: str) -> Tuple[str, Dict[str, str]]:
+def extract_query_string_params(path: str) -> list[str, Dict[str, str]]:
     parsed_path = urlparse.urlparse(path)
     path = parsed_path.path
     parsed_query_string_params = urlparse.parse_qs(parsed_path.query)
@@ -589,9 +586,7 @@ def apply_json_patch_safe(subject, patch_operations, in_place=True, return_list=
     return (results or [subject])[-1]
 
 
-def import_api_from_openapi_spec(
-    rest_api: apigateway_models.RestAPI, body: Dict, query_params: Dict
-) -> apigateway_models.RestAPI:
+def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Dict) -> RestAPI:
     """Import an API from an OpenAPI spec document"""
 
     resolved_schema = resolve_references(body)
@@ -662,7 +657,7 @@ def import_api_from_openapi_spec(
     def add_path(path, parts, parent_id=""):
         child_id = create_resource_id()
         path = path or "/"
-        resource = apigateway_models.Resource(
+        resource = Resource(
             resource_id=child_id,
             region_name=rest_api.region_name,
             api_id=rest_api.id,
@@ -692,12 +687,14 @@ def import_api_from_openapi_spec(
                     response_model,
                     response_parameters,
                 )
-            integration = apigateway_models.Integration(
+
+            integration = Integration(
                 http_method=method,
                 uri=method_integration.get("uri"),
                 integration_type=method_integration.get("type"),
                 passthrough_behavior=method_integration.get("passthroughBehavior"),
                 request_templates=method_integration.get("requestTemplates") or {},
+                request_parameters=method_integration.get("requestParameters") or {},
             )
             integration.create_integration_response(
                 status_code=method_integration.get("responses", {})
@@ -894,6 +891,21 @@ def extract_api_id_from_hostname_in_url(hostname: str) -> str:
     """Extract API ID 'id123' from URLs like https://id123.execute-api.localhost.localstack.cloud:4566"""
     match = re.match(HOST_REGEX_EXECUTE_API, hostname)
     return match.group(1)
+
+
+# This need to be extended to handle mappings and not just literal values.
+def create_invocation_headers(invocation_context: ApiInvocationContext) -> Dict[str, Any]:
+    headers = invocation_context.headers
+    integration = invocation_context.integration
+
+    if request_parameters := integration.get("requestParameters"):
+        for req_parameter_key, req_parameter_value in request_parameters.items():
+            if header_name := list(
+                filter(None, req_parameter_key.split("integration.request.header."))
+            ):
+                headers.update({header_name[0]: req_parameter_value})
+
+    return headers
 
 
 # TODO:

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -15,7 +15,7 @@ from localstack.services.apigateway.helpers import (
     import_api_from_openapi_spec,
 )
 from localstack.utils.collections import ensure_list
-from localstack.utils.common import DelSafeDict, short_uid, str_to_bool, to_str
+from localstack.utils.common import DelSafeDict, str_to_bool, to_str
 from localstack.utils.json import parse_json_or_yaml
 
 LOG = logging.getLogger(__name__)
@@ -47,39 +47,6 @@ def apply_patches():
 
     apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init
-
-    def apigateway_models_Integration_init(
-        self,
-        integration_type,
-        uri,
-        http_method,
-        request_templates=None,
-        passthrough_behavior="WHEN_NO_MATCH",
-        cache_key_parameters=None,
-        *args,
-        **kwargs,
-    ):
-        if cache_key_parameters is None:
-            cache_key_parameters = []
-        apigateway_models_Integration_init_orig(
-            self,
-            integration_type=integration_type,
-            uri=uri,
-            http_method=http_method,
-            request_templates=request_templates,
-            *args,
-            **kwargs,
-        )
-
-        self["passthroughBehavior"] = passthrough_behavior
-        self["cacheKeyParameters"] = cache_key_parameters
-        self["cacheNamespace"] = self.get("cacheNamespace") or short_uid()
-
-        # httpMethod not present in response if integration_type is None, verified against AWS
-        if integration_type == "MOCK":
-            self["httpMethod"] = None
-        if request_templates:
-            self["requestTemplates"] = request_templates
 
     def apigateway_models_backend_put_rest_api(self, function_id, body, query_params):
         rest_api = self.get_rest_api(function_id)
@@ -501,6 +468,4 @@ def apply_patches():
     APIGatewayResponse.resource_method_responses = apigateway_response_resource_method_responses
     apigateway_response_usage_plan_individual_orig = APIGatewayResponse.usage_plan_individual
     APIGatewayResponse.usage_plan_individual = apigateway_response_usage_plan_individual
-    apigateway_models_Integration_init_orig = apigateway_models.Integration.__init__
-    apigateway_models.Integration.__init__ = apigateway_models_Integration_init
     apigateway_models.RestAPI.to_dict = apigateway_models_RestAPI_to_dict

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -179,6 +179,7 @@ def apply_patches():
             request_parameters = self._get_param("requestParameters") or {}
             cache_key_parameters = self._get_param("cacheKeyParameters") or []
             content_handling = self._get_param("contentHandling")
+            integration["cacheNamespace"] = resource_id
             integration["timeoutInMillis"] = timeout_milliseconds
             integration["requestParameters"] = request_parameters
             integration["cacheKeyParameters"] = cache_key_parameters

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -368,7 +368,7 @@ def process_apigateway_invocation(
             method or "GET",
             path,
         )
-        asynchronous = not config.SYNCHRONOUS_API_GATEWAY_EVENTS
+        asynchronous = headers.get("X-Amz-Invocation-Type") == "'Event'"
         inv_result = run_lambda(
             func_arn=func_arn,
             event=event,

--- a/tests/integration/files/api_definition.yaml
+++ b/tests/integration/files/api_definition.yaml
@@ -1,0 +1,75 @@
+openapi: 3.0.1
+info:
+  title: wait-for-seconds
+  description: Test API for asynchronous Lambda invocation
+  version: 2022-04-12T15:36:55Z
+paths:
+  "/echo/{data}":
+    x-amazon-apigateway-any-method:
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Empty"
+      x-amazon-apigateway-integration:
+        type: mock
+        responses:
+          default:
+            statusCode: "200"
+            responseTemplates:
+              application/json: >
+                {"data": $input.params(\"data\"), "response": "mocked"}
+        requestTemplates:
+          application/json: '{"data", $input.params(\"data\"), "statusCode": 200}'
+        passthroughBehavior: when_no_templates
+  "/wait/{seconds}":
+    x-amazon-apigateway-any-method:
+      parameters:
+        - name: seconds
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: 200 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Empty"
+      x-amazon-apigateway-integration:
+        type: aws
+        httpMethod: POST
+        uri: ${lambda_invocation_arn}
+        responses:
+          default:
+            statusCode: "200"
+        requestParameters:
+          integration.request.header.X-Amz-Invocation-Type: "'Event'"
+        requestTemplates:
+          application/json: >
+            #set($allParams = $input.params())
+
+            {
+              "params" : {
+                #foreach($type in $allParams.keySet())
+                  #set($params = $allParams.get($type))
+                  "$type" : {
+                    #foreach($paramName in $params.keySet())
+                      "$paramName" : "$util.escapeJavaScript($params.get($paramName))"
+                      #if($foreach.hasNext),#end
+                    #end
+                  }
+                  #if($foreach.hasNext),#end
+                #end
+              }
+            }
+        passthroughBehavior: when_no_templates
+        contentHandling: CONVERT_TO_TEXT
+components:
+  schemas:
+    Empty:
+      title: Empty Schema
+      type: object

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -11,6 +11,7 @@ from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.helpers import (
     Resolver,
     apply_json_patch_safe,
+    create_invocation_headers,
     extract_path_params,
     extract_query_string_params,
     get_resource_for_path,
@@ -408,3 +409,20 @@ def test_openapi_resolver_given_list_references():
         "schema": {"value": ["v1", "v2"]},
         "definitions": {"Found": {"value": ["v1", "v2"]}},
     }
+
+
+def test_create_invocation_headers():
+    invocation_context = ApiInvocationContext(
+        method="GET", path="/", data="", headers={"X-Header": "foobar"}
+    )
+    invocation_context.integration = {
+        "requestParameters": {"integration.request.header.X-Custom": "'Event'"}
+    }
+    headers = create_invocation_headers(invocation_context)
+    assert headers == {"X-Header": "foobar", "X-Custom": "'Event'"}
+
+    invocation_context.integration = {
+        "requestParameters": {"integration.request.path.foobar": "'CustomValue'"}
+    }
+    headers = create_invocation_headers(invocation_context)
+    assert headers == {"X-Header": "foobar", "X-Custom": "'Event'"}


### PR DESCRIPTION
Currently, in Localstack, an API Gateway setup with a backend Lambda integration had no option to invoke the lambda [asynchronously](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-integration-async.html). To invoke a lambda asynchronously through API Gateway we need to set up the integration to pass the header `X-Amz-Invocation-Type` with `"'Event'"` value to the lambda runtime.

The integration configuration setup looks like the following,
```
  request_parameters = {
    "integration.request.header.X-Amz-Invocation-Type" = "'Event'"
  }
```

Before we invoke the lambda executor we parse the request parameters and add the headers included in the configuration.

The next iteration will improve upon this feature by sourcing method request parameters and pass them to integration request parameters.

Relates with https://github.com/localstack/localstack/issues/5850