### PR TITLE
Add pip install to ensure latest dev releases are not overwritten

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,10 +240,12 @@ RUN make init
 
 # Install the latest version of localstack-ext and generate the plugin entrypoints.
 # If this is a pre-release build, also include dev releases of these packages.
+# Run pip twice, also with --no-deps, to ensure the versions do not get overwritten by transitive dependencies.
 ARG LOCALSTACK_PRE_RELEASE=1
 RUN (PIP_ARGS=$([[ "$LOCALSTACK_PRE_RELEASE" == "1" ]] && echo "--pre" || true); \
       virtualenv .venv && source .venv/bin/activate && \
-      pip3 install --upgrade ${PIP_ARGS} localstack-ext plux)
+      pip3 install --upgrade ${PIP_ARGS} localstack-ext plux && \
+      pip3 install --upgrade ${PIP_ARGS} --no-deps localstack-ext plux)
 RUN make entrypoints
 
 # Add the build date and git hash at last (changes everytime)

--- a/Dockerfile
+++ b/Dockerfile
@@ -151,9 +151,6 @@ ADD bin/localstack bin/localstack.bat bin/
 RUN make install-runtime
 RUN make freeze > requirements-runtime.txt
 
-# remove localstack (added as a transitive dependency of localstack-ext)
-RUN (virtualenv .venv && source .venv/bin/activate && pip3 uninstall -y localstack)
-
 
 
 # base-light: Stage which does not add additional dependencies (like elasticsearch)
@@ -240,12 +237,10 @@ RUN make init
 
 # Install the latest version of localstack-ext and generate the plugin entrypoints.
 # If this is a pre-release build, also include dev releases of these packages.
-# Run pip twice, also with --no-deps, to ensure the versions do not get overwritten by transitive dependencies.
 ARG LOCALSTACK_PRE_RELEASE=1
 RUN (PIP_ARGS=$([[ "$LOCALSTACK_PRE_RELEASE" == "1" ]] && echo "--pre" || true); \
       virtualenv .venv && source .venv/bin/activate && \
-      pip3 install --upgrade ${PIP_ARGS} localstack-ext plux && \
-      pip3 install --upgrade ${PIP_ARGS} --no-deps localstack-ext plux)
+      pip3 install --upgrade ${PIP_ARGS} localstack-ext)
 RUN make entrypoints
 
 # Add the build date and git hash at last (changes everytime)


### PR DESCRIPTION
Add second pip install with `--no-deps` to ensure latest dev releases are properly installed and not overwritten in the Docker image.

This is an attempt to ensure we're installing the latest dev releases, which are currently being overwritten by the transitive dependency localstack-ext(`0.14.5.devX`)->localstack(`>=0.14.3.2` -> resolves to `0.14.4`). 

Theoretically, we could end up in a situation where some of the other transitive dependencies (any non plux/localstack/-ext libraries) no longer match with the shallow install of -ext, although arguably this would be an unlikely corner case. To be discussed..