### PR TITLE
[SecretsManager] Fixed raising of incorrect error message when creating a secret staged for deletion.

### DIFF
--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -72,10 +72,9 @@ AWSPENDING: Final[str] = "AWSPENDING"
 AWSCURRENT: Final[str] = "AWSCURRENT"
 #
 # Error Messages.
-AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION: Final[str] = (
-    "An error occurred (InvalidRequestException) when calling the CreateSecret operation: "
-    "You can't create this secret because a secret with this name is already scheduled for deletion."
-)
+AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION: Final[
+    str
+] = "You can't create this secret because a secret with this name is already scheduled for deletion."
 
 LOG = logging.getLogger(__name__)
 
@@ -169,8 +168,11 @@ class SecretsmanagerProvider(SecretsmanagerApi):
     def delete_secret(
         self, context: RequestContext, request: DeleteSecretRequest
     ) -> DeleteSecretResponse:
-        self._raise_if_invalid_secret_id(request["SecretId"])
-        return self._call_moto_with_request_secret_id(context, request)
+        secret_id: str = request["SecretId"]
+        self._raise_if_invalid_secret_id(secret_id)
+        res = self._call_moto_with_request_secret_id(context, request)
+        delete_arn_binding_for(context.region, secret_id)
+        return res
 
     @handler("DescribeSecret", expand=False)
     def describe_secret(
@@ -574,8 +576,12 @@ def backend_rotate_secret(
     return secret.to_short_dict()
 
 
-def secretsmanager_models_secret_arn(region, secret_id):
-    k = f"{region}_{secret_id}"
+def get_arn_binding_key_for(region: str, secret_id: str) -> str:
+    return f"{region}_{secret_id}"
+
+
+def get_arn_binding_for(region, secret_id):
+    k = get_arn_binding_key_for(region, secret_id)
     if k not in SECRET_ARN_STORAGE:
         id_string = short_uid()[:6]
         arn = aws_stack.secretsmanager_secret_arn(
@@ -583,6 +589,12 @@ def secretsmanager_models_secret_arn(region, secret_id):
         )
         SECRET_ARN_STORAGE[k] = arn
     return SECRET_ARN_STORAGE[k]
+
+
+def delete_arn_binding_for(region: str, secret_id: str) -> None:
+    k = get_arn_binding_key_for(region, secret_id)
+    if k in SECRET_ARN_STORAGE:
+        del SECRET_ARN_STORAGE[k]
 
 
 # patching resource policy in moto
@@ -648,7 +660,7 @@ def put_resource_policy_response(self):
 
 
 def apply_patches():
-    secretsmanager_models.secret_arn = secretsmanager_models_secret_arn
+    secretsmanager_models.secret_arn = get_arn_binding_for
     setattr(SecretsManagerBackend, "get_resource_policy", get_resource_policy_model)
     setattr(SecretsManagerResponse, "get_resource_policy", get_resource_policy_response)
 

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 from typing import Optional, Pattern
 
+from localstack.aws.api.secretsmanager import CreateSecretResponse
 from localstack.testing.snapshots.transformer import (
     JsonpathTransformer,
     KeyValueBasedTransformer,
@@ -189,6 +190,19 @@ class TransformerUtility:
             TransformerUtility.key_value("AlarmName"),
             KeyValueBasedTransformer(_resource_name_transformer, "SubscriptionArn"),
             TransformerUtility.key_value("Region", "region-name-full"),
+        ]
+
+    @staticmethod
+    def secretsmanager_secret_id_arn(create_secret_res: CreateSecretResponse, index: int):
+        secret_id_repl = f"<SecretId-{index}idx>"
+        arn_part_repl = f"<ArnPart-{index}idx>"
+
+        secret_id: str = create_secret_res["Name"]
+        arn_part: str = "".join(create_secret_res["ARN"].rpartition("-")[-2:])
+
+        return [
+            RegexTransformer(arn_part, arn_part_repl),
+            RegexTransformer(secret_id, secret_id_repl),
         ]
 
     # TODO add example

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -9,13 +9,16 @@ import requests
 from py._code.code import ExceptionInfo
 
 from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.api.secretsmanager import CreateSecretRequest, DeleteSecretRequest
-from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
-from localstack.services.secretsmanager.provider import (
-    AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION,
+from localstack.aws.api.secretsmanager import (
+    CreateSecretRequest,
+    CreateSecretResponse,
+    DeleteSecretRequest,
+    DeleteSecretResponse,
 )
+from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
+from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import short_uid
 from localstack.utils.time import today_no_time
 from tests.integration.awslambda.test_lambda import TEST_LAMBDA_PYTHON_VERSION
@@ -1714,7 +1717,7 @@ class TestSecretsManager:
         assert response["ARN"] is not None
         assert response["DeletionDate"] is not None
 
-    def test_exp_raised_on_creation_of_secret_scheduled_for_deletion(self, sm_client):
+    def test_exp_raised_on_creation_of_secret_scheduled_for_deletion(self, sm_client, snapshot):
         create_secret_req: CreateSecretRequest = CreateSecretRequest(
             Name=f"secret-{short_uid()}", SecretString=f"secretstr-{short_uid()}"
         )
@@ -1722,18 +1725,26 @@ class TestSecretsManager:
             SecretId=create_secret_req["Name"], RecoveryWindowInDays=7
         )
 
-        sm_client.create_secret(**create_secret_req)
-        sm_client.delete_secret(**stage_deletion_req)
+        res = sm_client.create_secret(**create_secret_req)
+        create_secret_res: CreateSecretResponse = select_from_typed_dict(CreateSecretResponse, res)
+        snapshot.add_transformers_list(
+            snapshot.transform.secretsmanager_secret_id_arn(create_secret_res, 0)
+        )
+
+        res = sm_client.delete_secret(**stage_deletion_req)
+        delete_res: DeleteSecretResponse = select_from_typed_dict(DeleteSecretResponse, res)
+        snapshot.match("delete_res", delete_res)
 
         with pytest.raises(Exception) as invalid_req_ex:
             sm_client.create_secret(**create_secret_req)
-        assert invalid_req_ex.typename == "InvalidRequestException"
-        assert (
-            invalid_req_ex.value.response["Error"]["Message"]
-            == AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION
-        )
 
-    def test_can_recreate_delete_secret(self, sm_client):
+        ex_log: Dict = {"typename": invalid_req_ex.typename, "message": str(invalid_req_ex.value)}
+        snapshot.match("invalid_req_ex", ex_log)
+
+    def test_can_recreate_delete_secret(self, sm_client, snapshot):
+        # NOTE: AWS will behave as staged deletion for a small number of seconds (<10).
+        # We assume forced deletion is instantaneous, until the precise behaviour is understood.
+
         create_secret_req: CreateSecretRequest = CreateSecretRequest(
             Name=f"secret-{short_uid()}", SecretString=f"secretstr-{short_uid()}"
         )
@@ -1741,8 +1752,26 @@ class TestSecretsManager:
             SecretId=create_secret_req["Name"], ForceDeleteWithoutRecovery=True
         )
 
-        sm_client.create_secret(**create_secret_req)
-        sm_client.delete_secret(**stage_deletion_req)
-        sm_client.create_secret(**create_secret_req)
+        res = sm_client.create_secret(**create_secret_req)
+        create_secret_res_0: CreateSecretResponse = select_from_typed_dict(
+            CreateSecretResponse, res
+        )
+        snapshot.add_transformers_list(
+            snapshot.transform.secretsmanager_secret_id_arn(create_secret_res_0, 0)
+        )
+        snapshot.match("create_secret_res_0", create_secret_res_0)
+
+        res = sm_client.delete_secret(**stage_deletion_req)
+        delete_res_1: DeleteSecretResponse = select_from_typed_dict(DeleteSecretResponse, res)
+        snapshot.match("delete_res_1", delete_res_1)
+
+        res = sm_client.create_secret(**create_secret_req)
+        create_secret_res_1: CreateSecretResponse = select_from_typed_dict(
+            CreateSecretResponse, res
+        )
+        snapshot.add_transformers_list(
+            snapshot.transform.secretsmanager_secret_id_arn(create_secret_res_1, 1)
+        )
+        snapshot.match("create_secret_res_1", create_secret_res_1)
 
         sm_client.delete_secret(**stage_deletion_req)

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -1714,7 +1714,7 @@ class TestSecretsManager:
         assert response["ARN"] is not None
         assert response["DeletionDate"] is not None
 
-    def test_exp_raised_on_creation_of_seret_scheduled_for_deletion(self, sm_client):
+    def test_exp_raised_on_creation_of_secret_scheduled_for_deletion(self, sm_client):
         create_secret_req: CreateSecretRequest = CreateSecretRequest(
             Name=f"secret-{short_uid()}", SecretString=f"secretstr-{short_uid()}"
         )

--- a/tests/integration/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/integration/secretsmanager/test_secretsmanager.snapshot.json
@@ -1,0 +1,36 @@
+{
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_can_recreate_delete_secret": {
+    "recorded-date": "03-08-2022, 14:27:54",
+    "recorded-content": {
+      "create_secret_res_0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<uuid:1>"
+      },
+      "delete_res_1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "DeletionDate": "datetime"
+      },
+      "create_secret_res_1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-1idx>",
+        "Name": "<SecretId-0idx>",
+        "VersionId": "<uuid:2>"
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_exp_raised_on_creation_of_secret_scheduled_for_deletion": {
+    "recorded-date": "03-08-2022, 14:47:19",
+    "recorded-content": {
+      "delete_res": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "DeletionDate": "datetime"
+      },
+      "invalid_req_ex": {
+        "typename": "InvalidRequestException",
+        "message": "An error occurred (InvalidRequestException) when calling the CreateSecret operation: You can't create this secret because a secret with this name is already scheduled for deletion."
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to: https://github.com/localstack/localstack/issues/6530

- Updates the `SecretsManager`'s `CreateSecret` routine to raise an `InvalidRequestException` whenever a secret sharing its `SecretId` with another secret staged for deletion is received.
- Updates the arn tagging strategy to ensure creation of new secrets with past secret ids leads to new generation of new arn parts
Achieved by:
- carried out parity checks against AWS about this scenario
- added a patch to moto's SecretsManager backend, specifically to the `create_secret` function, now if condition is met this raises an `InvalidRequestException` with AWS message `AWS_INVALID_REQUEST_MESSAGE_CREATE_WITH_SCHEDULED_DELETION`
- added snapshot integration tests for the following scenario `test_exp_raised_on_creation_of_secret_scheduled_for_deletion` and one for creation of secret after deletion (staging completed) `test_can_recreate_delete_secret`.

