### PR TITLE
fix None check in AccountIdEnricher

### DIFF
--- a/localstack/aws/handlers/auth.py
+++ b/localstack/aws/handlers/auth.py
@@ -1,7 +1,7 @@
 import logging
 
 from localstack.aws.accounts import get_account_id_from_access_key_id, set_ctx_aws_access_key_id
-from localstack.constants import HEADER_LOCALSTACK_ACCOUNT_ID
+from localstack.constants import HEADER_LOCALSTACK_ACCOUNT_ID, TEST_AWS_ACCESS_KEY_ID
 from localstack.http import Response
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
 
@@ -34,6 +34,9 @@ class AccountIdEnricher(Handler):
 
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
         access_key_id = extract_access_key_id_from_auth_header(context.request.headers)
+
+        if not access_key_id:
+            access_key_id = TEST_AWS_ACCESS_KEY_ID
 
         # Save the request access key ID in the current thread local storage
         set_ctx_aws_access_key_id(access_key_id)


### PR DESCRIPTION
Fixes an issue where `access_key_id` could be None when parsing non-AWS requests.