### PR TITLE
refactor sns tests and fifo topic validations

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -576,6 +576,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         return CreateEndpointResponse(**result)
 
     def unsubscribe(self, context: RequestContext, subscription_arn: subscriptionARN) -> None:
+        call_moto(context)
         sns_backend = SNSBackend.get()
 
         def should_be_kept(current_subscription, target_subscription_arn):

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -448,19 +448,19 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
     ) -> PublishBatchResponse:
         if len(publish_batch_request_entries) > 10:
             raise TooManyEntriesInBatchRequestException(
-                "The batch request contains more entries than permissible"
+                "The batch request contains more entries than permissible."
             )
 
         ids = [entry["Id"] for entry in publish_batch_request_entries]
         if len(set(ids)) != len(publish_batch_request_entries):
             raise BatchEntryIdsNotDistinctException(
-                "Two or more batch entries in the request have the same Id"
+                "Two or more batch entries in the request have the same Id."
             )
 
         if topic_arn and ".fifo" in topic_arn:
             if not all(["MessageGroupId" in entry for entry in publish_batch_request_entries]):
                 raise InvalidParameterException(
-                    "The MessageGroupId parameter is required for FIFO topics"
+                    "Invalid parameter: The MessageGroupId parameter is required for FIFO topics"
                 )
         response = {"Successful": [], "Failed": []}
         for entry in publish_batch_request_entries:
@@ -651,7 +651,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
     ) -> PublishResponse:
         # We do not want the request to be forwarded to SNS backend
         if subject == "":
-            raise InvalidParameterException("Empty string for subject is not supported")
+            raise InvalidParameterException("Invalid parameter: Subject")
         if not message or all(not m for m in message):
             raise InvalidParameterException("Empty message")
 
@@ -821,7 +821,9 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         topic_arn = moto_response["TopicArn"]
         tag_resource_success = extract_tags(topic_arn, tags, True, sns_backend)
         if not tag_resource_success:
-            raise InvalidParameterException("Topic already exists with different tags")
+            raise InvalidParameterException(
+                "Invalid parameter: Tags Reason: Topic already exists with different tags"
+            )
         if tags:
             self.tag_resource(context=context, resource_arn=topic_arn, tags=tags)
         sns_backend.sns_subscriptions[topic_arn] = (
@@ -845,6 +847,7 @@ def message_to_subscribers(
     skip_checks=False,
     message_attributes=None,
 ):
+    # AWS allows using TargetArn to publish to a topic, for backward compatibility
     if not topic_arn:
         topic_arn = req_data.get("TargetArn")
     sns_backend = SNSBackend.get()

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -12,6 +12,7 @@ from typing import Dict, List
 import botocore.exceptions
 import requests as requests
 from flask import Response as FlaskResponse
+from moto.sns import sns_backends as moto_sns_backends
 from moto.sns.exceptions import DuplicateSnsEndpointError
 from moto.sns.models import MAXIMUM_MESSAGE_LENGTH
 from requests.models import Response
@@ -653,14 +654,30 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if subject == "":
             raise InvalidParameterException("Invalid parameter: Subject")
         if not message or all(not m for m in message):
-            raise InvalidParameterException("Empty message")
+            raise InvalidParameterException("Invalid parameter: Empty message")
 
         if len(message) > MAXIMUM_MESSAGE_LENGTH:
-            raise InvalidParameterException("Message too long")
+            raise InvalidParameterException("Invalid parameter: Message too long")
 
-        if topic_arn and ".fifo" in topic_arn and not message_group_id:
+        if topic_arn and ".fifo" in topic_arn:
+            if not message_group_id:
+                raise InvalidParameterException(
+                    "The MessageGroupId parameter is required for FIFO topics",
+                )
+            moto_sns_backend = moto_sns_backends[context.region]
+            if moto_sns_backend.get_topic(arn=topic_arn).content_based_deduplication == "false":
+                if not message_deduplication_id:
+                    raise InvalidParameterException(
+                        "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
+                    )
+        elif message_deduplication_id:
+            # this is the first one to raise if both are set while the topic is not fifo
             raise InvalidParameterException(
-                "The MessageGroupId parameter is required for FIFO topics",
+                "Invalid parameter: MessageDeduplicationId Reason: The request includes MessageDeduplicationId parameter that is not valid for this topic type"
+            )
+        elif message_group_id:
+            raise InvalidParameterException(
+                "Invalid parameter: MessageGroupId Reason: The request includes MessageGroupId parameter that is not valid for this topic type"
             )
 
         sns_backend = SNSBackend.get()

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1582,16 +1582,14 @@ class TestSNSProvider:
         snapshot.add_transformer(snapshot.transform.sqs_api())
         # Need to skip the MD5OfBody/Signature, because it contains a timestamp
         snapshot.add_transformer(
-            snapshot.transform.jsonpath(
-                "$.json_encoded_delivery..Body.Signature",
+            snapshot.transform.key_value(
+                "Signature",
                 "<signature>",
                 reference_replacement=False,
             )
         )
         snapshot.add_transformer(
-            snapshot.transform.jsonpath(
-                "$.json_encoded_delivery..MD5OfBody", "<md5-hash>", reference_replacement=False
-            )
+            snapshot.transform.key_value("MD5OfBody", "<md5-hash>", reference_replacement=False)
         )
 
         topic_arn = sns_create_topic()["TopicArn"]

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -112,5 +112,63 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[True]": {
+    "recorded-date": "03-08-2022, 16:38:45",
+    "recorded-content": {
+      "raw_message_delivery": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>",
+            "MD5OfBody": "<md5-hash>",
+            "Body": "test_dlq_after_sqs_endpoint_deleted"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[False]": {
+    "recorded-date": "03-08-2022, 16:38:48",
+    "recorded-content": {
+      "json_encoded_delivery": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>",
+            "MD5OfBody": "<md5-hash>",
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:2>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "test_dlq_after_sqs_endpoint_deleted",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>",
+              "MessageAttributes": {
+                "attr2": {
+                  "Type": "Binary",
+                  "Value": "AgME"
+                },
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "111"
+                }
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This is a first PR to extend with complete snapshot validation of all AWS validated tests.
31/43 tests are AWS validated (1 more coming with snapshots)
10 are only Localstack (related to SMS and http endpoints)
1 is skipped

Some validation was added, especially concerning FIFO topics. The behaviour is not implemented (it differs a bit from SQS, and is managed at the topic level), there is no feature request for it yet. 

Added a `call_moto` call to the `unsubscribe` operation, it would make Moto not synced concerning subscriptions with our own backend