### PR TITLE
fix Werkzeug dependency version pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,7 +82,7 @@ runtime =
     Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
-    Werkzeug==2.1.2
+    Werkzeug>=2.2.1
     xmltodict>=0.11.0
 
 # @deprecated - use extra 'runtime' instead.


### PR DESCRIPTION
With #6514, the werkzeug version was pinned to avoid an update to the newest release (since it caused issues with the routing).
It seems like these issues might have been fixed. A new version of Werkzeug (2.2.1) has been released already: https://github.com/pallets/werkzeug/releases/tag/2.2.1

This PR removes the pin again (and again just demands a minimum version).