### PR TITLE
add Athena NamedQueryId to CloudFormation resource properties

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1120,6 +1120,9 @@ def update_resource_details(stack, resource_id, details, action=None):
     if resource_type == "ApiGateway::RestApi":
         resource_props["id"] = details["id"]
 
+    if resource_type == "Athena::NamedQuery":
+        resource_props["NamedQueryId"] = details["NamedQueryId"]
+
     if resource_type == "KMS::Key":
         resource["PhysicalResourceId"] = details["KeyMetadata"]["KeyId"]
 


### PR DESCRIPTION
This PR contains a small fix which allows the Athena CloudFormation models to access the `NamedQueryId` (which is contained in the create response).