### PR TITLE
fix error serialization for default error members

### DIFF
--- a/localstack/aws/api/cloudwatch/__init__.py
+++ b/localstack/aws/api/cloudwatch/__init__.py
@@ -12,7 +12,6 @@ from localstack.aws.api import RequestContext, ServiceException, ServiceRequest,
 AccountId = str
 ActionPrefix = str
 ActionsEnabled = bool
-ActionsSuppressedReason = str
 AlarmArn = str
 AlarmDescription = str
 AlarmName = str
@@ -83,17 +82,10 @@ Stat = str
 StateReason = str
 StateReasonData = str
 StorageResolution = int
-SuppressorPeriod = int
 TagKey = str
 TagValue = str
 Threshold = float
 TreatMissingData = str
-
-
-class ActionsSuppressedBy(str):
-    WaitPeriod = "WaitPeriod"
-    ExtensionPeriod = "ExtensionPeriod"
-    Alarm = "Alarm"
 
 
 class AlarmType(str):
@@ -396,12 +388,6 @@ class CompositeAlarm(TypedDict, total=False):
     StateReasonData: Optional[StateReasonData]
     StateUpdatedTimestamp: Optional[Timestamp]
     StateValue: Optional[StateValue]
-    StateTransitionedTimestamp: Optional[Timestamp]
-    ActionsSuppressedBy: Optional[ActionsSuppressedBy]
-    ActionsSuppressedReason: Optional[ActionsSuppressedReason]
-    ActionsSuppressor: Optional[AlarmArn]
-    ActionsSuppressorWaitPeriod: Optional[SuppressorPeriod]
-    ActionsSuppressorExtensionPeriod: Optional[SuppressorPeriod]
 
 
 CompositeAlarms = List[CompositeAlarm]
@@ -928,9 +914,6 @@ class PutCompositeAlarmInput(ServiceRequest):
     InsufficientDataActions: Optional[ResourceList]
     OKActions: Optional[ResourceList]
     Tags: Optional[TagList]
-    ActionsSuppressor: Optional[AlarmArn]
-    ActionsSuppressorWaitPeriod: Optional[SuppressorPeriod]
-    ActionsSuppressorExtensionPeriod: Optional[SuppressorPeriod]
 
 
 class PutDashboardInput(ServiceRequest):
@@ -1296,9 +1279,6 @@ class CloudwatchApi:
         insufficient_data_actions: ResourceList = None,
         ok_actions: ResourceList = None,
         tags: TagList = None,
-        actions_suppressor: AlarmArn = None,
-        actions_suppressor_wait_period: SuppressorPeriod = None,
-        actions_suppressor_extension_period: SuppressorPeriod = None,
     ) -> None:
         raise NotImplementedError
 

--- a/localstack/aws/api/ec2/__init__.py
+++ b/localstack/aws/api/ec2/__init__.py
@@ -1585,7 +1585,6 @@ class InstanceType(str):
     c7g_8xlarge = "c7g.8xlarge"
     c7g_12xlarge = "c7g.12xlarge"
     c7g_16xlarge = "c7g.16xlarge"
-    mac2_metal = "mac2.metal"
 
 
 class InstanceTypeHypervisor(str):

--- a/localstack/aws/api/kms/__init__.py
+++ b/localstack/aws/api/kms/__init__.py
@@ -55,7 +55,6 @@ class ConnectionErrorCodeType(str):
     USER_NOT_FOUND = "USER_NOT_FOUND"
     USER_LOGGED_IN = "USER_LOGGED_IN"
     SUBNET_NOT_FOUND = "SUBNET_NOT_FOUND"
-    INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET = "INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET"
 
 
 class ConnectionStateType(str):
@@ -79,7 +78,6 @@ class CustomerMasterKeySpec(str):
     HMAC_256 = "HMAC_256"
     HMAC_384 = "HMAC_384"
     HMAC_512 = "HMAC_512"
-    SM2 = "SM2"
 
 
 class DataKeyPairSpec(str):
@@ -90,7 +88,6 @@ class DataKeyPairSpec(str):
     ECC_NIST_P384 = "ECC_NIST_P384"
     ECC_NIST_P521 = "ECC_NIST_P521"
     ECC_SECG_P256K1 = "ECC_SECG_P256K1"
-    SM2 = "SM2"
 
 
 class DataKeySpec(str):
@@ -102,7 +99,6 @@ class EncryptionAlgorithmSpec(str):
     SYMMETRIC_DEFAULT = "SYMMETRIC_DEFAULT"
     RSAES_OAEP_SHA_1 = "RSAES_OAEP_SHA_1"
     RSAES_OAEP_SHA_256 = "RSAES_OAEP_SHA_256"
-    SM2PKE = "SM2PKE"
 
 
 class ExpirationModelType(str):
@@ -147,7 +143,6 @@ class KeySpec(str):
     HMAC_256 = "HMAC_256"
     HMAC_384 = "HMAC_384"
     HMAC_512 = "HMAC_512"
-    SM2 = "SM2"
 
 
 class KeyState(str):
@@ -200,7 +195,6 @@ class SigningAlgorithmSpec(str):
     ECDSA_SHA_256 = "ECDSA_SHA_256"
     ECDSA_SHA_384 = "ECDSA_SHA_384"
     ECDSA_SHA_512 = "ECDSA_SHA_512"
-    SM2DSA = "SM2DSA"
 
 
 class WrappingKeySpec(str):
@@ -451,9 +445,9 @@ class CreateAliasRequest(ServiceRequest):
 
 class CreateCustomKeyStoreRequest(ServiceRequest):
     CustomKeyStoreName: CustomKeyStoreNameType
-    CloudHsmClusterId: Optional[CloudHsmClusterIdType]
-    TrustAnchorCertificate: Optional[TrustAnchorCertificateType]
-    KeyStorePassword: Optional[KeyStorePasswordType]
+    CloudHsmClusterId: CloudHsmClusterIdType
+    TrustAnchorCertificate: TrustAnchorCertificateType
+    KeyStorePassword: KeyStorePasswordType
 
 
 class CreateCustomKeyStoreResponse(TypedDict, total=False):
@@ -1070,9 +1064,9 @@ class KmsApi:
         self,
         context: RequestContext,
         custom_key_store_name: CustomKeyStoreNameType,
-        cloud_hsm_cluster_id: CloudHsmClusterIdType = None,
-        trust_anchor_certificate: TrustAnchorCertificateType = None,
-        key_store_password: KeyStorePasswordType = None,
+        cloud_hsm_cluster_id: CloudHsmClusterIdType,
+        trust_anchor_certificate: TrustAnchorCertificateType,
+        key_store_password: KeyStorePasswordType,
     ) -> CreateCustomKeyStoreResponse:
         raise NotImplementedError
 

--- a/localstack/aws/api/lambda_/__init__.py
+++ b/localstack/aws/api/lambda_/__init__.py
@@ -256,36 +256,42 @@ class CodeSigningConfigNotFoundException(ServiceException):
     code: str = "CodeSigningConfigNotFoundException"
     sender_fault: bool = False
     status_code: int = 404
+    Type: Optional[String]
 
 
 class CodeStorageExceededException(ServiceException):
     code: str = "CodeStorageExceededException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class CodeVerificationFailedException(ServiceException):
     code: str = "CodeVerificationFailedException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class EC2AccessDeniedException(ServiceException):
     code: str = "EC2AccessDeniedException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class EC2ThrottledException(ServiceException):
     code: str = "EC2ThrottledException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class EC2UnexpectedException(ServiceException):
     code: str = "EC2UnexpectedException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
     EC2ErrorCode: Optional[String]
 
 
@@ -293,156 +299,182 @@ class EFSIOException(ServiceException):
     code: str = "EFSIOException"
     sender_fault: bool = False
     status_code: int = 410
+    Type: Optional[String]
 
 
 class EFSMountConnectivityException(ServiceException):
     code: str = "EFSMountConnectivityException"
     sender_fault: bool = False
     status_code: int = 408
+    Type: Optional[String]
 
 
 class EFSMountFailureException(ServiceException):
     code: str = "EFSMountFailureException"
     sender_fault: bool = False
     status_code: int = 403
+    Type: Optional[String]
 
 
 class EFSMountTimeoutException(ServiceException):
     code: str = "EFSMountTimeoutException"
     sender_fault: bool = False
     status_code: int = 408
+    Type: Optional[String]
 
 
 class ENILimitReachedException(ServiceException):
     code: str = "ENILimitReachedException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class InvalidCodeSignatureException(ServiceException):
     code: str = "InvalidCodeSignatureException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class InvalidParameterValueException(ServiceException):
     code: str = "InvalidParameterValueException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class InvalidRequestContentException(ServiceException):
     code: str = "InvalidRequestContentException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class InvalidRuntimeException(ServiceException):
     code: str = "InvalidRuntimeException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class InvalidSecurityGroupIDException(ServiceException):
     code: str = "InvalidSecurityGroupIDException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class InvalidSubnetIDException(ServiceException):
     code: str = "InvalidSubnetIDException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class InvalidZipFileException(ServiceException):
     code: str = "InvalidZipFileException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class KMSAccessDeniedException(ServiceException):
     code: str = "KMSAccessDeniedException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class KMSDisabledException(ServiceException):
     code: str = "KMSDisabledException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class KMSInvalidStateException(ServiceException):
     code: str = "KMSInvalidStateException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class KMSNotFoundException(ServiceException):
     code: str = "KMSNotFoundException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class PolicyLengthExceededException(ServiceException):
     code: str = "PolicyLengthExceededException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class PreconditionFailedException(ServiceException):
     code: str = "PreconditionFailedException"
     sender_fault: bool = False
     status_code: int = 412
+    Type: Optional[String]
 
 
 class ProvisionedConcurrencyConfigNotFoundException(ServiceException):
     code: str = "ProvisionedConcurrencyConfigNotFoundException"
     sender_fault: bool = False
     status_code: int = 404
+    Type: Optional[String]
 
 
 class RequestTooLargeException(ServiceException):
     code: str = "RequestTooLargeException"
     sender_fault: bool = False
     status_code: int = 413
+    Type: Optional[String]
 
 
 class ResourceConflictException(ServiceException):
     code: str = "ResourceConflictException"
     sender_fault: bool = False
     status_code: int = 409
+    Type: Optional[String]
 
 
 class ResourceInUseException(ServiceException):
     code: str = "ResourceInUseException"
     sender_fault: bool = False
     status_code: int = 400
+    Type: Optional[String]
 
 
 class ResourceNotFoundException(ServiceException):
     code: str = "ResourceNotFoundException"
     sender_fault: bool = False
     status_code: int = 404
+    Type: Optional[String]
 
 
 class ResourceNotReadyException(ServiceException):
     code: str = "ResourceNotReadyException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class ServiceException(ServiceException):
     code: str = "ServiceException"
     sender_fault: bool = False
     status_code: int = 500
+    Type: Optional[String]
 
 
 class SubnetIPAddressLimitReachedException(ServiceException):
     code: str = "SubnetIPAddressLimitReachedException"
     sender_fault: bool = False
     status_code: int = 502
+    Type: Optional[String]
 
 
 class TooManyRequestsException(ServiceException):
@@ -450,6 +482,7 @@ class TooManyRequestsException(ServiceException):
     sender_fault: bool = False
     status_code: int = 429
     retryAfterSeconds: Optional[String]
+    Type: Optional[String]
     Reason: Optional[ThrottleReason]
 
 
@@ -457,6 +490,7 @@ class UnsupportedMediaTypeException(ServiceException):
     code: str = "UnsupportedMediaTypeException"
     sender_fault: bool = False
     status_code: int = 415
+    Type: Optional[String]
 
 
 Long = int

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -523,13 +523,10 @@ class BaseXMLResponseSerializer(ResponseSerializer):
             params = {}
             # TODO add a possibility to serialize simple non-modelled errors (like S3 NoSuchBucket#BucketName)
             for member in shape.members:
-                if hasattr(error, member):
+                # XML protocols do not add modeled default fields to the root node
+                # (tested for cloudfront, route53, cloudwatch, iam)
+                if member.lower() not in ["code", "message"] and hasattr(error, member):
                     params[member] = getattr(error, member)
-                elif member.lower() in ["code", "message", "type"] and hasattr(
-                    error, member.lower()
-                ):
-                    # Default error message fields can sometimes have different casing in the specs
-                    params[member] = getattr(error, member.lower())
 
             # If there is an error shape with members which should be set, they need to be added to the node
             if params:
@@ -1036,15 +1033,13 @@ class JSONResponseSerializer(ResponseSerializer):
         shape: StructureShape,
         operation_model: OperationModel,
     ) -> None:
+        body = {}
+
         # TODO implement different service-specific serializer configurations
         #   - currently we set both, the `__type` member as well as the `X-Amzn-Errortype` header
         #   - the specification defines that it's either the __type field OR the header
-        #     (https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#operation-error-serialization)
-        body = {"__type": error.code}
         response.headers["X-Amzn-Errortype"] = error.code
-        message = self._get_error_message(error)
-        if message is not None:
-            body["message"] = message
+        body["__type"] = error.code
 
         if shape:
             remaining_params = {}
@@ -1052,12 +1047,16 @@ class JSONResponseSerializer(ResponseSerializer):
             for member in shape.members:
                 if hasattr(error, member):
                     remaining_params[member] = getattr(error, member)
-                elif member.lower() in ["code", "message", "type"] and hasattr(
-                    error, member.lower()
-                ):
-                    # Default error message fields can sometimes have different casing in the specs
+                # Default error message fields can sometimes have different casing in the specs
+                elif member.lower() in ["code", "message"] and hasattr(error, member.lower()):
                     remaining_params[member] = getattr(error, member.lower())
             self._serialize(body, remaining_params, shape)
+
+        # Only set the message if it has not been set with the shape members
+        if "message" not in body and "Message" not in body:
+            message = self._get_error_message(error)
+            if message is not None:
+                body["message"] = message
 
         response.set_json(body)
 

--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -154,7 +154,7 @@ class ShapeNode:
         remaining_members = {
             k: v
             for k, v in self.shape.members.items()
-            if not self.is_exception or k.lower() not in ["message", "code", "type"]
+            if not self.is_exception or k.lower() not in ["message", "code"]
         }
 
         for k, v in remaining_members.items():

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -323,7 +323,21 @@ def route53_client() -> "Route53Client":
 
 
 @pytest.fixture
-def dynamodb_create_table_with_parameters(dynamodb_client):
+def dynamodb_wait_for_table_active(dynamodb_client):
+    def wait_for_table_active(table_name: str):
+        def wait():
+            return (
+                dynamodb_client.describe_table(TableName=table_name)["Table"]["TableStatus"]
+                == "ACTIVE"
+            )
+
+        poll_condition(wait, timeout=30)
+
+    return wait_for_table_active
+
+
+@pytest.fixture
+def dynamodb_create_table_with_parameters(dynamodb_client, dynamodb_wait_for_table_active):
     tables = []
 
     def factory(**kwargs):
@@ -339,13 +353,7 @@ def dynamodb_create_table_with_parameters(dynamodb_client):
     for table in tables:
         try:
             # table has to be in ACTIVE state before deletion
-            def wait_for_table_created():
-                return (
-                    dynamodb_client.describe_table(TableName=table)["Table"]["TableStatus"]
-                    == "ACTIVE"
-                )
-
-            poll_condition(wait_for_table_created, timeout=30)
+            dynamodb_wait_for_table_active(table)
             dynamodb_client.delete_table(TableName=table)
         except Exception as e:
             LOG.debug("error cleaning up table %s: %s", table, e)
@@ -373,13 +381,7 @@ def dynamodb_create_table(dynamodb_client):
     for table in tables:
         try:
             # table has to be in ACTIVE state before deletion
-            def wait_for_table_created():
-                return (
-                    dynamodb_client.describe_table(TableName=table)["Table"]["TableStatus"]
-                    == "ACTIVE"
-                )
-
-            poll_condition(wait_for_table_created, timeout=30)
+            dynamodb_wait_for_table_active(table)
             dynamodb_client.delete_table(TableName=table)
         except Exception as e:
             LOG.debug("error cleaning up table %s: %s", table, e)

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -360,7 +360,7 @@ def dynamodb_create_table_with_parameters(dynamodb_client, dynamodb_wait_for_tab
 
 
 @pytest.fixture
-def dynamodb_create_table(dynamodb_client):
+def dynamodb_create_table(dynamodb_client, dynamodb_wait_for_table_active):
     # beware, this swallows exception in create_dynamodb_table utility function
     tables = []
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -478,7 +478,6 @@ class TestSNSProvider:
     # todo: the message key is added to the error response body, but not in AWS
     # check with serializer?
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..message"])
     def test_tags(self, sns_client, sns_create_topic, snapshot):
 
         topic_arn = sns_create_topic()["TopicArn"]


### PR DESCRIPTION
This PR addresses an issue with the error serialization mentioned in #6571.

After some digging, it turns out that there are several XML-services (`rest-xml`, `query`) which define default members in their error shapes (f.e. cloudfront, route53, cloudwatch, iam,...). These default members are _not_ added to the root node, while non-default members are.

For JSON-services (`json`, `rest-json`), there is no sub-element for the error metadata. All members are added to the root node. Here, defined default members in the spec can modify the casing (f.e. `Message` in DynamoDB's `TransactionCanceledException`).


The following changes are contained in this PR:
- Enhance the error serialization for error shapes which define additional members which "conflict" with the default error fields (like "message" or "code").
- Remove the member "type" from the special handling (this was a wrong assumption in the past, it doesn't correlate with the code, only `__type` for json protocols do). F.e. in Lambda, the "Type" field on exceptions is "SOAP"-like and contains the value "User" to indicate that it's a user-triggered error.
- Fix the scaffold to also generate an additional "Type" field (f.e. for Lambda).
- Regenerate the APIs (since the scaffold was modified).
- Clean up some tests and added some more.