### PR TITLE
Support limiting ReservedConcurrentExecutions for Lambda invocations

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
@@ -116,6 +116,9 @@ class StreamEventSourceListener(EventSourceListener):
         self._COORDINATOR_THREAD = FuncThread(self._monitor_stream_event_sources)
         self._COORDINATOR_THREAD.start()
 
+    # FIXME: this should be replaced by Lambda API calls and a concurrency guard in *front* of it
+    #   => the parallelization and concurrency limit here should be handled *before* the invoke call
+    #   (i.e. separate from the function concurrency)
     def _invoke_lambda(
         self, function_arn, payload, lock_discriminator, parallelization_factor
     ) -> Tuple[bool, int]:

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -5,7 +5,6 @@ import re
 import socket
 import sys
 import threading
-import time
 from functools import lru_cache
 from typing import Dict, Optional, Union
 from urllib.parse import urlparse
@@ -936,7 +935,6 @@ def create_dynamodb_table(
     stream_view_type=None,
     region_name=None,
     client=None,
-    sleep_after=2,
 ):
     """Utility method to create a DynamoDB table"""
 
@@ -957,6 +955,7 @@ def create_dynamodb_table(
             ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
             StreamSpecification=stream_spec,
         )
+        dynamodb.get_waiter("table_exists").wait(TableName=table_name)
     except Exception as e:
         if "ResourceInUseException" in str(e):
             # Table already exists -> return table reference
@@ -965,10 +964,6 @@ def create_dynamodb_table(
             )
         if "AccessDeniedException" in str(e):
             raise
-
-    if sleep_after:
-        # TODO: do we need this?
-        time.sleep(sleep_after)
 
     return table
 

--- a/tests/integration/awslambda/functions/lambda_dynamodb_counter.py
+++ b/tests/integration/awslambda/functions/lambda_dynamodb_counter.py
@@ -1,0 +1,40 @@
+import os
+import time
+
+import boto3
+
+
+def create_client():
+    if "LOCALSTACK_HOSTNAME" in os.environ:
+        endpoint_url = "{}://{}:{}".format("http", os.environ["LOCALSTACK_HOSTNAME"], 4566)
+        return boto3.client("dynamodb", endpoint_url=endpoint_url)
+    else:
+        return boto3.client("dynamodb")
+
+
+dynamodb_client = create_client()
+table_name = os.environ["TABLE_NAME"]
+wait_s = int(os.environ["TEST_WAIT_TIME_S"])
+
+
+def handler(event, context):
+    dynamodb_client.update_item(
+        TableName=table_name,
+        Key={"Id": {"S": "testcountid"}},
+        UpdateExpression="SET TestCounterStart = TestCounterStart + :incr",
+        ExpressionAttributeValues={":incr": {"N": "1"}},
+        ReturnValues="ALL_NEW",
+    )
+
+    print(f"Sleeping for {wait_s} seconds.")
+    time.sleep(wait_s)
+
+    update_response = dynamodb_client.update_item(
+        TableName=table_name,
+        Key={"Id": {"S": "testcountid"}},
+        UpdateExpression="SET TestCounterStop = TestCounterStop + :incr",
+        ExpressionAttributeValues={":incr": {"N": "1"}},
+        ReturnValues="ALL_NEW",
+    )
+
+    return update_response["Attributes"]


### PR DESCRIPTION
Still not fully prod ready.

There are some drawbacks to using this approach but I think it's the least intrusive in regards of changes to the old Lambda provider since it reuses the locks "register" that was introduced previously for handling event source mapping concurrency.

Not very happy with the test pattern here yet, since it leads to a fairly long test execution duration of about a minute. It does cover a few different scenarios though and I'd love to introduce a better "parallel invocation" counter soon to validate how async  (Event type) invokes are processed by the Lambda service.
