### PR TITLE
minor: Add test dependency to deepdiff

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,12 +100,13 @@ full =
 
 # for running tests and coverage analysis
 test =
+    # coverage version should be synced with bin/Dockerfile.base
+    coverage[toml]>=5.5
+    deepdiff>=5.5.0
+    jsonpath-ng>=1.5.3
     pytest==6.2.4
     pytest-httpserver>=1.0.1
     pytest-rerunfailures==10.0
-    # coverage version should be synced with bin/Dockerfile.base
-    coverage[toml]>=5.5
-    jsonpath-ng>=1.5.3
 
 # for developing localstack
 dev =


### PR DESCRIPTION
Add test dependency to `deepdiff`. This library is being used in the `testing.snapshots` package, and we are currently depending on it transitively via -ext. This dependency is going to be removed upstream, hence adding it here directly.