### PR TITLE
fix: print conserved docker logs if container is not running

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -180,12 +180,17 @@ def cmd_stop():
 )
 @publish_invocation
 def cmd_logs(follow: bool):
+    from localstack.utils.bootstrap import LocalstackContainer
     from localstack.utils.docker_utils import DOCKER_CLIENT
 
     container_name = config.MAIN_CONTAINER_NAME
+    logfile = LocalstackContainer(container_name).logfile
 
     if not DOCKER_CLIENT.is_container_running(container_name):
         console.print("localstack container not running")
+        with open(logfile) as fd:
+            for line in fd:
+                console.print(line.rstrip("\n\r"))
         sys.exit(1)
 
     if follow:

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -188,9 +188,11 @@ def cmd_logs(follow: bool):
 
     if not DOCKER_CLIENT.is_container_running(container_name):
         console.print("localstack container not running")
-        with open(logfile) as fd:
-            for line in fd:
-                console.print(line.rstrip("\n\r"))
+        if os.path.exists(logfile):
+            console.print("printing logs from previous run")
+            with open(logfile) as fd:
+                for line in fd:
+                    click.echo(line, nl=False)
         sys.exit(1)
 
     if follow:


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack/issues/5820