### PR TITLE
refactor API Gateway ASF provier / routing

### DIFF
--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -126,7 +126,9 @@ class Router(Generic[E]):
     def __init__(
         self, dispatcher: Dispatcher[E] = None, converters: Mapping[str, Type[BaseConverter]] = None
     ):
-        self.url_map = Map(host_matching=True, strict_slashes=False, converters=converters)
+        self.url_map = Map(
+            host_matching=True, strict_slashes=False, converters=converters, redirect_defaults=False
+        )
         self.dispatcher = dispatcher or call_endpoint
         self._mutex = threading.RLock()
 

--- a/localstack/services/apigateway/provider_asf.py
+++ b/localstack/services/apigateway/provider_asf.py
@@ -1,10 +1,5 @@
 """A version of the API Gateway provider that uses ASF constructs to dispatch user routes."""
 import logging
-from typing import Any, Dict
-
-from requests.structures import CaseInsensitiveDict
-from werkzeug.datastructures import Headers
-from werkzeug.exceptions import NotFound
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.apigateway import (
@@ -13,64 +8,31 @@ from localstack.aws.api.apigateway import (
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
 )
-from localstack.http import Request, Response, Router
-from localstack.http.dispatcher import Handler
-from localstack.http.request import restore_payload
-from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.helpers import API_REGIONS
 from localstack.services.apigateway.invocations import invoke_rest_api_from_request
 from localstack.services.apigateway.provider import ApigatewayProvider
+from localstack.services.apigateway.router_asf import ApigatewayRouter, to_invocation_context
 from localstack.services.edge import ROUTER
-from localstack.utils.aws.aws_responses import LambdaResponse
 from localstack.utils.json import parse_json_or_yaml
 from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 
 
-def to_invocation_context(
-    request: Request, url_params: Dict[str, Any] = None
-) -> ApiInvocationContext:
-    """
-    Converts an HTTP Request object into an ApiInvocationContext.
-
-    :param request: the original request
-    :param url_params: the parameters extracted from the URL matching rules
-    :return: the ApiInvocationContext
-    """
-    method = request.method
-    path = request.full_path if request.query_string else request.path
-    data = restore_payload(request)
-    headers = Headers(request.headers)
-
-    # adjust the X-Forwarded-For header
-    x_forwarded_for = headers.getlist("X-Forwarded-For")
-    x_forwarded_for.append(request.remote_addr)
-    x_forwarded_for.append(request.host)
-    headers["X-Forwarded-For"] = ", ".join(x_forwarded_for)
-
-    # this is for compatibility with the lower layers of apigw and lambda that make assumptions about header casing
-    headers = CaseInsensitiveDict({k: ", ".join(headers.getlist(k)) for k in headers.keys()})
-
-    # FIXME: Use the already parsed url params instead of parsing them into the ApiInvocationContext part-by-part.
-    #   We already would have all params at hand to avoid _all_ the parsing, but the parsing
-    #   has side-effects (f.e. setting the region in a thread local)!
-    #   It would be best to use a small (immutable) context for the already parsed params and the Request object
-    #   and use it everywhere.
-    return ApiInvocationContext(method, path, data, headers, stage=url_params.get("stage"))
-
-
 class AsfApigatewayProvider(ApigatewayProvider):
-    """Modern ASF provider that uses the router handler to dispatch requests to user routes."""
+    """
+    Modern ASF provider that uses the ApigatwayRouter (based on the router handler)
+    to dispatch requests to user routes.
+    """
 
-    router: Router[Handler]
+    router: ApigatewayRouter
 
-    def __init__(self, router: Router[Handler] = None):
-        self.router = router or ROUTER
+    def __init__(self, router: ApigatewayRouter = None):
+        self.router = router or ApigatewayRouter(ROUTER)
 
     def on_after_init(self):
         super(AsfApigatewayProvider, self).on_after_init()
-        self.register_routes()
+        self.router.register_routes()
 
     def create_rest_api(self, context: RequestContext, request: CreateRestApiRequest) -> RestApi:
         result: RestApi = super().create_rest_api(context, request)
@@ -104,56 +66,3 @@ class AsfApigatewayProvider(ApigatewayProvider):
             headers=dict(result.headers),
             body=to_str(result.content),
         )
-
-    def register_routes(self) -> None:
-        """Registers all API Gateway user invocation routes as parameterized routes."""
-        # add the canonical execute-api handler
-        self.router.add(
-            "/",
-            host="<api_id>.execute-api.<regex('.*'):server>",
-            endpoint=self.invoke_rest_api,
-            defaults={"path": "", "stage": None},
-        )
-        self.router.add(
-            "/<stage>/",
-            host="<api_id>.execute-api.<regex('.*'):server>",
-            endpoint=self.invoke_rest_api,
-            defaults={"path": ""},
-        )
-        self.router.add(
-            "/<stage>/<path:path>",
-            host="<api_id>.execute-api.<regex('.*'):server>",
-            endpoint=self.invoke_rest_api,
-        )
-
-        # add the localstack-specific _user_request_ routes
-        self.router.add(
-            "/restapis/<api_id>/<stage>/_user_request_",
-            endpoint=self.invoke_rest_api,
-            defaults={"path": ""},
-        )
-        self.router.add(
-            "/restapis/<api_id>/<stage>/_user_request_/<path:path>",
-            endpoint=self.invoke_rest_api,
-        )
-
-    def invoke_rest_api(self, request: Request, **url_params: Dict[str, Any]) -> Response:
-        if not url_params["api_id"] in API_REGIONS:
-            return Response(status=404)
-        invocation_context = to_invocation_context(request, url_params)
-        result = invoke_rest_api_from_request(invocation_context)
-        if result is not None:
-            if isinstance(result, LambdaResponse):
-                headers = Headers(dict(result.headers))
-                for k, values in result.multi_value_headers.items():
-                    for value in values:
-                        headers.add(k, value)
-            else:
-                headers = dict(result.headers)
-            return Response(
-                response=result.content,
-                status=result.status_code,
-                headers=headers,
-            )
-
-        raise NotFound()

--- a/localstack/services/apigateway/provider_asf.py
+++ b/localstack/services/apigateway/provider_asf.py
@@ -50,9 +50,7 @@ def to_invocation_context(
     headers["X-Forwarded-For"] = ", ".join(x_forwarded_for)
 
     # this is for compatibility with the lower layers of apigw and lambda that make assumptions about header casing
-    headers = CaseInsensitiveDict(
-        {k.title(): ", ".join(headers.getlist(k)) for k in headers.keys()}
-    )
+    headers = CaseInsensitiveDict({k: ", ".join(headers.getlist(k)) for k in headers.keys()})
 
     # FIXME: Use the already parsed url params instead of parsing them into the ApiInvocationContext part-by-part.
     #   We already would have all params at hand to avoid _all_ the parsing, but the parsing
@@ -139,8 +137,7 @@ class AsfApigatewayProvider(ApigatewayProvider):
             endpoint=self.invoke_rest_api,
         )
 
-    @staticmethod
-    def invoke_rest_api(request: Request, **url_params: Dict[str, Any]) -> Response:
+    def invoke_rest_api(self, request: Request, **url_params: Dict[str, Any]) -> Response:
         if not url_params["api_id"] in API_REGIONS:
             return Response(status=404)
         invocation_context = to_invocation_context(request, url_params)

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -1,0 +1,121 @@
+import logging
+from typing import Any, Dict
+
+from requests.models import Response as RequestsResponse
+from requests.structures import CaseInsensitiveDict
+from werkzeug.datastructures import Headers
+from werkzeug.exceptions import NotFound
+
+from localstack.http import Request, Response, Router
+from localstack.http.dispatcher import Handler
+from localstack.http.request import restore_payload
+from localstack.services.apigateway.context import ApiInvocationContext
+from localstack.services.apigateway.helpers import API_REGIONS
+from localstack.services.apigateway.invocations import invoke_rest_api_from_request
+from localstack.utils.aws.aws_responses import LambdaResponse
+
+LOG = logging.getLogger(__name__)
+
+
+def to_invocation_context(
+    request: Request, url_params: Dict[str, Any] = None
+) -> ApiInvocationContext:
+    """
+    Converts an HTTP Request object into an ApiInvocationContext.
+
+    :param request: the original request
+    :param url_params: the parameters extracted from the URL matching rules
+    :return: the ApiInvocationContext
+    """
+    method = request.method
+    path = request.full_path if request.query_string else request.path
+    data = restore_payload(request)
+    headers = Headers(request.headers)
+
+    # adjust the X-Forwarded-For header
+    x_forwarded_for = headers.getlist("X-Forwarded-For")
+    x_forwarded_for.append(request.remote_addr)
+    x_forwarded_for.append(request.host)
+    headers["X-Forwarded-For"] = ", ".join(x_forwarded_for)
+
+    # this is for compatibility with the lower layers of apigw and lambda that make assumptions about header casing
+    headers = CaseInsensitiveDict({k: ", ".join(headers.getlist(k)) for k in headers.keys()})
+
+    # FIXME: Use the already parsed url params instead of parsing them into the ApiInvocationContext part-by-part.
+    #   We already would have all params at hand to avoid _all_ the parsing, but the parsing
+    #   has side-effects (f.e. setting the region in a thread local)!
+    #   It would be best to use a small (immutable) context for the already parsed params and the Request object
+    #   and use it everywhere.
+    return ApiInvocationContext(method, path, data, headers, stage=url_params.get("stage"))
+
+
+def convert_response(result: RequestsResponse) -> Response:
+    """
+    Utility function to convert a response for the requests library to our internal (Werkzeug based) Response object.
+    """
+    if result is None:
+        return Response()
+    if isinstance(result, LambdaResponse):
+        headers = Headers(dict(result.headers))
+        for k, values in result.multi_value_headers.items():
+            for value in values:
+                headers.add(k, value)
+    else:
+        headers = dict(result.headers)
+    return Response(
+        response=result.content,
+        status=result.status_code,
+        headers=headers,
+    )
+
+
+class ApigatewayRouter:
+    """
+    Simple implementation around a Router to manage dynamic restapi routes (routes added by a user through the
+    apigateway API).
+    """
+
+    router: Router[Handler]
+
+    def __init__(self, router: Router[Handler]):
+        self.router = router
+
+    def register_routes(self) -> None:
+        """Registers parameterized routes for API Gateway user invocations."""
+        self.router.add(
+            "/",
+            host="<api_id>.execute-api.<regex('.*'):server>",
+            endpoint=self.invoke_rest_api,
+            defaults={"path": "", "stage": None},
+        )
+        self.router.add(
+            "/<stage>/",
+            host="<api_id>.execute-api.<regex('.*'):server>",
+            endpoint=self.invoke_rest_api,
+            defaults={"path": ""},
+        )
+        self.router.add(
+            "/<stage>/<path:path>",
+            host="<api_id>.execute-api.<regex('.*'):server>",
+            endpoint=self.invoke_rest_api,
+        )
+
+        # add the localstack-specific _user_request_ routes
+        self.router.add(
+            "/restapis/<api_id>/<stage>/_user_request_",
+            endpoint=self.invoke_rest_api,
+            defaults={"path": ""},
+        )
+        self.router.add(
+            "/restapis/<api_id>/<stage>/_user_request_/<path:path>",
+            endpoint=self.invoke_rest_api,
+        )
+
+    def invoke_rest_api(self, request: Request, **url_params: Dict[str, Any]) -> Response:
+        if not url_params["api_id"] in API_REGIONS:
+            return Response(status=404)
+        invocation_context = to_invocation_context(request, url_params)
+        result = invoke_rest_api_from_request(invocation_context)
+        if result is not None:
+            return convert_response(result)
+        raise NotFound()


### PR DESCRIPTION
With #6040, a new provider for API Gateway has been introduced, which uses native ASF features for the routing instead of the legacy proxy listener. It registered a route for each created API in API Gateway.
This PR refactors the new routing approach a bit such that it only registers a handful of parameterized routes.
This has the following benefits:
- The `ApigatewayRouter` now correctly returns an HTTP 404 if a request targets a non-existing API.
- The `ApigatewayRouter` now already parses all the path and host parameters (`stage`, `api_id`, `path`).
  - These aren't used yet, but these should essentially replace all the regex parsing in `helpers.py#set_api_id_stage_invocation_path`.
  - These should be introduced with a bigger refactoring of the API Gateway infrastructure.
- The `ApigatewayRouter` completely handles the routing, the creation of the invocation context, and finally the invocation of the API.