### PR TITLE
Moving zip utilities

### DIFF
--- a/localstack/utils/archives.py
+++ b/localstack/utils/archives.py
@@ -72,3 +72,23 @@ def untar(path: str, target_dir: str):
     mode = "r:gz" if path.endswith("gz") else "r"
     with tarfile.open(path, mode) as tar:
         tar.extractall(path=target_dir)
+
+
+def create_zip_file_cli(source_path, base_dir, zip_file):
+    # Using the native zip command can be an order of magnitude faster on Travis-CI
+    source = "*" if source_path == base_dir else os.path.basename(source_path)
+    command = "cd %s; zip -r %s %s" % (base_dir, zip_file, source)
+    run(command)
+
+
+def create_zip_file_python(source_path, base_dir, zip_file, mode="w", content_root=None):
+    with zipfile.ZipFile(zip_file, mode) as zip_file:
+        for root, dirs, files in os.walk(base_dir):
+            for name in files:
+                full_name = os.path.join(root, name)
+                relative = os.path.relpath(root, start=base_dir)
+                if content_root:
+                    dest = os.path.join(content_root, relative, name)
+                else:
+                    dest = os.path.join(relative, name)
+                zip_file.write(full_name, dest)


### PR DESCRIPTION
This PR simply moves some zipping utilities into `localstack.utils.archives` (from `testutils`) for a two-fold reason: i) it is a better fitting module; ii) it avoids runtime imports from the CLI.