### PR TITLE
fix CI dep issues for newly introduced ext runtime deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,7 +240,7 @@ RUN make init
 ARG LOCALSTACK_PRE_RELEASE=1
 RUN (PIP_ARGS=$([[ "$LOCALSTACK_PRE_RELEASE" == "1" ]] && echo "--pre" || true); \
       virtualenv .venv && source .venv/bin/activate && \
-      pip3 install --upgrade ${PIP_ARGS} localstack-ext)
+      pip3 install --upgrade ${PIP_ARGS} localstack-ext[runtime])
 RUN make entrypoints
 
 # Add the build date and git hash at last (changes everytime)


### PR DESCRIPTION
In our CI environment, we currently see issues with newly introduced dependencies in our extensions (f.e. builds for [#6376](https://app.circleci.com/pipelines/github/localstack/localstack/7209/workflows/d4fbaba1-4bb5-4bba-bfd1-5926ab610d68)).
Therefore this PR ensures that also the runtime dependencies of `localstack-ext` are updated at the end.

The current issues (and the "flaky" looks of it) are caused by the Docker layer caching in combination with our dev releases:
- `localstack` defines `localstack-ext[runtime]>=0.14.5.dev,<0.14.6`
  - This includes the latest dev releases (due to the `.dev` suffix).
- If there are no changes to the layers before `make install-runtime` is called in the `Dockerfile` but a new ext dev release (not contained in the cache yet) defines a new dependency, it will not be installed since the final update of `localstack-ext` at the end of the Docker image build only installs the `install` dependencies without the `runtime` extra.

This PR addresses this by adding the runtime extra to the final ext-update command.