### PR TITLE
fix aws service router to match endpointPrefixes on the host

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -292,13 +292,6 @@ def determine_aws_service_name(
 
     # 3. check the path if it is set and not a trivial root path
     if path and path != "/":
-        # iterate over the service spec's endpoint prefix
-        for prefix, services_per_prefix in services.endpoint_prefix_index.items():
-            if path.startswith(prefix):
-                if len(services_per_prefix) == 1:
-                    return services_per_prefix[0]
-                candidates.update(services_per_prefix)
-
         # try to find a match with the custom path rules
         custom_path_match = custom_path_addressing_rules(path)
         if custom_path_match:
@@ -306,6 +299,13 @@ def determine_aws_service_name(
 
     # 4. check the host (custom host addressing rules)
     if host:
+        # iterate over the service spec's endpoint prefix
+        for prefix, services_per_prefix in services.endpoint_prefix_index.items():
+            if host.startswith(prefix):
+                if len(services_per_prefix) == 1:
+                    return services_per_prefix[0]
+                candidates.update(services_per_prefix)
+
         custom_host_match = custom_host_addressing_rules(host)
         if custom_host_match:
             return custom_host_match

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -175,3 +175,20 @@ def test_service_router_works_for_every_service(
 
     # Make sure the detected service is the same as the one we generated the request for
     assert service.service_name == detected_service_name
+
+
+def test_endpoint_prefix_based_routing():
+    # TODO could be generalized using endpoint resolvers and replacing "amazonaws.com" with "localhost.localstack.cloud"
+    detected_service_name = determine_aws_service_name(
+        Request(method="GET", path="/", headers={"Host": "sqs.localhost.localstack.cloud"})
+    )
+    assert detected_service_name == "sqs"
+
+    detected_service_name = determine_aws_service_name(
+        Request(
+            method="POST",
+            path="/app-instances",
+            headers={"Host": "identity-chime.localhost.localstack.cloud"},
+        )
+    )
+    assert detected_service_name == "chime"

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -191,4 +191,4 @@ def test_endpoint_prefix_based_routing():
             headers={"Host": "identity-chime.localhost.localstack.cloud"},
         )
     )
-    assert detected_service_name == "chime"
+    assert detected_service_name == "chime-sdk-identity"


### PR DESCRIPTION
This PR fixes an error in the service router that has not surfaced yet because we don't use the feature. it relates to matching services based on the endpointPrefix described in the spec, which is part of the host, and not the path how it was implemented.

I added a small test that we can extend in a future iteration when the feature is used.

This actually gives us a way to disambiguate services like chime, where we can tell the user to set `awslocal --endpoint-url http://identity-chime.localhost.localstack.cloud` if they want to use the service.