### PR TITLE
fix logging for CLI

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -1,5 +1,3 @@
-import logging
-
 from localstack.aws import handlers
 from localstack.aws.handlers.metric_handler import MetricHandler
 from localstack.aws.handlers.service_plugin import ServiceLoader
@@ -8,8 +6,6 @@ from localstack.services.plugins import SERVICE_PLUGINS, ServiceManager, Service
 from .gateway import Gateway
 from .handlers.fallback import EmptyResponseHandler
 from .handlers.service import ServiceRequestRouter
-
-LOG = logging.getLogger("localstack.gateway")
 
 
 class LocalstackAwsGateway(Gateway):

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -90,12 +90,11 @@ class ResponseLogger:
             # log an AWS response
             if context.service_exception:
                 aws_logger.info(
-                    "AWS %s.%s => %d (%s))",
+                    "AWS %s.%s => %d (%s)",
                     context.service.service_name,
                     context.operation.name,
                     response.status_code,
                     context.service_exception.code,
-                    # request
                     extra={
                         # request
                         "input_type": context.operation.input_shape.name

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 from typing import Dict, List, Optional
@@ -31,12 +32,12 @@ def create_with_plugins() -> LocalstackCli:
 
 
 def _setup_cli_debug():
-    from localstack.utils.bootstrap import setup_logging
+    from localstack.logging.setup import setup_logging_for_cli
 
     config.DEBUG = True
     os.environ["DEBUG"] = "1"
 
-    setup_logging()
+    setup_logging_for_cli(logging.DEBUG if config.DEBUG else logging.INFO)
 
 
 @click.group(name="localstack", help="The LocalStack Command Line Interface (CLI)")

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -34,6 +34,16 @@ trace_internal_log_levels = {
 }
 
 
+def setup_logging_for_cli(log_level=logging.INFO):
+    logging.basicConfig(level=log_level)
+
+    # set log levels of loggers
+    logging.root.setLevel(log_level)
+    logging.getLogger("localstack").setLevel(log_level)
+    for logger, level in default_log_levels.items():
+        logging.getLogger(logger).setLevel(level)
+
+
 def get_log_level_from_config():
     # overriding the log level if LS_LOG has been set
     if config.LS_LOG:


### PR DESCRIPTION
This PR fixes logging for the CLI. We were using a feature of python 3.8 for the runtime logging (the `force=True` flag of `basicConfig`) which was essential to the setup process, so i simplified the logging configuration for the CLI to make it work for python 3.7.
i also cleaned up a couple of things that were left over from #6424 

tested locally with pyenv and python 3.7 as well as 3.10