### PR TITLE
add plugin installation for opensearch 1.1+

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -121,6 +121,11 @@ ELASTICSEARCH_DELETE_MODULES = ["ingest-geoip"]
 # the version of opensearch which is used by default
 OPENSEARCH_DEFAULT_VERSION = "OpenSearch_1.1"
 
+# See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
+OPENSEARCH_PLUGIN_LIST = [
+    "ingest-attachment",
+]
+
 ELASTICMQ_JAR_URL = (
     "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar"
 )


### PR DESCRIPTION
This PR adds a plugin installer for OpenSearch and installs the `ingest-attachment` plugin by default.
However, these plugins are only installed for OpenSearch versions >= 1.1.0 ([for earlier versions the plugin installation is not working](https://forum.opensearch.org/t/ingest-attachment-cannot-be-installed/6494/12)).
For now, only the `ingest-attachment` plugin is installed (in order to avoid longer installation times caused by unused plugins).