### PR TITLE
Default access key for legacy gateway

### DIFF
--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -11,6 +11,7 @@ from localstack.aws.accounts import get_account_id_from_access_key_id, set_ctx_a
 from localstack.aws.api import RequestContext
 from localstack.aws.skeleton import Skeleton
 from localstack.aws.spec import load_service
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Request, Response
 from localstack.http.adapters import ProxyListenerAdapter
 from localstack.services.generic_proxy import ProxyListener
@@ -46,7 +47,9 @@ class AwsApiListener(ProxyListenerAdapter):
         return context
 
     def get_account_id_from_request(self, request: Request) -> str:
-        access_key_id = extract_access_key_id_from_auth_header(request.headers)
+        access_key_id = (
+            extract_access_key_id_from_auth_header(request.headers) or TEST_AWS_ACCESS_KEY_ID
+        )
         set_ctx_aws_access_key_id(access_key_id)
         return get_account_id_from_access_key_id(access_key_id)
 


### PR DESCRIPTION
Handles situations where the access key is not set in the request.

```
2022-06-22T13:57:36.536:ERROR:localstack.aws.handlers.logging: exception during call chain
Traceback (most recent call last):
  File "/opt/code/localstack/localstack/aws/chain.py", line 57, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/localstack/aws/handlers/service.py", line 120, in __call__
    handler(chain, context, response)
  File "/opt/code/localstack/localstack/aws/handlers/legacy.py", line 69, in __call__
    result = self.forward_request(
  File "/opt/code/localstack/localstack/aws/handlers/legacy.py", line 129, in forward_request
    return do_forward_request(
  File "/opt/code/localstack/localstack/utils/patch.py", line 38, in proxy
    return new(target, *args, **kwargs)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/localstack_ext/services/edge.py", line 156, in do_forward_request
    return fn(api, method, path, data, headers, *args, **kwargs)
  File "/opt/code/localstack/localstack/services/edge.py", line 225, in do_forward_request
    result = do_forward_request_inmem(api, method, path, data, headers, port=port)
  File "/opt/code/localstack/localstack/services/edge.py", line 249, in do_forward_request_inmem
    response = modify_and_forward(
  File "/opt/code/localstack/localstack/services/generic_proxy.py", line 589, in wrapper
    value = func(*args, **kwargs)
  File "/opt/code/localstack/localstack/services/generic_proxy.py", line 669, in modify_and_forward
    listener_result = listener.forward_request(
  File "/opt/code/localstack/localstack/http/adapters.py", line 51, in forward_request
    response = self.request(request)
  File "/opt/code/localstack/localstack/services/sts/provider.py", line 37, in request
    response = super().request(request)
  File "/opt/code/localstack/localstack/aws/proxy.py", line 37, in request
    context = self.create_request_context(request)
  File "/opt/code/localstack/localstack/aws/proxy.py", line 45, in create_request_context
    context.account_id = self.get_account_id_from_request(request)
  File "/opt/code/localstack/localstack/aws/proxy.py", line 51, in get_account_id_from_request
    return get_account_id_from_access_key_id(access_key_id)
  File "/opt/code/localstack/localstack/aws/accounts.py", line 30, in get_account_id_from_access_key_id
    if re.match(r"\d{12}", access_key_id):
  File "/usr/local/lib/python3.10/re.py", line 190, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```