### PR TITLE
Remove deprecated docker-compose defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,17 @@ services:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack
     ports:
-      - "127.0.0.1:53:53"                # only required for Pro (DNS)
-      - "127.0.0.1:53:53/udp"            # only required for Pro (DNS)
-      - "127.0.0.1:443:443"              # only required for Pro (LocalStack HTTPS Edge Proxy)
-      - "127.0.0.1:4510-4559:4510-4559"  # external service port range
-      - "127.0.0.1:4566:4566"            # LocalStack Edge Proxy
+      - "127.0.0.1:4566:4566"            # LocalStack Gateway
+      - "127.0.0.1:4510-4559:4510-4559"  # external services port range
+      - "127.0.0.1:53:53"                # DNS config (only required for Pro)
+      - "127.0.0.1:53:53/udp"            # DNS config (only required for Pro)
+      - "127.0.0.1:443:443"              # LocalStack HTTPS Gateway (only required for Pro)
     environment:
       - DEBUG=${DEBUG-}
-      - DATA_DIR=${DATA_DIR-}
+      - PERSISTENCE=${PERSISTENCE-}
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR-}
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # only required for Pro
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - "${TMPDIR:-/tmp}/localstack:/var/lib/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack
-    network_mode: bridge
     ports:
       - "127.0.0.1:53:53"                # only required for Pro (DNS)
       - "127.0.0.1:53:53/udp"            # only required for Pro (DNS)
@@ -16,8 +15,7 @@ services:
       - DATA_DIR=${DATA_DIR-}
       - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR-}
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY-}  # only required for Pro
-      - HOST_TMP_FOLDER=${TMPDIR:-/tmp/}localstack
       - DOCKER_HOST=unix:///var/run/docker.sock
     volumes:
-      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "${TMPDIR:-/tmp}/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -354,7 +354,6 @@ def validate_localstack_config(name):
         )
 
     # prepare config options
-    network_mode = ls_service_details.get("network_mode")
     image_name = ls_service_details.get("image")
     container_name = ls_service_details.get("container_name") or ""
     docker_ports = (port.split(":")[-2] for port in ls_service_details.get("ports", []))
@@ -375,12 +374,6 @@ def validate_localstack_config(name):
             'and requires to use the "localstack/localstack-full" image.'
         )
 
-    if not docker_env.get("HOST_TMP_FOLDER"):
-        warns.append(
-            'Please configure the "HOST_TMP_FOLDER" environment variable to point to the '
-            + "absolute path of a temp folder on your host system (e.g., HOST_TMP_FOLDER=${TMPDIR})"
-        )
-
     if (main_container not in container_name) and not docker_env.get("MAIN_CONTAINER_NAME"):
         warns.append(
             'Please use "container_name: %s" or add "MAIN_CONTAINER_NAME" in "environment".'
@@ -399,13 +392,6 @@ def validate_localstack_config(name):
                 'to the "ports" section of the docker-compose file.'
             )
             % edge_port
-        )
-
-    if network_mode != "bridge" and not docker_env.get("LAMBDA_DOCKER_NETWORK"):
-        warns.append(
-            'Network mode is not set to "bridge" which may cause networking issues in Lambda containers. '
-            'Consider adding "network_mode: bridge" to your docker-compose file, or configure '
-            "LAMBDA_DOCKER_NETWORK with the name of the Docker network of your compose stack."
         )
 
     # print warning/info messages


### PR DESCRIPTION
Currently, we have some legacy configuration in the docker-compose file, which are replaced (in v1 or before) by automatic detection.
This includes:
* network_mode: bridge : This configuration is not necessary anymore, as we detect the docker network automatically using the get_main_container_network utility. Also it leads to problems when we use host aliases or want to use docker dns capabilities.
* HOST_TMP_FOLDER: this is also automatically detected now, where necessary (lambda code mounting), by inspecting the LS docker container and finding the appropriate path.

As v1 is needing configuration changes anyway, we should sneak those in as well.