### PR TITLE
added support for route53resolver group association

### DIFF
--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -1,7 +1,8 @@
 from typing import Dict
 
-from localstack.aws.api.route53resolver import FirewallRuleGroup
+from localstack.aws.api.route53resolver import FirewallRuleGroup, ResourceNotFoundException
 from localstack.services.generic_proxy import RegionBackend
+from localstack.utils.aws import aws_stack
 
 
 class Route53ResolverBackend(RegionBackend):
@@ -13,3 +14,76 @@ class Route53ResolverBackend(RegionBackend):
         self.firewall_domain_lists = {}
         self.firewall_domains = {}
         self.firewall_rules = {}
+        self.firewall_rule_group_associations = {}
+
+    def get_firewall_rule_group(self, id):
+        firewall_rule_group = self.firewall_rule_groups.get(id)
+        if not firewall_rule_group:
+            raise ResourceNotFoundException(
+                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )
+        return firewall_rule_group
+
+    def delete_firewall_rule_group(self, id):
+        # if firewall_rule_groups doesn't exist it will throw an error
+        firewall_rule_group = self.get_firewall_rule_group(id)
+        self.firewall_rule_groups.pop(id)
+        return firewall_rule_group
+
+    def get_firewall_rule_group_association(self, id):
+        firewall_rule_group_association = self.firewall_rule_group_associations.get(id)
+        if not firewall_rule_group_association:
+            raise ResourceNotFoundException(
+                f"[RSLVR-02025] Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )
+        return self.firewall_rule_group_associations.get(id)
+
+    def delete_firewall_rule_group_association(self, id):
+        # if firewall_rule_group_associations doesn't exist it will throw an error
+        firewall_rule_group_associations = self.get_firewall_rule_group_association(id)
+        self.firewall_rule_group_associations.pop(id)
+        return firewall_rule_group_associations
+
+    def get_firewall_domain(self, id):
+        firewall_domain = self.firewall_domains.get(id)
+        if not firewall_domain:
+            raise ResourceNotFoundException(
+                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )
+        return firewall_domain
+
+    def delete_firewall_domain(self, id):
+        # if firewall_domains doesn't exist it will throw an error
+        firewall_domain = self.get_firewall_domain(id)
+        self.firewall_domains.pop(id)
+        return firewall_domain
+
+    def get_firewall_domain_lists(self, id):
+        firewall_domain_list = self.firewall_domain_lists.get(id)
+        if not firewall_domain_list:
+            raise ResourceNotFoundException(
+                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )
+        return firewall_domain_list
+
+    def delete_firewall_domain_list(self, id):
+        # if firewall_domain_lists doesn't exist it will throw an error
+        firewall_domain_list = self.get_firewall_domain_lists(id)
+        self.firewall_domain_lists.pop(id)
+        return firewall_domain_list
+
+    def get_firewall_rule(self, firewall_rule_group_id, firewall_domain_list_id):
+        firewall_rule = self.firewall_rules.get(firewall_rule_group_id, {}).get(
+            firewall_domain_list_id
+        )
+        if not firewall_rule:
+            raise ResourceNotFoundException(
+                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )
+        return firewall_rule
+
+    def delete_firewall_rule(self, firewall_rule_group_id, firewall_domain_list_id):
+        # if firewall_rules doesn't exist it will throw an error
+        firewall_rule = self.get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
+        self.firewall_rules.get(firewall_rule_group_id, {}).pop(firewall_domain_list_id)
+        return firewall_rule

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -19,6 +19,7 @@ class Route53ResolverBackend(RegionBackend):
 
 ## helper functions for the backend
 def get_firewall_rule_group(id):
+    """returns firewall rule group with the given id if it exists"""
     region_details = Route53ResolverBackend.get()
     firewall_rule_group = region_details.firewall_rule_groups.get(id)
     if not firewall_rule_group:
@@ -29,6 +30,7 @@ def get_firewall_rule_group(id):
 
 
 def delete_firewall_rule_group(id):
+    """deletes the firewall rule group with the given id"""
     # if firewall_rule_groups doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
     firewall_rule_group = region_details.get_firewall_rule_group(id)
@@ -37,6 +39,7 @@ def delete_firewall_rule_group(id):
 
 
 def get_firewall_rule_group_association(id):
+    """returns firewall rule group association with the given id if it exists"""
     region_details = Route53ResolverBackend.get()
     firewall_rule_group_association = region_details.firewall_rule_group_associations.get(id)
     if not firewall_rule_group_association:
@@ -47,6 +50,7 @@ def get_firewall_rule_group_association(id):
 
 
 def delete_firewall_rule_group_association(id):
+    """deletes the firewall rule group association with the given id"""
     # if firewall_rule_group_associations doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
     firewall_rule_group_associations = region_details.get_firewall_rule_group_association(id)
@@ -55,6 +59,7 @@ def delete_firewall_rule_group_association(id):
 
 
 def get_firewall_domain(id):
+    """returns firewall domain with the given id if it exists"""
     # firewall_domain can return none
     region_details = Route53ResolverBackend.get()
     firewall_domain = region_details.firewall_domains.get(id)
@@ -62,6 +67,7 @@ def get_firewall_domain(id):
 
 
 def get_firewall_domain_list(id):
+    """returns firewall domain list with the given id if it exists"""
     region_details = Route53ResolverBackend.get()
     firewall_domain_list = region_details.firewall_domain_lists.get(id)
     if not firewall_domain_list:
@@ -72,6 +78,7 @@ def get_firewall_domain_list(id):
 
 
 def delete_firewall_domain_list(id):
+    """deletes the firewall domain list with the given id"""
     # if firewall_domain_lists doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
     firewall_domain_list = region_details.get_firewall_domain_list(id)
@@ -80,6 +87,7 @@ def delete_firewall_domain_list(id):
 
 
 def get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
+    """returns firewall rule with the given id if it exists"""
     region_details = Route53ResolverBackend.get()
     firewall_rule = region_details.firewall_rules.get(firewall_rule_group_id, {}).get(
         firewall_domain_list_id
@@ -92,6 +100,7 @@ def get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
 
 
 def delete_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
+    """deletes the firewall rule with the given id"""
     # if firewall_rules doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
     firewall_rule = region_details.get_firewall_rule(

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -27,12 +27,14 @@ def get_firewall_rule_group(id):
         )
     return firewall_rule_group
 
+
 def delete_firewall_rule_group(id):
     # if firewall_rule_groups doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
     firewall_rule_group = region_details.get_firewall_rule_group(id)
     region_details.firewall_rule_groups.pop(id)
     return firewall_rule_group
+
 
 def get_firewall_rule_group_association(id):
     region_details = Route53ResolverBackend.get()
@@ -43,6 +45,7 @@ def get_firewall_rule_group_association(id):
         )
     return region_details.firewall_rule_group_associations.get(id)
 
+
 def delete_firewall_rule_group_association(id):
     # if firewall_rule_group_associations doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
@@ -50,18 +53,13 @@ def delete_firewall_rule_group_association(id):
     region_details.firewall_rule_group_associations.pop(id)
     return firewall_rule_group_associations
 
+
 def get_firewall_domain(id):
     # firewall_domain can return none
     region_details = Route53ResolverBackend.get()
     firewall_domain = region_details.firewall_domains.get(id)
     return firewall_domain
 
-def delete_firewall_domain(id):
-    # if firewall_domains doesn't exist it will throw an error
-    region_details = Route53ResolverBackend.get()
-    firewall_domain = region_details.get_firewall_domain(id)
-    region_details.firewall_domains.pop(id)
-    return firewall_domain
 
 def get_firewall_domain_list(id):
     region_details = Route53ResolverBackend.get()
@@ -72,12 +70,14 @@ def get_firewall_domain_list(id):
         )
     return firewall_domain_list
 
+
 def delete_firewall_domain_list(id):
     # if firewall_domain_lists doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
     firewall_domain_list = region_details.get_firewall_domain_list(id)
     region_details.firewall_domain_lists.pop(id)
     return firewall_domain_list
+
 
 def get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
     region_details = Route53ResolverBackend.get()
@@ -90,9 +90,12 @@ def get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
         )
     return firewall_rule
 
+
 def delete_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
     # if firewall_rules doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
-    firewall_rule = region_details.get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
+    firewall_rule = region_details.get_firewall_rule(
+        firewall_rule_group_id, firewall_domain_list_id
+    )
     region_details.firewall_rules.get(firewall_rule_group_id, {}).pop(firewall_domain_list_id)
     return firewall_rule

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -45,11 +45,8 @@ class Route53ResolverBackend(RegionBackend):
         return firewall_rule_group_associations
 
     def get_firewall_domain(self, id):
+        # firewall_domain can return none
         firewall_domain = self.firewall_domains.get(id)
-        if not firewall_domain:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
         return firewall_domain
 
     def delete_firewall_domain(self, id):
@@ -58,7 +55,7 @@ class Route53ResolverBackend(RegionBackend):
         self.firewall_domains.pop(id)
         return firewall_domain
 
-    def get_firewall_domain_lists(self, id):
+    def get_firewall_domain_list(self, id):
         firewall_domain_list = self.firewall_domain_lists.get(id)
         if not firewall_domain_list:
             raise ResourceNotFoundException(
@@ -68,7 +65,7 @@ class Route53ResolverBackend(RegionBackend):
 
     def delete_firewall_domain_list(self, id):
         # if firewall_domain_lists doesn't exist it will throw an error
-        firewall_domain_list = self.get_firewall_domain_lists(id)
+        firewall_domain_list = self.get_firewall_domain_list(id)
         self.firewall_domain_lists.pop(id)
         return firewall_domain_list
 

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -33,7 +33,7 @@ def delete_firewall_rule_group(id):
     """deletes the firewall rule group with the given id"""
     # if firewall_rule_groups doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
-    firewall_rule_group = region_details.get_firewall_rule_group(id)
+    firewall_rule_group = get_firewall_rule_group(id)
     region_details.firewall_rule_groups.pop(id)
     return firewall_rule_group
 
@@ -53,7 +53,7 @@ def delete_firewall_rule_group_association(id):
     """deletes the firewall rule group association with the given id"""
     # if firewall_rule_group_associations doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
-    firewall_rule_group_associations = region_details.get_firewall_rule_group_association(id)
+    firewall_rule_group_associations = get_firewall_rule_group_association(id)
     region_details.firewall_rule_group_associations.pop(id)
     return firewall_rule_group_associations
 
@@ -81,7 +81,7 @@ def delete_firewall_domain_list(id):
     """deletes the firewall domain list with the given id"""
     # if firewall_domain_lists doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
-    firewall_domain_list = region_details.get_firewall_domain_list(id)
+    firewall_domain_list = get_firewall_domain_list(id)
     region_details.firewall_domain_lists.pop(id)
     return firewall_domain_list
 
@@ -103,8 +103,6 @@ def delete_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
     """deletes the firewall rule with the given id"""
     # if firewall_rules doesn't exist it will throw an error
     region_details = Route53ResolverBackend.get()
-    firewall_rule = region_details.get_firewall_rule(
-        firewall_rule_group_id, firewall_domain_list_id
-    )
+    firewall_rule = get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
     region_details.firewall_rules.get(firewall_rule_group_id, {}).pop(firewall_domain_list_id)
     return firewall_rule

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -16,71 +16,83 @@ class Route53ResolverBackend(RegionBackend):
         self.firewall_rules = {}
         self.firewall_rule_group_associations = {}
 
-    def get_firewall_rule_group(self, id):
-        firewall_rule_group = self.firewall_rule_groups.get(id)
-        if not firewall_rule_group:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        return firewall_rule_group
 
-    def delete_firewall_rule_group(self, id):
-        # if firewall_rule_groups doesn't exist it will throw an error
-        firewall_rule_group = self.get_firewall_rule_group(id)
-        self.firewall_rule_groups.pop(id)
-        return firewall_rule_group
-
-    def get_firewall_rule_group_association(self, id):
-        firewall_rule_group_association = self.firewall_rule_group_associations.get(id)
-        if not firewall_rule_group_association:
-            raise ResourceNotFoundException(
-                f"[RSLVR-02025] Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        return self.firewall_rule_group_associations.get(id)
-
-    def delete_firewall_rule_group_association(self, id):
-        # if firewall_rule_group_associations doesn't exist it will throw an error
-        firewall_rule_group_associations = self.get_firewall_rule_group_association(id)
-        self.firewall_rule_group_associations.pop(id)
-        return firewall_rule_group_associations
-
-    def get_firewall_domain(self, id):
-        # firewall_domain can return none
-        firewall_domain = self.firewall_domains.get(id)
-        return firewall_domain
-
-    def delete_firewall_domain(self, id):
-        # if firewall_domains doesn't exist it will throw an error
-        firewall_domain = self.get_firewall_domain(id)
-        self.firewall_domains.pop(id)
-        return firewall_domain
-
-    def get_firewall_domain_list(self, id):
-        firewall_domain_list = self.firewall_domain_lists.get(id)
-        if not firewall_domain_list:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        return firewall_domain_list
-
-    def delete_firewall_domain_list(self, id):
-        # if firewall_domain_lists doesn't exist it will throw an error
-        firewall_domain_list = self.get_firewall_domain_list(id)
-        self.firewall_domain_lists.pop(id)
-        return firewall_domain_list
-
-    def get_firewall_rule(self, firewall_rule_group_id, firewall_domain_list_id):
-        firewall_rule = self.firewall_rules.get(firewall_rule_group_id, {}).get(
-            firewall_domain_list_id
+## helper functions for the backend
+def get_firewall_rule_group(id):
+    region_details = Route53ResolverBackend.get()
+    firewall_rule_group = region_details.firewall_rule_groups.get(id)
+    if not firewall_rule_group:
+        raise ResourceNotFoundException(
+            f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
         )
-        if not firewall_rule:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        return firewall_rule
+    return firewall_rule_group
 
-    def delete_firewall_rule(self, firewall_rule_group_id, firewall_domain_list_id):
-        # if firewall_rules doesn't exist it will throw an error
-        firewall_rule = self.get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
-        self.firewall_rules.get(firewall_rule_group_id, {}).pop(firewall_domain_list_id)
-        return firewall_rule
+def delete_firewall_rule_group(id):
+    # if firewall_rule_groups doesn't exist it will throw an error
+    region_details = Route53ResolverBackend.get()
+    firewall_rule_group = region_details.get_firewall_rule_group(id)
+    region_details.firewall_rule_groups.pop(id)
+    return firewall_rule_group
+
+def get_firewall_rule_group_association(id):
+    region_details = Route53ResolverBackend.get()
+    firewall_rule_group_association = region_details.firewall_rule_group_associations.get(id)
+    if not firewall_rule_group_association:
+        raise ResourceNotFoundException(
+            f"[RSLVR-02025] Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+        )
+    return region_details.firewall_rule_group_associations.get(id)
+
+def delete_firewall_rule_group_association(id):
+    # if firewall_rule_group_associations doesn't exist it will throw an error
+    region_details = Route53ResolverBackend.get()
+    firewall_rule_group_associations = region_details.get_firewall_rule_group_association(id)
+    region_details.firewall_rule_group_associations.pop(id)
+    return firewall_rule_group_associations
+
+def get_firewall_domain(id):
+    # firewall_domain can return none
+    region_details = Route53ResolverBackend.get()
+    firewall_domain = region_details.firewall_domains.get(id)
+    return firewall_domain
+
+def delete_firewall_domain(id):
+    # if firewall_domains doesn't exist it will throw an error
+    region_details = Route53ResolverBackend.get()
+    firewall_domain = region_details.get_firewall_domain(id)
+    region_details.firewall_domains.pop(id)
+    return firewall_domain
+
+def get_firewall_domain_list(id):
+    region_details = Route53ResolverBackend.get()
+    firewall_domain_list = region_details.firewall_domain_lists.get(id)
+    if not firewall_domain_list:
+        raise ResourceNotFoundException(
+            f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+        )
+    return firewall_domain_list
+
+def delete_firewall_domain_list(id):
+    # if firewall_domain_lists doesn't exist it will throw an error
+    region_details = Route53ResolverBackend.get()
+    firewall_domain_list = region_details.get_firewall_domain_list(id)
+    region_details.firewall_domain_lists.pop(id)
+    return firewall_domain_list
+
+def get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
+    region_details = Route53ResolverBackend.get()
+    firewall_rule = region_details.firewall_rules.get(firewall_rule_group_id, {}).get(
+        firewall_domain_list_id
+    )
+    if not firewall_rule:
+        raise ResourceNotFoundException(
+            f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+        )
+    return firewall_rule
+
+def delete_firewall_rule(firewall_rule_group_id, firewall_domain_list_id):
+    # if firewall_rules doesn't exist it will throw an error
+    region_details = Route53ResolverBackend.get()
+    firewall_rule = region_details.get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
+    region_details.firewall_rules.get(firewall_rule_group_id, {}).pop(firewall_domain_list_id)
+    return firewall_rule

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -62,17 +62,16 @@ from localstack.services.route53resolver.models import (
     get_firewall_rule_group,
     get_firewall_rule_group_association,
 )
-from localstack.utils.aws import aws_stack
-from localstack.utils.collections import select_from_typed_dict
-from localstack.utils.patch import patch
-
-from .utils import (
+from localstack.services.route53resolver.utils import (
     get_route53_resolver_firewall_domain_list_id,
     get_route53_resolver_firewall_rule_group_association_id,
     get_route53_resolver_firewall_rule_group_id,
     validate_mutation_protection,
     validate_priority,
 )
+from localstack.utils.aws import aws_stack
+from localstack.utils.collections import select_from_typed_dict
+from localstack.utils.patch import patch
 
 
 class Route53ResolverProvider(Route53ResolverApi):

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -167,7 +167,7 @@ class Route53ResolverProvider(Route53ResolverApi):
     ) -> GetFirewallDomainListResponse:
         """Get the details of a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain(
+        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain_list(
             firewall_domain_list_id
         )
         return GetFirewallDomainListResponse(FirewallDomainList=firewall_domain_list)
@@ -193,7 +193,7 @@ class Route53ResolverProvider(Route53ResolverApi):
     ) -> UpdateFirewallDomainsResponse:
         """Update the domains in a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain_lists(
+        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain_list(
             firewall_domain_list_id
         )
         firewall_domains = region_details.get_firewall_domain(firewall_domain_list_id)

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -193,7 +193,7 @@ class Route53ResolverProvider(Route53ResolverApi):
     ) -> UpdateFirewallDomainsResponse:
         """Update the domains in a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain_list(
+        firewall_domain_list: FirewallDomainList = get_firewall_domain_list(
             firewall_domain_list_id
         )
 

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -193,9 +193,7 @@ class Route53ResolverProvider(Route53ResolverApi):
     ) -> UpdateFirewallDomainsResponse:
         """Update the domains in a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        firewall_domain_list: FirewallDomainList = get_firewall_domain_list(
-            firewall_domain_list_id
-        )
+        firewall_domain_list: FirewallDomainList = get_firewall_domain_list(firewall_domain_list_id)
 
         firewall_domain_list: FirewallDomainList = get_firewall_domain_list(firewall_domain_list_id)
         firewall_domains = get_firewall_domain(firewall_domain_list_id)

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from typing import Optional
 
 from moto.route53resolver.models import Route53ResolverBackend as MotoRoute53ResolverBackend
 from moto.route53resolver.models import route53resolver_backends as moto_route53resolver_backends
@@ -7,6 +6,7 @@ from moto.route53resolver.models import route53resolver_backends as moto_route53
 from localstack.aws.api import RequestContext
 from localstack.aws.api.route53resolver import (
     Action,
+    AssociateFirewallRuleGroupResponse,
     BlockOverrideDnsType,
     BlockOverrideDomain,
     BlockOverrideTtl,
@@ -18,6 +18,7 @@ from localstack.aws.api.route53resolver import (
     DeleteFirewallDomainListResponse,
     DeleteFirewallRuleGroupResponse,
     DeleteFirewallRuleResponse,
+    DisassociateFirewallRuleGroupResponse,
     FirewallDomainList,
     FirewallDomainListMetadata,
     FirewallDomainName,
@@ -25,8 +26,10 @@ from localstack.aws.api.route53resolver import (
     FirewallDomainUpdateOperation,
     FirewallRule,
     FirewallRuleGroup,
+    FirewallRuleGroupAssociation,
     FirewallRuleGroupMetadata,
     GetFirewallDomainListResponse,
+    GetFirewallRuleGroupAssociationResponse,
     GetFirewallRuleGroupResponse,
     ListDomainMaxResults,
     ListFirewallDomainListsResponse,
@@ -34,6 +37,7 @@ from localstack.aws.api.route53resolver import (
     ListFirewallRuleGroupsResponse,
     ListFirewallRulesResponse,
     MaxResults,
+    MutationProtectionStatus,
     Name,
     NextToken,
     Priority,
@@ -42,6 +46,7 @@ from localstack.aws.api.route53resolver import (
     Route53ResolverApi,
     TagList,
     UpdateFirewallDomainsResponse,
+    UpdateFirewallRuleGroupAssociationResponse,
     UpdateFirewallRuleResponse,
     ValidationException,
 )
@@ -49,15 +54,14 @@ from localstack.services.route53resolver.models import Route53ResolverBackend
 from localstack.utils.aws import aws_stack
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.patch import patch
-from localstack.utils.strings import get_random_hex
 
-
-def get_route53_resolver_firewall_rule_group_id():
-    return f"rslvr-frg-{get_random_hex(17)}"
-
-
-def get_route53_resolver_firewall_domain_list_id():
-    return f"rslvr-fdl-{get_random_hex(17)}"
+from .utils import (
+    get_route53_resolver_firewall_domain_list_id,
+    get_route53_resolver_firewall_rule_group_association_id,
+    get_route53_resolver_firewall_rule_group_id,
+    validate_mutation_protection,
+    validate_priority,
+)
 
 
 class Route53ResolverProvider(Route53ResolverApi):
@@ -68,10 +72,11 @@ class Route53ResolverProvider(Route53ResolverApi):
         name: Name,
         tags: TagList = None,
     ) -> CreateFirewallRuleGroupResponse:
+        """Create a Firewall Rule Group."""
         region_details = Route53ResolverBackend.get()
         id = get_route53_resolver_firewall_rule_group_id()
         arn = aws_stack.get_route53_resolver_firewall_rule_group_arn(id)
-        firewall_rule_group: Optional[FirewallRuleGroup] = FirewallRuleGroup(
+        firewall_rule_group = FirewallRuleGroup(
             Id=id,
             Arn=arn,
             Name=name,
@@ -91,12 +96,9 @@ class Route53ResolverProvider(Route53ResolverApi):
     def delete_firewall_rule_group(
         self, context: RequestContext, firewall_rule_group_id: ResourceId
     ) -> DeleteFirewallRuleGroupResponse:
+        """Delete a Firewall Rule Group."""
         region_details = Route53ResolverBackend.get()
-        if not region_details.firewall_rule_groups.get(firewall_rule_group_id):
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '1-{get_random_hex(8)}-{get_random_hex(24)}'"
-            )
-        firewall_rule_group: Optional[FirewallRuleGroup] = region_details.firewall_rule_groups.pop(
+        firewall_rule_group: FirewallRuleGroup = region_details.delete_firewall_rule_group(
             firewall_rule_group_id
         )
         return DeleteFirewallRuleGroupResponse(FirewallRuleGroup=firewall_rule_group)
@@ -104,19 +106,17 @@ class Route53ResolverProvider(Route53ResolverApi):
     def get_firewall_rule_group(
         self, context: RequestContext, firewall_rule_group_id: ResourceId
     ) -> GetFirewallRuleGroupResponse:
+        """Get the details of a Firewall Rule Group."""
         region_details = Route53ResolverBackend.get()
-        firewall_rule_group: Optional[FirewallRuleGroup] = region_details.firewall_rule_groups.get(
+        firewall_rule_group: FirewallRuleGroup = region_details.get_firewall_rule_group(
             firewall_rule_group_id
         )
-        if not firewall_rule_group:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '1-{get_random_hex(8)}-{get_random_hex(24)}'"
-            )
         return GetFirewallRuleGroupResponse(FirewallRuleGroup=firewall_rule_group)
 
     def list_firewall_rule_groups(
         self, context: RequestContext, max_results: MaxResults = None, next_token: NextToken = None
     ) -> ListFirewallRuleGroupsResponse:
+        """List Firewall Rule Groups."""
         region_details = Route53ResolverBackend.get()
         firewall_rule_groups = []
         for firewall_rule_group in region_details.firewall_rule_groups.values():
@@ -132,6 +132,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         name: Name,
         tags: TagList = None,
     ) -> CreateFirewallDomainListResponse:
+        """Create a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
         id = get_route53_resolver_firewall_domain_list_id()
         arn = aws_stack.get_route53_resolver_firewall_domain_list_arn(id)
@@ -154,32 +155,27 @@ class Route53ResolverProvider(Route53ResolverApi):
     def delete_firewall_domain_list(
         self, context: RequestContext, firewall_domain_list_id: ResourceId
     ) -> DeleteFirewallDomainListResponse:
+        """Delete a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        if not region_details.firewall_domain_lists.get(firewall_domain_list_id):
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_domain_list_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        firewall_domain_list: Optional[
-            FirewallDomainList
-        ] = region_details.firewall_domain_lists.pop(firewall_domain_list_id)
+        firewall_domain_list: FirewallDomainList = region_details.delete_firewall_domain_list(
+            firewall_domain_list_id
+        )
         return DeleteFirewallDomainListResponse(FirewallDomainList=firewall_domain_list)
 
     def get_firewall_domain_list(
         self, context: RequestContext, firewall_domain_list_id: ResourceId
     ) -> GetFirewallDomainListResponse:
+        """Get the details of a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        firewall_domain_list: Optional[
-            FirewallDomainList
-        ] = region_details.firewall_domain_lists.get(firewall_domain_list_id)
-        if not firewall_domain_list:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_domain_list_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
+        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain(
+            firewall_domain_list_id
+        )
         return GetFirewallDomainListResponse(FirewallDomainList=firewall_domain_list)
 
     def list_firewall_domain_lists(
         self, context: RequestContext, max_results: MaxResults = None, next_token: NextToken = None
     ) -> ListFirewallDomainListsResponse:
+        """List all Firewall Domain Lists."""
         region_details = Route53ResolverBackend.get()
         firewall_domain_lists = []
         for firewall_domain_list in region_details.firewall_domain_lists.values():
@@ -195,20 +191,19 @@ class Route53ResolverProvider(Route53ResolverApi):
         operation: FirewallDomainUpdateOperation,
         domains: FirewallDomains,
     ) -> UpdateFirewallDomainsResponse:
+        """Update the domains in a Firewall Domain List."""
         region_details = Route53ResolverBackend.get()
-        firewall_domain_list: FirewallDomainList = region_details.firewall_domain_lists.get(
+        firewall_domain_list: FirewallDomainList = region_details.get_firewall_domain_lists(
             firewall_domain_list_id
         )
-        if not firewall_domain_list:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_domain_list_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        firewall_domains = region_details.firewall_domains.get(firewall_domain_list_id)
+        firewall_domains = region_details.get_firewall_domain(firewall_domain_list_id)
+
         if operation == FirewallDomainUpdateOperation.ADD:
             if not firewall_domains:
                 region_details.firewall_domains[firewall_domain_list_id] = domains
             else:
                 region_details.firewall_domains[firewall_domain_list_id].append(domains)
+
         if operation == FirewallDomainUpdateOperation.REMOVE:
             if firewall_domains:
                 for domain in domains:
@@ -218,9 +213,12 @@ class Route53ResolverProvider(Route53ResolverApi):
                         raise ValidationException(
                             f"[RSLVR-02502] The following domains don't exist in the DNS Firewall domain list '{firewall_domain_list_id}'. You can't delete a domain that isn't in a domain list. Example unknown domain: '{domain}'. Trace Id: '{aws_stack.get_trace_id()}'"
                         )
+
         if operation == FirewallDomainUpdateOperation.REPLACE:
             region_details.firewall_domains[firewall_domain_list_id] = domains
+
         firewall_domain_list["StatusMessage"] = "Finished domain list update"
+        firewall_domain_list["ModificationTime"] = datetime.now(timezone.utc).isoformat()
         return UpdateFirewallDomainsResponse(
             Id=firewall_domain_list.get("Id"),
             Name=firewall_domain_list.get("Name"),
@@ -235,6 +233,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         max_results: ListDomainMaxResults = None,
         next_token: NextToken = None,
     ) -> ListFirewallDomainsResponse:
+        """List the domains in a DNS Firewall domain list."""
         region_details = Route53ResolverBackend.get()
         firewall_domains: FirewallDomains[FirewallDomainName] = []
         if region_details.firewall_domains.get(firewall_domain_list_id):
@@ -256,6 +255,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         block_override_dns_type: BlockOverrideDnsType = None,
         block_override_ttl: BlockOverrideTtl = None,
     ) -> CreateFirewallRuleResponse:
+        """Create a new firewall rule"""
         region_details = Route53ResolverBackend.get()
         firewall_rule = FirewallRule(
             FirewallRuleGroupId=firewall_rule_group_id,
@@ -288,16 +288,11 @@ class Route53ResolverProvider(Route53ResolverApi):
         firewall_rule_group_id: ResourceId,
         firewall_domain_list_id: ResourceId,
     ) -> DeleteFirewallRuleResponse:
+        """Delete a firewall rule"""
         region_details = Route53ResolverBackend.get()
-        if not region_details.firewall_rules.get(firewall_rule_group_id, {}).get(
-            firewall_domain_list_id
-        ):
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
-        firewall_rule: FirewallRule = region_details.firewall_rules.get(
-            firewall_rule_group_id, {}
-        ).pop(firewall_domain_list_id)
+        firewall_rule: FirewallRule = region_details.delete_firewall_rule(
+            firewall_rule_group_id, firewall_domain_list_id
+        )
         return DeleteFirewallRuleResponse(
             FirewallRule=firewall_rule,
         )
@@ -311,6 +306,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         max_results: MaxResults = None,
         next_token: NextToken = None,
     ) -> ListFirewallRulesResponse:
+        """List all the firewall rules in a firewall rule group."""
         region_details = Route53ResolverBackend.get()
         firewall_rules = []
         for firewall_rule in region_details.firewall_rules.get(firewall_rule_group_id, {}).values():
@@ -336,14 +332,12 @@ class Route53ResolverProvider(Route53ResolverApi):
         block_override_ttl: BlockOverrideTtl = None,
         name: Name = None,
     ) -> UpdateFirewallRuleResponse:
+        """Updates a firewall rule"""
         region_details = Route53ResolverBackend.get()
-        firewall_rule: FirewallRule = region_details.firewall_rules.get(
-            firewall_rule_group_id, {}
-        ).get(firewall_domain_list_id)
-        if not firewall_rule:
-            raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
-            )
+        firewall_rule: FirewallRule = region_details.get_firewall_rule(
+            firewall_rule_group_id, firewall_domain_list_id
+        )
+
         if priority:
             firewall_rule["Priority"] = priority
         if action:
@@ -362,6 +356,109 @@ class Route53ResolverProvider(Route53ResolverApi):
             FirewallRule=firewall_rule,
         )
 
+    def associate_firewall_rule_group(
+        self,
+        context: RequestContext,
+        creator_request_id: CreatorRequestId,
+        firewall_rule_group_id: ResourceId,
+        vpc_id: ResourceId,
+        priority: Priority,
+        name: Name,
+        mutation_protection: MutationProtectionStatus = None,
+        tags: TagList = None,
+    ) -> AssociateFirewallRuleGroupResponse:
+        """Associate a firewall rule group with a VPC."""
+        region_details = Route53ResolverBackend.get()
+        validate_priority(priority=priority)
+        validate_mutation_protection(mutation_protection=mutation_protection)
+
+        for (
+            firewall_rule_group_association
+        ) in region_details.firewall_rule_group_associations.values():
+            if (
+                firewall_rule_group_association.get("VpcId") == vpc_id
+                and firewall_rule_group_association.get("FirewallRuleGroupId")
+                == firewall_rule_group_id
+            ):
+                raise ValidationException(
+                    f"[RSLVR-02302] This DNS Firewall rule group can't be associated to a VPC: '{vpc_id}'. It is already associated to VPC '{firewall_rule_group_id}'. Try again with another VPC or DNS Firewall rule group. Trace Id: '{aws_stack.get_trace_id()}'"
+                )
+
+        id = get_route53_resolver_firewall_rule_group_association_id()
+        arn = aws_stack.get_route53_resolver_firewall_rule_group_associations_arn(id)
+
+        firewall_rule_group_association = FirewallRuleGroupAssociation(
+            Id=id,
+            Arn=arn,
+            FirewallRuleGroupId=firewall_rule_group_id,
+            VpcId=vpc_id,
+            Name=name,
+            Priority=priority,
+            MutationProtection=mutation_protection or "DISABLED",
+            Status="COMPLETE",
+            StatusMessage="Creating Firewall Rule Group Association",
+            CreatorRequestId=creator_request_id,
+            CreationTime=datetime.now(timezone.utc).isoformat(),
+            ModificationTime=datetime.now(timezone.utc).isoformat(),
+        )
+        region_details.firewall_rule_group_associations[id] = firewall_rule_group_association
+        moto_route53resolver_backends[context.region].tagger.tag_resource(arn, tags or [])
+        return AssociateFirewallRuleGroupResponse(
+            FirewallRuleGroupAssociation=firewall_rule_group_association
+        )
+
+    def disassociate_firewall_rule_group(
+        self, context: RequestContext, firewall_rule_group_association_id: ResourceId
+    ) -> DisassociateFirewallRuleGroupResponse:
+        """Disassociate a DNS Firewall rule group from a VPC."""
+        region_details = Route53ResolverBackend.get()
+        firewall_rule_group_association = region_details.delete_firewall_rule_group_association(
+            firewall_rule_group_association_id
+        )
+        return DisassociateFirewallRuleGroupResponse(
+            FirewallRuleGroupAssociation=firewall_rule_group_association
+        )
+
+    def get_firewall_rule_group_association(
+        self, context: RequestContext, firewall_rule_group_association_id: ResourceId
+    ) -> GetFirewallRuleGroupAssociationResponse:
+        """Returns the Firewall Rule Group Association that you specified."""
+        region_details = Route53ResolverBackend.get()
+        firewall_rule_group_association = region_details.get_firewall_rule_group_association(
+            firewall_rule_group_association_id
+        )
+        return GetFirewallRuleGroupAssociationResponse(
+            FirewallRuleGroupAssociation=firewall_rule_group_association
+        )
+
+    def update_firewall_rule_group_association(
+        self,
+        context: RequestContext,
+        firewall_rule_group_association_id: ResourceId,
+        priority: Priority = None,
+        mutation_protection: MutationProtectionStatus = None,
+        name: Name = None,
+    ) -> UpdateFirewallRuleGroupAssociationResponse:
+        """Updates the specified Firewall Rule Group Association."""
+        region_details = Route53ResolverBackend.get()
+        validate_priority(priority=priority)
+        validate_mutation_protection(mutation_protection=mutation_protection)
+
+        firewall_rule_group_association = region_details.get_firewall_rule_group_association(
+            firewall_rule_group_association_id
+        )
+
+        if priority:
+            firewall_rule_group_association["Priority"] = priority
+        if mutation_protection:
+            firewall_rule_group_association["MutationProtection"] = mutation_protection
+        if name:
+            firewall_rule_group_association["Name"] = name
+
+        return UpdateFirewallRuleGroupAssociationResponse(
+            FirewallRuleGroupAssociation=firewall_rule_group_association
+        )
+
 
 @patch(MotoRoute53ResolverBackend._matched_arn)
 def Route53ResolverBackend_matched_arn(fn, self, resource_arn):
@@ -372,5 +469,8 @@ def Route53ResolverBackend_matched_arn(fn, self, resource_arn):
             return
     for firewall_domain_list in region_details.firewall_domain_lists.values():
         if firewall_domain_list.get("Arn") == resource_arn:
+            return
+    for firewall_rule_group_association in region_details.firewall_rule_group_associations.values():
+        if firewall_rule_group_association.get("Arn") == resource_arn:
             return
     fn(self, resource_arn)

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -50,7 +50,18 @@ from localstack.aws.api.route53resolver import (
     UpdateFirewallRuleResponse,
     ValidationException,
 )
-from localstack.services.route53resolver.models import Route53ResolverBackend, delete_firewall_domain, delete_firewall_domain_list, delete_firewall_rule, delete_firewall_rule_group, delete_firewall_rule_group_association, get_firewall_domain, get_firewall_domain_list, get_firewall_rule, get_firewall_rule_group, get_firewall_rule_group_association
+from localstack.services.route53resolver.models import (
+    Route53ResolverBackend,
+    delete_firewall_domain_list,
+    delete_firewall_rule,
+    delete_firewall_rule_group,
+    delete_firewall_rule_group_association,
+    get_firewall_domain,
+    get_firewall_domain_list,
+    get_firewall_rule,
+    get_firewall_rule_group,
+    get_firewall_rule_group_association,
+)
 from localstack.utils.aws import aws_stack
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.patch import patch
@@ -150,7 +161,9 @@ class Route53ResolverProvider(Route53ResolverApi):
         self, context: RequestContext, firewall_domain_list_id: ResourceId
     ) -> DeleteFirewallDomainListResponse:
         """Delete a Firewall Domain List."""
-        firewall_domain_list: FirewallDomainList = delete_firewall_domain_list(firewall_domain_list_id)
+        firewall_domain_list: FirewallDomainList = delete_firewall_domain_list(
+            firewall_domain_list_id
+        )
         return DeleteFirewallDomainListResponse(FirewallDomainList=firewall_domain_list)
 
     def get_firewall_domain_list(
@@ -279,7 +292,9 @@ class Route53ResolverProvider(Route53ResolverApi):
         firewall_domain_list_id: ResourceId,
     ) -> DeleteFirewallRuleResponse:
         """Delete a firewall rule"""
-        firewall_rule: FirewallRule = delete_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
+        firewall_rule: FirewallRule = delete_firewall_rule(
+            firewall_rule_group_id, firewall_domain_list_id
+        )
         return DeleteFirewallRuleResponse(
             FirewallRule=firewall_rule,
         )
@@ -321,7 +336,9 @@ class Route53ResolverProvider(Route53ResolverApi):
         name: Name = None,
     ) -> UpdateFirewallRuleResponse:
         """Updates a firewall rule"""
-        firewall_rule: FirewallRule = get_firewall_rule(firewall_rule_group_id, firewall_domain_list_id)
+        firewall_rule: FirewallRule = get_firewall_rule(
+            firewall_rule_group_id, firewall_domain_list_id
+        )
 
         if priority:
             firewall_rule["Priority"] = priority
@@ -396,7 +413,9 @@ class Route53ResolverProvider(Route53ResolverApi):
         self, context: RequestContext, firewall_rule_group_association_id: ResourceId
     ) -> DisassociateFirewallRuleGroupResponse:
         """Disassociate a DNS Firewall rule group from a VPC."""
-        firewall_rule_group_association: FirewallRuleGroupAssociation = delete_firewall_rule_group_association(firewall_rule_group_association_id)
+        firewall_rule_group_association: FirewallRuleGroupAssociation = (
+            delete_firewall_rule_group_association(firewall_rule_group_association_id)
+        )
         return DisassociateFirewallRuleGroupResponse(
             FirewallRuleGroupAssociation=firewall_rule_group_association
         )
@@ -405,8 +424,9 @@ class Route53ResolverProvider(Route53ResolverApi):
         self, context: RequestContext, firewall_rule_group_association_id: ResourceId
     ) -> GetFirewallRuleGroupAssociationResponse:
         """Returns the Firewall Rule Group Association that you specified."""
-        firewall_rule_group_association: FirewallRuleGroupAssociation = get_firewall_rule_group_association(firewall_rule_group_association_id)
-        region_details = Route53ResolverBackend.get()
+        firewall_rule_group_association: FirewallRuleGroupAssociation = (
+            get_firewall_rule_group_association(firewall_rule_group_association_id)
+        )
         return GetFirewallRuleGroupAssociationResponse(
             FirewallRuleGroupAssociation=firewall_rule_group_association
         )
@@ -420,12 +440,11 @@ class Route53ResolverProvider(Route53ResolverApi):
         name: Name = None,
     ) -> UpdateFirewallRuleGroupAssociationResponse:
         """Updates the specified Firewall Rule Group Association."""
-        region_details = Route53ResolverBackend.get()
         validate_priority(priority=priority)
         validate_mutation_protection(mutation_protection=mutation_protection)
 
-        firewall_rule_group_association = region_details.get_firewall_rule_group_association(
-            firewall_rule_group_association_id
+        firewall_rule_group_association: FirewallRuleGroupAssociation = (
+            get_firewall_rule_group_association(firewall_rule_group_association_id)
         )
 
         if priority:

--- a/localstack/services/route53resolver/utils.py
+++ b/localstack/services/route53resolver/utils.py
@@ -1,0 +1,32 @@
+from localstack.aws.api.route53resolver import ValidationException
+from localstack.utils.aws import aws_stack
+from localstack.utils.strings import get_random_hex
+
+
+def get_route53_resolver_firewall_rule_group_id():
+    return f"rslvr-frg-{get_random_hex(17)}"
+
+
+def get_route53_resolver_firewall_domain_list_id():
+    return f"rslvr-fdl-{get_random_hex(17)}"
+
+
+def get_route53_resolver_firewall_rule_group_association_id():
+    return f"rslvr-frgassoc-{get_random_hex(17)}"
+
+
+def validate_priority(priority):
+    # value of priority can be null in case of update
+    if priority:
+        if priority not in range(100, 9900):
+            raise ValidationException(
+                f"[RSLVR-02017] The priority value you provided is reserved. Provide a number between '100' and '9900'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )
+
+
+def validate_mutation_protection(mutation_protection):
+    if mutation_protection:
+        if mutation_protection not in ["ENABLED", "DISABLED"]:
+            raise ValidationException(
+                f"[RSLVR-02018] The mutation protection value you provided is reserved. Provide a value of 'ENABLED' or 'DISABLED'. Trace Id: '{aws_stack.get_trace_id()}'"
+            )

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -1291,5 +1291,12 @@ def get_route53_resolver_firewall_domain_list_arn(
     return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
 
 
+def get_route53_resolver_firewall_rule_group_associations_arn(
+    id: str, account_id: str = None, region_name: str = None
+):
+    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group-association/%s"
+    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
+
+
 def get_trace_id():
     return f"1-{get_random_hex(8)}-{get_random_hex(24)}"

--- a/tests/terraform/terraform-tests.yaml
+++ b/tests/terraform/terraform-tests.yaml
@@ -7,9 +7,7 @@ route53resolver:
     - TestAccRoute53ResolverFirewallRule_block
     - TestAccRoute53ResolverFirewallRule_blockOverride
     - TestAccRoute53ResolverFirewallRule_disappears
-    - TestAccRoute53ResolverFirewallRuleGroup_basic
-    - TestAccRoute53ResolverFirewallRuleGroup_disappears
-    - TestAccRoute53ResolverFirewallRuleGroup_tags
+    - TestAccRoute53ResolverFirewallRuleGroup
     - TestAccRoute53ResolverFirewallDomainList
 s3:
     - TestAccS3ObjectCopy


### PR DESCRIPTION
## APIs
- associate_firewall_rule_group
- disassociate_firewall_rule_group
- get_firewall_rule_group_association
- update_firewall_rule_group_association

## Improvements
- Isolated retrieval in models
- Added utils file


## Terraform Tests
**TestAccRoute53ResolverFirewallRuleGroupAssociation**
(this test will be included in - `TestAccRoute53ResolverFirewallRuleGroup` for tf Pipeline)
- route53resolver:TestAccRoute53ResolverFirewallRuleGroupAssociation_basic
- route53resolver:TestAccRoute53ResolverFirewallRuleGroupAssociation_name
- route53resolver:TestAccRoute53ResolverFirewallRuleGroupAssociation_mutationProtection
- route53resolver:TestAccRoute53ResolverFirewallRuleGroupAssociation_priority
- route53resolver:TestAccRoute53ResolverFirewallRuleGroupAssociation_disappears
- route53resolver:TestAccRoute53ResolverFirewallRuleGroupAssociation_tags