### PR TITLE
Fix windows volume mount path for CLI localstack start

### DIFF
--- a/localstack/utils/files.py
+++ b/localstack/utils/files.py
@@ -39,7 +39,7 @@ def cache_dir() -> Path:
     from localstack.utils.platform import is_linux, is_mac_os, is_windows
 
     if is_windows():
-        return Path("%LOCALAPPDATA%", "cache", "localstack")
+        return Path(os.path.expandvars(r"%LOCALAPPDATA%\cache\localstack"))
     if is_mac_os():
         return Path.home() / "Library" / "Caches" / "localstack"
     if is_linux():


### PR DESCRIPTION
Currently, we do not expand the path variable `%LOCALAPPDATA%`. Since we do not run the docker command in a shell, it does not take kindly to this path, and will essentially fail on windows.

This PR manually expands the path variable before setting the path into docker, and therefore solving the issue (as long as it is expandable, which I _hope_ is always the case on windows).