### PR TITLE
add convenience GitHub workflows for release branches

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -4,8 +4,7 @@ on:
     inputs:
       targetRef:
         description: 'LocalStack Pro Ref to test with'
-        required: true
-        default: 'master'
+        required: false
   pull_request:
     paths:
       - ".github/workflows/pro-integration.yml"
@@ -20,6 +19,7 @@ on:
       - "bin/**"
     branches:
       - master
+      - 'v[0-9]+'
   push:
     paths:
       - ".github/workflows/pro-integration.yml"
@@ -49,11 +49,67 @@ jobs:
     environment: localstack-ext-tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository  # skip job if fork PR
     steps:
+      - name: Determine companion-ref
+        id: determine-companion-ref
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          result-encoding: string
+          script: |
+            if (context.payload.inputs && context.payload.inputs.targetRef) {
+              console.log("Using manually set target reference: ", context.payload.inputs.targetRef)
+              return context.payload.inputs.targetRef
+            }
+
+            const DEFAULT_REF = "refs/heads/master"
+
+            async function isCompanionRefExisting(refName) {
+              try {
+                // strip the leading "refs/" for the API call
+                const apiRef = refName.substr(5)
+                console.log("Checking if companion repo has ref: ", apiRef)
+                await github.rest.git.getRef({owner: "localstack", repo: "localstack-ext", ref: apiRef})
+                return true
+              } catch (error) {
+                  if (error.status == 404) {
+                    return false
+                  } else {
+                    // another (unexpected) error ocurred, raise the error
+                    throw new Error(`Fetching companion refs failed: ${JSON.stringify(error)}`)
+                  }
+              }
+            }
+
+            let ref = context.ref
+            let baseRef = null
+            if (context.payload.pull_request) {
+              // pull requests have their own refs (f.e. 'refs/pull/1/merge')
+              // use the PR head ref instead
+              ref = `refs/heads/${context.payload.pull_request.head.ref}`
+              baseRef = `refs/heads/${context.payload.pull_request.base.ref}`
+            }
+
+            if (ref == DEFAULT_REF) {
+              console.log("Current ref is default ref. Using the same for ext repo: ", DEFAULT_REF)
+              return DEFAULT_REF
+            }
+
+            if (await isCompanionRefExisting(ref)) {
+              console.log("Using companion ref in ext repo: ", ref)
+              return ref
+            } else if (baseRef && baseRef != DEFAULT_REF && (await isCompanionRefExisting(baseRef))) {
+              console.log("Using PR base companion ref in ext repo: ", baseRef)
+              return baseRef
+            }
+
+            // the companion repo does not have a companion ref, use the default
+            console.log("Ext repo does not have a companion ref. Using default: ", DEFAULT_REF)
+            return DEFAULT_REF
       - name: Checkout Pro
         uses: actions/checkout@v2
         with:
           repository: localstack/localstack-ext
-          ref: ${{ github.event.inputs.targetRef }}
+          ref: ${{steps.determine-companion-ref.outputs.result}}
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
           path: localstack-ext
       - name: Checkout Open Source

--- a/.github/workflows/rebase-release-prs.yml
+++ b/.github/workflows/rebase-release-prs.yml
@@ -1,0 +1,18 @@
+name: Rebase release PRs
+on:
+  push:
+    branches:
+    - master
+jobs:
+  rebase:
+    strategy:
+      matrix:
+        # TODO use a pattern here (once there's a clear branch name pattern)
+        head: ['localstack:v1']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/rebase@v2
+        with:
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          head: ${{ matrix.head }}
+          base: master

--- a/.github/workflows/rebase-release-targeting-prs.yml
+++ b/.github/workflows/rebase-release-targeting-prs.yml
@@ -1,0 +1,22 @@
+name: Rebase PRs targeting release branches
+on:
+  push:
+    branches:
+    # TODO use a better pattern here (once there's a clear branch name pattern)
+    - 'v[0-9]+'
+jobs:
+  rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine base ref
+        id: determine-base-ref
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            // remove the ref prefx "refs/heads/"
+            return context.payload.ref.substr(11)
+      - uses: peter-evans/rebase@v2
+        with:
+          token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          base: ${{steps.determine-base-ref.outputs.result}}


### PR DESCRIPTION
This PR adds convenience features to our GitHub workflows concerning the handling of our release branch PR (#6272) as well as  PRs targeting the release branch.

In order to keep the branches up to date, two workflows are added:
- `rebase-release-prs.yml` / `Rebase release PRs`
  - This workflow is triggered by every push into master and rebases our release branches.
  - It tries to rebase the Release PRs (f.e. #6272) upon the latest commit.
  - i.e. For every push to master the release branches for which PRs exist are tried to be rebased upon the latest commit.
  - Currently, the list of branches to rebase is hard-coded. The used action currently cannot handle a more elaborate head branch pattern.
- `rebase-release-targeting-prs.yml` / `Rebase PRs targeting release branches`
  - This workflow is triggered by every push to a release branch (i.e. also by the rebases performed by the action above).
  - It tries to rebase those PRs which target a release PR upon the latest commit in the target branch.
  - i.e. for every push to a release branch, all PRs which target this branch are tried to be rebased upon the latest commit.

Also, we often work changes which are both in our open core as well as in our extensions (for example our release branches).
In order to get correct workflow executions, they need to test against the companion branches in the ext repo.
- `pro-integration.yml` / integration-tests-against-pro`
  - The workflow is now now only executed for PRs targeting the master branch, but also those targeting a release branch.
  - The `targetRef` is optional, it does not default to master anymore.
  - A new step has been introduced which determines the correct branch of the ext repo to test against:
    - If the `targetRef` has been set manually (in a `workflow_dispatch` event), it always uses that.
    - Otherwise, it checks the `ref` of the worflow execution:
      - If it is the default branch (`refs/head/master`), it directly uses it (we assume it is also present in the ext repo).
      - Otherwise check if the `ref` exists in the companion repo (i.e. `ext`, f.e. `fix-v1`).
        - If it does, it uses it.
        - Otherwise, if it's a PR, check if the base ref exists in the companion repo (f.e. `v1`).
          - If it does, it uses it.
          - Otherwise, there is no proper companion PR. We fallback to the default ref (`master`).

Here's a flow chart visualizing the algorithm to determine the ref:
```mermaid
graph TD;
  targetRef{{"Is targetRef set?"}}-->|Yes|useTargetRef("Use targetRef")
  targetRef-->|No|isRefDefault{{"Is workflow ref default ref?"}}
  isRefDefault-->|Yes|useDefaultRef("Use default ref (master)")
  isRefDefault-->|No|refExists{{"Does the ref exist in companion repo?"}}
  refExists-->|Yes|useRef("Use companion ref")
  refExists-->|No|baseRefExists{{"Does PR base ref exist in companion repo?"}}
  baseRefExists-->|Yes|useBaseRef("Use PR base companion ref")
  baseRefExists-->|No|useDefaultRef
```

This is obviously quite complex, but it feels like it's the most intuitive for me. It basically boils down to:
- If there's a branch with the same name in the companion repo, I want to test against that (instead of the master).
- If not and there's a branch with the same name as my PR target, I want to test against that (instead of the master).
- In every other case fall back to the master.

I'm happy for any feedback. I'm also happy to close the PR if we decide that it's too complex, confusing, or unreliable.