### PR TITLE
remove `fix_return_consumed_capacity`, fixes #6437

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -536,7 +536,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             existing_item = ItemFinder.find_existing_item(put_item_input)
 
         # forward request to backend
-        self.fix_return_consumed_capacity(put_item_input)
         result = self.forward_request(context, put_item_input)
 
         # Get stream specifications details for the table
@@ -574,7 +573,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             existing_item = ItemFinder.find_existing_item(delete_item_input)
 
         # forward request to backend
-        self.fix_return_consumed_capacity(delete_item_input)
         result = self.forward_request(context, delete_item_input)
 
         # determine and forward stream record
@@ -612,7 +610,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             existing_item = ItemFinder.find_existing_item(update_item_input)
 
         # forward request to backend
-        self.fix_return_consumed_capacity(update_item_input)
         result = self.forward_request(context, update_item_input)
 
         # construct and forward stream record
@@ -1038,15 +1035,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             r"Credential=([^/]+/[^/]+)/local(host)?/",
             rf"Credential=\1/{aws_stack.get_local_region()}/",
         )
-
-    def fix_return_consumed_capacity(self, request_dict):
-        # Fix incorrect values if ReturnValues==ALL_OLD and ReturnConsumedCapacity is
-        # empty, see https://github.com/localstack/localstack/issues/2049
-        return_values_all = (request_dict.get("ReturnValues") == "ALL_OLD") or (
-            not request_dict.get("ReturnValues")
-        )
-        if return_values_all and not request_dict.get("ReturnConsumedCapacity"):
-            request_dict["ReturnConsumedCapacity"] = "TOTAL"
 
     def fix_consumed_capacity(self, request: Dict, result: Dict):
         # make sure we append 'ConsumedCapacity', which is properly

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -428,12 +428,12 @@ class TestDynamoDB:
         )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
-        def _validate_response(response, expected: Dict = {}):
-        """ 
-        Validates the response against the optionally expected one.
-        It checks that the response doesn't contain `Attributes`,
-        `ConsumedCapacity` and `ItemCollectionMetrics` unless they are expected.
-        """
+        def _validate_response(response, expected: dict = {}):
+            """
+            Validates the response against the optionally expected one.
+            It checks that the response doesn't contain `Attributes`,
+            `ConsumedCapacity` and `ItemCollectionMetrics` unless they are expected.
+            """
             should_not_contain = {
                 "Attributes",
                 "ConsumedCapacity",
@@ -460,7 +460,7 @@ class TestDynamoDB:
         # now a previous version of data is present, so when we pass return
         # values as 'ALL_OLD' it should give us the old attributes
         response = table.put_item(Item=item1b, ReturnValues="ALL_OLD")
-        validate_response(response, expected={"Attributes": item1})
+        _validate_response(response, expected={"Attributes": item1})
 
         response = table.put_item(Item=item2)
         # we do not have any same item as item2 already so when we add this by default

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -455,7 +455,7 @@ class TestDynamoDB:
         # now the same data is present so when we pass return values as 'ALL_OLD'
         # it should give us attributes
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
-        validate_response(response, expected={"Attributes": item1})
+        _validate_response(response, expected={"Attributes": item1})
 
         # now a previous version of data is present, so when we pass return
         # values as 'ALL_OLD' it should give us the old attributes

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -465,7 +465,7 @@ class TestDynamoDB:
         response = table.put_item(Item=item2)
         # we do not have any same item as item2 already so when we add this by default
         # return values is set to None so no Attribute values should be returned
-        validate_response(response)
+        _validate_response(response)
 
         response = table.put_item(Item=item2)
         # in this case we already have item2 in the table so on this request

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -451,7 +451,7 @@ class TestDynamoDB:
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
         # there is no data present in the table already so even if return values
         # is set to 'ALL_OLD' as there is no data it will not return any data.
-        validate_response(response)
+        _validate_response(response)
         # now the same data is present so when we pass return values as 'ALL_OLD'
         # it should give us attributes
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -428,10 +428,12 @@ class TestDynamoDB:
         )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
-        # validates the response against your optionally expected response.
-        # It checks that the response doesn't contain `Attributes`,
-        # `ConsumedCapacity` and `ItemCollectionMetrics` unless they are expected.
-        def validate_response(response, expected={}):
+        def _validate_response(response, expected: Dict = {}):
+        """ 
+        Validates the response against the optionally expected one.
+        It checks that the response doesn't contain `Attributes`,
+        `ConsumedCapacity` and `ItemCollectionMetrics` unless they are expected.
+        """
             should_not_contain = {
                 "Attributes",
                 "ConsumedCapacity",

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -471,7 +471,7 @@ class TestDynamoDB:
         # in this case we already have item2 in the table so on this request
         # it should not return any data as return values is set to None so no
         # Attribute values should be returned
-        validate_response(response)
+        _validate_response(response)
 
         # cleanup
         table.delete()

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -432,24 +432,38 @@ class TestDynamoDB:
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
         # there is no data present in the table already so even if return values
         # is set to 'ALL_OLD' as there is no data it will not return any data.
-        assert not response.get("Attributes")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert "Attributes" not in response
+        assert "ConsumedCapacity" not in response
+        assert "ItemCollectionMetrics" not in response
         # now the same data is present so when we pass return values as 'ALL_OLD'
         # it should give us attributes
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
-        assert response.get("Attributes")
-        assert item1.get("id") == response.get("Attributes").get("id")
-        assert item1.get("data") == response.get("Attributes").get("data")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert response["Attributes"] == item1
+        assert "ConsumedCapacity" not in response
+        assert "ItemCollectionMetrics" not in response
 
         response = table.put_item(Item=item2)
         # we do not have any same item as item2 already so when we add this by default
         # return values is set to None so no Attribute values should be returned
-        assert not response.get("Attributes")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert "Attributes" not in response
+        assert "ConsumedCapacity" not in response
+        assert "ItemCollectionMetrics" not in response
 
         response = table.put_item(Item=item2)
         # in this case we already have item2 in the table so on this request
         # it should not return any data as return values is set to None so no
         # Attribute values should be returned
-        assert not response.get("Attributes")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert "Attributes" not in response
+        assert "ConsumedCapacity" not in response
+        assert "ItemCollectionMetrics" not in response
+
+        # cleanup
+        table.delete()
+
 
     @pytest.mark.aws_validated
     def test_empty_and_binary_values(self, dynamodb, dynamodb_client):

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -472,7 +472,6 @@ class TestDynamoDB:
         # cleanup
         table.delete()
 
-
     @pytest.mark.aws_validated
     def test_empty_and_binary_values(self, dynamodb, dynamodb_client):
         aws_stack.create_dynamodb_table(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -427,6 +427,7 @@ class TestDynamoDB:
 
         # items which are being used to put in the table
         item1 = {PARTITION_KEY: "id1", "data": "foobar"}
+        item1b = {PARTITION_KEY: "id1", "data": "barfoo"}
         item2 = {PARTITION_KEY: "id2", "data": "foobar"}
 
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
@@ -439,6 +440,13 @@ class TestDynamoDB:
         # now the same data is present so when we pass return values as 'ALL_OLD'
         # it should give us attributes
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert response["Attributes"] == item1
+        assert "ConsumedCapacity" not in response
+        assert "ItemCollectionMetrics" not in response
+        # now a previous version of data is present, so when we pass return
+        # values as 'ALL_OLD' it should give us the old attributes
+        response = table.put_item(Item=item1b, ReturnValues="ALL_OLD")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         assert response["Attributes"] == item1
         assert "ConsumedCapacity" not in response


### PR DESCRIPTION
`fix_return_consumed_capacity` was added for issue #2049.

This seems to be the cause of issue #6437 and it doesn't solve the problem for issue #2049 from what I can tell.
If `ReturnValues` are not specified it always forces `ReturnConsumedCapacity` as `TOTAL`.

Steps to try reproduce #2049 without success:
```bash
# Create table to repro the issue
awslocal dynamodb create-table \
  --table-name "put-item-response" \
  --billing-mode "PAY_PER_REQUEST" \
  --attribute-definitions \
    AttributeName=pkey,AttributeType=S \
  --key-schema \
    AttributeName=pkey,KeyType=HASH \
  --region eu-west-1

# This works as expected, no values are returned as there is no previous item
awslocal dynamodb put-item \
  --table-name "put-item-response" \
  --item '{"pkey":{"S":"test"}}' \
  --return-values "ALL_OLD"

# This works as expected, the values for the previous item is returned.
awslocal dynamodb put-item \
  --table-name "put-item-response" \
  --item '{"pkey":{"S":"test"},"val":{"S":"foo"}}' \
  --return-values "ALL_OLD"

# Cleanup resources
awslocal dynamodb delete-table \
  --table-name "put-item-response"
```