### PR TITLE
add snapshot examples

### DIFF
--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -320,7 +320,6 @@ def test_execute_change_set(
     is_change_set_failed_and_unavailable,
     cleanup_changesets,
     cleanup_stacks,
-    snapshot,
 ):
     """check if executing a change set succeeds in creating/modifying the resources in changed"""
 

--- a/tests/integration/cloudformation/test_cloudformation_logs.py
+++ b/tests/integration/cloudformation/test_cloudformation_logs.py
@@ -1,26 +1,42 @@
 import os.path
-import re
 
 
-def test_logstream(logs_client, deploy_cfn_template):
+def test_logstream(logs_client, deploy_cfn_template, snapshot):
     stack = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../templates/logs_group_and_stream.yaml"
         )
     )
+    # approach 1: cloudformation_api + custom transformer for key_value "LogGroupNameOutput"
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.key_value("LogGroupNameOutput"))
+
+    # approach 2: cloudformation_api + two custom replacements with priority for LogStreamNameOutput
+    # snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    # snapshot.add_transformer(snapshot.transform.key_value("LogStreamNameOutput"), priority=-1)
+    # snapshot.add_transformer(snapshot.transform.key_value("LogGroupNameOutput"))
+
+    # approach 3: two custom transformer:
+    # snapshot.add_transformer(snapshot.transform.key_value("LogStreamNameOutput"))
+    # snapshot.add_transformer(snapshot.transform.key_value("LogGroupNameOutput"))
 
     group_name = stack.outputs["LogGroupNameOutput"]
     stream_name = stack.outputs["LogStreamNameOutput"]
-    assert group_name
-    assert stream_name
+
+    # lets assert this by snapshot -> it's not aws response, but outputs is a dict, so we can use it here
+    # assert group_name
+    # assert stream_name
+    snapshot.match("outputs", stack.outputs)
 
     streams = logs_client.describe_log_streams(
         logGroupName=group_name, logStreamNamePrefix=stream_name
     )["logStreams"]
-    assert len(streams) == 1
-    assert streams[0]["logStreamName"] == stream_name
-    assert re.match(
-        r"arn:(aws|aws-cn|aws-iso|aws-iso-b|aws-us-gov):logs:.+:.+:log-group:.+:log-stream:.+",
-        streams[0]["arn"],
-    )
+    # this is already asserted by snapshot and can be removed
+    # assert len(streams) == 1
+    # assert streams[0]["logStreamName"] == stream_name
+    # assert re.match(
+    #    r"arn:(aws|aws-cn|aws-iso|aws-iso-b|aws-us-gov):logs:.+:.+:log-group:.+:log-stream:.+",
+    #    streams[0]["arn"],
+    # )
     assert logs_client.meta.partition == streams[0]["arn"].split(":")[1]
+    snapshot.match("describe_log_streams", streams)

--- a/tests/integration/cloudformation/test_cloudformation_logs.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_logs.snapshot.json
@@ -1,0 +1,19 @@
+{
+  "tests/integration/cloudformation/test_cloudformation_logs.py::test_logstream": {
+    "recorded-date": "29-07-2022, 13:22:53",
+    "recorded-content": {
+      "outputs": {
+        "LogStreamNameOutput": "<resource:1>",
+        "LogGroupNameOutput": "<log-group-name-output:1>"
+      },
+      "describe_log_streams": [
+        {
+          "logStreamName": "<resource:1>",
+          "creationTime": "timestamp",
+          "arn": "arn:aws:logs:<region>:111111111111:log-group:<log-group-name-output:1>:log-stream:<resource:1>",
+          "storedBytes": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
* adds snapshot test (was discussed in detail during the workshop, including different approaches how to solve)
* updated comments for `test_basic_invoke` (also discussed during the workshop)
* removes `snapshot` fixture from a test that does not use it

