### PR TITLE
fix moto fallback dispatching on 404 errors

### DIFF
--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -9,6 +9,7 @@ from moto.backends import get_backend as get_moto_backend
 from moto.core.exceptions import RESTError
 from moto.core.utils import BackendDict
 from moto.moto_server.utilities import RegexConverter
+from werkzeug.exceptions import NotFound
 from werkzeug.routing import Map, Rule
 
 from localstack import __version__ as localstack_version
@@ -139,7 +140,12 @@ def get_dispatcher(service: str, path: str) -> MotoDispatcher:
         return rule.endpoint
 
     matcher = url_map.bind(config.LOCALSTACK_HOSTNAME)
-    endpoint, _ = matcher.match(path_info=path)
+    try:
+        endpoint, _ = matcher.match(path_info=path)
+    except NotFound as e:
+        raise NotImplementedError(
+            f"No moto route for service {service} on path {path} found."
+        ) from e
     return endpoint
 
 

--- a/tests/integration/test_moto.py
+++ b/tests/integration/test_moto.py
@@ -3,7 +3,7 @@ import pytest
 from localstack import config
 from localstack.aws.api import ServiceException, handler
 from localstack.services import moto
-from localstack.services.moto import MotoFallbackDispatcher, get_dispatcher
+from localstack.services.moto import MotoFallbackDispatcher
 from localstack.utils.common import short_uid, to_str
 
 
@@ -222,11 +222,6 @@ def test_moto_fallback_dispatcher():
     response = _dispatch("ListQueues", None)
     assert len(provider.calls) == 1
     assert len([url for url in response["QueueUrls"] if qname in url])
-
-
-def test_get_dispatcher_for_path_with_optional_slashes():
-    assert get_dispatcher("route53", "/2013-04-01/hostedzone/BOR36Z3H458JKS9/rrset/")
-    assert get_dispatcher("route53", "/2013-04-01/hostedzone/BOR36Z3H458JKS9/rrset")
 
 
 def test_request_with_response_header_location_fields():

--- a/tests/unit/test_moto.py
+++ b/tests/unit/test_moto.py
@@ -1,52 +1,60 @@
-import unittest
 from urllib.parse import parse_qs
 
+import pytest
 from moto.core.responses import BaseResponse
 
+from localstack.services.moto import get_dispatcher
 from localstack.utils.aws.aws_responses import parse_urlencoded_data
 
 
-class TestMoto(unittest.TestCase):
-    def test_request_parsing(self):
-        qs = (
-            "Action=PutMetricAlarm&Version=2010-08-01&ComparisonOperator=GreaterThanOrEqualToThreshold&"
-            + "EvaluationPeriods=1&AlarmActions.member.1=test123&AlarmDescription=Upper+threshold+scaling+alarm&"
-            + "Metrics.member.1.Expression=e1%2F%28%281000%2A30%2A60%29%2F100%29&Metrics.member.1.Id=expr_1&"
-            + "Metrics.member.2.Expression=FILL%28m1%2C0%29&Metrics.member.2.Id=e1&"
-            + "Metrics.member.2.ReturnData=false&Metrics.member.3.Id=m1&"
-            + "Metrics.member.3.MetricStat.Metric.Dimensions.member.1.Name=StreamName&"
-            + "Metrics.member.3.MetricStat.Metric.Dimensions.member.1.Value=arn%3Aaws%3Akinesis%3A123&"
-            + "Metrics.member.3.MetricStat.Metric.MetricName=PutRecords.TotalRecords&"
-            + "Metrics.member.3.MetricStat.Metric.Namespace=AWS%2FKinesis&Metrics.member.3.MetricStat.Period=60&"
-            + "Metrics.member.3.MetricStat.Stat=Sum&Metrics.member.3.ReturnData=false&Threshold=80&"
-            + "AlarmName=mctesterson-application-tests-kds-fastpipe-stack-dataops-None-e8f05d1a"
-        )
+def test_request_parsing():
+    qs = (
+        "Action=PutMetricAlarm&Version=2010-08-01&ComparisonOperator=GreaterThanOrEqualToThreshold&"
+        + "EvaluationPeriods=1&AlarmActions.member.1=test123&AlarmDescription=Upper+threshold+scaling+alarm&"
+        + "Metrics.member.1.Expression=e1%2F%28%281000%2A30%2A60%29%2F100%29&Metrics.member.1.Id=expr_1&"
+        + "Metrics.member.2.Expression=FILL%28m1%2C0%29&Metrics.member.2.Id=e1&"
+        + "Metrics.member.2.ReturnData=false&Metrics.member.3.Id=m1&"
+        + "Metrics.member.3.MetricStat.Metric.Dimensions.member.1.Name=StreamName&"
+        + "Metrics.member.3.MetricStat.Metric.Dimensions.member.1.Value=arn%3Aaws%3Akinesis%3A123&"
+        + "Metrics.member.3.MetricStat.Metric.MetricName=PutRecords.TotalRecords&"
+        + "Metrics.member.3.MetricStat.Metric.Namespace=AWS%2FKinesis&Metrics.member.3.MetricStat.Period=60&"
+        + "Metrics.member.3.MetricStat.Stat=Sum&Metrics.member.3.ReturnData=false&Threshold=80&"
+        + "AlarmName=mctesterson-application-tests-kds-fastpipe-stack-dataops-None-e8f05d1a"
+    )
 
-        expected = [
-            {"Expression": "e1/((1000*30*60)/100)", "Id": "expr_1"},
-            {"Expression": "FILL(m1,0)", "Id": "e1", "ReturnData": "false"},
-            {
-                "Id": "m1",
-                "MetricStat": {
-                    "Metric": {
-                        "Dimensions.member": [
-                            {"Name": "StreamName", "Value": "arn:aws:kinesis:123"}
-                        ],
-                        "MetricName": "PutRecords.TotalRecords",
-                        "Namespace": "AWS/Kinesis",
-                    },
-                    "Period": "60",
-                    "Stat": "Sum",
+    expected = [
+        {"Expression": "e1/((1000*30*60)/100)", "Id": "expr_1"},
+        {"Expression": "FILL(m1,0)", "Id": "e1", "ReturnData": "false"},
+        {
+            "Id": "m1",
+            "MetricStat": {
+                "Metric": {
+                    "Dimensions.member": [{"Name": "StreamName", "Value": "arn:aws:kinesis:123"}],
+                    "MetricName": "PutRecords.TotalRecords",
+                    "Namespace": "AWS/Kinesis",
                 },
-                "ReturnData": "false",
+                "Period": "60",
+                "Stat": "Sum",
             },
-        ]
+            "ReturnData": "false",
+        },
+    ]
 
-        response = BaseResponse()
-        response.querystring = parse_qs(qs)
-        result = response._get_multi_param("Metrics.member", skip_result_conversion=True)
-        self.assertEqual(result, expected)
+    response = BaseResponse()
+    response.querystring = parse_qs(qs)
+    result = response._get_multi_param("Metrics.member", skip_result_conversion=True)
+    assert result == expected
 
-        # assert parsing via util
-        result = parse_urlencoded_data(parse_qs(qs), "Metrics.member")
-        self.assertEqual(result, expected)
+    # assert parsing via util
+    result = parse_urlencoded_data(parse_qs(qs), "Metrics.member")
+    assert result == expected
+
+
+def test_get_dispatcher_for_path_with_optional_slashes():
+    assert get_dispatcher("route53", "/2013-04-01/hostedzone/BOR36Z3H458JKS9/rrset/")
+    assert get_dispatcher("route53", "/2013-04-01/hostedzone/BOR36Z3H458JKS9/rrset")
+
+
+def test_get_dispatcher_for_non_existing_path_raises_not_implemented():
+    with pytest.raises(NotImplementedError):
+        get_dispatcher("route53", "/non-existing")


### PR DESCRIPTION
This PR fixes an issue with the moto fallback dispatching of for operations which are not implemented.
Previously, the dispatcher raised Werkzeug's `NotFound` exception, which was interpreted as an internal error (resulting in a 500 error):
```
awslocal route53 update-traffic-policy-instance --id 123 --ttl 123 --traffic-policy-id 123 --traffic-policy-version 123

An error occurred (InternalError) when calling the UpdateTrafficPolicyInstance operation (reached max retries: 4): exception while calling route53.UpdateTrafficPolicyInstance: Traceback (most recent call last):
  ...
  File ".../localstack/services/moto.py", line 142, in get_dispatcher
    endpoint, _ = matcher.match(path_info=path)
  File ".../.venv/lib/python3.10/site-packages/werkzeug/routing.py", line 2047, in match
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
```

With this PR, `NotFound` errors are caught when performing the URL matching. A `NotImplementedException` is raised instead (which in turn will be forwarded to the client as a 501):
```
An error occurred (InternalFailure) when calling the UpdateTrafficPolicyInstance operation: API action 'UpdateTrafficPolicyInstance' for service 'route53' not yet implemented
```

/cc @dominikschubert 