### PR TITLE
Fix Swagger spec imports of REST APIs with base paths

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -346,7 +346,7 @@ def find_api_subentity_by_id(api_id, entity_id, map_name):
     return ([a for a in auth_list if a["id"] == entity_id] or [None])[0]
 
 
-def path_based_url(api_id, stage_name, path):
+def path_based_url(api_id: str, stage_name: str, path: str) -> str:
     """Return URL for inbound API gateway for given API ID, stage name, and path"""
     pattern = "%s/restapis/{api_id}/{stage_name}/%s{path}" % (
         config.service_url("apigateway"),
@@ -638,7 +638,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                         authorizers.update({security_scheme_name: authorizer})
                     return authorizer
 
-    def get_or_create_path(path):
+    def get_or_create_path(path: str):
         parts = path.rstrip("/").replace("//", "/").split("/")
         parent_id = ""
         if len(parts) > 1:
@@ -653,7 +653,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
             return existing[0]
         return add_path(path, parts, parent_id=parent_id)
 
-    def add_path(path, parts, parent_id=""):
+    def add_path(path: str, parts: List[str], parent_id=""):
         child_id = create_resource_id()
         path = path or "/"
         resource = Resource(
@@ -664,7 +664,10 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
             parent_id=parent_id,
         )
 
-        for method, method_schema in resolved_schema["paths"].get(path, {}).items():
+        paths_dict = resolved_schema["paths"]
+        relative_path = path.removeprefix(base_path)
+        method_paths = paths_dict.get(relative_path, {})
+        for method, method_schema in method_paths.items():
             method = method.upper()
 
             method_integration = method_schema.get("x-amazon-apigateway-integration", {})

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -729,8 +729,15 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
         for name, model in definitions.items():
             rest_api.add_model(name=name, schema=model, content_type=APPLICATION_JSON)
 
+    # determine base path
     basepath_mode = (query_params.get("basepath") or ["prepend"])[0]
-    base_path = (resolved_schema.get("basePath") or "") if basepath_mode == "prepend" else ""
+    base_path = ""
+    if basepath_mode == "prepend":
+        base_path = resolved_schema.get("basePath") or ""
+    if basepath_mode == "split":
+        base_path = (resolved_schema.get("basePath") or "").strip("/").split("/")[0]
+        base_path = f"/{base_path}" if base_path else ""
+
     for path in resolved_schema.get("paths", {}):
         get_or_create_path(base_path + path)
 

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -48,7 +48,9 @@ def apply_patches():
     apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init
 
-    def apigateway_models_backend_put_rest_api(self, function_id, body, query_params):
+    def apigateway_models_backend_put_rest_api(
+        self, function_id: str, body: Dict, query_params: Dict
+    ):
         rest_api = self.get_rest_api(function_id)
         return import_api_from_openapi_spec(rest_api, body, query_params)
 

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -119,16 +119,17 @@ class GatewayRestAPI(GenericBaseModel):
             resource = resources[resource_id]
             props = resource["Properties"]
 
+            # TODO: add missing attributes
             result = client.create_rest_api(
                 name=props["Name"], description=props.get("Description", "")
-            )  # TODO: rest of the attributes
+            )
             body = props.get("Body")
-            if body is not None:
+            if body:
                 body = json.dumps(body) if isinstance(body, dict) else body
                 client.put_rest_api(restApiId=result["id"], body=to_bytes(body))
 
         return {
-            "create": [{"function": _create}],
+            "create": {"function": _create},
             "delete": {
                 "function": "delete_rest_api",
                 "parameters": {

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -125,8 +125,12 @@ class GatewayRestAPI(GenericBaseModel):
             )
             body = props.get("Body")
             if body:
+                # the default behavior for imports via CFn is basepath=ignore (validated against AWS)
+                api_params = {"basepath": "ignore"}
                 body = json.dumps(body) if isinstance(body, dict) else body
-                client.put_rest_api(restApiId=result["id"], body=to_bytes(body))
+                client.put_rest_api(
+                    restApiId=result["id"], body=to_bytes(body), parameters=api_params
+                )
 
         return {
             "create": {"function": _create},

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -922,9 +922,8 @@ def deploy_cfn_template(
                 )
 
             assert wait_until(_await_stack_delete, _max_wait=60)
-            time.sleep(
-                2
-            )  # TODO: fix in localstack. stack should only be in DELETE_COMPLETE state after all resources have been deleted
+            # TODO: fix in localstack. stack should only be in DELETE_COMPLETE state after all resources have been deleted
+            time.sleep(2)
 
         return DeployResult(
             change_set_id, stack_id, stack_name, change_set_name, mapped_outputs, _destroy_stack

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -212,9 +212,13 @@ def get_partition(region_name: str = None):
 def get_local_region():
     global LOCAL_REGION
     if LOCAL_REGION is None:
-        session = boto3.session.Session()
-        LOCAL_REGION = session.region_name or ""
+        LOCAL_REGION = get_boto3_region() or ""
     return config.DEFAULT_REGION or LOCAL_REGION
+
+
+def get_boto3_region() -> str:
+    """Return the region name, as determined from the environment when creating a new boto3 session"""
+    return boto3.session.Session().region_name
 
 
 def is_internal_call_context(headers):

--- a/tests/integration/apigateway_fixtures.py
+++ b/tests/integration/apigateway_fixtures.py
@@ -2,6 +2,8 @@ from enum import Enum
 from typing import Dict
 
 from localstack.services.apigateway.helpers import host_based_url, path_based_url
+from localstack.testing.aws.util import is_aws_cloud
+from localstack.utils.aws import aws_stack
 
 
 def assert_response_is_200(response: Dict) -> bool:
@@ -144,6 +146,8 @@ def delete_cognito_user_pool_client(cognito_idp, **kwargs):
 #
 # Common utilities
 #
+
+
 class UrlType(Enum):
     HOST_BASED = 0
     PATH_BASED = 1
@@ -152,7 +156,9 @@ class UrlType(Enum):
 def api_invoke_url(
     api_id: str, stage: str = "", path: str = "/", url_type: UrlType = UrlType.HOST_BASED
 ):
+    if is_aws_cloud():
+        stage = f"/{stage}" if stage else ""
+        return f"https://{api_id}.execute-api.{aws_stack.get_boto3_region()}.amazonaws.com{stage}{path}"
     if url_type == UrlType.HOST_BASED:
         return host_based_url(api_id, stage_name=stage, path=path)
-    else:
-        return path_based_url(api_id, stage_name=stage, path=path)
+    return path_based_url(api_id, stage_name=stage, path=path)

--- a/tests/integration/files/swagger.json
+++ b/tests/integration/files/swagger.json
@@ -4,6 +4,7 @@
     "title": "test",
     "version": "2020-07-23T23:02:57Z"
   },
+  "basePath": "/base",
   "servers": [
     {
       "url": "https://rei6t36l9d.execute-api.us-east-1.amazonaws.com/{basePath}",

--- a/tests/integration/files/swagger.yaml
+++ b/tests/integration/files/swagger.yaml
@@ -2,6 +2,7 @@ openapi: 3.0.1
 info:
   title: test
   version: '2020-07-23T23:02:57Z'
+basePath: /base
 servers:
 - url: https://rei6t36l9d.execute-api.us-east-1.amazonaws.com/{basePath}
   variables:

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -32,7 +32,7 @@ def test_http_integration(apigateway_client):
         restApiId=api_id, resourceId=root_id, httpMethod="GET", statusCode="200"
     )
 
-    response = apigateway_client.put_integration(
+    apigateway_client.put_integration(
         restApiId=api_id,
         resourceId=root_id,
         httpMethod="GET",


### PR DESCRIPTION
Fix OpenAPI spec imports of REST APIs with base paths.

This surfaced while debugging a user issue, using a SAM template - if `basePath: /base` is defined in the template, then we were previously incorrectly performing a lookup of the absolute path within `paths`, whereas we should perform lookup with the relative path (stripping off the `basePath` prefix).