### PR TITLE
Pin quart and werkzeug versions to fix recent changes in req ctx stack, URL Map

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -148,9 +148,8 @@ TERRAFORM_BIN = os.path.join(dirs.static_libs, f"terraform-{TERRAFORM_VERSION}",
 
 # Java Test Jar Download (used for tests)
 TEST_LAMBDA_JAVA = os.path.join(config.dirs.var_libs, "localstack-utils-tests.jar")
-MAVEN_BASE_URL = "https://repo.maven.apache.org/maven2"
 TEST_LAMBDA_JAR_URL = "{url}/cloud/localstack/{name}/{version}/{name}-{version}-tests.jar".format(
-    version=LOCALSTACK_MAVEN_VERSION, url=MAVEN_BASE_URL, name="localstack-utils"
+    version=LOCALSTACK_MAVEN_VERSION, url=MAVEN_REPO_URL, name="localstack-utils"
 )
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/v0.1.1-pre/aws-lambda-rie-{arch}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ runtime =
     Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
-    Werkzeug>=2.0
+    Werkzeug==2.1.2
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ runtime =
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl>=21.0.0
-    Quart>=0.6.15
+    Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
     Werkzeug>=2.0

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -343,7 +343,7 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_create_disabled_event_source_mapping(self):
         createResponse = self.client.post(
-            "{0}/event-source-mappings/".format(API_PATH_ROOT),
+            f"{API_PATH_ROOT}/event-source-mappings/",
             data=json.dumps(
                 {
                     "FunctionName": "test-lambda-function",


### PR DESCRIPTION
Pin `quart` version to `0.17` to fix recent change in request context stack.

The `_*_ctx_stack` globals have been removed in `0.18` - see this commit for rationale/background: https://github.com/pallets/quart/commit/b2b614b336d99071a05a8525d4d0e18b9a1d66ec

Seems easy enough to pin the version for now, but we should also keep an eye on developments in flask (looks like `_request_ctx_stack` will be [removed there soon](https://github.com/pallets/flask/blob/cbebdae698272eeea2739988ccce54b1f14a1a67/src/flask/__init__.py#L64-L68) as well).

---
Update: Also pinning werkzeug to version `2.1.2` for now, as the latest released version `2.2.0` seems to have changed the logic of URL Map routing - our routes with `strict_slashes=False` in the Lambda API are now failing when sending a request with a trailing slash in the path.

---

Also sneaking in a small change to remove duplicate constant `MAVEN_BASE_URL`.