### PR TITLE
Introduce colored output format for snapshot diffs in integration tests

### DIFF
--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -34,16 +34,22 @@ def pytest_addoption(parser: Parser, pluginmanager: PytestPluginManager):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> Optional[TestReport]:
+    use_legacy_report = os.environ.get("SNAPSHOT_LEGACY_REPORT", "0") == "1"
+
     result: _Result = yield
     report: TestReport = result.result
 
     if call.excinfo is not None and isinstance(call.excinfo.value, SnapshotAssertionError):
         err: SnapshotAssertionError = call.excinfo.value
-        error_report = ""
-        for res in err.result:
-            if not res:
-                error_report = f"{error_report}Match failed for '{res.key}':\n{json.dumps(json.loads(res.result.to_json()), indent=2)}\n\n"
-        report.longrepr = "\n".join([str(render_report(r)) for r in err.result if not r])
+
+        if use_legacy_report:
+            error_report = ""
+            for res in err.result:
+                if not res:
+                    error_report = f"{error_report}Match failed for '{res.key}':\n{json.dumps(json.loads(res.result.to_json()), indent=2)}\n\n"
+            report.longrepr = error_report
+        else:
+            report.longrepr = "\n".join([str(render_report(r)) for r in err.result if not r])
     return report
 
 

--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -15,6 +15,7 @@ from localstack.testing.pytest.fixtures import (  # TODO(!) fix. shouldn't impor
     _client,
 )
 from localstack.testing.snapshots import SnapshotAssertionError, SnapshotSession
+from localstack.testing.snapshots.report import render_report
 from localstack.testing.snapshots.transformer import RegexTransformer
 from localstack.testing.snapshots.transformer_utility import SNAPSHOT_BASIC_TRANSFORMER
 
@@ -42,7 +43,7 @@ def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> Optional[Test
         for res in err.result:
             if not res:
                 error_report = f"{error_report}Match failed for '{res.key}':\n{json.dumps(json.loads(res.result.to_json()), indent=2)}\n\n"
-        report.longrepr = error_report
+        report.longrepr = "\n".join([str(render_report(r)) for r in err.result if not r])
     return report
 
 

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -27,7 +27,7 @@ class SnapshotMatchResult:
     def __init__(self, a: dict, b: dict, key: str = ""):
         self.a = a
         self.b = b
-        self.result = DeepDiff(a, b, verbose_level=2)
+        self.result = DeepDiff(a, b, verbose_level=2, ignore_order=True, view="tree")
         self.key = key
 
     def __bool__(self) -> bool:

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -27,7 +27,7 @@ class SnapshotMatchResult:
     def __init__(self, a: dict, b: dict, key: str = ""):
         self.a = a
         self.b = b
-        self.result = DeepDiff(a, b, verbose_level=2, ignore_order=True, view="tree")
+        self.result = DeepDiff(a, b, verbose_level=2, view="tree")
         self.key = key
 
     def __bool__(self) -> bool:

--- a/localstack/testing/snapshots/report.py
+++ b/localstack/testing/snapshots/report.py
@@ -1,0 +1,114 @@
+from localstack.testing.snapshots import SnapshotMatchResult
+
+_esctable = dict(
+    # text colors
+    black=30,
+    red=31,
+    green=32,
+    yellow=33,
+    blue=34,
+    purple=35,
+    cyan=36,
+    white=37,
+    # background colors
+    Black=40,
+    Red=41,
+    Green=42,
+    Yellow=43,
+    Blue=44,
+    Purple=45,
+    Cyan=46,
+    White=47,
+    # special
+    bold=1,
+    light=2,
+    blink=5,
+    invert=7,
+    strikethrough=9,
+    underlined=4,
+)
+
+
+class PatchPath(str):
+    """
+    used to wrap a path string to compare hierarchically & lexically by going through
+    each path level
+    """
+
+    def __lt__(self, other):
+        if not isinstance(other, PatchPath):
+            raise ValueError("Incompatible types")
+
+        parts = zip(self.split("/"), other.split("/"))
+        for (sa, sb) in parts:
+            if sa < sb:
+                return True
+
+        return False
+
+
+def render_report(result: SnapshotMatchResult):
+    def _line(c) -> [(str, str)]:
+        def _render_path_part(part):
+            if isinstance(part, int):
+                return f"[{part}]"  # wrap iterable index in [] to more clearly denote it being such
+            return str(part)
+
+        path_parts = [_render_path_part(p) for p in c.path(output_format="list")]
+        change_path = "/" + "/".join(path_parts)
+
+        expected = c.t1
+        actual = c.t2
+
+        if c.report_type in [
+            "dictionary_item_removed",
+        ]:
+            return [(change_path, f"[remove](-)[/remove] {change_path} ( {expected} )")]
+        elif c.report_type in ["iterable_item_removed"]:
+            if actual:
+                # seems to be a bug with deepdiff, if there's the same number of items in the iterable and one differs
+                # it will report the missing one but won't report the "additional" on the corresponding position
+                return [
+                    (change_path, f"[remove](-)[/remove] {change_path} ( {expected} )"),
+                    (change_path, f"[add](+)[/add] {change_path} ( {actual} )"),
+                ]
+            return [(change_path, f"[remove](-)[/remove] {change_path} ( {expected} )")]
+        elif c.report_type in ["dictionary_item_added", "iterable_item_added"]:
+            return [(change_path, f"[add](+)[/add] {change_path} ( {actual} )")]
+        elif c.report_type in ["values_changed"]:
+            # TODO: more fancy change detection and visualization (e.g. parts of a string)
+            return [
+                (
+                    change_path,
+                    f"[replace](~)[/replace] {change_path} {expected} → {actual} ... (expected → actual)",
+                )
+            ]
+        else:
+            raise ValueError(
+                f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support."
+            )
+
+    lines = []
+    for cat, changes in result.result.tree.items():
+        for change in changes:
+            lines.extend(_line(change))
+
+    printstr = f">> match key: {result.key}\n"
+
+    for (a, b) in sorted(lines, key=lambda x: PatchPath(x[0])):
+        printstr += f"\t{b}\n"
+
+    # you can add more entries to the lists to combine effects (e.g. red & underlined)
+    replacement_map = {
+        "remove": [_esctable["red"]],
+        "add": [_esctable["green"]],
+        "replace": [_esctable["yellow"]],
+        "s": [_esctable["strikethrough"]],
+    }
+
+    # replace [x] tokens with the corresponding codes
+    for token, replacements in replacement_map.items():
+        printstr = printstr.replace(f"[{token}]", "".join(f"\x1b[{code}m" for code in replacements))
+        printstr = printstr.replace(f"[/{token}]", "\x1b[0m")
+
+    return printstr

--- a/localstack/testing/snapshots/report.py
+++ b/localstack/testing/snapshots/report.py
@@ -85,7 +85,7 @@ def render_report(result: SnapshotMatchResult):
             ]
         else:
             raise ValueError(
-                f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support."
+                f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support. {c.t1=} | {c.t2=}"
             )
 
     lines = []

--- a/localstack/testing/snapshots/report.py
+++ b/localstack/testing/snapshots/report.py
@@ -91,6 +91,7 @@ def render_report(result: SnapshotMatchResult):
             LOG.warning(
                 f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support. {expected=} | {actual=}"
             )
+        return []
 
     lines = []
     for cat, changes in result.result.tree.items():

--- a/localstack/testing/snapshots/report.py
+++ b/localstack/testing/snapshots/report.py
@@ -1,4 +1,8 @@
+import logging
+
 from localstack.testing.snapshots import SnapshotMatchResult
+
+LOG = logging.getLogger(__file__)
 
 _esctable = dict(
     # text colors
@@ -84,8 +88,8 @@ def render_report(result: SnapshotMatchResult):
                 )
             ]
         else:
-            raise ValueError(
-                f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support. {c.t1=} | {c.t2=}"
+            LOG.warning(
+                f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support. {expected=} | {actual=}"
             )
 
     lines = []


### PR DESCRIPTION
Produces diff results that are a bit more readable and (if used with a proper terminal) prettier due to custom coloring.

/cc @steffyP