### PR TITLE
fix access key id auth header extraction for different signature versions

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -552,12 +552,20 @@ def extract_region_from_auth_header(headers: Dict[str, str], use_default=True) -
     return region
 
 
-def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> str:
+def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[str]:
     auth = headers.get("Authorization") or ""
-    access_id = re.sub(r".*Credential=([^/]+)/[^/]+/[^/]+/.*", r"\1", auth)
-    if access_id == auth:
-        access_id = None
-    return access_id
+
+    if auth.startswith("AWS4-"):
+        # For Signature Version 4
+        access_id = re.findall(r".*Credential=([^/]+)/[^/]+/[^/]+/.*", auth)
+        if len(access_id):
+            return access_id[0]
+
+    elif auth.startswith("AWS "):
+        # For Signature Version 2
+        access_id = auth.removeprefix("AWS ").split(":")
+        if len(access_id):
+            return access_id[0]
 
 
 # TODO: extract ARN utils into separate file!

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -3,8 +3,8 @@ import json
 import pytest
 import requests
 from botocore.exceptions import ClientError
-from moto.core import ACCOUNT_ID
 
+from localstack.aws.accounts import get_aws_account_id
 from localstack.services.apigateway.helpers import path_based_url
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
@@ -469,7 +469,7 @@ def test_put_integration_validation(apigateway_client):
             restApiId=api_id,
             resourceId=root_id,
             credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
-                ACCOUNT_ID
+                get_aws_account_id()
             ),
             httpMethod="GET",
             type=_type,
@@ -494,7 +494,7 @@ def test_put_integration_validation(apigateway_client):
                 restApiId=api_id,
                 resourceId=root_id,
                 credentials="arn:aws:iam::{}:role/service-role/testfunction-role-oe783psq".format(
-                    ACCOUNT_ID
+                    get_aws_account_id()
                 ),
                 httpMethod="GET",
                 type=_type,


### PR DESCRIPTION
This PR fixes following failing tests in `v1` branch:

```
FAILED tests/integration/test_s3.py::TestS3::test_presigned_url_signature_authentication
FAILED tests/integration/test_s3.py::TestS3::test_presigned_url_signature_authentication_virtual_host_addressing
FAILED tests/integration/test_apigateway_api.py::test_put_integration_validation
```