### PR TITLE
Modify file ownership in localstack image to support Openshift deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,7 @@ ADD localstack/ localstack/
 # Download some more dependencies (make init needs the LocalStack code)
 # FIXME the init python code should be independent (i.e. not depend on the localstack code), idempotent/reproducible,
 #       modify only folders outside of the localstack package folder, and executed in the builder stage.
-RUN make init
+RUN make init && chmod -R 775 /usr/lib/localstack
 
 # Install the latest version of localstack-ext and generate the plugin entrypoints.
 # If this is a pre-release build, also include dev releases of these packages.


### PR DESCRIPTION
The Openshift documentation [1] states that "[...] directories and files that are written to by processes in the image must be owned by the root group and be read/writable by that group. Files to be executed must also have group execute permissions."

The official localstack image does not satisfy these requirements. The following  permission error prevents running localstack in Openshift:
```
Error starting infrastructure: [Errno 13] Permission denied: '/opt/code/localstack/localstack/infra/dynamodb/log4j2.xml' Traceback (most recent call last):
  File "/opt/code/localstack/localstack/services/infra.py", line 366, in start_infra
    do_start_infra(asynchronous, apis, is_in_docker)
  File "/opt/code/localstack/localstack/services/infra.py", line 427, in do_start_infra
    prepare_installation()
  File "/opt/code/localstack/localstack/utils/analytics/profiler.py", line 156, in wrapped
    return f(*args, **kwargs)
  File "/opt/code/localstack/localstack/services/infra.py", line 403, in prepare_installation
    install.install_components(apis)
  File "/opt/code/localstack/localstack/services/install.py", line 246, in install_components
    parallelize(install_component, names)
  File "/opt/code/localstack/localstack/utils/common.py", line 1261, in parallelize
    result = pool.map(func, list)
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 768, in get
    raise self._value
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/opt/code/localstack/localstack/services/install.py", line 242, in install_component
    installer()
  File "/opt/code/localstack/localstack/services/install.py", line 203, in install_dynamodb_local
    save_file(log4j2_file, log4j2_config)
  File "/opt/code/localstack/localstack/utils/common.py", line 804, in save_file
    with open(file, mode) as f:
PermissionError: [Errno 13] Permission denied: '/opt/code/localstack/localstack/infra/dynamodb/log4j2.xml'

```

Note the permissions on the files in the k8s pod, and the Openshift user ID:
```
/opt/code/localstack $ id
uid=1005450000(1005450000) gid=0(root) groups=1005450000
/opt/code/localstack $ id localstack
uid=1001(localstack) gid=1001(localstack) groups=1001(localstack)
/opt/code/localstack $ ls -l /opt/code/localstack/localstack/infra/dynamodb/
total 3728
-rw-r--r--    1 root     root       3787565 Nov  6  2020 DynamoDBLocal.jar
drwxr-xr-x    2 localsta localsta      4096 May 28  2020 DynamoDBLocal_lib
-rw-r--r--    1 localsta localsta      8644 May 28  2020 LICENSE.txt
-rw-r--r--    1 localsta localsta      1856 May 28  2020 README.txt
-rw-r--r--    1 localsta localsta	344 Nov  6  2020 log4j2.xml
drwxr-xr-x    2 localsta localsta      4096 May 28  2020 third_party_licenses
```

To avoid the file permission error mentioned above, it is necessary for Openshift users to 
maintain a separate localstack image with modified file permissions.  

For example, I can successfully deploy localstack to my Openshift namespace using the following Dockerfile:
```
FROM docker.io/localstack/localstack:latest

RUN chgrp -R 0 /opt/code/localstack/localstack && \
    chmod -R g=u /opt/code/localstack/localstack

ENTRYPOINT ["docker-entrypoint.sh"]
```
I'm requesting to make the same file permissions modifications (those which allow me to run localstack in Openshift) in the official localstack image.

[1] https://docs.openshift.com/container-platform/4.10/openshift_images/create-images.html