### PR TITLE
fix python 3.7 compat of setup_hypercorn_logger for cli

### DIFF
--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -105,10 +105,12 @@ def setup_hypercorn_logger(hypercorn_config) -> None:
 
     :param hypercorn_config: a hypercorn.Config object
     """
-    if logger := hypercorn_config.log.access_logger:
+    logger = hypercorn_config.log.access_logger
+    if logger:
         logger.handlers[0].addFilter(AddFormattedAttributes())
         logger.handlers[0].setFormatter(DefaultFormatter())
 
-    if logger := hypercorn_config.log.error_logger:
+    logger = hypercorn_config.log.error_logger
+    if logger:
         logger.handlers[0].addFilter(AddFormattedAttributes())
         logger.handlers[0].setFormatter(DefaultFormatter())


### PR DESCRIPTION
This PR fixes a python 3.7 compat issue with the CLI that would raise a syntax error:

```
thomas@om /tmp/test37 % python -m localstack.cli.main --debug start --host
error importing entrypoint EntryPoint(name='login', value='localstack_ext.cli.localstack:LoginCliPlugin', group='localstack.plugins.cli'): cannot import name 'Literal' from 'typing' (/home/thomas/.pyenv/versions/3.7.13/lib/python3.7/typing.py)
error importing entrypoint EntryPoint(name='pro', value='localstack_ext.cli.localstack:ProCliPlugin', group='localstack.plugins.cli'): cannot import name 'Literal' from 'typing' (/home/thomas/.pyenv/versions/3.7.13/lib/python3.7/typing.py)
Traceback (most recent call last):
  File "/home/thomas/.pyenv/versions/3.7.13/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/thomas/.pyenv/versions/3.7.13/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/thomas/workspace/localstack/localstack/localstack/cli/main.py", line 10, in <module>
    main()
  File "/home/thomas/workspace/localstack/localstack/localstack/cli/main.py", line 6, in main
    cli()
  File "/home/thomas/workspace/localstack/localstack/localstack/cli/plugin.py", line 15, in __call__
    self.group(*args, **kwargs)
  File "/tmp/test37/.venv/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/tmp/test37/.venv/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/tmp/test37/.venv/lib/python3.7/site-packages/click/core.py", line 1654, in invoke
    super().invoke(ctx)
  File "/tmp/test37/.venv/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/tmp/test37/.venv/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/thomas/workspace/localstack/localstack/localstack/cli/localstack.py", line 51, in localstack
    _setup_cli_debug()
  File "/home/thomas/workspace/localstack/localstack/localstack/cli/localstack.py", line 35, in _setup_cli_debug
    from localstack.logging.setup import setup_logging_for_cli
  File "/home/thomas/workspace/localstack/localstack/localstack/logging/setup.py", line 108
    if logger := hypercorn_config.log.access_logger:
               ^
SyntaxError: invalid syntax
```