### PR TITLE
Minor fixes to mark DynamoDB test with binary data as aws_validated

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -361,8 +361,6 @@ def dynamodb_create_table(dynamodb_client):
         if "partition_key" not in kwargs:
             kwargs["partition_key"] = "id"
 
-        kwargs["sleep_after"] = 0
-
         tables.append(kwargs["table_name"])
 
         return create_dynamodb_table(**kwargs)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -42,7 +42,7 @@ from localstack.utils.collections import pick_attributes
 from localstack.utils.functions import run_safe
 from localstack.utils.http import make_http_request
 from localstack.utils.strings import is_string, is_string_or_bytes, to_str
-from localstack.utils.sync import retry
+from localstack.utils.sync import poll_condition, retry
 
 # AWS environment variable names
 ENV_ACCESS_KEY = "AWS_ACCESS_KEY_ID"
@@ -930,19 +930,16 @@ def dynamodb_get_item_raw(request):
 
 
 def create_dynamodb_table(
-    table_name,
-    partition_key,
-    env=None,
-    stream_view_type=None,
-    region_name=None,
+    table_name: str,
+    partition_key: str,
+    stream_view_type: str = None,
+    region_name: str = None,
     client=None,
-    sleep_after=2,
+    wait_for_active: bool = True,
 ):
     """Utility method to create a DynamoDB table"""
 
-    dynamodb = client or connect_to_service(
-        "dynamodb", env=env, client=True, region_name=region_name
-    )
+    dynamodb = client or connect_to_service("dynamodb", region_name=region_name)
     stream_spec = {"StreamEnabled": False}
     key_schema = [{"AttributeName": partition_key, "KeyType": "HASH"}]
     attr_defs = [{"AttributeName": partition_key, "AttributeType": "S"}]
@@ -954,21 +951,22 @@ def create_dynamodb_table(
             TableName=table_name,
             KeySchema=key_schema,
             AttributeDefinitions=attr_defs,
-            ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+            BillingMode="PAY_PER_REQUEST",
             StreamSpecification=stream_spec,
         )
     except Exception as e:
         if "ResourceInUseException" in str(e):
             # Table already exists -> return table reference
-            return connect_to_resource("dynamodb", env=env, region_name=region_name).Table(
-                table_name
-            )
+            return connect_to_resource("dynamodb", region_name=region_name).Table(table_name)
         if "AccessDeniedException" in str(e):
             raise
 
-    if sleep_after:
-        # TODO: do we need this?
-        time.sleep(sleep_after)
+    if wait_for_active:
+
+        def _is_active():
+            return dynamodb.describe_table(TableName=table_name)["Table"]["TableStatus"] == "ACTIVE"
+
+        poll_condition(_is_active)
 
     return table
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -5,7 +5,6 @@ import re
 import socket
 import sys
 import threading
-import time
 from functools import lru_cache
 from typing import Dict, Optional, Union
 from urllib.parse import urlparse
@@ -961,11 +960,10 @@ def create_dynamodb_table(
         if "AccessDeniedException" in str(e):
             raise
 
+    def _is_active():
+        return dynamodb.describe_table(TableName=table_name)["Table"]["TableStatus"] == "ACTIVE"
+
     if wait_for_active:
-
-        def _is_active():
-            return dynamodb.describe_table(TableName=table_name)["Table"]["TableStatus"] == "ACTIVE"
-
         poll_condition(_is_active)
 
     return table

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -203,10 +203,14 @@ class TestDynamoDB:
 
         # clean up
         delete_table(table_name)
+
+        def _assert_stream_deleted():
+            stream_tables = [s["TableName"] for s in ddbstreams.list_streams()["Streams"]]
+            assert table_name not in stream_tables
+            assert stream_name not in kinesis.list_streams()["StreamNames"]
+
         # assert stream has been deleted
-        stream_tables = [s["TableName"] for s in ddbstreams.list_streams()["Streams"]]
-        assert table_name not in stream_tables
-        assert stream_name not in kinesis.list_streams()["StreamNames"]
+        retry(_assert_stream_deleted, sleep=0.4, retries=5)
 
     def test_multiple_update_expressions(self, dynamodb):
         dynamodb_client = aws_stack.create_external_boto_client("dynamodb")


### PR DESCRIPTION
Minor fixes to mark DynamoDB test with binary data as `aws_validated`. The starting point for this investigation was the PR https://github.com/localstack/localstack/pull/6371 .

Summary of changes:
* Remove deprecated `sleep_after=2` argument in the `create_dynamodb_table(..)` utility, instead add a `wait_for_active=True` parameter, which is required for parity testing against AWS (waiting for the table to become available)
* Changed the default DynamoDB test table `BillingMode` from `PROVISIONED` to `PAY_PER_REQUEST` - this is to avoid situations where we accidentally create (and don't clean up) `PROVISIONED` tables in AWS - they can become **really** expensive.. :)
* Remove obsolete/deprecated `env=..` parameter (this is totally outdated, and should get removed from the entire codebase over time)
* Mark `test_empty_and_binary_values` as `aws_validated`, and change the binary data to non-printable characters (`b"\x90"`)