### PR TITLE
fix CLA allowlist (renamve renovate-bot to renovate)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,4 +26,4 @@ jobs:
           path-to-signatures: "etc/cla-signatures/signatures.json"
           path-to-document: "https://github.com/localstack/localstack/blob/master/.github/CLA.md"
           branch: "cla-signatures"
-          allowlist: "localstack-bot,renovate-bot"
+          allowlist: "localstack-bot,renovate-bot,renovate"


### PR DESCRIPTION
It seems that due to a rebranding, it's not @renovate-bot anymore which creates our Docker image hash update PRs (like https://github.com/localstack/localstack/pull/6469).
This PR adds the user "renovate" to the allowlist of the CLA action to avoid CLA action run failures on automatically created PRs by Renovate.