### PR TITLE
Enhance parity for SSM logic and integration tests

### DIFF
--- a/localstack/services/ssm/provider.py
+++ b/localstack/services/ssm/provider.py
@@ -1,9 +1,10 @@
+import copy
 import json
 import time
 from abc import ABC
-from typing import Optional
+from typing import Dict, Optional
 
-from localstack.aws.api import RequestContext
+from localstack.aws.api import CommonServiceException, RequestContext
 from localstack.aws.api.ssm import (
     Boolean,
     DeleteParameterResult,
@@ -21,11 +22,102 @@ from localstack.aws.api.ssm import (
 )
 from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.utils.aws import aws_stack
+from localstack.utils.collections import remove_attributes
+from localstack.utils.objects import keys_to_lower
 
 PARAM_PREFIX_SECRETSMANAGER = "/aws/reference/secretsmanager"
 
 
+class ValidationException(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("ValidationException", message=message, sender_fault=True)
+
+
+# TODO: check if _normalize_name(..) calls are still required here
 class SsmProvider(SsmApi, ABC):
+    def get_parameters(
+        self,
+        context: RequestContext,
+        names: ParameterNameList,
+        with_decryption: Boolean = None,
+    ) -> GetParametersResult:
+        if SsmProvider._has_secrets(names):
+            return SsmProvider._get_params_and_secrets(names)
+
+        norm_names = list([SsmProvider._normalize_name(name, validate=True) for name in names])
+        request = {"Names": norm_names, "WithDecryption": bool(with_decryption)}
+        res = call_moto_with_request(context, request)
+
+        if not res.get("InvalidParameters"):
+            # note: simplifying assumption for now - only de-normalizing names if no invalid params were given
+            for i in range(len(res["Parameters"])):
+                self._denormalize_param_name_in_response(res["Parameters"][i], names[i])
+
+        return GetParametersResult(**res)
+
+    def put_parameter(
+        self, context: RequestContext, request: PutParameterRequest
+    ) -> PutParameterResult:
+        name = request["Name"]
+        nname = SsmProvider._normalize_name(name)
+        if name != nname:
+            request.update({"Name": nname})
+            moto_res = call_moto_with_request(context, request)
+        else:
+            moto_res = call_moto(context)
+        SsmProvider._notify_event_subscribers(nname, "Create")
+        return PutParameterResult(**moto_res)
+
+    def get_parameter(
+        self,
+        context: RequestContext,
+        name: PSParameterName,
+        with_decryption: Boolean = None,
+    ) -> GetParameterResult:
+        result = None
+
+        norm_name = self._normalize_name(name, validate=True)
+        details = norm_name.split("/")
+        if len(details) > 4:
+            service = details[3]
+            if service == "secretsmanager":
+                resource_name = "/".join(details[4:])
+                result = SsmProvider._get_secrets_information(norm_name, resource_name)
+
+        if not result:
+            result = call_moto_with_request(
+                context, {"Name": norm_name, "WithDecryption": bool(with_decryption)}
+            )
+
+        self._denormalize_param_name_in_response(result["Parameter"], name)
+
+        return GetParameterResult(**result)
+
+    def delete_parameter(
+        self, context: RequestContext, name: PSParameterName
+    ) -> DeleteParameterResult:
+        SsmProvider._notify_event_subscribers(name, "Delete")
+        call_moto(context)  # Return type is an emtpy type.
+        return DeleteParameterResult()
+
+    def label_parameter_version(
+        self,
+        context: RequestContext,
+        name: PSParameterName,
+        labels: ParameterLabelList,
+        parameter_version: PSParameterVersion = None,
+    ) -> LabelParameterVersionResult:
+        SsmProvider._notify_event_subscribers(name, "LabelParameterVersion")
+        return LabelParameterVersionResult(**call_moto(context))
+
+    # utility methods below
+
+    @staticmethod
+    def _denormalize_param_name_in_response(param_result: Dict, param_name: str):
+        result_name = param_result["Name"]
+        if result_name != param_name and result_name.lstrip("/") == param_name.lstrip("/"):
+            param_result["Name"] = param_name
+
     @staticmethod
     def _has_secrets(names: ParameterNameList) -> Boolean:
         maybe_secret = next(
@@ -34,7 +126,15 @@ class SsmProvider(SsmApi, ABC):
         return maybe_secret is not None
 
     @staticmethod
-    def _normalize_name(param_name: ParameterName) -> ParameterName:
+    def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:
+        if validate:
+            msg = (
+                'Parameter name: can\'t be prefixed with "ssm" (case-insensitive). '
+                "If formed as a path, it can consist of sub-paths divided by slash symbol; "
+                "each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_"
+            )
+            if "//" in param_name or ("/" in param_name and not param_name.startswith("/")):
+                raise ValidationException(msg)
         param_name = param_name.strip("/")
         param_name = param_name.replace("//", "/")
         if "/" in param_name:
@@ -48,12 +148,16 @@ class SsmProvider(SsmApi, ABC):
         client = aws_stack.connect_to_service("secretsmanager")
         try:
             secret_info = client.get_secret_value(SecretId=resource_name)
-            del secret_info["ResponseMetadata"]
+            secret_info.pop("ResponseMetadata", None)
             created_date_timestamp = time.mktime(secret_info["CreatedDate"].timetuple())
             secret_info["CreatedDate"] = created_date_timestamp
+            secret_info_lower = keys_to_lower(
+                remove_attributes(copy.deepcopy(secret_info), ["ARN"])
+            )
+            secret_info_lower["ARN"] = secret_info["ARN"]
             result = {
                 "Parameter": {
-                    "SourceResult": json.dumps(secret_info, default=str),
+                    "SourceResult": json.dumps(secret_info_lower, default=str),
                     "Name": name,
                     "Value": secret_info.get("SecretString"),
                     "Type": "SecureString",
@@ -102,69 +206,3 @@ class SsmProvider(SsmApi, ABC):
             "DetailType": "Parameter Store Change",
         }
         events.put_events(Entries=[event])
-
-    def get_parameters(
-        self,
-        context: RequestContext,
-        names: ParameterNameList,
-        with_decryption: Boolean = None,
-    ) -> GetParametersResult:
-        if SsmProvider._has_secrets(names):
-            return SsmProvider._get_params_and_secrets(names)
-        names = list([SsmProvider._normalize_name(name) for name in names])
-        request = {"Names": names, "WithDecryption": bool(with_decryption)}
-        res = call_moto_with_request(context, request)
-        return GetParametersResult(**res)
-
-    def put_parameter(
-        self, context: RequestContext, request: PutParameterRequest
-    ) -> PutParameterResult:
-        name = request["Name"]
-        nname = SsmProvider._normalize_name(name)
-        if name != nname:
-            request.update({"Name": nname})
-            moto_res = call_moto_with_request(context, request)
-        else:
-            moto_res = call_moto(context)
-        SsmProvider._notify_event_subscribers(nname, "Create")
-        return PutParameterResult(**moto_res)
-
-    def get_parameter(
-        self,
-        context: RequestContext,
-        name: PSParameterName,
-        with_decryption: Boolean = None,
-    ) -> GetParameterResult:
-        result = None
-        #
-        name = SsmProvider._normalize_name(name)
-        details = name.split("/")
-        if len(details) > 4:
-            service = details[3]
-            if service == "secretsmanager":
-                resource_name = "/".join(details[4:])
-                result = SsmProvider._get_secrets_information(name, resource_name)
-        #
-        if not result:
-            result = call_moto_with_request(
-                context, {"Name": name, "WithDecryption": bool(with_decryption)}
-            )
-        #
-        return GetParameterResult(**result)
-
-    def delete_parameter(
-        self, context: RequestContext, name: PSParameterName
-    ) -> DeleteParameterResult:
-        SsmProvider._notify_event_subscribers(name, "Delete")
-        call_moto(context)  # Return type is an emtpy type.
-        return DeleteParameterResult()
-
-    def label_parameter_version(
-        self,
-        context: RequestContext,
-        name: PSParameterName,
-        labels: ParameterLabelList,
-        parameter_version: PSParameterVersion = None,
-    ) -> LabelParameterVersionResult:
-        SsmProvider._notify_event_subscribers(name, "LabelParameterVersion")
-        return LabelParameterVersionResult(**call_moto(context))

--- a/localstack/services/ssm/provider.py
+++ b/localstack/services/ssm/provider.py
@@ -33,6 +33,16 @@ class ValidationException(CommonServiceException):
         super().__init__("ValidationException", message=message, sender_fault=True)
 
 
+class InvalidParameterNameException(ValidationException):
+    def __init__(self):
+        msg = (
+            'Parameter name: can\'t be prefixed with "ssm" (case-insensitive). '
+            "If formed as a path, it can consist of sub-paths divided by slash symbol; "
+            "each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_"
+        )
+        super().__init__(msg)
+
+
 # TODO: check if _normalize_name(..) calls are still required here
 class SsmProvider(SsmApi, ABC):
     def get_parameters(
@@ -128,13 +138,8 @@ class SsmProvider(SsmApi, ABC):
     @staticmethod
     def _normalize_name(param_name: ParameterName, validate=False) -> ParameterName:
         if validate:
-            msg = (
-                'Parameter name: can\'t be prefixed with "ssm" (case-insensitive). '
-                "If formed as a path, it can consist of sub-paths divided by slash symbol; "
-                "each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_"
-            )
             if "//" in param_name or ("/" in param_name and not param_name.startswith("/")):
-                raise ValidationException(msg)
+                raise InvalidParameterNameException()
         param_name = param_name.strip("/")
         param_name = param_name.replace("//", "/")
         if "/" in param_name:

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -40,7 +40,8 @@ class TestSSM:
         _assert(f"/{param_name}", f"/{param_name}", ssm_client)
 
     @pytest.mark.aws_validated
-    def test_hierarchical_parameter(self, ssm_client, create_parameter):
+    @pytest.mark.parametrize("param_name_pattern", ["/<param>//b//c", "<param>/b/c"])
+    def test_hierarchical_parameter(self, ssm_client, create_parameter, param_name_pattern):
         param_a = short_uid()
         create_parameter(
             Name=f"/{param_a}/b/c",
@@ -49,11 +50,11 @@ class TestSSM:
         )
 
         _assert(f"/{param_a}/b/c", f"/{param_a}/b/c", ssm_client)
-        for pname in [f"/{param_a}//b//c", f"{param_a}/b/c"]:
-            with pytest.raises(Exception) as exc:
-                _assert(pname, f"/{param_a}/b/c", ssm_client)
-            exc.match("ValidationException")
-            exc.match("sub-paths divided by slash symbol")
+        pname = param_name_pattern.replace("<param>", param_a)
+        with pytest.raises(Exception) as exc:
+            _assert(pname, f"/{param_a}/b/c", ssm_client)
+        exc.match("ValidationException")
+        exc.match("sub-paths divided by slash symbol")
 
     @pytest.mark.aws_validated
     def test_get_secret_parameter(self, ssm_client, create_secret):

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -1,9 +1,12 @@
+import json
+
 import pytest
 
 from localstack.utils.common import short_uid
+from localstack.utils.strings import to_str
 
 
-def _assert(search_name, param_name, ssm_client):
+def _assert(search_name: str, param_name: str, ssm_client):
     def do_assert(result):
         assert len(result) > 0
         assert param_name == result[0]["Name"]
@@ -16,13 +19,14 @@ def _assert(search_name, param_name, ssm_client):
     do_assert(response["Parameters"])
 
 
-# TODO: fix AWS compatibility
 class TestSSM:
+    @pytest.mark.aws_validated
     def test_describe_parameters(self, ssm_client):
         response = ssm_client.describe_parameters()
         assert "Parameters" in response
         assert isinstance(response["Parameters"], list)
 
+    @pytest.mark.aws_validated
     def test_put_parameters(self, ssm_client, create_parameter):
         param_name = f"param-{short_uid()}"
         create_parameter(
@@ -33,11 +37,11 @@ class TestSSM:
         )
 
         _assert(param_name, param_name, ssm_client)
-        _assert(f"/{param_name}", param_name, ssm_client)  # TODO: not valid
+        _assert(f"/{param_name}", f"/{param_name}", ssm_client)
 
-    # TODO botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the GetParameter operation: Parameter name: can't be prefixed with "ssm" (case-insensitive). If formed as a path, it can consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_
+    @pytest.mark.aws_validated
     def test_hierarchical_parameter(self, ssm_client, create_parameter):
-        param_a = f"{short_uid()}"
+        param_a = short_uid()
         create_parameter(
             Name=f"/{param_a}/b/c",
             Value="123",
@@ -45,10 +49,13 @@ class TestSSM:
         )
 
         _assert(f"/{param_a}/b/c", f"/{param_a}/b/c", ssm_client)
-        _assert(f"/{param_a}//b//c", f"/{param_a}/b/c", ssm_client)
-        _assert(f"{param_a}/b//c", f"/{param_a}/b/c", ssm_client)
+        for pname in [f"/{param_a}//b//c", f"{param_a}/b/c"]:
+            with pytest.raises(Exception) as exc:
+                _assert(pname, f"/{param_a}/b/c", ssm_client)
+            exc.match("ValidationException")
+            exc.match("sub-paths divided by slash symbol")
 
-    # TODO botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the GetParameter operation: WithDecryption flag must be True for retrieving a Secret Manager secret.
+    @pytest.mark.aws_validated
     def test_get_secret_parameter(self, ssm_client, create_secret):
         secret_name = f"test_secret-{short_uid()}"
         create_secret(
@@ -57,25 +64,35 @@ class TestSSM:
             Description="testing creation of secrets",
         )
 
-        result = ssm_client.get_parameter(Name=f"/aws/reference/secretsmanager/{secret_name}")
+        result = ssm_client.get_parameter(
+            Name=f"/aws/reference/secretsmanager/{secret_name}", WithDecryption=True
+        )
         assert f"/aws/reference/secretsmanager/{secret_name}" == result.get("Parameter").get("Name")
         assert "my_secret" == result.get("Parameter").get("Value")
 
         source_result = result.get("Parameter").get("SourceResult")
-        assert source_result is not None, "SourceResult should be present"
-        assert type(source_result) is str, "SourceResult should be a string"
+        assert source_result
+        source_result = json.loads(to_str(source_result))
+        assert source_result["name"] == secret_name
+        assert ":secretsmanager:" in source_result["ARN"]
 
+        # negative test for https://github.com/localstack/localstack/issues/6551
+        with pytest.raises(Exception):
+            ssm_client.get_parameter(Name=secret_name, WithDecryption=True)
+
+    @pytest.mark.aws_validated
     def test_get_inexistent_secret(self, ssm_client):
-        with pytest.raises(ssm_client.exceptions.ParameterNotFound):
-            ssm_client.get_parameter(
-                Name="/aws/reference/secretsmanager/inexistent", WithDecryption=True
-            )
+        invalid_name = "/aws/reference/secretsmanager/inexistent"
+        with pytest.raises(ssm_client.exceptions.ParameterNotFound) as exc:
+            ssm_client.get_parameter(Name=invalid_name, WithDecryption=True)
+        exc.match("ParameterNotFound")
+        exc.match(f"Secret .*{invalid_name.lstrip('/')}.* not found.")
 
-    # TODO: AssertionError: assert '/aws/reference/secretsmanager/9763a545_test_secret_params' in ['inexistent_param', '/aws/reference/secretsmanager/inexistent_secret']
+    @pytest.mark.aws_validated
     def test_get_parameters_and_secrets(self, ssm_client, create_parameter, create_secret):
         param_name = f"param-{short_uid()}"
         secret_path = "/aws/reference/secretsmanager/"
-        secret_name = f"{short_uid()}_test_secret_params"
+        secret_name = f"test_secret_param_{short_uid()}"
         complete_secret = secret_path + secret_name
 
         create_parameter(
@@ -97,7 +114,8 @@ class TestSSM:
                 complete_secret,
                 "inexistent_param",
                 secret_path + "inexistent_secret",
-            ]
+            ],
+            WithDecryption=True,
         )
         found = response.get("Parameters")
         not_found = response.get("InvalidParameters")
@@ -105,9 +123,9 @@ class TestSSM:
         for param in found:
             assert param["Name"] in [param_name, complete_secret]
         for param in not_found:
-            # TODO: AssertionError: assert '/aws/reference/secretsmanager/9763a545_test_secret_params' in ['inexistent_param', '/aws/reference/secretsmanager/inexistent_secret']
             assert param in ["inexistent_param", secret_path + "inexistent_secret"]
 
+    @pytest.mark.aws_validated
     def test_get_parameters_by_path_and_filter_by_labels(self, ssm_client, create_parameter):
         prefix = f"/prefix-{short_uid()}"
         path = f"{prefix}/path"


### PR DESCRIPTION
This PR marks the tests in `test_ssm.py` as `aws_validated`, and adds minor refactorings to achieve parity with the logic in real AWS. Addresses https://github.com/localstack/localstack/issues/6551 