### PR TITLE
Fix logging in config if DATA_DIR is set

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -933,9 +933,10 @@ if DEBUG:
     logging.getLogger("").setLevel(logging.DEBUG)
     logging.getLogger("localstack").setLevel(logging.DEBUG)
 
+LOG = logging.getLogger(__name__)
+
 if LS_LOG in TRACE_LOG_LEVELS:
     load_end_time = time.time()
-    LOG = logging.getLogger(__name__)
     LOG.debug(
         "Initializing the configuration took %s ms", int((load_end_time - load_start_time) * 1000)
     )


### PR DESCRIPTION
Currently, our whole docker execution breaks if DATA_DIR is set but LS_TRACE, since the logger for the warning (for data_dir set) is not created if LS_TRACE is not set.

This PR moves the logger outside to be initialized unconditionally.