### PR TITLE
Setting LS default user to root, support user permission boundary

### DIFF
--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -94,7 +94,7 @@ class RequestContext:
         return ServiceOperation(self.service.service_name, self.operation.name)
 
     def __repr__(self):
-        return f"<RequestContext {self.service=}, {self.operation=}, {self.region=}, {self.account_id=}, {self.request=}, {self.service_request=}>"
+        return f"<RequestContext {self.service=}, {self.operation=}, {self.region=}, {self.account_id=}, {self.request=}>"
 
 
 class ServiceRequestHandler(Protocol):

--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -93,6 +93,9 @@ class RequestContext:
             return None
         return ServiceOperation(self.service.service_name, self.operation.name)
 
+    def __repr__(self):
+        return f"<RequestContext {self.service=}, {self.operation=}, {self.region=}, {self.account_id=}, {self.request=}, {self.service_request=}>"
+
 
 class ServiceRequestHandler(Protocol):
     def __call__(

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -24,7 +24,7 @@ class ExceptionLogger(ExceptionHandler):
         response: Response,
     ):
         if isinstance(exception, ServiceException):
-            # We do not want to log an error/stacktrace if the handler is working as expected, but chooses to through
+            # We do not want to log an error/stacktrace if the handler is working as expected, but chooses to throw
             # a service exception
             return
         if self.logger.isEnabledFor(level=logging.DEBUG):

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -1,7 +1,7 @@
 """Handlers for logging."""
 import logging
 
-from localstack.aws.api import RequestContext
+from localstack.aws.api import RequestContext, ServiceException
 from localstack.aws.chain import ExceptionHandler, HandlerChain
 from localstack.http import Response
 
@@ -23,6 +23,10 @@ class ExceptionLogger(ExceptionHandler):
         context: RequestContext,
         response: Response,
     ):
+        if isinstance(exception, ServiceException):
+            # We do not want to log an error/stacktrace if the handler is working as expected, but chooses to through
+            # a service exception
+            return
         if self.logger.isEnabledFor(level=logging.DEBUG):
             self.logger.exception("exception during call chain", exc_info=exception)
         else:

--- a/localstack/aws/proxy.py
+++ b/localstack/aws/proxy.py
@@ -26,6 +26,14 @@ def get_region(request: Request) -> str:
     return extract_region_from_headers(request.headers)
 
 
+def get_account_id_from_request(request: Request) -> str:
+    access_key_id = (
+        extract_access_key_id_from_auth_header(request.headers) or TEST_AWS_ACCESS_KEY_ID
+    )
+    set_ctx_aws_access_key_id(access_key_id)
+    return get_account_id_from_access_key_id(access_key_id)
+
+
 class AwsApiListener(ProxyListenerAdapter):
     service: ServiceModel
 
@@ -42,15 +50,8 @@ class AwsApiListener(ProxyListenerAdapter):
         context.service = self.service
         context.request = request
         context.region = get_region(request)
-        context.account_id = self.get_account_id_from_request(request)
+        context.account_id = get_account_id_from_request(request)
         return context
-
-    def get_account_id_from_request(self, request: Request) -> str:
-        access_key_id = (
-            extract_access_key_id_from_auth_header(request.headers) or TEST_AWS_ACCESS_KEY_ID
-        )
-        set_ctx_aws_access_key_id(access_key_id)
-        return get_account_id_from_access_key_id(access_key_id)
 
 
 def _raise_not_implemented_error(*args, **kwargs):

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -150,8 +150,6 @@ class Skeleton:
                 )
                 raise NotImplementedError
 
-            self.is_request_allowed(context, instance)
-
             return self.dispatch_request(context, instance)
         except ServiceException as e:
             return self.on_service_exception(context, e)
@@ -211,16 +209,3 @@ class Skeleton:
         context.service_exception = error
 
         return serializer.serialize_error_to_response(error, operation)
-
-    # TODO naming
-    def is_request_allowed(self, context: RequestContext, service_request: ServiceRequest) -> None:
-        """
-        Called by invoke to determine if request is allowed (IAM permissions, etc).
-        :param context: the request context
-        :param service_request: the service request
-        """
-        # TODO this import is cancerous, just for getting it somehow into the code
-        from localstack_ext.services.iam.policy_engine import engine
-
-        # TODO add abc for engine, and add dependency injection
-        engine.ENGINE.is_request_allowed(context, service_request)

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -222,4 +222,5 @@ class Skeleton:
         # TODO this import is cancerous, just for getting it somehow into the code
         from localstack_ext.services.iam.policy_engine import engine
 
+        # TODO add abc for engine, and add dependency injection
         engine.ENGINE.is_request_allowed(context, service_request)

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -150,6 +150,8 @@ class Skeleton:
                 )
                 raise NotImplementedError
 
+            self.is_request_allowed(context, instance)
+
             return self.dispatch_request(context, instance)
         except ServiceException as e:
             return self.on_service_exception(context, e)
@@ -209,3 +211,15 @@ class Skeleton:
         context.service_exception = error
 
         return serializer.serialize_error_to_response(error, operation)
+
+    # TODO naming
+    def is_request_allowed(self, context: RequestContext, service_request: ServiceRequest) -> None:
+        """
+        Called by invoke to determine if request is allowed (IAM permissions, etc).
+        :param context: the request context
+        :param service_request: the service request
+        """
+        # TODO this import is cancerous, just for getting it somehow into the code
+        from localstack_ext.services.iam.policy_engine import engine
+
+        engine.ENGINE.is_request_allowed(context, service_request)

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -637,10 +637,6 @@ WINDOWS_DOCKER_MOUNT_PREFIX = os.environ.get("WINDOWS_DOCKER_MOUNT_PREFIX", "/ho
 # whether to skip S3 presign URL signature validation (TODO: currently enabled, until all issues are resolved)
 S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false("S3_SKIP_SIGNATURE_VALIDATION")
 
-# user ID of default user, to be returned on sts.get_caller_identity
-TEST_IAM_USER_ID = str(os.environ.get("TEST_IAM_USER_ID") or "").strip()
-TEST_IAM_USER_NAME = str(os.environ.get("TEST_IAM_USER_NAME") or "").strip()
-
 # user-defined lambda executor mode
 LAMBDA_EXECUTOR = os.environ.get("LAMBDA_EXECUTOR", "").strip()
 

--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -350,7 +350,7 @@ class IamProvider(IamApi):
         moto_user_name = response["User"]["UserName"]
         moto_user = moto_iam_backend.users.get(moto_user_name)
         # if the user does not exist or is no user
-        if not moto_user:
+        if not moto_user and not user_name:
             access_key_id = extract_access_key_id_from_auth_header(context.request.headers)
             sts_client = aws_stack.connect_to_service(
                 "sts",

--- a/localstack/services/sts/provider.py
+++ b/localstack/services/sts/provider.py
@@ -3,7 +3,6 @@ import re
 
 import xmltodict
 
-from localstack import config
 from localstack.aws.api import RequestContext
 from localstack.aws.api.sts import GetCallerIdentityResponse, StsApi
 from localstack.aws.proxy import AwsApiListener
@@ -21,10 +20,9 @@ LOG = logging.getLogger(__name__)
 class StsProvider(StsApi, ServiceLifecycleHook):
     def get_caller_identity(self, context: RequestContext) -> GetCallerIdentityResponse:
         result = call_moto(context)
-        username = config.TEST_IAM_USER_NAME or "localstack"
-        result["Arn"] = result["Arn"].replace("user/moto", f"user/{username}")
-        if config.TEST_IAM_USER_ID:
-            result["UserId"] = config.TEST_IAM_USER_ID
+        if "user/moto" in result["Arn"] and "sts" in result["Arn"]:
+            # FIXME double replace is ugly AF
+            result["Arn"] = result["Arn"].replace("user/moto", "root").replace(":sts:", ":iam:")
         return result
 
 

--- a/localstack/services/sts/provider.py
+++ b/localstack/services/sts/provider.py
@@ -21,8 +21,7 @@ class StsProvider(StsApi, ServiceLifecycleHook):
     def get_caller_identity(self, context: RequestContext) -> GetCallerIdentityResponse:
         result = call_moto(context)
         if "user/moto" in result["Arn"] and "sts" in result["Arn"]:
-            # FIXME double replace is ugly AF
-            result["Arn"] = result["Arn"].replace("user/moto", "root").replace(":sts:", ":iam:")
+            result["Arn"] = f"arn:aws:iam::{result['Account']}:root"
         return result
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ packages=find:
 install_requires =
     boto3>=1.20
     click>=7.0
-    cachetools>=3.1.1,<4.0.0
+    cachetools~=5.0.0
     # dataclasses needed for python3.6 compat
     dataclasses; python_version < '3.7'
     #dnspython==1.16.0

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -8,7 +8,7 @@ from botocore.exceptions import ClientError
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.iam import Tag
 from localstack.services.iam.provider import ADDITIONAL_MANAGED_POLICIES
-from localstack.testing.aws.util import create_client_with_keys
+from localstack.testing.aws.util import create_client_with_keys, wait_for_user
 from localstack.utils.common import short_uid
 from localstack.utils.kinesis import kinesis_connector
 from localstack.utils.strings import long_uid
@@ -27,9 +27,7 @@ GET_USER_POLICY_DOC = """{
 
 
 class TestIAMExtensions:
-    def test_get_user_without_username_as_user(
-        self, create_user, iam_client, sts_client, wait_for_user
-    ):
+    def test_get_user_without_username_as_user(self, create_user, iam_client, sts_client):
         user_name = f"user-{short_uid()}"
         policy_name = f"policy={short_uid()}"
         create_user(UserName=user_name)

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -101,6 +101,9 @@ class TestIAMExtensions:
             "PermissionsBoundaryArn": policy_arn,
             "PermissionsBoundaryType": "Policy",
         } == get_user_reply["User"]["PermissionsBoundary"]
+        iam_client.delete_user_permissions_boundary(UserName=user_name)
+        get_user_reply = iam_client.get_user(UserName=user_name)
+        assert "PermissionsBoundary" not in get_user_reply["User"]
 
     def test_create_user_add_permission_boundary_afterwards(
         self, iam_client, create_user, create_policy
@@ -121,6 +124,9 @@ class TestIAMExtensions:
             "PermissionsBoundaryArn": policy_arn,
             "PermissionsBoundaryType": "Policy",
         } == get_user_reply["User"]["PermissionsBoundary"]
+        iam_client.delete_user_permissions_boundary(UserName=user_name)
+        get_user_reply = iam_client.get_user(UserName=user_name)
+        assert "PermissionsBoundary" not in get_user_reply["User"]
 
 
 class TestIAMIntegrations:


### PR DESCRIPTION
## PR reason
This changes are needed to support advanced policy evaluation as part of our efforts to improve IAM policy enforcement.
It contains several breaking changes, which is the reason for the PR target being v1.

## Major changes
* The default principal you are assumed to be when using localstack with invalid (not registered with IAM/sts) credentials is the root principal, not the (invalid) principal `arn:aws:sts::000000000000:user/localstack`. This might change client code for some users, which is why this PR targets v1.
* Deprecate feature to customize the before-mentioned invalid user using TEST_IAM_USER_NAME/ID. Since it was never part of the documentation, the impacted user base should be minimal, still a breaking change. Reason for removal is little benefit, while introducing a inconsistency (you "are" a user which does not exist) in our model.
## Feature additions
* Allow for permission boundaries to be set for users
* IAM getuser will now return correct response, depending on the principal calling this operation
## Side effects
* Moved a lot of fixtures / test helpers from pro to community to help with iam entity management during tests.