### PR TITLE
fix authorizer object for rest api

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -173,7 +173,6 @@ jobs:
           source .venv/bin/activate
           bin/test_localstack_pro.sh
       - name: Run community integration tests
-        if: ${{ false }}
         env:
           DEBUG: 1
           DNS_ADDRESS: 0
@@ -182,19 +181,22 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "test"
           AWS_ACCESS_KEY_ID: "test"
           AWS_DEFAULT_REGION: "us-east-1"
+          HOST_TMP_FOLDER: /tmp/localstack
           PYTEST_LOGLEVEL: debug
         run: |
           # Remove the host tmp folder (might contain remnant files with different permissions)
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
           source .venv/bin/activate
-          python -m pytest --capture=no --reruns 2 --durations=10 --junitxml=target/reports/pytest.xml ../localstack/tests/integration/
+          python -m pytest --capture=no --reruns 2 --durations=10 --junitxml=target/reports/pytest.xml \
+            -k test_lambda_streams_batch_and_transactions \
+            ../localstack/tests/integration/
       - name: Run Lambda Tests for lambda executor docker
-        if: ${{ false }}
         env:
-          DEBUG: 0
+          DEBUG: 1
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "docker"
           LOCALSTACK_API_KEY: "test"
+          HOST_TMP_FOLDER: /tmp/localstack
         run: |
           # Remove the host tmp folder (might contain remnant files with different permissions)
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -187,12 +187,10 @@ jobs:
           # Remove the host tmp folder (might contain remnant files with different permissions)
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
           source .venv/bin/activate
-          python -m pytest --capture=no --reruns 2 --durations=10 --junitxml=target/reports/pytest.xml \
-            -k test_lambda_streams_batch_and_transactions \
-            ../localstack/tests/integration/
+          python -m pytest --capture=no --reruns 2 --durations=10 --junitxml=target/reports/pytest.xml ../localstack/tests/integration/
       - name: Run Lambda Tests for lambda executor docker
         env:
-          DEBUG: 1
+          DEBUG: 0
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "docker"
           LOCALSTACK_API_KEY: "test"
@@ -202,7 +200,6 @@ jobs:
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
           source .venv/bin/activate
           python -m pytest --reruns 2 --durations=10 --show-capture=no --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='lambda-docker' \
-            -k test_lambda_streams_batch_and_transactions \
             ../localstack/tests/integration/awslambda/ \
             ../localstack/tests/integration/test_integration.py \
             ../localstack/tests/integration/test_apigateway.py
@@ -218,7 +215,6 @@ jobs:
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
           source .venv/bin/activate
           python -m pytest --reruns 2 --durations=10 --show-capture=no --junitxml=target/reports/lambda-docker-reuse.xml -o junit_suite_name='lambda-docker-reuse' \
-            -k test_lambda_streams_batch_and_transactions \
             ../localstack/tests/integration/awslambda/ \
             ../localstack/tests/integration/test_integration.py \
             ../localstack/tests/integration/test_apigateway.py

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -173,6 +173,7 @@ jobs:
           source .venv/bin/activate
           bin/test_localstack_pro.sh
       - name: Run community integration tests
+        if: ${{ false }}
         env:
           DEBUG: 1
           DNS_ADDRESS: 0
@@ -188,6 +189,7 @@ jobs:
           source .venv/bin/activate
           python -m pytest --capture=no --reruns 2 --durations=10 --junitxml=target/reports/pytest.xml ../localstack/tests/integration/
       - name: Run Lambda Tests for lambda executor docker
+        if: ${{ false }}
         env:
           DEBUG: 0
           DNS_ADDRESS: 0
@@ -198,12 +200,13 @@ jobs:
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
           source .venv/bin/activate
           python -m pytest --reruns 2 --durations=10 --show-capture=no --junitxml=target/reports/lambda-docker.xml -o junit_suite_name='lambda-docker' \
+            -k test_lambda_streams_batch_and_transactions \
             ../localstack/tests/integration/awslambda/ \
             ../localstack/tests/integration/test_integration.py \
             ../localstack/tests/integration/test_apigateway.py
       - name: Run Lambda Tests for lambda executor docker-reuse
         env:
-          DEBUG: 0
+          DEBUG: 1
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "docker-reuse"
           LOCALSTACK_API_KEY: "test"
@@ -212,6 +215,7 @@ jobs:
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp
           source .venv/bin/activate
           python -m pytest --reruns 2 --durations=10 --show-capture=no --junitxml=target/reports/lambda-docker-reuse.xml -o junit_suite_name='lambda-docker-reuse' \
+            -k test_lambda_streams_batch_and_transactions \
             ../localstack/tests/integration/awslambda/ \
             ../localstack/tests/integration/test_integration.py \
             ../localstack/tests/integration/test_apigateway.py

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -210,6 +210,7 @@ jobs:
           DNS_ADDRESS: 0
           LAMBDA_EXECUTOR: "docker-reuse"
           LOCALSTACK_API_KEY: "test"
+          HOST_TMP_FOLDER: /tmp/localstack
         run: |
           # Remove the host tmp folder (might contain remnant files with different permissions)
           sudo rm -rf ../localstack/.filesystem/var/lib/localstack/tmp

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -167,10 +167,7 @@ class LambdaProxyIntegration(BackendIntegration):
             func_arn = uri.split(":lambda:path")[1].split("functions/")[1].split("/invocations")[0]
 
         if invocation_context.authorizer_type:
-            authorizer_context = {
-                invocation_context.authorizer_type: invocation_context.auth_context
-            }
-            invocation_context.context["authorizer"] = authorizer_context
+            invocation_context.context["authorizer"] = invocation_context.auth_context
 
         payload = self.request_templates.render(invocation_context)
 
@@ -203,7 +200,6 @@ class LambdaProxyIntegration(BackendIntegration):
             parsed_result = {} if parsed_result is None else parsed_result
 
             keys = parsed_result.keys()
-
             if not ("statusCode" in keys and "body" in keys):
                 LOG.warning(
                     'Lambda output should follow the next JSON format: { "isBase64Encoded": true|false, "statusCode": httpStatusCode, "headers": { "headerName": "headerValue", ... },"body": "..."}'

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -10,11 +10,6 @@ import pytest
 import xmltodict
 from botocore.exceptions import ClientError
 from jsonpatch import apply_patch
-
-from tests.integration.apigateway_fixtures import create_rest_api, create_rest_resource, create_rest_resource_method, \
-    create_rest_api_integration, api_invoke_url
-
-from localstack.utils.aws.aws_stack import create_api_gateway
 from moto.apigateway.models import APIGatewayBackend
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
@@ -34,7 +29,8 @@ from localstack.services.awslambda.lambda_api import add_event_source, use_docke
 from localstack.services.awslambda.lambda_utils import (
     LAMBDA_RUNTIME_NODEJS12X,
     LAMBDA_RUNTIME_NODEJS14X,
-    LAMBDA_RUNTIME_PYTHON36, LAMBDA_RUNTIME_PYTHON39,
+    LAMBDA_RUNTIME_PYTHON36,
+    LAMBDA_RUNTIME_PYTHON39,
 )
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
@@ -43,6 +39,13 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import select_attributes, short_uid, to_str
+from tests.integration.apigateway_fixtures import (
+    api_invoke_url,
+    create_rest_api,
+    create_rest_api_integration,
+    create_rest_resource,
+    create_rest_resource_method,
+)
 from tests.integration.awslambda.test_lambda_integration import TEST_STAGE_NAME
 
 from ..unit.test_apigateway import load_test_resource
@@ -324,8 +327,7 @@ class TestAPIGateway:
         body = response.json()
 
         # authorizer contains an object that does not contain the authorizer type ('lambda', 'sns')
-        assert body.get("requestContext").get("authorizer") == {'context': {}, 'identity': {}}
-
+        assert body.get("requestContext").get("authorizer") == {"context": {}, "identity": {}}
 
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
     def test_api_gateway_http_integrations(self, int_type, monkeypatch):

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -10,6 +10,11 @@ import pytest
 import xmltodict
 from botocore.exceptions import ClientError
 from jsonpatch import apply_patch
+
+from tests.integration.apigateway_fixtures import create_rest_api, create_rest_resource, create_rest_resource_method, \
+    create_rest_api_integration, api_invoke_url
+
+from localstack.utils.aws.aws_stack import create_api_gateway
 from moto.apigateway.models import APIGatewayBackend
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
@@ -29,7 +34,7 @@ from localstack.services.awslambda.lambda_api import add_event_source, use_docke
 from localstack.services.awslambda.lambda_utils import (
     LAMBDA_RUNTIME_NODEJS12X,
     LAMBDA_RUNTIME_NODEJS14X,
-    LAMBDA_RUNTIME_PYTHON36,
+    LAMBDA_RUNTIME_PYTHON36, LAMBDA_RUNTIME_PYTHON39,
 )
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
@@ -278,6 +283,49 @@ class TestAPIGateway:
         messages = aws_stack.sqs_receive_message(queue_name)["Messages"]
         assert 1 == len(messages)
         assert test_data == json.loads(base64.b64decode(messages[0]["Body"]))
+
+    def test_api_gateway_lambda_integration(self, apigateway_client, create_lambda_function):
+        """
+        API gateway to lambda integration test returns a response with the same body as the lambda function input.
+        """
+        fn_name = f"test-{short_uid()}"
+        create_lambda_function(
+            func_name=fn_name,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            runtime=LAMBDA_RUNTIME_PYTHON39,
+        )
+        lambda_arn = aws_stack.lambda_function_arn(fn_name)
+
+        api_id, _, root = create_rest_api(apigateway_client, name="aws lambda api")
+        resource_id, _ = create_rest_resource(
+            apigateway_client, restApiId=api_id, parentId=root, pathPart="test"
+        )
+
+        # create method and integration
+        create_rest_resource_method(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            authorizationType="NONE",
+        )
+        create_rest_api_integration(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="GET",
+            integrationHttpMethod="GET",
+            type="AWS",
+            uri=f"arn:aws:apigateway:{aws_stack.get_region()}:lambda:path//2015-03-31/functions/{lambda_arn}/invocations",
+        )
+
+        url = api_invoke_url(api_id=api_id, stage="local", path="/test")
+        response = requests.get(url)
+        body = response.json()
+
+        # authorizer contains an object that does not contain the authorizer type ('lambda', 'sns')
+        assert body.get("requestContext").get("authorizer") == {'context': {}, 'identity': {}}
+
 
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
     def test_api_gateway_http_integrations(self, int_type, monkeypatch):


### PR DESCRIPTION
The authorizer event object is not prefixed with the authorizer type like it is for V2. This PR removes the integration prefix (authorizer-type) from the object.  