### PR TITLE
Install sqlite native libs for DynamoDB on OSX arm64 (M1)

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -30,6 +30,7 @@ LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 
 # version of the Maven dependency with Java utility code
 LOCALSTACK_MAVEN_VERSION = "0.2.19"
+MAVEN_REPO_URL = "https://repo1.maven.org/maven2"
 
 # map of default service APIs and ports to be spun up (fetch map from localstack_client)
 DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
@@ -129,11 +130,14 @@ OPENSEARCH_PLUGIN_LIST = [
 ELASTICMQ_JAR_URL = (
     "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar"
 )
-STS_JAR_URL = "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar"
+STS_JAR_URL = (
+    f"{MAVEN_REPO_URL}/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar"
+)
 STEPFUNCTIONS_ZIP_URL = "https://s3.amazonaws.com/stepfunctionslocal/StepFunctionsLocal.zip"
 KMS_URL_PATTERN = "https://s3-eu-west-2.amazonaws.com/local-kms/3/local-kms_<arch>.bin"
 
 DYNAMODB_JAR_URL = "https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.zip"
+LIBSQLITE_AARCH64_URL = f"{MAVEN_REPO_URL}/io/github/ganadist/sqlite4java/libsqlite4java-osx-aarch64/1.0.392/libsqlite4java-osx-aarch64-1.0.392.dylib"
 
 # API endpoint for analytics events
 API_ENDPOINT = os.environ.get("API_ENDPOINT") or "https://api.localstack.cloud/v1"

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -28,6 +28,7 @@ from localstack.constants import (
     ELASTICSEARCH_DELETE_MODULES,
     ELASTICSEARCH_PLUGIN_LIST,
     KMS_URL_PATTERN,
+    LIBSQLITE_AARCH64_URL,
     LOCALSTACK_MAVEN_VERSION,
     MODULE_MAIN_PATH,
     OPENSEARCH_DEFAULT_VERSION,
@@ -49,7 +50,7 @@ from localstack.utils.files import (
 )
 from localstack.utils.functions import run_safe
 from localstack.utils.http import download
-from localstack.utils.platform import get_arch, is_windows
+from localstack.utils.platform import get_arch, is_mac_os, is_windows
 from localstack.utils.run import run
 from localstack.utils.sync import retry
 from localstack.utils.threads import parallelize
@@ -542,6 +543,14 @@ def install_dynamodb_local():
         # download and extract archive
         tmp_archive = os.path.join(tempfile.gettempdir(), "localstack.ddb.zip")
         download_and_extract_with_retry(DYNAMODB_JAR_URL, tmp_archive, INSTALL_DIR_DDB)
+
+    # download additional libs for Mac M1 (for local dev mode)
+    if is_mac_os() and get_arch() == "arm64":
+        target_path = os.path.join(
+            INSTALL_DIR_DDB, "DynamoDBLocal_lib", "libsqlite4java-osx-aarch64.dylib"
+        )
+        if not file_exists_not_empty(target_path):
+            download(LIBSQLITE_AARCH64_URL, target_path)
 
     # fix logging configuration for DynamoDBLocal
     log4j2_config = """<Configuration status="WARN">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 line_length = 100
 include = '(localstack/.*\.py$|tests/.*\.py$)'
-extend_exclude = '(localstack/infra|localstack/node_modules)'
+extend_exclude = '(localstack/infra|localstack/node_modules|.filesystem)'
 
 [tool.isort]
 profile = 'black'
-extend_skip = ['localstack/infra/', 'localstack/node_modules', 'bin']
+extend_skip = ['localstack/infra/', 'localstack/node_modules', 'bin', '.filesystem']
 line_length = 100
 
 # call using pflake8
@@ -18,7 +18,7 @@ line_length = 100
 max-line-length = 110
 ignore = 'E203,E266,E501,W503,F403'
 select = 'B,C,E,F,I,W,T4,B9'
-exclude = 'node_modules,.venv*,venv*,dist,build,target,*.egg-info,fixes,localstack/infra,localstack/node_modules'
+exclude = 'node_modules,.venv*,venv*,dist,build,target,*.egg-info,fixes,localstack/infra,localstack/node_modules,.filesystem'
 
 [tool.coverage.run]
 relative_files = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,6 @@ license = Apache License 2.0
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     License :: OSI Approved :: Apache Software License
     Topic :: Internet


### PR DESCRIPTION
Install sqlite native libs for DynamoDB on OSX arm64. This is required to get up and running in local dev mode using M1 MacBooks.

/cc @pandomic would be great if you could also take a quick look and see if that works on your M1.. 👍 

Also adds a few linter exclusions for `.filesystem` in anticipation of the `v1` merge. (Just ran into a few linter errors with Lambdas inside `.filesystem/var/lib/localstack/tmp/...`). Could also raise it against `v1` branch, but can't harm to have them in here already now..