### PR TITLE
fix apigw LambdaResponse with async invocation to return empty body

### DIFF
--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -379,14 +379,20 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
                 response = result
             else:
                 response = LambdaResponse()
-                parsed_result = (
-                    result if isinstance(result, dict) else json.loads(str(result or "{}"))
-                )
-                parsed_result = common.json_safe(parsed_result)
-                parsed_result = {} if parsed_result is None else parsed_result
-                response.status_code = 200
-                response._content = parsed_result
-                update_content_length(response)
+                is_async = headers.get("X-Amz-Invocation-Type", "").strip("'") == "Event"
+
+                if is_async:
+                    response._content = ""
+                    response.status_code = 200
+                else:
+                    parsed_result = (
+                        result if isinstance(result, dict) else json.loads(str(result or "{}"))
+                    )
+                    parsed_result = common.json_safe(parsed_result)
+                    parsed_result = {} if parsed_result is None else parsed_result
+                    response.status_code = 200
+                    response._content = parsed_result
+                    update_content_length(response)
 
             # apply custom response template
             invocation_context.response = response


### PR DESCRIPTION
This PR fixes a compatibility issue with the ASF API Gateway implementation, where async responses would render to `"{}"` rather than `""`.

The `LambdaResponse` content field would be an empty dictionary, and with the old edge proxy we're setting that to `""` in a very generalized way: https://github.com/localstack/localstack/blob/0ae805df648e1a8c5824cddf5abbd1200acd2532/localstack/utils/server/http2_server.py#L207

we don't manipulate response bodies in the same way without knowing anything about their content types in the ASF gateway, so this PR makes sure the LambdaResponse content is set to `""` before it even leaves the apigateway provider.