### PR TITLE
Fix default content-type for APIGW-Lambda integration

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -197,6 +197,7 @@ class LambdaProxyIntegration(BackendIntegration):
             response = result
         else:
             response = LambdaResponse()
+            response.headers.update({"content-type": "application/json"})
             parsed_result = result if isinstance(result, dict) else json.loads(str(result or "{}"))
             parsed_result = common.json_safe(parsed_result)
             parsed_result = {} if parsed_result is None else parsed_result
@@ -208,7 +209,6 @@ class LambdaProxyIntegration(BackendIntegration):
                     'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}'
                 )
                 response.status_code = 502
-                response.headers.update({"content-type": "application/json"})
                 response._content = json.dumps({"message": "Internal server error"})
                 return response
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -382,7 +382,6 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
                 response = result
             else:
                 response = LambdaResponse()
-                response.headers.update({"content-type": "application/json"})
 
                 parsed_result = (
                     result if isinstance(result, dict) else json.loads(str(result or "{}"))

--- a/tests/integration/awslambda/test_lambda_integration.py
+++ b/tests/integration/awslambda/test_lambda_integration.py
@@ -481,6 +481,8 @@ class TestLambdaHttpInvocation:
         result = safe_requests.get(url)
 
         assert result.status_code == 502
+        assert result.headers.get("Content-Type") == "application/json"
+        assert json.loads(result.content)["message"] == "Internal server error"
 
 
 class TestKinesisSource:


### PR DESCRIPTION
This PR should close #6134. The problem was that when I moved my code, adapting it for the rebase of #6170, I moved all the lines except for the one that sets the default content-type value. 