### PR TITLE
add exception metadata to ASF generated ServiceException

### DIFF
--- a/localstack/aws/api/acm/__init__.py
+++ b/localstack/aws/api/acm/__init__.py
@@ -147,66 +147,114 @@ class ValidationMethod(str):
 
 
 class AccessDeniedException(ServiceException):
+    code: str = "AccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ServiceErrorMessage]
 
 
 class ConflictException(ServiceException):
+    code: str = "ConflictException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidArgsException(ServiceException):
+    code: str = "InvalidArgsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidArnException(ServiceException):
+    code: str = "InvalidArnException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidDomainValidationOptionsException(ServiceException):
+    code: str = "InvalidDomainValidationOptionsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidParameterException(ServiceException):
+    code: str = "InvalidParameterException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidStateException(ServiceException):
+    code: str = "InvalidStateException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidTagException(ServiceException):
+    code: str = "InvalidTagException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class RequestInProgressException(ServiceException):
+    code: str = "RequestInProgressException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class TagPolicyException(ServiceException):
+    code: str = "TagPolicyException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ThrottlingException(ServiceException):
+    code: str = "ThrottlingException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[AvailabilityErrorMessage]
 
 
 class TooManyTagsException(ServiceException):
+    code: str = "TooManyTagsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ValidationException(ServiceException):
+    code: str = "ValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ValidationExceptionMessage]
 
 

--- a/localstack/aws/api/apigateway/__init__.py
+++ b/localstack/aws/api/apigateway/__init__.py
@@ -169,33 +169,54 @@ class VpcLinkStatus(str):
 
 
 class BadRequestException(ServiceException):
+    code: str = "BadRequestException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ConflictException(ServiceException):
+    code: str = "ConflictException"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[String]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 429
     retryAfterSeconds: Optional[String]
     message: Optional[String]
 
 
 class NotFoundException(ServiceException):
+    code: str = "NotFoundException"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[String]
 
 
 class ServiceUnavailableException(ServiceException):
+    code: str = "ServiceUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 503
     retryAfterSeconds: Optional[String]
     message: Optional[String]
 
 
 class TooManyRequestsException(ServiceException):
+    code: str = "TooManyRequestsException"
+    sender_fault: bool = False
+    status_code: int = 429
     retryAfterSeconds: Optional[String]
     message: Optional[String]
 
 
 class UnauthorizedException(ServiceException):
+    code: str = "UnauthorizedException"
+    sender_fault: bool = False
+    status_code: int = 401
     message: Optional[String]
 
 

--- a/localstack/aws/api/awslambda/__init__.py
+++ b/localstack/aws/api/awslambda/__init__.py
@@ -12,6 +12,7 @@ from localstack.aws.api import RequestContext, ServiceException, ServiceRequest,
 Action = str
 AdditionalVersion = str
 Alias = str
+AllowCredentials = bool
 Arn = str
 BatchSize = int
 BisectBatchOnFunctionError = bool
@@ -24,11 +25,15 @@ Enabled = bool
 Endpoint = str
 EnvironmentVariableName = str
 EnvironmentVariableValue = str
+EphemeralStorageSize = int
 EventSourceToken = str
 FileSystemArn = str
 FunctionArn = str
 FunctionName = str
+FunctionUrl = str
+FunctionUrlQualifier = str
 Handler = str
+Header = str
 HttpStatus = int
 Integer = int
 KMSKeyArn = str
@@ -41,7 +46,9 @@ LayerVersionArn = str
 LicenseInfo = str
 LocalMountPath = str
 MasterRegion = str
+MaxAge = int
 MaxFunctionEventInvokeConfigListItems = int
+MaxItems = int
 MaxLayerListItems = int
 MaxListItems = int
 MaxProvisionedConcurrencyConfigListItems = int
@@ -51,15 +58,18 @@ MaximumRecordAgeInSeconds = int
 MaximumRetryAttempts = int
 MaximumRetryAttemptsEventSourceMapping = int
 MemorySize = int
+Method = str
 NameSpacedFunctionArn = str
 NamespacedFunctionName = str
 NamespacedStatementId = str
 NonNegativeInteger = int
 OrganizationId = str
+Origin = str
 ParallelizationFactor = int
 Pattern = str
 PositiveInteger = int
 Principal = str
+PrincipalOrgID = str
 Qualifier = str
 Queue = str
 ReservedConcurrentExecutions = int
@@ -111,6 +121,11 @@ class EventSourcePosition(str):
 
 class FunctionResponseType(str):
     ReportBatchItemFailures = "ReportBatchItemFailures"
+
+
+class FunctionUrlAuthType(str):
+    NONE = "NONE"
+    AWS_IAM = "AWS_IAM"
 
 
 class FunctionVersion(str):
@@ -166,6 +181,7 @@ class Runtime(str):
     nodejs10_x = "nodejs10.x"
     nodejs12_x = "nodejs12.x"
     nodejs14_x = "nodejs14.x"
+    nodejs16_x = "nodejs16.x"
     java8 = "java8"
     java8_al2 = "java8.al2"
     java11 = "java11"
@@ -237,167 +253,266 @@ class TracingMode(str):
 
 
 class CodeSigningConfigNotFoundException(ServiceException):
+    code: str = "CodeSigningConfigNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 404
     Type: Optional[String]
     Message: Optional[String]
 
 
 class CodeStorageExceededException(ServiceException):
+    code: str = "CodeStorageExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     message: Optional[String]
 
 
 class CodeVerificationFailedException(ServiceException):
+    code: str = "CodeVerificationFailedException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     Message: Optional[String]
 
 
 class EC2AccessDeniedException(ServiceException):
+    code: str = "EC2AccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class EC2ThrottledException(ServiceException):
+    code: str = "EC2ThrottledException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class EC2UnexpectedException(ServiceException):
+    code: str = "EC2UnexpectedException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
     EC2ErrorCode: Optional[String]
 
 
 class EFSIOException(ServiceException):
+    code: str = "EFSIOException"
+    sender_fault: bool = False
+    status_code: int = 410
     Type: Optional[String]
     Message: Optional[String]
 
 
 class EFSMountConnectivityException(ServiceException):
+    code: str = "EFSMountConnectivityException"
+    sender_fault: bool = False
+    status_code: int = 408
     Type: Optional[String]
     Message: Optional[String]
 
 
 class EFSMountFailureException(ServiceException):
+    code: str = "EFSMountFailureException"
+    sender_fault: bool = False
+    status_code: int = 403
     Type: Optional[String]
     Message: Optional[String]
 
 
 class EFSMountTimeoutException(ServiceException):
+    code: str = "EFSMountTimeoutException"
+    sender_fault: bool = False
+    status_code: int = 408
     Type: Optional[String]
     Message: Optional[String]
 
 
 class ENILimitReachedException(ServiceException):
+    code: str = "ENILimitReachedException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class InvalidCodeSignatureException(ServiceException):
+    code: str = "InvalidCodeSignatureException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     Message: Optional[String]
 
 
 class InvalidParameterValueException(ServiceException):
+    code: str = "InvalidParameterValueException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     message: Optional[String]
 
 
 class InvalidRequestContentException(ServiceException):
+    code: str = "InvalidRequestContentException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     message: Optional[String]
 
 
 class InvalidRuntimeException(ServiceException):
+    code: str = "InvalidRuntimeException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class InvalidSecurityGroupIDException(ServiceException):
+    code: str = "InvalidSecurityGroupIDException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class InvalidSubnetIDException(ServiceException):
+    code: str = "InvalidSubnetIDException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class InvalidZipFileException(ServiceException):
+    code: str = "InvalidZipFileException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class KMSAccessDeniedException(ServiceException):
+    code: str = "KMSAccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class KMSDisabledException(ServiceException):
+    code: str = "KMSDisabledException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class KMSInvalidStateException(ServiceException):
+    code: str = "KMSInvalidStateException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class KMSNotFoundException(ServiceException):
+    code: str = "KMSNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class PolicyLengthExceededException(ServiceException):
+    code: str = "PolicyLengthExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     message: Optional[String]
 
 
 class PreconditionFailedException(ServiceException):
+    code: str = "PreconditionFailedException"
+    sender_fault: bool = False
+    status_code: int = 412
     Type: Optional[String]
     message: Optional[String]
 
 
 class ProvisionedConcurrencyConfigNotFoundException(ServiceException):
+    code: str = "ProvisionedConcurrencyConfigNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 404
     Type: Optional[String]
     message: Optional[String]
 
 
 class RequestTooLargeException(ServiceException):
+    code: str = "RequestTooLargeException"
+    sender_fault: bool = False
+    status_code: int = 413
     Type: Optional[String]
     message: Optional[String]
 
 
 class ResourceConflictException(ServiceException):
+    code: str = "ResourceConflictException"
+    sender_fault: bool = False
+    status_code: int = 409
     Type: Optional[String]
     message: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     Type: Optional[String]
     Message: Optional[String]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 404
     Type: Optional[String]
     Message: Optional[String]
 
 
 class ResourceNotReadyException(ServiceException):
+    code: str = "ResourceNotReadyException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     message: Optional[String]
 
 
 class ServiceException(ServiceException):
+    code: str = "ServiceException"
+    sender_fault: bool = False
+    status_code: int = 500
     Type: Optional[String]
     Message: Optional[String]
 
 
 class SubnetIPAddressLimitReachedException(ServiceException):
+    code: str = "SubnetIPAddressLimitReachedException"
+    sender_fault: bool = False
+    status_code: int = 502
     Type: Optional[String]
     Message: Optional[String]
 
 
 class TooManyRequestsException(ServiceException):
+    code: str = "TooManyRequestsException"
+    sender_fault: bool = False
+    status_code: int = 429
     retryAfterSeconds: Optional[String]
     Type: Optional[String]
     message: Optional[String]
@@ -405,6 +520,9 @@ class TooManyRequestsException(ServiceException):
 
 
 class UnsupportedMediaTypeException(ServiceException):
+    code: str = "UnsupportedMediaTypeException"
+    sender_fault: bool = False
+    status_code: int = 415
     Type: Optional[String]
     message: Optional[String]
 
@@ -453,6 +571,8 @@ class AddPermissionRequest(ServiceRequest):
     EventSourceToken: Optional[EventSourceToken]
     Qualifier: Optional[Qualifier]
     RevisionId: Optional[String]
+    PrincipalOrgID: Optional[PrincipalOrgID]
+    FunctionUrlAuthType: Optional[FunctionUrlAuthType]
 
 
 class AddPermissionResponse(TypedDict, total=False):
@@ -476,6 +596,8 @@ class AliasConfiguration(TypedDict, total=False):
 
 
 AliasList = List[AliasConfiguration]
+AllowMethodsList = List[Method]
+AllowOriginsList = List[Origin]
 SigningProfileVersionArns = List[Arn]
 
 
@@ -508,6 +630,18 @@ CompatibleRuntimes = List[Runtime]
 
 class Concurrency(TypedDict, total=False):
     ReservedConcurrentExecutions: Optional[ReservedConcurrentExecutions]
+
+
+HeadersList = List[Header]
+
+
+class Cors(TypedDict, total=False):
+    AllowCredentials: Optional[AllowCredentials]
+    AllowHeaders: Optional[HeadersList]
+    AllowMethods: Optional[AllowMethodsList]
+    AllowOrigins: Optional[AllowOriginsList]
+    ExposeHeaders: Optional[HeadersList]
+    MaxAge: Optional[MaxAge]
 
 
 class CreateAliasRequest(ServiceRequest):
@@ -596,6 +730,10 @@ class CreateEventSourceMappingRequest(ServiceRequest):
     FunctionResponseTypes: Optional[FunctionResponseTypeList]
 
 
+class EphemeralStorage(TypedDict, total=False):
+    Size: EphemeralStorageSize
+
+
 StringList = List[String]
 
 
@@ -669,6 +807,22 @@ class CreateFunctionRequest(ServiceRequest):
     ImageConfig: Optional[ImageConfig]
     CodeSigningConfigArn: Optional[CodeSigningConfigArn]
     Architectures: Optional[ArchitecturesList]
+    EphemeralStorage: Optional[EphemeralStorage]
+
+
+class CreateFunctionUrlConfigRequest(ServiceRequest):
+    FunctionName: FunctionName
+    Qualifier: Optional[FunctionUrlQualifier]
+    AuthType: FunctionUrlAuthType
+    Cors: Optional[Cors]
+
+
+class CreateFunctionUrlConfigResponse(TypedDict, total=False):
+    FunctionUrl: FunctionUrl
+    FunctionArn: FunctionArn
+    AuthType: FunctionUrlAuthType
+    Cors: Optional[Cors]
+    CreationTime: Timestamp
 
 
 class DeleteAliasRequest(ServiceRequest):
@@ -704,6 +858,11 @@ class DeleteFunctionEventInvokeConfigRequest(ServiceRequest):
 class DeleteFunctionRequest(ServiceRequest):
     FunctionName: FunctionName
     Qualifier: Optional[Qualifier]
+
+
+class DeleteFunctionUrlConfigRequest(ServiceRequest):
+    FunctionName: FunctionName
+    Qualifier: Optional[FunctionUrlQualifier]
 
 
 class DeleteLayerVersionRequest(ServiceRequest):
@@ -826,6 +985,7 @@ class FunctionConfiguration(TypedDict, total=False):
     SigningProfileVersionArn: Optional[Arn]
     SigningJobArn: Optional[Arn]
     Architectures: Optional[ArchitecturesList]
+    EphemeralStorage: Optional[EphemeralStorage]
 
 
 class FunctionEventInvokeConfig(TypedDict, total=False):
@@ -838,6 +998,18 @@ class FunctionEventInvokeConfig(TypedDict, total=False):
 
 FunctionEventInvokeConfigList = List[FunctionEventInvokeConfig]
 FunctionList = List[FunctionConfiguration]
+
+
+class FunctionUrlConfig(TypedDict, total=False):
+    FunctionUrl: FunctionUrl
+    FunctionArn: FunctionArn
+    CreationTime: Timestamp
+    LastModifiedTime: Timestamp
+    Cors: Optional[Cors]
+    AuthType: FunctionUrlAuthType
+
+
+FunctionUrlConfigList = List[FunctionUrlConfig]
 
 
 class GetAccountSettingsRequest(ServiceRequest):
@@ -903,6 +1075,20 @@ class GetFunctionResponse(TypedDict, total=False):
     Code: Optional[FunctionCodeLocation]
     Tags: Optional[Tags]
     Concurrency: Optional[Concurrency]
+
+
+class GetFunctionUrlConfigRequest(ServiceRequest):
+    FunctionName: FunctionName
+    Qualifier: Optional[FunctionUrlQualifier]
+
+
+class GetFunctionUrlConfigResponse(TypedDict, total=False):
+    FunctionUrl: FunctionUrl
+    FunctionArn: FunctionArn
+    AuthType: FunctionUrlAuthType
+    Cors: Optional[Cors]
+    CreationTime: Timestamp
+    LastModifiedTime: Timestamp
 
 
 class GetLayerVersionByArnRequest(ServiceRequest):
@@ -1065,6 +1251,17 @@ class ListFunctionEventInvokeConfigsRequest(ServiceRequest):
 
 class ListFunctionEventInvokeConfigsResponse(TypedDict, total=False):
     FunctionEventInvokeConfigs: Optional[FunctionEventInvokeConfigList]
+    NextMarker: Optional[String]
+
+
+class ListFunctionUrlConfigsRequest(ServiceRequest):
+    FunctionName: FunctionName
+    Marker: Optional[String]
+    MaxItems: Optional[MaxItems]
+
+
+class ListFunctionUrlConfigsResponse(TypedDict, total=False):
+    FunctionUrlConfigs: FunctionUrlConfigList
     NextMarker: Optional[String]
 
 
@@ -1319,6 +1516,7 @@ class UpdateFunctionConfigurationRequest(ServiceRequest):
     Layers: Optional[LayerList]
     FileSystemConfigs: Optional[FileSystemConfigList]
     ImageConfig: Optional[ImageConfig]
+    EphemeralStorage: Optional[EphemeralStorage]
 
 
 class UpdateFunctionEventInvokeConfigRequest(ServiceRequest):
@@ -1327,6 +1525,22 @@ class UpdateFunctionEventInvokeConfigRequest(ServiceRequest):
     MaximumRetryAttempts: Optional[MaximumRetryAttempts]
     MaximumEventAgeInSeconds: Optional[MaximumEventAgeInSeconds]
     DestinationConfig: Optional[DestinationConfig]
+
+
+class UpdateFunctionUrlConfigRequest(ServiceRequest):
+    FunctionName: FunctionName
+    Qualifier: Optional[FunctionUrlQualifier]
+    AuthType: Optional[FunctionUrlAuthType]
+    Cors: Optional[Cors]
+
+
+class UpdateFunctionUrlConfigResponse(TypedDict, total=False):
+    FunctionUrl: FunctionUrl
+    FunctionArn: FunctionArn
+    AuthType: FunctionUrlAuthType
+    Cors: Optional[Cors]
+    CreationTime: Timestamp
+    LastModifiedTime: Timestamp
 
 
 class LambdaApi:
@@ -1361,6 +1575,8 @@ class LambdaApi:
         event_source_token: EventSourceToken = None,
         qualifier: Qualifier = None,
         revision_id: String = None,
+        principal_org_id: PrincipalOrgID = None,
+        function_url_auth_type: FunctionUrlAuthType = None,
     ) -> AddPermissionResponse:
         raise NotImplementedError
 
@@ -1437,7 +1653,19 @@ class LambdaApi:
         image_config: ImageConfig = None,
         code_signing_config_arn: CodeSigningConfigArn = None,
         architectures: ArchitecturesList = None,
+        ephemeral_storage: EphemeralStorage = None,
     ) -> FunctionConfiguration:
+        raise NotImplementedError
+
+    @handler("CreateFunctionUrlConfig")
+    def create_function_url_config(
+        self,
+        context: RequestContext,
+        function_name: FunctionName,
+        auth_type: FunctionUrlAuthType,
+        qualifier: FunctionUrlQualifier = None,
+        cors: Cors = None,
+    ) -> CreateFunctionUrlConfigResponse:
         raise NotImplementedError
 
     @handler("DeleteAlias")
@@ -1479,6 +1707,15 @@ class LambdaApi:
     @handler("DeleteFunctionEventInvokeConfig")
     def delete_function_event_invoke_config(
         self, context: RequestContext, function_name: FunctionName, qualifier: Qualifier = None
+    ) -> None:
+        raise NotImplementedError
+
+    @handler("DeleteFunctionUrlConfig")
+    def delete_function_url_config(
+        self,
+        context: RequestContext,
+        function_name: FunctionName,
+        qualifier: FunctionUrlQualifier = None,
     ) -> None:
         raise NotImplementedError
 
@@ -1553,6 +1790,15 @@ class LambdaApi:
     def get_function_event_invoke_config(
         self, context: RequestContext, function_name: FunctionName, qualifier: Qualifier = None
     ) -> FunctionEventInvokeConfig:
+        raise NotImplementedError
+
+    @handler("GetFunctionUrlConfig")
+    def get_function_url_config(
+        self,
+        context: RequestContext,
+        function_name: FunctionName,
+        qualifier: FunctionUrlQualifier = None,
+    ) -> GetFunctionUrlConfigResponse:
         raise NotImplementedError
 
     @handler("GetLayerVersion")
@@ -1646,6 +1892,16 @@ class LambdaApi:
         marker: String = None,
         max_items: MaxFunctionEventInvokeConfigListItems = None,
     ) -> ListFunctionEventInvokeConfigsResponse:
+        raise NotImplementedError
+
+    @handler("ListFunctionUrlConfigs")
+    def list_function_url_configs(
+        self,
+        context: RequestContext,
+        function_name: FunctionName,
+        marker: String = None,
+        max_items: MaxItems = None,
+    ) -> ListFunctionUrlConfigsResponse:
         raise NotImplementedError
 
     @handler("ListFunctions")
@@ -1894,6 +2150,7 @@ class LambdaApi:
         layers: LayerList = None,
         file_system_configs: FileSystemConfigList = None,
         image_config: ImageConfig = None,
+        ephemeral_storage: EphemeralStorage = None,
     ) -> FunctionConfiguration:
         raise NotImplementedError
 
@@ -1907,4 +2164,15 @@ class LambdaApi:
         maximum_event_age_in_seconds: MaximumEventAgeInSeconds = None,
         destination_config: DestinationConfig = None,
     ) -> FunctionEventInvokeConfig:
+        raise NotImplementedError
+
+    @handler("UpdateFunctionUrlConfig")
+    def update_function_url_config(
+        self,
+        context: RequestContext,
+        function_name: FunctionName,
+        qualifier: FunctionUrlQualifier = None,
+        auth_type: FunctionUrlAuthType = None,
+        cors: Cors = None,
+    ) -> UpdateFunctionUrlConfigResponse:
         raise NotImplementedError

--- a/localstack/aws/api/cloudformation/__init__.py
+++ b/localstack/aws/api/cloudformation/__init__.py
@@ -525,91 +525,136 @@ class Visibility(str):
 
 
 class AlreadyExistsException(ServiceException):
-    pass
+    code: str = "AlreadyExistsException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class CFNRegistryException(ServiceException):
+    code: str = "CFNRegistryException"
+    sender_fault: bool = True
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class ChangeSetNotFoundException(ServiceException):
-    pass
+    code: str = "ChangeSetNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class CreatedButModifiedException(ServiceException):
-    pass
+    code: str = "CreatedButModifiedException"
+    sender_fault: bool = True
+    status_code: int = 409
 
 
 class InsufficientCapabilitiesException(ServiceException):
-    pass
+    code: str = "InsufficientCapabilitiesException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidChangeSetStatusException(ServiceException):
-    pass
+    code: str = "InvalidChangeSetStatus"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidOperationException(ServiceException):
-    pass
+    code: str = "InvalidOperationException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidStateTransitionException(ServiceException):
-    pass
+    code: str = "InvalidStateTransition"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class NameAlreadyExistsException(ServiceException):
-    pass
+    code: str = "NameAlreadyExistsException"
+    sender_fault: bool = True
+    status_code: int = 409
 
 
 class OperationIdAlreadyExistsException(ServiceException):
-    pass
+    code: str = "OperationIdAlreadyExistsException"
+    sender_fault: bool = True
+    status_code: int = 409
 
 
 class OperationInProgressException(ServiceException):
-    pass
+    code: str = "OperationInProgressException"
+    sender_fault: bool = True
+    status_code: int = 409
 
 
 class OperationNotFoundException(ServiceException):
-    pass
+    code: str = "OperationNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class OperationStatusCheckFailedException(ServiceException):
-    pass
+    code: str = "ConditionalCheckFailed"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class StackInstanceNotFoundException(ServiceException):
-    pass
+    code: str = "StackInstanceNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class StackNotFoundException(ServiceException):
-    pass
+    code: str = "StackNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class StackSetNotEmptyException(ServiceException):
-    pass
+    code: str = "StackSetNotEmptyException"
+    sender_fault: bool = True
+    status_code: int = 409
 
 
 class StackSetNotFoundException(ServiceException):
-    pass
+    code: str = "StackSetNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class StaleRequestException(ServiceException):
-    pass
+    code: str = "StaleRequestException"
+    sender_fault: bool = True
+    status_code: int = 409
 
 
 class TokenAlreadyExistsException(ServiceException):
-    pass
+    code: str = "TokenAlreadyExistsException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class TypeConfigurationNotFoundException(ServiceException):
-    pass
+    code: str = "TypeConfigurationNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class TypeNotFoundException(ServiceException):
-    pass
+    code: str = "TypeNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class AccountGateResult(TypedDict, total=False):

--- a/localstack/aws/api/cloudwatch/__init__.py
+++ b/localstack/aws/api/cloudwatch/__init__.py
@@ -185,7 +185,9 @@ class StatusCode(str):
 
 
 class ConcurrentModificationException(ServiceException):
-    pass
+    code: str = "ConcurrentModificationException"
+    sender_fault: bool = True
+    status_code: int = 429
 
 
 class DashboardValidationMessage(TypedDict, total=False):
@@ -197,51 +199,86 @@ DashboardValidationMessages = List[DashboardValidationMessage]
 
 
 class DashboardInvalidInputError(ServiceException):
+    code: str = "InvalidParameterInput"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[DashboardErrorMessage]
     dashboardValidationMessages: Optional[DashboardValidationMessages]
 
 
 class DashboardNotFoundError(ServiceException):
+    code: str = "ResourceNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[DashboardErrorMessage]
 
 
 class InternalServiceFault(ServiceException):
+    code: str = "InternalServiceError"
+    sender_fault: bool = False
+    status_code: int = 500
     Message: Optional[FaultDescription]
 
 
 class InvalidFormatFault(ServiceException):
+    code: str = "InvalidFormat"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidNextToken(ServiceException):
+    code: str = "InvalidNextToken"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidParameterCombinationException(ServiceException):
+    code: str = "InvalidParameterCombination"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[AwsQueryErrorMessage]
 
 
 class InvalidParameterValueException(ServiceException):
+    code: str = "InvalidParameterValue"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[AwsQueryErrorMessage]
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class LimitExceededFault(ServiceException):
+    code: str = "LimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class MissingRequiredParameterException(ServiceException):
+    code: str = "MissingParameter"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[AwsQueryErrorMessage]
 
 
 class ResourceNotFound(ServiceException):
+    code: str = "ResourceNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = True
+    status_code: int = 404
     ResourceType: Optional[ResourceType]
     ResourceId: Optional[ResourceId]
 

--- a/localstack/aws/api/config/__init__.py
+++ b/localstack/aws/api/config/__init__.py
@@ -399,215 +399,322 @@ class ResourceValueType(str):
 
 
 class ConformancePackTemplateValidationException(ServiceException):
-    pass
+    code: str = "ConformancePackTemplateValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InsufficientDeliveryPolicyException(ServiceException):
-    pass
+    code: str = "InsufficientDeliveryPolicyException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InsufficientPermissionsException(ServiceException):
-    pass
+    code: str = "InsufficientPermissionsException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidConfigurationRecorderNameException(ServiceException):
-    pass
+    code: str = "InvalidConfigurationRecorderNameException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidDeliveryChannelNameException(ServiceException):
-    pass
+    code: str = "InvalidDeliveryChannelNameException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidExpressionException(ServiceException):
-    pass
+    code: str = "InvalidExpressionException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidLimitException(ServiceException):
-    pass
+    code: str = "InvalidLimitException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidNextTokenException(ServiceException):
-    pass
+    code: str = "InvalidNextTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidParameterValueException(ServiceException):
-    pass
+    code: str = "InvalidParameterValueException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidRecordingGroupException(ServiceException):
-    pass
+    code: str = "InvalidRecordingGroupException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidResultTokenException(ServiceException):
-    pass
+    code: str = "InvalidResultTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidRoleException(ServiceException):
-    pass
+    code: str = "InvalidRoleException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidS3KeyPrefixException(ServiceException):
-    pass
+    code: str = "InvalidS3KeyPrefixException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidS3KmsKeyArnException(ServiceException):
-    pass
+    code: str = "InvalidS3KmsKeyArnException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidSNSTopicARNException(ServiceException):
-    pass
+    code: str = "InvalidSNSTopicARNException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidTimeRangeException(ServiceException):
-    pass
+    code: str = "InvalidTimeRangeException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class LastDeliveryChannelDeleteFailedException(ServiceException):
-    pass
+    code: str = "LastDeliveryChannelDeleteFailedException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxActiveResourcesExceededException(ServiceException):
-    pass
+    code: str = "MaxActiveResourcesExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfConfigRulesExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfConfigRulesExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfConfigurationRecordersExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfConfigurationRecordersExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfConformancePacksExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfConformancePacksExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfDeliveryChannelsExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfDeliveryChannelsExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfOrganizationConfigRulesExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfOrganizationConfigRulesExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfOrganizationConformancePacksExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfOrganizationConformancePacksExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MaxNumberOfRetentionConfigurationsExceededException(ServiceException):
-    pass
+    code: str = "MaxNumberOfRetentionConfigurationsExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoAvailableConfigurationRecorderException(ServiceException):
-    pass
+    code: str = "NoAvailableConfigurationRecorderException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoAvailableDeliveryChannelException(ServiceException):
-    pass
+    code: str = "NoAvailableDeliveryChannelException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoAvailableOrganizationException(ServiceException):
-    pass
+    code: str = "NoAvailableOrganizationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoRunningConfigurationRecorderException(ServiceException):
-    pass
+    code: str = "NoRunningConfigurationRecorderException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchBucketException(ServiceException):
-    pass
+    code: str = "NoSuchBucketException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchConfigRuleException(ServiceException):
-    pass
+    code: str = "NoSuchConfigRuleException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchConfigRuleInConformancePackException(ServiceException):
-    pass
+    code: str = "NoSuchConfigRuleInConformancePackException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchConfigurationAggregatorException(ServiceException):
-    pass
+    code: str = "NoSuchConfigurationAggregatorException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchConfigurationRecorderException(ServiceException):
-    pass
+    code: str = "NoSuchConfigurationRecorderException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchConformancePackException(ServiceException):
-    pass
+    code: str = "NoSuchConformancePackException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchDeliveryChannelException(ServiceException):
-    pass
+    code: str = "NoSuchDeliveryChannelException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchOrganizationConfigRuleException(ServiceException):
-    pass
+    code: str = "NoSuchOrganizationConfigRuleException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchOrganizationConformancePackException(ServiceException):
-    pass
+    code: str = "NoSuchOrganizationConformancePackException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchRemediationConfigurationException(ServiceException):
-    pass
+    code: str = "NoSuchRemediationConfigurationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchRemediationExceptionException(ServiceException):
-    pass
+    code: str = "NoSuchRemediationExceptionException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class NoSuchRetentionConfigurationException(ServiceException):
-    pass
+    code: str = "NoSuchRetentionConfigurationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class OrganizationAccessDeniedException(ServiceException):
-    pass
+    code: str = "OrganizationAccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class OrganizationAllFeaturesNotEnabledException(ServiceException):
-    pass
+    code: str = "OrganizationAllFeaturesNotEnabledException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class OrganizationConformancePackTemplateValidationException(ServiceException):
-    pass
+    code: str = "OrganizationConformancePackTemplateValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class OversizedConfigurationItemException(ServiceException):
-    pass
+    code: str = "OversizedConfigurationItemException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class RemediationInProgressException(ServiceException):
-    pass
+    code: str = "RemediationInProgressException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceConcurrentModificationException(ServiceException):
+    code: str = "ResourceConcurrentModificationException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceInUseException(ServiceException):
-    pass
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceNotDiscoveredException(ServiceException):
-    pass
+    code: str = "ResourceNotDiscoveredException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceNotFoundException(ServiceException):
-    pass
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class TooManyTagsException(ServiceException):
-    pass
+    code: str = "TooManyTagsException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ValidationException(ServiceException):
-    pass
+    code: str = "ValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 AggregatorRegionList = List[String]

--- a/localstack/aws/api/dynamodb/__init__.py
+++ b/localstack/aws/api/dynamodb/__init__.py
@@ -310,106 +310,184 @@ class TimeToLiveStatus(str):
 
 
 class BackupInUseException(ServiceException):
+    code: str = "BackupInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class BackupNotFoundException(ServiceException):
+    code: str = "BackupNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ConditionalCheckFailedException(ServiceException):
+    code: str = "ConditionalCheckFailedException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ContinuousBackupsUnavailableException(ServiceException):
+    code: str = "ContinuousBackupsUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DuplicateItemException(ServiceException):
+    code: str = "DuplicateItemException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ExportConflictException(ServiceException):
+    code: str = "ExportConflictException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ExportNotFoundException(ServiceException):
+    code: str = "ExportNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class GlobalTableAlreadyExistsException(ServiceException):
+    code: str = "GlobalTableAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class GlobalTableNotFoundException(ServiceException):
+    code: str = "GlobalTableNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class IdempotentParameterMismatchException(ServiceException):
+    code: str = "IdempotentParameterMismatchException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class IndexNotFoundException(ServiceException):
+    code: str = "IndexNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InternalServerError(ServiceException):
+    code: str = "InternalServerError"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidExportTimeException(ServiceException):
+    code: str = "InvalidExportTimeException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidRestoreTimeException(ServiceException):
+    code: str = "InvalidRestoreTimeException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ItemCollectionSizeLimitExceededException(ServiceException):
+    code: str = "ItemCollectionSizeLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class PointInTimeRecoveryUnavailableException(ServiceException):
+    code: str = "PointInTimeRecoveryUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ProvisionedThroughputExceededException(ServiceException):
+    code: str = "ProvisionedThroughputExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ReplicaAlreadyExistsException(ServiceException):
+    code: str = "ReplicaAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ReplicaNotFoundException(ServiceException):
+    code: str = "ReplicaNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class RequestLimitExceeded(ServiceException):
+    code: str = "RequestLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceInUseException(ServiceException):
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TableAlreadyExistsException(ServiceException):
+    code: str = "TableAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TableInUseException(ServiceException):
+    code: str = "TableInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TableNotFoundException(ServiceException):
+    code: str = "TableNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
@@ -445,15 +523,24 @@ CancellationReasonList = List[CancellationReason]
 
 
 class TransactionCanceledException(ServiceException):
+    code: str = "TransactionCanceledException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
     CancellationReasons: Optional[CancellationReasonList]
 
 
 class TransactionConflictException(ServiceException):
+    code: str = "TransactionConflictException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TransactionInProgressException(ServiceException):
+    code: str = "TransactionInProgressException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/api/dynamodbstreams/__init__.py
+++ b/localstack/aws/api/dynamodbstreams/__init__.py
@@ -58,22 +58,37 @@ class StreamViewType(str):
 
 
 class ExpiredIteratorException(ServiceException):
+    code: str = "ExpiredIteratorException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InternalServerError(ServiceException):
+    code: str = "InternalServerError"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TrimmedDataAccessException(ServiceException):
+    code: str = "TrimmedDataAccessException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -2242,11 +2242,6 @@ class SpotInstanceType(str):
     persistent = "persistent"
 
 
-class SpreadLevel(str):
-    host = "host"
-    rack = "rack"
-
-
 class State(str):
     PendingAcceptance = "PendingAcceptance"
     Pending = "Pending"
@@ -6239,7 +6234,6 @@ class CreatePlacementGroupRequest(ServiceRequest):
     Strategy: Optional[PlacementStrategy]
     PartitionCount: Optional[Integer]
     TagSpecifications: Optional[TagSpecificationList]
-    SpreadLevel: Optional[SpreadLevel]
 
 
 class PlacementGroup(TypedDict, total=False):
@@ -6250,7 +6244,6 @@ class PlacementGroup(TypedDict, total=False):
     GroupId: Optional[String]
     Tags: Optional[TagList]
     GroupArn: Optional[String]
-    SpreadLevel: Optional[SpreadLevel]
 
 
 class CreatePlacementGroupResult(TypedDict, total=False):
@@ -16277,7 +16270,6 @@ class Ec2Api:
         strategy: PlacementStrategy = None,
         partition_count: Integer = None,
         tag_specifications: TagSpecificationList = None,
-        spread_level: SpreadLevel = None,
     ) -> CreatePlacementGroupResult:
         raise NotImplementedError
 

--- a/localstack/aws/api/es/__init__.py
+++ b/localstack/aws/api/es/__init__.py
@@ -295,47 +295,70 @@ class VolumeType(str):
 
 
 class AccessDeniedException(ServiceException):
-    pass
+    code: str = "AccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 403
 
 
 class BaseException(ServiceException):
+    code: str = "BaseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ConflictException(ServiceException):
-    pass
+    code: str = "ConflictException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class DisabledOperationException(ServiceException):
-    pass
+    code: str = "DisabledOperationException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class InternalException(ServiceException):
-    pass
+    code: str = "InternalException"
+    sender_fault: bool = False
+    status_code: int = 500
 
 
 class InvalidPaginationTokenException(ServiceException):
-    pass
+    code: str = "InvalidPaginationTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidTypeException(ServiceException):
-    pass
+    code: str = "InvalidTypeException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class ResourceAlreadyExistsException(ServiceException):
-    pass
+    code: str = "ResourceAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class ResourceNotFoundException(ServiceException):
-    pass
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class ValidationException(ServiceException):
-    pass
+    code: str = "ValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class AcceptInboundCrossClusterSearchConnectionRequest(ServiceRequest):

--- a/localstack/aws/api/events/__init__.py
+++ b/localstack/aws/api/events/__init__.py
@@ -214,47 +214,69 @@ class RuleState(str):
 
 
 class ConcurrentModificationException(ServiceException):
-    pass
+    code: str = "ConcurrentModificationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class IllegalStatusException(ServiceException):
-    pass
+    code: str = "IllegalStatusException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InternalException(ServiceException):
-    pass
+    code: str = "InternalException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidEventPatternException(ServiceException):
-    pass
+    code: str = "InvalidEventPatternException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidStateException(ServiceException):
-    pass
+    code: str = "InvalidStateException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ManagedRuleException(ServiceException):
-    pass
+    code: str = "ManagedRuleException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class OperationDisabledException(ServiceException):
-    pass
+    code: str = "OperationDisabledException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class PolicyLengthExceededException(ServiceException):
-    pass
+    code: str = "PolicyLengthExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceAlreadyExistsException(ServiceException):
-    pass
+    code: str = "ResourceAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceNotFoundException(ServiceException):
-    pass
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ActivateEventSourceRequest(ServiceRequest):

--- a/localstack/aws/api/firehose/__init__.py
+++ b/localstack/aws/api/firehose/__init__.py
@@ -232,31 +232,52 @@ class SplunkS3BackupMode(str):
 
 
 class ConcurrentModificationException(ServiceException):
+    code: str = "ConcurrentModificationException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidArgumentException(ServiceException):
+    code: str = "InvalidArgumentException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidKMSResourceException(ServiceException):
+    code: str = "InvalidKMSResourceException"
+    sender_fault: bool = False
+    status_code: int = 400
     code: Optional[ErrorCode]
     message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceInUseException(ServiceException):
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ServiceUnavailableException(ServiceException):
+    code: str = "ServiceUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/api/iam/__init__.py
+++ b/localstack/aws/api/iam/__init__.py
@@ -263,110 +263,191 @@ class summaryKeyType(str):
 
 
 class ConcurrentModificationException(ServiceException):
+    code: str = "ConcurrentModification"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[ConcurrentModificationMessage]
 
 
 class CredentialReportExpiredException(ServiceException):
+    code: str = "ReportExpired"
+    sender_fault: bool = True
+    status_code: int = 410
     message: Optional[credentialReportExpiredExceptionMessage]
 
 
 class CredentialReportNotPresentException(ServiceException):
+    code: str = "ReportNotPresent"
+    sender_fault: bool = True
+    status_code: int = 410
     message: Optional[credentialReportNotPresentExceptionMessage]
 
 
 class CredentialReportNotReadyException(ServiceException):
+    code: str = "ReportInProgress"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[credentialReportNotReadyExceptionMessage]
 
 
 class DeleteConflictException(ServiceException):
+    code: str = "DeleteConflict"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[deleteConflictMessage]
 
 
 class DuplicateCertificateException(ServiceException):
+    code: str = "DuplicateCertificate"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[duplicateCertificateMessage]
 
 
 class DuplicateSSHPublicKeyException(ServiceException):
+    code: str = "DuplicateSSHPublicKey"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[duplicateSSHPublicKeyMessage]
 
 
 class EntityAlreadyExistsException(ServiceException):
+    code: str = "EntityAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[entityAlreadyExistsMessage]
 
 
 class EntityTemporarilyUnmodifiableException(ServiceException):
+    code: str = "EntityTemporarilyUnmodifiable"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[entityTemporarilyUnmodifiableMessage]
 
 
 class InvalidAuthenticationCodeException(ServiceException):
+    code: str = "InvalidAuthenticationCode"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[invalidAuthenticationCodeMessage]
 
 
 class InvalidCertificateException(ServiceException):
+    code: str = "InvalidCertificate"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[invalidCertificateMessage]
 
 
 class InvalidInputException(ServiceException):
+    code: str = "InvalidInput"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[invalidInputMessage]
 
 
 class InvalidPublicKeyException(ServiceException):
+    code: str = "InvalidPublicKey"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[invalidPublicKeyMessage]
 
 
 class InvalidUserTypeException(ServiceException):
+    code: str = "InvalidUserType"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[invalidUserTypeMessage]
 
 
 class KeyPairMismatchException(ServiceException):
+    code: str = "KeyPairMismatch"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[keyPairMismatchMessage]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[limitExceededMessage]
 
 
 class MalformedCertificateException(ServiceException):
+    code: str = "MalformedCertificate"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[malformedCertificateMessage]
 
 
 class MalformedPolicyDocumentException(ServiceException):
+    code: str = "MalformedPolicyDocument"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[malformedPolicyDocumentMessage]
 
 
 class NoSuchEntityException(ServiceException):
+    code: str = "NoSuchEntity"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[noSuchEntityMessage]
 
 
 class PasswordPolicyViolationException(ServiceException):
+    code: str = "PasswordPolicyViolation"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[passwordPolicyViolationMessage]
 
 
 class PolicyEvaluationException(ServiceException):
+    code: str = "PolicyEvaluation"
+    sender_fault: bool = False
+    status_code: int = 500
     message: Optional[policyEvaluationErrorMessage]
 
 
 class PolicyNotAttachableException(ServiceException):
+    code: str = "PolicyNotAttachable"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[policyNotAttachableMessage]
 
 
 class ReportGenerationLimitExceededException(ServiceException):
+    code: str = "ReportGenerationLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 409
     message: Optional[reportGenerationLimitExceededMessage]
 
 
 class ServiceFailureException(ServiceException):
+    code: str = "ServiceFailure"
+    sender_fault: bool = False
+    status_code: int = 500
     message: Optional[serviceFailureExceptionMessage]
 
 
 class ServiceNotSupportedException(ServiceException):
+    code: str = "NotSupportedService"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[serviceNotSupportedMessage]
 
 
 class UnmodifiableEntityException(ServiceException):
+    code: str = "UnmodifiableEntity"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[unmodifiableEntityMessage]
 
 
 class UnrecognizedPublicKeyEncodingException(ServiceException):
+    code: str = "UnrecognizedPublicKeyEncoding"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[unrecognizedPublicKeyEncodingMessage]
 
 

--- a/localstack/aws/api/kms/__init__.py
+++ b/localstack/aws/api/kms/__init__.py
@@ -202,138 +202,240 @@ class WrappingKeySpec(str):
 
 
 class AlreadyExistsException(ServiceException):
+    code: str = "AlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterInUseException(ServiceException):
+    code: str = "CloudHsmClusterInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterInvalidConfigurationException(ServiceException):
+    code: str = "CloudHsmClusterInvalidConfigurationException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterNotActiveException(ServiceException):
+    code: str = "CloudHsmClusterNotActiveException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterNotFoundException(ServiceException):
+    code: str = "CloudHsmClusterNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CloudHsmClusterNotRelatedException(ServiceException):
+    code: str = "CloudHsmClusterNotRelatedException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreHasCMKsException(ServiceException):
+    code: str = "CustomKeyStoreHasCMKsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreInvalidStateException(ServiceException):
+    code: str = "CustomKeyStoreInvalidStateException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreNameInUseException(ServiceException):
+    code: str = "CustomKeyStoreNameInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class CustomKeyStoreNotFoundException(ServiceException):
+    code: str = "CustomKeyStoreNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class DependencyTimeoutException(ServiceException):
+    code: str = "DependencyTimeoutException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class DisabledException(ServiceException):
+    code: str = "DisabledException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class ExpiredImportTokenException(ServiceException):
+    code: str = "ExpiredImportTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class IncorrectKeyException(ServiceException):
+    code: str = "IncorrectKeyException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class IncorrectKeyMaterialException(ServiceException):
+    code: str = "IncorrectKeyMaterialException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class IncorrectTrustAnchorException(ServiceException):
+    code: str = "IncorrectTrustAnchorException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidAliasNameException(ServiceException):
+    code: str = "InvalidAliasNameException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidArnException(ServiceException):
+    code: str = "InvalidArnException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidCiphertextException(ServiceException):
+    code: str = "InvalidCiphertextException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidGrantIdException(ServiceException):
+    code: str = "InvalidGrantIdException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidGrantTokenException(ServiceException):
+    code: str = "InvalidGrantTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidImportTokenException(ServiceException):
+    code: str = "InvalidImportTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidKeyUsageException(ServiceException):
+    code: str = "InvalidKeyUsageException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class InvalidMarkerException(ServiceException):
+    code: str = "InvalidMarkerException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class KMSInternalException(ServiceException):
+    code: str = "KMSInternalException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class KMSInvalidMacException(ServiceException):
+    code: str = "KMSInvalidMacException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class KMSInvalidSignatureException(ServiceException):
+    code: str = "KMSInvalidSignatureException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class KMSInvalidStateException(ServiceException):
+    code: str = "KMSInvalidStateException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class KeyUnavailableException(ServiceException):
+    code: str = "KeyUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class MalformedPolicyDocumentException(ServiceException):
+    code: str = "MalformedPolicyDocumentException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class NotFoundException(ServiceException):
+    code: str = "NotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class TagException(ServiceException):
+    code: str = "TagException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 
 class UnsupportedOperationException(ServiceException):
+    code: str = "UnsupportedOperationException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessageType]
 
 

--- a/localstack/aws/api/logs/__init__.py
+++ b/localstack/aws/api/logs/__init__.py
@@ -125,23 +125,35 @@ class StandardUnit(str):
 
 
 class DataAlreadyAcceptedException(ServiceException):
+    code: str = "DataAlreadyAcceptedException"
+    sender_fault: bool = False
+    status_code: int = 400
     expectedSequenceToken: Optional[SequenceToken]
 
 
 class InvalidOperationException(ServiceException):
-    pass
+    code: str = "InvalidOperationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidParameterException(ServiceException):
-    pass
+    code: str = "InvalidParameterException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidSequenceTokenException(ServiceException):
+    code: str = "InvalidSequenceTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     expectedSequenceToken: Optional[SequenceToken]
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class QueryCompileErrorLocation(TypedDict, total=False):
@@ -155,27 +167,40 @@ class QueryCompileError(TypedDict, total=False):
 
 
 class MalformedQueryException(ServiceException):
+    code: str = "MalformedQueryException"
+    sender_fault: bool = False
+    status_code: int = 400
     queryCompileError: Optional[QueryCompileError]
 
 
 class OperationAbortedException(ServiceException):
-    pass
+    code: str = "OperationAbortedException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceAlreadyExistsException(ServiceException):
-    pass
+    code: str = "ResourceAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ResourceNotFoundException(ServiceException):
-    pass
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ServiceUnavailableException(ServiceException):
-    pass
+    code: str = "ServiceUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class UnrecognizedClientException(ServiceException):
-    pass
+    code: str = "UnrecognizedClientException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class AssociateKmsKeyRequest(ServiceRequest):

--- a/localstack/aws/api/opensearch/__init__.py
+++ b/localstack/aws/api/opensearch/__init__.py
@@ -337,47 +337,70 @@ class VolumeType(str):
 
 
 class AccessDeniedException(ServiceException):
-    pass
+    code: str = "AccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 403
 
 
 class BaseException(ServiceException):
+    code: str = "BaseException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ConflictException(ServiceException):
-    pass
+    code: str = "ConflictException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class DisabledOperationException(ServiceException):
-    pass
+    code: str = "DisabledOperationException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class InternalException(ServiceException):
-    pass
+    code: str = "InternalException"
+    sender_fault: bool = False
+    status_code: int = 500
 
 
 class InvalidPaginationTokenException(ServiceException):
-    pass
+    code: str = "InvalidPaginationTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidTypeException(ServiceException):
-    pass
+    code: str = "InvalidTypeException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class ResourceAlreadyExistsException(ServiceException):
-    pass
+    code: str = "ResourceAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class ResourceNotFoundException(ServiceException):
-    pass
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 409
 
 
 class ValidationException(ServiceException):
-    pass
+    code: str = "ValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class AWSDomainInformation(TypedDict, total=False):

--- a/localstack/aws/api/redshift/__init__.py
+++ b/localstack/aws/api/redshift/__init__.py
@@ -201,507 +201,759 @@ class UsageLimitPeriod(str):
 
 
 class AccessToClusterDeniedFault(ServiceException):
-    pass
+    code: str = "AccessToClusterDenied"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class AccessToSnapshotDeniedFault(ServiceException):
-    pass
+    code: str = "AccessToSnapshotDenied"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class AuthenticationProfileAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "AuthenticationProfileAlreadyExistsFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class AuthenticationProfileNotFoundFault(ServiceException):
-    pass
+    code: str = "AuthenticationProfileNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class AuthenticationProfileQuotaExceededFault(ServiceException):
-    pass
+    code: str = "AuthenticationProfileQuotaExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class AuthorizationAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "AuthorizationAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class AuthorizationNotFoundFault(ServiceException):
-    pass
+    code: str = "AuthorizationNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class AuthorizationQuotaExceededFault(ServiceException):
-    pass
+    code: str = "AuthorizationQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class BatchDeleteRequestSizeExceededFault(ServiceException):
-    pass
+    code: str = "BatchDeleteRequestSizeExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class BatchModifyClusterSnapshotsLimitExceededFault(ServiceException):
-    pass
+    code: str = "BatchModifyClusterSnapshotsLimitExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class BucketNotFoundFault(ServiceException):
-    pass
+    code: str = "BucketNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ClusterAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterNotFoundFault(ServiceException):
-    pass
+    code: str = "ClusterNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ClusterOnLatestRevisionFault(ServiceException):
-    pass
+    code: str = "ClusterOnLatestRevision"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterParameterGroupAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ClusterParameterGroupAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterParameterGroupNotFoundFault(ServiceException):
-    pass
+    code: str = "ClusterParameterGroupNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ClusterParameterGroupQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ClusterParameterGroupQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ClusterQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSecurityGroupAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ClusterSecurityGroupAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSecurityGroupNotFoundFault(ServiceException):
-    pass
+    code: str = "ClusterSecurityGroupNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ClusterSecurityGroupQuotaExceededFault(ServiceException):
-    pass
+    code: str = "QuotaExceeded.ClusterSecurityGroup"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSnapshotAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ClusterSnapshotAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSnapshotNotFoundFault(ServiceException):
-    pass
+    code: str = "ClusterSnapshotNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ClusterSnapshotQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ClusterSnapshotQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSubnetGroupAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ClusterSubnetGroupAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSubnetGroupNotFoundFault(ServiceException):
-    pass
+    code: str = "ClusterSubnetGroupNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSubnetGroupQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ClusterSubnetGroupQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ClusterSubnetQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ClusterSubnetQuotaExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class CopyToRegionDisabledFault(ServiceException):
-    pass
+    code: str = "CopyToRegionDisabledFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class DependentServiceRequestThrottlingFault(ServiceException):
-    pass
+    code: str = "DependentServiceRequestThrottlingFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class DependentServiceUnavailableFault(ServiceException):
-    pass
+    code: str = "DependentServiceUnavailableFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EndpointAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "EndpointAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EndpointAuthorizationAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "EndpointAuthorizationAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EndpointAuthorizationNotFoundFault(ServiceException):
-    pass
+    code: str = "EndpointAuthorizationNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class EndpointAuthorizationsPerClusterLimitExceededFault(ServiceException):
-    pass
+    code: str = "EndpointAuthorizationsPerClusterLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EndpointNotFoundFault(ServiceException):
-    pass
+    code: str = "EndpointNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class EndpointsPerAuthorizationLimitExceededFault(ServiceException):
-    pass
+    code: str = "EndpointsPerAuthorizationLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EndpointsPerClusterLimitExceededFault(ServiceException):
-    pass
+    code: str = "EndpointsPerClusterLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EventSubscriptionQuotaExceededFault(ServiceException):
-    pass
+    code: str = "EventSubscriptionQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class HsmClientCertificateAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "HsmClientCertificateAlreadyExistsFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class HsmClientCertificateNotFoundFault(ServiceException):
-    pass
+    code: str = "HsmClientCertificateNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class HsmClientCertificateQuotaExceededFault(ServiceException):
-    pass
+    code: str = "HsmClientCertificateQuotaExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class HsmConfigurationAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "HsmConfigurationAlreadyExistsFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class HsmConfigurationNotFoundFault(ServiceException):
-    pass
+    code: str = "HsmConfigurationNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class HsmConfigurationQuotaExceededFault(ServiceException):
-    pass
+    code: str = "HsmConfigurationQuotaExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InProgressTableRestoreQuotaExceededFault(ServiceException):
-    pass
+    code: str = "InProgressTableRestoreQuotaExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class IncompatibleOrderableOptions(ServiceException):
-    pass
+    code: str = "IncompatibleOrderableOptions"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InsufficientClusterCapacityFault(ServiceException):
-    pass
+    code: str = "InsufficientClusterCapacity"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InsufficientS3BucketPolicyFault(ServiceException):
-    pass
+    code: str = "InsufficientS3BucketPolicyFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidAuthenticationProfileRequestFault(ServiceException):
-    pass
+    code: str = "InvalidAuthenticationProfileRequestFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidAuthorizationStateFault(ServiceException):
-    pass
+    code: str = "InvalidAuthorizationState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterParameterGroupStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterParameterGroupState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterSecurityGroupStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterSecurityGroupState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterSnapshotScheduleStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterSnapshotScheduleState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterSnapshotStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterSnapshotState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterSubnetGroupStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterSubnetGroupStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterSubnetStateFault(ServiceException):
-    pass
+    code: str = "InvalidClusterSubnetStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidClusterTrackFault(ServiceException):
-    pass
+    code: str = "InvalidClusterTrack"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidDataShareFault(ServiceException):
-    pass
+    code: str = "InvalidDataShareFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidElasticIpFault(ServiceException):
-    pass
+    code: str = "InvalidElasticIpFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidEndpointStateFault(ServiceException):
-    pass
+    code: str = "InvalidEndpointState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidHsmClientCertificateStateFault(ServiceException):
-    pass
+    code: str = "InvalidHsmClientCertificateStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidHsmConfigurationStateFault(ServiceException):
-    pass
+    code: str = "InvalidHsmConfigurationStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidNamespaceFault(ServiceException):
-    pass
+    code: str = "InvalidNamespaceFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidReservedNodeStateFault(ServiceException):
-    pass
+    code: str = "InvalidReservedNodeState"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidRestoreFault(ServiceException):
-    pass
+    code: str = "InvalidRestore"
+    sender_fault: bool = True
+    status_code: int = 406
 
 
 class InvalidRetentionPeriodFault(ServiceException):
-    pass
+    code: str = "InvalidRetentionPeriodFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidS3BucketNameFault(ServiceException):
-    pass
+    code: str = "InvalidS3BucketNameFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidS3KeyPrefixFault(ServiceException):
-    pass
+    code: str = "InvalidS3KeyPrefixFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidScheduleFault(ServiceException):
-    pass
+    code: str = "InvalidSchedule"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidScheduledActionFault(ServiceException):
-    pass
+    code: str = "InvalidScheduledAction"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidSnapshotCopyGrantStateFault(ServiceException):
-    pass
+    code: str = "InvalidSnapshotCopyGrantStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidSubnet(ServiceException):
-    pass
+    code: str = "InvalidSubnet"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidSubscriptionStateFault(ServiceException):
-    pass
+    code: str = "InvalidSubscriptionStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidTableRestoreArgumentFault(ServiceException):
-    pass
+    code: str = "InvalidTableRestoreArgument"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidTagFault(ServiceException):
-    pass
+    code: str = "InvalidTagFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidUsageLimitFault(ServiceException):
-    pass
+    code: str = "InvalidUsageLimit"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidVPCNetworkStateFault(ServiceException):
-    pass
+    code: str = "InvalidVPCNetworkStateFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class LimitExceededFault(ServiceException):
-    pass
+    code: str = "LimitExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class NumberOfNodesPerClusterLimitExceededFault(ServiceException):
-    pass
+    code: str = "NumberOfNodesPerClusterLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class NumberOfNodesQuotaExceededFault(ServiceException):
-    pass
+    code: str = "NumberOfNodesQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class PartnerNotFoundFault(ServiceException):
-    pass
+    code: str = "PartnerNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ReservedNodeAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ReservedNodeAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ReservedNodeAlreadyMigratedFault(ServiceException):
-    pass
+    code: str = "ReservedNodeAlreadyMigrated"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ReservedNodeExchangeNotFoundFault(ServiceException):
-    pass
+    code: str = "ReservedNodeExchangeNotFond"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ReservedNodeNotFoundFault(ServiceException):
-    pass
+    code: str = "ReservedNodeNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ReservedNodeOfferingNotFoundFault(ServiceException):
-    pass
+    code: str = "ReservedNodeOfferingNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ReservedNodeQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ReservedNodeQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ResizeNotFoundFault(ServiceException):
-    pass
+    code: str = "ResizeNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ResourceNotFoundFault(ServiceException):
-    pass
+    code: str = "ResourceNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class SNSInvalidTopicFault(ServiceException):
-    pass
+    code: str = "SNSInvalidTopic"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SNSNoAuthorizationFault(ServiceException):
-    pass
+    code: str = "SNSNoAuthorization"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SNSTopicArnNotFoundFault(ServiceException):
-    pass
+    code: str = "SNSTopicArnNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class ScheduleDefinitionTypeUnsupportedFault(ServiceException):
-    pass
+    code: str = "ScheduleDefinitionTypeUnsupported"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ScheduledActionAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "ScheduledActionAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ScheduledActionNotFoundFault(ServiceException):
-    pass
+    code: str = "ScheduledActionNotFound"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ScheduledActionQuotaExceededFault(ServiceException):
-    pass
+    code: str = "ScheduledActionQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ScheduledActionTypeUnsupportedFault(ServiceException):
-    pass
+    code: str = "ScheduledActionTypeUnsupported"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotCopyAlreadyDisabledFault(ServiceException):
-    pass
+    code: str = "SnapshotCopyAlreadyDisabledFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotCopyAlreadyEnabledFault(ServiceException):
-    pass
+    code: str = "SnapshotCopyAlreadyEnabledFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotCopyDisabledFault(ServiceException):
-    pass
+    code: str = "SnapshotCopyDisabledFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotCopyGrantAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "SnapshotCopyGrantAlreadyExistsFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotCopyGrantNotFoundFault(ServiceException):
-    pass
+    code: str = "SnapshotCopyGrantNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotCopyGrantQuotaExceededFault(ServiceException):
-    pass
+    code: str = "SnapshotCopyGrantQuotaExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotScheduleAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "SnapshotScheduleAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotScheduleNotFoundFault(ServiceException):
-    pass
+    code: str = "SnapshotScheduleNotFound"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotScheduleQuotaExceededFault(ServiceException):
-    pass
+    code: str = "SnapshotScheduleQuotaExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SnapshotScheduleUpdateInProgressFault(ServiceException):
-    pass
+    code: str = "SnapshotScheduleUpdateInProgress"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SourceNotFoundFault(ServiceException):
-    pass
+    code: str = "SourceNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class SubnetAlreadyInUse(ServiceException):
-    pass
+    code: str = "SubnetAlreadyInUse"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SubscriptionAlreadyExistFault(ServiceException):
-    pass
+    code: str = "SubscriptionAlreadyExist"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class SubscriptionCategoryNotFoundFault(ServiceException):
-    pass
+    code: str = "SubscriptionCategoryNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class SubscriptionEventIdNotFoundFault(ServiceException):
-    pass
+    code: str = "SubscriptionEventIdNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class SubscriptionNotFoundFault(ServiceException):
-    pass
+    code: str = "SubscriptionNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class SubscriptionSeverityNotFoundFault(ServiceException):
-    pass
+    code: str = "SubscriptionSeverityNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class TableLimitExceededFault(ServiceException):
-    pass
+    code: str = "TableLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class TableRestoreNotFoundFault(ServiceException):
-    pass
+    code: str = "TableRestoreNotFoundFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class TagLimitExceededFault(ServiceException):
-    pass
+    code: str = "TagLimitExceededFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class UnauthorizedOperation(ServiceException):
-    pass
+    code: str = "UnauthorizedOperation"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class UnauthorizedPartnerIntegrationFault(ServiceException):
-    pass
+    code: str = "UnauthorizedPartnerIntegration"
+    sender_fault: bool = True
+    status_code: int = 401
 
 
 class UnknownSnapshotCopyRegionFault(ServiceException):
-    pass
+    code: str = "UnknownSnapshotCopyRegionFault"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class UnsupportedOperationFault(ServiceException):
-    pass
+    code: str = "UnsupportedOperation"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class UnsupportedOptionFault(ServiceException):
-    pass
+    code: str = "UnsupportedOptionFault"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class UsageLimitAlreadyExistsFault(ServiceException):
-    pass
+    code: str = "UsageLimitAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class UsageLimitNotFoundFault(ServiceException):
-    pass
+    code: str = "UsageLimitNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
 
 
 class AcceptReservedNodeExchangeInputMessage(ServiceRequest):

--- a/localstack/aws/api/resourcegroupstaggingapi/__init__.py
+++ b/localstack/aws/api/resourcegroupstaggingapi/__init__.py
@@ -48,26 +48,44 @@ class TargetIdType(str):
 
 
 class ConcurrentModificationException(ServiceException):
+    code: str = "ConcurrentModificationException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class ConstraintViolationException(ServiceException):
+    code: str = "ConstraintViolationException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InternalServiceException(ServiceException):
+    code: str = "InternalServiceException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InvalidParameterException(ServiceException):
+    code: str = "InvalidParameterException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class PaginationTokenExpiredException(ServiceException):
+    code: str = "PaginationTokenExpiredException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class ThrottledException(ServiceException):
+    code: str = "ThrottledException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 

--- a/localstack/aws/api/route53/__init__.py
+++ b/localstack/aws/api/route53/__init__.py
@@ -298,98 +298,170 @@ class VPCRegion(str):
 
 
 class CidrBlockInUseException(ServiceException):
+    code: str = "CidrBlockInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class CidrCollectionAlreadyExistsException(ServiceException):
+    code: str = "CidrCollectionAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class CidrCollectionInUseException(ServiceException):
+    code: str = "CidrCollectionInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class CidrCollectionVersionMismatchException(ServiceException):
+    code: str = "CidrCollectionVersionMismatchException"
+    sender_fault: bool = False
+    status_code: int = 409
     Message: Optional[ErrorMessage]
 
 
 class ConcurrentModification(ServiceException):
+    code: str = "ConcurrentModification"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ConflictingDomainExists(ServiceException):
+    code: str = "ConflictingDomainExists"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ConflictingTypes(ServiceException):
+    code: str = "ConflictingTypes"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DNSSECNotFound(ServiceException):
+    code: str = "DNSSECNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DelegationSetAlreadyCreated(ServiceException):
+    code: str = "DelegationSetAlreadyCreated"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DelegationSetAlreadyReusable(ServiceException):
+    code: str = "DelegationSetAlreadyReusable"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DelegationSetInUse(ServiceException):
+    code: str = "DelegationSetInUse"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DelegationSetNotAvailable(ServiceException):
+    code: str = "DelegationSetNotAvailable"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DelegationSetNotReusable(ServiceException):
+    code: str = "DelegationSetNotReusable"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class HealthCheckAlreadyExists(ServiceException):
+    code: str = "HealthCheckAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class HealthCheckInUse(ServiceException):
+    code: str = "HealthCheckInUse"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class HealthCheckVersionMismatch(ServiceException):
+    code: str = "HealthCheckVersionMismatch"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class HostedZoneAlreadyExists(ServiceException):
+    code: str = "HostedZoneAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class HostedZoneNotEmpty(ServiceException):
+    code: str = "HostedZoneNotEmpty"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class HostedZoneNotFound(ServiceException):
+    code: str = "HostedZoneNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class HostedZoneNotPrivate(ServiceException):
+    code: str = "HostedZoneNotPrivate"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class HostedZonePartiallyDelegated(ServiceException):
+    code: str = "HostedZonePartiallyDelegated"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class IncompatibleVersion(ServiceException):
+    code: str = "IncompatibleVersion"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InsufficientCloudWatchLogsResourcePolicy(ServiceException):
+    code: str = "InsufficientCloudWatchLogsResourcePolicy"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidArgument(ServiceException):
+    code: str = "InvalidArgument"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
@@ -397,183 +469,318 @@ ErrorMessages = List[ErrorMessage]
 
 
 class InvalidChangeBatch(ServiceException):
+    code: str = "InvalidChangeBatch"
+    sender_fault: bool = False
+    status_code: int = 400
     messages: Optional[ErrorMessages]
     message: Optional[ErrorMessage]
 
 
 class InvalidDomainName(ServiceException):
+    code: str = "InvalidDomainName"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidInput(ServiceException):
+    code: str = "InvalidInput"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidKMSArn(ServiceException):
+    code: str = "InvalidKMSArn"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidKeySigningKeyName(ServiceException):
+    code: str = "InvalidKeySigningKeyName"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidKeySigningKeyStatus(ServiceException):
+    code: str = "InvalidKeySigningKeyStatus"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidPaginationToken(ServiceException):
+    code: str = "InvalidPaginationToken"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidSigningStatus(ServiceException):
+    code: str = "InvalidSigningStatus"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidTrafficPolicyDocument(ServiceException):
+    code: str = "InvalidTrafficPolicyDocument"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidVPCId(ServiceException):
+    code: str = "InvalidVPCId"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class KeySigningKeyAlreadyExists(ServiceException):
+    code: str = "KeySigningKeyAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class KeySigningKeyInParentDSRecord(ServiceException):
+    code: str = "KeySigningKeyInParentDSRecord"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class KeySigningKeyInUse(ServiceException):
+    code: str = "KeySigningKeyInUse"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class KeySigningKeyWithActiveStatusNotFound(ServiceException):
+    code: str = "KeySigningKeyWithActiveStatusNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class LastVPCAssociation(ServiceException):
+    code: str = "LastVPCAssociation"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class LimitsExceeded(ServiceException):
+    code: str = "LimitsExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class NoSuchChange(ServiceException):
+    code: str = "NoSuchChange"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchCidrCollectionException(ServiceException):
+    code: str = "NoSuchCidrCollectionException"
+    sender_fault: bool = False
+    status_code: int = 404
     Message: Optional[ErrorMessage]
 
 
 class NoSuchCidrLocationException(ServiceException):
+    code: str = "NoSuchCidrLocationException"
+    sender_fault: bool = False
+    status_code: int = 404
     Message: Optional[ErrorMessage]
 
 
 class NoSuchCloudWatchLogsLogGroup(ServiceException):
+    code: str = "NoSuchCloudWatchLogsLogGroup"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchDelegationSet(ServiceException):
+    code: str = "NoSuchDelegationSet"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class NoSuchGeoLocation(ServiceException):
+    code: str = "NoSuchGeoLocation"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchHealthCheck(ServiceException):
+    code: str = "NoSuchHealthCheck"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchHostedZone(ServiceException):
+    code: str = "NoSuchHostedZone"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchKeySigningKey(ServiceException):
+    code: str = "NoSuchKeySigningKey"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchQueryLoggingConfig(ServiceException):
+    code: str = "NoSuchQueryLoggingConfig"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchTrafficPolicy(ServiceException):
+    code: str = "NoSuchTrafficPolicy"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NoSuchTrafficPolicyInstance(ServiceException):
+    code: str = "NoSuchTrafficPolicyInstance"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class NotAuthorizedException(ServiceException):
+    code: str = "NotAuthorizedException"
+    sender_fault: bool = False
+    status_code: int = 401
     message: Optional[ErrorMessage]
 
 
 class PriorRequestNotComplete(ServiceException):
+    code: str = "PriorRequestNotComplete"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class PublicZoneVPCAssociation(ServiceException):
+    code: str = "PublicZoneVPCAssociation"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class QueryLoggingConfigAlreadyExists(ServiceException):
+    code: str = "QueryLoggingConfigAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class ThrottlingException(ServiceException):
+    code: str = "ThrottlingException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyHealthChecks(ServiceException):
+    code: str = "TooManyHealthChecks"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyHostedZones(ServiceException):
+    code: str = "TooManyHostedZones"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyKeySigningKeys(ServiceException):
+    code: str = "TooManyKeySigningKeys"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyTrafficPolicies(ServiceException):
+    code: str = "TooManyTrafficPolicies"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyTrafficPolicyInstances(ServiceException):
+    code: str = "TooManyTrafficPolicyInstances"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyTrafficPolicyVersionsForCurrentPolicy(ServiceException):
+    code: str = "TooManyTrafficPolicyVersionsForCurrentPolicy"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyVPCAssociationAuthorizations(ServiceException):
+    code: str = "TooManyVPCAssociationAuthorizations"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TrafficPolicyAlreadyExists(ServiceException):
+    code: str = "TrafficPolicyAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class TrafficPolicyInUse(ServiceException):
+    code: str = "TrafficPolicyInUse"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TrafficPolicyInstanceAlreadyExists(ServiceException):
+    code: str = "TrafficPolicyInstanceAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 409
     message: Optional[ErrorMessage]
 
 
 class VPCAssociationAuthorizationNotFound(ServiceException):
+    code: str = "VPCAssociationAuthorizationNotFound"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 
 class VPCAssociationNotFound(ServiceException):
+    code: str = "VPCAssociationNotFound"
+    sender_fault: bool = False
+    status_code: int = 404
     message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/api/route53resolver/__init__.py
+++ b/localstack/aws/api/route53resolver/__init__.py
@@ -211,72 +211,120 @@ class Validation(str):
 
 
 class AccessDeniedException(ServiceException):
+    code: str = "AccessDeniedException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class ConflictException(ServiceException):
+    code: str = "ConflictException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InternalServiceErrorException(ServiceException):
+    code: str = "InternalServiceErrorException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InvalidNextTokenException(ServiceException):
+    code: str = "InvalidNextTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidParameterException(ServiceException):
+    code: str = "InvalidParameterException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: ExceptionMessage
     FieldName: Optional[String]
 
 
 class InvalidPolicyDocument(ServiceException):
+    code: str = "InvalidPolicyDocument"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InvalidRequestException(ServiceException):
+    code: str = "InvalidRequestException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InvalidTagException(ServiceException):
+    code: str = "InvalidTagException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     ResourceType: Optional[String]
 
 
 class ResourceExistsException(ServiceException):
+    code: str = "ResourceExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     ResourceType: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     ResourceType: Optional[String]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     ResourceType: Optional[String]
 
 
 class ResourceUnavailableException(ServiceException):
+    code: str = "ResourceUnavailableException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     ResourceType: Optional[String]
 
 
 class ThrottlingException(ServiceException):
+    code: str = "ThrottlingException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class UnknownResourceException(ServiceException):
+    code: str = "UnknownResourceException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class ValidationException(ServiceException):
+    code: str = "ValidationException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 

--- a/localstack/aws/api/s3control/__init__.py
+++ b/localstack/aws/api/s3control/__init__.py
@@ -294,50 +294,84 @@ class TransitionStorageClass(str):
 
 
 class BadRequestException(ServiceException):
+    code: str = "BadRequestException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class BucketAlreadyExists(ServiceException):
-    pass
+    code: str = "BucketAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class BucketAlreadyOwnedByYou(ServiceException):
-    pass
+    code: str = "BucketAlreadyOwnedByYou"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class IdempotencyException(ServiceException):
+    code: str = "IdempotencyException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InternalServiceException(ServiceException):
+    code: str = "InternalServiceException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InvalidNextTokenException(ServiceException):
+    code: str = "InvalidNextTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class InvalidRequestException(ServiceException):
+    code: str = "InvalidRequestException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class JobStatusException(ServiceException):
+    code: str = "JobStatusException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class NoSuchPublicAccessBlockConfiguration(ServiceException):
+    code: str = "NoSuchPublicAccessBlockConfiguration"
+    sender_fault: bool = False
+    status_code: int = 404
     Message: Optional[NoSuchPublicAccessBlockConfigurationMessage]
 
 
 class NotFoundException(ServiceException):
+    code: str = "NotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class TooManyRequestsException(ServiceException):
+    code: str = "TooManyRequestsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 
 class TooManyTagsException(ServiceException):
+    code: str = "TooManyTagsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ExceptionMessage]
 
 

--- a/localstack/aws/api/secretsmanager/__init__.py
+++ b/localstack/aws/api/secretsmanager/__init__.py
@@ -65,50 +65,86 @@ class StatusType(str):
 
 
 class DecryptionFailure(ServiceException):
+    code: str = "DecryptionFailure"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class EncryptionFailure(ServiceException):
+    code: str = "EncryptionFailure"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class InternalServiceError(ServiceException):
+    code: str = "InternalServiceError"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class InvalidNextTokenException(ServiceException):
+    code: str = "InvalidNextTokenException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class InvalidParameterException(ServiceException):
+    code: str = "InvalidParameterException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class InvalidRequestException(ServiceException):
+    code: str = "InvalidRequestException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class LimitExceededException(ServiceException):
+    code: str = "LimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class MalformedPolicyDocumentException(ServiceException):
+    code: str = "MalformedPolicyDocumentException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class PreconditionNotMetException(ServiceException):
+    code: str = "PreconditionNotMetException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class PublicPolicyException(ServiceException):
+    code: str = "PublicPolicyException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class ResourceExistsException(ServiceException):
+    code: str = "ResourceExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/api/ses/__init__.py
+++ b/localstack/aws/api/ses/__init__.py
@@ -183,143 +183,235 @@ class VerificationStatus(str):
 
 
 class AccountSendingPausedException(ServiceException):
-    pass
+    code: str = "AccountSendingPausedException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class AlreadyExistsException(ServiceException):
+    code: str = "AlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
     Name: Optional[RuleOrRuleSetName]
 
 
 class CannotDeleteException(ServiceException):
+    code: str = "CannotDelete"
+    sender_fault: bool = True
+    status_code: int = 400
     Name: Optional[RuleOrRuleSetName]
 
 
 class ConfigurationSetAlreadyExistsException(ServiceException):
+    code: str = "ConfigurationSetAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
 
 
 class ConfigurationSetDoesNotExistException(ServiceException):
+    code: str = "ConfigurationSetDoesNotExist"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
 
 
 class ConfigurationSetSendingPausedException(ServiceException):
+    code: str = "ConfigurationSetSendingPausedException"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
 
 
 class CustomVerificationEmailInvalidContentException(ServiceException):
-    pass
+    code: str = "CustomVerificationEmailInvalidContent"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class CustomVerificationEmailTemplateAlreadyExistsException(ServiceException):
+    code: str = "CustomVerificationEmailTemplateAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
     CustomVerificationEmailTemplateName: Optional[TemplateName]
 
 
 class CustomVerificationEmailTemplateDoesNotExistException(ServiceException):
+    code: str = "CustomVerificationEmailTemplateDoesNotExist"
+    sender_fault: bool = True
+    status_code: int = 400
     CustomVerificationEmailTemplateName: Optional[TemplateName]
 
 
 class EventDestinationAlreadyExistsException(ServiceException):
+    code: str = "EventDestinationAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
     EventDestinationName: Optional[EventDestinationName]
 
 
 class EventDestinationDoesNotExistException(ServiceException):
+    code: str = "EventDestinationDoesNotExist"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
     EventDestinationName: Optional[EventDestinationName]
 
 
 class FromEmailAddressNotVerifiedException(ServiceException):
+    code: str = "FromEmailAddressNotVerified"
+    sender_fault: bool = True
+    status_code: int = 400
     FromEmailAddress: Optional[FromAddress]
 
 
 class InvalidCloudWatchDestinationException(ServiceException):
+    code: str = "InvalidCloudWatchDestination"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
     EventDestinationName: Optional[EventDestinationName]
 
 
 class InvalidConfigurationSetException(ServiceException):
-    pass
+    code: str = "InvalidConfigurationSet"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidDeliveryOptionsException(ServiceException):
-    pass
+    code: str = "InvalidDeliveryOptions"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidFirehoseDestinationException(ServiceException):
+    code: str = "InvalidFirehoseDestination"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
     EventDestinationName: Optional[EventDestinationName]
 
 
 class InvalidLambdaFunctionException(ServiceException):
+    code: str = "InvalidLambdaFunction"
+    sender_fault: bool = True
+    status_code: int = 400
     FunctionArn: Optional[AmazonResourceName]
 
 
 class InvalidPolicyException(ServiceException):
-    pass
+    code: str = "InvalidPolicy"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidRenderingParameterException(ServiceException):
+    code: str = "InvalidRenderingParameter"
+    sender_fault: bool = True
+    status_code: int = 400
     TemplateName: Optional[TemplateName]
 
 
 class InvalidS3ConfigurationException(ServiceException):
+    code: str = "InvalidS3Configuration"
+    sender_fault: bool = True
+    status_code: int = 400
     Bucket: Optional[S3BucketName]
 
 
 class InvalidSNSDestinationException(ServiceException):
+    code: str = "InvalidSNSDestination"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
     EventDestinationName: Optional[EventDestinationName]
 
 
 class InvalidSnsTopicException(ServiceException):
+    code: str = "InvalidSnsTopic"
+    sender_fault: bool = True
+    status_code: int = 400
     Topic: Optional[AmazonResourceName]
 
 
 class InvalidTemplateException(ServiceException):
+    code: str = "InvalidTemplate"
+    sender_fault: bool = True
+    status_code: int = 400
     TemplateName: Optional[TemplateName]
 
 
 class InvalidTrackingOptionsException(ServiceException):
-    pass
+    code: str = "InvalidTrackingOptions"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class LimitExceededException(ServiceException):
-    pass
+    code: str = "LimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class MailFromDomainNotVerifiedException(ServiceException):
-    pass
+    code: str = "MailFromDomainNotVerifiedException"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class MessageRejected(ServiceException):
-    pass
+    code: str = "MessageRejected"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class MissingRenderingAttributeException(ServiceException):
+    code: str = "MissingRenderingAttribute"
+    sender_fault: bool = True
+    status_code: int = 400
     TemplateName: Optional[TemplateName]
 
 
 class ProductionAccessNotGrantedException(ServiceException):
-    pass
+    code: str = "ProductionAccessNotGranted"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class RuleDoesNotExistException(ServiceException):
+    code: str = "RuleDoesNotExist"
+    sender_fault: bool = True
+    status_code: int = 400
     Name: Optional[RuleOrRuleSetName]
 
 
 class RuleSetDoesNotExistException(ServiceException):
+    code: str = "RuleSetDoesNotExist"
+    sender_fault: bool = True
+    status_code: int = 400
     Name: Optional[RuleOrRuleSetName]
 
 
 class TemplateDoesNotExistException(ServiceException):
+    code: str = "TemplateDoesNotExist"
+    sender_fault: bool = True
+    status_code: int = 400
     TemplateName: Optional[TemplateName]
 
 
 class TrackingOptionsAlreadyExistsException(ServiceException):
+    code: str = "TrackingOptionsAlreadyExistsException"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
 
 
 class TrackingOptionsDoesNotExistException(ServiceException):
+    code: str = "TrackingOptionsDoesNotExistException"
+    sender_fault: bool = True
+    status_code: int = 400
     ConfigurationSetName: Optional[ConfigurationSetName]
 
 

--- a/localstack/aws/api/sns/__init__.py
+++ b/localstack/aws/api/sns/__init__.py
@@ -75,130 +75,226 @@ class SMSSandboxPhoneNumberVerificationStatus(str):
 
 
 class AuthorizationErrorException(ServiceException):
+    code: str = "AuthorizationError"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[string]
 
 
 class BatchEntryIdsNotDistinctException(ServiceException):
+    code: str = "BatchEntryIdsNotDistinct"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class BatchRequestTooLongException(ServiceException):
+    code: str = "BatchRequestTooLong"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class ConcurrentAccessException(ServiceException):
+    code: str = "ConcurrentAccess"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class EmptyBatchRequestException(ServiceException):
+    code: str = "EmptyBatchRequest"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class EndpointDisabledException(ServiceException):
+    code: str = "EndpointDisabled"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class FilterPolicyLimitExceededException(ServiceException):
+    code: str = "FilterPolicyLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[string]
 
 
 class InternalErrorException(ServiceException):
+    code: str = "InternalError"
+    sender_fault: bool = False
+    status_code: int = 500
     message: Optional[string]
 
 
 class InvalidBatchEntryIdException(ServiceException):
+    code: str = "InvalidBatchEntryId"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class InvalidParameterException(ServiceException):
+    code: str = "InvalidParameter"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class InvalidParameterValueException(ServiceException):
+    code: str = "ParameterValueInvalid"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class InvalidSecurityException(ServiceException):
+    code: str = "InvalidSecurity"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[string]
 
 
 class KMSAccessDeniedException(ServiceException):
+    code: str = "KMSAccessDenied"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class KMSDisabledException(ServiceException):
+    code: str = "KMSDisabled"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class KMSInvalidStateException(ServiceException):
+    code: str = "KMSInvalidState"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class KMSNotFoundException(ServiceException):
+    code: str = "KMSNotFound"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class KMSOptInRequired(ServiceException):
+    code: str = "KMSOptInRequired"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[string]
 
 
 class KMSThrottlingException(ServiceException):
+    code: str = "KMSThrottling"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class NotFoundException(ServiceException):
+    code: str = "NotFound"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[string]
 
 
 class OptedOutException(ServiceException):
+    code: str = "OptedOut"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class PlatformApplicationDisabledException(ServiceException):
+    code: str = "PlatformApplicationDisabled"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class ResourceNotFoundException(ServiceException):
+    code: str = "ResourceNotFound"
+    sender_fault: bool = True
+    status_code: int = 404
     message: Optional[string]
 
 
 class StaleTagException(ServiceException):
+    code: str = "StaleTag"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class SubscriptionLimitExceededException(ServiceException):
+    code: str = "SubscriptionLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[string]
 
 
 class TagLimitExceededException(ServiceException):
+    code: str = "TagLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class TagPolicyException(ServiceException):
+    code: str = "TagPolicy"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class ThrottledException(ServiceException):
+    code: str = "Throttled"
+    sender_fault: bool = True
+    status_code: int = 429
     message: Optional[string]
 
 
 class TooManyEntriesInBatchRequestException(ServiceException):
+    code: str = "TooManyEntriesInBatchRequest"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class TopicLimitExceededException(ServiceException):
+    code: str = "TopicLimitExceeded"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[string]
 
 
 class UserErrorException(ServiceException):
+    code: str = "UserError"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[string]
 
 
 class ValidationException(ServiceException):
+    code: str = "ValidationException"
+    sender_fault: bool = True
+    status_code: int = 400
     Message: string
 
 
 class VerificationException(ServiceException):
+    code: str = "VerificationException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: string
     Status: string
 

--- a/localstack/aws/api/sqs/__init__.py
+++ b/localstack/aws/api/sqs/__init__.py
@@ -59,67 +59,99 @@ class QueueAttributeName(str):
 
 
 class BatchEntryIdsNotDistinct(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.BatchEntryIdsNotDistinct"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class BatchRequestTooLong(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.BatchRequestTooLong"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class EmptyBatchRequest(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.EmptyBatchRequest"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidAttributeName(ServiceException):
-    pass
+    code: str = "InvalidAttributeName"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidBatchEntryId(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.InvalidBatchEntryId"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class InvalidIdFormat(ServiceException):
-    pass
+    code: str = "InvalidIdFormat"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidMessageContents(ServiceException):
-    pass
+    code: str = "InvalidMessageContents"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class MessageNotInflight(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.MessageNotInflight"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class OverLimit(ServiceException):
-    pass
+    code: str = "OverLimit"
+    sender_fault: bool = True
+    status_code: int = 403
 
 
 class PurgeQueueInProgress(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.PurgeQueueInProgress"
+    sender_fault: bool = True
+    status_code: int = 403
 
 
 class QueueDeletedRecently(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.QueueDeletedRecently"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class QueueDoesNotExist(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.NonExistentQueue"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class QueueNameExists(ServiceException):
-    pass
+    code: str = "QueueAlreadyExists"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class ReceiptHandleIsInvalid(ServiceException):
-    pass
+    code: str = "ReceiptHandleIsInvalid"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class TooManyEntriesInBatchRequest(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.TooManyEntriesInBatchRequest"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 class UnsupportedOperation(ServiceException):
-    pass
+    code: str = "AWS.SimpleQueueService.UnsupportedOperation"
+    sender_fault: bool = True
+    status_code: int = 400
 
 
 AWSAccountIdList = List[String]

--- a/localstack/aws/api/ssm/__init__.py
+++ b/localstack/aws/api/ssm/__init__.py
@@ -994,333 +994,567 @@ class StopType(str):
 
 
 class AlreadyExistsException(ServiceException):
+    code: str = "AlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AssociatedInstances(ServiceException):
-    pass
+    code: str = "AssociatedInstances"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class AssociationAlreadyExists(ServiceException):
-    pass
+    code: str = "AssociationAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class AssociationDoesNotExist(ServiceException):
+    code: str = "AssociationDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AssociationExecutionDoesNotExist(ServiceException):
+    code: str = "AssociationExecutionDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AssociationLimitExceeded(ServiceException):
-    pass
+    code: str = "AssociationLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class AssociationVersionLimitExceeded(ServiceException):
+    code: str = "AssociationVersionLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AutomationDefinitionNotApprovedException(ServiceException):
+    code: str = "AutomationDefinitionNotApprovedException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AutomationDefinitionNotFoundException(ServiceException):
+    code: str = "AutomationDefinitionNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AutomationDefinitionVersionNotFoundException(ServiceException):
+    code: str = "AutomationDefinitionVersionNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AutomationExecutionLimitExceededException(ServiceException):
+    code: str = "AutomationExecutionLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AutomationExecutionNotFoundException(ServiceException):
+    code: str = "AutomationExecutionNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class AutomationStepNotFoundException(ServiceException):
+    code: str = "AutomationStepNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class ComplianceTypeCountLimitExceededException(ServiceException):
+    code: str = "ComplianceTypeCountLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class CustomSchemaCountLimitExceededException(ServiceException):
+    code: str = "CustomSchemaCountLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DocumentAlreadyExists(ServiceException):
+    code: str = "DocumentAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DocumentLimitExceeded(ServiceException):
+    code: str = "DocumentLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DocumentPermissionLimit(ServiceException):
+    code: str = "DocumentPermissionLimit"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DocumentVersionLimitExceeded(ServiceException):
+    code: str = "DocumentVersionLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DoesNotExistException(ServiceException):
+    code: str = "DoesNotExistException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DuplicateDocumentContent(ServiceException):
+    code: str = "DuplicateDocumentContent"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DuplicateDocumentVersionName(ServiceException):
+    code: str = "DuplicateDocumentVersionName"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class DuplicateInstanceId(ServiceException):
-    pass
+    code: str = "DuplicateInstanceId"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class FeatureNotAvailableException(ServiceException):
+    code: str = "FeatureNotAvailableException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class HierarchyLevelLimitExceededException(ServiceException):
+    code: str = "HierarchyLevelLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class HierarchyTypeMismatchException(ServiceException):
+    code: str = "HierarchyTypeMismatchException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class IdempotentParameterMismatch(ServiceException):
+    code: str = "IdempotentParameterMismatch"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class IncompatiblePolicyException(ServiceException):
+    code: str = "IncompatiblePolicyException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InternalServerError(ServiceException):
+    code: str = "InternalServerError"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidActivation(ServiceException):
+    code: str = "InvalidActivation"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidActivationId(ServiceException):
+    code: str = "InvalidActivationId"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidAggregatorException(ServiceException):
+    code: str = "InvalidAggregatorException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidAllowedPatternException(ServiceException):
+    code: str = "InvalidAllowedPatternException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidAssociation(ServiceException):
+    code: str = "InvalidAssociation"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidAssociationVersion(ServiceException):
+    code: str = "InvalidAssociationVersion"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidAutomationExecutionParametersException(ServiceException):
+    code: str = "InvalidAutomationExecutionParametersException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidAutomationSignalException(ServiceException):
+    code: str = "InvalidAutomationSignalException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidAutomationStatusUpdateException(ServiceException):
+    code: str = "InvalidAutomationStatusUpdateException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidCommandId(ServiceException):
-    pass
+    code: str = "InvalidCommandId"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidDeleteInventoryParametersException(ServiceException):
+    code: str = "InvalidDeleteInventoryParametersException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDeletionIdException(ServiceException):
+    code: str = "InvalidDeletionIdException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDocument(ServiceException):
+    code: str = "InvalidDocument"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDocumentContent(ServiceException):
+    code: str = "InvalidDocumentContent"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDocumentOperation(ServiceException):
+    code: str = "InvalidDocumentOperation"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDocumentSchemaVersion(ServiceException):
+    code: str = "InvalidDocumentSchemaVersion"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDocumentType(ServiceException):
+    code: str = "InvalidDocumentType"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidDocumentVersion(ServiceException):
+    code: str = "InvalidDocumentVersion"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidFilter(ServiceException):
+    code: str = "InvalidFilter"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidFilterKey(ServiceException):
-    pass
+    code: str = "InvalidFilterKey"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidFilterOption(ServiceException):
+    code: str = "InvalidFilterOption"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidFilterValue(ServiceException):
+    code: str = "InvalidFilterValue"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidInstanceId(ServiceException):
+    code: str = "InvalidInstanceId"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidInstanceInformationFilterValue(ServiceException):
+    code: str = "InvalidInstanceInformationFilterValue"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidInventoryGroupException(ServiceException):
+    code: str = "InvalidInventoryGroupException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidInventoryItemContextException(ServiceException):
+    code: str = "InvalidInventoryItemContextException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidInventoryRequestException(ServiceException):
+    code: str = "InvalidInventoryRequestException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidItemContentException(ServiceException):
+    code: str = "InvalidItemContentException"
+    sender_fault: bool = False
+    status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
     Message: Optional[String]
 
 
 class InvalidKeyId(ServiceException):
+    code: str = "InvalidKeyId"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidNextToken(ServiceException):
+    code: str = "InvalidNextToken"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidNotificationConfig(ServiceException):
+    code: str = "InvalidNotificationConfig"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidOptionException(ServiceException):
+    code: str = "InvalidOptionException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidOutputFolder(ServiceException):
-    pass
+    code: str = "InvalidOutputFolder"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidOutputLocation(ServiceException):
-    pass
+    code: str = "InvalidOutputLocation"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidParameters(ServiceException):
+    code: str = "InvalidParameters"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidPermissionType(ServiceException):
+    code: str = "InvalidPermissionType"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidPluginName(ServiceException):
-    pass
+    code: str = "InvalidPluginName"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidPolicyAttributeException(ServiceException):
+    code: str = "InvalidPolicyAttributeException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidPolicyTypeException(ServiceException):
+    code: str = "InvalidPolicyTypeException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class InvalidResourceId(ServiceException):
-    pass
+    code: str = "InvalidResourceId"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidResourceType(ServiceException):
-    pass
+    code: str = "InvalidResourceType"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class InvalidResultAttributeException(ServiceException):
+    code: str = "InvalidResultAttributeException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidRole(ServiceException):
+    code: str = "InvalidRole"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidSchedule(ServiceException):
+    code: str = "InvalidSchedule"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidTarget(ServiceException):
+    code: str = "InvalidTarget"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidTargetMaps(ServiceException):
+    code: str = "InvalidTargetMaps"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidTypeNameException(ServiceException):
+    code: str = "InvalidTypeNameException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvalidUpdate(ServiceException):
+    code: str = "InvalidUpdate"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class InvocationDoesNotExist(ServiceException):
-    pass
+    code: str = "InvocationDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class ItemContentMismatchException(ServiceException):
+    code: str = "ItemContentMismatchException"
+    sender_fault: bool = False
+    status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
     Message: Optional[String]
 
 
 class ItemSizeLimitExceededException(ServiceException):
+    code: str = "ItemSizeLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
     Message: Optional[String]
 
 
 class MaxDocumentSizeExceeded(ServiceException):
+    code: str = "MaxDocumentSizeExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class OpsItemAlreadyExistsException(ServiceException):
+    code: str = "OpsItemAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     OpsItemId: Optional[String]
 
@@ -1329,11 +1563,17 @@ OpsItemParameterNamesList = List[String]
 
 
 class OpsItemInvalidParameterException(ServiceException):
+    code: str = "OpsItemInvalidParameterException"
+    sender_fault: bool = False
+    status_code: int = 400
     ParameterNames: Optional[OpsItemParameterNamesList]
     Message: Optional[String]
 
 
 class OpsItemLimitExceededException(ServiceException):
+    code: str = "OpsItemLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     ResourceTypes: Optional[OpsItemParameterNamesList]
     Limit: Optional[Integer]
     LimitType: Optional[String]
@@ -1341,163 +1581,278 @@ class OpsItemLimitExceededException(ServiceException):
 
 
 class OpsItemNotFoundException(ServiceException):
+    code: str = "OpsItemNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class OpsItemRelatedItemAlreadyExistsException(ServiceException):
+    code: str = "OpsItemRelatedItemAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
     ResourceUri: Optional[OpsItemRelatedItemAssociationResourceUri]
     OpsItemId: Optional[OpsItemId]
 
 
 class OpsItemRelatedItemAssociationNotFoundException(ServiceException):
+    code: str = "OpsItemRelatedItemAssociationNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class OpsMetadataAlreadyExistsException(ServiceException):
+    code: str = "OpsMetadataAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class OpsMetadataInvalidArgumentException(ServiceException):
+    code: str = "OpsMetadataInvalidArgumentException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class OpsMetadataKeyLimitExceededException(ServiceException):
+    code: str = "OpsMetadataKeyLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class OpsMetadataLimitExceededException(ServiceException):
+    code: str = "OpsMetadataLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class OpsMetadataNotFoundException(ServiceException):
+    code: str = "OpsMetadataNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class OpsMetadataTooManyUpdatesException(ServiceException):
+    code: str = "OpsMetadataTooManyUpdatesException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterAlreadyExists(ServiceException):
+    code: str = "ParameterAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterLimitExceeded(ServiceException):
+    code: str = "ParameterLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterMaxVersionLimitExceeded(ServiceException):
+    code: str = "ParameterMaxVersionLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterNotFound(ServiceException):
+    code: str = "ParameterNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterPatternMismatchException(ServiceException):
+    code: str = "ParameterPatternMismatchException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterVersionLabelLimitExceeded(ServiceException):
+    code: str = "ParameterVersionLabelLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ParameterVersionNotFound(ServiceException):
+    code: str = "ParameterVersionNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class PoliciesLimitExceededException(ServiceException):
+    code: str = "PoliciesLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class ResourceDataSyncAlreadyExistsException(ServiceException):
+    code: str = "ResourceDataSyncAlreadyExistsException"
+    sender_fault: bool = False
+    status_code: int = 400
     SyncName: Optional[ResourceDataSyncName]
 
 
 class ResourceDataSyncConflictException(ServiceException):
+    code: str = "ResourceDataSyncConflictException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class ResourceDataSyncCountExceededException(ServiceException):
+    code: str = "ResourceDataSyncCountExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class ResourceDataSyncInvalidConfigurationException(ServiceException):
+    code: str = "ResourceDataSyncInvalidConfigurationException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class ResourceDataSyncNotFoundException(ServiceException):
+    code: str = "ResourceDataSyncNotFoundException"
+    sender_fault: bool = False
+    status_code: int = 400
     SyncName: Optional[ResourceDataSyncName]
     SyncType: Optional[ResourceDataSyncType]
     Message: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
+    code: str = "ResourceInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class ResourceLimitExceededException(ServiceException):
+    code: str = "ResourceLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class ServiceSettingNotFound(ServiceException):
+    code: str = "ServiceSettingNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class StatusUnchanged(ServiceException):
-    pass
+    code: str = "StatusUnchanged"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class SubTypeCountLimitExceededException(ServiceException):
+    code: str = "SubTypeCountLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class TargetInUseException(ServiceException):
+    code: str = "TargetInUseException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class TargetNotConnected(ServiceException):
+    code: str = "TargetNotConnected"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class TooManyTagsError(ServiceException):
-    pass
+    code: str = "TooManyTagsError"
+    sender_fault: bool = False
+    status_code: int = 400
 
 
 class TooManyUpdates(ServiceException):
+    code: str = "TooManyUpdates"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class TotalSizeLimitExceededException(ServiceException):
+    code: str = "TotalSizeLimitExceededException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class UnsupportedCalendarException(ServiceException):
+    code: str = "UnsupportedCalendarException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class UnsupportedFeatureRequiredException(ServiceException):
+    code: str = "UnsupportedFeatureRequiredException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class UnsupportedInventoryItemContextException(ServiceException):
+    code: str = "UnsupportedInventoryItemContextException"
+    sender_fault: bool = False
+    status_code: int = 400
     TypeName: Optional[InventoryItemTypeName]
     Message: Optional[String]
 
 
 class UnsupportedInventorySchemaVersionException(ServiceException):
+    code: str = "UnsupportedInventorySchemaVersionException"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class UnsupportedOperatingSystem(ServiceException):
+    code: str = "UnsupportedOperatingSystem"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 
 class UnsupportedParameterType(ServiceException):
+    code: str = "UnsupportedParameterType"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[String]
 
 
 class UnsupportedPlatformType(ServiceException):
+    code: str = "UnsupportedPlatformType"
+    sender_fault: bool = False
+    status_code: int = 400
     Message: Optional[String]
 
 

--- a/localstack/aws/api/stepfunctions/__init__.py
+++ b/localstack/aws/api/stepfunctions/__init__.py
@@ -125,99 +125,171 @@ class SyncExecutionStatus(str):
 
 
 class ActivityDoesNotExist(ServiceException):
+    code: str = "ActivityDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ActivityLimitExceeded(ServiceException):
+    code: str = "ActivityLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ActivityWorkerLimitExceeded(ServiceException):
+    code: str = "ActivityWorkerLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ExecutionAlreadyExists(ServiceException):
+    code: str = "ExecutionAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ExecutionDoesNotExist(ServiceException):
+    code: str = "ExecutionDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ExecutionLimitExceeded(ServiceException):
+    code: str = "ExecutionLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidArn(ServiceException):
+    code: str = "InvalidArn"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidDefinition(ServiceException):
+    code: str = "InvalidDefinition"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidExecutionInput(ServiceException):
+    code: str = "InvalidExecutionInput"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidLoggingConfiguration(ServiceException):
+    code: str = "InvalidLoggingConfiguration"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidName(ServiceException):
+    code: str = "InvalidName"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidOutput(ServiceException):
+    code: str = "InvalidOutput"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidToken(ServiceException):
+    code: str = "InvalidToken"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InvalidTracingConfiguration(ServiceException):
+    code: str = "InvalidTracingConfiguration"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class MissingRequiredParameter(ServiceException):
+    code: str = "MissingRequiredParameter"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class ResourceNotFound(ServiceException):
+    code: str = "ResourceNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
     resourceName: Optional[Arn]
 
 
 class StateMachineAlreadyExists(ServiceException):
+    code: str = "StateMachineAlreadyExists"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class StateMachineDeleting(ServiceException):
+    code: str = "StateMachineDeleting"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class StateMachineDoesNotExist(ServiceException):
+    code: str = "StateMachineDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class StateMachineLimitExceeded(ServiceException):
+    code: str = "StateMachineLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class StateMachineTypeNotSupported(ServiceException):
+    code: str = "StateMachineTypeNotSupported"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TaskDoesNotExist(ServiceException):
+    code: str = "TaskDoesNotExist"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TaskTimedOut(ServiceException):
+    code: str = "TaskTimedOut"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyTags(ServiceException):
+    code: str = "TooManyTags"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
     resourceName: Optional[Arn]
 

--- a/localstack/aws/api/sts/__init__.py
+++ b/localstack/aws/api/sts/__init__.py
@@ -51,34 +51,58 @@ webIdentitySubjectType = str
 
 
 class ExpiredTokenException(ServiceException):
+    code: str = "ExpiredTokenException"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[expiredIdentityTokenMessage]
 
 
 class IDPCommunicationErrorException(ServiceException):
+    code: str = "IDPCommunicationError"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[idpCommunicationErrorMessage]
 
 
 class IDPRejectedClaimException(ServiceException):
+    code: str = "IDPRejectedClaim"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[idpRejectedClaimMessage]
 
 
 class InvalidAuthorizationMessageException(ServiceException):
+    code: str = "InvalidAuthorizationMessageException"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[invalidAuthorizationMessage]
 
 
 class InvalidIdentityTokenException(ServiceException):
+    code: str = "InvalidIdentityToken"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[invalidIdentityTokenMessage]
 
 
 class MalformedPolicyDocumentException(ServiceException):
+    code: str = "MalformedPolicyDocument"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[malformedPolicyDocumentMessage]
 
 
 class PackedPolicyTooLargeException(ServiceException):
+    code: str = "PackedPolicyTooLarge"
+    sender_fault: bool = True
+    status_code: int = 400
     message: Optional[packedPolicyTooLargeMessage]
 
 
 class RegionDisabledException(ServiceException):
+    code: str = "RegionDisabledException"
+    sender_fault: bool = True
+    status_code: int = 403
     message: Optional[regionDisabledMessage]
 
 

--- a/localstack/aws/api/support/__init__.py
+++ b/localstack/aws/api/support/__init__.py
@@ -44,38 +44,65 @@ TimeCreated = str
 
 
 class AttachmentIdNotFound(ServiceException):
+    code: str = "AttachmentIdNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class AttachmentLimitExceeded(ServiceException):
+    code: str = "AttachmentLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class AttachmentSetExpired(ServiceException):
+    code: str = "AttachmentSetExpired"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class AttachmentSetIdNotFound(ServiceException):
+    code: str = "AttachmentSetIdNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class AttachmentSetSizeLimitExceeded(ServiceException):
+    code: str = "AttachmentSetSizeLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class CaseCreationLimitExceeded(ServiceException):
+    code: str = "CaseCreationLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class CaseIdNotFound(ServiceException):
+    code: str = "CaseIdNotFound"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DescribeAttachmentLimitExceeded(ServiceException):
+    code: str = "DescribeAttachmentLimitExceeded"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class InternalServerError(ServiceException):
+    code: str = "InternalServerError"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/api/swf/__init__.py
+++ b/localstack/aws/api/swf/__init__.py
@@ -288,42 +288,72 @@ class WorkflowExecutionTimeoutType(str):
 
 
 class DefaultUndefinedFault(ServiceException):
+    code: str = "DefaultUndefinedFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DomainAlreadyExistsFault(ServiceException):
+    code: str = "DomainAlreadyExistsFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class DomainDeprecatedFault(ServiceException):
+    code: str = "DomainDeprecatedFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class LimitExceededFault(ServiceException):
+    code: str = "LimitExceededFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class OperationNotPermittedFault(ServiceException):
+    code: str = "OperationNotPermittedFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TooManyTagsFault(ServiceException):
+    code: str = "TooManyTagsFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TypeAlreadyExistsFault(ServiceException):
+    code: str = "TypeAlreadyExistsFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class TypeDeprecatedFault(ServiceException):
+    code: str = "TypeDeprecatedFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class UnknownResourceFault(ServiceException):
+    code: str = "UnknownResourceFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 
 class WorkflowExecutionAlreadyStartedFault(ServiceException):
+    code: str = "WorkflowExecutionAlreadyStartedFault"
+    sender_fault: bool = False
+    status_code: int = 400
     message: Optional[ErrorMessage]
 
 

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -138,7 +138,12 @@ class ShapeNode:
         if doc:
             self.print_shape_doc(output, self.shape)
 
-        if not self.shape.members:
+        if self.is_exception:
+            error_spec = self.shape.metadata.get("error", {})
+            output.write(f'    code: str = "{error_spec.get("code", self.shape.name)}"\n')
+            output.write(f'    sender_fault: bool = {error_spec.get("senderFault", False)}\n')
+            output.write(f'    status_code: int = {error_spec.get("httpStatusCode", 400)}\n')
+        elif not self.shape.members:
             output.write("    pass\n")
 
         for k, v in self.shape.members.items():


### PR DESCRIPTION
This PR extends the scaffold script as described in #6406 

I also regenerated all APIs. For localstack-ext, the renovate but should do the work for us after we merge.

The newly generated exceptions look like this:
```python
class EmptyBatchRequest(ServiceException):
    code: str = "AWS.SimpleQueueService.EmptyBatchRequest"
    sender_fault: bool = True
    status_code: int = 400
```