### PR TITLE
Adding a KMS test for encryption with different key formats.

### DIFF
--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -220,3 +220,24 @@ class TestKMS:
 
         response = kms_client.list_aliases(KeyId=comparison_key["KeyId"])
         assert len(response["Aliases"]) == 0
+
+    # Key ARNs, key IDs, aliases of keys and ARNs of those aliases are supposed to work.
+    def test_all_types_of_key_id_can_be_used_for_encryption(
+        self, kms_client, kms_create_key, kms_create_alias
+    ):
+        def get_alias_arn_by_alias_name(kms_client, alias_name):
+            for response in kms_client.get_paginator("list_aliases").paginate(KeyId=key_id):
+                for alias_list_entry in response["Aliases"]:
+                    if alias_list_entry["AliasName"] == alias_name:
+                        return alias_list_entry["AliasArn"]
+
+        key_metadata = kms_create_key()
+        key_arn = key_metadata["Arn"]
+        key_id = key_metadata["KeyId"]
+        alias_name = kms_create_alias(TargetKeyId=key_id)
+        alias_arn = get_alias_arn_by_alias_name(kms_client, alias_name)
+        assert alias_arn
+        kms_client.encrypt(KeyId=key_arn, Plaintext="encrypt-me")
+        kms_client.encrypt(KeyId=key_id, Plaintext="encrypt-me")
+        kms_client.encrypt(KeyId=alias_arn, Plaintext="encrypt-me")
+        kms_client.encrypt(KeyId=alias_name, Plaintext="encrypt-me")


### PR DESCRIPTION
KMS tests change:
- Adding a fixture for alias creation / cleanup.
- Adding a test to check that encrypt accepts all key representations: key ID, key ARN, alias, alias ARN.

Addresses https://github.com/localstack/localstack/issues/6471
