### PR TITLE
add streaming types to ASF scaffold and APIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,7 @@ jobs:
           name: Test ASF Lambda provider
           environment:
             PROVIDER_OVERRIDE_LAMBDA: "asf"
+            LS_LOG: "trace"
             TEST_PATH: "tests/integration/awslambda/test_lambda_api.py"
             PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/lambda_asf.xml -o junit_suite_name='lambda_asf'"
             COVERAGE_ARGS: "-p"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,6 @@ jobs:
           name: Test ASF Lambda provider
           environment:
             PROVIDER_OVERRIDE_LAMBDA: "asf"
-            LS_LOG: "trace"
             TEST_PATH: "tests/integration/awslambda/test_lambda_api.py"
             PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/lambda_asf.xml -o junit_suite_name='lambda_asf'"
             COVERAGE_ARGS: "-p"

--- a/localstack/aws/api/apigateway/__init__.py
+++ b/localstack/aws/api/apigateway/__init__.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import IO, Dict, Iterable, List, Optional, Union
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -733,9 +733,9 @@ class DomainNames(TypedDict, total=False):
 
 
 class ExportResponse(TypedDict, total=False):
+    body: Optional[Union[Blob, IO[Blob], Iterable[Blob]]]
     contentType: Optional[String]
     contentDisposition: Optional[String]
-    body: Optional[Blob]
 
 
 class FlushStageAuthorizersCacheRequest(ServiceRequest):
@@ -1037,22 +1037,22 @@ class GetVpcLinksRequest(ServiceRequest):
 
 
 class ImportApiKeysRequest(ServiceRequest):
-    body: Blob
+    body: IO[Blob]
     format: ApiKeysFormat
     failOnWarnings: Optional[Boolean]
 
 
 class ImportDocumentationPartsRequest(ServiceRequest):
+    body: IO[Blob]
     restApiId: String
     mode: Optional[PutMode]
     failOnWarnings: Optional[Boolean]
-    body: Blob
 
 
 class ImportRestApiRequest(ServiceRequest):
+    body: IO[Blob]
     failOnWarnings: Optional[Boolean]
     parameters: Optional[MapOfStringToString]
-    body: Blob
 
 
 class TlsConfig(TypedDict, total=False):
@@ -1356,11 +1356,11 @@ class PutMethodResponseRequest(ServiceRequest):
 
 
 class PutRestApiRequest(ServiceRequest):
+    body: IO[Blob]
     restApiId: String
     mode: Optional[PutMode]
     failOnWarnings: Optional[Boolean]
     parameters: Optional[MapOfStringToString]
-    body: Blob
 
 
 class RequestValidators(TypedDict, total=False):
@@ -1379,9 +1379,9 @@ class RestApis(TypedDict, total=False):
 
 
 class SdkResponse(TypedDict, total=False):
+    body: Optional[Union[Blob, IO[Blob], Iterable[Blob]]]
     contentType: Optional[String]
     contentDisposition: Optional[String]
-    body: Optional[Blob]
 
 
 class SdkTypes(TypedDict, total=False):
@@ -2300,7 +2300,7 @@ class ApigatewayApi:
     def import_api_keys(
         self,
         context: RequestContext,
-        body: Blob,
+        body: IO[Blob],
         format: ApiKeysFormat,
         fail_on_warnings: Boolean = None,
     ) -> ApiKeyIds:
@@ -2311,7 +2311,7 @@ class ApigatewayApi:
         self,
         context: RequestContext,
         rest_api_id: String,
-        body: Blob,
+        body: IO[Blob],
         mode: PutMode = None,
         fail_on_warnings: Boolean = None,
     ) -> DocumentationPartIds:
@@ -2321,7 +2321,7 @@ class ApigatewayApi:
     def import_rest_api(
         self,
         context: RequestContext,
-        body: Blob,
+        body: IO[Blob],
         fail_on_warnings: Boolean = None,
         parameters: MapOfStringToString = None,
     ) -> RestApi:
@@ -2396,7 +2396,7 @@ class ApigatewayApi:
         self,
         context: RequestContext,
         rest_api_id: String,
-        body: Blob,
+        body: IO[Blob],
         mode: PutMode = None,
         fail_on_warnings: Boolean = None,
         parameters: MapOfStringToString = None,

--- a/localstack/aws/api/config/__init__.py
+++ b/localstack/aws/api/config/__init__.py
@@ -20,6 +20,7 @@ AwsRegion = str
 BaseResourceId = str
 Boolean = bool
 ChannelName = str
+ComplianceScore = str
 ConfigRuleName = str
 Configuration = str
 ConfigurationAggregatorArn = str
@@ -411,6 +412,15 @@ class ResourceType(str):
 
 class ResourceValueType(str):
     RESOURCE_ID = "RESOURCE_ID"
+
+
+class SortBy(str):
+    SCORE = "SCORE"
+
+
+class SortOrder(str):
+    ASCENDING = "ASCENDING"
+    DESCENDING = "DESCENDING"
 
 
 class ConformancePackTemplateValidationException(ServiceException):
@@ -1150,6 +1160,21 @@ class ConformancePackComplianceFilters(TypedDict, total=False):
 
 
 ConformancePackComplianceResourceIds = List[StringWithCharLimit256]
+LastUpdatedTime = datetime
+
+
+class ConformancePackComplianceScore(TypedDict, total=False):
+    Score: Optional[ComplianceScore]
+    ConformancePackName: Optional[ConformancePackName]
+    LastUpdatedTime: Optional[LastUpdatedTime]
+
+
+ConformancePackComplianceScores = List[ConformancePackComplianceScore]
+ConformancePackNameFilter = List[ConformancePackName]
+
+
+class ConformancePackComplianceScoresFilters(TypedDict, total=False):
+    ConformancePackNames: ConformancePackNameFilter
 
 
 class ConformancePackComplianceSummary(TypedDict, total=False):
@@ -2172,6 +2197,19 @@ class ListAggregateDiscoveredResourcesResponse(TypedDict, total=False):
     NextToken: Optional[NextToken]
 
 
+class ListConformancePackComplianceScoresRequest(ServiceRequest):
+    Filters: Optional[ConformancePackComplianceScoresFilters]
+    SortOrder: Optional[SortOrder]
+    SortBy: Optional[SortBy]
+    Limit: Optional[PageSizeLimit]
+    NextToken: Optional[NextToken]
+
+
+class ListConformancePackComplianceScoresResponse(TypedDict, total=False):
+    NextToken: Optional[NextToken]
+    ConformancePackComplianceScores: ConformancePackComplianceScores
+
+
 ResourceIdList = List[ResourceId]
 
 
@@ -3020,6 +3058,18 @@ class ConfigApi:
         limit: Limit = None,
         next_token: NextToken = None,
     ) -> ListAggregateDiscoveredResourcesResponse:
+        raise NotImplementedError
+
+    @handler("ListConformancePackComplianceScores")
+    def list_conformance_pack_compliance_scores(
+        self,
+        context: RequestContext,
+        filters: ConformancePackComplianceScoresFilters = None,
+        sort_order: SortOrder = None,
+        sort_by: SortBy = None,
+        limit: PageSizeLimit = None,
+        next_token: NextToken = None,
+    ) -> ListConformancePackComplianceScoresResponse:
         raise NotImplementedError
 
     @handler("ListDiscoveredResources")

--- a/localstack/aws/api/es/__init__.py
+++ b/localstack/aws/api/es/__init__.py
@@ -292,6 +292,7 @@ class VolumeType(str):
     standard = "standard"
     gp2 = "gp2"
     io1 = "io1"
+    gp3 = "gp3"
 
 
 class AccessDeniedException(ServiceException):
@@ -698,6 +699,7 @@ class EBSOptions(TypedDict, total=False):
     VolumeType: Optional[VolumeType]
     VolumeSize: Optional[IntegerClass]
     Iops: Optional[IntegerClass]
+    Throughput: Optional[IntegerClass]
 
 
 class ZoneAwarenessConfig(TypedDict, total=False):

--- a/localstack/aws/api/lambda_/__init__.py
+++ b/localstack/aws/api/lambda_/__init__.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import IO, Dict, Iterable, List, Optional, Union
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -1121,25 +1121,25 @@ class GetProvisionedConcurrencyConfigResponse(TypedDict, total=False):
 
 
 class InvocationRequest(ServiceRequest):
+    Payload: Optional[IO[Blob]]
     FunctionName: NamespacedFunctionName
     InvocationType: Optional[InvocationType]
     LogType: Optional[LogType]
     ClientContext: Optional[String]
-    Payload: Optional[Blob]
     Qualifier: Optional[Qualifier]
 
 
 class InvocationResponse(TypedDict, total=False):
+    Payload: Optional[Union[Blob, IO[Blob], Iterable[Blob]]]
     StatusCode: Optional[Integer]
     FunctionError: Optional[String]
     LogResult: Optional[String]
-    Payload: Optional[Blob]
     ExecutedVersion: Optional[Version]
 
 
 class InvokeAsyncRequest(ServiceRequest):
+    InvokeArgs: IO[BlobStream]
     FunctionName: NamespacedFunctionName
-    InvokeArgs: BlobStream
 
 
 class InvokeAsyncResponse(TypedDict, total=False):
@@ -1808,7 +1808,7 @@ class LambdaApi:
         invocation_type: InvocationType = None,
         log_type: LogType = None,
         client_context: String = None,
-        payload: Blob = None,
+        payload: IO[Blob] = None,
         qualifier: Qualifier = None,
     ) -> InvocationResponse:
         raise NotImplementedError
@@ -1818,7 +1818,7 @@ class LambdaApi:
         self,
         context: RequestContext,
         function_name: NamespacedFunctionName,
-        invoke_args: BlobStream,
+        invoke_args: IO[BlobStream],
     ) -> InvokeAsyncResponse:
         raise NotImplementedError
 

--- a/localstack/aws/api/opensearch/__init__.py
+++ b/localstack/aws/api/opensearch/__init__.py
@@ -334,6 +334,7 @@ class VolumeType(str):
     standard = "standard"
     gp2 = "gp2"
     io1 = "io1"
+    gp3 = "gp3"
 
 
 class AccessDeniedException(ServiceException):
@@ -767,6 +768,7 @@ class EBSOptions(TypedDict, total=False):
     VolumeType: Optional[VolumeType]
     VolumeSize: Optional[IntegerClass]
     Iops: Optional[IntegerClass]
+    Throughput: Optional[IntegerClass]
 
 
 class CreateDomainRequest(ServiceRequest):

--- a/localstack/aws/handlers/metric_handler.py
+++ b/localstack/aws/handlers/metric_handler.py
@@ -1,9 +1,8 @@
-import copy
 import logging
 from typing import List, Optional
 
 from localstack import config
-from localstack.aws.api import RequestContext, ServiceRequest
+from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.http import Response
 from localstack.utils.aws.aws_stack import is_internal_call_context
@@ -18,13 +17,13 @@ class MetricHandlerItem:
 
     request_id: str
     request_context: RequestContext
-    request_after_parse: Optional[ServiceRequest]
+    parameters_after_parse: Optional[List[str]]
 
     def __init__(self, request_contex: RequestContext) -> None:
         super().__init__()
         self.request_id = str(hash(request_contex))
         self.request_context = request_contex
-        self.request_after_parse = None
+        self.parameters_after_parse = None
 
 
 class Metric:
@@ -134,7 +133,9 @@ class MetricHandler:
         if not config.is_collect_metrics_mode():
             return
         item = self._get_metric_handler_item_for_context(context)
-        item.request_after_parse = copy.deepcopy(context.service_request)
+        item.parameters_after_parse = (
+            list(context.service_request.keys()) if context.service_request else []
+        )
 
     def record_exception(
         self, chain: HandlerChain, exception: Exception, context: RequestContext, response: Response
@@ -153,8 +154,9 @@ class MetricHandler:
         is_internal = is_internal_call_context(context.request.headers)
         item = self._get_metric_handler_item_for_context(context)
 
-        # parameters might get changed when dispatched to the service - we use the params stored in request_after_parse
-        parameters = ",".join(item.request_after_parse or "")
+        # parameters might get changed when dispatched to the service - we use the params stored in
+        # parameters_after_parse
+        parameters = ",".join(item.parameters_after_parse or [])
 
         response_data = response.data.decode("utf-8") if response.status_code >= 300 else ""
 

--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -69,6 +69,7 @@ import re
 from abc import ABC
 from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
+from typing.io import IO
 from xml.etree import ElementTree as ETree
 
 import cbor2
@@ -592,7 +593,7 @@ class BaseRestRequestParser(RequestParser):
                 # only set the parameter if content_length=0, which indicates an empty request. If the content length is
                 # not set, it could be a streaming response.
                 if request.content_length != 0:
-                    payload_parsed[payload_member_name] = request._get_stream_for_parsing()
+                    payload_parsed[payload_member_name] = self.create_input_stream(request)
             else:
                 original_parsed = self._initial_body_parse(request)
                 payload_parsed[payload_member_name] = self._parse_shape(
@@ -628,6 +629,18 @@ class BaseRestRequestParser(RequestParser):
     def _create_event_stream(self, request: HttpRequest, shape: Shape) -> Any:
         # TODO handle event streams
         raise NotImplementedError("_create_event_stream")
+
+    def create_input_stream(self, request: HttpRequest) -> IO[bytes]:
+        """
+        Returns an IO object that makes the payload of the HttpRequest available for streaming.
+
+        :param request: the http request
+        :return: the input stream that allows services to consume the request payload
+        """
+        # for now _get_stream_for_parsing seems to be a good compromise. it can be used even after `request.data` was
+        # previously called. however the reverse doesn't work. once the stream has been consumed, `request.data` will
+        # return b''
+        return request._get_stream_for_parsing()
 
 
 class RestXMLRequestParser(BaseRestRequestParser):

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -746,7 +746,7 @@ class BaseRestResponseSerializer(ResponseSerializer, ABC):
     ) -> None:
         header_params, payload_params = self._partition_members(parameters, shape)
         self._process_header_members(header_params, response, shape)
-        # "HEAD" responeses are basically "GET" responses without the actual body.
+        # "HEAD" responses are basically "GET" responses without the actual body.
         # Do not process the body payload in this case (setting a body could also manipulate the headers)
         if operation_model.http.get("method") != "HEAD":
             self._serialize_payload(payload_params, response, shape, shape_members, operation_model)

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -1,8 +1,8 @@
 import io
 import keyword
 import re
-from multiprocessing import Pool
 from functools import cached_property
+from multiprocessing import Pool
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -2,8 +2,9 @@ import io
 import keyword
 import re
 from multiprocessing import Pool
+from functools import cached_property
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 import click
 from botocore import xform_name
@@ -72,24 +73,47 @@ class ShapeNode:
         self.service = service
         self.shape = shape
 
-    @property
-    def is_request(self):
+    @cached_property
+    def request_operation(self) -> Optional[OperationModel]:
         for operation_name in self.service.operation_names:
             operation = self.service.operation_model(operation_name)
             if operation.input_shape is None:
                 continue
+
             if to_valid_python_name(self.shape.name) == to_valid_python_name(
                 operation.input_shape.name
             ):
-                return True
+                return operation
 
-        return False
+        return None
+
+    @cached_property
+    def response_operation(self) -> Optional[OperationModel]:
+        for operation_name in self.service.operation_names:
+            operation = self.service.operation_model(operation_name)
+            if operation.output_shape is None:
+                continue
+
+            if to_valid_python_name(self.shape.name) == to_valid_python_name(
+                operation.output_shape.name
+            ):
+                return operation
+
+        return None
+
+    @cached_property
+    def is_request(self):
+        return self.request_operation is not None
+
+    @cached_property
+    def is_response(self):
+        return self.response_operation is not None
 
     @property
     def name(self) -> str:
         return to_valid_python_name(self.shape.name)
 
-    @property
+    @cached_property
     def is_exception(self):
         metadata = self.shape.metadata
         return metadata.get("error") or metadata.get("exception")
@@ -156,6 +180,32 @@ class ShapeNode:
             for k, v in self.shape.members.items()
             if not self.is_exception or k.lower() not in ["message", "code"]
         }
+
+        # render any streaming payload first
+        if self.is_request and self.request_operation.has_streaming_input:
+            member: str = self.request_operation.input_shape.serialization.get("payload")
+            shape: Shape = self.request_operation.get_streaming_input()
+            if member in self.shape.required_members:
+                output.write(f"    {member}: IO[{q}{to_valid_python_name(shape.name)}{q}]\n")
+            else:
+                output.write(
+                    f"    {member}: Optional[IO[{q}{to_valid_python_name(shape.name)}{q}]]\n"
+                )
+            del remaining_members[member]
+        # render the streaming payload first
+        if self.is_response and self.response_operation.has_streaming_output:
+            member: str = self.response_operation.output_shape.serialization.get("payload")
+            shape: Shape = self.response_operation.get_streaming_output()
+            shape_name = to_valid_python_name(shape.name)
+            if member in self.shape.required_members:
+                output.write(
+                    f"    {member}: Union[{q}{shape_name}{q}, IO[{q}{shape_name}{q}], Iterable[{q}{shape_name}{q}]]\n"
+                )
+            else:
+                output.write(
+                    f"    {member}: Optional[Union[{q}{shape_name}{q}, IO[{q}{shape_name}{q}], Iterable[{q}{shape_name}{q}]]]\n"
+                )
+            del remaining_members[member]
 
         for k, v in remaining_members.items():
             if k in self.shape.required_members:
@@ -230,9 +280,9 @@ class ShapeNode:
         elif shape.type_name == "boolean":
             output.write(f"{to_valid_python_name(shape.name)} = bool")
         elif shape.type_name == "blob":
-            output.write(
-                f"{to_valid_python_name(shape.name)} = bytes"
-            )  # FIXME check what type blob really is
+            # blobs are often associated with streaming payloads, but we handle that on operation level,
+            # not on shape level
+            output.write(f"{to_valid_python_name(shape.name)} = bytes")
         elif shape.type_name == "timestamp":
             output.write(f"{to_valid_python_name(shape.name)} = datetime")
         else:
@@ -262,7 +312,7 @@ class ShapeNode:
 
 def generate_service_types(output, service: ServiceModel, doc=True):
     output.write("import sys\n")
-    output.write("from typing import Dict, List, Optional, Iterator\n")
+    output.write("from typing import Dict, List, Optional, Iterator, Iterable, IO, Union\n")
     output.write("from datetime import datetime\n")
     output.write("if sys.version_info >= (3, 8):\n")
     output.write("    from typing import TypedDict\n")
@@ -337,18 +387,29 @@ def generate_service_api(output, service: ServiceModel, doc=True):
         parameters = OrderedDict()
         param_shapes = OrderedDict()
 
-        input_shape = operation.input_shape
-        if input_shape is not None:
+        if input_shape := operation.input_shape:
             members = list(input_shape.members)
+
+            streaming_payload_member = None
+            if operation.has_streaming_input:
+                streaming_payload_member = operation.input_shape.serialization.get("payload")
+
             for m in input_shape.required_members:
                 members.remove(m)
                 m_shape = input_shape.members[m]
-                parameters[xform_name(m)] = to_valid_python_name(m_shape.name)
+                type_name = to_valid_python_name(m_shape.name)
+                if m == streaming_payload_member:
+                    type_name = f"IO[{type_name}]"
+                parameters[xform_name(m)] = type_name
                 param_shapes[xform_name(m)] = m_shape
+
             for m in members:
                 m_shape = input_shape.members[m]
                 param_shapes[xform_name(m)] = m_shape
-                parameters[xform_name(m)] = f"{to_valid_python_name(m_shape.name)} = None"
+                type_name = to_valid_python_name(m_shape.name)
+                if m == streaming_payload_member:
+                    type_name = f"IO[{type_name}]"
+                parameters[xform_name(m)] = f"{type_name} = None"
 
         if any(map(is_bad_param_name, parameters.keys())):
             # if we cannot render the parameter name, don't expand the parameters in the handler

--- a/localstack/http/response.py
+++ b/localstack/http/response.py
@@ -33,7 +33,7 @@ class Response(WerkzeugResponse):
         Returns a read-only version of a response dictionary as it is often expected by other libraries like boto.
         """
         return {
-            "body": self.get_data(as_text=True).encode("utf-8"),
+            "body": self.stream if self.is_streamed else self.data,
             "status_code": self.status_code,
             "headers": dict(self.headers),
         }

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from copy import deepcopy
+from typing import IO
 
 from localstack.aws.api import RequestContext, ServiceRequest, handler
 from localstack.aws.api.apigateway import (
@@ -650,12 +651,13 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
     def import_rest_api(
         self,
         context: RequestContext,
-        body: Blob,
+        body: IO[Blob],
         fail_on_warnings: Boolean = None,
         parameters: MapOfStringToString = None,
     ) -> RestApi:
+        body_data = body.read()
 
-        openapi_spec = parse_json_or_yaml(to_str(body))
+        openapi_spec = parse_json_or_yaml(to_str(body_data))
         response = _call_moto(
             context,
             "CreateRestApi",
@@ -669,7 +671,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                 restApiId=response.get("id"),
                 failOnWarnings=str_to_bool(fail_on_warnings) or False,
                 parameters=parameters or {},
-                body=body,
+                body=body_data,
             ),
         )
 

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import threading
 import time
+from typing import IO
 
 from localstack.aws.api import RequestContext
 from localstack.aws.api.lambda_ import (
@@ -14,6 +15,7 @@ from localstack.aws.api.lambda_ import (
     Description,
     Environment,
     EnvironmentResponse,
+    EphemeralStorage,
     FileSystemConfigList,
     FunctionCode,
     FunctionCodeLocation,
@@ -123,6 +125,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         image_config: ImageConfig = None,  # TODO: ignored
         code_signing_config_arn: CodeSigningConfigArn = None,  # TODO: ignored
         architectures: ArchitecturesList = None,
+        ephemeral_storage: EphemeralStorage = None,  # TODO: ignored
     ) -> FunctionConfiguration:
         # TODO: initial validations
         if architectures and Architecture.arm64 in architectures:
@@ -203,7 +206,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         invocation_type: InvocationType = None,
         log_type: LogType = None,
         client_context: String = None,
-        payload: Blob = None,
+        payload: IO[Blob] = None,
         qualifier: Qualifier = None,
     ) -> InvocationResponse:
         LOG.debug("Lambda function got invoked! Params: %s", dict(locals()))
@@ -217,7 +220,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             function_arn_qualified=qualified_arn,
             invocation_type=invocation_type,
             client_context=client_context,
-            payload=payload,
+            payload=payload.read() if payload else None,
         )
         try:
             invocation_result = result.result()

--- a/tests/integration/test_moto.py
+++ b/tests/integration/test_moto.py
@@ -75,8 +75,10 @@ def test_call_with_sqs_modifies_state_in_moto_backend():
     assert qname not in sqs_backends[config.AWS_REGION_US_EAST_1].queues
 
 
-@pytest.mark.parametrize("test_type", ["string", "bytes", "file_like"])
-def test_call_s3_with_streaming_trait(test_type, monkeypatch):
+@pytest.mark.parametrize(
+    "payload", ["foobar", b"foobar", BytesIO(b"foobar")], ids=["str", "bytes", "IO[bytes]"]
+)
+def test_call_s3_with_streaming_trait(payload, monkeypatch):
     monkeypatch.setenv("MOTO_S3_CUSTOM_ENDPOINTS", "s3.localhost.localstack.cloud:4566")
 
     bucket_name = f"bucket-{short_uid()}"
@@ -85,19 +87,9 @@ def test_call_s3_with_streaming_trait(test_type, monkeypatch):
     # create the bucket
     moto.call_moto(moto.create_aws_request_context("s3", "CreateBucket", {"Bucket": bucket_name}))
 
-    # test the different input types for streaming payload
-    if test_type == "string":
-        body = "foobar"
-    elif test_type == "bytes":
-        body = b"foobar"
-    elif test_type == "file_like":
-        body = BytesIO(b"foobar")
-    else:
-        raise ValueError(test_type)
-
     moto.call_moto(
         moto.create_aws_request_context(
-            "s3", "PutObject", {"Bucket": bucket_name, "Key": key_name, "Body": body}
+            "s3", "PutObject", {"Bucket": bucket_name, "Key": key_name, "Body": payload}
         )
     )
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from io import BytesIO
 from urllib.parse import unquote, urlencode, urlsplit
 
 import pytest
@@ -840,7 +841,7 @@ def test_parse_appconfig_non_json_blob_payload():
         action="CreateHostedConfigurationVersion",
         ApplicationId="test-application-id",
         ConfigurationProfileId="test-configuration-profile-id",
-        Content=b"<html></html>",
+        Content=BytesIO(b"<html></html>"),
         ContentType="application/html",
     )
 
@@ -922,7 +923,11 @@ def test_restjson_operation_detection_with_query_suffix_in_requesturi():
     Test if the correct operation is detected if the requestURI pattern of the specification contains the first query
     parameter, f.e. API Gateway's ImportRestApi: "/restapis?mode=import
     """
-    _botocore_parser_integration_test(service="apigateway", action="ImportRestApi", body=b"Test")
+    _botocore_parser_integration_test(
+        service="apigateway",
+        action="ImportRestApi",
+        body=BytesIO(b"Test"),
+    )
 
 
 def test_rest_url_parameter_with_dashes():
@@ -1041,7 +1046,7 @@ def test_s3_put_object_keys_with_slashes():
         Bucket="test-bucket",
         Key="/test-key",
         ContentLength=6,
-        Body=b"foobar",
+        Body=BytesIO(b"foobar"),
         Metadata={},
     )
 
@@ -1087,7 +1092,7 @@ def test_restxml_header_date_parsing():
         Bucket="test-bucket",
         Key="test-key",
         ContentLength=3,
-        Body=b"foo",
+        Body=BytesIO(b"foo"),
         Metadata={},
         Expires=datetime(2015, 1, 1, 0, 0, tzinfo=timezone.utc),
     )

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -3,7 +3,8 @@ import io
 import json
 import re
 from datetime import datetime
-from typing import Any, Dict, Iterator, Optional
+from io import BytesIO
+from typing import Any, Dict, Iterator, List, Optional
 from xml.etree import ElementTree
 
 import pytest
@@ -13,6 +14,7 @@ from botocore.parsers import ResponseParser, create_parser
 from dateutil.tz import tzlocal, tzutc
 from requests.models import Response as RequestsResponse
 from urllib3 import HTTPResponse as UrlLibHttpResponse
+from werkzeug.wrappers import ResponseStream
 
 from localstack.aws.api import CommonServiceException, ServiceException
 from localstack.aws.api.dynamodb import (
@@ -1585,3 +1587,112 @@ def test_serializer_error_on_unknown_error():
     serializer._serialize_response = raise_error
     with pytest.raises(UnknownSerializerError):
         serializer.serialize_to_response({}, operation_model)
+
+
+class ComparableBytesIO(BytesIO):
+    """
+    BytesIO object that's treated like a value object when comparing it to other streams.
+    """
+
+    def __eq__(self, other):
+        if hasattr(other, "read"):
+            return other.read() == self.read()
+
+        if isinstance(other, ResponseStream):
+            return other.response.data == self.read()
+
+        return super(ComparableBytesIO, self).__eq__(other)
+
+
+class ComparableBytesList(list):
+    """
+    Makes a list of bytes comparable to strings.
+    """
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return b"".join(self) == other.encode("utf-8")
+
+        return super(ComparableBytesList, self).__eq__(other)
+
+
+class ComparableBytesIterator(Iterator[bytes]):
+    def __init__(self, bytes_list: List[bytes]):
+        self.gen = iter(bytes_list)
+        self.value = b"".join(bytes_list)
+
+    def __next__(self) -> bytes:
+        return next(self.gen)
+
+    def __iter__(self) -> Iterator[bytes]:
+        return self.gen
+
+    def __eq__(self, other):
+        if hasattr(other, "read"):
+            return other.read() == self.value
+
+        if isinstance(other, ResponseStream):
+            return other.response.data == self.value
+
+        return super(ComparableBytesIterator, self).__eq__(other)
+
+
+@pytest.mark.parametrize("payload_type", ["bytes", "list", "file_like", "iterator"])
+def test_restxml_streaming_payload(payload_type):
+    """Tests an operation where the payload is can be streaming for rest-xml. We're testing four cases,
+    two non-streaming and two streaming: a literal, a list (that's treated specially by werkzeug), a file-like
+    ``IO[bytes]`` object, and an iterator. Since the _botocore_serializer_integration_test does equality checks on
+    parameters, and we're receiving different objects for streams, we wrap the payloads in custom classes that can be
+    compared to strings."""
+
+    if payload_type == "bytes":
+        body = "<foo-bar/>"
+    elif payload_type == "list":
+        body = ComparableBytesList([b"<", b"foo-bar", b"/>"])
+        # if something is `Sized`, werkzeug does not treat it as streamable, it just encodes
+        assert len(body)
+    elif payload_type == "file_like":
+        # if this works, then the following also works: body = open('/path/to/file', 'rb')
+        body = ComparableBytesIO(b"<foo-bar/>")
+    elif payload_type == "iterator":
+        # this also verifies that serialization works for generators
+        body = ComparableBytesIterator([b"<", b"foo-bar", b"/>"])
+    else:
+        raise ValueError(payload_type)
+
+    parameters = {
+        "ContentLength": 10,
+        "Body": body,
+        "ContentType": "text/xml",
+        "Metadata": {},
+    }
+    _botocore_serializer_integration_test("s3", "GetObject", parameters)
+
+
+@pytest.mark.parametrize("payload_type", ["bytes", "list", "file_like", "iterator"])
+def test_restjson_streaming_payload(payload_type):
+    """See docs for ``test_restxml_streaming_payload``."""
+
+    if payload_type == "bytes":
+        payload = '{"foo":"bar"}'
+    elif payload_type == "list":
+        payload = ComparableBytesList([b"{", b'"foo"', b":", b'"bar"', b"}"])
+        # if something is `Sized`, werkzeug does not treat it as streamable, it just encodes
+        assert len(payload)
+    elif payload_type == "file_like":
+        # if this works, then the following also works: payload = open('/path/to/file', 'rb')
+        payload = ComparableBytesIO(b'{"foo":"bar"}')
+    elif payload_type == "iterator":
+        # this also verifies that serialization works for generators
+        payload = ComparableBytesIterator([b"{", b'"foo"', b":", b'"bar"', b"}"])
+    else:
+        raise ValueError(payload_type)
+
+    _botocore_serializer_integration_test(
+        "lambda",
+        "Invoke",
+        {
+            "StatusCode": 200,
+            "Payload": payload,
+        },
+    )


### PR DESCRIPTION
This PR updates ASF to correctly handle smithy [streaming](https://awslabs.github.io/smithy/1.0/spec/core/stream-traits.html) types. This is one of the last big changes to ASF, and will unblock the S3 migration.

The changes include:
* updated scaffold to generate streaming types (see details)
* re-generated community APIs
* updated serializer and parser to deal with streaming types
* added several tests on different layers
* update lambda and API gateway providers /cc @dfangl @dominikschubert
* changed the `MetricHandler` a bit (see details below) /cc @steffyP 

## some details on the API

After several discussions with @alexrashed, we decided *not* to make the service-level shapes the streaming types, but to only type hint the members of request/response objects.

* For _Requests_, which are set by the server, we specify `typing.IO[bytes]`, which will essentially be set to `werkzeug.Request.stream` by the parser. This will require the most changes, as we need to update all implementing services that expect `payload` to be `bytes`, to use `payload.read()` which will be a stream.
* For _Responses_, which are set by the developer, we specify `Union[bytes, IO[bytes], Iterable[bytes]`, making it possible to deal with the three cases outlined in #6527. These three types are also supported by the `werkzeug.Response` object, so nothing needs to be done in the serializer, and no changes are necessary im services.


## metric handler change

with the new streaming trait, `ServiceRequest` dictionaries can contain file-like or other IO objects that cannot be serialized. in `record_parsed_request` we were copying the entire request using deep copy, and that was now [raising errors](https://app.circleci.com/pipelines/github/localstack/localstack/7953/workflows/77c9cbb0-cef2-4ca6-aa1a-f36a8579077d/jobs/49159). on certain requests.

it seems we weren't really using the entire request, but just collecting the names of the parameters that were in the request, so i simplified the logic to just collect the parameter names rather than the entire request, which is now a harmless call to `list(request.keys())`.

if we at some point need the entire request in the metric collection, we'll need to revisit this change.

## limitations

http request IO is still a problem. when you consume an incoming request payload, e.g., in s3 `PutObject`, using `body.read()`, you are consuming the stream underlying the http request, which is shared with werkzeug's Request object. that means, if you at a later point want to call `request.data` on the request object, you'll get an empty byte buffer back. although this is expected and correct behavior, it's also very inconvenient and i can see a lot of hours going into debugging of weird "why is my request empty" issues.

since quite a bit of the code base still builds on the assumption of always having access to the raw http request data, we may need to make some compromises with respect to performance and memory usage. ideally, we never read from the stream until we need it, because there's always a chance that we are going to proxy large payloads to some backend (like invoking a lambda), in which case you don't want to load everything into memory, keep it there, and then flush it to the outgoing socket again. but if you want reliable access to `request.data`, even though we've previously run `body.read()`, then we're going to have to store the stream data somewhere, and make it seekable, e.g., through `TemporarySpooledFile`s, which would solve the problem of loading large payloads into memory (if they exceed a certain size the file is rolled to disk, otherwise it is kept in memory), but obviously still has the overhead when proxying. :shrug: 

fixes #6527 