### PR TITLE
fix EC2 ASF error serialization and botocore parsing

### DIFF
--- a/localstack/aws/client.py
+++ b/localstack/aws/client.py
@@ -175,7 +175,7 @@ def parse_service_exception(
     response: Response, parsed_response: Dict
 ) -> Optional[ServiceException]:
     """
-    Creates a ServiceException from a parsed response (one that botocore would return).
+    Creates a ServiceException (one ASF can handle) from a parsed response (one that botocore would return).
     It does not automatically raise the exception (see #raise_service_exception).
     :param response: Un-parsed response
     :param parsed_response: Parsed response
@@ -192,7 +192,9 @@ def parse_service_exception(
     )
     # Add all additional fields in the parsed response as members of the exception
     for key, value in parsed_response.items():
-        if key.lower() not in ["code", "message", "type"] and not hasattr(service_exception, key):
+        if key.lower() not in ["code", "message", "type", "error"] and not hasattr(
+            service_exception, key
+        ):
             setattr(service_exception, key, value)
     return service_exception
 

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1029,8 +1029,9 @@ class EC2ResponseSerializer(QueryResponseSerializer):
             if "xmlNamespace" in operation_model.metadata
             else None
         )
-        root = ETree.Element("Errors", attr)
-        error_tag = ETree.SubElement(root, "Error")
+        root = ETree.Element("Response", attr)
+        errors_tag = ETree.SubElement(root, "Errors")
+        error_tag = ETree.SubElement(errors_tag, "Error")
         self._add_error_tags(error, error_tag)
         request_id = ETree.SubElement(root, "RequestID")
         request_id.text = gen_amzn_requestid_long()

--- a/tests/unit/aws/test_client.py
+++ b/tests/unit/aws/test_client.py
@@ -1,0 +1,23 @@
+from localstack.aws.api import ServiceException
+from localstack.aws.client import parse_service_exception
+from localstack.http import Response
+
+
+def test_parse_service_exception():
+    response = Response(status=400)
+    parsed_response = {
+        "Error": {
+            "Code": "InvalidSubnetID.NotFound",
+            "Message": "The subnet ID 'vpc-test' does not exist",
+        }
+    }
+    exception = parse_service_exception(response, parsed_response)
+    assert exception
+    assert isinstance(exception, ServiceException)
+    assert exception.code == "InvalidSubnetID.NotFound"
+    assert exception.message == "The subnet ID 'vpc-test' does not exist"
+    assert exception.status_code == 400
+    assert not exception.sender_fault
+    # Ensure that the parsed exception does not have the "Error" field from the botocore response dict
+    assert not hasattr(exception, "Error")
+    assert not hasattr(exception, "error")


### PR DESCRIPTION
The EC2 protocol is quite similar to the query protocol, but one difference is that the root element of error responses is a `Response` node:
```xml
<Response>
  <Errors>
    <Error>
      <Code>InvalidInstanceID.Malformed</Code>
      <Message>Invalid id: "1343124"</Message>
    </Error>
  </Errors>
  <RequestID>12345</RequestID>
</Response>
```
This PR fixes a small issue concerning the EC2 protocol error serialization, where the `Errors` node was the root node.
In addition, it fixes a small issue with our client where the `Error` member of a parsed botocore response would be added to an ASF `ServiceException`.

Fixes #6528.