### PR TITLE
update .dockerignore to new filesystem hierarchy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,15 @@
 .git
 .venv*
-localstack/dashboard/web/node_modules/
-localstack/infra/
-!localstack/infra/stepfunctions
-!localstack/infra/localstack-*.jar
-# TODO: remove, was moved to static_libs dir (currently localstack/infra)
-localstack/node_modules/
-tests/integration/serverless/node_modules/
 
-# ignore files generated in CI build (e.g., large Docker image .tar file)
+.filesystem
+# these files are required to be in the build context (see Dockerfile)
+!.filesystem/usr/lib/localstack/stepfunctions
+!.filesystem/usr/lib/localstack/localstack-*.jar
+
+# ignore files generated in CI build
+tests/integration/**/node_modules
+tests/integration/**/.terraform
+**/__pycache__
 target/
+htmlcov/
+.coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -232,8 +232,8 @@ RUN mkdir -p /.npm && \
 # Install the latest version of awslocal globally
 RUN pip3 install --upgrade awscli awscli-local requests
 
-# Adds the results of `make init` to the container.
-# `make init` _needs_ to be executed before building this docker image (since the execution needs docker itself).
+# Adds the results of `make init` that are explicitly include in .dockerignore to the image.
+# `make init` needs to be executed before building the image, because some package installers need docker themselves.
 ADD .filesystem/usr/lib/localstack /usr/lib/localstack
 # Add the code in the last step
 ADD localstack/ localstack/


### PR DESCRIPTION
This PR updates the `.dockerignore` file to match the current layout of the local build environment. I also clarified the documentation in the Dockerfile to better explain what's going on and that the `.dockerignore` file is relevant to the line.

I also added glob patterns for `node_modules` and `.terraform` folders in the integration tests, and some other local artifacts, which can be useful when you build the docker image locally and previously executed the test suite.

Alternatively we could include the entire .filesystem/usr/lib/localstack directory from the host