### PR TITLE
fix SNS MessageAttributes parity with AWS

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -978,7 +978,7 @@ async def message_to_subscriber(
                 message_id,
                 # see the format here
                 # https://docs.aws.amazon.com/lambda/latest/dg/with-sns.html
-                # issue with cdk to serialize the attribute inside lambda
+                # issue with sdk to serialize the attribute inside lambda
                 prepare_message_attributes(message_attributes),
                 unsubscribe_url,
                 subject=req_data.get("Subject")[0],

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -1384,18 +1384,3 @@ def unsubscribe_sqs_queue(queue_url):
             sub_url = subscriber.get("sqs_queue_url") or subscriber["Endpoint"]
             if queue_url == sub_url:
                 subscriptions.remove(subscriber)
-
-
-def get_subscribe_attributes(req_data):
-    attributes = {}
-    for key in req_data.keys():
-        if ".key" in key:
-            attributes[req_data[key][0]] = req_data[key.replace("key", "value")][0]
-    defaults = {
-        # TODO: this is required to get TF "aws_sns_topic_subscription" working, but this should
-        # be revisited (e.g., cross-account subscriptions should not be confirmed automatically)
-        "PendingConfirmation": "false"
-    }
-    for key, value in defaults.items():
-        attributes[key] = attributes.get(key, value)
-    return attributes

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -62,7 +62,7 @@ class TestNotifications(unittest.TestCase):
             # make sure we receive the correct topic ARN in notifications
             assertions.append({"TopicArn": topic_info["TopicArn"]})
             # make sure the notification contains message attributes
-            assertions.append({"StringValue": test_value})
+            assertions.append({"Value": test_value})
             self._receive_assert_delete(queue_url, assertions, sqs_client)
 
         retry(assert_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
@@ -332,8 +332,6 @@ class TestNotifications(unittest.TestCase):
         messages = []
         for m in response["Messages"]:
             message = json.loads(to_str(m["Body"]))
-            message_attributes = m.get("MessageAttributes", {})
-            message.update(message_attributes)
             messages.append(message)
         testutil.assert_objects(assertions, messages)
         for message in response["Messages"]:

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2,6 +2,7 @@
 import json
 import queue
 import random
+from base64 import b64encode
 
 import pytest
 import requests
@@ -99,32 +100,30 @@ class TestSNSSubscription:
 
 
 class TestSNSProvider:
+    @pytest.mark.aws_validated
     def test_publish_unicode_chars(
         self,
         sns_client,
         sns_create_topic,
         sqs_create_queue,
         sqs_client,
-        sqs_queue_arn,
-        sns_subscription,
+        sns_create_sqs_subscription,
     ):
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
-        queue_arn = sqs_queue_arn(queue_url)
-        sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
 
         # publish message to SNS, receive it from SQS, assert that messages are equal
         message = 'ö§a1"_!?,. £$-'
         sns_client.publish(TopicArn=topic_arn, Message=message)
 
-        def check_message():
-            msgs = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)
-            msg_received = msgs["Messages"][0]
-            msg_received = json.loads(to_str(msg_received["Body"]))
-            msg_received = msg_received["Message"]
-            assert message == msg_received
-
-        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )
+        msg_received = response["Messages"][0]
+        msg_received = json.loads(to_str(msg_received["Body"]))
+        msg_received = msg_received["Message"]
+        assert message == msg_received
 
     def test_subscribe_with_invalid_protocol(self, sns_client, sns_create_topic, sns_subscription):
         topic_arn = sns_create_topic()["TopicArn"]
@@ -137,28 +136,26 @@ class TestSNSProvider:
         assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
         assert e.value.response["Error"]["Code"] == "InvalidParameter"
 
+    @pytest.mark.aws_validated
     def test_attribute_raw_subscribe(
-        self, sqs_client, sns_client, sns_create_topic, sqs_queue, sqs_queue_arn, sns_subscription
+        self,
+        sqs_client,
+        sns_client,
+        sns_create_topic,
+        sqs_create_queue,
+        sns_create_sqs_subscription,
     ):
         topic_arn = sns_create_topic()["TopicArn"]
-        # create SNS topic and connect it to an SQS queue
-        queue_url = sqs_queue
-        queue_arn = sqs_queue_arn(queue_url)
-        attributes = {"RawMessageDelivery": "True"}
-        sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=queue_arn,
-            Attributes=attributes,
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="RawMessageDelivery",
+            AttributeValue="true",
         )
 
-        # fetch subscription information
-        subscription_list = sns_client.list_subscriptions()
-
-        subscription_arn = ""
-        for subscription in subscription_list["Subscriptions"]:
-            if subscription["TopicArn"] == topic_arn:
-                subscription_arn = subscription["SubscriptionArn"]
         actual_attributes = sns_client.get_subscription_attributes(
             SubscriptionArn=subscription_arn
         )["Attributes"]
@@ -177,40 +174,36 @@ class TestSNSProvider:
             MessageAttributes={"store": {"DataType": "Binary", "BinaryValue": binary_attribute}},
         )
 
-        def check_message():
-            msgs = sqs_client.receive_message(
-                QueueUrl=queue_url, MessageAttributeNames=["All"], VisibilityTimeout=0
-            )
-            msg_received = msgs["Messages"][0]
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            VisibilityTimeout=0,
+            WaitTimeSeconds=4,
+        )
+        msg_received = response["Messages"][0]
+        assert message == msg_received["Body"]
+        # MessageAttributes are attached to the message when RawDelivery is true
+        assert binary_attribute == msg_received["MessageAttributes"]["store"]["BinaryValue"]
 
-            assert message == msg_received["Body"]
-            assert binary_attribute == msg_received["MessageAttributes"]["store"]["BinaryValue"]
-
-        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-        sns_client.unsubscribe(SubscriptionArn=subscription_arn)
-
+    @pytest.mark.aws_validated
     def test_filter_policy(
         self,
-        sqs_create_queue,
-        sqs_queue_arn,
         sns_client,
-        sns_create_topic,
         sqs_client,
-        sns_subscription,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription,
     ):
-        # connect SNS topic to an SQS queue
-        queue_name = f"queue-{short_uid()}"
-        queue_url = sqs_create_queue(QueueName=queue_name)
-        queue_arn = sqs_queue_arn(queue_url)
         topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
 
         filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
-        sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=queue_arn,
-            Attributes={"FilterPolicy": json.dumps(filter_policy)},
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(filter_policy),
         )
 
         # get number of messages
@@ -227,13 +220,11 @@ class TestSNSProvider:
             MessageAttributes=message_attributes,
         )
 
-        def check_message():
-            msgs_1 = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
-            num_msgs_1 = len(msgs_1)
-            assert num_msgs_1 == (num_msgs_0 + 1)
-            return num_msgs_1
-
-        num_msgs_1 = retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+        msgs_1 = sqs_client.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )["Messages"]
+        num_msgs_1 = len(msgs_1)
+        assert num_msgs_1 == (num_msgs_0 + 1)
 
         # publish message that does not satisfy the filter policy, assert that message is not received
         message = "This is another test message"
@@ -243,41 +234,33 @@ class TestSNSProvider:
             MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
         )
 
-        def check_message2():
-            num_msgs_2 = len(
-                sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
-            )
-            assert num_msgs_2 == num_msgs_1
-            return num_msgs_2
+        num_msgs_2 = len(
+            sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4)[
+                "Messages"
+            ]
+        )
+        assert num_msgs_2 == num_msgs_1
 
-        retry(check_message2, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
+    @pytest.mark.aws_validated
     def test_exists_filter_policy(
         self,
-        sqs_create_queue,
-        sqs_queue_arn,
-        sns_create_topic,
         sns_client,
         sqs_client,
-        sns_subscription,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription,
     ):
-        # connect SNS topic to an SQS queue
-        queue_name = f"queue-{short_uid()}"
-        queue_url = sqs_create_queue(QueueName=queue_name)
-        queue_arn = sqs_queue_arn(queue_url)
         topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
 
         filter_policy = {"store": [{"exists": True}]}
-
-        def do_subscribe(filter_policy, queue_arn):
-            sns_subscription(
-                TopicArn=topic_arn,
-                Protocol="sqs",
-                Endpoint=queue_arn,
-                Attributes={"FilterPolicy": json.dumps(filter_policy)},
-            )
-
-        do_subscribe(filter_policy, queue_arn)
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(filter_policy),
+        )
 
         # get number of messages
         num_msgs_0 = len(
@@ -285,89 +268,93 @@ class TestSNSProvider:
         )
 
         # publish message that satisfies the filter policy, assert that message is received
-        message = f"message-{short_uid()}"
+        message_1 = f"message-{short_uid()}"
         sns_client.publish(
             TopicArn=topic_arn,
-            Message=message,
+            Message=message_1,
             MessageAttributes={
                 "store": {"DataType": "Number", "StringValue": "99"},
                 "def": {"DataType": "Number", "StringValue": "99"},
             },
         )
+        msgs_1 = sqs_client.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )["Messages"]
 
-        def check_message1():
-            num_msgs_1 = len(
-                sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
-            )
-            assert num_msgs_1 == (num_msgs_0 + 1)
-            return num_msgs_1
-
-        num_msgs_1 = retry(check_message1, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+        num_msgs_1 = len(msgs_1)
+        assert message_1 == json.loads(msgs_1[0]["Body"])["Message"]
+        assert num_msgs_1 == (num_msgs_0 + 1)
 
         # publish message that does not satisfy the filter policy, assert that message is not received
-        message = f"message-{short_uid()}"
+        message_2 = f"message-{short_uid()}"
         sns_client.publish(
             TopicArn=topic_arn,
-            Message=message,
+            Message=message_2,
             MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
         )
 
-        def check_message2():
-            num_msgs_2 = len(
-                sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)["Messages"]
-            )
-            assert num_msgs_2 == num_msgs_1
-            return num_msgs_2
+        msgs_2 = sqs_client.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )["Messages"]
+        num_msgs_2 = len(msgs_2)
+        # assert that it's still the same message that #1
+        assert json.loads(msgs_2[0]["Body"])["Message"] == message_1
+        assert num_msgs_2 == num_msgs_1
 
-        retry(check_message2, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+        # delete first message
+        sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=msgs_1[0]["ReceiptHandle"])
 
         # test with exist operator set to false.
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
-        filter_policy = {"store": [{"exists": False}]}
-        do_subscribe(filter_policy, queue_arn)
-        # get number of messages
-        num_msgs_0 = len(sqs_client.receive_message(QueueUrl=queue_url).get("Messages", []))
+        filter_policy = json.dumps({"store": [{"exists": False}]})
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=filter_policy,
+        )
 
-        # publish message with the attribute and see if its getting filtered.
-        message = f"message-{short_uid()}"
+        def get_filter_policy():
+            subscription_attrs = sns_client.get_subscription_attributes(
+                SubscriptionArn=subscription_arn
+            )
+            return subscription_attrs["Attributes"]["FilterPolicy"] == filter_policy
+
+        # wait for the new filter policy to be in effect
+        poll_condition(lambda: get_filter_policy() == filter_policy, timeout=4)
+
+        # publish message that satisfies the filter policy, assert that message is received
+        message_3 = f"message-{short_uid()}"
         sns_client.publish(
             TopicArn=topic_arn,
-            Message=message,
+            Message=message_3,
+            MessageAttributes={"def": {"DataType": "Number", "StringValue": "99"}},
+        )
+
+        msgs_3 = sqs_client.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )["Messages"]
+        num_msgs_3 = len(msgs_3)
+        # assert that it is not the the same message that #1
+        assert json.loads(msgs_3[0]["Body"])["Message"] == message_3
+        assert num_msgs_3 == num_msgs_1
+
+        # publish message that does not satisfy the filter policy, assert that message is not received
+        message_4 = f"message-{short_uid()}"
+        sns_client.publish(
+            TopicArn=topic_arn,
+            Message=message_4,
             MessageAttributes={
                 "store": {"DataType": "Number", "StringValue": "99"},
                 "def": {"DataType": "Number", "StringValue": "99"},
             },
         )
 
-        def check_message():
-            num_msgs_1 = len(
-                sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0).get(
-                    "Messages", []
-                )
-            )
-            assert num_msgs_1 == num_msgs_0
-            return num_msgs_1
-
-        num_msgs_1 = retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-        # publish message that without the attribute and see if its getting filtered.
-        message = f"message-{short_uid()}"
-        sns_client.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "111"}},
-        )
-
-        def check_message3():
-            num_msgs_2 = len(
-                sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0).get(
-                    "Messages", []
-                )
-            )
-            assert num_msgs_2 == num_msgs_1
-            return num_msgs_2
-
-        retry(check_message3, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+        msgs_4 = sqs_client.receive_message(
+            QueueUrl=queue_url, VisibilityTimeout=0, WaitTimeSeconds=4
+        )["Messages"]
+        num_msgs_4 = len(msgs_4)
+        # assert that it's still the same message that #3
+        assert json.loads(msgs_4[0]["Body"])["Message"] == message_3
+        assert num_msgs_4 == num_msgs_3
 
     @pytest.mark.aws_validated
     def test_subscribe_sqs_queue(
@@ -1016,25 +1003,25 @@ class TestSNSProvider:
 
         retry(check_messages, sleep=0.5)
 
+    @pytest.mark.aws_validated
     def test_publish_sqs_from_sns(
         self,
         sns_client,
-        sns_create_topic,
         sqs_client,
+        sns_create_topic,
         sqs_create_queue,
-        sqs_queue_arn,
-        sns_subscription,
+        sns_create_sqs_subscription,
     ):
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
-        queue_arn = sqs_queue_arn(queue_url)
-        subscription_arn = sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=queue_arn,
-            Attributes={"RawMessageDelivery": "true"},
-        )["SubscriptionArn"]
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
 
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="RawMessageDelivery",
+            AttributeValue="true",
+        )
         string_value = "99.12"
         sns_client.publish(
             TopicArn=topic_arn,
@@ -1042,18 +1029,20 @@ class TestSNSProvider:
             MessageAttributes={"attr1": {"DataType": "Number", "StringValue": string_value}},
         )
 
-        def get_message_with_attributes(queue_url):
-            response = sqs_client.receive_message(
-                QueueUrl=queue_url, MessageAttributeNames=["All"], VisibilityTimeout=0
-            )
-            assert response["Messages"][0]["MessageAttributes"] == {
-                "attr1": {"DataType": "Number", "StringValue": string_value}
-            }
-            sqs_client.delete_message(
-                QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
-            )
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            VisibilityTimeout=0,
+            WaitTimeSeconds=4,
+        )
+        # format is of SQS MessageAttributes when RawDelivery is set to "true"
+        assert response["Messages"][0]["MessageAttributes"] == {
+            "attr1": {"DataType": "Number", "StringValue": string_value}
+        }
 
-        retry(get_message_with_attributes, retries=3, sleep=3, queue_url=queue_url)
+        sqs_client.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=response["Messages"][0]["ReceiptHandle"]
+        )
 
         sns_client.set_subscription_attributes(
             SubscriptionArn=subscription_arn,
@@ -1066,26 +1055,36 @@ class TestSNSProvider:
             Message="Test msg",
             MessageAttributes={"attr1": {"DataType": "Number", "StringValue": string_value}},
         )
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url,
+            MessageAttributeNames=["All"],
+            VisibilityTimeout=0,
+            WaitTimeSeconds=4,
+        )
+        message_body = json.loads(response["Messages"][0]["Body"])
+        # format is SNS MessageAttributes when RawDelivery is "false"
+        assert message_body["MessageAttributes"] == {
+            "attr1": {"Type": "Number", "Value": string_value}
+        }
 
-        retry(get_message_with_attributes, retries=3, sleep=3, queue_url=queue_url)
-
+    @pytest.mark.aws_validated
     def test_publish_batch_messages_from_sns_to_sqs(
         self,
         sns_client,
+        sqs_client,
         sns_create_topic,
         sqs_create_queue,
-        sqs_queue_arn,
-        sqs_client,
-        sns_subscription,
+        sns_create_sqs_subscription,
     ):
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
-        queue_arn = sqs_queue_arn(queue_url)
-        sns_subscription(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=queue_arn,
-            Attributes={"RawMessageDelivery": "true"},
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        subscription_arn = subscription["SubscriptionArn"]
+
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_arn,
+            AttributeName="RawMessageDelivery",
+            AttributeValue="true",
         )
 
         publish_batch_response = sns_client.publish_batch(
@@ -1117,22 +1116,23 @@ class TestSNSProvider:
                 },
             ],
         )
-
         assert "Successful" in publish_batch_response
+        assert len(publish_batch_response["Successful"]) == 4
         assert "Failed" in publish_batch_response
 
         for successful_resp in publish_batch_response["Successful"]:
             assert "Id" in successful_resp
             assert "MessageId" in successful_resp
 
-        def get_messages(queue_url):
+        message_received = set()
+
+        def get_messages():
             response = sqs_client.receive_message(
-                QueueUrl=queue_url,
-                MessageAttributeNames=["All"],
-                MaxNumberOfMessages=10,
+                QueueUrl=queue_url, MessageAttributeNames=["All"], WaitTimeSeconds=1
             )
-            assert len(response["Messages"]) == 4
+
             for message in response["Messages"]:
+                message_received.add(message["MessageId"])
                 assert "Body" in message
 
                 if message["Body"] == "Test Message with two attributes":
@@ -1156,7 +1156,9 @@ class TestSNSProvider:
                 elif message["Body"] == "Test Message without attribute":
                     assert message.get("MessageAttributes") is None
 
-        retry(get_messages, retries=5, sleep=1, queue_url=queue_url)
+            assert len(message_received) == 4
+
+        retry(get_messages, retries=3, sleep=1)
 
     def test_publish_batch_messages_from_fifo_topic_to_fifo_queue(
         self, sns_client, sns_create_topic, sqs_client, sqs_create_queue, sns_subscription
@@ -1546,19 +1548,20 @@ class TestSNSProvider:
         assert (
             len(response["Messages"]) == 1
         ), f"invalid number of messages in DLQ response {response}"
-        print(response)
-        # if raw_message_delivery:
-        # assert response["Messages"][0]["Body"] == message
-        # snapshot.match("raw_message_delivery", response)
-        # else:
-        # received_message = json.loads(response["Messages"][0]["Body"])
-        # assert received_message["Type"] == "Notification"
-        # assert received_message["Message"] == message
 
-        # Set the decoded JSON Body to be able to skip keys directly
-        # response["Messages"][0]["Body"] = received_message
+        if raw_message_delivery:
+            assert response["Messages"][0]["Body"] == message
+            # MessageAttributes are lost with RawDelivery in AWS
+            assert "MessageAttributes" not in response["Messages"][0]
+            snapshot.match("raw_message_delivery", response)
+        else:
+            received_message = json.loads(response["Messages"][0]["Body"])
+            assert received_message["Type"] == "Notification"
+            assert received_message["Message"] == message
 
-        # snapshot.match("json_encoded_delivery", response)
+            # Set the decoded JSON Body to be able to skip keys directly
+            response["Messages"][0]["Body"] = received_message
+            snapshot.match("json_encoded_delivery", response)
 
     @pytest.mark.aws_validated
     def test_message_attributes_not_missing(
@@ -1574,20 +1577,22 @@ class TestSNSProvider:
         queue_url = sqs_create_queue()
 
         subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
-
-        # sns_client.set_subscription_attributes(
-        #     SubscriptionArn=subscription["SubscriptionArn"],
-        #     AttributeName="RawMessageDelivery",
-        #     AttributeValue="true",
-        # )
-
         assert subscription["SubscriptionArn"]
+
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="RawMessageDelivery",
+            AttributeValue="true",
+        )
+        attributes = {
+            "an-attribute-key": {"DataType": "String", "StringValue": "an-attribute-value"},
+            "binary-attribute": {"DataType": "Binary", "BinaryValue": b"\x02\x03\x04"},
+        }
+
         publish_response = sns_client.publish(
             TopicArn=topic_arn,
             Message="text",
-            MessageAttributes={
-                "an-attribute-key": {"DataType": "String", "StringValue": "an-attribute-value"}
-            },
+            MessageAttributes=attributes,
         )
         assert publish_response["MessageId"]
         msg = sqs_client.receive_message(
@@ -1596,8 +1601,41 @@ class TestSNSProvider:
             MessageAttributeNames=["All"],
             WaitTimeSeconds=3,
         )
-        print(msg)
-        # assert "an-attribute-key" in msg["Messages"][0]["MessageAttributes"]
+        # as SNS piggybacks on SQS MessageAttributes when RawDelivery is true
+        # BinaryValue depends on SQS implementation, and is decoded automatically
+        assert msg["Messages"][0]["MessageAttributes"] == attributes
+        sqs_client.delete_message(
+            QueueUrl=queue_url, ReceiptHandle=msg["Messages"][0]["ReceiptHandle"]
+        )
+
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription["SubscriptionArn"],
+            AttributeName="RawMessageDelivery",
+            AttributeValue="false",
+        )
+
+        publish_response = sns_client.publish(
+            TopicArn=topic_arn,
+            Message="text",
+            MessageAttributes=attributes,
+        )
+        assert publish_response["MessageId"]
+        msg = sqs_client.receive_message(
+            QueueUrl=queue_url,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+            WaitTimeSeconds=3,
+        )
+        assert json.loads(msg["Messages"][0]["Body"])["MessageAttributes"] == {
+            "an-attribute-key": {"Type": "String", "Value": "an-attribute-value"},
+            "binary-attribute": {
+                # binary payload in base64 encoded by AWS, UTF-8 for JSON
+                # https://docs.aws.amazon.com/sns/latest/api/API_MessageAttributeValue.html
+                # need to be decoded manually as it's part of the message Body
+                "Type": "Binary",
+                "Value": b64encode(b"\x02\x03\x04").decode("utf-8"),
+            },
+        }
 
     @pytest.mark.only_localstack
     @pytest.mark.aws_validated

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/test_sns.py::TestSNSProvider::test_dead_letter_queue_with_deleted_sqs_queue[True]": {
-    "recorded-date": "01-06-2022, 14:07:57",
+    "recorded-date": "29-06-2022, 16:43:14",
     "recorded-content": {
       "raw_message_delivery": {
         "Messages": [
@@ -12,14 +12,14 @@
           }
         ],
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_dead_letter_queue_with_deleted_sqs_queue[False]": {
-    "recorded-date": "01-06-2022, 14:08:00",
+    "recorded-date": "29-06-2022, 16:43:18",
     "recorded-content": {
       "json_encoded_delivery": {
         "Messages": [
@@ -36,13 +36,23 @@
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>"
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>",
+              "MessageAttributes": {
+                "attr2": {
+                  "Type": "Binary",
+                  "Value": "AgME"
+                },
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "111"
+                }
+              }
             }
           }
         ],
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/unit/test_sns.py
+++ b/tests/unit/test_sns.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import re
 import uuid
@@ -9,8 +8,6 @@ import pytest
 from localstack.services.sns.provider import (
     check_filter_policy,
     create_sns_message_body,
-    create_sqs_message_attributes,
-    get_message_attributes,
     get_subscribe_attributes,
     is_raw_message_delivery,
 )
@@ -165,35 +162,6 @@ class TestSns:
         result = create_sns_message_body(subscriber, action)
 
         assert {"message": "sqs version"} == result
-
-    def test_create_sqs_message_attributes(self, subscriber):
-        subscriber["RawMessageDelivery"] = "true"
-        action = {
-            "Message": ["msg"],
-            "Subject": ["subject"],
-            "MessageAttributes.entry.1.Name": ["attr1"],
-            "MessageAttributes.entry.1.Value.DataType": ["String"],
-            "MessageAttributes.entry.1.Value.StringValue": ["value1"],
-            "MessageAttributes.entry.2.Name": ["attr2"],
-            "MessageAttributes.entry.2.Value.DataType": ["Binary"],
-            # SNS gets binary data as base64 encoded string, but it should pass raw bytes further to SQS
-            "MessageAttributes.entry.2.Value.BinaryValue": [
-                base64.b64encode("value2".encode("utf-8"))
-            ],
-            "MessageAttributes.entry.3.Name": ["attr3"],
-            "MessageAttributes.entry.3.Value.DataType": ["Number"],
-            "MessageAttributes.entry.3.Value.StringValue": ["3"],
-        }
-
-        attributes = get_message_attributes(action)
-        result = create_sqs_message_attributes(subscriber, attributes)
-
-        assert "String" == result["attr1"]["DataType"]
-        assert "value1" == result["attr1"]["StringValue"]
-        assert "Binary" == result["attr2"]["DataType"]
-        assert "value2".encode("utf-8") == result["attr2"]["BinaryValue"]
-        assert "Number" == result["attr3"]["DataType"]
-        assert "3" == result["attr3"]["StringValue"]
 
     def test_create_sns_message_timestamp_millis(self, subscriber):
         action = {"Message": ["msg"]}


### PR DESCRIPTION
This PR fixes `MessageAttributes` for SNS, and add parity with AWS.

### Problem
A user encounter issue while trying to cast `MessageAttributes` with aws-sdk in Java I believe, inside a lambda.
The fields of our `MessageAttributes` were wrong: `"DataType"` and `"{type}Value"` where it should have been `"Type"` and `"Value"` for a message sent to a Lambda.

### Solution
I've done a round of check to fix `MessageAttributes` format where it was needed, and I checked those against AWS by rewriting some tests to be `aws_validated`.
https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html

Some behaviour has changed, as where `MessageAttributes` is located depends on `RawMessageDelivery` (SNS adds metadata or not to the message, and encapsulates the message inside a `"Body"` field).
When `RawMessageDelivery` is `true`, SNS piggybacks on SQS MessageAttributes to add them to the message for SQS endpoints. For other type of endpoints, `MessageAttributes` are not sent. See:
https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html
Before, we would only use SQS `MessageAttributes` for everything, but when `RawMessageDelivery` is set to `false`, those attributes are added to the `Body` of the message and not added to SQS.

edit: Had to delete a unit test that still tested a deleted method that was used with the old provider. With ASF, it wasn't used anymore (getting attributes from url encoded data)

_fixes #6245_