### PR TITLE
Add support for S3 notifications to EventBridge

### DIFF
--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -445,7 +445,7 @@ def send_notification_for_subscriber(
             events_client.put_events(Entries=[entry])
         except Exception as e:
             LOGGER.exception(
-                'Unable to send notification for S3 bucket "%s" to EventBridge', bucket_name
+                f'Unable to send notification for S3 bucket "{bucket_name}" to EventBridge', e
             )
 
     if not filter(lambda x: notification.get(x), NOTIFICATION_DESTINATION_TYPES):

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -416,7 +416,7 @@ def send_notification_for_subscriber(
                 "bucket": {"name": bucket_name},
                 "object": {
                     "key": key,
-                    "size": 4,
+                    "size": object_data.get("ContentLength"),
                     "etag": object_data.get("ETag", ""),
                     "sequencer": "0062E99A88DC407460",
                 },
@@ -433,6 +433,9 @@ def send_notification_for_subscriber(
         if action == "ObjectRemoved":
             entry["DetailType"] = "Object Deleted"
             entry["Detail"]["reason"] = f"{api_method}Object"
+            entry["Detail"]["deletion-type"] = "Permanently Deleted"
+            entry["Detail"]["object"].pop("etag")
+            entry["Detail"]["object"].pop("size")
 
         if action == "ObjectTagging":
             entry["DetailType"] = (

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -444,8 +444,8 @@ def send_notification_for_subscriber(
         try:
             events_client.put_events(Entries=[entry])
         except Exception as e:
-            LOGGER.warning(
-                f'Unable to send notification for S3 bucket "{bucket_name}" to EventBridge', e
+            LOGGER.exception(
+                'Unable to send notification for S3 bucket "%s" to EventBridge', bucket_name
             )
 
     if not filter(lambda x: notification.get(x), NOTIFICATION_DESTINATION_TYPES):

--- a/tests/integration/s3/test_s3_notifications_eventbridge.py
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+
+class TestS3NotificationsToEventBridge:
+    @pytest.mark.aws_validated
+    def test_object_created_put(
+        self,
+        s3_client,
+        s3_create_bucket,
+        sqs_client,
+        sqs_create_queue,
+        sqs_queue_arn,
+        events_client,
+        events_create_rule,
+    ):
+
+        bus_name = "default"
+        queue_name = f"test-queue-{short_uid()}"
+        bucket_name = f"test-bucket-{short_uid()}"
+        rule_name = f"test-rule-{short_uid()}"
+        target_id = f"test-target-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name)
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name, NotificationConfiguration={"EventBridgeConfiguration": {}}
+        )
+
+        pattern = {
+            "source": ["aws.s3"],
+            "detail-type": [
+                "Object Created",
+                "Object Deleted",
+                "Object Restore Initiated",
+                "Object Restore Completed",
+                "Object Restore Expired",
+                "Object Tags Added",
+                "Object Tags Deleted",
+                "Object ACL Updated",
+                "Object Storage Class Changed",
+                "Object Access Tier Changed",
+            ],
+            "detail": {"bucket": {"name": [bucket_name]}},
+        }
+        rule_arn = events_create_rule(Name=rule_name, EventBusName=bus_name, EventPattern=pattern)
+
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        queue_arn = sqs_queue_arn(queue_url)
+        queue_policy = {
+            "Statement": [
+                {
+                    "Sid": "EventsToMyQueue",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "events.amazonaws.com"},
+                    "Action": "sqs:SendMessage",
+                    "Resource": queue_arn,
+                    "Condition": {"ArnEquals": {"aws:SourceArn": rule_arn}},
+                }
+            ]
+        }
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={"Policy": json.dumps(queue_policy), "ReceiveMessageWaitTimeSeconds": "5"},
+        )
+        events_client.put_targets(Rule=rule_name, Targets=[{"Id": target_id, "Arn": queue_arn}])
+
+        test_key = "test-key"
+        s3_client.put_object(Bucket=bucket_name, Key=test_key, Body=b"data")
+        s3_client.delete_object(Bucket=bucket_name, Key=test_key)
+
+        messages = {}
+
+        def _validate_messages():
+            received = sqs_client.receive_message(QueueUrl=queue_url).get("Messages", [])
+            for msg in received:
+                messages.update({msg["MessageId"]: msg})
+            assert len(messages) == 2
+            messages_array = list(messages.values())
+
+            delete_event_message = json.loads(messages_array[0]["Body"])
+            create_event_message = json.loads(messages_array[1]["Body"])
+
+            assert delete_event_message["detail-type"] == "Object Deleted"
+            assert create_event_message["detail-type"] == "Object Created"
+
+            assert delete_event_message["source"] == "aws.s3"
+            assert create_event_message["source"] == "aws.s3"
+
+            assert delete_event_message["detail"]["bucket"]["name"] == bucket_name
+            assert create_event_message["detail"]["bucket"]["name"] == bucket_name
+
+            assert delete_event_message["detail"]["object"]["key"] == test_key
+            assert create_event_message["detail"]["object"]["key"] == test_key
+
+        retry(_validate_messages)

--- a/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -1,0 +1,62 @@
+{
+  "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put": {
+    "recorded-date": "16-08-2022, 11:38:49",
+    "recorded-content": {
+      "object_deleted": {
+        "account": "111111111111",
+        "detail": {
+          "bucket": {
+            "name": "<bucket-name:1>"
+          },
+          "deletion-type": "Permanently Deleted",
+          "object": {
+            "key": "<key-name:1>",
+            "sequencer": "object-sequencer"
+          },
+          "reason": "DeleteObject",
+          "request-id": "request-id",
+          "requester": "<111111111111:1>",
+          "source-ip-address": "<ip-address:1>",
+          "version": "0"
+        },
+        "detail-type": "Object Deleted",
+        "id": "<uuid:1>",
+        "region": "<region>",
+        "resources": [
+          "arn:aws:s3:::<bucket-name:1>"
+        ],
+        "source": "aws.s3",
+        "time": "date",
+        "version": "0"
+      },
+      "object_created": {
+        "account": "111111111111",
+        "detail": {
+          "bucket": {
+            "name": "<bucket-name:1>"
+          },
+          "object": {
+            "etag": "<object-etag:1>",
+            "key": "<key-name:1>",
+            "sequencer": "object-sequencer",
+            "size": 4
+          },
+          "reason": "PutObject",
+          "request-id": "request-id",
+          "requester": "<111111111111:1>",
+          "source-ip-address": "<ip-address:1>",
+          "version": "0"
+        },
+        "detail-type": "Object Created",
+        "id": "<uuid:2>",
+        "region": "<region>",
+        "resources": [
+          "arn:aws:s3:::<bucket-name:1>"
+        ],
+        "source": "aws.s3",
+        "time": "date",
+        "version": "0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses issue #5994. With these changes, the S3 Notifications can be send to the EventBridgeService.