### PR TITLE
implement HTTP proxy framework

### DIFF
--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -38,6 +38,7 @@ def populate_wsgi_environment(environ: "WSGIEnvironment", scope: "HTTPScope"):
         environ["QUERY_STRING"] = query_string.decode("latin1")
     else:
         raw_uri = scope["raw_path"]
+        environ["QUERY_STRING"] = ""
 
     environ["RAW_URI"] = environ["REQUEST_URI"] = raw_uri.decode("utf-8")
 

--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -1,0 +1,60 @@
+import abc
+
+import requests
+from werkzeug import Request, Response
+from werkzeug.datastructures import Headers
+
+from localstack.http.request import restore_payload
+
+
+class HttpClient(abc.ABC):
+    """
+    An HTTP client that can make http requests using werkzeug's request object.
+    """
+
+    def request(self, request: Request) -> Response:
+        """
+        Make the given HTTP as a client.
+
+        :param request: the request to make
+        :return: the response.
+        """
+        raise NotImplementedError
+
+
+class SimpleRequestsClient(HttpClient):
+    def request(self, request: Request) -> Response:
+        """
+        Very naive implementation to make the given HTTP request using the requests library, i.e., process the request
+        as a client.
+
+        TODO: over time, this should become more sophisticated, specifically the use of restore_payload should only be
+         used only when necessary (when the stream has been consumed), and by default the underlying stream should be
+         streamed to the destination.
+
+        :param request: the request to perform
+        :return: the response.
+        """
+        response = requests.request(
+            method=request.method,
+            url=request.url,
+            params=request.args,
+            headers=request.headers,
+            data=restore_payload(request),
+        )
+
+        return Response(
+            response=response.content,
+            status=response.status_code,
+            headers=Headers(dict(response.headers)),
+        )
+
+
+def make_request(request: Request) -> Response:
+    """
+    Convenience method to make the given HTTP as a client.
+
+    :param request: the request to make
+    :return: the response.
+    """
+    return SimpleRequestsClient().request(request)

--- a/localstack/http/proxy.py
+++ b/localstack/http/proxy.py
@@ -1,0 +1,133 @@
+from io import BytesIO
+from typing import Mapping, Union
+
+from werkzeug import Request, Response
+from werkzeug.datastructures import Headers
+from werkzeug.test import EnvironBuilder
+
+from .client import HttpClient, SimpleRequestsClient
+from .request import restore_payload
+
+
+def forward(
+    request: Request,
+    forward_base_url: str,
+    forward_path: str = None,
+    headers: Union[Headers, Mapping[str, str]] = None,
+) -> Response:
+    """
+    Convenience method that creates a new Proxy and immediately calls proxy.forward(...). See ``Proxy`` for more
+    information.
+    """
+    return Proxy(forward_base_url=forward_base_url).forward(
+        request, forward_path=forward_path, headers=headers
+    )
+
+
+class Proxy:
+    def __init__(self, forward_base_url: str, client: HttpClient = None):
+        """
+        Creates a new HTTP Proxy which can be used to forward incoming requests according to the configuration.
+
+        :param forward_base_url: the base url (backend) to forward the requests to.
+        :param client: the HTTP Client used to make the requests
+        """
+        self.forward_base_url = forward_base_url
+        self.client = client or SimpleRequestsClient()
+
+    def forward(
+        self,
+        request: Request,
+        forward_path: str = None,
+        headers: Union[Headers, Mapping[str, str]] = None,
+    ):
+        """
+        Uses the client to forward the given request according to the proxy's configuration.
+
+        :param request: the base request to forward (with the original URL and path data)
+        :param forward_path: the path to forward the request to. if set, the original path will be replaced completely,
+            otherwise the original path will be used
+        :param headers:
+        :return:
+        """
+        headers = Headers(headers) if headers else Headers()
+
+        if client_ip := request.remote_addr:
+            if xff := request.headers.get("X-Forwarded-For"):
+                headers["X-Forwarded-For"] = f"{xff}, {client_ip}"
+            else:
+                headers["X-Forwarded-For"] = f"{client_ip}"
+
+        if forward_path is None:
+            forward_path = request.path
+        if forward_path:
+            forward_path = "/" + forward_path.lstrip("/")
+
+        proxy_request = _copy_request(request, self.forward_base_url, forward_path, headers)
+        return self.client.request(proxy_request)
+
+
+class ProxyHandler:
+    """
+    A dispatcher Handler which can be used in a ``Router[Handler]`` that proxies incoming requests according to the
+    configuration.
+
+    The Handler is expected to be used together with a route that uses a ``path`` parameter named ``path`` in the URL.
+    Fir example: if you want to forward all requests from ``/foobar/<path>`` to ``http://localhost:8080/v1/<path>``,
+    you would do the following::
+
+        router = Router(dispatcher=handler_dispatcher())
+        router.add("/foobar/<path:path>", ProxyHandler("http://localhost:8080/v1")
+
+    This is similar to the common nginx configuration where proxy_pass is a URI::
+
+        location /foobar {
+            proxy_pass http://localhost:8080/v1/;
+        }
+    """
+
+    def __init__(self, forward_base_url: str):
+        """
+        Creates a new Proxy with the given ``forward_base_url`` (see ``Proxy``).
+
+        :param forward_base_url: the base url (backend) to forward the requests to.
+        """
+        self.proxy = Proxy(forward_base_url=forward_base_url)
+
+    def __call__(self, request: Request, **kwargs) -> Response:
+        return self.proxy.forward(request, forward_path=kwargs.get("path", ""))
+
+
+def _copy_request(
+    request: Request,
+    base_url: str = None,
+    path: str = None,
+    headers: Union[Headers, Mapping[str, str]] = None,
+) -> Request:
+    """
+    Creates a new request from the given one that can be used to perform a proxy call.
+
+    :param request: the original request
+    :param base_url: the url to forward the request to (e.g., http://localhost:8080)
+    :param path: the path to forward the request to (e.g., /foobar), if set to None, the original path will be used
+    :param headers: optional headers to overwrite
+    :return: a new request with slightly modified underlying environment but the same data stream
+    """
+    builder = EnvironBuilder.from_environ(request.environ)
+
+    if base_url:
+        builder.base_url = base_url
+        builder.headers["Host"] = builder.host
+
+    if path is not None:
+        builder.path = path
+
+    if headers:
+        builder.headers.update(headers)
+
+    # FIXME: unfortunately, EnvironBuilder expects the input stream to be seekable, but we don't have that when using
+    #  the asgi/wsgi bridge. we need a better way of dealing with IO!
+    builder.input_stream = BytesIO(restore_payload(request))
+
+    new_request = builder.get_request()
+    return new_request

--- a/localstack/http/request.py
+++ b/localstack/http/request.py
@@ -56,8 +56,7 @@ def dummy_wsgi_environment(
 
     data = strings.to_bytes(body) if body else b""
 
-    if query_string is not None:
-        environ["QUERY_STRING"] = query_string
+    environ["QUERY_STRING"] = query_string or ""
 
     if raw_uri:
         if query_string:

--- a/tests/unit/http_/conftest.py
+++ b/tests/unit/http_/conftest.py
@@ -1,0 +1,55 @@
+import asyncio
+import logging
+from asyncio import AbstractEventLoop
+
+import pytest
+from hypercorn import Config
+from hypercorn.typing import ASGI3Framework
+
+from localstack.http.asgi import ASGIAdapter
+from localstack.http.hypercorn import HypercornServer
+from localstack.utils import net
+from localstack.utils.sync import poll_condition
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture()
+def serve_asgi_app():
+    _servers = []
+
+    def _create(
+        app: ASGI3Framework, config: Config = None, event_loop: AbstractEventLoop = None
+    ) -> HypercornServer:
+        if not config:
+            config = Config()
+            config.bind = f"localhost:{net.get_free_tcp_port()}"
+
+        srv = HypercornServer(app, config, loop=event_loop)
+        _servers.append(srv)
+        srv.start()
+        assert srv.wait_is_up(timeout=10), "gave up waiting for server to start up"
+        return srv
+
+    yield _create
+
+    for server in _servers:
+        server.shutdown()
+        assert poll_condition(
+            lambda: not server.is_up(), timeout=10
+        ), "gave up waiting for server to shut down"
+
+
+@pytest.fixture()
+def serve_asgi_adapter(serve_asgi_app):
+    def _create(wsgi_app):
+        loop = asyncio.new_event_loop()
+        return serve_asgi_app(
+            ASGIAdapter(
+                wsgi_app,
+                event_loop=loop,
+            ),
+            event_loop=loop,
+        )
+
+    yield _create

--- a/tests/unit/http_/test_proxy.py
+++ b/tests/unit/http_/test_proxy.py
@@ -1,0 +1,202 @@
+import json
+from typing import Tuple
+
+import pytest
+import requests
+from pytest_httpserver import HTTPServer
+from werkzeug import Request, Response
+
+from localstack.http import Router
+from localstack.http.dispatcher import handler_dispatcher
+from localstack.http.hypercorn import HypercornServer
+from localstack.http.proxy import ProxyHandler, forward
+
+
+@pytest.fixture
+def router_server(serve_asgi_adapter) -> Tuple[Router, HypercornServer]:
+    """Creates a new Router with a handler dispatcher, serves it through a newly created ASGI server, and returns
+    both the router and the server.
+    """
+    router = Router(dispatcher=handler_dispatcher())
+    app = Request.application(router.dispatch)
+    return router, serve_asgi_adapter(app)
+
+
+class TestPathForwarder:
+    def test_get_with_path_rule(self, router_server, httpserver: HTTPServer):
+        router, proxy = router_server
+        backend = httpserver
+
+        backend.expect_request("/").respond_with_data("ok/")
+        backend.expect_request("/bar").respond_with_data("ok/bar")
+        backend.expect_request("/bar/ed").respond_with_data("ok/bar/ed")
+
+        router.add("/foo/<path:path>", ProxyHandler(backend.url_for("/")))
+
+        response = requests.get(proxy.url + "/foo/bar")
+        assert response.ok
+        assert response.text == "ok/bar"
+
+        response = requests.get(proxy.url + "/foo/bar/ed")
+        assert response.ok
+        assert response.text == "ok/bar/ed"
+
+        response = requests.get(proxy.url)
+        assert not response.ok
+
+        response = requests.get(proxy.url + "/bar")
+        assert not response.ok
+
+        backend.check()
+
+    def test_get_with_plain_rule(self, router_server, httpserver: HTTPServer):
+        router, proxy = router_server
+        backend = httpserver
+
+        backend.expect_request("/").respond_with_data("ok")
+
+        router.add("/foo", ProxyHandler(backend.url_for("/")))
+
+        response = requests.get(proxy.url + "/foo")
+        assert response.ok
+        assert response.text == "ok"
+
+        response = requests.get(proxy.url + "/foo/bar")
+        assert not response.ok
+
+    def test_get_with_different_base_url(self, router_server, httpserver: HTTPServer):
+        router, proxy = router_server
+        backend = httpserver
+
+        backend.expect_request("/bar/ed").respond_with_data("ok/bar/ed")
+        backend.expect_request("/bar/ed/baz").respond_with_data("ok/bar/ed/baz")
+
+        router.add("/foo/<path:path>", ProxyHandler(backend.url_for("/bar")))
+
+        response = requests.get(proxy.url + "/foo/ed")
+        assert response.ok
+        assert response.text == "ok/bar/ed"
+
+        response = requests.get(proxy.url + "/foo/ed/baz")
+        assert response.ok
+        assert response.text == "ok/bar/ed/baz"
+
+    def test_get_with_different_base_url_plain_rule(self, router_server, httpserver: HTTPServer):
+        router, proxy = router_server
+        backend = httpserver
+
+        backend.expect_request("/bar").respond_with_data("ok/bar")
+        backend.expect_request("/bar/").respond_with_data("ok/bar/")
+
+        router.add("/foo", ProxyHandler(backend.url_for("/bar")))
+
+        response = requests.get(proxy.url + "/foo")
+        assert response.ok
+        assert response.text == "ok/bar/"  # it's calling /bar/ because it's part of the root URL
+
+    def test_xff_header(self, router_server, httpserver: HTTPServer):
+        router, proxy = router_server
+        backend = httpserver
+
+        def _echo_headers(request):
+            return Response(json.dumps(dict(request.headers)), mimetype="application/json")
+
+        backend.expect_request("/echo").respond_with_handler(_echo_headers)
+
+        router.add("/<path:path>", ProxyHandler(backend.url_for("/")))
+
+        response = requests.get(proxy.url + "/echo")
+        assert response.ok
+        headers = response.json()
+        assert headers["X-Forwarded-For"] == "127.0.0.1"
+
+        # check that it appends remote address correctly if an header is already present
+        response = requests.get(proxy.url + "/echo", headers={"X-Forwarded-For": "127.0.0.2"})
+        assert response.ok
+        headers = response.json()
+        assert headers["X-Forwarded-For"] == "127.0.0.2, 127.0.0.1"
+
+    def test_post_form_data_with_query_args(self, router_server, httpserver: HTTPServer):
+        router, proxy = router_server
+        backend = httpserver
+
+        def _handler(request: Request):
+            data = {
+                "args": request.args,
+                "form": request.form,
+            }
+            return Response(json.dumps(data), mimetype="application/json")
+
+        backend.expect_request("/form").respond_with_handler(_handler)
+
+        router.add("/<path:path>", ProxyHandler(backend.url_for("/")))
+
+        response = requests.post(
+            proxy.url + "/form?q=yes",
+            data={"foo": "bar", "baz": "ed"},
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert response.ok
+        doc = response.json()
+        assert doc == {"args": {"q": "yes"}, "form": {"foo": "bar", "baz": "ed"}}
+
+
+@pytest.mark.parametrize("consume_data", [True, False])
+def test_forward_files_and_form_data_proxy_consumes_data(
+    consume_data, serve_asgi_adapter, tmp_path
+):
+    """Tests that, when the proxy consumes (or doesn't) consume the request object's data prior to forwarding,
+    the request is forwarded correctly. not using httpserver here because it consumes werkzeug data incorrectly (it
+    calls request.get_data())"""
+
+    @Request.application
+    def _backend_handler(request: Request):
+        data = {
+            "data": request.data.decode("utf-8"),
+            "args": request.args,
+            "form": request.form,
+            "files": {
+                name: storage.stream.read().decode("utf-8")
+                for name, storage in request.files.items()
+            },
+        }
+        return Response(json.dumps(data), mimetype="application/json")
+
+    @Request.application
+    def _proxy_handler(request: Request):
+        # heuristic to check whether the stream has been consumed
+        assert getattr(request, "_cached_data", None) is None, "data has already been cached"
+
+        if consume_data:
+            assert (
+                not request.data
+            )  # data should be empty because it is consumed by parsing form data
+
+        return forward(request, forward_base_url=backend.url)
+
+    backend = serve_asgi_adapter(_backend_handler)
+    proxy = serve_asgi_adapter(_proxy_handler)
+
+    tmp_file_1 = tmp_path / "temp_file_1.txt"
+    tmp_file_1.write_text("1: hello\nworld")
+
+    tmp_file_2 = tmp_path / "temp_file_2.txt"
+    tmp_file_2.write_text("2: foobar")
+
+    response = requests.post(
+        proxy.url,
+        params={"q": "yes"},
+        data={"foo": "bar", "baz": "ed"},
+        files={"upload_file_1": open(tmp_file_1, "rb"), "upload_file_2": open(tmp_file_2, "rb")},
+    )
+    assert response.ok
+    doc = response.json()
+    assert doc == {
+        "data": "",
+        "args": {"q": "yes"},
+        "form": {"foo": "bar", "baz": "ed"},
+        "files": {
+            "upload_file_1": "1: hello\nworld",
+            "upload_file_2": "2: foobar",
+        },
+    }


### PR DESCRIPTION
This PR extends our HTTP server framework with proxy components. This will need a second iteration, as some of the components still have a bit of a naive implementation, and also the problem around IO and `restore_payload` are still not resolved.

The central new APIs are `HttpClient` and `Proxy`.

## HttpClient
`HttpClient` is a client that can take Werkzeug's server-side `Request` object and actually perform the request as a client, and it returns a Werkzeug `Response`, which can be seamlessly handed down stream in the handler pipeline.

Currently there is only a very simple implementation using the [requests](https://github.com/psf/requests) library. The major limitation is that it relies on `restore_payload` to get the incoming request's data, which will always consume and reconstruct the HTTP request payload. Moving forward, it would be great if we could find a better implementation here somehow utilizing `request.stream` (which is difficult because there is currently no good way of determining whether the stream has been consumed or not).

## Proxy
`Proxy` takes a `forward_base_url` (the backend the requests are being sent to) and an `HttpClient`. The `forward` method takes the incoming Request and uses the http client to forward it to the `forward_base_url`, optionally allowing manipulation of the path and headers.

Around this construct there are several layers of APIs to make the Proxy more user friendly:

* `ForwardingHandler` can be used as an endpoint in a `Router[Handler]` (e.g., the `edge.ROUTER`) to forward the `path` of a url matching argument 
* `path_forwarder` just a simple factory for a `ForwardingHandler` to not have to instantiate the Proxy and HttpClient manually.

The core mechanism that makes this work is `_copy_request`, which is also a very naive implementation that uses werkzeug internals to make a copy of the WSGI environment underlying the Request object, modifying that, and then creating a new Request object from it. This is not ideal because a) we're using werkzeug test internals, b) again we rely on `restore_payload` to create a new stream of the request. So currently we need two calls to `restore_payload` to make a proxy call, which is not great and should be fixed soon(tm).

## Example use

```python
ROUTER.add("/myservice/<path:path>", path_forwarder("http://localhost:8081"))
```

which is roughly equivalent to:

```python
def handler(request: Request, path: str) -> Response:
    proxy = Proxy("http://localhost:8081", SimpleRequestsClient())
    response = proxy.forward(request, forward_path=path)
    return response

ROUTER.add("/myservice/<path:path>", handler)
```

Here's a WSGI server that uses the convenience method `forward` to forward request to httpbin:
```python
from werkzeug import Request
from werkzeug.exceptions import MethodNotAllowed
from werkzeug.serving import run_simple

from localstack.http.proxy import forward

@Request.application
def handler(request):
    verb = request.method.lower()
    if verb not in ["delete", "get", "patch", "post", "put"]:
        raise MethodNotAllowed()
    return forward(request, forward_base_url="https://httpbin.org", forward_path=f"/{verb}")

if __name__ == '__main__':
    run_simple("localhost", 8080, handler)
```

## Other changes

* Make sure `QUERY_STRING` is always in the WSGI environment (required by werkzeug's `EnvironBuilder`)
* Slightly refactored `dispatcher.py` to make it work when plain werkzeug Responses are returned by a dispatcher
* Slightly refactored the test fixtures to re-use the wsgi/asgi adapter serving