### PR TITLE
Remove python 3.6 compatibility mention from README, minor readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/localstack/localstack/issues/6398"><img src="./.github/images/v1-release.svg"></a>
+<a href="https://github.com/localstack/localstack/issues/6398"><img src="https://raw.githubusercontent.com/localstack/localstack/master/.github/images/v1-release.svg"></a>
 <p align="center">
   <img src="https://raw.githubusercontent.com/localstack/localstack/master/doc/localstack-readme-header.png" alt="LocalStack - A fully functional local cloud stack">
 </p>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ LocalStack also provides additional features to make your life as a cloud develo
 
 ## Requirements
 
-* `python` (Python 3.6 up to 3.10 supported)
+* `python` (Python 3.7 up to 3.10 supported)
 * `pip` (Python package manager)
 * `Docker`
 
@@ -76,7 +76,7 @@ Start LocalStack inside a Docker container by running:
   / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
  /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|
 
- 💻 LocalStack CLI 0.14.3
+ 💻 LocalStack CLI 1.0.0
 
 [20:22:20] starting LocalStack in Docker mode 🐳
 [20:22:21] detaching
@@ -186,7 +186,7 @@ You can also support this project by becoming a sponsor on [Open Collective](htt
 
 ## License
 
-Copyright (c) 2017-2021 LocalStack maintainers and contributors.
+Copyright (c) 2017-2022 LocalStack maintainers and contributors.
 
 Copyright (c) 2016 Atlassian and others.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,6 @@ install_requires =
     boto3>=1.20
     click>=7.0
     cachetools~=5.0.0
-    # dataclasses needed for python3.6 compat
-    dataclasses; python_version < '3.7'
     #dnspython==1.16.0
     localstack-client>=1.31
     localstack-ext>=1.0.1.dev,<1.0.2


### PR DESCRIPTION
Just some minor readme and setup.cfg changes:
* remove mention of python 3.6 as compatible (and remove dataclasses import) - python3.6 is EOL since Dec 2021.
* update copyright year
* update version in CLI example

