### PR TITLE
fix S3 BackendState to raise ASF NoSuchBucket exception

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -158,7 +158,7 @@ class BackendState:
         """
         Return a custom attribute for the given bucket.
         If the attribute is not yet defined, it is initialized with the given default value.
-        If the bucket does not exist in the backend, then None is returned.
+        If the bucket does not exist in the backend, then an exception is raised.
         """
         bucket = cls.get_bucket(bucket_name)
         if not hasattr(bucket, attr_name):

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -160,10 +160,7 @@ class BackendState:
         If the attribute is not yet defined, it is initialized with the given default value.
         If the bucket does not exist in the backend, then None is returned.
         """
-        try:
-            bucket = cls.get_bucket(bucket_name)
-        except NoSuchBucket:
-            return None
+        bucket = cls.get_bucket(bucket_name)
         if not hasattr(bucket, attr_name):
             setattr(bucket, attr_name, default)
         return getattr(bucket, attr_name)

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -304,6 +304,30 @@ class TestS3PresignedUrl:
         assert response.status_code == 200
         assert response.text == body
 
+    @pytest.mark.aws_validated
+    def test_get_object_no_such_bucket(self, s3_client):
+        with pytest.raises(ClientError) as e:
+            s3_client.get_object(Bucket=f"does-not-exist-{short_uid()}", Key="foobar")
+
+        # TODO: simplify with snapshot test once activated
+        response = e.value.response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        error = response["Error"]
+        assert error["Code"] == "NoSuchBucket"
+        assert error["Message"] == "The specified bucket does not exist"
+
+    @pytest.mark.aws_validated
+    def test_get_bucket_notification_configuration_no_such_bucket(self, s3_client):
+        with pytest.raises(ClientError) as e:
+            s3_client.get_bucket_notification_configuration(Bucket=f"doesnotexist-{short_uid()}")
+
+        # TODO: simplify with snapshot test once activated
+        response = e.value.response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        error = response["Error"]
+        assert error["Code"] == "NoSuchBucket"
+        assert error["Message"] == "The specified bucket does not exist"
+
 
 class TestS3DeepArchive:
     """
@@ -337,14 +361,3 @@ class TestS3DeepArchive:
         for obj in objects:
             keys.append(obj.key)
             assert obj.storage_class == "DEEP_ARCHIVE"
-
-    @pytest.mark.aws_validated
-    def test_get_object_no_such_bucket(self, s3_client):
-        with pytest.raises(ClientError) as e:
-            s3_client.get_object(Bucket=f"does-not-exist-{short_uid()}", Key="foobar")
-
-        response = e.value.response
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
-        error = response["Error"]
-        assert error["Code"] == "NoSuchBucket"
-        assert error["Message"] == "The specified bucket does not exist"


### PR DESCRIPTION
This PR fixes ASF compatibility with the recently introduced changes in #6325. The exception wasn't actually raised, should have seen that in the review.
I also moved the new test into `TestS3` which is the class grouping the basic API calls.