### PR TITLE
fix SQS ChangeVisibilityTimeout operation

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -352,6 +352,9 @@ class SqsQueue:
             if standard_message not in self.inflight:
                 raise MessageNotInflight()
 
+            # we also have to update last_received, since that is used to calculate the visibility deadline.
+            # last_received is not actually used to indicate "true" receipts via receive_message, so this is safe.
+            standard_message.last_received = time.time()
             standard_message.visibility_timeout = visibility_timeout
 
             if visibility_timeout == 0:

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -542,8 +542,66 @@ class TestSqsProvider:
         result = sqs_client.receive_message(QueueUrl=queue_url)
         assert "Messages" not in result
 
-    def test_update_message_visibility_timeout(self):
-        pass
+    @pytest.mark.aws_validated
+    def test_extend_message_visibility_timeout_set_in_queue(self, sqs_client, sqs_create_queue):
+        queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "2"})
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+        response = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
+        receipt = response["Messages"][0]["ReceiptHandle"]
+
+        # update even if time expires
+        for _ in range(4):
+            time.sleep(1)
+            # we've waited a total of four seconds, although the visibility timeout is 2, so we are extending it
+            sqs_client.change_message_visibility(
+                QueueUrl=queue_url, ReceiptHandle=receipt, VisibilityTimeout=2
+            )
+            assert sqs_client.receive_message(QueueUrl=queue_url).get("Messages", []) == []
+
+        messages = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)["Messages"]
+        assert messages[0]["Body"] == "test"
+        assert len(messages) == 1
+
+    @pytest.mark.aws_validated
+    def test_receive_message_with_visibility_timeout_updates_timeout(
+        self, sqs_client, sqs_create_queue
+    ):
+        queue_url = sqs_create_queue()
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=2, VisibilityTimeout=0
+        )
+        assert len(response["Messages"]) == 1
+
+        response = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
+        assert len(response["Messages"]) == 1
+
+        response = sqs_client.receive_message(QueueUrl=queue_url)
+        assert response.get("Messages", []) == []
+
+    @pytest.mark.aws_validated
+    def test_terminate_visibility_timeout_after_receive(self, sqs_client, sqs_create_queue):
+        queue_url = sqs_create_queue()
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=2, VisibilityTimeout=0
+        )
+        receipt_1 = response["Messages"][0]["ReceiptHandle"]
+        assert len(response["Messages"]) == 1
+
+        response = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
+        assert len(response["Messages"]) == 1
+
+        sqs_client.change_message_visibility(
+            QueueUrl=queue_url, ReceiptHandle=receipt_1, VisibilityTimeout=0
+        )
+        response = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        assert len(response["Messages"]) == 1
 
     def test_delete_message_batch_from_lambda(
         self, sqs_client, sqs_create_queue, lambda_client, create_lambda_function


### PR DESCRIPTION
This PR corrects the behavior of `change_visibility_timeout`, which previously had not the correct effect on `message.is_visible`, which we are calculating like this:
```python
if time.time() >= (self.last_received + self.visibility_timeout):
    return True
```

So clearly updating only the `visibility_timeout` had no effect. We had to reset the entire visibility timer as defined by the AWS docs linked in the original issue.

**update**: i refactored the logic to use a dedicated `visibility_deadline` value that is calculated differently depending on whether the visibility timeout is updated or the message is received.

- Fixes #6454 
