### PR TITLE
Fix pytest log capture for integration tests

### DIFF
--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -86,7 +86,7 @@ def setup_logging(log_level=logging.INFO) -> None:
     log_handler = create_default_handler(log_level)
 
     # replace any existing handlers
-    logging.basicConfig(level=log_level, handlers=[log_handler], force=True)
+    logging.basicConfig(level=log_level, handlers=[log_handler])
 
     # disable some logs and warnings
     warnings.filterwarnings("ignore")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,5 @@ exclude_lines = [
 [tool.pytest.ini_options]
 log_cli = true
 log_level = "DEBUG"
-log_cli_format = "%(asctime)s.%(msecs)03d:%(levelname)s:%(name)s: %(message)s"
+log_cli_format = "%(asctime)s.%(msecs)03d %(level_name)5s --- [%(thread)12s] %(name)-26s : %(message)s"
 log_cli_date_format = "%Y-%m-%dT%H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,5 +41,5 @@ exclude_lines = [
 [tool.pytest.ini_options]
 log_cli = true
 log_level = "DEBUG"
-log_cli_format = "%(asctime)s.%(msecs)03d %(level_name)5s --- [%(thread)12s] %(name)-26s : %(message)s"
+log_cli_format = "%(asctime)s.%(msecs)03d %(levelname)5s --- [%(threadName)12s] %(name)-26s : %(message)s"
 log_cli_date_format = "%Y-%m-%dT%H:%M:%S"


### PR DESCRIPTION
Currently, due to the force deletion of all registered log handlers, we take the possibility of pytest to capture log entries. This behavior was introduced with #6424 .

Due to the -s selector in most circleci tests, this does not affect the community tests as much as the pro tests.

This PR fixes this behavior and adjusts the test logs to (almost) match our usual log.