### PR TITLE
fix crypto unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu-amd64-machine-image:
     type: string
-    default: "ubuntu-2204:2022.04.2"
+    default: "ubuntu-2004:2022.04.1"
   ubuntu-arm64-machine-image:
     type: string
-    default: "ubuntu-2004:2022.04.2"
+    default: "ubuntu-2004:2022.04.1"
 
 executors:
   ubuntu-machine-amd64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   ubuntu-amd64-machine-image:
     type: string
-    default: "ubuntu-2004:2022.04.1"
+    default: "ubuntu-2204:2022.04.2"
   ubuntu-arm64-machine-image:
     type: string
-    default: "ubuntu-2004:2022.04.1"
+    default: "ubuntu-2004:2022.04.2"
 
 executors:
   ubuntu-machine-amd64:

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,8 @@ runtime =
     botocore>=1.12.13
     cbor2>=5.2.0
     crontab>=0.22.6
-    cryptography
+    # TODO remove the pin as soon as the unit tests on circle ci work again
+    cryptography==37.0.2
     docker==5.0.0
     flask>=1.0.2
     flask-cors>=3.0.3,<3.1.0

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -151,7 +151,11 @@ def _generate_test_name(param: Any):
     _collect_operations(),
     ids=_generate_test_name,
 )
-def test_service_router_works_for_every_service(service: ServiceModel, operation: OperationModel):
+def test_service_router_works_for_every_service(
+    service: ServiceModel, operation: OperationModel, caplog
+):
+    caplog.set_level("CRITICAL", "botocore")
+
     # Create a dummy request for the service router
     client = _client(service.service_name)
     request_context = {


### PR DESCRIPTION
The latest version of cryptography ([37.0.3](https://pypi.org/project/cryptography/37.0.3/)) causes issues in our CircleCI environment.

This PR is an attempt to fix these issues pinning the version of cryptography to the previous version (`37.0.2`).
In addition it also limits the log output of the service router unit tests introduced in https://github.com/localstack/localstack/pull/6311.