### PR TITLE
Add support stepfunctions integration

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -2,10 +2,8 @@ import base64
 import json
 import logging
 from abc import ABC, abstractmethod
-from enum import Enum
 from http import HTTPStatus
-from typing import Any, Dict, Union
-from urllib.parse import quote_plus, unquote_plus
+from typing import Any, Dict
 
 from flask import Response as FlaskResponse
 from requests import Response
@@ -19,6 +17,11 @@ from localstack.services.apigateway.helpers import (
     extract_query_string_params,
     get_event_request_context,
 )
+from localstack.services.apigateway.templates import (
+    MappingTemplates,
+    RequestTemplates,
+    ResponseTemplates,
+)
 from localstack.services.awslambda import lambda_api
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
 from localstack.utils import common
@@ -28,89 +31,11 @@ from localstack.utils.aws.aws_responses import (
     flask_to_requests_response,
     requests_response,
 )
-from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
 from localstack.utils.common import make_http_request, to_str
-from localstack.utils.json import extract_jsonpath, json_safe
-from localstack.utils.numbers import is_number, to_number
+from localstack.utils.json import json_safe
 from localstack.utils.strings import camel_to_snake_case, to_bytes
 
 LOG = logging.getLogger(__name__)
-
-
-class PassthroughBehavior(Enum):
-    WHEN_NO_MATCH = "WHEN_NO_MATCH"
-    WHEN_NO_TEMPLATES = "WHEN_NO_TEMPLATES"
-    NEVER = "NEVER"
-
-
-class MappingTemplates:
-    """
-    API Gateway uses mapping templates to transform incoming requests before they are sent to the
-    integration back end. With API Gateway, you can define one mapping template for each possible
-    content type. The content type selection is based on the Content-Type header of the incoming
-    request. If no content type is specified in the request, API Gateway uses an application/json
-    mapping template. By default, mapping templates are configured to simply pass through the
-    request input. Mapping templates use Apache Velocity to generate a request to your back end.
-    """
-
-    passthrough_behavior: PassthroughBehavior
-
-    class UnsupportedMediaType(Exception):
-        pass
-
-    def __init__(self, passthrough_behaviour: str):
-        self.passthrough_behavior = self.get_passthrough_behavior(passthrough_behaviour)
-
-    def check_passthrough_behavior(self, request_template):
-        """
-        Specifies how the method request body of an unmapped content type will be passed through
-        the integration request to the back end without transformation.
-        A content type is unmapped if no mapping template is defined in the integration or the
-        content type does not match any of the mapped content types, as specified in requestTemplates
-        """
-        if not request_template and self.passthrough_behavior in {
-            PassthroughBehavior.NEVER,
-            PassthroughBehavior.WHEN_NO_TEMPLATES,
-        }:
-            raise MappingTemplates.UnsupportedMediaType()
-
-    @staticmethod
-    def get_passthrough_behavior(passthrough_behaviour: str):
-        return getattr(PassthroughBehavior, passthrough_behaviour, None)
-
-
-class IntegrationSubtypes(Enum):
-    def __new__(cls, value: str, implemented: bool):
-        obj = object.__new__(cls)
-        obj._value_ = value
-        obj.implemented = implemented
-        return obj
-
-    def invoke(self, api_context: ApiInvocationContext):
-        if not self.implemented:
-            raise NotImplementedError(f"Integration subtype {self._value_} is not implemented")
-
-        match self.value:
-            case IntegrationSubtypes.STEPFUNCTIONS_STARTEXECUTION.value:
-                api_context.integration["uri"] = "StartExecution"
-                return StepFunctionIntegration().invoke(api_context)
-            case IntegrationSubtypes.STEPFUNCTIONS_STARTSYNCEXECUTION.value:
-                api_context.integration["uri"] = "StartSyncExecution"
-                return StepFunctionIntegration().invoke(api_context)
-            case IntegrationSubtypes.STEPFUNCTIONS_STOPEXECUTION.value:
-                api_context.integration["uri"] = "StopExecution"
-                return StepFunctionIntegration().invoke(api_context)
-
-    EVENTBRIDGE_PUTEVENTS = "EventBridge-PutEvents", False
-    SQS_SENDMESSAGE = "SQS-SendMessage", False
-    SQS_RECEIVEMESSAGE = "SQS-ReceiveMessage", False
-    SQS_DELETEMESSAGE = "SQS-DeleteMessage", False
-    SQS_PURGEQUEUE = "SQS-PurgeQueue", False
-    APPCONFIG_GETCONFIGURATION = "AppConfig-GetConfiguration", False
-    KINESIS_PUTRECORD = "Kinesis-PutRecord", False
-    STEPFUNCTIONS_STARTEXECUTION = "StepFunctions-StartExecution", True
-    STEPFUNCTIONS_STARTSYNCEXECUTION = "StepFunctions-StartSyncExecution", False
-    STEPFUNCTIONS_STOPEXECUTION = "StepFunctions-StopExecution", False
 
 
 class BackendIntegration(ABC):
@@ -497,187 +422,42 @@ class StepFunctionIntegration(BackendIntegration):
         return response
 
 
-class VelocityUtilApiGateway(VelocityUtil):
-    """
-    Simple class to mimic the behavior of variable '$util' in AWS API Gateway integration
-    velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
-    """
+class IntegrationSubtypes:
 
-    def base64Encode(self, s):
-        if not isinstance(s, str):
-            s = json.dumps(s)
-        encoded_str = s.encode(config.DEFAULT_ENCODING)
-        encoded_b64_str = base64.b64encode(encoded_str)
-        return encoded_b64_str.decode(config.DEFAULT_ENCODING)
+    EVENTBRIDGE_PUTEVENTS = "EventBridge-PutEvents"
+    SQS_SENDMESSAGE = "SQS-SendMessage"
+    SQS_RECEIVESMESSAGE = "SQS-ReceiveMessage"
+    SQS_DELETEMESSAGE = "SQS-DeleteMessage"
+    SQS_PURGEQUEUE = "SQS-PurgeQueue"
+    APPCONFIG_GETCONFIGURATION = "AppConfig-GetConfiguration"
+    KINESIS_PUTRECORD = "Kinesis-PutRecord"
+    STEPFUNCTIONS_STARTEXECUTION = "StepFunctions-StartExecution"
+    STEPFUNCTIONS_STARTSYNCEXECUTION = "StepFunctions-StartSyncExecution"
+    STEPFUNCTIONS_STOPEXECUTION = "StepFunctions-StopExecution"
 
-    def base64Decode(self, s):
-        if not isinstance(s, str):
-            s = json.dumps(s)
-        return base64.b64decode(s)
+    integration_subtypes: Dict[str, BackendIntegration | None] = {
+        EVENTBRIDGE_PUTEVENTS: None,
+        SQS_SENDMESSAGE: None,
+        SQS_RECEIVESMESSAGE: None,
+        SQS_DELETEMESSAGE: None,
+        SQS_PURGEQUEUE: None,
+        APPCONFIG_GETCONFIGURATION: None,
+        KINESIS_PUTRECORD: None,
+        STEPFUNCTIONS_STARTEXECUTION: StepFunctionIntegration,
+        STEPFUNCTIONS_STARTSYNCEXECUTION: StepFunctionIntegration,
+        STEPFUNCTIONS_STOPEXECUTION: StepFunctionIntegration,
+    }
 
-    def toJson(self, obj):
-        return obj and json.dumps(obj)
-
-    def urlEncode(self, s):
-        return quote_plus(s)
-
-    def urlDecode(self, s):
-        return unquote_plus(s)
-
-    def escapeJavaScript(self, s):
-        try:
-            return json.dumps(json.loads(s))
-        except Exception:
-            primitive_types = (str, int, bool, float, type(None))
-            s = s if isinstance(s, primitive_types) else str(s)
-        if str(s).strip() in {"true", "false"}:
-            s = bool(s)
-        elif s not in [True, False] and is_number(s):
-            s = to_number(s)
-        return json.dumps(s)
-
-
-class VelocityInput:
-    """
-    Simple class to mimic the behavior of variable '$input' in AWS API Gateway integration
-    velocity templates.
-    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
-    """
-
-    def __init__(self, body, params):
-        self.parameters = params or {}
-        self.value = body
-
-    def path(self, path):
-        if not self.value:
-            return {}
-        value = self.value if isinstance(self.value, dict) else json.loads(self.value)
-        return extract_jsonpath(value, path)
-
-    def json(self, path):
-        path = path or "$"
-        matching = self.path(path)
-        if isinstance(matching, (list, dict)):
-            matching = json_safe(matching)
-        return json.dumps(matching)
-
-    @property
-    def body(self):
-        return self.value
-
-    def params(self, name=None):
-        if not name:
-            return self.parameters
-        for k in ["path", "querystring", "header"]:
-            if val := self.parameters.get(k).get(name):
-                return val
-        return ""
-
-    def __getattr__(self, name):
-        return self.value.get(name)
-
-    def __repr__(self):
-        return "$input"
-
-
-class ApiGatewayVtlTemplate(VtlTemplate):
-    """Util class for rendering VTL templates with API Gateway specific extensions"""
-
-    def prepare_namespace(self, variables) -> Dict[str, Any]:
-        namespace = super().prepare_namespace(variables)
-        if stage_var := variables.get("stage_variables") or {}:
-            namespace["stageVariables"] = stage_var
-        input_var = variables.get("input") or {}
-        variables = {
-            "input": VelocityInput(input_var.get("body"), input_var.get("params")),
-            "util": VelocityUtilApiGateway(),
-        }
-        namespace.update(variables)
-        return namespace
-
-
-class Templates:
-    __slots__ = ["vtl"]
-
-    def __init__(self):
-        self.vtl = ApiGatewayVtlTemplate()
-
-    def render(self, api_context: ApiInvocationContext) -> Union[bytes, str]:
-        pass
-
-    def render_vtl(self, template, variables):
-        return self.vtl.render_vtl(template, variables=variables)
+    @classmethod
+    def invoke(cls, integration_details: Dict[str, Any], api_context: ApiInvocationContext):
+        integration_subtype = integration_details.get("IntegrationSubtype")
+        if backend_integration := cls.integration_subtypes.get(integration_subtype):
+            api_context.integration["uri"] = IntegrationSubtypes.action_from_subtype_name(
+                integration_subtype
+            )
+            return backend_integration().invoke(api_context)
+        raise NotImplementedError(f'Integration subtype "{integration_subtype}" is not implemented')
 
     @staticmethod
-    def build_variables_mapping(api_context: ApiInvocationContext):
-        # TODO: make this (dict) an object so usages of "render_vtl" variables are defined
-        return {
-            "context": api_context.context or {},
-            "stage_variables": api_context.stage_variables or {},
-            "input": {
-                "body": api_context.data_as_string(),
-                "params": {
-                    "path": api_context.path_params,
-                    "querystring": api_context.query_params(),
-                    "header": api_context.headers,
-                },
-            },
-        }
-
-
-class RequestTemplates(Templates):
-    """
-    Handles request template rendering
-    """
-
-    def render(self, api_context: ApiInvocationContext) -> Union[bytes, str]:
-        LOG.info(
-            "Method request body before transformations: %s", to_str(api_context.data_as_string())
-        )
-        request_templates = api_context.integration.get("requestTemplates", {})
-        template = request_templates.get(APPLICATION_JSON, {})
-        if not template:
-            return api_context.data_as_string()
-
-        variables = self.build_variables_mapping(api_context)
-        result = self.render_vtl(template, variables=variables)
-        LOG.info(f"Endpoint request body after transformations:\n{result}")
-        return result
-
-
-class ResponseTemplates(Templates):
-    """
-    Handles response template rendering
-    """
-
-    def render(self, api_context: ApiInvocationContext, **kwargs) -> Union[bytes, str]:
-        # XXX: keep backwards compatibility until we migrate all integrations to this new classes
-        # api_context contains a response object that we want slowly remove from it
-        data = kwargs["response"] if "response" in kwargs else ""
-        response = data or api_context.response
-        integration = api_context.integration
-        # we set context data with the response content because later on we use context data as
-        # the body field in the template. We need to improve this by using the right source
-        # depending on the type of templates.
-        api_context.data = response._content
-
-        integration_responses = integration.get("integrationResponses") or {}
-        if not integration_responses:
-            return response._content
-        entries = list(integration_responses.keys())
-        return_code = str(response.status_code)
-        if return_code not in entries and len(entries) > 1:
-            LOG.info("Found multiple integration response status codes: %s", entries)
-            return response._content
-        return_code = entries[0]
-
-        response_templates = integration_responses[return_code].get("responseTemplates", {})
-        template = response_templates.get(APPLICATION_JSON, {})
-        if not template:
-            return response._content
-
-        variables = self.build_variables_mapping(api_context)
-        response._content = self.render_vtl(template, variables=variables)
-        LOG.info("Endpoint response body after transformations:\n%s", response._content)
-        return response._content
+    def action_from_subtype_name(subtype_name: str):
+        return subtype_name.split("-")[1]

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -103,7 +103,7 @@ class IntegrationSubtypes(Enum):
 
     EVENTBRIDGE_PUTEVENTS = "EventBridge-PutEvents", False
     SQS_SENDMESSAGE = "SQS-SendMessage", False
-    SQS_RECEIVESMESSAGE = "SQS-ReceiveMessage", False
+    SQS_RECEIVEMESSAGE = "SQS-ReceiveMessage", False
     SQS_DELETEMESSAGE = "SQS-DeleteMessage", False
     SQS_PURGEQUEUE = "SQS-PurgeQueue", False
     APPCONFIG_GETCONFIGURATION = "AppConfig-GetConfiguration", False

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -442,8 +442,7 @@ class StepFunctionIntegration(BackendIntegration):
         action = uri.split("/")[-1]
 
         if APPLICATION_JSON in invocation_context.integration.get("requestTemplates", {}):
-            request_templates = RequestTemplates()
-            payload = request_templates.render(invocation_context)
+            payload = self.request_templates.render(invocation_context)
             payload = json.loads(payload)
         else:
             payload = json.loads(invocation_context.data)

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -26,10 +26,9 @@ from localstack.services.apigateway.integration import (
     RequestTemplates,
     ResponseTemplates,
     SnsIntegration,
-    VtlTemplate,
+    VtlTemplate, StepFunctionIntegration,
 )
 from localstack.services.kinesis import kinesis_listener
-from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import request_response_stream, requests_response
@@ -380,60 +379,7 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
             return invocation_context.response
 
         elif "states:action/" in uri:
-            action = uri.split("/")[-1]
-
-            if APPLICATION_JSON in integration.get("requestTemplates", {}):
-                request_templates = RequestTemplates()
-                payload = request_templates.render(invocation_context)
-                payload = json.loads(payload)
-            else:
-                # XXX decoding in py3 sounds wrong, this actually might break
-                payload = json.loads(data.decode("utf-8"))
-            client = aws_stack.connect_to_service("stepfunctions")
-
-            if isinstance(payload.get("input"), dict):
-                payload["input"] = json.dumps(payload["input"])
-
-            # Hot fix since step functions local package responses: Unsupported Operation: 'StartSyncExecution'
-            method_name = (
-                camel_to_snake_case(action) if action != "StartSyncExecution" else "start_execution"
-            )
-
-            try:
-                method = getattr(client, method_name)
-            except AttributeError:
-                msg = "Invalid step function action: %s" % method_name
-                LOG.error(msg)
-                return make_error_response(msg, 400)
-
-            result = method(**payload)
-            result = json_safe({k: result[k] for k in result if k not in "ResponseMetadata"})
-            response = requests_response(
-                content=result,
-                headers=aws_stack.mock_aws_request_headers(),
-            )
-
-            if action == "StartSyncExecution":
-                # poll for the execution result and return it
-                result = await_sfn_execution_result(result["executionArn"])
-                result_status = result.get("status")
-                if result_status != "SUCCEEDED":
-                    return make_error_response(
-                        "StepFunctions execution %s failed with status '%s'"
-                        % (result["executionArn"], result_status),
-                        500,
-                    )
-                result = json_safe(result)
-                response = requests_response(content=result)
-
-            # apply response templates
-            invocation_context.response = response
-            response_templates = ResponseTemplates()
-            response_templates.render(invocation_context)
-            # response = apply_request_response_templates(
-            #     response, response_templates, content_type=APPLICATION_JSON
-            # )
-            return response
+            return StepFunctionIntegration().invoke(invocation_context)
         # https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
         elif ("s3:path/" in uri or "s3:action/" in uri) and method == "GET":
             s3 = aws_stack.connect_to_service("s3")

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -26,14 +26,13 @@ from localstack.services.apigateway.integration import (
     RequestTemplates,
     ResponseTemplates,
     SnsIntegration,
-    VtlTemplate, StepFunctionIntegration,
+    StepFunctionIntegration,
+    VtlTemplate,
 )
 from localstack.services.kinesis import kinesis_listener
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import request_response_stream, requests_response
-from localstack.utils.common import camel_to_snake_case, json_safe
-
 # set up logger
 from localstack.utils.http import add_query_params_to_url
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -23,10 +23,12 @@ from localstack.services.apigateway.integration import (
     LambdaIntegration,
     LambdaProxyIntegration,
     MockIntegration,
-    RequestTemplates,
-    ResponseTemplates,
     SnsIntegration,
     StepFunctionIntegration,
+)
+from localstack.services.apigateway.templates import (
+    RequestTemplates,
+    ResponseTemplates,
     VtlTemplate,
 )
 from localstack.services.kinesis import kinesis_listener

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -35,6 +35,7 @@ from localstack.services.kinesis import kinesis_listener
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import request_response_stream, requests_response
+
 # set up logger
 from localstack.utils.http import add_query_params_to_url
 

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -1,0 +1,244 @@
+import base64
+import json
+import logging
+from enum import Enum
+from typing import Any, Dict, Union
+from urllib.parse import quote_plus, unquote_plus
+
+from localstack import config
+from localstack.constants import APPLICATION_JSON
+from localstack.services.apigateway.context import ApiInvocationContext
+from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
+from localstack.utils.json import extract_jsonpath, json_safe
+from localstack.utils.numbers import is_number, to_number
+from localstack.utils.strings import to_str
+
+LOG = logging.getLogger(__name__)
+
+
+class PassthroughBehavior(Enum):
+    WHEN_NO_MATCH = "WHEN_NO_MATCH"
+    WHEN_NO_TEMPLATES = "WHEN_NO_TEMPLATES"
+    NEVER = "NEVER"
+
+
+class MappingTemplates:
+    """
+    API Gateway uses mapping templates to transform incoming requests before they are sent to the
+    integration back end. With API Gateway, you can define one mapping template for each possible
+    content type. The content type selection is based on the Content-Type header of the incoming
+    request. If no content type is specified in the request, API Gateway uses an application/json
+    mapping template. By default, mapping templates are configured to simply pass through the
+    request input. Mapping templates use Apache Velocity to generate a request to your back end.
+    """
+
+    passthrough_behavior: PassthroughBehavior
+
+    class UnsupportedMediaType(Exception):
+        pass
+
+    def __init__(self, passthrough_behaviour: str):
+        self.passthrough_behavior = self.get_passthrough_behavior(passthrough_behaviour)
+
+    def check_passthrough_behavior(self, request_template):
+        """
+        Specifies how the method request body of an unmapped content type will be passed through
+        the integration request to the back end without transformation.
+        A content type is unmapped if no mapping template is defined in the integration or the
+        content type does not match any of the mapped content types, as specified in requestTemplates
+        """
+        if not request_template and self.passthrough_behavior in {
+            PassthroughBehavior.NEVER,
+            PassthroughBehavior.WHEN_NO_TEMPLATES,
+        }:
+            raise MappingTemplates.UnsupportedMediaType()
+
+    @staticmethod
+    def get_passthrough_behavior(passthrough_behaviour: str):
+        return getattr(PassthroughBehavior, passthrough_behaviour, None)
+
+
+class VelocityUtilApiGateway(VelocityUtil):
+    """
+    Simple class to mimic the behavior of variable '$util' in AWS API Gateway integration
+    velocity templates.
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+    """
+
+    def base64Encode(self, s):
+        if not isinstance(s, str):
+            s = json.dumps(s)
+        encoded_str = s.encode(config.DEFAULT_ENCODING)
+        encoded_b64_str = base64.b64encode(encoded_str)
+        return encoded_b64_str.decode(config.DEFAULT_ENCODING)
+
+    def base64Decode(self, s):
+        if not isinstance(s, str):
+            s = json.dumps(s)
+        return base64.b64decode(s)
+
+    def toJson(self, obj):
+        return obj and json.dumps(obj)
+
+    def urlEncode(self, s):
+        return quote_plus(s)
+
+    def urlDecode(self, s):
+        return unquote_plus(s)
+
+    def escapeJavaScript(self, s):
+        try:
+            return json.dumps(json.loads(s))
+        except Exception:
+            primitive_types = (str, int, bool, float, type(None))
+            s = s if isinstance(s, primitive_types) else str(s)
+        if str(s).strip() in {"true", "false"}:
+            s = bool(s)
+        elif s not in [True, False] and is_number(s):
+            s = to_number(s)
+        return json.dumps(s)
+
+
+class VelocityInput:
+    """
+    Simple class to mimic the behavior of variable '$input' in AWS API Gateway integration
+    velocity templates.
+    See: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+    """
+
+    def __init__(self, body, params):
+        self.parameters = params or {}
+        self.value = body
+
+    def path(self, path):
+        if not self.value:
+            return {}
+        value = self.value if isinstance(self.value, dict) else json.loads(self.value)
+        return extract_jsonpath(value, path)
+
+    def json(self, path):
+        path = path or "$"
+        matching = self.path(path)
+        if isinstance(matching, (list, dict)):
+            matching = json_safe(matching)
+        return json.dumps(matching)
+
+    @property
+    def body(self):
+        return self.value
+
+    def params(self, name=None):
+        if not name:
+            return self.parameters
+        for k in ["path", "querystring", "header"]:
+            if val := self.parameters.get(k).get(name):
+                return val
+        return ""
+
+    def __getattr__(self, name):
+        return self.value.get(name)
+
+    def __repr__(self):
+        return "$input"
+
+
+class ApiGatewayVtlTemplate(VtlTemplate):
+    """Util class for rendering VTL templates with API Gateway specific extensions"""
+
+    def prepare_namespace(self, variables) -> Dict[str, Any]:
+        namespace = super().prepare_namespace(variables)
+        if stage_var := variables.get("stage_variables") or {}:
+            namespace["stageVariables"] = stage_var
+        input_var = variables.get("input") or {}
+        variables = {
+            "input": VelocityInput(input_var.get("body"), input_var.get("params")),
+            "util": VelocityUtilApiGateway(),
+        }
+        namespace.update(variables)
+        return namespace
+
+
+class Templates:
+    __slots__ = ["vtl"]
+
+    def __init__(self):
+        self.vtl = ApiGatewayVtlTemplate()
+
+    def render(self, api_context: ApiInvocationContext) -> Union[bytes, str]:
+        pass
+
+    def render_vtl(self, template, variables):
+        return self.vtl.render_vtl(template, variables=variables)
+
+    @staticmethod
+    def build_variables_mapping(api_context: ApiInvocationContext):
+        # TODO: make this (dict) an object so usages of "render_vtl" variables are defined
+        return {
+            "context": api_context.context or {},
+            "stage_variables": api_context.stage_variables or {},
+            "input": {
+                "body": api_context.data_as_string(),
+                "params": {
+                    "path": api_context.path_params,
+                    "querystring": api_context.query_params(),
+                    "header": api_context.headers,
+                },
+            },
+        }
+
+
+class RequestTemplates(Templates):
+    """
+    Handles request template rendering
+    """
+
+    def render(self, api_context: ApiInvocationContext) -> Union[bytes, str]:
+        LOG.info(
+            "Method request body before transformations: %s", to_str(api_context.data_as_string())
+        )
+        request_templates = api_context.integration.get("requestTemplates", {})
+        template = request_templates.get(APPLICATION_JSON, {})
+        if not template:
+            return api_context.data_as_string()
+
+        variables = self.build_variables_mapping(api_context)
+        result = self.render_vtl(template, variables=variables)
+        LOG.info(f"Endpoint request body after transformations:\n{result}")
+        return result
+
+
+class ResponseTemplates(Templates):
+    """
+    Handles response template rendering
+    """
+
+    def render(self, api_context: ApiInvocationContext, **kwargs) -> Union[bytes, str]:
+        # XXX: keep backwards compatibility until we migrate all integrations to this new classes
+        # api_context contains a response object that we want slowly remove from it
+        data = kwargs["response"] if "response" in kwargs else ""
+        response = data or api_context.response
+        integration = api_context.integration
+        # we set context data with the response content because later on we use context data as
+        # the body field in the template. We need to improve this by using the right source
+        # depending on the type of templates.
+        api_context.data = response._content
+
+        integration_responses = integration.get("integrationResponses") or {}
+        if not integration_responses:
+            return response._content
+        entries = list(integration_responses.keys())
+        return_code = str(response.status_code)
+        if return_code not in entries and len(entries) > 1:
+            LOG.info("Found multiple integration response status codes: %s", entries)
+            return response._content
+        return_code = entries[0]
+
+        response_templates = integration_responses[return_code].get("responseTemplates", {})
+        template = response_templates.get(APPLICATION_JSON, {})
+        if not template:
+            return response._content
+
+        variables = self.build_variables_mapping(api_context)
+        response._content = self.render_vtl(template, variables=variables)
+        LOG.info("Endpoint response body after transformations:\n%s", response._content)
+        return response._content

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -16,7 +16,7 @@ from localstack.services.apigateway.helpers import (
     extract_query_string_params,
     get_resource_for_path,
 )
-from localstack.services.apigateway.integration import (
+from localstack.services.apigateway.templates import (
     RequestTemplates,
     ResponseTemplates,
     VelocityUtilApiGateway,

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -16,15 +16,15 @@ from localstack.services.apigateway.helpers import (
     extract_query_string_params,
     get_resource_for_path,
 )
-from localstack.services.apigateway.templates import (
-    RequestTemplates,
-    ResponseTemplates,
-    VelocityUtilApiGateway,
-)
 from localstack.services.apigateway.invocations import (
     ApiInvocationContext,
     RequestValidator,
     apply_request_parameters,
+)
+from localstack.services.apigateway.templates import (
+    RequestTemplates,
+    ResponseTemplates,
+    VelocityUtilApiGateway,
 )
 from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.common import clone

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from localstack.services.apigateway.integration import ApiGatewayVtlTemplate
+from localstack.services.apigateway.templates import ApiGatewayVtlTemplate
 from localstack.utils.aws.templating import render_velocity_template
 
 # template used to transform incoming requests at the API Gateway (forward to Kinesis)


### PR DESCRIPTION
The support for stepfunctions integration currently is only supported for REST APIs. This PR wraps the logic related to invoking stepfunctions into a class that can be re-used by HTTP and Websockets API.

AWS` Services are also invoked using [integration subtypes](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html). This PR enumerates those subtypes and will dispatch actions to the existing integrations.

 