### PR TITLE
add response parser to handler chain

### DIFF
--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -30,7 +30,18 @@ class ServiceException(Exception):
     Do not use this exception directly (use the generated subclasses or CommonsServiceException instead).
     """
 
-    pass
+    code: str
+    status_code: int
+    sender_fault: bool
+    message: str
+
+    def __init__(self, *args):
+        super(ServiceException, self).__init__(*args)
+
+        if len(args) >= 1:
+            self.message = args[0]
+        else:
+            self.message = ""
 
 
 class CommonServiceException(ServiceException):
@@ -42,11 +53,10 @@ class CommonServiceException(ServiceException):
     """
 
     def __init__(self, code: str, message: str, status_code: int = 400, sender_fault: bool = False):
+        super().__init__(message)
         self.code = code
         self.status_code = status_code
         self.sender_fault = sender_fault
-        self.message = message
-        super().__init__(self.message)
 
 
 Operation = Type[ServiceRequest]

--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -53,7 +53,7 @@ class CommonServiceException(ServiceException):
     """
 
     def __init__(self, code: str, message: str, status_code: int = 400, sender_fault: bool = False):
-        super().__init__(message)
+        super(CommonServiceException, self).__init__(message)
         self.code = code
         self.status_code = status_code
         self.sender_fault = sender_fault
@@ -78,7 +78,6 @@ class RequestContext:
     service_exception: Optional[ServiceException]
 
     def __init__(self) -> None:
-        super().__init__()
         self.service = None
         self.operation = None
         self.region = None

--- a/localstack/aws/api/core.py
+++ b/localstack/aws/api/core.py
@@ -64,6 +64,8 @@ class RequestContext:
     region: Optional[str]
     account_id: Optional[str]
     service_request: Optional[ServiceRequest]
+    service_response: Optional[ServiceResponse]
+    service_exception: Optional[ServiceException]
 
     def __init__(self) -> None:
         super().__init__()
@@ -73,6 +75,8 @@ class RequestContext:
         self.account_id = None
         self.request = None
         self.service_request = None
+        self.service_response = None
+        self.service_exception = None
 
     @property
     def service_operation(self) -> Optional[ServiceOperation]:

--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -56,6 +56,7 @@ class LocalstackAwsGateway(Gateway):
         # response post-processing
         self.response_handlers.extend(
             [
+                handlers.parse_service_response,
                 handlers.run_custom_response_handlers,
                 handlers.add_cors_response_headers,
                 handlers.log_response,

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -19,6 +19,7 @@ handle_internal_failure = fallback.InternalFailureHandler()
 serve_custom_service_request_handlers = chain.CompositeHandler()
 serve_localstack_resources = internal.LocalstackResourceHandler()
 run_custom_response_handlers = chain.CompositeResponseHandler()
+parse_service_response = service.ServiceResponseParser()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()
 serve_default_listeners = legacy.DefaultListenerHandler()

--- a/localstack/aws/handlers/analytics.py
+++ b/localstack/aws/handlers/analytics.py
@@ -16,7 +16,6 @@ LOG = logging.getLogger(__name__)
 
 
 class ServiceRequestCounter:
-
     aggregator: ServiceRequestAggregator
 
     def __init__(self, service_request_aggregator: ServiceRequestAggregator = None):
@@ -52,14 +51,14 @@ class ServiceRequestCounter:
 
     def _get_err_type(self, context: RequestContext, response: Response) -> Optional[str]:
         """
-        Attempts to parse and return the error type from the response body, e.g. ResourceInUseException.
-
-        TODO: we need this type of logic frequently, so we should make sure the parsed response is re-usable by
-         multiple handlers, either by storing it in the context or the chain.
+        Attempts to re-use the existing service_response, or parse and return the error type from the response body,
+        e.g. ``ResourceInUseException``.
         """
         try:
-            parsed_response = parse_response(context.operation, response)
-            return parsed_response["Error"]["Code"]
+            response = context.service_response
+            if not response:
+                response = parse_response(context.operation, response)
+            return response["Error"]["Code"]
         except Exception:
             if config.DEBUG_ANALYTICS:
                 LOG.exception("error parsing error response")

--- a/localstack/aws/handlers/analytics.py
+++ b/localstack/aws/handlers/analytics.py
@@ -55,9 +55,10 @@ class ServiceRequestCounter:
         e.g. ``ResourceInUseException``.
         """
         try:
-            response = context.service_response
-            if not response:
-                response = parse_response(context.operation, response)
+            if context.service_exception:
+                return context.service_exception.code
+
+            response = parse_response(context.operation, response)
             return response["Error"]["Code"]
         except Exception:
             if config.DEBUG_ANALYTICS:

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -259,6 +259,11 @@ class ServiceResponseParser(Handler):
                 LOG.warning("Cannot parse exception %s", context.service_exception)
                 return
 
+        if response.content_length is None:
+            # cannot/should not parse streaming responses
+            context.service_response = {}
+            return
+
         # in this case we need to parse the raw response
         parsed = parse_response(context.operation, response)
         parsed.pop("ResponseMetadata", None)

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -228,16 +228,14 @@ class ServiceExceptionSerializer(ExceptionHandler):
 
 class ServiceResponseParser(Handler):
     """
-    This response handler makes sure that, if the current request in an AWS request,
-    that ``RequestContext.service_response`` is set to something sensible before other downstream response handlers
-    are called. When the Skeleton is invoked, this will mostly return immediately because the skeleton sets the
-    service response directly to what comes out of the provider. When responses come back from backends like Moto,
-    we may need to parse the raw HTTP response, since we sometimes proxy directly.
-
-    If the RequestContext.service_exception is set, then it will create a dictionary similar to that of botocore but
-    without the HTTPResponseMetadata, of the form::
-
-       {"Error": {"Code": "SomeServiceError", "Message": "oh noes"}
+    This response handler makes sure that, if the current request in an AWS request, that either ``service_response``
+    or ``service_exception`` of ``RequestContext`` is set to something sensible before other downstream response
+    handlers are called. When the Skeleton invokes an ASF-native provider, this will mostly return immediately
+    because the skeleton sets the service response directly to what comes out of the provider. When responses come
+    back from backends like Moto, we may need to parse the raw HTTP response, since we sometimes proxy directly. If
+    the ``service_response`` is an error, then we parse the response and create an appropriate exception from the
+    error response. If ``service_exception`` is set, then we also try to make sure the exception attributes like
+    code, sender_fault, and message have values.
     """
 
     def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -168,6 +168,8 @@ class Skeleton:
         if isinstance(result, HttpResponse):
             return result
 
+        context.service_response = result
+
         # Serialize result dict to an HTTPResponse and return it
         return self.serializer.serialize_to_response(result, operation)
 
@@ -181,6 +183,8 @@ class Skeleton:
         :param exception: the exception that was raised
         :return: an HttpResponse object
         """
+        context.service_exception = exception
+
         return self.serializer.serialize_error_to_response(exception, context.operation)
 
     def on_not_implemented_error(self, context: RequestContext) -> HttpResponse:
@@ -202,4 +206,6 @@ class Skeleton:
         analytics.log.event(
             "services_notimplemented", payload={"s": service_name, "a": action_name}
         )
+        context.service_exception = error
+
         return serializer.serialize_error_to_response(error, operation)

--- a/tests/unit/aws/handlers/service.py
+++ b/tests/unit/aws/handlers/service.py
@@ -1,0 +1,73 @@
+import pytest
+
+from localstack.aws.api import CommonServiceException, RequestContext
+from localstack.aws.chain import HandlerChain
+from localstack.aws.forwarder import create_aws_request_context
+from localstack.aws.handlers.service import ServiceResponseParser
+from localstack.aws.protocol.serializer import create_serializer
+from localstack.http import Request, Response
+
+
+@pytest.fixture
+def chain() -> HandlerChain:
+    """Returns a dummy chain for testing."""
+    return HandlerChain()
+
+
+@pytest.fixture
+def handler() -> ServiceResponseParser:
+    return ServiceResponseParser()
+
+
+class TestServiceResponseHandler:
+    def test_use_set_response(self, chain, handler):
+        context = create_aws_request_context("opensearch", "CreateDomain", {"DomainName": "foobar"})
+        context.service_response = {"sure": "why not"}
+
+        handler(chain, context, Response(status=200))
+        assert context.service_response == {"sure": "why not"}
+
+    def test_parse_response(self, chain, handler):
+        context = create_aws_request_context("sqs", "CreateQueue", {"QueueName": "foobar"})
+        backend_response = {"QueueUrl": "http://localhost:4566/000000000000/foobar"}
+        http_response = create_serializer(context.service).serialize_to_response(
+            backend_response, context.operation
+        )
+
+        handler(chain, context, http_response)
+        assert context.service_response == backend_response
+
+    def test_common_service_exception(self, chain, handler):
+        context = create_aws_request_context("opensearch", "CreateDomain", {"DomainName": "foobar"})
+        context.service_exception = CommonServiceException(
+            "InvalidTypeException", "oh noes", status_code=409, sender_fault=True
+        )
+
+        handler(chain, context, Response(status=409))
+        assert context.service_response == {
+            "Error": {"Code": "InvalidTypeException", "Message": "oh noes"}
+        }
+
+    def test_service_exception(self, chain, handler):
+        from localstack.aws.api.opensearch import ResourceAlreadyExistsException
+
+        context = create_aws_request_context("opensearch", "CreateDomain", {"DomainName": "foobar"})
+        context.service_exception = ResourceAlreadyExistsException("oh noes")
+
+        response = create_serializer(context.service).serialize_error_to_response(
+            context.service_exception, context.operation
+        )
+
+        handler(chain, context, response)
+        assert context.service_response == {
+            "Error": {"Code": "ResourceAlreadyExistsException", "Message": "oh noes"}
+        }
+
+    def test_nothing_set_does_nothing(self, chain, handler):
+        context = RequestContext()
+        context.request = Request("GET", "/health")
+
+        handler(chain, context, Response("ok", 200))
+
+        assert context.service_exception is None
+        assert context.service_response is None

--- a/tests/unit/aws/handlers/service.py
+++ b/tests/unit/aws/handlers/service.py
@@ -9,46 +9,42 @@ from localstack.http import Request, Response
 
 
 @pytest.fixture
-def chain() -> HandlerChain:
+def service_response_handler_chain() -> HandlerChain:
     """Returns a dummy chain for testing."""
-    return HandlerChain()
-
-
-@pytest.fixture
-def handler() -> ServiceResponseParser:
-    return ServiceResponseParser()
+    return HandlerChain(response_handlers=[ServiceResponseParser()])
 
 
 class TestServiceResponseHandler:
-    def test_use_set_response(self, chain, handler):
+    def test_use_set_response(self, service_response_handler_chain):
         context = create_aws_request_context("opensearch", "CreateDomain", {"DomainName": "foobar"})
         context.service_response = {"sure": "why not"}
 
-        handler(chain, context, Response(status=200))
+        service_response_handler_chain.handle(context, Response(status=200))
         assert context.service_response == {"sure": "why not"}
 
-    def test_parse_response(self, chain, handler):
+    def test_parse_response(self, service_response_handler_chain):
         context = create_aws_request_context("sqs", "CreateQueue", {"QueueName": "foobar"})
         backend_response = {"QueueUrl": "http://localhost:4566/000000000000/foobar"}
         http_response = create_serializer(context.service).serialize_to_response(
             backend_response, context.operation
         )
 
-        handler(chain, context, http_response)
+        service_response_handler_chain.handle(context, http_response)
         assert context.service_response == backend_response
 
-    def test_common_service_exception(self, chain, handler):
+    def test_common_service_exception(self, service_response_handler_chain):
         context = create_aws_request_context("opensearch", "CreateDomain", {"DomainName": "foobar"})
         context.service_exception = CommonServiceException(
-            "InvalidTypeException", "oh noes", status_code=409, sender_fault=True
+            "MyCommonException", "oh noes", status_code=409, sender_fault=True
         )
 
-        handler(chain, context, Response(status=409))
-        assert context.service_response == {
-            "Error": {"Code": "InvalidTypeException", "Message": "oh noes"}
-        }
+        service_response_handler_chain.handle(context, Response(status=409))
+        assert context.service_exception.message == "oh noes"
+        assert context.service_exception.code == "MyCommonException"
+        assert context.service_exception.sender_fault
+        assert context.service_exception.status_code == 409
 
-    def test_service_exception(self, chain, handler):
+    def test_service_exception(self, service_response_handler_chain):
         from localstack.aws.api.opensearch import ResourceAlreadyExistsException
 
         context = create_aws_request_context("opensearch", "CreateDomain", {"DomainName": "foobar"})
@@ -58,16 +54,65 @@ class TestServiceResponseHandler:
             context.service_exception, context.operation
         )
 
-        handler(chain, context, response)
-        assert context.service_response == {
-            "Error": {"Code": "ResourceAlreadyExistsException", "Message": "oh noes"}
-        }
+        service_response_handler_chain.handle(context, response)
+        assert context.service_exception.message == "oh noes"
+        assert context.service_exception.code == "ResourceAlreadyExistsException"
+        assert not context.service_exception.sender_fault
+        assert context.service_exception.status_code == 409
 
-    def test_nothing_set_does_nothing(self, chain, handler):
+    def test_service_exception_with_code_from_spec(self, service_response_handler_chain):
+        from localstack.aws.api.sqs import QueueDoesNotExist
+
+        context = create_aws_request_context(
+            "sqs",
+            "SendMessage",
+            {"QueueUrl": "http://localhost:4566/000000000000/foobared", "MessageBody": "foo"},
+        )
+        context.service_exception = QueueDoesNotExist()
+
+        response = create_serializer(context.service).serialize_error_to_response(
+            context.service_exception, context.operation
+        )
+
+        service_response_handler_chain.handle(context, response)
+
+        assert context.service_exception.message == ""
+        assert context.service_exception.code == "AWS.SimpleQueueService.NonExistentQueue"
+        assert context.service_exception.sender_fault
+        assert context.service_exception.status_code == 400
+
+    def test_sets_exception_from_error_response(self, service_response_handler_chain):
+        context = create_aws_request_context(
+            "opensearch", "DescribeDomain", {"DomainName": "foobar"}
+        )
+        response = Response(
+            b'{"__type": "ResourceNotFoundException", "message": "Domain not found: foobar"}',
+            409,
+        )
+        service_response_handler_chain.handle(context, response)
+
+        assert context.service_exception.message == "Domain not found: foobar"
+        assert context.service_exception.code == "ResourceNotFoundException"
+        assert not context.service_exception.sender_fault
+        assert context.service_exception.status_code == 409
+
+        assert context.service_response is None
+
+    def test_nothing_set_does_nothing(self, service_response_handler_chain):
         context = RequestContext()
         context.request = Request("GET", "/health")
 
-        handler(chain, context, Response("ok", 200))
+        service_response_handler_chain.handle(context, Response("ok", 200))
 
         assert context.service_exception is None
         assert context.service_response is None
+
+    def test_invalid_exception_does_nothing(self, service_response_handler_chain):
+        context = create_aws_request_context(
+            "opensearch", "DescribeDomain", {"DomainName": "foobar"}
+        )
+        context.service_exception = ValueError()
+        service_response_handler_chain.handle(context, Response(status=500))
+
+        assert context.service_response is None
+        assert isinstance(context.service_exception, ValueError)


### PR DESCRIPTION
This PR addresses an issue that is emerging because some advanced handlers require access to the AWS response dictionary, but since we don't always have access to that (e.g. when we forward to moto or other backends) we need to parse it.

* Added a common interface of attributes to `ServiceException`. In the future we would set those values directly from the scaffold
* Added two fields the the `RequestContext` that hold the parsed response and optionally the exception
* If the response is already set when reaching the handler (e.g., because the skeleton set the value directly to what came out of the provider), then be happy and do nothing
* When the exception is set, we check that the attributes are set (this is a workaround, see future work)
* Otherwise try to parse the HTTP response
* If the HTTP response is an error code, interpret the response as an error and instantiate an exception

now downstream response handlers can fairly safely access `context.service_response` if `context.operation` is set.


## Future work:
we should update the scaffold to something like:
```python
    def _print_as_class(self, output, base: str, doc=True, quote_types=False):
        output.write(f"class {to_valid_python_name(self.shape.name)}({base}):\n")

        q = '"' if quote_types else ""

        if doc:
            self.print_shape_doc(output, self.shape)

        if self.is_exception:
            # extract from the shape the error metadata
            error_spec = self.shape.metadata.get("error", {})
            output.write(f'    code: str = "{error_spec.get("code", self.shape.name)}"\n')
            output.write(f'    sender_fault: bool = {error_spec.get("senderFault", False)}\n')
            output.write(f'    status_code: int = {error_spec.get("httpStatusCode", 400)}\n')
        elif not self.shape.members:
            output.write("    pass\n")

        for k, v in self.shape.members.items():
            if k in self.shape.required_members:
                if v.serialization.get("eventstream"):
                    output.write(f"    {k}: Iterator[{q}{to_valid_python_name(v.name)}{q}]\n")
                else:
                    output.write(f"    {k}: {q}{to_valid_python_name(v.name)}{q}\n")
            else:
                if v.serialization.get("eventstream"):
                    output.write(f"    {k}: Iterator[{q}{to_valid_python_name(v.name)}{q}]\n")
                else:
                    output.write(f"    {k}: Optional[{q}{to_valid_python_name(v.name)}{q}]\n")
```

which will generate code of the form:
```python
class EmptyBatchRequest(ServiceException):
    code: str = "AWS.SimpleQueueService.EmptyBatchRequest"
    sender_fault: bool = True
    status_code: int = 400
```