### PR TITLE
Fix: auto confirm SNS subscription for lambda endpoint

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -646,8 +646,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 ],
             }
             publish_message(topic_arn, confirmation, {}, subscription_arn, skip_checks=True)
-        elif protocol == "sqs":
-            # Auto-confirm sqs subscriptions for now
+        elif protocol in ["sqs", "lambda"]:
+            # Auto-confirm sqs and lambda subscriptions for now
             # TODO: revisit for multi-account
             self.confirm_subscription(context, topic_arn, token)
         return SubscribeResponse(SubscriptionArn=subscription_arn)


### PR DESCRIPTION
### Problem
The Lambda endpoint subscription to a SNS topic is not auto confirmed for now even for same AWS account for the endpoint and topic.
The issue encountered by the user is that Terraform then timeout because the subscription attributes contain `"PendingConfirmation"="true"` indefinitely.

### Solution
Add a small change to auto confirm Lambda subscriptions to a SNS topic like for SQS (they have the same behaviour). This will need to be revisited for multi-account, as stated on AWS documentation for the `Subscribe` action.

https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html