### PR TITLE
Change error message for missing endpoints to reference PRO

### DIFF
--- a/localstack/aws/handlers/service.py
+++ b/localstack/aws/handlers/service.py
@@ -184,7 +184,8 @@ class ServiceExceptionSerializer(ExceptionHandler):
         if operation and isinstance(exception, NotImplementedError):
             action_name = operation.name
             message = (
-                f"API action '{action_name}' for service '{service_name}' " f"not yet implemented"
+                f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
+                f" - check https://docs.localstack.cloud/aws/feature-coverage for further information"
             )
             LOG.info(message)
             error = CommonServiceException("InternalFailure", message, status_code=501)

--- a/localstack/aws/skeleton.py
+++ b/localstack/aws/skeleton.py
@@ -199,7 +199,10 @@ class Skeleton:
 
         action_name = operation.name
         service_name = operation.service_model.service_name
-        message = f"API action '{action_name}' for service '{service_name}' not yet implemented"
+        message = (
+            f"API action '{action_name}' for service '{service_name}' not yet implemented or pro feature"
+            f" - check https://docs.localstack.cloud/aws/feature-coverage for further information"
+        )
         LOG.info(message)
         error = CommonServiceException("InternalFailure", message, status_code=501)
         # record event

--- a/localstack/utils/aws/request_context.py
+++ b/localstack/utils/aws/request_context.py
@@ -179,7 +179,10 @@ def patch_moto_request_handling():
                 if match:
                     action = snake_to_camel_case(match.group(1))
             service = extract_service_name_from_auth_header(request.headers)
-            msg = f"API action '{action}' for service '{service}' not yet implemented"
+            msg = (
+                f"API action '{action}' for service '{service}' not yet implemented or pro feature"
+                f" - check https://docs.localstack.cloud/aws/feature-coverage for further information"
+            )
             response = requests_error_response(request.headers, msg, code=501)
             if config.MOCK_UNIMPLEMENTED:
                 is_json = is_json_request(request.headers)


### PR DESCRIPTION
When trying out a PRO feature in community, the error message says that the feature is not yet implemented. This can lead to some confusion, as this feature is indeed implemented, but only in PRO. 

To avoid confusion we can either:

1. Implement something to check if a feature is implemented in PRO (which would introduce a dependency from community to PRO) and change the error message accordingly
2. or just change the error message to "API action 'foo' for service 'bar' not yet implemented or pro feature - check https://docs.localstack.cloud/aws/feature-coverage/ for more information."

This PR implemented option 2. 