### PR TITLE
defaults to None when attribute doesn't exist

### DIFF
--- a/localstack/utils/patch.py
+++ b/localstack/utils/patch.py
@@ -53,7 +53,7 @@ class Patch:
         super().__init__()
         self.obj = obj
         self.name = name
-        self.old = getattr(self.obj, name)
+        self.old = getattr(self.obj, name, None)
         self.new = new
         self.is_applied = False
 


### PR DESCRIPTION
Minor fix to `Patch` when the attribute is not present in the receiver object


```
File ".../localstack/services/edge.py", line 163, in forward_request
    self._require_service(api)
File ".../localstack/services/edge.py", line 220, in _require_service
    raise HTTPErrorResponse("failed to get service for %s: %s" % (api, e), code=500)
localstack.utils.server.http2_server.HTTPErrorResponse: failed to get service for iam: module 'localstack.services.iam.provider' has no attribute '_validate_resource_syntax'
```

Reproducible with https://github.com/localstack/localstack-terraform-samples/tree/master/apigatewayv2-ws-sub-protocol