### PR TITLE
fix aws header list parsing

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -233,6 +233,10 @@ class RequestParser(abc.ABC):
             if location == "header":
                 header_name = shape.serialization.get("name")
                 payload = request.headers.get(header_name)
+                if shape.type_name == "list":
+                    # headers may contain a comma separated list of values (e.g., the ObjectAttributes member in
+                    # s3.GetObjectAttributes), so we prepare it here for the handler, which will be `_parse_list`.
+                    payload = payload.split(",")
             elif location == "headers":
                 payload = self._parse_header_map(shape, request.headers)
                 # shapes with the location trait "headers" only contain strings and are not further processed

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -182,6 +182,17 @@ class TestS3:
         assert error["Code"] == "NoSuchBucket"
         assert error["Message"] == "The specified bucket does not exist"
 
+    @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        reason="currently not implemented in moto, see https://github.com/localstack/localstack/issues/6422"
+    )
+    def test_get_object_attributes_object_size(self, s3_client, s3_bucket):
+        s3_client.put_object(Bucket=s3_bucket, Key="data.txt", Body=b"69\n420\n")
+        response = s3_client.get_object_attributes(
+            Bucket=s3_bucket, Key="data.txt", ObjectAttributes=["ObjectSize"]
+        )
+        assert response["ObjectSize"] == 7
+
 
 class TestS3PresignedUrl:
     """

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1015,6 +1015,18 @@ def test_restxml_headers_parsing():
     )
 
 
+def test_restxml_header_list_parsing():
+    """Tests that list attributes that are encoded into headers are parsed correctly."""
+    _botocore_parser_integration_test(
+        service="s3",
+        action="GetObjectAttributes",
+        Bucket="test-bucket",
+        Key="/test-key",
+        # ObjectAttributesList is a list of strings with location:"header"
+        ObjectAttributes=["ObjectSize", "StorageClass"],
+    )
+
+
 def test_restxml_header_date_parsing():
     """Test the parsing of a map with the location trait 'headers'."""
     _botocore_parser_integration_test(


### PR DESCRIPTION
This PR fixes an issue with the ASF parser, where it didn't consider list-encoded types in header locations. See my comment in #6422, fix should be fairly self-explanatory.

I also added an integration test, but the feature is not implemented in moto yet, so cannot fix the issue right away.

## List header shapes

We previously made the assumption that shapes with the location "header" are only ever primitive types. However, "ObjectAttributes" in "s3.GetObjectAttributes" is a list shape which has the location "header".

The header arrives as, e.g., `x-amz-object-attributes: ObjectSize,StorageClass`.

I briefly verified that it's the only one. Here's the list of all shape members with location "header" that are not strings:
```
appconfig CreateHostedConfigurationVersion LatestVersionNumber Integer integer
ebs CompleteSnapshot ChangedBlocksCount ChangedBlocksCount integer
ebs PutSnapshotBlock DataLength DataLength integer
ebs PutSnapshotBlock Progress Progress integer
s3 CopyObject CopySourceIfModifiedSince CopySourceIfModifiedSince timestamp
s3 CopyObject CopySourceIfUnmodifiedSince CopySourceIfUnmodifiedSince timestamp
s3 CopyObject Expires Expires timestamp
s3 CopyObject BucketKeyEnabled BucketKeyEnabled boolean
s3 CopyObject ObjectLockRetainUntilDate ObjectLockRetainUntilDate timestamp
s3 CreateBucket ObjectLockEnabledForBucket ObjectLockEnabledForBucket boolean
s3 CreateMultipartUpload Expires Expires timestamp
s3 CreateMultipartUpload BucketKeyEnabled BucketKeyEnabled boolean
s3 CreateMultipartUpload ObjectLockRetainUntilDate ObjectLockRetainUntilDate timestamp
s3 DeleteObject BypassGovernanceRetention BypassGovernanceRetention boolean
s3 DeleteObjects BypassGovernanceRetention BypassGovernanceRetention boolean
s3 GetObject IfModifiedSince IfModifiedSince timestamp
s3 GetObject IfUnmodifiedSince IfUnmodifiedSince timestamp
s3 GetObjectAttributes MaxParts MaxParts integer
s3 GetObjectAttributes PartNumberMarker PartNumberMarker integer
s3 GetObjectAttributes ObjectAttributes ObjectAttributesList list
s3 HeadObject IfModifiedSince IfModifiedSince timestamp
s3 HeadObject IfUnmodifiedSince IfUnmodifiedSince timestamp
s3control CreateBucket ObjectLockEnabledForBucket ObjectLockEnabledForBucket boolean
s3control PutBucketPolicy ConfirmRemoveSelfBucketAccess ConfirmRemoveSelfBucketAccess boolean
sagemaker-runtime InvokeEndpointAsync RequestTTLSeconds RequestTTLSecondsHeader integer
```