### PR TITLE
Fix ConfirmSubscription in SNS http endpoint, match AWS behaviour

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -300,17 +300,19 @@ def determine_aws_service_name(
 
     # 5. check the query / form-data
     values = request.values
-    if "Action" in values and "Version" in values:
+    if "Action" in values:
         # query / ec2 protocol requests always have an action and a version (the action is more significant)
-        query_candidates = services.by_operation(values["Action"])
+        protocols = ["query", "ec2"]
+        query_candidates = services.by_protocol_and_operation(protocols, values["Action"])
         if len(query_candidates) == 1:
             return query_candidates[0]
 
-        for service in list(query_candidates):
-            service_model = services.get(service)
-            if values["Version"] != service_model.api_version:
-                # the combination of Version and Action is not unique, add matches to the candidates
-                query_candidates.remove(service)
+        if "Version" in values:
+            for service in list(query_candidates):
+                service_model = services.get(service)
+                if values["Version"] != service_model.api_version:
+                    # the combination of Version and Action is not unique, add matches to the candidates
+                    query_candidates.remove(service)
 
         if len(query_candidates) == 1:
             return query_candidates[0]

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -300,17 +300,18 @@ def determine_aws_service_name(
 
     # 5. check the query / form-data
     values = request.values
-    if "Action" in values and "Version" in values:
+    if "Action" in values:
         # query / ec2 protocol requests always have an action and a version (the action is more significant)
         query_candidates = services.by_operation(values["Action"])
         if len(query_candidates) == 1:
             return query_candidates[0]
 
-        for service in list(query_candidates):
-            service_model = services.get(service)
-            if values["Version"] != service_model.api_version:
-                # the combination of Version and Action is not unique, add matches to the candidates
-                query_candidates.remove(service)
+        if "Version" in values:
+            for service in list(query_candidates):
+                service_model = services.get(service)
+                if values["Version"] != service_model.api_version:
+                    # the combination of Version and Action is not unique, add matches to the candidates
+                    query_candidates.remove(service)
 
         if len(query_candidates) == 1:
             return query_candidates[0]

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -300,18 +300,17 @@ def determine_aws_service_name(
 
     # 5. check the query / form-data
     values = request.values
-    if "Action" in values:
+    if "Action" in values and "Version" in values:
         # query / ec2 protocol requests always have an action and a version (the action is more significant)
         query_candidates = services.by_operation(values["Action"])
         if len(query_candidates) == 1:
             return query_candidates[0]
 
-        if "Version" in values:
-            for service in list(query_candidates):
-                service_model = services.get(service)
-                if values["Version"] != service_model.api_version:
-                    # the combination of Version and Action is not unique, add matches to the candidates
-                    query_candidates.remove(service)
+        for service in list(query_candidates):
+            service_model = services.get(service)
+            if values["Version"] != service_model.api_version:
+                # the combination of Version and Action is not unique, add matches to the candidates
+                query_candidates.remove(service)
 
         if len(query_candidates) == 1:
             return query_candidates[0]

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -877,7 +877,7 @@ async def message_to_subscriber(
             )
             store_delivery_log(subscriber, False, message, message_id)
             message_body = create_sns_message_body(subscriber, req_data, message_id)
-            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], message_body, str(exc))
+            sns_error_to_dead_letter_queue(subscriber, message_body, str(exc))
         return
 
     elif subscriber["Protocol"] in ["http", "https"]:
@@ -921,7 +921,7 @@ async def message_to_subscriber(
                 "Received error on sending SNS message, putting to DLQ (if configured): %s", exc
             )
             store_delivery_log(subscriber, False, message, message_id)
-            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], message_body, str(exc))
+            sns_error_to_dead_letter_queue(subscriber, message_body, str(exc))
         return
 
     elif subscriber["Protocol"] == "application":
@@ -937,7 +937,7 @@ async def message_to_subscriber(
             )
             store_delivery_log(subscriber, False, message, message_id)
             message_body = create_sns_message_body(subscriber, req_data, message_id)
-            sns_error_to_dead_letter_queue(subscriber["SubscriptionArn"], message_body, str(exc))
+            sns_error_to_dead_letter_queue(subscriber, message_body, str(exc))
         return
 
     elif subscriber["Protocol"] in ["email", "email-json"]:

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -466,11 +466,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 external_url = external_service_url("sns")
                 token = short_uid()
                 message_id = long_uid()
-                # subscription_url = "%s/?Action=ConfirmSubscription&SubscriptionArn=%s&Token=%s" % (
-                #     external_url,
-                #     target_subscription_arn,
-                #     token,
-                # )
                 subscription_url = create_subscribe_url(
                     external_url, target_subscription_arn, token
                 )

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -402,6 +402,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             for i in v:
                 if i["TopicArn"] == topic_arn:
                     i["PendingConfirmation"] = "false"
+
         return ConfirmSubscriptionResponse(SubscriptionArn=sub_arn)
 
     def untag_resource(
@@ -464,15 +465,15 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
             if current_subscription["Protocol"] in ["http", "https"]:
                 external_url = external_service_url("sns")
-                token = short_uid()
+                subscription_token = short_uid()
                 message_id = long_uid()
                 subscription_url = create_subscribe_url(
-                    external_url, target_subscription_arn, token
+                    external_url, current_subscription["TopicArn"], subscription_token
                 )
                 message = {
                     "Type": ["UnsubscribeConfirmation"],
                     "MessageId": [message_id],
-                    "Token": [token],
+                    "Token": [subscription_token],
                     "TopicArn": [current_subscription["TopicArn"]],
                     "Message": [
                         "You have chosen to deactivate subscription %s.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message."
@@ -584,6 +585,10 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             raise InvalidParameterException(
                 f"Invalid parameter: Amazon SNS does not support this protocol string: {protocol}"
             )
+        elif protocol in ["http", "https"] and not endpoint.startswith(f"{protocol}://"):
+            raise InvalidParameterException(
+                "Invalid parameter: Endpoint must match the specified protocol"
+            )
         if ".fifo" in endpoint and ".fifo" not in topic_arn:
             raise InvalidParameterException(
                 "FIFO SQS Queues can not be subscribed to standard SNS topics"
@@ -619,29 +624,28 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if subscription_arn not in sns_backend.subscription_status:
             sns_backend.subscription_status[subscription_arn] = {}
 
-        token = short_uid()
+        subscription_token = short_uid()
         sns_backend.subscription_status[subscription_arn].update(
-            {"TopicArn": topic_arn, "Token": token, "Status": "Not Subscribed"}
+            {"TopicArn": topic_arn, "Token": subscription_token, "Status": "Not Subscribed"}
         )
         # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
         if protocol in ["http", "https"]:
-            token = short_uid()
             external_url = external_service_url("sns")
             subscription["UnsubscribeURL"] = create_unsubscribe_url(external_url, subscription_arn)
             confirmation = {
                 "Type": ["SubscriptionConfirmation"],
-                "Token": [token],
+                "Token": [subscription_token],
                 "Message": [
                     f"You have chosen to subscribe to the topic {topic_arn}.\n"
                     + "To confirm the subscription, visit the SubscribeURL included in this message."
                 ],
-                "SubscribeURL": [create_subscribe_url(external_url, topic_arn, token)],
+                "SubscribeURL": [create_subscribe_url(external_url, topic_arn, subscription_token)],
             }
             publish_message(topic_arn, confirmation, {}, subscription_arn, skip_checks=True)
         elif protocol == "sqs":
             # Auto-confirm sqs subscriptions for now
             # TODO: revisit for multi-account
-            self.confirm_subscription(context, topic_arn, token)
+            self.confirm_subscription(context, topic_arn, subscription_token)
         return SubscribeResponse(SubscriptionArn=subscription_arn)
 
     def tag_resource(
@@ -899,7 +903,7 @@ async def message_to_subscriber(
             # When raw message delivery is enabled, x-amz-sns-rawdelivery needs to be set to 'true'
             # indicating that the message has been published without JSON formatting.
             # https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
-            if is_raw_message_delivery(subscriber):
+            if msg_type == "Notification" and is_raw_message_delivery(subscriber):
                 headers["x-amz-sns-rawdelivery"] = "true"
 
             response = requests.post(
@@ -978,6 +982,7 @@ def get_subscription_by_arn(sub_arn):
 
 def create_sns_message_body(subscriber, req_data, message_id=None) -> str:
     message = req_data["Message"][0]
+    message_type = req_data.get("Type", ["Notification"])[0]
     protocol = subscriber["Protocol"]
     attributes = get_message_attributes(req_data)
 
@@ -988,7 +993,7 @@ def create_sns_message_body(subscriber, req_data, message_id=None) -> str:
         except KeyError:
             raise Exception("Unable to find 'default' key in message payload")
 
-    if is_raw_message_delivery(subscriber):
+    if message_type == "Notification" and is_raw_message_delivery(subscriber):
         if attributes:
             message["MessageAttributes"] = attributes
         return message
@@ -997,7 +1002,7 @@ def create_sns_message_body(subscriber, req_data, message_id=None) -> str:
     unsubscribe_url = create_unsubscribe_url(external_url, subscriber["SubscriptionArn"])
 
     data = {
-        "Type": req_data.get("Type", ["Notification"])[0],
+        "Type": message_type,
         "MessageId": message_id,
         "TopicArn": subscriber["TopicArn"],
         "Message": message,
@@ -1017,6 +1022,9 @@ def create_sns_message_body(subscriber, req_data, message_id=None) -> str:
     for key in HTTP_SUBSCRIPTION_ATTRIBUTES:
         if key in subscriber:
             data[key] = subscriber[key]
+
+    if data["Type"] == "UnsubscribeConfirmation":
+        data.pop("UnsubscribeURL")
 
     if attributes:
         data["MessageAttributes"] = attributes
@@ -1078,12 +1086,12 @@ def prepare_message_attributes(message_attributes):
     return attributes
 
 
-def create_subscribe_url(external_url, topic_arn, token):
-    return f"{external_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}&Version={SnsApi.version}"
+def create_subscribe_url(external_url, topic_arn, subscription_token):
+    return f"{external_url}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={subscription_token}"
 
 
 def create_unsubscribe_url(external_url, subscription_arn):
-    return f"{external_url}/?Action=Unsubscribe&SubscriptionArn={subscription_arn}&Version={SnsApi.version}"
+    return f"{external_url}/?Action=Unsubscribe&SubscriptionArn={subscription_arn}"
 
 
 def is_number(x):

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -32,16 +32,16 @@ def sqs_error_to_dead_letter_queue(queue_arn: str, event: Dict, error):
     return _send_to_dead_letter_queue("SQS", queue_arn, target_arn, event, error)
 
 
-def sns_error_to_dead_letter_queue(sns_subscriber_arn: str, event: str, error):
+def sns_error_to_dead_letter_queue(sns_subscriber: dict, event: str, error):
     # event should be of type str if coming from SNS, as it represents the message body being passed down
-    client = aws_stack.connect_to_service("sns")
-    attrs = client.get_subscription_attributes(SubscriptionArn=sns_subscriber_arn)
-    attrs = attrs.get("Attributes", {})
+    attrs = sns_subscriber.get("Attributes", {})
     policy = json.loads(attrs.get("RedrivePolicy") or "{}")
     target_arn = policy.get("deadLetterTargetArn")
     if not target_arn:
         return
-    return _send_to_dead_letter_queue("SNS", sns_subscriber_arn, target_arn, event, error)
+    return _send_to_dead_letter_queue(
+        "SNS", sns_subscriber["SubscriptionArn"], target_arn, event, error
+    )
 
 
 def lambda_error_to_dead_letter_queue(func_details: LambdaFunction, event: Dict, error):

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -32,16 +32,16 @@ def sqs_error_to_dead_letter_queue(queue_arn: str, event: Dict, error):
     return _send_to_dead_letter_queue("SQS", queue_arn, target_arn, event, error)
 
 
-def sns_error_to_dead_letter_queue(sns_subscriber: dict, event: str, error):
+def sns_error_to_dead_letter_queue(sns_subscriber_arn: str, event: str, error):
     # event should be of type str if coming from SNS, as it represents the message body being passed down
-    attrs = sns_subscriber.get("Attributes", {})
+    client = aws_stack.connect_to_service("sns")
+    attrs = client.get_subscription_attributes(SubscriptionArn=sns_subscriber_arn)
+    attrs = attrs.get("Attributes", {})
     policy = json.loads(attrs.get("RedrivePolicy") or "{}")
     target_arn = policy.get("deadLetterTargetArn")
     if not target_arn:
         return
-    return _send_to_dead_letter_queue(
-        "SNS", sns_subscriber["SubscriptionArn"], target_arn, event, error
-    )
+    return _send_to_dead_letter_queue("SNS", sns_subscriber_arn, target_arn, event, error)
 
 
 def lambda_error_to_dead_letter_queue(func_details: LambdaFunction, event: Dict, error):

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -144,6 +144,9 @@ class TestSNSProvider:
             f"{external_service_url('sns')}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
         )
 
+        confirm_subscribe_request = requests.get(subscribe_url)
+        assert "<ConfirmSubscriptionResult />" in confirm_subscribe_request.text
+
     def test_subscribe_with_invalid_protocol(self, sns_client, sns_create_topic, sns_subscription):
         topic_arn = sns_create_topic()["TopicArn"]
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
 import json
+import os
 import queue
 import random
 
 import pytest
 import requests
+import xmltodict
 from botocore.exceptions import ClientError
 from pytest_httpserver import HTTPServer
 from werkzeug import Response
 
 from localstack import config
-from localstack.config import external_service_url
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.install import SQS_BACKEND_IMPL
-from localstack.services.sns.provider import SNSBackend, SnsProvider
+from localstack.services.sns.provider import SNSBackend
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
@@ -115,44 +116,6 @@ class TestSNSProvider:
             assert message == msg_received
 
         retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-    def test_subscribe_http_endpoint(
-        self, sns_client, sns_create_topic, sns_subscription, httpserver: HTTPServer
-    ):
-        topic_arn = sns_create_topic()["TopicArn"]
-
-        # create HTTP endpoint and connect it to SNS topic
-        httpserver.expect_request("/").respond_with_data(status=200)
-        endpoint_url = httpserver.url_for("/")
-        wait_for_port_open(endpoint_url)
-
-        subscription = sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=endpoint_url)
-        subscription_arn = subscription["SubscriptionArn"]
-
-        assert poll_condition(lambda: len(httpserver.log) >= 1)
-
-        request, response = httpserver.log[0]
-        payload = request.get_json(True)
-
-        assert payload["Type"] == "SubscriptionConfirmation"
-        assert request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
-        assert "Signature" in payload
-        assert "SigningCertURL" in payload
-
-        token = payload["Token"]
-        subscribe_url = payload["SubscribeURL"]
-        assert subscribe_url == (
-            f"{external_service_url('sns')}/?"
-            f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}&Version={SnsProvider.version}"
-        )
-
-        confirm_subscribe_request = requests.get(subscribe_url)
-        assert "<ConfirmSubscriptionResult />" in confirm_subscribe_request.text
-
-        subscription_attributes = sns_client.get_subscription_attributes(
-            SubscriptionArn=subscription_arn
-        )
-        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
 
     def test_subscribe_with_invalid_protocol(self, sns_client, sns_create_topic, sns_subscription):
         topic_arn = sns_create_topic()["TopicArn"]
@@ -1509,6 +1472,7 @@ class TestSNSProvider:
         sqs_queue_arn,
         sqs_queue_exists,
         sns_create_sqs_subscription,
+        sns_allow_topic_sqs_queue,
         raw_message_delivery,
         snapshot,
     ):
@@ -1548,25 +1512,10 @@ class TestSNSProvider:
                 AttributeValue="true",
             )
 
-        # allow topic to write to the DLQ sqs queue
-        # taken from localstack.testing.pytest.fixtures.sns_create_sqs_subscription#494
-        sqs_client.set_queue_attributes(
-            QueueUrl=dlq_url,
-            Attributes={
-                "Policy": json.dumps(
-                    {
-                        "Statement": [
-                            {
-                                "Effect": "Allow",
-                                "Principal": {"Service": "sns.amazonaws.com"},
-                                "Action": "sqs:SendMessage",
-                                "Resource": dlq_arn,
-                                "Condition": {"ArnEquals": {"aws:SourceArn": topic_arn}},
-                            }
-                        ]
-                    }
-                )
-            },
+        sns_allow_topic_sqs_queue(
+            sqs_queue_url=dlq_url,
+            sqs_queue_arn=dlq_arn,
+            sns_topic_arn=topic_arn,
         )
 
         sqs_client.delete_queue(QueueUrl=queue_url)
@@ -1645,3 +1594,197 @@ class TestSNSProvider:
             WaitTimeSeconds=1,
         )
         assert "an-attribute-key" in msg["Messages"][0]["MessageAttributes"]
+
+    @pytest.mark.aws_validated
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    def test_subscribe_external_http_endpoint(
+        self,
+        sns_client,
+        sns_create_http_endpoint,
+        raw_message_delivery,
+    ):
+        if os.environ.get("TEST_TARGET", "") == "AWS_CLOUD":
+            pytest.skip("Necessitate manual set up to allow external access to endpoint")
+
+        topic_arn, subscription_arn, endpoint_url, server = sns_create_http_endpoint(
+            raw_message_delivery
+        )
+        assert poll_condition(
+            lambda: len(server.log) >= 1,
+            timeout=5,
+        )
+        sub_request, _ = server.log[0]
+        payload = sub_request.get_json(force=True)
+        assert payload["Type"] == "SubscriptionConfirmation"
+        assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
+        assert "Signature" in payload
+        assert "SigningCertURL" in payload
+
+        token = payload["Token"]
+        subscribe_url = payload["SubscribeURL"]
+        service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
+        assert subscribe_url == (
+            f"{service_url}/?Action=ConfirmSubscription" f"&TopicArn={topic_arn}&Token={token}"
+        )
+
+        confirm_subscribe_request = requests.get(subscribe_url)
+        confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
+        assert (
+            confirm_subscribe["ConfirmSubscriptionResponse"]["ConfirmSubscriptionResult"][
+                "SubscriptionArn"
+            ]
+            == subscription_arn
+        )
+
+        subscription_attributes = sns_client.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
+
+        message = "test_external_http_endpoint"
+        sns_client.publish(TopicArn=topic_arn, Message=message)
+
+        assert poll_condition(
+            lambda: len(server.log) >= 2,
+            timeout=5,
+        )
+        notification_request, _ = server.log[1]
+        assert notification_request.headers["x-amz-sns-message-type"] == "Notification"
+
+        expected_unsubscribe_url = (
+            f"{service_url}/?Action=Unsubscribe&SubscriptionArn={subscription_arn}"
+        )
+        if raw_message_delivery:
+            payload = notification_request.data.decode()
+            assert payload == message
+        else:
+            payload = notification_request.get_json(force=True)
+            assert payload["Type"] == "Notification"
+            assert "Signature" in payload
+            assert "SigningCertURL" in payload
+            assert payload["Message"] == message
+            assert payload["UnsubscribeURL"] == expected_unsubscribe_url
+
+        unsub_request = requests.get(expected_unsubscribe_url)
+        unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
+        assert "UnsubscribeResponse" in unsubscribe_confirmation
+
+        assert poll_condition(
+            lambda: len(server.log) >= 3,
+            timeout=5,
+        )
+        unsub_request, _ = server.log[2]
+
+        payload = unsub_request.get_json(force=True)
+        assert payload["Type"] == "UnsubscribeConfirmation"
+        assert unsub_request.headers["x-amz-sns-message-type"] == "UnsubscribeConfirmation"
+        assert "Signature" in payload
+        assert "SigningCertURL" in payload
+        token = payload["Token"]
+        assert payload["SubscribeURL"] == (
+            f"{service_url}/?" f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+        )
+
+    @pytest.mark.parametrize("raw_message_delivery", [True, False])
+    def test_dlq_external_http_endpoint(
+        self,
+        sns_client,
+        sqs_client,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_queue_arn,
+        sns_subscription,
+        sns_create_http_endpoint,
+        sns_create_sqs_subscription,
+        sns_allow_topic_sqs_queue,
+        raw_message_delivery,
+    ):
+        if os.environ.get("TEST_TARGET", "") == "AWS_CLOUD":
+            pytest.skip("Necessitate manual set up to allow external access to endpoint")
+
+        topic_arn, http_subscription_arn, endpoint_url, server = sns_create_http_endpoint(
+            raw_message_delivery
+        )
+
+        dlq_url = sqs_create_queue()
+        dlq_arn = sqs_queue_arn(dlq_url)
+
+        sns_allow_topic_sqs_queue(
+            sqs_queue_url=dlq_url, sqs_queue_arn=dlq_arn, sns_topic_arn=topic_arn
+        )
+
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=http_subscription_arn,
+            AttributeName="RedrivePolicy",
+            AttributeValue=json.dumps({"deadLetterTargetArn": dlq_arn}),
+        )
+        assert poll_condition(
+            lambda: len(server.log) >= 1,
+            timeout=5,
+        )
+        sub_request, _ = server.log[0]
+        payload = sub_request.get_json(force=True)
+        assert payload["Type"] == "SubscriptionConfirmation"
+        assert sub_request.headers["x-amz-sns-message-type"] == "SubscriptionConfirmation"
+
+        subscribe_url = payload["SubscribeURL"]
+        service_url, subscribe_url_path = payload["SubscribeURL"].rsplit("/", maxsplit=1)
+
+        confirm_subscribe_request = requests.get(subscribe_url)
+        confirm_subscribe = xmltodict.parse(confirm_subscribe_request.content)
+        assert (
+            confirm_subscribe["ConfirmSubscriptionResponse"]["ConfirmSubscriptionResult"][
+                "SubscriptionArn"
+            ]
+            == http_subscription_arn
+        )
+
+        subscription_attributes = sns_client.get_subscription_attributes(
+            SubscriptionArn=http_subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
+
+        server.stop()
+        wait_for_port_closed(server.port)
+
+        message = "test_dlq_external_http_endpoint"
+        sns_client.publish(TopicArn=topic_arn, Message=message)
+
+        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=3)
+        assert (
+            len(response["Messages"]) == 1
+        ), f"invalid number of messages in DLQ response {response}"
+
+        if raw_message_delivery:
+            assert response["Messages"][0]["Body"] == message
+        else:
+            received_message = json.loads(response["Messages"][0]["Body"])
+            assert received_message["Type"] == "Notification"
+            assert received_message["Message"] == message
+
+        receipt_handle = response["Messages"][0]["ReceiptHandle"]
+        sqs_client.delete_message(QueueUrl=dlq_url, ReceiptHandle=receipt_handle)
+
+        expected_unsubscribe_url = (
+            f"{service_url}/?Action=Unsubscribe&SubscriptionArn={http_subscription_arn}"
+        )
+
+        unsub_request = requests.get(expected_unsubscribe_url)
+        unsubscribe_confirmation = xmltodict.parse(unsub_request.content)
+        assert "UnsubscribeResponse" in unsubscribe_confirmation
+
+        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=2)
+        # AWS doesn't send to the DLQ if the UnsubscribeConfirmation fails to be delivered
+        assert "Messages" not in response
+
+    def test_publish_too_long_message(self, sns_client):
+        fake_arn = "arn:aws:sns:us-east-1:123456789012:i_dont_exist"
+        # simulate payload over 256kb
+        message = "This is a test message" * 12000
+
+        with pytest.raises(ClientError) as e:
+            sns_client.publish(TopicArn=fake_arn, Message=message)
+
+        assert e.value.response["Error"]["Code"] == "InvalidParameter"
+        assert e.value.response["Error"]["Message"] == "Message too long"
+        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -13,7 +13,7 @@ from localstack import config
 from localstack.config import external_service_url
 from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.services.install import SQS_BACKEND_IMPL
-from localstack.services.sns.provider import SNSBackend
+from localstack.services.sns.provider import SNSBackend, SnsProvider
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
@@ -141,7 +141,8 @@ class TestSNSProvider:
         token = payload["Token"]
         subscribe_url = payload["SubscribeURL"]
         assert subscribe_url == (
-            f"{external_service_url('sns')}/?Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}"
+            f"{external_service_url('sns')}/?"
+            f"Action=ConfirmSubscription&TopicArn={topic_arn}&Token={token}&Version={SnsProvider.version}"
         )
 
         confirm_subscribe_request = requests.get(subscribe_url)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -126,7 +126,8 @@ class TestSNSProvider:
         endpoint_url = httpserver.url_for("/")
         wait_for_port_open(endpoint_url)
 
-        sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=endpoint_url)
+        subscription = sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=endpoint_url)
+        subscription_arn = subscription["SubscriptionArn"]
 
         assert poll_condition(lambda: len(httpserver.log) >= 1)
 
@@ -147,6 +148,11 @@ class TestSNSProvider:
 
         confirm_subscribe_request = requests.get(subscribe_url)
         assert "<ConfirmSubscriptionResult />" in confirm_subscribe_request.text
+
+        subscription_attributes = sns_client.get_subscription_attributes(
+            SubscriptionArn=subscription_arn
+        )
+        assert subscription_attributes["Attributes"]["PendingConfirmation"] == "false"
 
     def test_subscribe_with_invalid_protocol(self, sns_client, sns_create_topic, sns_subscription):
         topic_arn = sns_create_topic()["TopicArn"]


### PR DESCRIPTION
This PR started as a fix to #6227. It was the occasion to check the behaviour of AWS against a HTTP endpoint.
It fixes the original issue, as well as small issues of headers, DLQ and message fields.
It overrides #6234 as the assumptions were wrong, and the PR scope is a bit wider. 

### Original problem

As stated in the issue, it wasn't possible to confirm a subscription from a http endpoint, as the URL contained in the message was missing a `Version` field which was required by the service router.
We checked with @alexrashed the best way to fix it, which required being less strict. A second problem arose, as we could have similar action names and not knowing which service was called.
Specifically the `Unsubscribe` action from `sns`(query protocol) and `codestar-notifications` (json-rest protocol).

### Solutions
The `operation_index` in `localstack/aws/spec.py` got a level added with the `protocol` of the request. The original issue is now fixed.
A bug in the test cleanup of the SNS http endpoint dragged me into trying to fix it, and checking AWS behaviour as well, as we needed to also know if AWS could route requests with `query` protocol without the `Version` parameter (it can and it does, the URL was properly constructed in our SNS implementation). 
Doing so, I then fixed some parity errors in message fields and headers, and matched AWS on DLQ delivery for UnsubscribeConfirmation messages. 
I saw a small minor issue with payload size in Slack, so I quickly fixed it and added a test. If it needs it own PR, I will move it.