### PR TITLE
Enhance parity for basic CloudFormation stack attributes

### DIFF
--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -235,6 +235,8 @@ def _resource_name_transformer(key: str, val: str) -> str:
             if res.startswith("<") and res.endswith(">"):
                 # value was already replaced
                 return None
+            if ":changeSet/" in val:
+                return val.split(":changeSet/")[-1]
             if "/" in res:
                 return res.split("/")[-1]
             if res.startswith("function:"):

--- a/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
@@ -1,0 +1,29 @@
+{
+  "tests/integration/cloudformation/test_cloudformation_stacks.py::test_stack_description_special_chars": {
+    "recorded-date": "03-08-2022, 13:35:51",
+    "recorded-content": {
+      "describe_stack": {
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+        "StackName": "<stack-name:1>",
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:2>",
+        "Description": "test <env>.test.net",
+        "CreationTime": "datetime",
+        "LastUpdatedTime": "datetime",
+        "RollbackConfiguration": {},
+        "StackStatus": "CREATE_COMPLETE",
+        "DisableRollback": false,
+        "NotificationARNs": [],
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "Tags": [],
+        "EnableTerminationProtection": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enhance parity for basic CloudFormation stack attributes. The starting point for this change was issue #3300 , which reported that the stack description is stored incorrectly (with invalid escaping of special characters). This has been fixed in the meantime and is no longer an issue with the ASF request parser. 👍 

Adding a snapshot test for this functionality revealed a few more gaps in the basic attributes we're storing for CloudFormation stack attributes. These gaps are addressed in the PR, and matched against the snapshot result accordingly.