### PR TITLE
fix GitHub action user (use PAT of @localstack-bot)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
         if: "(github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'"
         uses: "cla-assistant/github-action@v2.1.3-beta"
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.PRO_ACCESS_TOKEN }}"
           PERSONAL_ACCESS_TOKEN: "${{ secrets.PRO_ACCESS_TOKEN }}"
         with:
           remote-organization-name: "localstack"

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -45,5 +45,5 @@ jobs:
         # on an issue.
         minimum-upvotes-to-exempt: 2
 
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.PRO_ACCESS_TOKEN }}
         loglevel: DEBUG

--- a/.github/workflows/welcome-first-time-contributors.yml
+++ b/.github/workflows/welcome-first-time-contributors.yml
@@ -2,7 +2,7 @@ name: Welcome First Time Contributors ✨
 
 on:
   pull_request_target:
-    types: 
+    types:
       - opened
   issues:
     types:
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/github-script@v3
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.PRO_ACCESS_TOKEN }}
         script: |
           const issueMessage = `Welcome to LocalStack! Thanks for reporting your first issue and our team will be working towards fixing the issue for you or reach out for more background information. We recommend joining our [Slack Community](https://localstack.cloud/contact/) for real-time help and drop a message to LocalStack Pro Support if you are a Pro user! If you are willing to contribute towards fixing this issue, please have a look at our [contributing guidelines](https://github.com/localstack/.github/blob/main/CONTRIBUTING.md) and our [developer guide](https://docs.localstack.cloud/developer-guide/).`;
           const prMessage = `Welcome to LocalStack! Thanks for raising your first Pull Request and landing in your contributions. Our team will reach out with any reviews or feedbacks that we have shortly. We recommend joining our [Slack Community](https://localstack.cloud/contact/) and share your PR on the **#community** channel to share your contributions with us. Please make sure you are following our [contributing guidelines](https://github.com/localstack/.github/blob/main/CONTRIBUTING.md) and our [Code of Conduct](https://github.com/localstack/.github/blob/main/CODE_OF_CONDUCT.md).`;


### PR DESCRIPTION
This PR changes the token for the following actions:
- CLA Assistant
- Triage Stale issues
- Welcome First Time Contributors ✨

Previously, the comments by this actions looked as follows:
- CLA Assistant
![image](https://user-images.githubusercontent.com/2796604/176628063-b8920d5f-72eb-4054-a306-69a6ffe09374.png)

- Triage Stale issues
![image](https://user-images.githubusercontent.com/2796604/176627888-5a92d449-495d-4e5c-bdd3-5800f08ed0e2.png)

- Welcome First Time Contributors ✨ 
![image](https://user-images.githubusercontent.com/2796604/176627718-48596c03-d0cc-45bc-a170-0a10d462c96d.png)


Instead of the default token, they now use the `PRO_ACCESS_TOKEN`, a Personal Access Token of @localstack-bot.
This should change the appearance of the three actions in PRs and issues from @github-actions to @localstack-bot.