### PR TITLE
Bump moto-ext to 3.1.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -84,7 +84,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=0.14.4.dev,<0.15
-    moto-ext[all]==3.1.10
+    moto-ext[all]==3.1.12
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl>=21.0.0


### PR DESCRIPTION
Bump moto-ext to 3.1.12 . This mini release contains a few cherry-picked commits that were contributed upstream by our team, and are required for some follow-up changes (e.g., https://github.com/localstack/localstack/pull/6277).

We're currently _not_ yet upgrading to latest upstream moto `master`, as there are still some conflicting changes with the recent multi-account rework.