### PR TITLE
fix mock integration invocations

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -695,16 +695,18 @@ def import_api_from_openapi_spec(
             integration = apigateway_models.Integration(
                 http_method=method,
                 uri=method_integration.get("uri"),
-                integration_type=method_integration["type"],
+                integration_type=method_integration.get("type"),
                 passthrough_behavior=method_integration.get("passthroughBehavior"),
                 request_templates=method_integration.get("requestTemplates") or {},
             )
             integration.create_integration_response(
-                status_code=method_integration.get("default", {}).get("statusCode", 200),
+                status_code=method_integration.get("responses", {})
+                .get("default", {})
+                .get("statusCode", 200),
                 selection_pattern=None,
-                response_templates=method_integration.get("default", {}).get(
-                    "responseTemplates", None
-                ),
+                response_templates=method_integration.get("responses", {})
+                .get("default", {})
+                .get("responseTemplates", None),
                 content_handling=None,
             )
             resource.resource_methods[method]["methodIntegration"] = integration

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -2,11 +2,15 @@ import base64
 import json
 import logging
 from abc import ABC
+from enum import Enum
+from http import HTTPStatus
 from typing import Any, Dict
 from urllib.parse import quote_plus, unquote_plus
 
+from requests import Response
+
 from localstack import config
-from localstack.constants import APPLICATION_JSON
+from localstack.constants import APPLICATION_JSON, HEADER_CONTENT_TYPE
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
@@ -17,8 +21,85 @@ from localstack.utils.numbers import is_number, to_number
 LOG = logging.getLogger(__name__)
 
 
+class PassthroughBehavior(Enum):
+    WHEN_NO_MATCH = "WHEN_NO_MATCH"
+    WHEN_NO_TEMPLATES = "WHEN_NO_TEMPLATES"
+    NEVER = "NEVER"
+
+
+class MappingTemplates:
+    """
+    API Gateway uses mapping templates to transform incoming requests before they are sent to the
+    integration back end. With API Gateway, you can define one mapping template for each possible
+    content type. The content type selection is based on the Content-Type header of the incoming
+    request. If no content type is specified in the request, API Gateway uses an application/json
+    mapping template. By default, mapping templates are configured to simply pass through the
+    request input. Mapping templates use Apache Velocity to generate a request to your back end.
+    """
+
+    passthrough_behavior: PassthroughBehavior
+
+    class UnsupportedMediaType(Exception):
+        pass
+
+    def __init__(self, passthrough_behaviour: str):
+        self.passthrough_behavior = self.passthrough_behavior(passthrough_behaviour)
+
+    def request_body_passthrough(self, request_template):
+        """
+        Specifies how the method request body of an unmapped content type will be passed through
+        the integration request to the back end without transformation.
+        A content type is unmapped if no mapping template is defined in the integration or the
+        content type does not match any of the mapped content types, as specified in requestTemplates
+        """
+        if not request_template and self.passthrough_behavior in {
+            PassthroughBehavior.NEVER,
+            PassthroughBehavior.WHEN_NO_TEMPLATES,
+        }:
+            raise MappingTemplates.UnsupportedMediaType()
+
+    @staticmethod
+    def passthrough_behavior(passthrough_behaviour: str):
+        return getattr(PassthroughBehavior, passthrough_behaviour, None)
+
+
 class BackendIntegration(ABC):
     """Abstract base class representing a backend integration"""
+
+    def __init__(self):
+        self.request_templates = RequestTemplates()
+        self.response_templates = ResponseTemplates()
+
+    @classmethod
+    def _create_response(cls, status_code, headers, data=""):
+        response = Response()
+        response.status_code = status_code
+        response.headers = headers
+        response._content = data
+        return response
+
+    @classmethod
+    def apply_response_parameters(
+        cls, invocation_context: ApiInvocationContext, response: Response
+    ):
+        integration = invocation_context.integration
+        integration_responses = integration.get("integrationResponses") or {}
+        if not integration_responses:
+            return response
+        entries = list(integration_responses.keys())
+        return_code = str(response.status_code)
+        if return_code not in entries:
+            if len(entries) > 1:
+                LOG.info("Found multiple integration response status codes: %s", entries)
+                return response
+            return_code = entries[0]
+        response_params = integration_responses[return_code].get("responseParameters", {})
+        for key, value in response_params.items():
+            # TODO: add support for method.response.body, etc ...
+            if str(key).lower().startswith("method.response.header."):
+                header_name = key[len("method.response.header.") :]
+                response.headers[header_name] = value.strip("'")
+        return response
 
 
 class SnsIntegration(BackendIntegration):
@@ -40,6 +121,59 @@ class SnsIntegration(BackendIntegration):
         return make_http_request(
             config.service_url("sns"), method="POST", headers=headers, data=payload
         )
+
+
+class MockIntegration(BackendIntegration):
+    @classmethod
+    def evaluate_passthrough_behavior(cls, passthrough_behavior: str, request_template: str):
+        return MappingTemplates(passthrough_behavior).request_body_passthrough(request_template)
+
+    def invoke(self, invocation_context: ApiInvocationContext):
+        passthrough_behavior = invocation_context.integration.get("passthroughBehavior") or ""
+        request_template = invocation_context.integration.get("requestTemplates", {}).get(
+            invocation_context.headers.get(HEADER_CONTENT_TYPE)
+        )
+
+        # based on the configured passthrough behavior and the existence of template or not,
+        # we proceed calling the integration or raise an exception.
+        try:
+            self.evaluate_passthrough_behavior(passthrough_behavior, request_template)
+        except MappingTemplates.UnsupportedMediaType:
+            http_status = HTTPStatus(415)
+            return MockIntegration._create_response(
+                http_status.value,
+                headers={"Content-Type": APPLICATION_JSON},
+                data=json.dumps({"message": f"{http_status.phrase}"}),
+            )
+
+        # request template rendering
+        request_payload = self.request_templates.render(invocation_context)
+
+        # mapping is done based on "statusCode" field
+        status_code = 200
+        if invocation_context.headers.get(HEADER_CONTENT_TYPE) == APPLICATION_JSON:
+            try:
+                mock_response = json.loads(request_payload)
+                status_code = mock_response.get("statusCode", status_code)
+            except Exception as e:
+                LOG.warning("failed to deserialize request payload after transformation: %s", e)
+                http_status = HTTPStatus(500)
+                return MockIntegration._create_response(
+                    http_status.value,
+                    headers={"Content-Type": APPLICATION_JSON},
+                    data=json.dumps({"message": f"{http_status.phrase}"}),
+                )
+
+        # response template
+        response = MockIntegration._create_response(
+            status_code, invocation_context.headers, data=request_payload
+        )
+        response._content = self.response_templates.render(invocation_context, response=response)
+        # apply response parameters
+        response = self.apply_response_parameters(invocation_context, response)
+        if not invocation_context.headers.get(HEADER_CONTENT_TYPE):
+            invocation_context.headers.update({HEADER_CONTENT_TYPE: APPLICATION_JSON})
+        return response
 
 
 class VelocityUtilApiGateway(VelocityUtil):
@@ -196,24 +330,28 @@ class ResponseTemplates(Templates):
     Handles response template rendering
     """
 
-    def render(self, api_context: ApiInvocationContext):
-        response = api_context.response
+    def render(self, api_context: ApiInvocationContext, **kwargs):
+        # XXX: keep backwards compatibility until we migrate all integrations to this new classes
+        # api_context contains a response object that we want slowly remove from it
+        data = kwargs["response"] if "response" in kwargs else ""
+        response = data or api_context.response
         integration = api_context.integration
         # we set context data with the response content because later on we use context data as
         # the body field in the template. We need to improve this by using the right source
         # depending on the type of templates.
         api_context.data = response._content
-        int_responses = integration.get("integrationResponses") or {}
-        if not int_responses:
+
+        integration_responses = integration.get("integrationResponses") or {}
+        if not integration_responses:
             return response._content
-        entries = list(int_responses.keys())
+        entries = list(integration_responses.keys())
         return_code = str(response.status_code)
         if return_code not in entries and len(entries) > 1:
             LOG.info("Found multiple integration response status codes: %s", entries)
             return response._content
         return_code = entries[0]
 
-        response_templates = int_responses[return_code].get("responseTemplates", {})
+        response_templates = integration_responses[return_code].get("responseTemplates", {})
         template = response_templates.get(APPLICATION_JSON, {})
         if not template:
             return response

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -354,7 +354,7 @@ class ResponseTemplates(Templates):
         response_templates = integration_responses[return_code].get("responseTemplates", {})
         template = response_templates.get(APPLICATION_JSON, {})
         if not template:
-            return response
+            return response._content
 
         variables = self.build_variables_mapping(api_context)
         response._content = self.render_vtl(template, variables=variables)

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -25,6 +25,7 @@ from localstack.services.apigateway.helpers import (
     make_error_response,
 )
 from localstack.services.apigateway.integration import (
+    MockIntegration,
     RequestTemplates,
     ResponseTemplates,
     SnsIntegration,
@@ -653,15 +654,8 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
         return invocation_context.response
 
     elif integration_type == "MOCK":
-
-        # TODO: apply tell don't ask principle inside ResponseTemplates or InvocationContext
-        invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
-        invocation_context.response = requests_response({})
-
-        response_templates = ResponseTemplates()
-        response_templates.render(invocation_context)
-
-        return invocation_context.response
+        mock_integration = MockIntegration()
+        return mock_integration.invoke(invocation_context)
 
     if method == "OPTIONS":
         # fall back to returning CORS headers if this is an OPTIONS request

--- a/tests/integration/files/openapi-mock.json
+++ b/tests/integration/files/openapi-mock.json
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "wait-for-seconds",
+    "description": "Test API for asynchronous Lambda invocation",
+    "version": "2022-04-12T15:36:55Z"
+  },
+  "paths": {
+    "/echo/{data}": {
+      "x-amazon-apigateway-any-method": {
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseTemplates": {
+                "application/json": "{\"echo\": \"$input.params('data')\", \"response\": \"mocked\"}"
+              }
+            }
+          },
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200}"
+          },
+          "passthroughBehavior": "when_no_templates"
+        }
+      }
+    },
+    "/wait/{seconds}": {
+      "x-amazon-apigateway-any-method": {
+        "parameters": [
+          {
+            "name": "seconds",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Empty"
+                }
+              }
+            }
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "aws",
+          "httpMethod": "POST",
+          "uri": "${lambda_invocation_arn}",
+          "responses": {
+            "default": {
+              "statusCode": "200"
+            }
+          },
+          "requestParameters": {
+            "integration.request.header.X-Amz-Invocation-Type": "'Event'"
+          },
+          "requestTemplates": {
+            "application/json": "#set($allParams = $input.params())\n{\n  \"params\" : {\n    #foreach($type in $allParams.keySet())\n      #set($params = $allParams.get($type))\n      \"$type\" : {\n        #foreach($paramName in $params.keySet())\n          \"$paramName\" : \"$util.escapeJavaScript($params.get($paramName))\"\n          #if($foreach.hasNext),#end\n        #end\n      }\n      #if($foreach.hasNext),#end\n    #end\n  }\n}\n"
+          },
+          "passthroughBehavior": "when_no_templates",
+          "contentHandling": "CONVERT_TO_TEXT"
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Empty": {
+        "title": "Empty Schema",
+        "type": "object"
+      }
+    }
+  }
+}

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -69,6 +69,7 @@ TEST_SWAGGER_FILE_JSON = os.path.join(THIS_FOLDER, "files", "swagger.json")
 TEST_SWAGGER_FILE_YAML = os.path.join(THIS_FOLDER, "files", "swagger.yaml")
 TEST_IMPORT_REST_API_FILE = os.path.join(THIS_FOLDER, "files", "pets.json")
 TEST_IMPORT_PETSTORE_SWAGGER = os.path.join(THIS_FOLDER, "files", "petstore-swagger.json")
+TEST_IMPORT_MOCK_INTEGRATION = os.path.join(THIS_FOLDER, "files", "openapi-mock.json")
 
 ApiGatewayLambdaProxyIntegrationTestResult = namedtuple(
     "ApiGatewayLambdaProxyIntegrationTestResult",
@@ -153,7 +154,7 @@ class TestAPIGateway:
 
     def test_create_rest_api_with_custom_id(self):
         client = aws_stack.create_external_boto_client("apigateway")
-        apigw_name = "gw-%s" % short_uid()
+        apigw_name = f"gw-{short_uid()}"
         test_id = "testId123"
         result = client.create_rest_api(name=apigw_name, tags={TAG_KEY_CUSTOM_ID: test_id})
         assert test_id == result["id"]
@@ -251,7 +252,7 @@ class TestAPIGateway:
 
     def test_api_gateway_sqs_integration(self):
         # create target SQS stream
-        queue_name = "queue-%s" % short_uid()
+        queue_name = f"queue-{short_uid()}"
         aws_stack.create_sqs_queue(queue_name)
 
         # create API Gateway and connect it to the target queue
@@ -489,6 +490,17 @@ class TestAPIGateway:
             self.TEST_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM,
             self.API_PATH_LAMBDA_PROXY_BACKEND_ANY_METHOD_WITH_PATH_PARAM,
         )
+
+    def test_api_gateway_mock_integration(self, apigateway_client):
+        rest_api_name = f"apigw-{short_uid()}"
+        rest_api_id = apigateway_client.create_rest_api(name=rest_api_name)["id"]
+
+        spec_file = load_file(TEST_IMPORT_MOCK_INTEGRATION)
+        apigateway_client.put_rest_api(restApiId=rest_api_id, body=spec_file, mode="overwrite")
+
+        url = path_based_url(api_id=rest_api_id, stage_name="latest", path="/echo/foobar")
+        response = requests.get(url)
+        assert response._content == b'{"echo": "foobar", "response": "mocked"}'
 
     def test_api_gateway_authorizer_crud(self):
         apig = aws_stack.create_external_boto_client("apigateway")

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1461,8 +1461,6 @@ class TestAPIGateway:
             s3_client.delete_bucket(Bucket=bucket_name)
 
     def test_api_mock_integration_response_params(self):
-        # apigw_client = aws_stack.create_external_boto_client('apigateway')
-
         resps = [
             {
                 "statusCode": "204",


### PR DESCRIPTION
This PR makes sure the import API includes the response templates and extracts the MOCK Integration into his own class.


Fixes the use case described [here](https://github.com/nulib/localstack-api-gateway) for the MOCK backend integration.