### PR TITLE
fix Kinesis CreateStream without shardCount

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -114,7 +114,7 @@ URL_ASPECTJWEAVER = f"{MAVEN_REPO_URL}/org/aspectj/aspectjweaver/1.9.7/aspectjwe
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
 # kinesis-mock version
-KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.4"
+KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.5"
 KINESIS_MOCK_RELEASE_URL = (
     "https://api.github.com/repos/etspaceman/kinesis-mock/releases/tags/" + KINESIS_MOCK_VERSION
 )

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -672,8 +672,6 @@ def kinesis_create_stream(kinesis_client):
     def _create_stream(**kwargs):
         if "StreamName" not in kwargs:
             kwargs["StreamName"] = f"test-stream-{short_uid()}"
-        if "ShardCount" not in kwargs:
-            kwargs["ShardCount"] = 2
         kinesis_client.create_stream(**kwargs)
         stream_names.append(kwargs["StreamName"])
         return kwargs["StreamName"]

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -31,6 +31,19 @@ def get_shard_iterator(stream_name, kinesis_client):
 
 
 class TestKinesis:
+    @pytest.mark.aws_validated
+    def test_create_stream_without_shard_count(
+        self, kinesis_client, kinesis_create_stream, wait_for_stream_ready
+    ):
+        stream_name = kinesis_create_stream()
+        wait_for_stream_ready(stream_name)
+        describe_stream = kinesis_client.describe_stream(StreamName=stream_name)
+        assert describe_stream
+        assert "StreamDescription" in describe_stream
+        assert "Shards" in describe_stream["StreamDescription"]
+        # By default, new streams have a shard count of 4
+        assert len(describe_stream["StreamDescription"]["Shards"]) == 4
+
     def test_stream_consumers(
         self, kinesis_client, kinesis_create_stream, wait_for_stream_ready, wait_for_consumer_ready
     ):


### PR DESCRIPTION
This PR fixes a small bug in Kinesis, where a request to `CreateStream` would fail if the `shardCount` is not set (which should be optional).
It actually only contains an update of kinesis-mock to the new release (containing https://github.com/etspaceman/kinesis-mock/pull/339) and an integration test.