### PR TITLE
Disable parameter_validation for external clients

### DIFF
--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -380,13 +380,19 @@ def create_external_boto_client(
     *args,
     **kwargs,
 ):
+    disabled_validation = botocore.config.Config(parameter_validation=False)
+    if config is None:
+        config = disabled_validation
+    else:
+        config = config.merge(disabled_validation)
+
     return connect_to_service(
         service_name,
         client,
         env,
         region_name,
         endpoint_url,
-        config.merge(botocore.config.Config(parameter_validation=False)),
+        config,
         verify,
         cache,
         aws_access_key_id="__test_call__",

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -386,7 +386,7 @@ def create_external_boto_client(
         env,
         region_name,
         endpoint_url,
-        config,
+        config.merge(botocore.config.Config(parameter_validation=False)),
         verify,
         cache,
         aws_access_key_id="__test_call__",


### PR DESCRIPTION
We're testing here how disabling parameter validation in boto affects the current test suite