### PR TITLE
Upgrade JAR files to resolve some recent security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -260,6 +260,9 @@ ENV LOCALSTACK_BUILD_DATE=${LOCALSTACK_BUILD_DATE}
 ENV LOCALSTACK_BUILD_GIT_HASH=${LOCALSTACK_BUILD_GIT_HASH}
 ENV LOCALSTACK_BUILD_VERSION=${LOCALSTACK_BUILD_VERSION}
 
+# clean up some libs (e.g., Maven should be no longer required after "make init" has completed)
+RUN rm -rf /usr/share/maven
+
 # expose edge service, external service ports, and debugpy
 EXPOSE 4566 4510-4559 5678
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -29,7 +29,7 @@ LOCALHOST_IP = "127.0.0.1"
 LOCALHOST_HOSTNAME = "localhost.localstack.cloud"
 
 # version of the Maven dependency with Java utility code
-LOCALSTACK_MAVEN_VERSION = "0.2.19"
+LOCALSTACK_MAVEN_VERSION = "0.2.21"
 MAVEN_REPO_URL = "https://repo1.maven.org/maven2"
 
 # map of default service APIs and ports to be spun up (fetch map from localstack_client)

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -502,7 +502,7 @@ def install_stepfunctions_local():
         patch_url = f"{SFN_PATCH_URL_PREFIX}/{patch_class}"
         add_file_to_jar(patch_class, patch_url, target_jar=INSTALL_PATH_STEPFUNCTIONS_JAR)
 
-    # special case for Manifest file - extract first, replace content, then update in JAR file
+    # add additional classpath entries to JAR manifest file
     classpath = " ".join([os.path.basename(jar) for jar in JAR_URLS])
     update_jar_manifest(
         "StepFunctionsLocal.jar",
@@ -599,7 +599,8 @@ def update_jar_manifest(jar_file_name: str, parent_dir: str, search: str, replac
     if replace not in manifest:
         manifest = manifest.replace(search, replace, 1)
         save_file(manifest_file, manifest)
-        run(["zip", "-u", jar_file_name, manifest_file_path], cwd=parent_dir)
+        run(["zip", jar_file_name, manifest_file_path], cwd=parent_dir)
+    rm_rf(manifest_file)
 
 
 def install_amazon_kinesis_client_libs():

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -30,6 +30,7 @@ from localstack.constants import (
     KMS_URL_PATTERN,
     LIBSQLITE_AARCH64_URL,
     LOCALSTACK_MAVEN_VERSION,
+    MAVEN_REPO_URL,
     MODULE_MAIN_PATH,
     OPENSEARCH_DEFAULT_VERSION,
     OPENSEARCH_PLUGIN_LIST,
@@ -73,10 +74,9 @@ INSTALL_PATH_KMS_BINARY_PATTERN = os.path.join(INSTALL_DIR_KMS, "local-kms.<arch
 INSTALL_PATH_ELASTICMQ_JAR = os.path.join(INSTALL_DIR_ELASTICMQ, "elasticmq-server.jar")
 INSTALL_PATH_KINESALITE_CLI = os.path.join(INSTALL_DIR_NPM, "kinesalite", "cli.js")
 
-MAVEN_REPO = "https://repo1.maven.org/maven2"
 URL_LOCALSTACK_FAT_JAR = (
-    MAVEN_REPO + "/cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar"
-).format(v=LOCALSTACK_MAVEN_VERSION)
+    "{mvn}/cloud/localstack/localstack-utils/{v}/localstack-utils-{v}-fat.jar"
+).format(v=LOCALSTACK_MAVEN_VERSION, mvn=MAVEN_REPO_URL)
 
 MARKER_FILE_LIGHT_VERSION = f"{dirs.static_libs}/.light-version"
 IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local:1.7.9"
@@ -105,12 +105,12 @@ DDB_PATCH_URL_PREFIX = (
 )
 DDB_AGENT_JAR_URL = f"{DDB_PATCH_URL_PREFIX}/target/ddb-local-loader-0.1.jar"
 DDB_AGENT_JAR_PATH = os.path.join(INSTALL_DIR_DDB, "ddb-local-loader-0.1.jar")
-JAVASSIST_JAR_URL = f"{MAVEN_REPO}/org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA.jar"
+JAVASSIST_JAR_URL = f"{MAVEN_REPO_URL}/org/javassist/javassist/3.28.0-GA/javassist-3.28.0-GA.jar"
 JAVASSIST_JAR_PATH = os.path.join(INSTALL_DIR_DDB, "javassist.jar")
 
 # additional JAR libs required for multi-region and persistence (PRO only) support
-URL_ASPECTJRT = f"{MAVEN_REPO}/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar"
-URL_ASPECTJWEAVER = f"{MAVEN_REPO}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7.jar"
+URL_ASPECTJRT = f"{MAVEN_REPO_URL}/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar"
+URL_ASPECTJWEAVER = f"{MAVEN_REPO_URL}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7.jar"
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
 # kinesis-mock version
@@ -503,19 +503,13 @@ def install_stepfunctions_local():
         add_file_to_jar(patch_class, patch_url, target_jar=INSTALL_PATH_STEPFUNCTIONS_JAR)
 
     # special case for Manifest file - extract first, replace content, then update in JAR file
-    manifest_file = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "META-INF", "MANIFEST.MF")
-    if not os.path.exists(manifest_file):
-        content = run(["unzip", "-p", INSTALL_PATH_STEPFUNCTIONS_JAR, "META-INF/MANIFEST.MF"])
-        content = re.sub(
-            "Main-Class: .+", "Main-Class: cloud.localstack.StepFunctionsStarter", content
-        )
-        classpath = " ".join([os.path.basename(jar) for jar in JAR_URLS])
-        content = re.sub(r"Class-Path: \. ", f"Class-Path: {classpath} . ", content)
-        save_file(manifest_file, content)
-        run(
-            ["zip", INSTALL_PATH_STEPFUNCTIONS_JAR, "META-INF/MANIFEST.MF"],
-            cwd=INSTALL_DIR_STEPFUNCTIONS,
-        )
+    classpath = " ".join([os.path.basename(jar) for jar in JAR_URLS])
+    update_jar_manifest(
+        "StepFunctionsLocal.jar",
+        INSTALL_DIR_STEPFUNCTIONS,
+        "Class-Path: . ",
+        f"Class-Path: {classpath} . ",
+    )
 
     # download additional jar libs
     for jar_url in JAR_URLS:
@@ -545,10 +539,9 @@ def install_dynamodb_local():
         download_and_extract_with_retry(DYNAMODB_JAR_URL, tmp_archive, INSTALL_DIR_DDB)
 
     # download additional libs for Mac M1 (for local dev mode)
+    ddb_local_lib_dir = os.path.join(INSTALL_DIR_DDB, "DynamoDBLocal_lib")
     if is_mac_os() and get_arch() == "arm64":
-        target_path = os.path.join(
-            INSTALL_DIR_DDB, "DynamoDBLocal_lib", "libsqlite4java-osx-aarch64.dylib"
-        )
+        target_path = os.path.join(ddb_local_lib_dir, "libsqlite4java-osx-aarch64.dylib")
         if not file_exists_not_empty(target_path):
             download(LIBSQLITE_AARCH64_URL, target_path)
 
@@ -572,14 +565,41 @@ def install_dynamodb_local():
         download(DDB_AGENT_JAR_URL, DDB_AGENT_JAR_PATH)
     if not os.path.exists(JAVASSIST_JAR_PATH):
         download(JAVASSIST_JAR_URL, JAVASSIST_JAR_PATH)
+
+    # patch/update libraries with known CVEs
+    replacements = {
+        os.path.join(
+            ddb_local_lib_dir, "jackson-databind-*.jar"
+        ): f"{MAVEN_REPO_URL}/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar"
+    }
+    for local, remote in replacements.items():
+        matches = glob.glob(local)
+        print(matches)
+        if not matches:
+            continue
+        os.remove(matches[0])
+        parent_dir = os.path.dirname(local)
+        download(remote, os.path.join(parent_dir, os.path.basename(remote)))
+        # print("matches", matches)
+
     # ensure that javassist.jar is in the manifest classpath
-    run(["unzip", "-o", "DynamoDBLocal.jar", "META-INF/MANIFEST.MF"], cwd=INSTALL_DIR_DDB)
-    manifest_file = os.path.join(INSTALL_DIR_DDB, "META-INF", "MANIFEST.MF")
+    update_jar_manifest(
+        "DynamoDBLocal.jar", INSTALL_DIR_DDB, "Class-Path:", "Class-Path: javassist.jar"
+    )
+    update_jar_manifest(
+        "DynamoDBLocal.jar", INSTALL_DIR_DDB, "databind-2.12.3.jar", "databind-2.13.3.jar"
+    )
+
+
+def update_jar_manifest(jar_file_name: str, parent_dir: str, search: str, replace: str):
+    manifest_file_path = "META-INF/MANIFEST.MF"
+    run(["unzip", "-o", jar_file_name, manifest_file_path], cwd=parent_dir)
+    manifest_file = os.path.join(parent_dir, manifest_file_path)
     manifest = load_file(manifest_file)
-    if "javassist.jar" not in manifest:
-        manifest = manifest.replace("Class-Path:", "Class-Path: javassist.jar", 1)
+    if replace not in manifest:
+        manifest = manifest.replace(search, replace, 1)
         save_file(manifest_file, manifest)
-        run(["zip", "-u", "DynamoDBLocal.jar", "META-INF/MANIFEST.MF"], cwd=INSTALL_DIR_DDB)
+        run(["zip", "-u", jar_file_name, manifest_file_path], cwd=parent_dir)
 
 
 def install_amazon_kinesis_client_libs():

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -568,17 +568,16 @@ def install_dynamodb_local():
 
     # patch/update libraries with known CVEs
     replacements = {
-        os.path.join(
-            ddb_local_lib_dir, "jackson-databind-*.jar"
-        ): f"{MAVEN_REPO_URL}/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar"
+        "jackson-databind-*.jar": f"{MAVEN_REPO_URL}/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar",
+        "slf4j-ext-*.jar": f"{MAVEN_REPO_URL}/org/slf4j/slf4j-ext/1.8.0-beta4/slf4j-ext-1.8.0-beta4.jar",
     }
     for local, remote in replacements.items():
-        matches = glob.glob(local)
-        print(matches)
+        local_path = os.path.join(ddb_local_lib_dir, local)
+        matches = glob.glob(local_path)
         if not matches:
             continue
         os.remove(matches[0])
-        parent_dir = os.path.dirname(local)
+        parent_dir = os.path.dirname(local_path)
         download(remote, os.path.join(parent_dir, os.path.basename(remote)))
         # print("matches", matches)
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -650,13 +650,6 @@ def install_amazon_kinesis_client_libs():
             f'javac -source {JAVAC_TARGET_VERSION} -target {JAVAC_TARGET_VERSION} -cp "{classpath}" {java_files}'
         )
 
-    # patch/update libraries with known CVEs
-    upgrade_jar_file(
-        ".venv/lib/python3.10/site-packages/amazon_kclpy/jars",
-        "jackson-databind-*.jar",
-        "com/fasterxml/jackson/core/jackson-databind:2.13.3",
-    )
-
 
 def install_lambda_java_libs():
     # install LocalStack "fat" JAR file (contains all dependencies)


### PR DESCRIPTION
Upgrade JAR file versions in the Docker image to resolve some recent security vulnerabilities. Security scan results are taken from aquascan.com, which was used to analyze the Docker image.

Summary of changes:
* Introduce `update_jar_manifest(..)` util function that can be used to update the content of a MANIFEST file within a JAR archive (re-using the existing code we already had, but making it a bit more reusable)
* replace `jackson-databind-2.12.3.jar` -> `jackson-databind-2.13.3.jar`
* remove `maven` as one of the build steps in the `Dockerfile` - one of the CVEs reported is related to `/usr/share/maven/lib/maven-shared-utils-3.2.1.jar` in the image, and after the installation via `make init` is completed, it should technically no longer be required. (additionally, it saves us ~11MB uncompressed in the image). This will require a small adjustment in the tests in -ext.
* ~update version of `amazon-kclpy` and remove dependency to old/outdated `amazon_kclpy-ext`~ -> Handled in a [separate PR](https://github.com/localstack/localstack/pull/6502)