### PR TITLE
Make lambda states reflect internal state

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -652,7 +652,7 @@ LAMBDA_FORWARD_URL = os.environ.get("LAMBDA_FORWARD_URL", "").strip()
 # Time in seconds to wait at max while extracting Lambda code.
 # By default, it is 25 seconds for limiting the execution time
 # to avoid client/network timeout issues
-LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
+LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 10)
 
 # whether lambdas should use stay open mode if executed in "docker-reuse" executor
 LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -652,7 +652,7 @@ LAMBDA_FORWARD_URL = os.environ.get("LAMBDA_FORWARD_URL", "").strip()
 # Time in seconds to wait at max while extracting Lambda code.
 # By default, it is 25 seconds for limiting the execution time
 # to avoid client/network timeout issues
-LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 10)
+LAMBDA_CODE_EXTRACT_TIME = int(os.environ.get("LAMBDA_CODE_EXTRACT_TIME") or 25)
 
 # whether lambdas should use stay open mode if executed in "docker-reuse" executor
 LAMBDA_STAY_OPEN_MODE = is_in_docker and is_env_not_false("LAMBDA_STAY_OPEN_MODE")

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -721,11 +721,17 @@ def set_archive_code(code: Dict, lambda_name: str, zip_file_content: bytes = Non
 def set_function_code(lambda_function: LambdaFunction):
     def _set_and_configure(*args, **kwargs):
         try:
+            before = time.perf_counter()
             do_set_function_code(lambda_function)
             # initialize function code via plugins
             for plugin in lambda_executors.LambdaExecutorPlugin.get_plugins():
                 plugin.init_function_code(lambda_function)
             lambda_function.state = "Active"
+            LOG.debug(
+                "Function code initialization for function '%s' complete. State => Active (in %.3fs)",
+                lambda_function.name(),
+                time.perf_counter() - before,
+            )
         except Exception:
             lambda_function.state = "Failed"
             raise

--- a/localstack/utils/aws/aws_models.py
+++ b/localstack/utils/aws/aws_models.py
@@ -205,6 +205,7 @@ class LambdaFunction(Component):
         self.architectures = ["x86_64"]
         self.image_config = {}
         self.tracing_config = {}
+        self.state = None
 
     def set_dead_letter_config(self, data):
         config = data.get("DeadLetterConfig")

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -72,6 +72,8 @@ from localstack.utils.testutil import (
 from .functions import lambda_integration
 from .lambda_test_util import concurrency_update_done, get_invoke_init_type, update_done
 
+LOG = logging.getLogger(__name__)
+
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
 TEST_LAMBDA_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_integration.py")
 TEST_LAMBDA_PYTHON_ECHO = os.path.join(THIS_FOLDER, "functions/lambda_echo.py")
@@ -798,24 +800,45 @@ class TestLambdaBaseFeatures:
         result_data = json.loads(to_str(result_data))
         assert payload == result_data
 
-    def test_function_state(self, lambda_client, lambda_su_role):
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify  # skipped - the diff is too big
+    def test_function_state(self, lambda_client, lambda_su_role, snapshot):
         """Tests if a lambda starts in state "Pending" but moves to "Active" at some point"""
+        snapshot.add_transformer(snapshot.transform.lambda_api())
+        # necessary due to changing zip timestamps. We might need a reproducible archive method for this
+        snapshot.add_transformer(snapshot.transform.key_value("CodeSha256"))
         function_name = f"test-function-{short_uid()}"
         zip_file = create_lambda_archive(load_file(TEST_LAMBDA_PYTHON_ECHO), get_content=True)
-        response = lambda_client.create_function(
-            FunctionName=function_name,
-            Runtime="python3.9",
-            Role=lambda_su_role,
-            Code={"ZipFile": zip_file},
-        )
-        assert response["State"] == "Pending"
 
-        # lambda has to get active at some point
-        def _check_lambda_state():
-            response = lambda_client.get_function(FunctionName=function_name)
-            assert response["Configuration"]["State"] == "Active"
+        try:
 
-        retry(_check_lambda_state)
+            def create_function():
+                return lambda_client.create_function(
+                    FunctionName=function_name,
+                    Runtime="python3.9",
+                    Handler="handler.handler",
+                    Role=lambda_su_role,
+                    Code={"ZipFile": zip_file},
+                )
+
+            response = retry(create_function, sleep=3, retries=5)
+
+            snapshot.match("create-fn-response", response)
+            assert response["State"] == "Pending"
+
+            # lambda has to get active at some point
+            def _check_lambda_state():
+                response = lambda_client.get_function(FunctionName=function_name)
+                assert response["Configuration"]["State"] == "Active"
+                return response
+
+            response = retry(_check_lambda_state)
+            snapshot.match("get-fn-response", response)
+        finally:
+            try:
+                lambda_client.delete_function(FunctionName=function_name)
+            except Exception:
+                LOG.debug("Unable to delete function %s", function_name)
 
 
 parametrize_python_runtimes = pytest.mark.parametrize(

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -802,6 +802,10 @@ class TestLambdaBaseFeatures:
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify  # skipped - the diff is too big
+    @pytest.mark.skipif(
+        os.environ.get("TEST_TARGET") != "AWS_CLOUD",
+        reason="Lambda function state pending for small lambdas not supported on localstack",
+    )
     def test_function_state(self, lambda_client, lambda_su_role, snapshot):
         """Tests if a lambda starts in state "Pending" but moves to "Active" at some point"""
         snapshot.add_transformer(snapshot.transform.lambda_api())

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -86,6 +86,7 @@ def create_lambda_function_aws(
 @pytest.mark.snapshot
 @pytest.mark.aws_compatible
 class TestLambdaAsfApi:
+    @pytest.mark.skip_snapshot_verify
     def test_basic_invoke(
         self, lambda_client, create_lambda_function_aws, lambda_su_role, snapshot
     ):

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -86,7 +86,6 @@ def create_lambda_function_aws(
 @pytest.mark.snapshot
 @pytest.mark.aws_compatible
 class TestLambdaAsfApi:
-    @pytest.mark.skip_snapshot_verify
     def test_basic_invoke(
         self, lambda_client, create_lambda_function_aws, lambda_su_role, snapshot
     ):

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -1027,6 +1027,7 @@ class TestLambdaAPI(unittest.TestCase):
         region.lambdas[arn].last_modified = self.LAST_MODIFIED
         region.lambdas[arn].role = self.ROLE
         region.lambdas[arn].memory_size = self.MEMORY_SIZE
+        region.lambdas[arn].state = "Active"
 
     def _update_function_code(self, function_name, tags=None):
         if tags is None:


### PR DESCRIPTION
## Problem
On some machines, lambda extraction might take significantly longer than 25s. Lambdas executed afterwards end up in an inconsistent state, where parts of the lambda code might be missing.
Nevertheless these functions have an "Active" state, which should not be the case.

## Solution
The lambda states will - with this PR - correctly represent current internal state. During extraction, they will therefore be marked as "Pending", if the extraction fails for some reason, it will be set to "Failed", and once it completes, it will be set to "Active". A lambda not in "Active" state cannot be executed. This is on par with AWS behavior. For smaller lambdas, the "Active" state should be reached within a couple milliseconds. Problematic will be the "bigger" lambdas on macos bind mounts (see #6567), where the "Pending" state could be present for multiple minutes.

## Changes in this PR
* Function state will be now "Pending" as long as the function is being initialized, and "Active" afterwards. If the initialization fails, it will be "Failed"
* invoke calls to functions not "Active" will fail. This is also identical to AWS behavior, might lead to confusion for some users though.
* The function code is now deleted from memory after it is dumped on disk as zip, not after the invoke function returns
* The check of lambda function archive sizes was implemented wrong, leading to a lot of retries. we now return the correct exceptions, which leads to immediate failure instead of retries (returned 500s before).

## Other attempts
* removing create_function waiting time is not practicable, as some validation of the zip file only takes place in the init code, so running it completely async will not report back the validation errors correctly (like check for unzip size, check if the package is indeed a zipfile etc.).

Fixes #6566