### PR TITLE
Make hashable list/dict util classes immutable

### DIFF
--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,6 +1,14 @@
 from typing import Optional, TypedDict
 
-from localstack.utils.collections import HashableJsonDict, HashableList, select_from_typed_dict
+import pytest
+
+from localstack.utils.collections import (
+    HashableJsonDict,
+    HashableList,
+    ImmutableDict,
+    ImmutableList,
+    select_from_typed_dict,
+)
 
 
 class MyTypeDict(TypedDict):
@@ -20,6 +28,23 @@ def test_select_from_typed_dict():
     assert result == {"key_optional": "key_optional"}
 
 
+def test_immutable_dict():
+    d1 = ImmutableDict({"a": ["b"], "c": 1})
+
+    assert dict(d1) == {"a": ["b"], "c": 1}
+    assert {k for k in d1} == {"a", "c"}
+    assert d1["a"] == ["b"]
+    assert d1["c"] == 1
+    assert len(d1) == 2
+
+    assert "a" in d1
+    assert "z" not in d1
+
+    with pytest.raises(Exception) as exc:
+        d1["foo"] = "bar"
+    exc.match("does not support item assignment")
+
+
 def test_hashable_dict():
     d1 = HashableJsonDict({"a": ["b"], "c": 1})
     d2 = HashableJsonDict({"a": "b"})
@@ -35,6 +60,33 @@ def test_hashable_dict():
     assert {d1, d2, d3} != {d1, d3}
     assert {d4, d4} == {d4}
 
+    with pytest.raises(Exception) as exc:
+        d1["foo"] = "bar"
+    exc.match("does not support item assignment")
+
+
+def test_immutable_list():
+    l1 = ImmutableList([1, 2, 3])
+
+    assert list(l1) == [1, 2, 3]
+    assert l1[0] == 1
+    assert l1[1] == 2
+    assert list(l1) == [1, 2, 3]
+    assert len(l1) == 3
+
+    assert 2 in l1
+    assert 99 not in l1
+    assert l1.count(1) == 1
+    assert l1.count(99) == 0
+    assert l1.index(2) == 1
+    assert list(reversed(l1)) == [3, 2, 1]
+
+    with pytest.raises(Exception) as exc:
+        l1[0] = "foo"
+    exc.match("does not support item assignment")
+    with pytest.raises(Exception) as exc:
+        l1.append("foo")
+
 
 def test_hashable_list():
     l1 = HashableList([1, 2])
@@ -44,3 +96,7 @@ def test_hashable_list():
     assert {l1, l2} == {l1} == {l2, l2}
     assert {l1, l3} == {l2, l3}
     assert {l1, l2} != {l3}
+
+    with pytest.raises(Exception) as exc:
+        l1[0] = "foo"
+    exc.match("does not support item assignment")


### PR DESCRIPTION
Make hashable list/dict utility classes immutable. This is a great point raised by @dfangl - we should ensure that the hashable collections represent a frozen/immutable copy and cannot be modified under the covers, to avoid unexpected side effects further down the line. 👍 