### PR TITLE
Option for persistence path to stepfunctions

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -79,7 +79,7 @@ MARKER_FILE_LIGHT_VERSION = f"{dirs.static_libs}/.light-version"
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local:1.7.9"
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 SFN_PATCH_URL_PREFIX = (
-    f"{ARTIFACTS_REPO}/raw/2958554c8aeadff0e8f5d0e35f6e520d834854ea/stepfunctions-local-patch"
+    f"{ARTIFACTS_REPO}/raw/d644316ba05675709e20644688ada0413d9e9941/stepfunctions-local-patch"
 )
 SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
 SFN_PATCH_CLASS2 = (

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from localstack import config
 from localstack.constants import TEST_AWS_ACCOUNT_ID
@@ -64,7 +65,7 @@ def get_command(backend_port):
     return cmd
 
 
-def start_stepfunctions(asynchronous=True):
+def start_stepfunctions(asynchronous=True, persistence_path: Optional[str] = None):
     # TODO: introduce Server abstraction for StepFunctions process
     global PROCESS_THREAD
     backend_port = config.LOCAL_PORT_STEPFUNCTIONS
@@ -79,7 +80,7 @@ def start_stepfunctions(asynchronous=True):
         env_vars={
             "EDGE_PORT": config.EDGE_PORT_HTTP or config.EDGE_PORT,
             "EDGE_PORT_HTTP": config.EDGE_PORT_HTTP or config.EDGE_PORT,
-            "DATA_DIR": config.DATA_DIR,
+            "DATA_DIR": persistence_path or config.DATA_DIR,
         },
     )
     return PROCESS_THREAD
@@ -107,9 +108,9 @@ def check_stepfunctions(expect_shutdown=False, print_error=False):
         assert out and isinstance(out.get("stateMachines"), list)
 
 
-def restart_stepfunctions():
+def restart_stepfunctions(persistence_path: Optional[str] = None):
     if not PROCESS_THREAD:
         return
     LOG.debug("Restarting StepFunctions process ...")
     PROCESS_THREAD.stop()
-    start_stepfunctions(asynchronous=True)
+    start_stepfunctions(persistence_path=persistence_path)

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -106,22 +106,3 @@ def check_stepfunctions(expect_shutdown=False, print_error=False):
         assert out is None
     else:
         assert out and isinstance(out.get("stateMachines"), list)
-
-
-def restart_stepfunctions(persistence_path: Optional[str] = None):
-    if not PROCESS_THREAD or not PROCESS_THREAD.process:
-        return
-    LOG.debug("Restarting StepFunctions process ...")
-    pid = PROCESS_THREAD.process.pid
-    PROCESS_THREAD.stop()
-    _wait_for_process_to_be_killed(pid)
-    start_stepfunctions(persistence_path=persistence_path)
-
-
-def _wait_for_process_to_be_killed(pid):
-    import psutil
-
-    def _check_pid():
-        assert not psutil.pid_exists(pid)
-
-    retry(_check_pid, sleep=0.3, retries=10)

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -16,6 +16,7 @@ from localstack import config
 # TODO: remove imports from here (need to update any client code that imports these from utils.common)
 from localstack.utils.platform import is_linux, is_mac_os, is_windows  # noqa
 
+from .sync import retry
 from .threads import FuncThread, start_worker_thread
 
 LOG = logging.getLogger(__name__)
@@ -170,6 +171,15 @@ def kill_process_tree(parent_pid):
         except Exception:
             pass
     parent.kill()
+
+
+def wait_for_process_to_be_killed(pid: int, sleep: float = None, retries: int = None):
+    import psutil
+
+    def _check_pid():
+        assert not psutil.pid_exists(pid)
+
+    retry(_check_pid, sleep=sleep, retries=retries)
 
 
 def is_root() -> bool:


### PR DESCRIPTION
This small PR:
- adds the possibility to pass a custom persistence directory for stepfunctions (needed by Cloud Pods when `DATA_DIR` is not set);
- slightly check for killing the pid.