### PR TITLE
fix asf apigateway lambda response conversion

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -51,7 +51,7 @@ def pytest_runtestloop(session):
         parent_name = str(item.parent).lower()
         if any(opensearch_test in parent_name for opensearch_test in ["opensearch", "firehose"]):
             test_init_functions.add(opensearch_install_async)
-        if any(opensearch_test in parent_name for opensearch_test in ["es", "firehose"]):
+        if any(opensearch_test in parent_name for opensearch_test in ["test_es", "firehose"]):
             test_init_functions.add(es_install_async)
 
     # add init functions for certain tests that download/install things

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -85,7 +85,7 @@ def test_lambda_aws_integration(apigateway_client):
 
     url = api_invoke_url(api_id=api_id, stage="local", path="/test")
     response = requests.get(url)
-    assert response._content == b'{"message":"Hello from Lambda"}'
+    assert response.json() == {"message": "Hello from Lambda"}
 
 
 #


### PR DESCRIPTION
This PR fixes a recently introduced test #6289 when running with the `asf` apigateway provider.

The error originated from not converting lambda responses correctly into werkzeug Response objects (which was expecting strings but receiving dicts to convert to JSON).

FYI: there's at least one instance where content-length is set to '1' because a a dictionary is passed to `update_content_length`, although it expects a string/bytes value here: https://github.com/localstack/localstack/blob/d37917610da1dc95156f84aba5a353dda0104eac/localstack/services/apigateway/invocations.py#L388-L392

setting content-length manually leads to all sorts of problems and isn't necessary anymore as we move to werkzeug, which handles content-length itself. @calvernaz we should touch base to make sure we're using the new features from ASF, which will simplify a lot! :-)