### PR TITLE
implement localstack python extensions framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,6 +157,9 @@ ADD bin/localstack bin/localstack.bat bin/
 # install dependencies to run the localstack runtime and save which ones were installed
 RUN make install-runtime
 RUN make freeze > requirements-runtime.txt
+# link the extensions virtual environment into the localstack venv
+RUN echo /var/lib/localstack/lib/extensions/python_venv/lib/python3.10/site-packages > localstack-extensions-venv.pth && \
+    mv localstack-extensions-venv.pth .venv/lib/python*/site-packages/
 
 
 

--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/tmp/supervisord.log
 
 [program:infra]
 directory=/opt/code/localstack
-command=bin/localstack start --host --no-banner
+command=.venv/bin/python -m localstack.cli.main start --host --no-banner
 environment=
     LOCALSTACK_INFRA_PROCESS=1
 autostart=true

--- a/localstack/aws/chain.py
+++ b/localstack/aws/chain.py
@@ -159,6 +159,21 @@ class CompositeHandler(Handler):
         self.handlers = []
         self.return_on_stop = return_on_stop
 
+    def append(self, handler: Handler) -> None:
+        """
+        Adds the given handler to the list of handlers.
+
+        :param handler: the handler to add
+        """
+        self.handlers.append(handler)
+
+    def remove(self, handler: Handler) -> None:
+        """
+        Remove the given handler from the list of handlers
+        :param handler: the handler to remove
+        """
+        self.handlers.remove(handler)
+
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
         for handler in self.handlers:
             handler(chain, context, response)

--- a/localstack/cli/main.py
+++ b/localstack/cli/main.py
@@ -1,7 +1,7 @@
-from .localstack import create_with_plugins
-
-
 def main():
+    # initialize repositories
+    from .localstack import create_with_plugins
+
     cli = create_with_plugins()
     cli()
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -325,10 +325,10 @@ OVERRIDE_IN_DOCKER = is_env_true("OVERRIDE_IN_DOCKER")
 is_in_docker = in_docker()
 is_in_linux = is_linux()
 
-# the configuration profile to load
+# CLI specific: the configuration profile to load
 CONFIG_PROFILE = os.environ.get("CONFIG_PROFILE", "").strip()
 
-# host configuration directory
+# CLI specific: host configuration directory
 CONFIG_DIR = os.environ.get("CONFIG_DIR", os.path.expanduser("~/.localstack"))
 
 # keep this on top to populate environment

--- a/localstack/extensions/__init__.py
+++ b/localstack/extensions/__init__.py
@@ -1,0 +1,2 @@
+"""Extensions are third-party software modules to customize localstack."""
+name = "extensions"

--- a/localstack/extensions/api/__init__.py
+++ b/localstack/extensions/api/__init__.py
@@ -1,0 +1,6 @@
+"""Public facing API for users to build LocalStack extensions."""
+from .extension import Extension
+
+name = "api"
+
+__all__ = ["Extension"]

--- a/localstack/extensions/api/aws.py
+++ b/localstack/extensions/api/aws.py
@@ -1,0 +1,25 @@
+from localstack.aws.api import (
+    CommonServiceException,
+    RequestContext,
+    ServiceException,
+    ServiceRequest,
+    ServiceResponse,
+)
+from localstack.aws.chain import CompositeHandler, CompositeResponseHandler, ExceptionHandler
+from localstack.aws.chain import Handler as RequestHandler
+from localstack.aws.chain import Handler as ResponseHandler
+from localstack.aws.chain import HandlerChain
+
+__all__ = [
+    "RequestContext",
+    "ServiceRequest",
+    "ServiceResponse",
+    "ServiceException",
+    "CommonServiceException",
+    "RequestHandler",
+    "ResponseHandler",
+    "HandlerChain",
+    "CompositeHandler",
+    "ExceptionHandler",
+    "CompositeResponseHandler",
+]

--- a/localstack/extensions/api/extension.py
+++ b/localstack/extensions/api/extension.py
@@ -1,0 +1,86 @@
+from plugin import Plugin
+
+from .aws import CompositeHandler, CompositeResponseHandler
+from .http import RouteHandler, Router
+
+
+class BaseExtension(Plugin):
+    """
+    Base extension.
+    """
+
+    def load(self, *args, **kwargs):
+        """
+        Provided to plux to load the plugins. Do NOT overwrite! PluginManagers managing extensions expect the load method to return the Extension itself.
+
+        :param args: load arguments
+        :param kwargs: load keyword arguments
+        :return: this extension object
+        """
+        self.on_extension_load(*args, **kwargs)
+        return self
+
+    def on_extension_load(self, *args, **kwargs):
+        """
+        Called when LocalStack loads the extension.
+        """
+        raise NotImplementedError
+
+
+class Extension(BaseExtension):
+    """
+    An extension that is loaded into LocalStack dynamically.
+
+    The method execution order of an extension is as follows:
+
+    - on_extension_load
+    - on_platform_start
+    - update_gateway_routes
+    - update_request_handlers
+    - update_response_handlers
+    - on_platform_ready
+    """
+
+    namespace = "localstack.extensions"
+
+    def on_extension_load(self):
+        """
+        Called when LocalStack loads the extension.
+        """
+        pass
+
+    def on_platform_start(self):
+        """
+        Called when LocalStack starts the main runtime.
+        """
+        pass
+
+    def update_gateway_routes(self, router: Router[RouteHandler]):
+        """
+        Called with the Router attached to the LocalStack gateway. Overwrite this to add or update routes.
+
+        :param router: the Router attached in the gateway
+        """
+        pass
+
+    def update_request_handlers(self, handlers: CompositeHandler):
+        """
+        Called with the custom request handlers of the LocalStack gateway. Overwrite this to add or update handlers.
+
+        :param handlers: custom request handlers of the gateway
+        """
+        pass
+
+    def update_response_handlers(self, handlers: CompositeResponseHandler):
+        """
+        Called with the custom response handlers of the LocalStack gateway. Overwrite this to add or update handlers.
+
+        :param handlers: custom response handlers of the gateway
+        """
+        pass
+
+    def on_platform_ready(self):
+        """
+        Called when LocalStack is ready and the Ready marker has been printed.
+        """
+        pass

--- a/localstack/extensions/api/http.py
+++ b/localstack/extensions/api/http.py
@@ -1,0 +1,16 @@
+from localstack.http import Request, Response, Router
+from localstack.http.client import HttpClient, SimpleRequestsClient
+from localstack.http.dispatcher import Handler as RouteHandler
+from localstack.http.proxy import Proxy, ProxyHandler, forward
+
+__all__ = [
+    "Request",
+    "Response",
+    "Router",
+    "HttpClient",
+    "SimpleRequestsClient",
+    "Proxy",
+    "ProxyHandler",
+    "forward",
+    "RouteHandler",
+]

--- a/localstack/extensions/api/runtime.py
+++ b/localstack/extensions/api/runtime.py
@@ -1,0 +1,3 @@
+from localstack.utils.analytics import get_session_id
+
+__all__ = ["get_session_id"]

--- a/localstack/extensions/api/services.py
+++ b/localstack/extensions/api/services.py
@@ -1,0 +1,5 @@
+from localstack.utils.common import external_service_ports
+
+__all__ = [
+    "external_service_ports",
+]

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -6,6 +6,7 @@ import math
 import typing as t
 from asyncio import AbstractEventLoop
 from concurrent.futures import Executor
+from tempfile import SpooledTemporaryFile
 from urllib.parse import quote, unquote, urlparse
 
 if t.TYPE_CHECKING:
@@ -123,6 +124,7 @@ class HTTPRequestEventStreamAdapter:
 
         self._more_body = True
         self._buffer = bytearray()
+        self._buffer_file = SpooledTemporaryFile()
 
     def _read_into(self, buf: bytearray) -> t.Tuple[int, bool]:
         if not self._more_body:

--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -12,7 +12,8 @@ HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
 
 def hook(namespace: str, priority: int = 0, **kwargs):
     """
-    Decorator for creating functional plugins that have a hook_priority attribute.
+    Decorator for creating functional plugins that have a hook_priority attribute. Hooks with a higher priority value
+    will be executed earlier.
     """
 
     def wrapper(fn):
@@ -68,12 +69,18 @@ class HookManager(PluginManager):
         return self.__str__()
 
 
-# localstack container configuration (on the host)
 configure_localstack_container = hook_spec(HOOKS_CONFIGURE_LOCALSTACK_CONTAINER)
-# additional installers
+"""Hooks to configure the LocalStack container before it starts. Executed on the host when invoking the CLI."""
+
 install = hook_spec(HOOKS_INSTALL)
-# prepare the host that's starting localstack
+"""Additional programmatic installers."""
+
 prepare_host = hook_spec(HOOKS_PREPARE_HOST)
-# infra (runtime) lifecycle hooks
+"""Hooks to prepare the host that's starting LocalStack. Executed on the host when invoking the CLI."""
+
 on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
+"""Hooks that are executed right before starting the LocalStack infrastructure."""
+
 on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)
+"""Hooks that are execute after all startup hooks have been executed, and the LocalStack infrastructure has become
+available. """

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -321,11 +321,12 @@ def get_service_port_for_account(service, headers):
 
 
 PROXY_LISTENER_EDGE = ProxyListenerEdge()
-# the ROUTER is part of the edge proxy. use the router to inject custom handlers that are handled before actual
-# service calls
+
 ROUTER: Router[Handler] = Router(
     dispatcher=handler_dispatcher(), converters={"regex": RegexConverter}
 )
+"""This special Router is part of the edge proxy. Use the router to inject custom handlers that are handled before
+the actual AWS service call is made."""
 
 
 def is_trace_logging_enabled(headers) -> bool:

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -87,8 +87,8 @@ from localstack.services.opensearch.cluster_manager import (
 )
 from localstack.utils.analytics import event_publisher
 from localstack.utils.collections import PaginatedList, remove_none_values_from_dict
+from localstack.utils.objects import singleton_factory
 from localstack.utils.serving import Server
-from localstack.utils.sync import synchronized
 from localstack.utils.tagging import TaggingService
 
 LOG = logging.getLogger(__name__)
@@ -105,16 +105,10 @@ DEFAULT_OPENSEARCH_CLUSTER_CONFIG = ClusterConfig(
     DedicatedMasterCount=1,
 )
 
-# cluster manager singleton
-_cluster_manager = None
 
-
-@synchronized(_domain_mutex)
+@singleton_factory
 def cluster_manager() -> ClusterManager:
-    global _cluster_manager
-    if not _cluster_manager:
-        _cluster_manager = create_cluster_manager()
-    return _cluster_manager
+    return create_cluster_manager()
 
 
 def _run_cluster_startup_monitor(cluster: Server, domain_name: str, region: str):

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -1,5 +1,4 @@
 import dataclasses
-import functools
 import logging
 import os
 import platform
@@ -8,6 +7,7 @@ from localstack import config, constants
 from localstack.runtime import hooks
 from localstack.utils.functions import call_safe
 from localstack.utils.json import FileMappedDocument
+from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid, md5, short_uid
 
 LOG = logging.getLogger(__name__)
@@ -57,12 +57,16 @@ def read_client_metadata() -> ClientMetadata:
     )
 
 
-@functools.lru_cache()
+@singleton_factory
 def get_session_id() -> str:
+    """
+    Returns the unique ID for this LocalStack session.
+    :return: a UUID
+    """
     return _generate_session_id()
 
 
-@functools.lru_cache()
+@singleton_factory
 def get_client_metadata() -> ClientMetadata:
     metadata = read_client_metadata()
 
@@ -72,7 +76,7 @@ def get_client_metadata() -> ClientMetadata:
     return metadata
 
 
-@functools.lru_cache()
+@singleton_factory
 def get_machine_id() -> str:
     cache_path = os.path.join(config.dirs.cache, "machine.json")
     doc = FileMappedDocument(cache_path)

--- a/localstack/utils/common.py
+++ b/localstack/utils/common.py
@@ -222,6 +222,8 @@ class ExternalServicePortsManager(PortRange):
 
 
 external_service_ports = ExternalServicePortsManager()
+"""The PortRange object of LocalStack's external service port range. This port range is by default exposed by the
+localstack container when starting via the CLI."""
 
 # TODO: replace references with config.get_protocol/config.edge_ports_info
 get_service_protocol = config.get_protocol

--- a/localstack/utils/venv.py
+++ b/localstack/utils/venv.py
@@ -1,0 +1,100 @@
+import io
+import os
+import sys
+from functools import cached_property
+from pathlib import Path
+from typing import Union
+
+
+class VirtualEnvironment:
+    """
+    Encapsulates methods to operate and navigate on a python virtual environment.
+    """
+
+    def __init__(self, venv_dir: str | os.PathLike[str]):
+        self._venv_dir = venv_dir
+
+    def create(self):
+        """
+        Uses the virtualenv cli to create the virtual environment.
+        :return:
+        """
+        self.venv_dir.mkdir(parents=True, exist_ok=True)
+        from venv import main
+
+        main([str(self.venv_dir)])
+
+    @property
+    def exists(self) -> bool:
+        """
+        Checks whether the virtual environment exists by checking whether the site-package directory of the venv exists.
+        :return: the if the venv exists
+        :raises NotADirectoryError: if the venv path exists but is not a directory
+        """
+        try:
+            return True if self.site_dir else False
+        except FileNotFoundError:
+            return False
+
+    @cached_property
+    def venv_dir(self) -> Path:
+        """
+        Returns the path of the virtual environment directory
+        :return: the path to the venv
+        """
+        return Path(self._venv_dir).absolute()
+
+    @cached_property
+    def site_dir(self) -> Path:
+        """
+        Resolves and returns the site-packages directory of the virtual environment. Once resolved successfully the
+        result is cached.
+
+        :return: the path to the site-packages dir.
+        :raise FileNotFoundError: if the venv does not exist or the site-packages could not be found, or there are
+         multiple lib/python* directories.
+        :raise NotADirectoryError: if the venv is not a directory
+        """
+        venv = self.venv_dir
+
+        if not venv.exists():
+            raise FileNotFoundError(f"expected venv directory to exist at {venv}")
+
+        if not venv.is_dir():
+            raise NotADirectoryError(f"expected {venv} to be a directory")
+
+        matches = list(venv.glob("lib/python*/site-packages"))
+
+        if not matches:
+            raise FileNotFoundError(f"could not find site-packages directory in {venv}")
+
+        if len(matches) > 1:
+            raise FileNotFoundError(f"multiple python versions found in {venv}: {matches}")
+
+        return matches[0]
+
+    def inject_to_sys_path(self):
+        if path := str(self.site_dir):
+            if path not in sys.path:
+                sys.path.append(path)
+
+    def add_pth(self, name, path: Union[str, os.PathLike[str], "VirtualEnvironment"]) -> None:
+        """
+        Add a <name>.pth file into the virtual environment and append the given path to it. Does nothing if the path
+        is already in the file.
+
+        :param name: the name of the path file (without the .pth extensions)
+        :param path: the path to be appended
+        """
+        pth_file = self.site_dir / f"{name}.pth"
+
+        if isinstance(path, VirtualEnvironment):
+            path = path.site_dir
+
+        line = io.text_encoding(str(path)) + "\n"
+
+        if pth_file.exists() and line in pth_file.read_text():
+            return
+
+        with open(pth_file, "a") as fd:
+            fd.write(line)

--- a/tests/unit/utils/test_objects.py
+++ b/tests/unit/utils/test_objects.py
@@ -1,6 +1,8 @@
+from unittest.mock import MagicMock
+
 import pytest
 
-from localstack.utils.objects import SubtypesInstanceManager
+from localstack.utils.objects import SubtypesInstanceManager, singleton_factory
 
 
 def test_subtypes_instance_manager():
@@ -34,3 +36,74 @@ def test_subtypes_instance_manager():
     instance2 = BaseClass.get("c2")
     assert BaseClass.get("c2") == instance2
     assert instance2.foo() == "baz"
+
+
+class TestSingletonFactory:
+    def test_call_and_clear(self):
+        mock = MagicMock()
+        mock.return_value = "foobar"
+
+        @singleton_factory
+        def my_singleton():
+            return mock()
+
+        assert my_singleton() == mock.return_value
+        mock.assert_called_once()
+
+        assert my_singleton() == mock.return_value
+        mock.assert_called_once()
+
+        my_singleton.clear()
+
+        assert my_singleton() == mock.return_value
+        mock.assert_has_calls([(), ()])
+
+        assert my_singleton() == mock.return_value
+        mock.assert_has_calls([(), ()])
+
+    def test_exception_does_not_set_a_value(self):
+
+        mock = MagicMock()
+
+        @singleton_factory
+        def my_singleton():
+            mock()
+            raise ValueError("oh noes")
+
+        with pytest.raises(ValueError):
+            my_singleton()
+
+        mock.assert_has_calls([()])
+
+        with pytest.raises(ValueError):
+            my_singleton()
+
+        mock.assert_has_calls([(), ()])
+
+    def test_set_none_value_does_not_set_singleton(self):
+        mock = MagicMock()
+        mock.return_value = None
+
+        @singleton_factory
+        def my_singleton():
+            return mock()
+
+        assert my_singleton() is None
+        mock.assert_has_calls([()])
+
+        assert my_singleton() is None
+        mock.assert_has_calls([(), ()])
+
+    def test_set_falsy_value_sets_singleton(self):
+        mock = MagicMock()
+        mock.return_value = False
+
+        @singleton_factory
+        def my_singleton():
+            return mock()
+
+        assert my_singleton() is False
+        mock.assert_called_once()
+
+        assert my_singleton() is False
+        mock.assert_called_once()


### PR DESCRIPTION
This PR introduces the extensions API and a simple mechanism to manage python dependencies through the container in a virtual environment stored on the host.

## Basic changes
* Circular venv from `/var/lib/localstack/lib/extensions/python_venv` <-> `/opt/code/localstack/.venv ` (paths don't have to exist, python site will ignore them.
* three cli commands `localstack extensions` `init | install | uninstall` (which are basically just: create venv, pip install, pip uninstall)
* internal cli to perform the operations when inside the container
* expose parts of our internal API via `localstack.extensions.api`
* added several [PEP 224](https://peps.python.org/pep-0224/)-style attribute docs for special variables exposed through the extensions API.

Example use: https://github.com/localstack/localstack-stripe/blob/main/localstack_stripe/extension.py

## Test

* build `localstack/localstack` container image locally from this branch (including localstack-ext changes)
* activate venv
* run `python -m localstack.cli.main extensions init
* run `python -m localstack.cli.main extensions install "git+https://github.com/localstack/localstack-stripe.git#egg=localstack-stripe"`
* run `python -m localstack.cli.main start`
* run `curl stripe.localhost.localstack.cloud:4566/v1/customers -u sk_test_12345:`
