### PR TITLE
fix docker inspect health check log output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -257,7 +257,7 @@ ENV LOCALSTACK_BUILD_VERSION=${LOCALSTACK_BUILD_VERSION}
 # expose edge service, external service ports, and debugpy
 EXPOSE 4566 4510-4559 5678
 
-HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD ./bin/localstack status services
+HEALTHCHECK --interval=10s --start-period=15s --retries=5 --timeout=5s CMD ./bin/localstack status services --format=json
 
 # define command at startup
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
With https://github.com/localstack/localstack/pull/6297, a Docker-native `HEALTHCHECK` has been introduced.
Docker shows the log output of the command when inspecting the container (this is also contained in our diagnose endpoint data).
For the health check, the CLI's `status services` command is used, which by default prints a nicely formatted table.
This table obviously is quite unreadable in the logs (because it's basically just a bunch of unicode characters):
```
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2022-06-24T09:55:41.209356566+02:00",
      "End": "2022-06-24T09:55:41.915356053+02:00",
      "ExitCode": 0,
      "Output": "┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓\n┃ Service                  ┃ Status      ┃\n┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩\n│ acm                      │ ✔ available │\n│ apigateway               │ ✔ available │\n│ cloudformation           │ ✔ available │\n│ cloudwatch               │ ✔ available │\n│ config                   │ ✔ available │\n│ dynamodb                 │ ✔ available │\n│ dynamodbstreams          │ ✔ available │\n│ ec2                      │ ✔ available │\n│ es                       │ ✔ available │\n│ events                   │ ✔ available │\n│ firehose                 │ ✔ available │\n│ iam                      │ ✔ available │\n│ kinesis                  │ ✔ available │\n│ kms                      │ ✔ available │\n│ lambda                   │ ✔ available │\n│ logs                     │ ✔ available │\n│ opensearch               │ ✔ available │\n│ redshift                 │ ✔ available │\n│ resource-groups          │ ✔ available │\n│ resourcegroupstaggingapi │ ✔ available │\n│ route53                  │ ✔ available │\n│ route53resolver          │ ✔ available │\n│ s3                       │ ✔ available │\n│ s3control                │ ✔ available │\n│ secretsmanager           │ ✔ available │\n│ ses                      │ ✔ available │\n│ sns                      │ ✔ available │\n│ sqs                      │ ✔ available │\n│ ssm                      │ ✔ available │\n│ stepfunctions            │ ✔ available │\n│ sts                      │ ✔ available │\n│ support                  │ ✔ available │\n│ swf                      │ ✔ available │\n└──────────────────────────┴─────────────┘\n"
    }
  ]
}
```

This PR changes the formatting of the health check command output to JSON, which makes the health (machine) logs readable when running `docker inspect` or looking at the diagnose endoint result:
```
$ docker inspect localstack_main | jq -r .[0].State.Health
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2022-06-24T09:53:41.115539305+02:00",
      "End": "2022-06-24T09:53:41.802036479+02:00",
      "ExitCode": 0,
      "Output": "{\"acm\": \"available\", \"apigateway\": \"available\", \"cloudformation\": \"available\", \n\"cloudwatch\": \"available\", \"config\": \"available\", \"dynamodb\": \"available\", \n\"dynamodbstreams\": \"available\", \"ec2\": \"available\", \"es\": \"available\", \"events\":\n\"available\", \"firehose\": \"available\", \"iam\": \"available\", \"kinesis\": \n\"available\", \"kms\": \"available\", \"lambda\": \"available\", \"logs\": \"available\", \n\"opensearch\": \"available\", \"redshift\": \"available\", \"resource-groups\": \n\"available\", \"resourcegroupstaggingapi\": \"available\", \"route53\": \"available\", \n\"route53resolver\": \"available\", \"s3\": \"available\", \"s3control\": \"available\", \n\"secretsmanager\": \"available\", \"ses\": \"available\", \"sns\": \"available\", \"sqs\": \n\"available\", \"ssm\": \"available\", \"stepfunctions\": \"available\", \"sts\": \n\"available\", \"support\": \"available\", \"swf\": \"available\"}\n"
    }
  ]
}
```