### PR TITLE
Add fallback to default provider if configured provider is not available

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -495,13 +495,28 @@ class ServicePluginManager(ServiceManager):
         self.provider_config = provider_config or config.SERVICE_PROVIDER_CONFIG
 
     def get_active_provider(self, service: str) -> str:
+        """
+        Get configured provider for a given service
+
+        :param service: Service name
+        :return: configured provider
+        """
         return self.provider_config.get_provider(service)
+
+    def get_default_provider(self) -> str:
+        """
+        Get the default provider
+
+        :return: default provider
+        """
+        return self.provider_config.default_value
 
     # TODO make the abstraction clearer, to provide better information if service is available versus discoverable
     # especially important when considering pro services
     def list_available(self) -> List[str]:
         """
         List all available services, which have an available, configured provider
+
         :return: List of service names
         """
         return [
@@ -513,6 +528,7 @@ class ServicePluginManager(ServiceManager):
     def list_loaded_services(self) -> List[str]:
         """
         Lists all the services which have a provider that has been initialized
+
         :return: a list of service names
         """
         return [
@@ -585,13 +601,17 @@ class ServicePluginManager(ServiceManager):
         if preferred_provider in providers:
             provider = preferred_provider
         else:
+            default = self.get_default_provider()
             LOG.warning(
-                "Configured provider (%s) does not exist for service (%s). Available options are: %s",
+                "Configured provider (%s) does not exist for service (%s). Available options are: %s. "
+                "Falling back to default provider '%s'. This can impact the availability of Pro functionality, "
+                "please fix this configuration issue as soon as possible.",
                 preferred_provider,
                 name,
                 providers,
+                default,
             )
-            return None
+            provider = default
 
         plugin_name = f"{name}:{provider}"
         plugin = self.plugin_manager.load(plugin_name)


### PR DESCRIPTION
Fixes #6361

This PR introduces a fallback logic to the currently configured default provider, if the configured provider of a service cannot be found.
While quite straightforward, this approach has a significant caveat: If Pro services are activated, it will still fallback to the community service in case the configuration provided is wrong.

We could solve this (possibly in another PR), for example by providing some kind of ordering logic to the ProviderConfig class, to be able to register provider overrides with some kind of priority, and therefore iterate over them in case one provider is not actually available. Thoughts @thrau ?