### PR TITLE
fix asgi header extraction for h11 and h2

### DIFF
--- a/localstack/aws/serving/wsgi.py
+++ b/localstack/aws/serving/wsgi.py
@@ -41,7 +41,7 @@ class WsgiGateway:
         if "asgi.headers" in environ:
             # restores raw headers from ASGI scope, which allows dashes in header keys
             # see https://github.com/pallets/werkzeug/issues/940
-            request.headers = Headers(environ["asgi.headers"].raw_items())
+            request.headers = Headers(environ["asgi.headers"])
         else:
             # by default, werkzeug requests from environ are immutable
             request.headers = Headers(request.headers)

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -12,7 +12,6 @@ if t.TYPE_CHECKING:
     from _typeshed import WSGIApplication, WSGIEnvironment
     from hypercorn.typing import ASGIReceiveCallable, ASGISendCallable, HTTPScope, Scope
 
-
 LOG = logging.getLogger(__name__)
 
 
@@ -72,8 +71,18 @@ def populate_wsgi_environment(environ: "WSGIEnvironment", scope: "HTTPScope"):
     environ["wsgi.multiprocess"] = False
     environ["wsgi.run_once"] = False
 
-    # custom key to allow downstream applications to circumvent WSGI header processing
-    environ["asgi.headers"] = scope.get("headers")
+    # asgi.headers: a custom key to allow downstream applications to circumvent WSGI header processing. we try to map
+    # asgi.headers to a List[Tuple[byte, byte]]. in our case the headers typically come from hypercorn which uses
+    # h11/h2 as protocol library. in the case of h2, the headers will be simply a List[Tuple[byte, byte]],
+    # and in the case of h11, it will be a Headers object that we can extract the list of raw headers from.
+    headers = scope.get("headers")
+    environ["asgi.headers"] = headers
+    if not isinstance(headers, list):
+        try:
+            # these are h11 headers from which we extract the raw list
+            environ["asgi.headers"] = headers.raw_items()
+        except AttributeError:
+            environ["asgi.headers"] = headers
 
 
 async def to_async_generator(


### PR DESCRIPTION
In #6354 we introduced a `.raw_items()` call to the headers object coming from the ASGI/WSGI bridge. We are serving through hypercorn, which uses the h2 protocol library for HTTP2, and h11 for HTTP 1.1. In the case of h11, the headers in the ASGI scope are a `h11._headers.Headers` object, which had the `raw_items` method. In the case of HTTP2, h2 was already passing a list of raw headers. I introduced a switch to check that.

Thanks for @whummer for the clear replication instructions:
```bash
curl 'https://localhost.localstack.cloud:4566/' -X OPTIONS -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:102.0) Gecko/20100101 Firefox/102.0' -H 'Accept: */*' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate, br' -H 'Access-Control-Request-Method: POST' -H 'Access-Control-Request-Headers: authorization,content-type,x-amz-content-sha256,x-amz-date,x-amz-target,x-amz-user-agent' -H 'Referer: https://app.localstack.cloud/' -H 'Origin: https://app.localstack.cloud/' -H 'Connection: keep-alive' -H 'Sec-Fetch-Dest: empty' -H 'Sec-Fetch-Mode: cors' -H 'Sec-Fetch-Site: same-site' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache' -H 'TE: trailers'
```