### PR TITLE
fix(types): use typing

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -394,7 +394,7 @@ def extract_path_params(path: str, extracted_path: str) -> Dict[str, str]:
     return path_params
 
 
-def extract_query_string_params(path: str) -> list[str, Dict[str, str]]:
+def extract_query_string_params(path: str) -> Tuple[str, Dict[str, str]]:
     parsed_path = urlparse.urlparse(path)
     path = parsed_path.path
     parsed_query_string_params = urlparse.parse_qs(parsed_path.query)
@@ -408,7 +408,7 @@ def extract_query_string_params(path: str) -> list[str, Dict[str, str]]:
 
     # strip trailing slashes from path to fix downstream lookups
     path = path.rstrip("/") or "/"
-    return [path, query_string_params]
+    return path, query_string_params
 
 
 def get_cors_response(headers):

--- a/localstack/testing/pytest/filters.py
+++ b/localstack/testing/pytest/filters.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 from _pytest.config import Config, PytestPluginManager
 from _pytest.config.argparsing import Parser
@@ -11,7 +13,7 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
 
 
 @pytest.hookimpl
-def pytest_collection_modifyitems(session: Session, config: Config, items: list[Item]):
+def pytest_collection_modifyitems(session: Session, config: Config, items: List[Item]):
     ff = config.getoption("--filter-fixtures")
     if ff:
         # TODO: add more sophisticated combinations (=> like pytest -m and -k)

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1416,7 +1416,7 @@ def pytest_configure(config: Config):
 
 
 @pytest.hookimpl
-def pytest_collection_modifyitems(config: Config, items: list[Item]):
+def pytest_collection_modifyitems(config: Config, items: List[Item]):
     only_localstack = pytest.mark.skipif(
         os.environ.get("TEST_TARGET") == "AWS_CLOUD",
         reason="test only applicable if run against localstack",

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from json import JSONDecodeError
 from pathlib import Path
 from re import Pattern
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from botocore.response import StreamingBody
 from deepdiff import DeepDiff
@@ -49,16 +49,16 @@ class SnapshotSession:
     it assumes that a single snapshot file is only being written to sequentially
     """
 
-    results: list[SnapshotMatchResult]
-    recorded_state: dict[str, dict]  # previously persisted state
-    observed_state: dict[str, dict]  # current state from match calls
+    results: List[SnapshotMatchResult]
+    recorded_state: Dict[str, dict]  # previously persisted state
+    observed_state: Dict[str, dict]  # current state from match calls
 
-    called_keys: set[str]
-    transformers: list[(Transformer, int)]  # (transformer, priority)
+    called_keys: Set[str]
+    transformers: List[(Transformer, int)]  # (transformer, priority)
 
     transform: TransformerUtility
 
-    skip_verification_paths: list[str]
+    skip_verification_paths: List[str]
 
     def __init__(
         self,
@@ -83,7 +83,7 @@ class SnapshotSession:
         self.transform = TransformerUtility
 
     def add_transformers_list(
-        self, transformer_list: list[Transformer], priority: Optional[int] = 0
+        self, transformer_list: List[Transformer], priority: Optional[int] = 0
     ):
         for transformer in transformer_list:
             self.transformers.append((transformer, priority))  # TODO
@@ -147,7 +147,7 @@ class SnapshotSession:
         return True
 
     def _assert_all(
-        self, verify: bool = True, skip_verification_paths: list[str] = []
+        self, verify: bool = True, skip_verification_paths: List[str] = []
     ) -> List[SnapshotMatchResult]:
         """use after all match calls to get a combined diff"""
         results = []

--- a/localstack/testing/snapshots/transformer.py
+++ b/localstack/testing/snapshots/transformer.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import re
 from re import Pattern
-from typing import Callable, Optional, Protocol
+from typing import Callable, Dict, List, Optional, Protocol
 
 from jsonpath_ng.ext import parse
 
@@ -15,9 +15,9 @@ GlobalReplacementFn = Callable[[str], str]
 
 
 class TransformContext:
-    _cache: dict
-    replacements: list[GlobalReplacementFn]
-    scoped_tokens: dict[str, int]
+    _cache: Dict
+    replacements: List[GlobalReplacementFn]
+    scoped_tokens: Dict[str, int]
 
     def __init__(self):
         self.replacements = []
@@ -25,7 +25,7 @@ class TransformContext:
         self._cache = {}
 
     @property
-    def serialized_replacements(self) -> list[GlobalReplacementFn]:  # TODO: naming
+    def serialized_replacements(self) -> List[GlobalReplacementFn]:  # TODO: naming
         return self.replacements
 
     def register_serialized_replacement(self, fn: GlobalReplacementFn):  # TODO: naming

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -901,7 +901,7 @@ def kinesis_stream_name(kinesis_arn):
 
 def mock_aws_request_headers(
     service="dynamodb", region_name=None, access_key=None, internal=False
-) -> dict[str, str]:
+) -> Dict[str, str]:
     ctype = APPLICATION_AMZ_JSON_1_0
     if service == "kinesis":
         ctype = APPLICATION_AMZ_JSON_1_1

--- a/tests/unit/test_region_backend.py
+++ b/tests/unit/test_region_backend.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 from unittest.mock import patch
 
 from pytest import fixture, mark
@@ -10,8 +10,8 @@ from localstack.services.generic_proxy import RegionBackend
 @fixture
 def sample_region_backend():
     class SampleRegionBackend(RegionBackend):
-        CLASS_ATTR: list[Any] = []
-        instance_attr: list[Any]
+        CLASS_ATTR: List[Any] = []
+        instance_attr: List[Any]
 
         def __init__(self):
             self.instance_attr = []


### PR DESCRIPTION
## Summary



Use `typing` to soften migration to `3.10 `