### PR TITLE
add rds docdb and neptune to the list of known API conflicts

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -234,6 +234,8 @@ def resolve_conflicts(candidates: Set[str], request: Request):
     """
     if candidates == {"timestream-query", "timestream-write"}:
         return "timestream-query"
+    if candidates == {"docdb", "neptune", "rds"}:
+        return "rds"
 
 
 def determine_aws_service_name(
@@ -288,8 +290,8 @@ def determine_aws_service_name(
     if len(candidates) == 1:
         return candidates.pop()
 
-    # 3. check the path
-    if path:
+    # 3. check the path if it is set and not a trivial root path
+    if path and path != "/":
         # iterate over the service spec's endpoint prefix
         for prefix, services_per_prefix in services.endpoint_prefix_index.items():
             if path.startswith(prefix):

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -65,8 +65,8 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
                 )
             # Exclude services / operations which have ambiguities and where the service routing needs to resolve those
             elif (
-                service.service_name in ["rds", "docdb", "neptune"]
-                or service.service_name in "timestream-write"
+                service.service_name in ["docdb", "neptune"]  # maps to rds
+                or service.service_name in "timestream-write"  # maps to timestream-query
                 or (
                     service.service_name == "sesv2"
                     and operation_name == "PutEmailIdentityDkimSigningAttributes"


### PR DESCRIPTION
This PR adds RDS routing to the community version of the service name parser using the same mechanism introduced in #6311 

I also added a small optimization to avoid checking custom endpoint path rules if the path is `/` (for which there aren't any custom path rules). while doing that, i saw that the code in block 3. is actually nonsense, specifically the `if path.startswith(endpointPrefix)`, since the endpointPrefix pertains to the host, not the path. i'll do that in a follow-up PR.