### PR TITLE
Add HEALTHCHECK to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -261,5 +261,7 @@ ENV LOCALSTACK_BUILD_VERSION=${LOCALSTACK_BUILD_VERSION}
 # expose edge service, external service ports, and debugpy
 EXPOSE 4566 4510-4559 5678
 
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD curl --fail http://localhost:4566/health || exit 1
+
 # define command at startup
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -58,5 +58,7 @@ ENV LOCALSTACK_BUILD_GIT_HASH=${LOCALSTACK_BUILD_GIT_HASH}
 # expose ports
 EXPOSE 4510-4559 4566
 
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD curl --fail http://localhost:4566/health || exit 1
+
 # define command at startup
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
Hi!

Thanks for the useful software! After using localstack in a docker-compose project I thought it might be beneficial for a container health-check to be supported directly by the [localstack/localstack](https://hub.docker.com/r/localstack/localstack/#!) container. As it would be hard to provide tests for something like this I provided a screenshot of `docker ps` with these changes in my local environment.

![image](https://user-images.githubusercontent.com/771345/174446367-e169e48e-853a-46c0-86b0-1a13e70a9b60.png)

> Note: To get this branch working in your own local environment you'll need to either build and run the Docker container directly or update the `docker-compose.yml` file to build from the local Dockerfile and not pull an image from Dockerhub.

I'm assuming there's some build process in the localstack CI/CD that will generate the appropriate container image and push it to Dockerhub. If there are additional changes necessary for this I'll be more than happy to implement them with some guidance.

Thanks for considering my PR!

_Commit message below_
---

Adds a healthcheck to Dockerfile and Dockerfile.rh. Using curl it will
ping the /health endpoint every 10s, starting 15s after the container
has started running. If the /health endpoint returns any failure
response the container will be marked unhealthy.

There are 2 primary motivations for adding this directly to the Dockerfile:

1. Potentially less boilerplate in docker-compose.yml files that make use of
   localstack.
2. Docker container health status is no longer reliant on docker-compose
   to determine. If you're running just the localstack container
   you'll still be able to get access to the health.

**Please refer to the contribution guidelines in the README when submitting PRs.**
