### PR TITLE
fix cryptography updates / remove pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,8 +75,7 @@ runtime =
     botocore>=1.12.13
     cbor2>=5.2.0
     crontab>=0.22.6
-    # TODO remove the pin as soon as the unit tests on circle ci work again
-    cryptography==37.0.2
+    cryptography
     docker==5.0.0
     flask>=1.0.2
     flask-cors>=3.0.3,<3.1.0


### PR DESCRIPTION
With https://github.com/localstack/localstack/pull/6318, we had to pin the version of cryptography in order to fix our unit tests in Circle CI.
A new version of cryptography (built on OpenSSL 3.0.5), which contains security updates as well as a fix for the issue which broke our CI, [has been released a few hours ago](https://pypi.org/project/cryptography/37.0.4/). This PR removes the pin and therefore updates cryptography to the newly released version.

Thanks to @dfangl for making me aware of the new release.