### PR TITLE
remove terraform restore cache keys

### DIFF
--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -57,8 +57,6 @@ jobs:
       with:
         path: ./.venv/
         key: ${{ runner.os }}-venv-${{ hashFiles('**/setup.cfg') }}
-        restore-keys: |
-          ${{ runner.os }}-venv-
 
     - name: Install system dependencies
       run: |
@@ -92,8 +90,6 @@ jobs:
           ~/go/pkg/mod
           ~/.cache/go-build
         key: ${{ runner.os }}-go-${{ hashFiles('**/terraform-provider-aws/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Run Test Cases
       run: |


### PR DESCRIPTION
These keys will prefix match - therefore the cache will not be invalidated _ever_. 

This might have an impact on the currently failing terraform tests on v1.

As seen here: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key the cache keys will fall back to prefix matching.

Since we want to invalidate caches if setup.cfg or go.sum changes, we need to remove the restore keys here.