### PR TITLE
fix ASF / botocore CBOR decoding

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -890,6 +890,15 @@ class BaseJSONRequestParser(RequestParser, ABC):
     ) -> bool:
         return super()._noop_parser(request, shape, node, uri_params)
 
+    def _parse_blob(
+        self, request: HttpRequest, shape: Shape, node: bool, uri_params: Mapping[str, Any] = None
+    ) -> bytes:
+        if isinstance(node, bytes) and request.mimetype.startswith("application/x-amz-cbor"):
+            # CBOR does not base64 encode binary data
+            return bytes(node)
+        else:
+            return super()._parse_blob(request, shape, node, uri_params)
+
 
 class JSONRequestParser(BaseJSONRequestParser):
     """

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -553,6 +553,58 @@ def test_json_parser_cognito_with_botocore():
     )
 
 
+def test_json_cbor_blob_parsing():
+    serialized_request = {
+        "url_path": "/",
+        "query_string": "",
+        "method": "POST",
+        "headers": {
+            "Host": "localhost:4566",
+            "amz-sdk-invocation-id": "d77968c6-b536-155d-7228-d4dfe6372154",
+            "amz-sdk-request": "attempt=1; max=3",
+            "Content-Length": "103",
+            "Content-Type": "application/x-amz-cbor-1.1",
+            "X-Amz-Date": "20220721T081553Z",
+            "X-Amz-Target": "Kinesis_20131202.PutRecord",
+            "x-localstack-tgt-api": "kinesis",
+        },
+        "body": b"\xbfjStreamNamedtestdDataMhello, world!lPartitionKeylpartitionkey\xff",
+        "url": "/",
+        "context": {},
+    }
+
+    prepare_request_dict(serialized_request, "")
+    split_url = urlsplit(serialized_request.get("url"))
+    path = split_url.path
+    query_string = split_url.query
+
+    # Use our parser to parse the serialized body
+    # Load the appropriate service
+    service = load_service("kinesis")
+    operation_model = service.operation_model("PutRecord")
+    parser = create_parser(service)
+    parsed_operation_model, parsed_request = parser.parse(
+        HttpRequest(
+            method=serialized_request.get("method") or "GET",
+            path=unquote(path),
+            query_string=to_str(query_string),
+            headers=serialized_request.get("headers"),
+            body=serialized_request["body"],
+            raw_path=path,
+        )
+    )
+
+    # Check if the determined operation_model is correct
+    assert parsed_operation_model == operation_model
+
+    assert "Data" in parsed_request
+    assert parsed_request["Data"] == b"hello, world!"
+    assert "StreamName" in parsed_request
+    assert parsed_request["StreamName"] == "test"
+    assert "PartitionKey" in parsed_request
+    assert parsed_request["PartitionKey"] == "partitionkey"
+
+
 def test_restjson_parser_xray_with_botocore():
     _botocore_parser_integration_test(
         service="xray",


### PR DESCRIPTION
This PR addresses the handling of CBOR encoded messages.
It contains two fixes:
- ASF's  `BaseJSONRequestParser`: Proper binary decoding for CBOR (since the binary data is not base64 encoded).
- `botocore`: Adds support for basic CBOR decoding to `botocore` (which doesn't support CBOR at all).
  - When using the botocore parser (in `client.py`) we configure the JSON parser to properly handle CBOR datetime and blobs.

Fixes #6492