### PR TITLE
fix multi-registration of shared ASF API GW router

### DIFF
--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -79,9 +79,15 @@ class ApigatewayRouter:
 
     def __init__(self, router: Router[Handler]):
         self.router = router
+        self.registered = False
 
     def register_routes(self) -> None:
         """Registers parameterized routes for API Gateway user invocations."""
+        if self.registered:
+            LOG.debug("Skipped API gateway route registration (routes already registered).")
+            return
+        self.registered = True
+        LOG.debug("Registering parameterized API gateway routes.")
         self.router.add(
             "/",
             host="<api_id>.execute-api.<regex('.*'):server>",


### PR DESCRIPTION
This PR only contains a small change in the ASF API Gateway router (which is not enabled yet in master) introduced with https://github.com/localstack/localstack/pull/6267.
It ensures that a single instance of the router only registers its dynamic routes once.
This allows a router instance to be shared among multiple providers or be called by a single provider multiple times while ensuring that the HTTP router isn't spammed with duplicate routes.