### PR TITLE
rework SQS message delaying to calculate approximate number of messages delayed

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -70,6 +70,7 @@ from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws.aws_stack import parse_arn
 from localstack.utils.common import long_uid, md5, now, start_thread
 from localstack.utils.run import FuncThread
+from localstack.utils.scheduler import Scheduler
 
 LOG = logging.getLogger(__name__)
 
@@ -164,8 +165,10 @@ class Permission(NamedTuple):
 
 class SqsMessage:
     message: Message
+    created: float
     visibility_timeout: int
     receive_times: int
+    delay_seconds: Optional[int]
     receipt_handles: Set[str]
     last_received: Optional[float]
     first_received: Optional[float]
@@ -182,10 +185,12 @@ class SqsMessage:
         message_deduplication_id: str = None,
         message_group_id: str = None,
     ) -> None:
+        self.created = time.time()
         self.message = message
         self.receive_times = 0
         self.receipt_handles = set()
 
+        self.delay_seconds = None
         self.last_received = None
         self.first_received = None
         self.deleted = False
@@ -243,6 +248,12 @@ class SqsMessage:
 
         return False
 
+    @property
+    def is_delayed(self) -> bool:
+        if self.delay_seconds is None:
+            return False
+        return time.time() <= self.created + self.delay_seconds
+
     def __gt__(self, other):
         return self.priority > other.priority
 
@@ -274,6 +285,7 @@ class SqsQueue:
     purge_in_progress: bool
 
     visible: PriorityQueue
+    delayed: Set[SqsMessage]
     inflight: Set[SqsMessage]
     receipts: Dict[str, SqsMessage]
 
@@ -286,6 +298,7 @@ class SqsQueue:
         self.tags = tags or {}
 
         self.visible = PriorityQueue()
+        self.delayed = set()
         self.inflight = set()
         self.receipts = {}
 
@@ -301,7 +314,7 @@ class SqsQueue:
         return {
             QueueAttributeName.ApproximateNumberOfMessages: self.visible._qsize,
             QueueAttributeName.ApproximateNumberOfMessagesNotVisible: lambda: len(self.inflight),
-            QueueAttributeName.ApproximateNumberOfMessagesDelayed: "0",  # FIXME: this should also be callable
+            QueueAttributeName.ApproximateNumberOfMessagesDelayed: lambda: len(self.delayed),
             QueueAttributeName.CreatedTimestamp: str(now()),
             QueueAttributeName.DelaySeconds: "0",
             QueueAttributeName.LastModifiedTimestamp: str(now()),
@@ -312,6 +325,17 @@ class SqsQueue:
             QueueAttributeName.VisibilityTimeout: "30",
             QueueAttributeName.SqsManagedSseEnabled: "false",
         }
+
+    def update_delay_seconds(self, value: int):
+        """
+        For standard queues, the per-queue delay setting is not retroactive—changing the setting doesn't affect the delay of messages already in the queue.
+        For FIFO queues, the per-queue delay setting is retroactive—changing the setting affects the delay of messages already in the queue.
+
+        https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html
+
+        :param value: the number of seconds
+        """
+        self.attributes[QueueAttributeName.DelaySeconds] = str(value)
 
     def update_last_modified(self, timestamp: int = None):
         if timestamp is None:
@@ -351,6 +375,10 @@ class SqsQueue:
     @property
     def visibility_timeout(self) -> int:
         return int(self.attributes[QueueAttributeName.VisibilityTimeout])
+
+    @property
+    def delay_seconds(self) -> int:
+        return int(self.attributes[QueueAttributeName.DelaySeconds])
 
     @property
     def wait_time_seconds(self) -> int:
@@ -431,6 +459,7 @@ class SqsQueue:
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
+        delay_seconds: int = None,
     ):
         raise NotImplementedError
 
@@ -489,16 +518,30 @@ class SqsQueue:
             return
 
         with self.mutex:
-            messages = list(self.inflight)
+            messages = [message for message in self.inflight if message.is_visible]
             for standard_message in messages:
-                if standard_message.is_visible:
-                    LOG.debug(
-                        "re-queueing inflight messages %s into queue %s",
-                        standard_message.message["MessageId"],
-                        self.arn,
-                    )
-                    self.inflight.remove(standard_message)
-                    self.visible.put_nowait(standard_message)
+                LOG.debug(
+                    "re-queueing inflight messages %s into queue %s",
+                    standard_message.message["MessageId"],
+                    self.arn,
+                )
+                self.inflight.remove(standard_message)
+                self.visible.put_nowait(standard_message)
+
+    def enqueue_delayed_messages(self):
+        if not self.delayed:
+            return
+
+        with self.mutex:
+            messages = [message for message in self.delayed if not message.is_delayed]
+            for standard_message in messages:
+                LOG.debug(
+                    "enqueueing delayed messages %s into queue %s",
+                    standard_message.message["MessageId"],
+                    self.arn,
+                )
+                self.delayed.remove(standard_message)
+                self.visible.put_nowait(standard_message)
 
     def _assert_queue_name(self, name):
         if not re.match(r"^[a-zA-Z0-9_-]{1,80}$", name):
@@ -525,8 +568,8 @@ class StandardQueue(SqsQueue):
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
+        delay_seconds: int = None,
     ):
-
         if message_deduplication_id:
             raise InvalidParameterValue(
                 f"Value {message_deduplication_id} for parameter MessageDeduplicationId is invalid. Reason: The "
@@ -546,18 +589,29 @@ class StandardQueue(SqsQueue):
             # use the attribute from the queue
             standard_message.visibility_timeout = self.visibility_timeout
 
-        self.visible.put_nowait(standard_message)
+        if delay_seconds is not None:
+            standard_message.delay_seconds = delay_seconds
+        else:
+            standard_message.delay_seconds = self.delay_seconds
+
+        if standard_message.is_delayed:
+            self.delayed.add(standard_message)
+        else:
+            self.visible.put_nowait(standard_message)
 
 
 class FifoQueue(SqsQueue):
-    visible: PriorityQueue
-    inflight: Set[SqsMessage]
-    receipts: Dict[str, SqsMessage]
+
     deduplication: Dict[str, Dict[str, SqsMessage]]
 
     def __init__(self, name: str, region: str, account_id: str, attributes=None, tags=None) -> None:
         super().__init__(name, region, account_id, attributes, tags)
         self.deduplication = {}
+
+    def update_delay_seconds(self, value: int):
+        super(FifoQueue, self).update_delay_seconds(value)
+        for message in self.delayed:
+            message.delay_seconds = value
 
     def put(
         self,
@@ -565,7 +619,14 @@ class FifoQueue(SqsQueue):
         visibility_timeout: int = None,
         message_deduplication_id: str = None,
         message_group_id: str = None,
+        delay_seconds: int = None,
     ):
+        if delay_seconds is not None:
+            # in fifo queues, delay is only applied on queue level
+            raise InvalidParameterValue(
+                f"Value {delay_seconds} for parameter DelaySeconds is invalid. Reason: The request include parameter "
+                f"that is not valid for this queue type."
+            )
 
         if not message_group_id:
             raise MissingParameter("The request must contain the parameter MessageGroupId.")
@@ -582,32 +643,43 @@ class FifoQueue(SqsQueue):
                 "explicitly "
             )
 
-        qm = SqsMessage(
+        fifo_message = SqsMessage(
             time.time(),
             message,
             message_deduplication_id=dedup_id,
             message_group_id=message_group_id,
         )
         if visibility_timeout is not None:
-            qm.visibility_timeout = visibility_timeout
+            fifo_message.visibility_timeout = visibility_timeout
         else:
             # use the attribute from the queue
-            qm.visibility_timeout = self.visibility_timeout
+            fifo_message.visibility_timeout = self.visibility_timeout
+
+        if delay_seconds is not None:
+            fifo_message.delay_seconds = delay_seconds
+        else:
+            fifo_message.delay_seconds = self.delay_seconds
+
         original_message = None
         original_message_group = self.deduplication.get(message_group_id)
         if original_message_group:
             original_message = original_message_group.get(dedup_id)
+
         if (
             original_message
             and not original_message.deleted
-            and original_message.priority + DEDUPLICATION_INTERVAL_IN_SEC > qm.priority
+            and original_message.priority + DEDUPLICATION_INTERVAL_IN_SEC > fifo_message.priority
         ):
             message["MessageId"] = original_message.message["MessageId"]
         else:
-            self.visible.put_nowait(qm)
+            if fifo_message.is_delayed:
+                self.delayed.add(fifo_message)
+            else:
+                self.visible.put_nowait(fifo_message)
+
             if not original_message_group:
                 self.deduplication[message_group_id] = {}
-            self.deduplication[message_group_id][dedup_id] = qm
+            self.deduplication[message_group_id][dedup_id] = fifo_message
 
     def _assert_queue_name(self, name):
         if not name.endswith(".fifo"):
@@ -638,42 +710,55 @@ class FifoQueue(SqsQueue):
         return _create_mock_sequence_number()
 
 
-class InflightUpdateWorker:
+class QueueUpdateWorker:
     """
-    Regularly re-queues inflight messages whose visibility timeout has expired.
-
-    FIXME: very crude implementation. it would be better to have event-driven communication.
+    Regularly re-queues inflight and delayed messages whose visibility timeout has expired or delay deadline has been
+    reached.
     """
 
     def __init__(self) -> None:
         super().__init__()
-        self.running = False
+        self.scheduler = Scheduler()
         self.thread: Optional[FuncThread] = None
+        self.mutex = threading.RLock()
+
+    def do_update_all_queues(self):
+        for region in SqsBackend.regions().keys():
+            backend = SqsBackend.get(region)
+            for queue in backend.queues.values():
+                try:
+                    queue.requeue_inflight_messages()
+                except Exception:
+                    LOG.exception("error re-queueing inflight messages")
+
+                try:
+                    queue.enqueue_delayed_messages()
+                except Exception:
+                    LOG.exception("error enqueueing delayed messages")
 
     def start(self):
-        if self.thread:
-            return
+        with self.mutex:
+            if self.thread:
+                return
 
-        def _run(*_args):
-            self.running = True
-            self.run()
+            self.scheduler = Scheduler()
+            self.scheduler.schedule(self.do_update_all_queues, period=1)
 
-        self.thread = start_thread(_run)
+            def _run(*_args):
+                self.scheduler.run()
+
+            self.thread = start_thread(_run)
 
     def stop(self):
-        if self.thread:
-            self.thread.stop()
+        with self.mutex:
+            if self.scheduler:
+                self.scheduler.close()
 
-        self.running = False
-        self.thread = None
+            if self.thread:
+                self.thread.stop()
 
-    def run(self):
-        while self.running:
-            time.sleep(1)
-            for region in SqsBackend.regions().keys():
-                backend = SqsBackend.get(region)
-                for queue in backend.queues.values():
-                    queue.requeue_inflight_messages()
+            self.thread = None
+            self.scheduler = None
 
 
 def check_attributes(message_attributes: MessageBodyAttributeMap):
@@ -767,13 +852,13 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
     def __init__(self) -> None:
         super().__init__()
         self._mutex = threading.RLock()
-        self._inflight_worker = InflightUpdateWorker()
+        self._queue_update_worker = QueueUpdateWorker()
 
     def on_before_start(self):
-        self._inflight_worker.start()
+        self._queue_update_worker.start()
 
     def on_before_stop(self):
-        self._inflight_worker.stop()
+        self._queue_update_worker.stop()
 
     def _require_queue(self, context: RequestContext, name: str) -> SqsQueue:
         """
@@ -1079,7 +1164,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         check_fifo_id(message_deduplication_id)
         check_fifo_id(message_group_id)
 
-        message: Message = Message(
+        message = Message(
             MessageId=generate_message_id(),
             MD5OfBody=md5(message_body),
             Body=message_body,
@@ -1087,23 +1172,13 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             MD5OfMessageAttributes=_create_message_attribute_hash(message_attributes),
             MessageAttributes=message_attributes,
         )
-        delay_seconds = delay_seconds or queue.attributes.get(QueueAttributeName.DelaySeconds, "0")
 
-        if int(delay_seconds):
-            # FIXME: this is a pretty bad implementation (one thread per message...). polling on a priority queue
-            #  would probably be better. We also need access to delayed messages for the
-            #  ApproximateNumberrOfDelayedMessages attribute.
-            threading.Timer(
-                int(delay_seconds),
-                queue.put,
-                args=(message, message_deduplication_id, message_group_id),
-            ).start()
-        else:
-            queue.put(
-                message=message,
-                message_deduplication_id=message_deduplication_id,
-                message_group_id=message_group_id,
-            )
+        queue.put(
+            message=message,
+            message_deduplication_id=message_deduplication_id,
+            message_group_id=message_group_id,
+            delay_seconds=int(delay_seconds) if delay_seconds is not None else None,
+        )
 
         return message
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -352,6 +352,9 @@ class SqsQueue:
             if standard_message not in self.inflight:
                 raise MessageNotInflight()
 
+            # we also have to update last_received, since that is used to calculate the visibility deadline.
+            # last_received is not actually used to indicate "true" receipts via receive_message, so this is safe.
+            standard_message.last_received = time.time()
             standard_message.visibility_timeout = visibility_timeout
 
             if visibility_timeout == 0:

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -496,6 +496,45 @@ class TestSqsProvider:
         assert "Messages" in result
         assert len(result["Messages"]) == 1
 
+    @pytest.mark.only_localstack
+    def test_approximate_number_of_messages_delayed(self, sqs_client, sqs_queue):
+        # this test does not work against AWS in the same way, because AWS only has eventual consistency guarantees
+        # for the tested attributes that can take up to a minute to update.
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="ed")
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="foo", DelaySeconds=2)
+        sqs_client.send_message(QueueUrl=sqs_queue, MessageBody="bar", DelaySeconds=2)
+
+        result = sqs_client.get_queue_attributes(
+            QueueUrl=sqs_queue,
+            AttributeNames=[
+                "ApproximateNumberOfMessages",
+                "ApproximateNumberOfMessagesNotVisible",
+                "ApproximateNumberOfMessagesDelayed",
+            ],
+        )
+        assert result["Attributes"] == {
+            "ApproximateNumberOfMessages": "1",
+            "ApproximateNumberOfMessagesNotVisible": "0",
+            "ApproximateNumberOfMessagesDelayed": "2",
+        }
+
+        def _assert():
+            _result = sqs_client.get_queue_attributes(
+                QueueUrl=sqs_queue,
+                AttributeNames=[
+                    "ApproximateNumberOfMessages",
+                    "ApproximateNumberOfMessagesNotVisible",
+                    "ApproximateNumberOfMessagesDelayed",
+                ],
+            )
+            assert _result["Attributes"] == {
+                "ApproximateNumberOfMessages": "3",
+                "ApproximateNumberOfMessagesNotVisible": "0",
+                "ApproximateNumberOfMessagesDelayed": "0",
+            }
+
+        retry(_assert)
+
     @pytest.mark.aws_validated
     def test_receive_after_visibility_timeout(self, sqs_client, sqs_create_queue):
         queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "1"})
@@ -810,6 +849,52 @@ class TestSqsProvider:
         receive_and_check_order()
         time.sleep(timeout + 1)
         receive_and_check_order()
+
+    @pytest.mark.aws_validated
+    def test_fifo_queue_send_message_with_delay_seconds_fails(
+        self, sqs_client, sqs_create_queue, snapshot
+    ):
+        queue_url = sqs_create_queue(
+            QueueName=f"queue-{short_uid()}.fifo",
+            Attributes={"FifoQueue": "true", "ContentBasedDeduplication": "true"},
+        )
+
+        with pytest.raises(ClientError) as e:
+            sqs_client.send_message(
+                QueueUrl=queue_url, MessageBody="message-1", MessageGroupId="1", DelaySeconds=2
+            )
+
+        snapshot.match("send_message", e.value)
+
+    @pytest.mark.aws_validated
+    def test_fifo_queue_send_message_with_delay_on_queue_works(self, sqs_client, sqs_create_queue):
+        queue_url = sqs_create_queue(
+            QueueName=f"queue-{short_uid()}.fifo",
+            Attributes={
+                "FifoQueue": "true",
+                "ContentBasedDeduplication": "true",
+                "DelaySeconds": "2",
+            },
+        )
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="message-1", MessageGroupId="1")
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="message-2", MessageGroupId="2")
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="message-3", MessageGroupId="3")
+
+        response = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        assert response.get("Messages", []) == []
+
+        messages = []
+
+        def _collect():
+            _response = sqs_client.receive_message(QueueUrl=queue_url)
+            messages.extend(_response.get("Messages", []))
+            assert len(messages) == 3
+
+        retry(_collect, sleep_before=2)  # let the delay expire first
+        assert messages[0]["Body"] == "message-1"
+        assert messages[1]["Body"] == "message-2"
+        assert messages[2]["Body"] == "message-3"
 
     @pytest.mark.aws_validated
     def test_list_queue_tags(self, sqs_client, sqs_create_queue):
@@ -1691,10 +1776,6 @@ class TestSqsProvider:
                 QueueUrl=queue_url, MessageBody=message_content, MessageDeduplicationId=dedup_id
             )
         e.match("MissingParameter")
-
-    def test_approximate_number_of_messages_delayed(self):
-        # TODO: test approximateNumberOfMessages once delayed Messages are properly counted
-        pass
 
     @pytest.mark.aws_validated
     def test_posting_to_queue_via_queue_name(self, sqs_client, sqs_create_queue):

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -542,8 +542,66 @@ class TestSqsProvider:
         result = sqs_client.receive_message(QueueUrl=queue_url)
         assert "Messages" not in result
 
-    def test_update_message_visibility_timeout(self):
-        pass
+    @pytest.mark.aws_validated
+    def test_extend_message_visibility_timeout_set_in_queue(self, sqs_client, sqs_create_queue):
+        queue_url = sqs_create_queue(Attributes={"VisibilityTimeout": "2"})
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+        response = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
+        receipt = response["Messages"][0]["ReceiptHandle"]
+
+        # update even if time expires
+        for _ in range(4):
+            time.sleep(1)
+            # we've waited a total of four seconds, although the visibility timeout is 2, so we are extending it
+            sqs_client.change_message_visibility(
+                QueueUrl=queue_url, ReceiptHandle=receipt, VisibilityTimeout=2
+            )
+            assert sqs_client.receive_message(QueueUrl=queue_url).get("Messages", []) == []
+
+        messages = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)["Messages"]
+        assert messages[0]["Body"] == "test"
+        assert len(messages) == 1
+
+    @pytest.mark.aws_validated
+    def test_receive_message_with_visibility_timeout_updates_timeout(
+        self, sqs_client, sqs_create_queue
+    ):
+        queue_url = sqs_create_queue()
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=2, VisibilityTimeout=0
+        )
+        assert len(response["Messages"]) == 1
+
+        response = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
+        assert len(response["Messages"]) == 1
+
+        response = sqs_client.receive_message(QueueUrl=queue_url)
+        assert response.get("Messages", []) == []
+
+    @pytest.mark.aws_validated
+    def test_terminate_visibility_timeout_after_receive(self, sqs_client, sqs_create_queue):
+        queue_url = sqs_create_queue()
+
+        sqs_client.send_message(QueueUrl=queue_url, MessageBody="test")
+
+        response = sqs_client.receive_message(
+            QueueUrl=queue_url, WaitTimeSeconds=2, VisibilityTimeout=0
+        )
+        receipt_1 = response["Messages"][0]["ReceiptHandle"]
+        assert len(response["Messages"]) == 1
+
+        response = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=3)
+        assert len(response["Messages"]) == 1
+
+        sqs_client.change_message_visibility(
+            QueueUrl=queue_url, ReceiptHandle=receipt_1, VisibilityTimeout=0
+        )
+        response = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
+        assert len(response["Messages"]) == 1
 
     def test_delete_message_batch_from_lambda(
         self, sqs_client, sqs_create_queue, lambda_client, create_lambda_function

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -344,5 +344,11 @@
     "recorded-content": {
       "error": "An error occurred (InvalidAttributeName) when calling the SetQueueAttributes operation: You can use one type of server-side encryption (SSE) at one time. You can either enable KMS SSE or SQS SSE."
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_queue_send_message_with_delay_seconds_fails": {
+    "recorded-date": "03-08-2022, 18:36:23",
+    "recorded-content": {
+      "send_message": "An error occurred (InvalidParameterValue) when calling the SendMessage operation: Value 2 for parameter DelaySeconds is invalid. Reason: The request include parameter that is not valid for this queue type."
+    }
   }
 }


### PR DESCRIPTION
This PR re-works the way message delaying works in the provider, and enables the calculation of `ApproximateNumberOfMessagesDelayed`

Previously we were simply spawning a timer for the delayed message that would put the message in the queue after the delay. I've introduced a structure that works analogously to the `inflight` messages for a queue, and re-purposed the `InflightUpdateWorker` to also queue all the delayed messages. I used the `Scheduler` utility for that to create a fixed-rate schedule for updating queues, that way the schedule doesn't drift if there are many messages in the inflight or delayed set and it takes longer to queue them

- [ ] currently based on #6573 to avoid conflicts, and can be re-based once that is merged.
- fixes #6416