### PR TITLE
fix missing (rest-)json error type header field

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1105,7 +1105,12 @@ class JSONResponseSerializer(ResponseSerializer):
         operation_model: OperationModel,
     ) -> None:
         # TODO handle error shapes with members
+        # TODO implement different service-specific serializer configurations
+        #   - currently we set both, the `__type` member as well as the `X-Amzn-Errortype` header
+        #   - the specification defines that it's either the __type field OR the header
+        #     (https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#operation-error-serialization)
         body = {"__type": code}
+        response.headers["X-Amzn-Errortype"] = code
         message = self._get_error_message(error)
         if message is not None:
             body["message"] = message

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -288,6 +288,17 @@ class TestOpensearchProvider:
             opensearch_client.create_domain(DomainName="abc#")  # no special characters allowed
         assert e.value.response["Error"]["Code"] == "ValidationException"
 
+    @pytest.mark.aws_validated
+    def test_exception_header_field(self, opensearch_client):
+        """Test if the error response correctly sets the error code in the headers (see #6304)."""
+        with pytest.raises(botocore.exceptions.ClientError) as e:
+            # use an invalid domain name to provoke an exception
+            opensearch_client.create_domain(DomainName="123")
+        assert (
+            e.value.response["ResponseMetadata"]["HTTPHeaders"]["x-amzn-errortype"]
+            == "ValidationException"
+        )
+
     def test_create_existing_domain_causes_exception(
         self, opensearch_client, opensearch_wait_for_cluster
     ):


### PR DESCRIPTION
This PR fixes a small issue in the ASF error serialization for (rest-)json protocols with (misbehaving) clients.

The specs ([json 1.0](https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#operation-error-serialization), [json 1.1](https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#operation-error-serialization), [rest-json](https://awslabs.github.io/smithy/1.0/spec/aws/aws-restjson1-protocol.html)) define that an error may either have a JSON member `__type` _or_ a JSON member `code` _or_ a header field `X-Amzn-Errortype` indicating the error code shape.

This PR adds the header field in addition to the `__type` member in order to avoid service-specific serializer configurations and in order to increase the support among different clients / services.

This fixes an issue (#6304) with the Terraform OpenSearch provider, which violates the client spec since it only checks for the header field while the spec for `rest-json` (the protocol of both - `es` and `opensearch` - services) explicitly states:

> Clients MUST accept any one of the following: an additional header with the name X-Amzn-Errortype, a body field with the name __type, or a body field named code. The value of this component SHOULD contain only the [shape name](https://awslabs.github.io/smithy/1.0/spec/core/model.html#grammar-token-smithy-identifier) of the error's [Shape ID](https://awslabs.github.io/smithy/1.0/spec/core/model.html#shape-id).

Fixes #6304.
I verified that the fix resolves the issues with the terraform script attached to the issue. Thanks a lot @Squallium for the _incredible_ issue report!