### PR TITLE
feat: add aws s3 latest region support

### DIFF
--- a/localstack/aws/api/s3control/__init__.py
+++ b/localstack/aws/api/s3control/__init__.py
@@ -101,15 +101,24 @@ class BucketCannedACL(str):
 class BucketLocationConstraint(str):
     EU = "EU"
     eu_west_1 = "eu-west-1"
+    eu_west_2 = "eu-west-2"
+    eu_west_3 = "eu-west-3"
+    eu_north_1 = "eu-north-1"
     us_west_1 = "us-west-1"
     us_west_2 = "us-west-2"
+    us_east_1 = "us-east-1" # Virginial
+    us_east_2 = "us-east-2" # Ohio
+    ap_east_1 = "ap-east-1" # Hong Kong
     ap_south_1 = "ap-south-1"
     ap_southeast_1 = "ap-southeast-1"
     ap_southeast_2 = "ap-southeast-2"
     ap_northeast_1 = "ap-northeast-1"
+    ap_northeast_2 = "ap-northeast-2" # Seoul
+    ap_northeast_3 = "ap-northeast-3" # Osaka
     sa_east_1 = "sa-east-1"
     cn_north_1 = "cn-north-1"
     eu_central_1 = "eu-central-1"
+    ca_central_1 = "ca-central-1"
 
 
 class ExpirationStatus(str):


### PR DESCRIPTION
# Summary
This PR is for added full aws region support (as of Today, 18/07/2022).

The region is important for local development and integration. eg: serverless lambda deployment bucket.