### PR TITLE
fix s3 delete_bucket compatibility with ASF gateway

### DIFF
--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -146,6 +146,42 @@ class TestS3:
 
         assert is_sub_dict(sub_dict, response)
 
+    @pytest.mark.aws_validated
+    def test_get_object_no_such_bucket(self, s3_client):
+        with pytest.raises(ClientError) as e:
+            s3_client.get_object(Bucket=f"does-not-exist-{short_uid()}", Key="foobar")
+
+        # TODO: simplify with snapshot test once activated
+        response = e.value.response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        error = response["Error"]
+        assert error["Code"] == "NoSuchBucket"
+        assert error["Message"] == "The specified bucket does not exist"
+
+    @pytest.mark.aws_validated
+    def test_delete_bucket_no_such_bucket(self, s3_client):
+        with pytest.raises(ClientError) as e:
+            s3_client.delete_bucket(Bucket=f"does-not-exist-{short_uid()}")
+
+        # TODO: simplify with snapshot test once activated
+        response = e.value.response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        error = response["Error"]
+        assert error["Code"] == "NoSuchBucket"
+        assert error["Message"] == "The specified bucket does not exist"
+
+    @pytest.mark.aws_validated
+    def test_get_bucket_notification_configuration_no_such_bucket(self, s3_client):
+        with pytest.raises(ClientError) as e:
+            s3_client.get_bucket_notification_configuration(Bucket=f"doesnotexist-{short_uid()}")
+
+        # TODO: simplify with snapshot test once activated
+        response = e.value.response
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
+        error = response["Error"]
+        assert error["Code"] == "NoSuchBucket"
+        assert error["Message"] == "The specified bucket does not exist"
+
 
 class TestS3PresignedUrl:
     """
@@ -303,30 +339,6 @@ class TestS3PresignedUrl:
         response = requests.get(url, data=b"get body is ignored by AWS")
         assert response.status_code == 200
         assert response.text == body
-
-    @pytest.mark.aws_validated
-    def test_get_object_no_such_bucket(self, s3_client):
-        with pytest.raises(ClientError) as e:
-            s3_client.get_object(Bucket=f"does-not-exist-{short_uid()}", Key="foobar")
-
-        # TODO: simplify with snapshot test once activated
-        response = e.value.response
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
-        error = response["Error"]
-        assert error["Code"] == "NoSuchBucket"
-        assert error["Message"] == "The specified bucket does not exist"
-
-    @pytest.mark.aws_validated
-    def test_get_bucket_notification_configuration_no_such_bucket(self, s3_client):
-        with pytest.raises(ClientError) as e:
-            s3_client.get_bucket_notification_configuration(Bucket=f"doesnotexist-{short_uid()}")
-
-        # TODO: simplify with snapshot test once activated
-        response = e.value.response
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 404
-        error = response["Error"]
-        assert error["Code"] == "NoSuchBucket"
-        assert error["Message"] == "The specified bucket does not exist"
 
 
 class TestS3DeepArchive:

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -617,16 +617,6 @@ class TestS3(unittest.TestCase):
         self.assertEqual("Requester", response["Payer"])
         self._delete_bucket(bucket_name)
 
-    def test_delete_non_existing_bucket(self):
-        bucket_name = "test-%s" % short_uid()
-        with self.assertRaises(ClientError) as ctx:
-            self.s3_client.delete_bucket(Bucket=bucket_name)
-        self.assertEqual("NoSuchBucket", ctx.exception.response["Error"]["Code"])
-        self.assertEqual(
-            "The specified bucket does not exist",
-            ctx.exception.response["Error"]["Message"],
-        )
-
     def test_bucket_exists(self):
         # Test setup
         bucket = "test-bucket-%s" % short_uid()


### PR DESCRIPTION
This PR follows up on #6344 which i didn't test completely against v1. There's a patch that changes moto to call an `s3_listener` method, which can raise a `NoSuchBucket` error, which moto doesn't know how to handle, so we have to translate back to a moto `MissingBucket` exception.

I also migrated the affected test and refactored them to correctly be under `TestS3` class.

It fixes the [failing s3 tests](https://app.circleci.com/pipelines/github/localstack/localstack/7096/workflows/642ef431-5b37-4d04-b0b8-515945ca9f6c/jobs/42907/tests#failed-test) in the v1 integration