### PR TITLE
fix passing down of use_ssl when starting edge

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -366,7 +366,7 @@ def do_start_edge_proxy(bind_address, port, use_ssl, asynchronous=False):
     proxy = start_proxy_server(
         port,
         bind_address=bind_address,
-        use_ssl=True,
+        use_ssl=use_ssl,
         update_listener=listeners,
         check_port=False,
     )
@@ -437,7 +437,7 @@ def start_edge(port=None, use_ssl=True, asynchronous=False):
         do_start_edge(
             config.EDGE_BIND_HOST,
             config.EDGE_PORT_HTTP,
-            use_ssl=False,
+            use_ssl=use_ssl,
             asynchronous=True,
         )
     if port > 1024 or is_root():


### PR DESCRIPTION
This PR fixes an issue that would prevent the ASF gateway from starting with SSL mode enabled.

In the edge proxy we were completely ignoring the `use_ssl` attribute, doing some really strange things:

* first we were ignoring it and setting it to false by default: https://github.com/localstack/localstack/blob/d37917610da1dc95156f84aba5a353dda0104eac/localstack/services/edge.py#L437-L440
* then we were ignoring it again, and setting it to true by default: https://github.com/localstack/localstack/blob/d37917610da1dc95156f84aba5a353dda0104eac/localstack/services/edge.py#L366-L369
* but we're never actually setting it in the first place, because here it's set to true by default and never set explicitly when calling `start_component` https://github.com/localstack/localstack/blob/d37917610da1dc95156f84aba5a353dda0104eac/localstack/services/edge.py#L394

what a ride

/cc @alexrashed 