### PR TITLE
Remove API_REGIONS cache, replace with in-memory lookup

### DIFF
--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -44,7 +44,6 @@ from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL
 from localstack.services.apigateway import helpers
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.helpers import (
-    API_REGIONS,
     PATH_REGEX_TEST_INVOKE_API,
     PATH_REGEX_USER_REQUEST,
     APIGatewayRegion,
@@ -112,14 +111,6 @@ class ApigatewayApiListener(AwsApiListener):
             and response.status_code == 404
         ):
             return requests_response({"position": "1", "items": []})
-
-        # keep track of API regions for faster lookup later on
-        # TODO - to be removed - see comment for API_REGIONS variable
-        if method == "POST" and path == "/restapis":
-            content = json.loads(to_str(response.content))
-            api_id = content["id"]
-            region = aws_stack.extract_region_from_auth_header(headers)
-            API_REGIONS[api_id] = region
 
 
 class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):

--- a/localstack/services/apigateway/provider_asf.py
+++ b/localstack/services/apigateway/provider_asf.py
@@ -8,7 +8,6 @@ from localstack.aws.api.apigateway import (
     TestInvokeMethodRequest,
     TestInvokeMethodResponse,
 )
-from localstack.services.apigateway.helpers import API_REGIONS
 from localstack.services.apigateway.invocations import invoke_rest_api_from_request
 from localstack.services.apigateway.provider import ApigatewayProvider
 from localstack.services.apigateway.router_asf import ApigatewayRouter, to_invocation_context
@@ -33,11 +32,6 @@ class AsfApigatewayProvider(ApigatewayProvider):
     def on_after_init(self):
         super(AsfApigatewayProvider, self).on_after_init()
         self.router.register_routes()
-
-    def create_rest_api(self, context: RequestContext, request: CreateRestApiRequest) -> RestApi:
-        result: RestApi = super().create_rest_api(context, request)
-        API_REGIONS[result["id"]] = context.region
-        return result
 
     @handler("TestInvokeMethod", expand=False)
     def test_invoke_method(

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -10,7 +10,7 @@ from localstack.http import Request, Response, Router
 from localstack.http.dispatcher import Handler
 from localstack.http.request import restore_payload
 from localstack.services.apigateway.context import ApiInvocationContext
-from localstack.services.apigateway.helpers import API_REGIONS
+from localstack.services.apigateway.helpers import get_api_region
 from localstack.services.apigateway.invocations import invoke_rest_api_from_request
 from localstack.utils.aws.aws_responses import LambdaResponse
 
@@ -128,7 +128,7 @@ class ApigatewayRouter:
         )
 
     def invoke_rest_api(self, request: Request, **url_params: Dict[str, Any]) -> Response:
-        if not url_params["api_id"] in API_REGIONS:
+        if not get_api_region(url_params["api_id"]):
             return Response(status=404)
         invocation_context = to_invocation_context(request, url_params)
         result = invoke_rest_api_from_request(invocation_context)


### PR DESCRIPTION
Remove `API_REGIONS` cache and replace it with in-memory lookup. As this cache dict has limited value and is the root cause for inconsistencies, it is time to get it removed (as discussed before).