### PR TITLE
Feature: SNS msg delivery to Firehose endpoint

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -1130,6 +1130,15 @@ async def message_to_subscriber(
                 Destination={"ToAddresses": [subscriber.get("Endpoint")]},
             )
             store_delivery_log(subscriber, True, message, message_id)
+    elif subscriber["Protocol"] == "firehose":
+        firehose_client = aws_stack.connect_to_service("firehose")
+        endpoint = subscriber["Endpoint"]
+        if endpoint:
+            firehose_client.put_record(
+                DeliverStreamName=endpoint, Record={"Data": to_bytes(message)}
+            )
+            store_delivery_log(subscriber, True, message, message_id)
+        return
     else:
         LOG.warning('Unexpected protocol "%s" for SNS subscription', subscriber["Protocol"])
 

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -1133,9 +1133,13 @@ async def message_to_subscriber(
     elif subscriber["Protocol"] == "firehose":
         firehose_client = aws_stack.connect_to_service("firehose")
         endpoint = subscriber["Endpoint"]
+        sns_body = create_sns_message_body(
+            subscriber=subscriber, req_data=req_data, message_id=message_id
+        )
         if endpoint:
+            delivery_stream = aws_stack.extract_resource_from_arn(endpoint).split("/")[1]
             firehose_client.put_record(
-                DeliverStreamName=endpoint, Record={"Data": to_bytes(message)}
+                DeliveryStreamName=delivery_stream, Record={"Data": to_bytes(sns_body)}
             )
             store_delivery_log(subscriber, True, message, message_id)
         return

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1461,6 +1461,25 @@ def create_iam_role_with_policy(iam_client):
 
 
 @pytest.fixture
+def firehose_create_delivery_stream(firehose_client, wait_for_delivery_stream_ready):
+    delivery_streams = {}
+
+    def _create_delivery_stream(**kwargs):
+        if "DeliveryStreamName" not in kwargs:
+            kwargs["DeliveryStreamName"] = f"test-delivery-stream-{short_uid()}"
+
+        delivery_stream = firehose_client.create_delivery_stream(**kwargs)
+        delivery_streams.update({kwargs["DeliveryStreamName"]: delivery_stream})
+        wait_for_delivery_stream_ready(kwargs["DeliveryStreamName"])
+        return delivery_stream
+
+    yield _create_delivery_stream
+
+    for delivery_stream_name in delivery_streams.keys():
+        firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
+
+
+@pytest.fixture
 def cleanups(ec2_client):
     cleanup_fns = []
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -704,6 +704,23 @@ def wait_for_stream_ready(kinesis_client):
     return _wait_for_stream_ready
 
 
+@pytest.fixture
+def wait_for_delivery_stream_ready(firehose_client):
+    def _wait_for_stream_ready(delivery_stream_name: str):
+        def is_stream_ready():
+            describe_stream_response = firehose_client.describe_delivery_stream(
+                DeliveryStreamName=delivery_stream_name
+            )
+            return (
+                describe_stream_response["DeliveryStreamDescription"]["DeliveryStreamStatus"]
+                == "ACTIVE"
+            )
+
+        poll_condition(is_stream_ready)
+
+    return _wait_for_stream_ready
+
+
 @pytest.fixture()
 def kms_create_key(kms_client):
     key_ids = []

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -3,6 +3,7 @@ import json
 import queue
 import random
 import time
+from io import BytesIO
 from operator import itemgetter
 
 import pytest
@@ -19,7 +20,7 @@ from localstack.services.sns.provider import SNSBackend
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils import testutil
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
-from localstack.utils.strings import short_uid
+from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
@@ -2185,3 +2186,108 @@ class TestSNSProvider:
             )
 
             snapshot.match(f"message-{i}-after-delete", response)
+
+    def test_publish_to_firehose_with_s3(
+        self,
+        s3_client,
+        iam_client,
+        firehose_client,
+        sns_client,
+        create_role,
+        s3_create_bucket,
+        wait_for_delivery_stream_ready,
+        sns_create_topic,
+        sns_subscription,
+    ):
+        role_name = f"test-role-{short_uid()}"
+        stream_name = f"test-stream-{short_uid()}"
+        bucket_name = f"test-bucket-{short_uid()}"
+        topic_name = f"test_topic_{short_uid()}"
+
+        subscription_role_arn = f"arn:aws:iam::{get_aws_account_id()}:role/{role_name}"
+        if is_aws_cloud():
+            trust_policy = {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "s3.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "firehose.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "sns.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    },
+                ],
+            }
+
+            role = create_role(
+                RoleName=role_name, AssumeRolePolicyDocument=json.dumps(trust_policy)
+            )
+
+            iam_client.attach_role_policy(
+                RoleName=role_name,
+                PolicyArn="arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess",
+            )
+
+            iam_client.attach_role_policy(
+                RoleName=role_name, PolicyArn="arn:aws:iam::aws:policy/AmazonS3FullAccess"
+            )
+            subscription_role_arn = role["Role"]["Arn"]
+            # if used instantly, permissions are not complete
+            time.sleep(10)
+
+        s3_create_bucket(Bucket=bucket_name)
+
+        stream = firehose_client.create_delivery_stream(
+            DeliveryStreamName=stream_name,
+            DeliveryStreamType="DirectPut",
+            S3DestinationConfiguration={
+                "RoleARN": subscription_role_arn,
+                "BucketARN": f"arn:aws:s3:::{bucket_name}",
+            },
+        )
+
+        wait_for_delivery_stream_ready(stream_name)
+
+        topic = sns_create_topic(Name=topic_name)
+        sns_subscription(
+            TopicArn=topic["TopicArn"],
+            Protocol="firehose",
+            Endpoint=stream["DeliveryStreamARN"],
+            Attributes={"SubscriptionRoleArn": subscription_role_arn},
+            ReturnSubscriptionArn=True,
+        )
+
+        message = json.dumps({"message": "hello world"})
+        message_attributes = {
+            "testAttribute": {"DataType": "String", "StringValue": "valueOfAttribute"}
+        }
+        sns_client.publish(
+            TopicArn=topic["TopicArn"], Message=message, MessageAttributes=message_attributes
+        )
+
+        def validate_content():
+            files = s3_client.list_objects(Bucket=bucket_name)["Contents"]
+            f = BytesIO()
+            s3_client.download_fileobj(bucket_name, files[0]["Key"], f)
+            content = to_str(f.getvalue())
+
+            sns_message = json.loads(content.split("\n")[0])
+
+            assert "Type" in sns_message
+            assert "MessageId" in sns_message
+            assert "Message" in sns_message
+            assert "Timestamp" in sns_message
+
+            assert message == sns_message["Message"]
+
+        retry(validate_content, retries=10, sleep_before=0, sleep=1.5)
+
+        firehose_client.delete_delivery_stream(DeliveryStreamName=stream_name)


### PR DESCRIPTION
This PR addresses issue #5602. Allows the SNS to deliver messages to Firehose subscriptions.

Must be merged after spulec/moto#5303 has been integrated. If it takes too long I guess I'll merge it into the Moto-ext fork.