### PR TITLE
fix ASF integration of to_invocation_context

### DIFF
--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -27,6 +27,9 @@ def to_invocation_context(
     :param url_params: the parameters extracted from the URL matching rules
     :return: the ApiInvocationContext
     """
+    if url_params is None:
+        url_params = {}
+
     method = request.method
     path = request.full_path if request.query_string else request.path
     data = restore_payload(request)
@@ -39,7 +42,9 @@ def to_invocation_context(
     headers["X-Forwarded-For"] = ", ".join(x_forwarded_for)
 
     # this is for compatibility with the lower layers of apigw and lambda that make assumptions about header casing
-    headers = CaseInsensitiveDict({k: ", ".join(headers.getlist(k)) for k in headers.keys()})
+    headers = CaseInsensitiveDict(
+        {k.title(): ", ".join(headers.getlist(k)) for k in headers.keys()}
+    )
 
     # FIXME: Use the already parsed url params instead of parsing them into the ApiInvocationContext part-by-part.
     #   We already would have all params at hand to avoid _all_ the parsing, but the parsing


### PR DESCRIPTION
This PR fixes two regressions in the ASF apigateway provider that were (probably) introduced by #6267

* One relates to header casing (the casing is expected to be title-cased, but is then transformed again via `canonicalize_api_names` for lambda calls)
* One protects `invoke_rest_api` from a null pointer