### PR TITLE
Pin flask to 2.1.3 for compatibility with werkzeug version pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ runtime =
     crontab>=0.22.6
     cryptography
     docker==5.0.0
-    flask>=1.0.2
+    flask==2.1.3
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
     jsonpatch>=1.24,<2.0
@@ -82,6 +82,7 @@ runtime =
     Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9
+    # TODO: remove werkzeug&flask version pins once we can upgrade to latest versions
     Werkzeug==2.1.2
     xmltodict>=0.11.0
 


### PR DESCRIPTION
Pin `flask` to 2.1.3 for compatibility with the `werkzeug` version pin we recently introduced. Addresses #6587