### PR TITLE
fix parse_response to handle streaming responses

### DIFF
--- a/localstack/aws/client.py
+++ b/localstack/aws/client.py
@@ -1,27 +1,74 @@
 """Utils to process AWS requests as a client."""
+import io
+import logging
+
 from botocore.model import OperationModel
 from botocore.parsers import create_parser as create_response_parser
 from werkzeug import Response
 
 from localstack.aws.api import ServiceResponse
 
+LOG = logging.getLogger(__name__)
+
+
+class _ResponseStream(io.RawIOBase):
+    """
+    Wraps a Response and makes it available as a readable IO stream.
+
+    Adapted from https://stackoverflow.com/a/20260030/804840
+    """
+
+    def __init__(self, response: Response):
+        self.iterator = response.iter_encoded()
+        self._buf = None
+
+    def readable(self):
+        return True
+
+    def readinto(self, b):
+        try:
+            upto = len(b)  # We're supposed to return at most this much
+            chunk = self._buf or next(self.iterator)
+            output, self._buf = chunk[:upto], chunk[upto:]
+            b[: len(output)] = output
+            return len(output)
+        except StopIteration:
+            return 0  # indicate EOF
+
 
 def parse_response(operation: OperationModel, response: Response) -> ServiceResponse:
     """
-    Parses an HTTP response object into an AWS response object using botocore.
+    Parses an HTTP Response object into an AWS response object using botocore. It does this by adapting the
+    procedure of ``botocore.endpoint.convert_to_response_dict`` to work with Werkzeug's server-side response object.
 
     :param operation: the operation of the original request
     :param response: the HTTP response object containing the response of the operation
     :return: a parsed dictionary as it is returned by botocore
     """
-    response_dict = {  # this is what botocore.endpoint.convert_to_response_dict normally does
+    # this is what botocore.endpoint.convert_to_response_dict normally does
+    response_dict = {
         "headers": dict(response.headers.items()),  # boto doesn't like werkzeug headers
         "status_code": response.status_code,
-        "body": response.data,
         "context": {
             "operation_name": operation.name,
         },
     }
+
+    if response_dict["status_code"] >= 300:
+        response_dict["body"] = response.data
+    elif operation.has_event_stream_output:
+        # TODO
+        LOG.warning(
+            "don't know how to parse an event stream output for %s.%s",
+            operation.service_model.service_name,
+            operation.name,
+        )
+        response_dict["body"] = response.data
+    elif operation.has_streaming_output:
+        # for s3.GetObject for example, the Body attribute is actually a stream, not the raw bytes value
+        response_dict["body"] = _ResponseStream(response)
+    else:
+        response_dict["body"] = response.data
 
     parser = create_response_parser(operation.service_model.protocol)
     return parser.parse(response_dict, operation.output_shape)

--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -259,7 +259,7 @@ class ServiceResponseParser(Handler):
                 LOG.warning("Cannot parse exception %s", context.service_exception)
                 return
 
-        if response.content_length is None:
+        if response.content_length is None or context.operation.has_event_stream_output:
             # cannot/should not parse streaming responses
             context.service_response = {}
             return


### PR DESCRIPTION
This PR fixes an issue/limitation of the `parse_response` operation in our aws client module.

The problem was that we were not really implementing the parsing logic of botocore correctly, in particular when streaming binary responses are expected, like in `s3.GetObject`, which caused a problem here: https://github.com/boto/botocore/blob/ae44d1de241c13626d05a9301cf62e460833c950/botocore/parsers.py#L910-L914

In boto, when you call `s3_client.get_object(...)`, the `Body` attribute of the response (i.e., the payload), will not actually be bytes, but a readable `io` object. This PR introduces the same behavior for the `parse_response` method.

I modeled the implementation after the version in boto core https://github.com/boto/botocore/blob/ae44d1de241c13626d05a9301cf62e460833c950/botocore/endpoint.py#L65-L74

Future work is `has_event_stream_output`, which I think covers things like the kinesis shard iterator.