### PR TITLE
fix pickling in multi-account region backend

### DIFF
--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import functools
+import inspect
 import json
 import logging
 import os
@@ -415,7 +416,9 @@ class RegionBackend:
         # To enable this, we keep copies of this class in `_ACCOUNT_CLS` by account IDs and instantiate that
         # copy of the class for different regions and same account ID
         if MULTI_ACCOUNTS and account_id not in cls._ACCOUNTS_CLS:
-            cls_dict = copy.deepcopy(dict(cls.__dict__))
+            # @classmethod descriptors will be part of a cls.__dict__, but they cannot be pickled by deepcopy
+            data = {k: v for k, v in cls.__dict__.items() if not inspect.ismethoddescriptor(v)}
+            cls_dict = copy.deepcopy(data)
             cls_dict["_ACCOUNTS_CLS"] = cls._ACCOUNTS_CLS
             cls_dict["_ACCOUNT_BACKENDS"] = cls._ACCOUNT_BACKENDS
 


### PR DESCRIPTION
This PR fixes an issue where `copy.deepcopy` would fail on a backend that looks like this:
```python

class MyProviderState(RegionBackend):
    distributions: Dict[str, Distribution]
    # ...

    def __init__(self):
        self.distributions = {}
        # ...

    @classmethod
    def get_current_request_region(cls):
        # Note: no regions required - distributions are global
        return "global"
```

calling `copy.deepcopy(MyProviderState.__dict__)` would fail here, because the dict of the class will contain the classmethod `get_current_request_region` as a method descriptor, which cannot be pickled by `deepcopy`, resulting in exceptions.

```
{
    '__module__': '__main__',
    '__annotations__': {
        'distributions': typing.Dict[str, ...]
    },
    '__init__': <function MyProviderState.__init__ at 0x7f7483ce9ea0>,
    'get_current_request_region': <classmethod(<function MyProviderState.get_current_request_region at 0x7f7483ce9fc0>)>,
    '__doc__': None
}
```

this simple fix just filters out method descriptors