### PR TITLE
order input for snapshot-match to fix reference-replacement

### DIFF
--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -139,9 +139,7 @@ class SnapshotSession:
         self.called_keys.add(key)
 
         # order the obj to guarantee reference replacement works as expected
-        self.observed_state[key] = (
-            self._order_dict(obj) if isinstance(obj, dict) else obj
-        )  # type is not enforced, we already have some tests using list-objects
+        self.observed_state[key] = self._order_dict(obj)
         # TODO: track them separately since the transformation is now done *just* before asserting
 
         if not self.update and (not self.recorded_state or not self.recorded_state.get(key)):

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -140,9 +140,10 @@ class SnapshotSession:
         self.called_keys.add(key)
 
         # order the obj to guarantee reference replacement works as expected
-        self.observed_state[key] = self._order_dict(
-            obj
-        )  # TODO: track them separately since the transformation is now done *just* before asserting
+        self.observed_state[key] = (
+            self._order_dict(obj) if isinstance(obj, dict) else obj
+        )  # type is not enforced, we already have some tests using list-objects
+        # TODO: track them separately since the transformation is now done *just* before asserting
 
         if not self.update and (not self.recorded_state or not self.recorded_state.get(key)):
             raise Exception("Please run the test first with --snapshot-update")

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -3,7 +3,6 @@ import logging
 import os
 from datetime import datetime
 from json import JSONDecodeError
-from operator import itemgetter
 from pathlib import Path
 from re import Pattern
 from typing import Dict, List, Optional
@@ -241,11 +240,19 @@ class SnapshotSession:
 
         return tmp
 
-    def _order_dict(self, response: dict) -> dict:
-        return {
-            key: self._order_dict(val) if isinstance(val, dict) else val
-            for key, val in sorted(response.items(), key=itemgetter(0))
-        }
+    def _order_dict(self, response) -> dict:
+        if isinstance(response, dict):
+            ordered_dict = {}
+            for key, val in sorted(response.items()):
+                if isinstance(val, dict):
+                    ordered_dict[key] = self._order_dict(val)
+                elif isinstance(val, list):
+                    ordered_dict[key] = [self._order_dict(entry) for entry in val]
+                else:
+                    ordered_dict[key] = val
+            return ordered_dict
+        else:
+            return response
 
     # LEGACY API
     def register_replacement(self, pattern: Pattern[str], value: str):

--- a/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
@@ -1,28 +1,28 @@
 {
   "tests/integration/cloudformation/test_cloudformation_stacks.py::test_stack_description_special_chars": {
-    "recorded-date": "03-08-2022, 13:35:51",
+    "recorded-date": "05-08-2022, 13:03:43",
     "recorded-content": {
       "describe_stack": {
-        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
-        "StackName": "<stack-name:1>",
-        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:2>",
-        "Description": "test <env>.test.net",
-        "CreationTime": "datetime",
-        "LastUpdatedTime": "datetime",
-        "RollbackConfiguration": {},
-        "StackStatus": "CREATE_COMPLETE",
-        "DisableRollback": false,
-        "NotificationARNs": [],
         "Capabilities": [
           "CAPABILITY_AUTO_EXPAND",
           "CAPABILITY_IAM",
           "CAPABILITY_NAMED_IAM"
         ],
-        "Tags": [],
-        "EnableTerminationProtection": false,
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "Description": "test <env>.test.net",
+        "DisableRollback": false,
         "DriftInformation": {
           "StackDriftStatus": "NOT_CHECKED"
-        }
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
       }
     }
   }

--- a/tests/integration/s3/test_s3_notifications_sns.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sns.snapshot.json
@@ -1,14 +1,10 @@
 {
   "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_object_created_put": {
-    "recorded-date": "07-06-2022, 16:15:43",
+    "recorded-date": "08-08-2022, 17:51:20",
     "recorded-content": {
       "receive_messages": {
         "messages": [
           {
-            "Type": "Notification",
-            "MessageId": "<uuid:1>",
-            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-            "Subject": "Amazon S3 Notification",
             "Message": {
               "Records": [
                 {
@@ -31,11 +27,11 @@
                     "s3SchemaVersion": "1.0",
                     "configurationId": "<config-id:1>",
                     "bucket": {
-                      "name": "<resource:2>",
+                      "name": "<resource:1>",
                       "ownerIdentity": {
                         "principalId": "<principal-id:1>"
                       },
-                      "arn": "arn:aws:s3:::<resource:2>"
+                      "arn": "arn:aws:s3:::<resource:1>"
                     },
                     "object": {
                       "key": "bucket-key",
@@ -47,17 +43,17 @@
                 }
               ]
             },
-            "Timestamp": "date",
-            "SignatureVersion": "1",
+            "MessageId": "<uuid:1>",
             "Signature": "signature",
+            "SignatureVersion": "1",
             "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
-            "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>"
+            "Subject": "Amazon S3 Notification",
+            "Timestamp": "date",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>",
+            "Type": "Notification",
+            "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:2>:<token:1>"
           },
           {
-            "Type": "Notification",
-            "MessageId": "<uuid:2>",
-            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
-            "Subject": "Amazon S3 Notification",
             "Message": {
               "Records": [
                 {
@@ -80,11 +76,11 @@
                     "s3SchemaVersion": "1.0",
                     "configurationId": "<config-id:1>",
                     "bucket": {
-                      "name": "<resource:2>",
+                      "name": "<resource:1>",
                       "ownerIdentity": {
                         "principalId": "<principal-id:1>"
                       },
-                      "arn": "arn:aws:s3:::<resource:2>"
+                      "arn": "arn:aws:s3:::<resource:1>"
                     },
                     "object": {
                       "key": "bucket-key",
@@ -96,11 +92,15 @@
                 }
               ]
             },
-            "Timestamp": "date",
-            "SignatureVersion": "1",
+            "MessageId": "<uuid:2>",
             "Signature": "signature",
+            "SignatureVersion": "1",
             "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
-            "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>"
+            "Subject": "Amazon S3 Notification",
+            "Timestamp": "date",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>",
+            "Type": "Notification",
+            "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:2>:<token:1>"
           }
         ]
       }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -114,15 +114,15 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[True]": {
-    "recorded-date": "03-08-2022, 16:38:45",
+    "recorded-date": "08-08-2022, 17:49:05",
     "recorded-content": {
       "raw_message_delivery": {
         "Messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>",
+            "Body": "test_dlq_after_sqs_endpoint_deleted",
             "MD5OfBody": "<md5-hash>",
-            "Body": "test_dlq_after_sqs_endpoint_deleted"
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
           }
         ],
         "ResponseMetadata": {
@@ -133,35 +133,35 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[False]": {
-    "recorded-date": "03-08-2022, 16:38:48",
+    "recorded-date": "08-08-2022, 17:49:08",
     "recorded-content": {
       "json_encoded_delivery": {
         "Messages": [
           {
-            "MessageId": "<uuid:1>",
-            "ReceiptHandle": "<receipt-handle:1>",
-            "MD5OfBody": "<md5-hash>",
             "Body": {
-              "Type": "Notification",
-              "MessageId": "<uuid:2>",
-              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
               "Message": "test_dlq_after_sqs_endpoint_deleted",
-              "Timestamp": "date",
-              "SignatureVersion": "1",
-              "Signature": "<signature>",
-              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>",
               "MessageAttributes": {
-                "attr2": {
-                  "Type": "Binary",
-                  "Value": "AgME"
-                },
                 "attr1": {
                   "Type": "Number",
                   "Value": "111"
+                },
+                "attr2": {
+                  "Type": "Binary",
+                  "Value": "AgME"
                 }
-              }
-            }
+              },
+              "MessageId": "<uuid:1>",
+              "Signature": "<signature>",
+              "SignatureVersion": "1",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>.pem",
+              "Timestamp": "date",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Type": "Notification",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<token:1>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
           }
         ],
         "ResponseMetadata": {


### PR DESCRIPTION
Fix problem with reference-replacement for snapshots: match-object needs to be sorted to guarantee same outcome/replacement order (as tested/suggested by @bentsku).
