### PR TITLE
fix CONTAINER_*_FOLDER usage for new file system hierarchy

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -110,10 +110,15 @@ class Directories:
         """
         defaults = Directories.defaults()
 
+        # only set CONTAINER_VAR_LIBS_FOLDER/CONTAINER_CACHE_FOLDER inside the container to redirect var_libs/cache to
+        # another directory to avoid override by host mount
+        var_libs = os.environ.get("CONTAINER_VAR_LIBS_FOLDER", "").strip() or defaults.var_libs
+        cache = os.environ.get("CONTAINER_CACHE_FOLDER", "").strip() or defaults.cache
+
         return Directories(
             static_libs=defaults.static_libs,
-            var_libs=defaults.var_libs,
-            cache=defaults.cache,
+            var_libs=var_libs,
+            cache=cache,
             tmp=defaults.tmp,
             functions=defaults.functions,
             data=defaults.data if PERSISTENCE else os.path.join(defaults.tmp, "state"),


### PR DESCRIPTION
With #6302, a new file system hierarchy has been implemented.
Until now, the new config did not take the following environment variables into account:
- `CONTAINER_VAR_LIBS_FOLDER`
- `CONTAINER_CACHE_FOLDER`

These variables are used for configurations where the `libs` and the `cache` folder are pre-populated in the Docker image (and should therefore not be overwritten by a volume mount).
While it is planned to deprecate these variables and replace it with a fallback-mechanism and selective targets for LPM, we still need them for now.
This PR simply adds a few lines to `config.py#for_container` to take these config variables into account.