### PR TITLE
Return stream name for CFn Firehose stream Ref, add snapshot test

### DIFF
--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -15,7 +15,14 @@ class FirehoseDeliveryStream(GenericBaseModel):
             DeliveryStreamName=stream_name
         )
 
+    def get_cfn_attribute(self, attribute_name):
+        if attribute_name == "Arn":
+            return aws_stack.firehose_stream_arn(self.props.get("DeliveryStreamName"))
+        return super().get_cfn_attribute(attribute_name)
+
     def get_physical_resource_id(self, attribute=None, **kwargs):
+        if attribute == "Arn":
+            return self.get_cfn_attribute("Arn")
         return self.props.get("DeliveryStreamName")
 
     @staticmethod

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -15,6 +15,9 @@ class FirehoseDeliveryStream(GenericBaseModel):
             DeliveryStreamName=stream_name
         )
 
+    def get_physical_resource_id(self, attribute=None, **kwargs):
+        return self.props.get("DeliveryStreamName")
+
     @staticmethod
     def get_deploy_templates():
         return {

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -217,7 +217,6 @@ class FirehoseProvider(FirehoseApi):
             HasMoreDestinations=False,
             VersionId="1",
             CreateTimestamp=datetime.now(),
-            LastUpdateTimestamp=datetime.now(),
             Destinations=destinations,
             Source=convert_source_config_to_desc(kinesis_stream_source_configuration),
         )

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -873,6 +873,7 @@ def deploy_cfn_template(
         template_path: Optional[str | os.PathLike] = None,
         template_mapping: Optional[Dict[str, any]] = None,
         parameters: Optional[Dict[str, str]] = None,
+        max_wait: Optional[int] = None,
     ) -> DeployResult:
         if is_update:
             assert stack_name
@@ -902,7 +903,8 @@ def deploy_cfn_template(
 
         assert wait_until(is_change_set_created_and_available(change_set_id), _max_wait=60)
         cfn_client.execute_change_set(ChangeSetName=change_set_id)
-        assert wait_until(is_change_set_finished(change_set_id), _max_wait=60)
+        # TODO: potentially poll for ExecutionStatus=ROLLBACK_COMPLETE here as well, to catch errors early on
+        assert wait_until(is_change_set_finished(change_set_id), _max_wait=max_wait or 60)
 
         outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0].get("Outputs", [])
 

--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -82,9 +82,7 @@ def fixture_snapshot(request: SubRequest, account_id, region):
             request.fspath.dirname, f"{request.fspath.purebasename}.snapshot.json"
         ),
         scope_key=request.node.nodeid,
-        update=request.config.option.snapshot_update
-        if update_overwrite is None
-        else update_overwrite,
+        update=update_overwrite or request.config.option.snapshot_update,
         verify=False if request.config.option.snapshot_skip_all else True,
     )
     sm.add_transformer(RegexTransformer(account_id, "1" * 12), priority=2)

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1057,8 +1057,6 @@ def determine_resource_physical_id(resource_id, stack=None, attribute=None):
         return resource_props.get("StageName")
     elif resource_type == "AppSync::DataSource":
         return resource_props.get("DataSourceArn")
-    elif resource_type == "KinesisFirehose::DeliveryStream":
-        return aws_stack.firehose_stream_arn(resource_props.get("DeliveryStreamName"))
     elif resource_type == "StepFunctions::StateMachine":
         return aws_stack.state_machine_arn(
             resource_props.get("StateMachineName")

--- a/tests/integration/cloudformation/test_cloudformation_firehose.py
+++ b/tests/integration/cloudformation/test_cloudformation_firehose.py
@@ -3,6 +3,7 @@ import os.path
 import pytest
 
 from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
 
 
 @pytest.mark.aws_validated
@@ -27,6 +28,13 @@ def test_firehose_stack_with_kinesis_as_source(deploy_cfn_template, firehose_cli
         max_wait=150,
     )
     snapshot.match("outputs", stack.outputs)
+
+    def _assert_stream_available():
+        status = firehose_client.describe_delivery_stream(DeliveryStreamName=delivery_stream_name)
+        assert status["DeliveryStreamDescription"]["DeliveryStreamStatus"] == "ACTIVE"
+
+    # wait until stream becomes available
+    retry(_assert_stream_available, sleep=1, retries=15)
 
     response = firehose_client.describe_delivery_stream(DeliveryStreamName=delivery_stream_name)
     assert delivery_stream_name == response["DeliveryStreamDescription"]["DeliveryStreamName"]

--- a/tests/integration/cloudformation/test_cloudformation_firehose.py
+++ b/tests/integration/cloudformation/test_cloudformation_firehose.py
@@ -1,0 +1,33 @@
+import os.path
+
+import pytest
+
+from localstack.utils.strings import short_uid
+
+
+@pytest.mark.aws_validated
+# TODO: enable validation of Destinations - currently too many discrepancies
+@pytest.mark.skip_snapshot_verify(paths=["$..Destinations"])
+def test_firehose_stack_with_kinesis_as_source(deploy_cfn_template, firehose_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+
+    bucket_name = f"bucket-{short_uid()}"
+    stream_name = f"stream-{short_uid()}"
+    delivery_stream_name = f"delivery-stream-{short_uid()}"
+
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "..", "templates", "firehose_kinesis_as_source.yaml"
+        ),
+        parameters={
+            "BucketName": bucket_name,
+            "StreamName": stream_name,
+            "DeliveryStreamName": delivery_stream_name,
+        },
+        max_wait=150,
+    )
+    snapshot.match("outputs", stack.outputs)
+
+    response = firehose_client.describe_delivery_stream(DeliveryStreamName=delivery_stream_name)
+    assert delivery_stream_name == response["DeliveryStreamDescription"]["DeliveryStreamName"]
+    snapshot.match("delivery_stream", response)

--- a/tests/integration/cloudformation/test_cloudformation_firehose.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_firehose.snapshot.json
@@ -1,0 +1,99 @@
+{
+  "tests/integration/cloudformation/test_cloudformation_firehose.py::test_firehose_stack_with_kinesis_as_source": {
+    "recorded-date": "03-08-2022, 11:17:42",
+    "recorded-content": {
+      "outputs": {
+        "deliveryStreamRef": "<resource:1>"
+      },
+      "delivery_stream": {
+        "DeliveryStreamDescription": {
+          "DeliveryStreamName": "<resource:1>",
+          "DeliveryStreamARN": "arn:aws:firehose:<region>:111111111111:deliverystream/<resource:1>",
+          "DeliveryStreamStatus": "ACTIVE",
+          "DeliveryStreamType": "KinesisStreamAsSource",
+          "VersionId": "1",
+          "CreateTimestamp": "timestamp",
+          "Source": {
+            "KinesisStreamSourceDescription": {
+              "KinesisStreamARN": "arn:aws:kinesis:<region>:111111111111:stream/<resource:2>",
+              "RoleARN": "arn:aws:iam::111111111111:role/<resource:3>",
+              "DeliveryStartTimestamp": "timestamp"
+            }
+          },
+          "Destinations": [
+            {
+              "DestinationId": "destinationId-000000000001",
+              "S3DestinationDescription": {
+                "RoleARN": "arn:aws:iam::111111111111:role/<resource:3>",
+                "BucketARN": "arn:aws:s3:::<resource:4>",
+                "Prefix": "firehoseTest/!{partitionKeyFromQuery:s3Prefix}",
+                "ErrorOutputPrefix": "firehoseTest-errors/!{firehose:error-output-type}/",
+                "BufferingHints": {
+                  "SizeInMBs": 64,
+                  "IntervalInSeconds": 60
+                },
+                "CompressionFormat": "UNCOMPRESSED",
+                "EncryptionConfiguration": {
+                  "NoEncryptionConfig": "NoEncryption"
+                },
+                "CloudWatchLoggingOptions": {
+                  "Enabled": false
+                }
+              },
+              "ExtendedS3DestinationDescription": {
+                "RoleARN": "arn:aws:iam::111111111111:role/<resource:3>",
+                "BucketARN": "arn:aws:s3:::<resource:4>",
+                "Prefix": "firehoseTest/!{partitionKeyFromQuery:s3Prefix}",
+                "ErrorOutputPrefix": "firehoseTest-errors/!{firehose:error-output-type}/",
+                "BufferingHints": {
+                  "SizeInMBs": 64,
+                  "IntervalInSeconds": 60
+                },
+                "CompressionFormat": "UNCOMPRESSED",
+                "EncryptionConfiguration": {
+                  "NoEncryptionConfig": "NoEncryption"
+                },
+                "CloudWatchLoggingOptions": {
+                  "Enabled": false
+                },
+                "ProcessingConfiguration": {
+                  "Enabled": true,
+                  "Processors": [
+                    {
+                      "Type": "MetadataExtraction",
+                      "Parameters": [
+                        {
+                          "ParameterName": "MetadataExtractionQuery",
+                          "ParameterValue": "{s3Prefix: .tableName}"
+                        },
+                        {
+                          "ParameterName": "JsonParsingEngine",
+                          "ParameterValue": "JQ-1.6"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "S3BackupMode": "Disabled",
+                "DataFormatConversionConfiguration": {
+                  "Enabled": false
+                },
+                "DynamicPartitioningConfiguration": {
+                  "RetryOptions": {
+                    "DurationInSeconds": 300
+                  },
+                  "Enabled": true
+                }
+              }
+            }
+          ],
+          "HasMoreDestinations": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/templates/firehose_kinesis_as_source.yaml
+++ b/tests/integration/templates/firehose_kinesis_as_source.yaml
@@ -1,47 +1,78 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  BucketName:
+    Type: String
+  StreamName:
+    Type: String
+  DeliveryStreamName:
+    Type: String
 Resources:
   bucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: {{BucketName}}
+      BucketName: !Ref BucketName
   stream:
     Type: AWS::Kinesis::Stream
     Properties: 
-      Name: {{StreamName}}
-      ShardCount: 2    
+      Name: !Ref StreamName
+      ShardCount: 2
+  role:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action: 'sts:AssumeRole'
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: kinesis.amazonaws.com
+            Action: 'sts:AssumeRole'
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "*"
+                Resource: "*"
   deliveryStream:
     DependsOn:
       - bucket
       - stream
     Type: AWS::KinesisFirehose::DeliveryStream
     Properties: 
-      DeliveryStreamName: {{DeliveryStreamName}}
+      DeliveryStreamName: !Ref DeliveryStreamName
       DeliveryStreamType: KinesisStreamAsSource
       KinesisStreamSourceConfiguration:
         KinesisStreamARN: !GetAtt 'stream.Arn'
-        RoleARN: arn:aws:iam::000000000000:role/Firehose-Role
+        RoleARN: !GetAtt 'role.Arn'
       ExtendedS3DestinationConfiguration: 
         BucketARN: !GetAtt 'bucket.Arn'
-        RoleARN: arn:aws:iam::000000000000:role/Firehose-Role
+        RoleARN: !GetAtt 'role.Arn'
         BufferingHints:
           IntervalInSeconds: 60
           SizeInMBs: 64
-        DynamicPartitioningConfiguration: 
-          Enabled: true
-        ProcessingConfiguration: 
+        ProcessingConfiguration:
           Enabled: true
           Processors:
             - Type: MetadataExtraction
               Parameters: 
-                - ParameterName: "MetadatExtractionQuery"
+                - ParameterName: "MetadataExtractionQuery"
                   ParameterValue: "{s3Prefix: .tableName}"
                 - ParameterName: "JsonParsingEngine"
                   ParameterValue: "JQ-1.6"
-        DataFormatConversionConfiguration: 
+        DynamicPartitioningConfiguration:
           Enabled: true
-        CompressionFormat: "GZIP"
-        Prefix: "firehoseTest/!{partitionKeyFromQuery:s3Prefix}/!{partitionKeyFromLambda:companyId}/!{partitionKeyFromLambda:year}/!{partitionKeyFromLambda:month}/"
+        DataFormatConversionConfiguration:
+          Enabled: false
+        Prefix: "firehoseTest/!{partitionKeyFromQuery:s3Prefix}"
         ErrorOutputPrefix: "firehoseTest-errors/!{firehose:error-output-type}/"
-        CloudWatchLoggingOptions:
-          Enabled: true
-          LogGroupName: 'FirehoseStreamLog'
+Outputs:
+  deliveryStreamRef:
+    Value:
+      Ref: deliveryStream

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1830,23 +1830,6 @@ class TestCloudFormation:
         test_tag = tags["Tags"]["test"]
         assert test_tag == aws_stack.ssm_parameter_arn("cdk-bootstrap/q123/version")
 
-    def test_firehose_stack_with_kinesis_as_source(self, deploy_cfn_template, firehose_client):
-        bucket_name = f"bucket-{short_uid()}"
-        stream_name = f"stream-{short_uid()}"
-        delivery_stream_name = f"delivery-stream-{short_uid()}"
-
-        deploy_cfn_template(
-            template_path=os.path.join(THIS_FOLDER, "templates", "firehose_kinesis_as_source.yaml"),
-            template_mapping={
-                "BucketName": bucket_name,
-                "StreamName": stream_name,
-                "DeliveryStreamName": delivery_stream_name,
-            },
-        )
-
-        response = firehose_client.describe_delivery_stream(DeliveryStreamName=delivery_stream_name)
-        assert delivery_stream_name == response["DeliveryStreamDescription"]["DeliveryStreamName"]
-
     def test_default_parameters_kinesis(self, deploy_cfn_template, kinesis_client):
         stack = deploy_cfn_template(
             template_path=os.path.join(THIS_FOLDER, "templates", "kinesis_default.yaml")


### PR DESCRIPTION
* return stream name for CFn Firehose stream Ref - addresses #6570
* add snapshot test for Firehose CFn test, move test to separate module inside `cloudformation` test package
* introduce `max_wait` parameter for stacks that take a long time to deploy in AWS (>60 secs)
* small fix around logic for `SNAPSHOT_UPDATE` (currently snapshots were not recorded if this env variable is not set)