### PR TITLE
Add simple hashable dict util class

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -43,13 +43,25 @@ class DelSafeDict(dict):
 
 
 class HashableList(list):
-    """Hashable list class that can be used with dicts or hashsets."""
+    """Hashable list class that can be used with dicts or hash sets."""
 
     def __hash__(self):
         result = 0
         for i in self:
             result += hash(i)
         return result
+
+
+class HashableJsonDict(dict):
+    """
+    Simple dict wrapper that can be used with dicts or hash sets. Note: the assumption is that the dict
+    can be JSON-encoded (i.e., must be acyclic and contain only lists/dicts and simple types)
+    """
+
+    def __hash__(self):
+        from localstack.utils.json import canonical_json
+
+        return hash(canonical_json(self))
 
 
 _ListType = TypeVar("_ListType")

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,6 +1,6 @@
 from typing import Optional, TypedDict
 
-from localstack.utils.collections import select_from_typed_dict
+from localstack.utils.collections import HashableJsonDict, HashableList, select_from_typed_dict
 
 
 class MyTypeDict(TypedDict):
@@ -18,3 +18,29 @@ def test_select_from_typed_dict():
     del d["key_one"]
     result = select_from_typed_dict(typed_dict=MyTypeDict, obj=d)
     assert result == {"key_optional": "key_optional"}
+
+
+def test_hashable_dict():
+    d1 = HashableJsonDict({"a": ["b"], "c": 1})
+    d2 = HashableJsonDict({"a": "b"})
+    d3 = HashableJsonDict({"c": 1, "a": ["b"]})
+    d4 = HashableJsonDict({})
+
+    assert len({d1, d2, d3}) == 2
+    assert {d1, d2, d3} == {d1, d2} == {d2, d3}
+    assert {d1, d3} == {d3, d1}
+    assert {d1, d1} == {d3, d3}
+    assert {d1, d2, d3} != {d1}
+    assert {d1, d2, d3} != {d2}
+    assert {d1, d2, d3} != {d1, d3}
+    assert {d4, d4} == {d4}
+
+
+def test_hashable_list():
+    l1 = HashableList([1, 2])
+    l2 = HashableList([1, 2])
+    l3 = HashableList([1, 2, 3])
+
+    assert {l1, l2} == {l1} == {l2, l2}
+    assert {l1, l3} == {l2, l3}
+    assert {l1, l2} != {l3}


### PR DESCRIPTION
Add simple hashable dict util class `HashableJsonDict`. This can be useful for adding dicts to, e.g., hash sets. It implements the `__hash__` function by computing the canonical JSON (which is unique and deterministic for JSON structures). Hence, this utility also only works for dicts that can be JSON encoded (as the name implies).