### PR TITLE
Fix volume dir path replacement for windows paths, use docker cmd client if not in docker

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1596,15 +1596,18 @@ class Util:
                         f"Mount to {DEFAULT_VOLUME_DIR} needs to be a bind mount for lambda code mounting to work"
                     )
 
-                relative_path = path.removeprefix(DEFAULT_VOLUME_DIR)
-                if relative_path == path:
+                if not path.startswith(f"{DEFAULT_VOLUME_DIR}/") and path != DEFAULT_VOLUME_DIR:
                     # We should be able to replace something here.
                     # if this warning is printed, the usage of this function is probably wrong.
-                    # Please check for missing slashes after DEFAULT_VOLUME_DIR etc.
+                    # Please check if the target path is indeed prefixed by /var/lib/localstack
+                    # if this happens, mounts may fail
                     LOG.warning(
-                        "Error while performing automatic host path replacement for path %s to source %s"
+                        "Error while performing automatic host path replacement for path '%s' to source '%s'",
+                        path,
+                        volume.source,
                     )
                 else:
+                    relative_path = path.removeprefix(DEFAULT_VOLUME_DIR)
                     result = volume.source + relative_path
                     return result
             else:

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1596,10 +1596,8 @@ class Util:
                         f"Mount to {DEFAULT_VOLUME_DIR} needs to be a bind mount for lambda code mounting to work"
                     )
 
-                result, subs = re.subn(
-                    r"^%s/(.*)$" % DEFAULT_VOLUME_DIR, r"%s/\1" % volume.source, path
-                )
-                if subs == 0:
+                relative_path = path.removeprefix(DEFAULT_VOLUME_DIR)
+                if relative_path == path:
                     # We should be able to replace something here.
                     # if this warning is printed, the usage of this function is probably wrong.
                     # Please check for missing slashes after DEFAULT_VOLUME_DIR etc.
@@ -1607,6 +1605,7 @@ class Util:
                         "Error while performing automatic host path replacement for path %s to source %s"
                     )
                 else:
+                    result = volume.source + relative_path
                     return result
             else:
                 raise ValueError(f"No volume mounted to {DEFAULT_VOLUME_DIR}")

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1036,7 +1036,6 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             image_name=container_config.image_name,
             remove=container_config.remove,
             interactive=container_config.interactive,
-            detach=container_config.detach,
             name=container_config.name,
             entrypoint=container_config.entrypoint,
             command=container_config.command,

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -22,7 +22,8 @@ def is_docker_sdk_installed() -> bool:
 
 
 def create_docker_client() -> ContainerClient:
-    if config.LEGACY_DOCKER_CLIENT or not is_docker_sdk_installed():
+    # never use the sdk client if it is not installed or not in docker - too risky for wrong version
+    if config.LEGACY_DOCKER_CLIENT or not is_docker_sdk_installed() or not config.is_in_docker:
         from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 
         LOG.debug(

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -10,11 +10,12 @@ import mock
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.awslambda import lambda_api, lambda_executors, lambda_utils
-from localstack.services.awslambda.lambda_executors import OutputLog
+from localstack.services.awslambda.lambda_executors import OutputLog, Util
 from localstack.services.awslambda.lambda_utils import API_PATH_ROOT
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.common import isoformat_milliseconds, mkdir, new_tmp_dir, save_file
+from localstack.utils.container_utils.container_client import VolumeInfo
 
 TEST_EVENT_SOURCE_ARN = "arn:aws:sqs:eu-west-1:000000000000:testq"
 TEST_SECRETSMANANAGER_EVENT_SOURCE_ARN = (
@@ -1130,3 +1131,53 @@ class TestLambdaEventInvokeConfig(unittest.TestCase):
         self.assertEqual(self.RETRY_ATTEMPTS, response["MaximumRetryAttempts"])
         self.assertEqual(self.EVENT_AGE, response["MaximumEventAgeInSeconds"])
         self.assertEqual(self.DL_QUEUE, response["DestinationConfig"]["OnFailure"]["Destination"])
+
+
+class TestLambdaUtils:
+    def test_host_path_for_path_in_docker_windows(self):
+        with mock.patch(
+            "localstack.services.awslambda.lambda_executors.get_default_volume_dir_mount"
+        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+            get_volume.return_value = VolumeInfo(
+                type="bind",
+                source=r"C:\Users\localstack\volume\mount",
+                destination="/var/lib/localstack",
+                mode="rw",
+                rw=True,
+                propagation="rprivate",
+            )
+            result = Util.get_host_path_for_path_in_docker("/var/lib/localstack/some/test/file")
+            get_volume.assert_called_once()
+            assert result == r"C:\Users\localstack\volume\mount\some\test\file"
+
+    def test_host_path_for_path_in_docker_linux(self):
+        with mock.patch(
+            "localstack.services.awslambda.lambda_executors.get_default_volume_dir_mount"
+        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+            get_volume.return_value = VolumeInfo(
+                type="bind",
+                source="/home/some-user/.cache/localstack/volume",
+                destination="/var/lib/localstack",
+                mode="rw",
+                rw=True,
+                propagation="rprivate",
+            )
+            result = Util.get_host_path_for_path_in_docker("/var/lib/localstack/some/test/file")
+            get_volume.assert_called_once()
+            assert result == "/home/some-user/.cache/localstack/volume/some/test/file"
+
+    def test_host_path_for_path_in_docker_linux_volume_dir(self):
+        with mock.patch(
+            "localstack.services.awslambda.lambda_executors.get_default_volume_dir_mount"
+        ) as get_volume, mock.patch("localstack.config.is_in_docker", True):
+            get_volume.return_value = VolumeInfo(
+                type="bind",
+                source="/home/some-user/.cache/localstack/volume",
+                destination="/var/lib/localstack",
+                mode="rw",
+                rw=True,
+                propagation="rprivate",
+            )
+            result = Util.get_host_path_for_path_in_docker("/var/lib/localstack")
+            get_volume.assert_called_once()
+            assert result == "/home/some-user/.cache/localstack/volume"


### PR DESCRIPTION
## PR reasons
1. Currently, since we use a regex replacement, the backslashes in Windows paths (as returned by docker for our mount detection - used for mounting the same paths into the lambda docker containers) will fail the method and therefore lambda execution.

2. A quick fix for #6458 - we currently use docker sdk if available, no matter the version installed

## Changes
1. use regular string logic instead of regex to avoid escaping backslashes, added tests for path replacements for multiple formats / cases
2.  do not use docker sdk even if it is installed on the host - version mismatch have bad consequences (due to AWS sam often an older version of the docker sdk is installed, which will start pulling all tags instead of latest)