### PR TITLE
fix content based message deduplication with sqs fifo queues

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -581,7 +581,7 @@ class FifoQueue(SqsQueue):
             self.visible.put_nowait(qm)
             if not original_message_group:
                 self.deduplication[message_group_id] = {}
-            self.deduplication[message_group_id][message_deduplication_id] = qm
+            self.deduplication[message_group_id][dedup_id] = qm
 
     def _assert_queue_name(self, name):
         if not name.endswith(".fifo"):


### PR DESCRIPTION
This PR fixes #6327. There was an oopsie in the deduplication code, where we are not using the message dedup id that we calculated earlier. in the case described in the issue `message_deduplication_id` would be `None`, which is used as key.