### PR TITLE
PaginatedList without explicit token_generator.

### DIFF
--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -104,7 +104,7 @@ class PaginatedList(List[_ListType]):
 
     def get_page(
         self,
-        token_generator: Callable[[_ListType], str],
+        token_generator: Optional[Callable[[_ListType], str]] = None,
         next_token: str = None,
         page_size: int = None,
         filter_function: Callable[[_ListType], bool] = None,
@@ -122,14 +122,22 @@ class PaginatedList(List[_ListType]):
 
         start_idx = 0
 
-        try:
-            start_item = next(item for item in result_list if token_generator(item) == next_token)
-            start_idx = result_list.index(start_item)
-        except StopIteration:
-            pass
+        if token_generator:
+            try:
+                start_item = next(
+                    item for item in result_list if token_generator(item) == next_token
+                )
+                start_idx = result_list.index(start_item)
+            except StopIteration:
+                pass
+        else:
+            start_idx = next_token or 0
 
         if start_idx + page_size < len(result_list):
-            next_token = token_generator(result_list[start_idx + page_size])
+            if token_generator:
+                next_token = token_generator(result_list[start_idx + page_size])
+            else:
+                next_token = start_idx + page_size
         else:
             next_token = None
 

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -7,6 +7,7 @@ from localstack.utils.collections import (
     HashableList,
     ImmutableDict,
     ImmutableList,
+    PaginatedList,
     select_from_typed_dict,
 )
 
@@ -100,3 +101,33 @@ def test_hashable_list():
     with pytest.raises(Exception) as exc:
         l1[0] = "foo"
     exc.match("does not support item assignment")
+
+
+class TestPaginatedList:
+    def test_returns_everything_if_page_size_is_big_enough(self):
+        initial_list = [10, 11, 12, 13, 14, 15, 16]
+        paginated_list = PaginatedList(initial_list)
+        page, next_token = paginated_list.get_page(page_size=10)
+        assert page == initial_list
+        assert next_token is None
+
+    def test_returns_first_page_correctly(self):
+        initial_list = [10, 11, 12, 13, 14, 15, 16]
+        paginated_list = PaginatedList(initial_list)
+        page, next_token = paginated_list.get_page(page_size=3)
+        assert page == [10, 11, 12]
+        assert next_token == 3
+
+    def test_returns_second_page_correctly(self):
+        initial_list = [10, 11, 12, 13, 14, 15, 16]
+        paginated_list = PaginatedList(initial_list)
+        page, next_token = paginated_list.get_page(page_size=3, next_token=3)
+        assert page == [13, 14, 15]
+        assert next_token == 6
+
+    def test_returns_last_page_correctly(self):
+        initial_list = [10, 11, 12, 13, 14, 15, 16]
+        paginated_list = PaginatedList(initial_list)
+        page, next_token = paginated_list.get_page(page_size=3, next_token=6)
+        assert page == [16]
+        assert next_token is None


### PR DESCRIPTION
We can use PaginatedList without explicit token_generator - by using indices in the list as tokens.

- This should make things a bit faster, as we won't have to loop over items to find the one used as a token, instead would just directly jump to the needed index.
- Would simplify code a bit, as we would be able to use the class without coming up with generators.
- Should not be worse than what we have with generators - we do not preserve lists between calls for different pages, we do not even sort lists. So if contents of a list change between calls for different pages, we would not track that and just start with the item acting like a token. Thus either missing some elements or outputting same elements for the second time. Or encountering a failure if the token element vanishes.

If we decide that we want to, we can easily obfuscate this index-as-a-token approach. E.g., by generating some random string and inserting the index at a specific position in that string instead of using the index as it is.
