### PR TITLE
DynamoDB streaming binary content

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -105,6 +105,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import select_attributes
 from localstack.utils.common import short_uid, to_bytes
+from localstack.utils.json import BytesEncoder
 from localstack.utils.strings import long_uid, to_str
 from localstack.utils.threads import start_worker_thread
 
@@ -194,7 +195,7 @@ class EventForwarder:
             partition_key = hash_keys[0]["AttributeName"]
             kinesis.put_record(
                 StreamName=stream_name,
-                Data=json.dumps(record),
+                Data=json.dumps(record, cls=BytesEncoder),
                 PartitionKey=partition_key,
             )
 
@@ -1179,7 +1180,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                         unprocessed_item = unprocessed_put_items[i]
                         if unprocessed_item:
                             unprocessed_items["PutRequest"].update(
-                                json.loads(json.dumps(unprocessed_item))
+                                json.loads(json.dumps(unprocessed_item, cls=BytesEncoder))
                             )
                 delete_request = request.get("DeleteRequest")
                 if delete_request:
@@ -1197,7 +1198,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                         unprocessed_item = unprocessed_delete_items[i]
                         if unprocessed_item:
                             unprocessed_items["DeleteRequest"].update(
-                                json.loads(json.dumps(unprocessed_item))
+                                json.loads(json.dumps(unprocessed_item, cls=BytesEncoder))
                             )
                 i += 1
         return records, unprocessed_items

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -9,6 +9,7 @@ from localstack.services.generic_proxy import RegionBackend
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import now_utc
+from localstack.utils.json import BytesEncoder
 
 DDB_KINESIS_STREAM_NAME_PREFIX = "__ddb_stream_"
 
@@ -77,7 +78,11 @@ def forward_events(records: Dict) -> None:
         if stream:
             table_name = table_name_from_stream_arn(stream["StreamArn"])
             stream_name = get_kinesis_stream_name(table_name)
-            kinesis.put_record(StreamName=stream_name, Data=json.dumps(record), PartitionKey="TODO")
+            kinesis.put_record(
+                StreamName=stream_name,
+                Data=json.dumps(record, cls=BytesEncoder),
+                PartitionKey="TODO",
+            )
 
 
 def delete_streams(table_arn: str) -> None:

--- a/localstack/utils/json.py
+++ b/localstack/utils/json.py
@@ -47,7 +47,7 @@ class BytesEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if isinstance(obj, bytes):
-            return to_str(obj)
+            return to_str(obj, errors="replace")
         return super().default(obj)
 
 

--- a/localstack/utils/json.py
+++ b/localstack/utils/json.py
@@ -48,7 +48,7 @@ class BytesEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, bytes):
             return to_str(obj)
-        return json.JSONEncoder.default(self, obj)
+        return super().default(obj)
 
 
 class JsonObject:

--- a/localstack/utils/json.py
+++ b/localstack/utils/json.py
@@ -42,6 +42,15 @@ class CustomEncoder(json.JSONEncoder):
             return None
 
 
+class BytesEncoder(json.JSONEncoder):
+    """Helper class that converts JSON documents with bytes"""
+
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            return to_str(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
 class JsonObject:
     """Generic JSON serializable object for simplified subclassing"""
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import re
+import time
 from datetime import datetime
 from time import sleep
 
@@ -498,6 +499,24 @@ class TestDynamoDB:
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         dynamodb_client.delete_table(TableName=table_name)
+
+    def test_binary_data_with_stream(self, wait_for_stream_ready, dynamodb_create_table_with_parameters, dynamodb_client, kinesis_client):
+        table_name = f"table-{short_uid()}"
+        dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+            StreamSpecification={
+                "StreamEnabled": True,
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+            }
+        )
+        stream_name = get_kinesis_stream_name(table_name)
+        wait_for_stream_ready(stream_name)
+        response = dynamodb_client.put_item(TableName=table_name, Item={"id": {"S": "id1"}, "data": {"B": b"binary_data"}})
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
 
     def test_dynamodb_stream_shard_iterator(self, wait_for_stream_ready):
         dynamodb = aws_stack.create_external_boto_client("dynamodb")

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -521,7 +521,7 @@ class TestDynamoDB:
         stream_name = get_kinesis_stream_name(table_name)
         wait_for_stream_ready(stream_name)
         response = dynamodb_client.put_item(
-            TableName=table_name, Item={"id": {"S": "id1"}, "data": {"B": b"binary_data"}}
+            TableName=table_name, Item={"id": {"S": "id1"}, "data": {"B": b"\x90"}}
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 


### PR DESCRIPTION
This PR addresses #6364 where the user reported error messages in the logs while trying to stream the DDB changes to Kinesis. This was due to errors in serializing bytes content. 
Introduced a new encoder for binary content (less broad than the `CustomEncoder` we already have) and introduced/refactored some tests.