### PR TITLE
Make SERVICES act as preload-list for EAGER_SERVICE_LOADING

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -815,6 +815,26 @@ def collect_config_items() -> List[Tuple[str, Any]]:
     return result
 
 
+def is_trace_logging_enabled():
+    if LS_LOG:
+        log_level = str(LS_LOG).upper()
+        return log_level.lower() in TRACE_LOG_LEVELS
+    return False
+
+
+# set log levels immediately, but will be overwritten later by setup_logging
+if DEBUG:
+    logging.getLogger("").setLevel(logging.DEBUG)
+    logging.getLogger("localstack").setLevel(logging.DEBUG)
+
+LOG = logging.getLogger(__name__)
+if is_trace_logging_enabled():
+    load_end_time = time.time()
+    LOG.debug(
+        "Initializing the configuration took %s ms", int((load_end_time - load_start_time) * 1000)
+    )
+
+
 def parse_service_ports() -> Dict[str, int]:
     """Parses the environment variable $SERVICES with a comma-separated list of services
     and (optional) ports they should run on: 'service1:port1,service2,service3:port3'"""
@@ -922,26 +942,6 @@ def edge_ports_info():
         result = "port %s" % EDGE_PORT
     result = "%s %s" % (get_protocol(), result)
     return result
-
-
-def is_trace_logging_enabled():
-    if LS_LOG:
-        log_level = str(LS_LOG).upper()
-        return log_level.lower() in TRACE_LOG_LEVELS
-    return False
-
-
-# set log levels immediately, but will be overwritten later by setup_logging
-if DEBUG:
-    logging.getLogger("").setLevel(logging.DEBUG)
-    logging.getLogger("localstack").setLevel(logging.DEBUG)
-
-LOG = logging.getLogger(__name__)
-if is_trace_logging_enabled():
-    load_end_time = time.time()
-    LOG.debug(
-        "Initializing the configuration took %s ms", int((load_end_time - load_start_time) * 1000)
-    )
 
 
 class ServiceProviderConfig(Mapping[str, str]):

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -819,6 +819,9 @@ def parse_service_ports() -> Dict[str, int]:
     """Parses the environment variable $SERVICES with a comma-separated list of services
     and (optional) ports they should run on: 'service1:port1,service2,service3:port3'"""
     service_ports = os.environ.get("SERVICES", "").strip()
+    if service_ports and not EAGER_SERVICE_LOADING:
+        LOG.warning("SERVICES variable is ignored if EAGER_SERVICE_LOADING=0.")
+        service_ports = None  # TODO remove logic once we clear up the service ports stuff
     if not service_ports:
         return DEFAULT_SERVICE_PORTS
     result = {}
@@ -842,11 +845,6 @@ def parse_service_ports() -> Dict[str, int]:
             port_number = 0
         result[service] = port_number
     return result
-
-
-# TODO: leaving temporarily for patch compatibilty - remove!
-def populate_configs(service_ports=None):
-    pass
 
 
 # TODO: use functools cache, instead of global variable here

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -105,7 +105,6 @@ from localstack.services.generic_proxy import RegionBackend
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
-from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.collections import select_attributes
 from localstack.utils.common import short_uid, to_bytes
 from localstack.utils.json import BytesEncoder
@@ -1213,9 +1212,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
     def delete_all_event_source_mappings(self, table_arn):
         if table_arn:
-            # fix start dynamodb service without lambda
-            if not is_api_enabled("lambda"):
-                return
 
             lambda_client = aws_stack.connect_to_service("lambda")
             result = lambda_client.list_event_source_mappings(EventSourceArn=table_arn)

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -23,7 +23,13 @@ from localstack.services.plugins import SERVICE_PLUGINS, ServiceDisabled, wait_f
 from localstack.utils import analytics, config_listener, files, persistence
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws.request_context import patch_moto_request_handling
-from localstack.utils.bootstrap import canonicalize_api_names, in_ci, log_duration, setup_logging
+from localstack.utils.bootstrap import (
+    canonicalize_api_names,
+    in_ci,
+    is_api_enabled,
+    log_duration,
+    setup_logging,
+)
 from localstack.utils.container_networking import get_main_container_id
 from localstack.utils.files import cleanup_tmp_files
 from localstack.utils.net import get_free_tcp_port, is_port_open
@@ -481,12 +487,16 @@ def do_start_infra(asynchronous, apis, is_in_docker):
             return
 
         for api in available_services:
-            try:
-                SERVICE_PLUGINS.require(api)
-            except ServiceDisabled as e:
-                LOG.debug("%s", e)
-            except Exception:
-                LOG.exception("could not load service plugin %s", api)
+            # this should be the only call to is_api_enabled left
+            if is_api_enabled(api):
+                try:
+                    SERVICE_PLUGINS.require(api)
+                except ServiceDisabled as e:
+                    LOG.debug("%s", e)
+                except Exception:
+                    LOG.exception("could not load service plugin %s", api)
+            else:
+                LOG.debug("Api %s not present in SERVICES variable, skipping eager loading...", api)
 
     @log_duration()
     def start_runtime_components():

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -13,7 +13,7 @@ from werkzeug import Request
 
 from localstack import config
 from localstack.config import ServiceProviderConfig
-from localstack.utils.bootstrap import get_enabled_apis, is_api_enabled, log_duration
+from localstack.utils.bootstrap import get_enabled_apis, log_duration
 from localstack.utils.functions import call_safe
 from localstack.utils.net import wait_for_port_status
 from localstack.utils.sync import poll_condition
@@ -214,10 +214,7 @@ class Service:
         return self.plugin_name
 
     def is_enabled(self):
-        if self.default_active:
-            return True
-
-        return is_api_enabled(self.name())
+        return True
 
 
 class ServiceState(Enum):

--- a/localstack/services/ssm/provider.py
+++ b/localstack/services/ssm/provider.py
@@ -21,7 +21,6 @@ from localstack.aws.api.ssm import (
 )
 from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.utils.aws import aws_stack
-from localstack.utils.bootstrap import is_api_enabled
 
 PARAM_PREFIX_SECRETSMANAGER = "/aws/reference/secretsmanager"
 
@@ -95,8 +94,6 @@ class SsmProvider(SsmApi, ABC):
     @staticmethod
     def _notify_event_subscribers(name: ParameterName, operation: str):
         """Publish an EventBridge event to notify subscribers of changes."""
-        if not is_api_enabled("events"):
-            return
         events = aws_stack.connect_to_service("events")
         detail = {"name": name, "operation": operation}
         event = {

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -240,6 +240,7 @@ def canonicalize_api_names(apis: Iterable[str] = None) -> List[str]:
     return list(apis)
 
 
+# DEPRECATED, lazy loading should be assumed
 def is_api_enabled(api: str) -> bool:
     apis = get_enabled_apis()
 

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -8,7 +8,6 @@ from flask import Response
 from localstack import config
 from localstack.utils.analytics import event_publisher
 from localstack.utils.aws import aws_stack
-from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.strings import to_str
 from localstack.utils.time import now_utc
 
@@ -69,8 +68,6 @@ def store_cloudwatch_logs(
     start_time=None,
     auto_create_group: Optional[bool] = True,
 ):
-    if not is_api_enabled("logs"):
-        return
     start_time = start_time or int(time.time() * 1000)
     logs_client = aws_stack.connect_to_service("logs")
     log_output = to_str(log_output)

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -21,43 +21,35 @@ from localstack.services.generic_proxy import (
 )
 from localstack.services.messages import Request, Response
 from localstack.utils.aws import aws_stack
-from localstack.utils.bootstrap import is_api_enabled
 from localstack.utils.common import get_free_tcp_port, short_uid, to_str
 from localstack.utils.xml import strip_xmlns
 
 
 class TestEdgeAPI:
-    @pytest.mark.skipif(not is_api_enabled("kinesis"), reason="kinesis not enabled")
     def test_invoke_kinesis(self):
         edge_url = config.get_edge_url()
         self._invoke_kinesis_via_edge(edge_url)
 
-    @pytest.mark.skipif(not is_api_enabled("dynamodbstreams"), reason="dynamodbstreams not enabled")
     def test_invoke_dynamodb(self):
         edge_url = config.get_edge_url()
         self._invoke_dynamodb_via_edge_go_sdk(edge_url)
 
-    @pytest.mark.skipif(not is_api_enabled("dynamodbstreams"), reason="dynamodbstreams not enabled")
     def test_invoke_dynamodbstreams(self):
         edge_url = config.get_edge_url()
         self._invoke_dynamodbstreams_via_edge(edge_url)
 
-    @pytest.mark.skipif(not is_api_enabled("firehose"), reason="firehose not enabled")
     def test_invoke_firehose(self):
         edge_url = config.get_edge_url()
         self._invoke_firehose_via_edge(edge_url)
 
-    @pytest.mark.skipif(not is_api_enabled("stepfunctions"), reason="stepfunctions not enabled")
     def test_invoke_stepfunctions(self):
         edge_url = config.get_edge_url()
         self._invoke_stepfunctions_via_edge(edge_url)
 
-    @pytest.mark.skipif(not is_api_enabled("s3"), reason="s3 not enabled")
     def test_invoke_s3(self):
         edge_url = config.get_edge_url()
         self._invoke_s3_via_edge(edge_url)
 
-    @pytest.mark.skipif(not is_api_enabled("s3"), reason="s3 not enabled")
     @pytest.mark.xfail(
         condition=not config.LEGACY_EDGE_PROXY, reason="failing with new HTTP gateway (only in CI)"
     )


### PR DESCRIPTION
## Current behavior
Currently, SERVICES will deactivate certain service plugins - which leads to all sorts of problems, a lot of `if is_api_enabled`s over the codebase, and the bad practice to define SERVICES variable - often without taking in mind the interconnection of a lot of services.

## New behavior
SERVICES will loose all functionality if EAGER_SERVICE_LOADING=0. This should be without impact for most costumers (due to lazy loading), except for the warning message printed at startup.
SERVICES will now define a list of services preloaded with `EAGER_SERVICE_LOADING=1`. If this is enabled, all services specified will be started on startup, everything else will be loaded on demand. There is no more failing of requests due to a service not specified in `SERVICES`
Service plugins cannot be disabled now, and are all enabled (but not necessarily loaded) by default.

## Impact
Impact should be, in general, minimal, due to the default activation of lazy service loading. It should however reduce SERVICES-related support cases.

## Future work
- remove SERVICE_PORTS and dependencies on localstack-client