### PR TITLE
Validate KMS tests and fix issues

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -707,8 +707,6 @@ def kms_create_key(kms_client):
     key_ids = []
 
     def _create_key(**kwargs):
-        if "Policy" not in kwargs:
-            kwargs["Policy"] = f"policy-{short_uid()}"
         if "Description" not in kwargs:
             kwargs["Description"] = f"test description - {short_uid()}"
         if "KeyUsage" not in kwargs:
@@ -732,11 +730,13 @@ def kms_key(kms_create_key):
 
 
 @pytest.fixture
-def kms_grant_and_key(kms_client, kms_key):
+def kms_grant_and_key(kms_client, kms_key, sts_client):
+    user_arn = sts_client.get_caller_identity()["Arn"]
+
     return [
         kms_client.create_grant(
             KeyId=kms_key["KeyId"],
-            GranteePrincipal="arn:aws:iam::000000000000:role/test",
+            GranteePrincipal=user_arn,
             Operations=["Decrypt", "Encrypt"],
         ),
         kms_key,

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -9,22 +9,25 @@ from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 
-from localstack import config
-from localstack.constants import TEST_AWS_ACCOUNT_ID
 from localstack.utils.crypto import encrypt
 from localstack.utils.strings import short_uid
 
 
 class TestKMS:
-    def test_create_key(self, kms_client):
+    @pytest.fixture(scope="class")
+    def test_user_arn(self, sts_client):
+        return sts_client.get_caller_identity()["Arn"]
+
+    @pytest.mark.aws_validated
+    def test_create_key(self, kms_client, sts_client):
+        account_id = sts_client.get_caller_identity()["Account"]
+        region = sts_client.meta.region_name
 
         response = kms_client.list_keys()
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         keys_before = response["Keys"]
 
-        response = kms_client.create_key(
-            Policy="policy1", Description="test key 123", KeyUsage="ENCRYPT_DECRYPT"
-        )
+        response = kms_client.create_key(Description="test key 123", KeyUsage="ENCRYPT_DECRYPT")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         key_id = response["KeyMetadata"]["KeyId"]
 
@@ -33,31 +36,35 @@ class TestKMS:
 
         response = kms_client.describe_key(KeyId=key_id)["KeyMetadata"]
         assert response["KeyId"] == key_id
-        assert ":%s:" % config.DEFAULT_REGION in response["Arn"]
-        assert ":%s:" % TEST_AWS_ACCOUNT_ID in response["Arn"]
+        assert f":{region}:" in response["Arn"]
+        assert f":{account_id}:" in response["Arn"]
 
-    def test_create_grant_with_invalid_key(self, kms_client):
+    @pytest.mark.aws_validated
+    def test_create_grant_with_invalid_key(self, kms_client, test_user_arn):
+
         with pytest.raises(botocore.exceptions.ClientError):
             kms_client.create_grant(
                 KeyId="invalid",
-                GranteePrincipal="arn:aws:iam::000000000000:role/test",
+                GranteePrincipal=test_user_arn,
                 Operations=["Decrypt", "Encrypt"],
             )
 
+    @pytest.mark.aws_validated
     def test_list_grants_with_invalid_key(self, kms_client):
         with pytest.raises(botocore.exceptions.ClientError):
             kms_client.list_grants(
                 KeyId="invalid",
             )
 
-    def test_create_grant_with_valid_key(self, kms_client, kms_key):
+    @pytest.mark.aws_validated
+    def test_create_grant_with_valid_key(self, kms_client, kms_key, test_user_arn):
         key_id = kms_key["KeyId"]
 
         grants_before = kms_client.list_grants(KeyId=key_id)["Grants"]
 
         grant = kms_client.create_grant(
             KeyId=key_id,
-            GranteePrincipal="arn:aws:iam::000000000000:role/test",
+            GranteePrincipal=test_user_arn,
             Operations=["Decrypt", "Encrypt"],
         )
         assert "GrantId" in grant
@@ -66,6 +73,7 @@ class TestKMS:
         grants_after = kms_client.list_grants(KeyId=key_id)["Grants"]
         assert len(grants_after) == len(grants_before) + 1
 
+    @pytest.mark.aws_validated
     def test_revoke_grant(self, kms_client, kms_grant_and_key):
         grant = kms_grant_and_key[0]
         key_id = kms_grant_and_key[1]["KeyId"]
@@ -76,6 +84,7 @@ class TestKMS:
         grants_after = kms_client.list_grants(KeyId=key_id)["Grants"]
         assert len(grants_after) == len(grants_before) - 1
 
+    @pytest.mark.aws_validated
     def test_retire_grant(self, kms_client, kms_grant_and_key):
         grant = kms_grant_and_key[0]
         key_id = kms_grant_and_key[1]["KeyId"]
@@ -116,10 +125,10 @@ class TestKMS:
         assert decrypted["Plaintext"] == result["PrivateKeyPlaintext"]
 
     @pytest.mark.parametrize("key_type", ["rsa", "ecc"])
-    def test_sign(self, kms_client, key_type):
+    def test_sign(self, kms_client, key_type, kms_create_key):
         key_spec = "RSA_2048" if key_type == "rsa" else "ECC_NIST_P256"
-        result = kms_client.create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)
-        key_id = result["KeyMetadata"]["KeyId"]
+        result = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)
+        key_id = result["KeyId"]
 
         message = b"test message 123 !%$@"
         algo = "RSASSA_PSS_SHA_256" if key_type == "rsa" else "ECDSA_SHA_384"
@@ -144,14 +153,11 @@ class TestKMS:
         with pytest.raises(InvalidSignature):
             _verify(result["Signature"] + b"foobar")
 
-    def test_get_and_list_sign_key(self, kms_client):
-        response = kms_client.create_key(
-            Description="test key 123",
-            KeyUsage="SIGN_VERIFY",
-            CustomerMasterKeySpec="ECC_NIST_P256",
-        )
+    @pytest.mark.aws_validated
+    def test_get_and_list_sign_key(self, kms_client, kms_create_key):
+        response = kms_create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="ECC_NIST_P256")
 
-        key_id = response["KeyMetadata"]["KeyId"]
+        key_id = response["KeyId"]
         describe_response = kms_client.describe_key(KeyId=key_id)["KeyMetadata"]
         assert describe_response["KeyId"] == key_id
 
@@ -164,9 +170,8 @@ class TestKMS:
 
         assert found is True
 
-    def test_import_key(self, kms_client):
-        # create key
-        key_id = kms_client.create_key()["KeyMetadata"]["KeyId"]
+    def test_import_key(self, kms_client, kms_key):
+        key_id = kms_key["KeyId"]
 
         # get key import params
         params = kms_client.get_parameters_for_import(
@@ -201,6 +206,7 @@ class TestKMS:
         )
         assert api_decrypted["Plaintext"] == plaintext
 
+    @pytest.mark.aws_validated
     def test_list_aliases_of_key(self, kms_client, kms_create_key):
         aliased_key = kms_create_key()
         comparison_key = kms_create_key()

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -15,7 +15,7 @@ from localstack.utils.strings import short_uid
 
 class TestKMS:
     @pytest.fixture(scope="class")
-    def test_user_arn(self, sts_client):
+    def user_arn(self, sts_client):
         return sts_client.get_caller_identity()["Arn"]
 
     @pytest.mark.aws_validated
@@ -40,12 +40,12 @@ class TestKMS:
         assert f":{account_id}:" in response["Arn"]
 
     @pytest.mark.aws_validated
-    def test_create_grant_with_invalid_key(self, kms_client, test_user_arn):
+    def test_create_grant_with_invalid_key(self, kms_client, user_arn):
 
         with pytest.raises(botocore.exceptions.ClientError):
             kms_client.create_grant(
                 KeyId="invalid",
-                GranteePrincipal=test_user_arn,
+                GranteePrincipal=user_arn,
                 Operations=["Decrypt", "Encrypt"],
             )
 
@@ -57,14 +57,14 @@ class TestKMS:
             )
 
     @pytest.mark.aws_validated
-    def test_create_grant_with_valid_key(self, kms_client, kms_key, test_user_arn):
+    def test_create_grant_with_valid_key(self, kms_client, kms_key, user_arn):
         key_id = kms_key["KeyId"]
 
         grants_before = kms_client.list_grants(KeyId=key_id)["Grants"]
 
         grant = kms_client.create_grant(
             KeyId=key_id,
-            GranteePrincipal=test_user_arn,
+            GranteePrincipal=user_arn,
             Operations=["Decrypt", "Encrypt"],
         )
         assert "GrantId" in grant


### PR DESCRIPTION
Validating KMS tests against AWS:

- [x] `test_create_key`
- [x] `test_create_grant_with_invalid_key`
- [x] `test_list_grants_with_invalid_key`
- [x] `test_create_grant_with_valid_key`
- [x] `test_revoke_grant`
- [x] `test_retire_grant`
- [ ] `test_asymmetric_keys`
- [ ] `test_sign`
- [x] `test_get_and_list_sign_key`
- [ ] `test_import_key`
- [x] `test_list_aliases_of_key`


The remaining tests have some implementation issues regarding the usage of correct ciphers with algorithms etc. /cc @whummer 