### PR TITLE
Fix host path replacement for lambda volume mounts

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1575,6 +1575,13 @@ class Util:
 
     @classmethod
     def get_host_path_for_path_in_docker(cls, path):
+        """
+        Returns the calculated host location for a given subpath of DEFAULT_VOLUME_DIR inside the localstack container.
+        The path **has** to be a subdirectory of DEFAULT_VOLUME_DIR (the dir itself *will not* work).
+
+        :param path: Path to be replaced (subpath of DEFAULT_VOLUME_DIR)
+        :return: Path on the host
+        """
         if config.LEGACY_DIRECTORIES:
             return re.sub(r"^%s/(.*)$" % config.dirs.tmp, r"%s/\1" % config.dirs.functions, path)
 

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1587,7 +1587,18 @@ class Util:
                         f"Mount to {DEFAULT_VOLUME_DIR} needs to be a bind mount for lambda code mounting to work"
                     )
 
-                return re.sub(r"^%s/(.*)$" % config.dirs.tmp, r"%s/\1" % volume.source, path)
+                result, subs = re.subn(
+                    r"^%s/(.*)$" % DEFAULT_VOLUME_DIR, r"%s/\1" % volume.source, path
+                )
+                if subs == 0:
+                    # We should be able to replace something here.
+                    # if this warning is printed, the usage of this function is probably wrong.
+                    # Please check for missing slashes after DEFAULT_VOLUME_DIR etc.
+                    LOG.warning(
+                        "Error while performing automatic host path replacement for path %s to source %s"
+                    )
+                else:
+                    return result
             else:
                 raise ValueError(f"No volume mounted to {DEFAULT_VOLUME_DIR}")
 

--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -30,7 +30,12 @@ def start_lambda(port=None, asynchronous=False):
             lambda_utils.get_executor_mode(),
         )
 
-    if config.is_in_docker and not config.LAMBDA_REMOTE_DOCKER and not config.dirs.functions:
+    if (
+        config.is_in_docker
+        and not config.LAMBDA_REMOTE_DOCKER
+        and not config.dirs.functions
+        and config.LEGACY_DIRECTORIES
+    ):
         LOG.warning(
             "!WARNING! - Looks like you have configured $LAMBDA_REMOTE_DOCKER=0 - "
             "please make sure to configure $HOST_TMP_FOLDER to point to your host's $TMPDIR"

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -305,7 +305,14 @@ def cleanup_resources():
     cleanup_threads_and_processes()
 
     if config.CLEAR_TMP_FOLDER:
-        files.rm_rf(config.dirs.tmp)
+        try:
+            files.rm_rf(config.dirs.tmp)
+        except PermissionError as e:
+            LOG.error(
+                "unable to delete temp folder %s: %s, please delete manually or you will keep seeing these errors",
+                config.dirs.tmp,
+                e,
+            )
 
 
 def log_startup_message(service):
@@ -371,7 +378,16 @@ def print_runtime_information(in_docker=False):
 
 def start_infra(asynchronous=False, apis=None):
     if config.CLEAR_TMP_FOLDER:
-        files.rm_rf(config.dirs.tmp)  # clear temp dir on startup
+        # try to clear temp dir on startup
+        try:
+            files.rm_rf(config.dirs.tmp)
+        except PermissionError as e:
+            LOG.error(
+                "unable to delete temp folder %s: %s, please delete manually or you will keep seeing these errors",
+                config.dirs.tmp,
+                e,
+            )
+
     config.dirs.mkdirs()
 
     events.infra_starting.set()


### PR DESCRIPTION
The method `get_host_path_for_path_in_docker` had a serious problem:
It would replace `/var/lib/localstack/tmp` instead of `/var/lib/localstack` in the path.
Therefore, the LS container path `/var/lib/localstack/tmp/zipfile.aaaaaaaa` (where the lambda code is located in the container) got mapped to `/tmp/localstack/zipfile.aaaaaaaa` instead of `/tmp/localstack/tmp/zipfile.aaaaaaaaa` (which would be the actual location).

This also resulted in an immediate failure in pro, since it tried to replace `/var/lib/localstack/tmp/(.*)` on `/var/lib/localstack/tmp`, which cannot work (due to missing trailing slash).

This PR fixes the behavior, introduces a function docstring which documents the expected behavior of the function, and logs a warning if the replacement should be unsuccessful.

Also suppresses warnings for missing HOST_TMP_DIR unless `LEGACY_DIRECTORIES` is set