### PR TITLE
add logs for lambda executor startup failure and removing containers on shutdown

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -2149,7 +2149,11 @@ def serve(port):
     from localstack.services import generic_proxy  # moved here to fix circular import errors
 
     # initialize the Lambda executor
-    LAMBDA_EXECUTOR.startup()
+    try:
+        LAMBDA_EXECUTOR.startup()
+    except Exception:
+        LOG.exception("Error while starting up lambda executor")
+        raise
     # print warnings for potentially incorrect config options
     validate_lambda_config()
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -2146,21 +2146,21 @@ def validate_lambda_config():
 
 
 def serve(port):
-    from localstack.services import generic_proxy  # moved here to fix circular import errors
-
-    # initialize the Lambda executor
     try:
+        from localstack.services import generic_proxy  # moved here to fix circular import errors
+
+        # initialize the Lambda executor
         LAMBDA_EXECUTOR.startup()
+        # print warnings for potentially incorrect config options
+        validate_lambda_config()
+
+        # initialize/import plugins - TODO find better place to import plugins! (to be integrated into proper plugin model)
+        import localstack.contrib.thundra  # noqa
+
+        generic_proxy.serve_flask_app(app=app, port=port)
     except Exception:
-        LOG.exception("Error while starting up lambda executor")
+        LOG.exception("Error while starting up lambda service")
         raise
-    # print warnings for potentially incorrect config options
-    validate_lambda_config()
-
-    # initialize/import plugins - TODO find better place to import plugins! (to be integrated into proper plugin model)
-    import localstack.contrib.thundra  # noqa
-
-    generic_proxy.serve_flask_app(app=app, port=port)
 
 
 # Config listener

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -909,6 +909,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             self.start_idle_container_destroyer_interval()
 
     def cleanup(self, arn: str = None):
+        LOG.debug("Cleaning up docker-reuse executor. Set arn: %s", arn)
         if arn:
             self.function_invoke_times.pop(arn, None)
             return self.destroy_docker_container(arn)
@@ -1097,6 +1098,7 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
         Stops and/or removes all lambda docker containers for localstack.
         :return: None
         """
+        LOG.debug("Destroying all running docker-reuse lambda containers")
         with self.docker_container_lock:
             container_names = self.get_all_container_names()
 


### PR DESCRIPTION
This PR adds some log output, to capture the reason for startup failures reported in #4973 and cleanup errors reported in #6312.

It will now log when:
* Containers should get cleaned up, this helps checking why the cleanup does not work
* Lambda throws an exception while starting (they are currently silenced by the functhread flask runs in)