### PR TITLE
fix message retry in lambda SQS event source mapping

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -124,21 +124,22 @@ class SQSEventSourceListener(EventSourceListener):
         records = []
         for msg in messages:
             message_attrs = message_attributes_to_lower(msg.get("MessageAttributes"))
-            records.append(
-                {
-                    "body": msg.get("Body", "MessageBody"),
-                    "receiptHandle": msg.get("ReceiptHandle"),
-                    "md5OfBody": msg.get("MD5OfBody") or msg.get("MD5OfMessageBody"),
-                    "eventSourceARN": queue_arn,
-                    "eventSource": lambda_executors.EVENT_SOURCE_SQS,
-                    "awsRegion": region,
-                    "messageId": msg["MessageId"],
-                    "attributes": msg.get("Attributes", {}),
-                    "messageAttributes": message_attrs,
-                    "md5OfMessageAttributes": msg.get("MD5OfMessageAttributes"),
-                    "sqs": True,
-                }
-            )
+            record = {
+                "body": msg.get("Body", "MessageBody"),
+                "receiptHandle": msg.get("ReceiptHandle"),
+                "md5OfBody": msg.get("MD5OfBody") or msg.get("MD5OfMessageBody"),
+                "eventSourceARN": queue_arn,
+                "eventSource": lambda_executors.EVENT_SOURCE_SQS,
+                "awsRegion": region,
+                "messageId": msg["MessageId"],
+                "attributes": msg.get("Attributes", {}),
+                "messageAttributes": message_attrs,
+            }
+
+            if md5OfMessageAttributes := msg.get("MD5OfMessageAttributes"):
+                record["md5OfMessageAttributes"] = md5OfMessageAttributes
+
+            records.append(record)
 
         event = {"Records": records}
 

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -51,6 +51,14 @@ class TransformerUtility:
         )
 
     @staticmethod
+    def resource_name(replacement_name: str = "resource"):
+        """Creates a new KeyValueBasedTransformer for the resource name.
+
+        :return: KeyValueBasedTransformer
+        """
+        return KeyValueBasedTransformer(_resource_name_transformer, replacement_name)
+
+    @staticmethod
     def jsonpath(jsonpath: str, value_replacement: str, reference_replacement: bool = True):
         """Creates a new JsonpathTransformer. If the jsonpath matches, the value will be replaced.
 

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -34,7 +34,7 @@ def lambda_result_to_destination(
     event: Dict,
     result: InvocationResult,
     is_async: bool,
-    error: InvocationException,
+    error: Optional[InvocationException],
 ):
     if not func_details.destination_enabled():
         return

--- a/tests/integration/awslambda/functions/lambda_sqs_integration.py
+++ b/tests/integration/awslambda/functions/lambda_sqs_integration.py
@@ -1,0 +1,55 @@
+"""This lambda is used for lambda/sqs integration tests. Since SQS event source mappings don't allow
+DestinationConfigurations that send lambda results to other source (like SQS queues), that can be used to verify
+invocations, this lambda does this manually. You can pass in an event that looks like this::
+
+    {
+        "destination": "<queue_url>",
+        "fail_attempts": 2
+    }
+
+Which will cause the lambda to fail twice (comparing the "ApproximateReceiveCount" of the SQS event triggering
+the lambda), and send either an error or success result to the SQS queue passed in the destination key.
+"""
+import json
+import os
+
+import boto3
+
+
+def handler(event, context):
+    # this lambda expects inputs from an SQS event source mapping
+    if not event.get("Records"):
+        raise ValueError("no records passed to event")
+
+    # it expects exactly one record where the message body is '{"destination": "<queue_url>"}' that mimics a
+    # DestinationConfig (which is not possible with SQS event source mappings).
+    record = event["Records"][0]
+    message = json.loads(record["body"])
+
+    if not message.get("destination"):
+        raise ValueError("no destination for the event given")
+
+    error = None
+    try:
+        if message["fail_attempts"] >= int(record["attributes"]["ApproximateReceiveCount"]):
+            raise ValueError("failed attempt")
+    except Exception as e:
+        error = e
+        raise
+    finally:
+        # we then send a message to the destination queue
+        result = {"error": None if not error else str(error), "event": event}
+        sqs = create_external_boto_client("sqs")
+        sqs.send_message(QueueUrl=message.get("destination"), MessageBody=json.dumps(result))
+
+
+def create_external_boto_client(service):
+    endpoint_url = None
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        endpoint_url = (
+            f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ.get('EDGE_PORT', 4566)}"
+        )
+    region_name = (
+        os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-east-1"
+    )
+    return boto3.client(service, endpoint_url=endpoint_url, region_name=region_name)

--- a/tests/integration/awslambda/functions/lambda_sqs_integration.py
+++ b/tests/integration/awslambda/functions/lambda_sqs_integration.py
@@ -18,8 +18,8 @@ import boto3
 
 def handler(event, context):
     # this lambda expects inputs from an SQS event source mapping
-    if not event.get("Records"):
-        raise ValueError("no records passed to event")
+    if len(event.get("Records", [])) != 1:
+        raise ValueError("the payload must consist of exactly one record")
 
     # it expects exactly one record where the message body is '{"destination": "<queue_url>"}' that mimics a
     # DestinationConfig (which is not possible with SQS event source mappings).
@@ -49,7 +49,4 @@ def create_external_boto_client(service):
         endpoint_url = (
             f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ.get('EDGE_PORT', 4566)}"
         )
-    region_name = (
-        os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-east-1"
-    )
-    return boto3.client(service, endpoint_url=endpoint_url, region_name=region_name)
+    return boto3.client(service, endpoint_url=endpoint_url)

--- a/tests/integration/awslambda/test_lambda_integration.py
+++ b/tests/integration/awslambda/test_lambda_integration.py
@@ -79,6 +79,8 @@ s3_lambda_permission = {
 
 
 class TestSQSEventSourceMapping:
+    # FIXME: refactor and move to test_lambda_sqs_integration
+
     @pytest.mark.skip_snapshot_verify
     def test_event_source_mapping_default_batch_size(
         self,

--- a/tests/integration/awslambda/test_lambda_sqs_integration.py
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.py
@@ -137,7 +137,6 @@ def test_failing_lambda_retries_after_visibility_timeout(
 
 @pytest.mark.skip_snapshot_verify(
     paths=[
-        # FIXME: this is most of the event source mapping unfortunately
         "$..ParallelizationFactor",
         "$..LastProcessingResult",
         "$..Topics",
@@ -158,9 +157,9 @@ def test_redrive_policy_with_failing_lambda(
     snapshot,
     cleanups,
 ):
-    """This test verifies a that SQS moves a message that is passed to a failing lambda to a DLQ according to the
+    """This test verifies that SQS moves a message that is passed to a failing lambda to a DLQ according to the
     redrive policy, and the lambda is invoked the correct number of times. The test retries twice and the event
-    source mapping should then automatically move the message to the DQL, but not earlier (see
+    source mapping should then automatically move the message to the DLQ, but not earlier (see
     https://github.com/localstack/localstack/issues/5283)"""
 
     # create queue used in the lambda to send events to (to verify lambda was invoked)

--- a/tests/integration/awslambda/test_lambda_sqs_integration.py
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.py
@@ -1,0 +1,242 @@
+import json
+import os
+import time
+
+import pytest
+
+from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON38
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+
+THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
+LAMBDA_SQS_INTEGRATION_FILE = os.path.join(THIS_FOLDER, "functions", "lambda_sqs_integration.py")
+
+
+def _await_event_source_mapping_enabled(lambda_client, uuid, retries=30):
+    def assert_mapping_enabled():
+        assert lambda_client.get_event_source_mapping(UUID=uuid)["State"] == "Enabled"
+
+    retry(assert_mapping_enabled, sleep_before=2, retries=retries)
+
+
+@pytest.fixture(autouse=True)
+def _snapshot_transformers(snapshot):
+    # manual transformers since we are passing SQS attributes through lambdas and back again
+    snapshot.add_transformer(snapshot.transform.key_value("QueueUrl"))
+    snapshot.add_transformer(snapshot.transform.key_value("ReceiptHandle"))
+    snapshot.add_transformer(snapshot.transform.key_value("SenderId", reference_replacement=False))
+    snapshot.add_transformer(snapshot.transform.resource_name())
+    # body contains dynamic attributes so md5 hash changes
+    snapshot.add_transformer(snapshot.transform.key_value("MD5OfBody"))
+    # lower-case for when messages are rendered in lambdas
+    snapshot.add_transformer(snapshot.transform.key_value("receiptHandle"))
+    snapshot.add_transformer(snapshot.transform.key_value("md5OfBody"))
+
+
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        # FIXME: this is most of the event source mapping unfortunately
+        "$..ParallelizationFactor",
+        "$..LastProcessingResult",
+        "$..Topics",
+        "$..MaximumRetryAttempts",
+        "$..MaximumBatchingWindowInSeconds",
+        "$..FunctionResponseTypes",
+        "$..StartingPosition",
+        "$..StateTransitionReason",
+    ]
+)
+def test_failing_lambda_retries_after_visibility_timeout(
+    create_lambda_function,
+    lambda_client,
+    sqs_client,
+    sqs_create_queue,
+    sqs_queue_arn,
+    lambda_su_role,
+    snapshot,
+    cleanups,
+):
+    """This test verifies a basic SQS retry scenario. The lambda uses an SQS queue as event source, and we are
+    testing whether the lambda automatically retries after the visibility timeout expires, and, after the retry,
+    properly deletes the message from the queue."""
+
+    # create queue used in the lambda to send events to (to verify lambda was invoked)
+    destination_queue_name = f"destination-queue-{short_uid()}"
+    destination_url = sqs_create_queue(QueueName=destination_queue_name)
+    snapshot.match(
+        "get_destination_queue_url", sqs_client.get_queue_url(QueueName=destination_queue_name)
+    )
+
+    retry_timeout = (
+        2  # timeout in seconds, used for both the lambda and the queue visibility timeout
+    )
+
+    # set up lambda function
+    function_name = f"failing-lambda-{short_uid()}"
+    create_lambda_function(
+        func_name=function_name,
+        handler_file=LAMBDA_SQS_INTEGRATION_FILE,
+        runtime=LAMBDA_RUNTIME_PYTHON38,
+        role=lambda_su_role,
+        timeout=retry_timeout,  # timeout needs to be <= than visibility timeout
+    )
+
+    # create event source queue
+    event_source_url = sqs_create_queue(
+        QueueName=f"source-queue-{short_uid()}",
+        Attributes={
+            # the visibility timeout is implicitly also the time between retries
+            "VisibilityTimeout": str(retry_timeout),
+        },
+    )
+    event_source_arn = sqs_queue_arn(event_source_url)
+
+    # wire everything with the event source mapping
+    response = lambda_client.create_event_source_mapping(
+        EventSourceArn=event_source_arn,
+        FunctionName=function_name,
+        BatchSize=1,
+    )
+    mapping_uuid = response["UUID"]
+    cleanups.append(lambda: lambda_client.delete_event_source_mapping(UUID=mapping_uuid))
+    _await_event_source_mapping_enabled(lambda_client, mapping_uuid)
+    response = lambda_client.get_event_source_mapping(UUID=mapping_uuid)
+    snapshot.match("event_source_mapping", response)
+
+    # trigger lambda with a message and pass the result destination url. the event format is expected by the
+    # lambda_sqs_integration.py lambda.
+    event = {"destination": destination_url, "fail_attempts": 1}
+    sqs_client.send_message(
+        QueueUrl=event_source_url,
+        MessageBody=json.dumps(event),
+    )
+
+    # now wait for the first invocation result which is expected to fail
+    then = time.time()
+    first_response = sqs_client.receive_message(
+        QueueUrl=destination_url, WaitTimeSeconds=15, MaxNumberOfMessages=1
+    )
+    assert "Messages" in first_response
+    snapshot.match("first_attempt", first_response)
+
+    # and then after a few seconds (at least the visibility timeout), we expect the
+    second_response = sqs_client.receive_message(
+        QueueUrl=destination_url, WaitTimeSeconds=15, MaxNumberOfMessages=1
+    )
+    assert "Messages" in second_response
+    snapshot.match("second_attempt", second_response)
+
+    # check that it took at least the retry timeout between the first and second attempt
+    assert time.time() >= then + retry_timeout
+
+    # assert message is removed from the queue
+    assert "Messages" not in sqs_client.receive_message(
+        QueueUrl=destination_url, WaitTimeSeconds=retry_timeout + 1, MaxNumberOfMessages=1
+    )
+
+
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        # FIXME: this is most of the event source mapping unfortunately
+        "$..ParallelizationFactor",
+        "$..LastProcessingResult",
+        "$..Topics",
+        "$..MaximumRetryAttempts",
+        "$..MaximumBatchingWindowInSeconds",
+        "$..FunctionResponseTypes",
+        "$..StartingPosition",
+        "$..StateTransitionReason",
+    ]
+)
+def test_redrive_policy_with_failing_lambda(
+    create_lambda_function,
+    lambda_client,
+    sqs_client,
+    sqs_create_queue,
+    sqs_queue_arn,
+    lambda_su_role,
+    snapshot,
+    cleanups,
+):
+    """This test verifies a that SQS moves a message that is passed to a failing lambda to a DLQ according to the
+    redrive policy, and the lambda is invoked the correct number of times. The test retries twice and the event
+    source mapping should then automatically move the message to the DQL, but not earlier (see
+    https://github.com/localstack/localstack/issues/5283)"""
+
+    # create queue used in the lambda to send events to (to verify lambda was invoked)
+    destination_queue_name = f"destination-queue-{short_uid()}"
+    destination_url = sqs_create_queue(QueueName=destination_queue_name)
+    snapshot.match(
+        "get_destination_queue_url", sqs_client.get_queue_url(QueueName=destination_queue_name)
+    )
+
+    retry_timeout = (
+        2  # timeout in seconds, used for both the lambda and the queue visibility timeout
+    )
+    retries = 2
+
+    # set up lambda function
+    function_name = f"failing-lambda-{short_uid()}"
+    create_lambda_function(
+        func_name=function_name,
+        handler_file=LAMBDA_SQS_INTEGRATION_FILE,
+        runtime=LAMBDA_RUNTIME_PYTHON38,
+        role=lambda_su_role,
+        timeout=retry_timeout,  # timeout needs to be <= than visibility timeout
+    )
+
+    # create dlq for event source queue
+    event_dlq_url = sqs_create_queue(QueueName=f"event-dlq-{short_uid()}")
+    event_dlq_arn = sqs_queue_arn(event_dlq_url)
+
+    # create event source queue
+    event_source_url = sqs_create_queue(
+        QueueName=f"source-queue-{short_uid()}",
+        Attributes={
+            # the visibility timeout is implicitly also the time between retries
+            "VisibilityTimeout": str(retry_timeout),
+            "RedrivePolicy": json.dumps(
+                {"deadLetterTargetArn": event_dlq_arn, "maxReceiveCount": retries}
+            ),
+        },
+    )
+    event_source_arn = sqs_queue_arn(event_source_url)
+
+    # wire everything with the event source mapping
+    mapping_uuid = lambda_client.create_event_source_mapping(
+        EventSourceArn=event_source_arn,
+        FunctionName=function_name,
+        BatchSize=1,
+    )["UUID"]
+    cleanups.append(lambda: lambda_client.delete_event_source_mapping(UUID=mapping_uuid))
+    _await_event_source_mapping_enabled(lambda_client, mapping_uuid)
+
+    # trigger lambda with a message and pass the result destination url. the event format is expected by the
+    # lambda_sqs_integration.py lambda.
+    event = {"destination": destination_url, "fail_attempts": retries}
+    sqs_client.send_message(
+        QueueUrl=event_source_url,
+        MessageBody=json.dumps(event),
+    )
+
+    # now wait for the first invocation result which is expected to fail
+    first_response = sqs_client.receive_message(
+        QueueUrl=destination_url, WaitTimeSeconds=15, MaxNumberOfMessages=1
+    )
+    assert "Messages" in first_response
+    snapshot.match("first_attempt", first_response)
+
+    # check that the DLQ is empty
+    assert "Messages" not in sqs_client.receive_message(QueueUrl=event_dlq_url, WaitTimeSeconds=1)
+
+    # the second is also expected to fail, and then the message moves into the DLQ
+    second_response = sqs_client.receive_message(
+        QueueUrl=destination_url, WaitTimeSeconds=15, MaxNumberOfMessages=1
+    )
+    assert "Messages" in second_response
+    snapshot.match("second_attempt", second_response)
+
+    # now check that the event messages was placed in the DLQ
+    dlq_response = sqs_client.receive_message(QueueUrl=event_dlq_url, WaitTimeSeconds=15)
+    assert "Messages" in dlq_response
+    snapshot.match("dlq_response", dlq_response)

--- a/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
@@ -1,0 +1,202 @@
+{
+  "tests/integration/awslambda/test_lambda_sqs_integration.py::test_failing_lambda_retries_after_visibility_timeout": {
+    "recorded-date": "06-08-2022, 20:38:01",
+    "recorded-content": {
+      "get_destination_queue_url": {
+        "QueueUrl": "<queue-url:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "event_source_mapping": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "UUID": "<uuid:1>",
+        "BatchSize": 1,
+        "MaximumBatchingWindowInSeconds": 0,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "LastModified": "datetime",
+        "State": "Enabled",
+        "StateTransitionReason": "USER_INITIATED",
+        "FunctionResponseTypes": []
+      },
+      "first_attempt": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>",
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "Body": {
+              "error": "failed attempt",
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:3>",
+                    "receiptHandle": "<receipt-handle:3>",
+                    "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 1}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:1>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_attempt": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>",
+            "MD5OfBody": "<m-d5-of-body:2>",
+            "Body": {
+              "error": null,
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:3>",
+                    "receiptHandle": "<receipt-handle:4>",
+                    "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 1}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "2",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:1>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_sqs_integration.py::test_redrive_policy_with_failing_lambda": {
+    "recorded-date": "06-08-2022, 21:14:45",
+    "recorded-content": {
+      "get_destination_queue_url": {
+        "QueueUrl": "<queue-url:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_attempt": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>",
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "Body": {
+              "error": "failed attempt",
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:2>",
+                    "receiptHandle": "<receipt-handle:4>",
+                    "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 2}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<m-d5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_attempt": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:2>",
+            "MD5OfBody": "<m-d5-of-body:2>",
+            "Body": {
+              "error": "failed attempt",
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:2>",
+                    "receiptHandle": "<receipt-handle:5>",
+                    "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 2}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "2",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<m-d5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dlq_response": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:3>",
+            "MD5OfBody": "<m-d5-of-body:3>",
+            "Body": {
+              "destination": "<queue-url:1>",
+              "fail_attempts": 2
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -2382,18 +2382,11 @@ class TestSqsProvider:
         sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
         sqs_client.delete_message(QueueUrl=sqs_queue, ReceiptHandle=handle)
 
+    # TODO: test message attributes and message system attributes
+
 
 def get_region():
     return os.environ.get("AWS_DEFAULT_REGION") or TEST_REGION
-
-
-# TODO: test visibility timeout (with various ways to set them: queue attributes, receive parameter, update call)
-# TODO: test message attributes and message system attributes
-
-
-class TestSqsLambdaIntegration:
-    pass
-    # TODO: move tests here
 
 
 @pytest.fixture()

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1515,56 +1515,6 @@ class TestSqsProvider:
         assert queue_url_1 in source_urls["queueUrls"]
         assert queue_url_2 in source_urls["queueUrls"]
 
-    def test_dead_letter_queue_execution(
-        self, sqs_client, sqs_create_queue, lambda_client, create_lambda_function
-    ):
-
-        # TODO: lambda creation does not work when testing against AWS
-        queue_name = f"queue-{short_uid()}"
-        dead_letter_queue_name = f"dl-queue-{short_uid()}"
-        dl_queue_url = sqs_create_queue(QueueName=dead_letter_queue_name)
-
-        # create arn
-        url_parts = dl_queue_url.split("/")
-        region = os.environ.get("AWS_DEFAULT_REGION") or TEST_REGION
-        dl_target_arn = "arn:aws:sqs:{}:{}:{}".format(
-            region, url_parts[len(url_parts) - 2], url_parts[-1]
-        )
-
-        policy = {"deadLetterTargetArn": dl_target_arn, "maxReceiveCount": 1}
-        queue_url = sqs_create_queue(
-            QueueName=queue_name, Attributes={"RedrivePolicy": json.dumps(policy)}
-        )
-
-        lambda_name = f"lambda-{short_uid()}"
-        create_lambda_function(
-            func_name=lambda_name,
-            libs=TEST_LAMBDA_LIBS,
-            handler_file=TEST_LAMBDA_PYTHON,
-            runtime=LAMBDA_RUNTIME_PYTHON36,
-        )
-        # create arn
-        url_parts = queue_url.split("/")
-        queue_arn = "arn:aws:sqs:{}:{}:{}".format(
-            region, url_parts[len(url_parts) - 2], url_parts[-1]
-        )
-        lambda_client.create_event_source_mapping(
-            EventSourceArn=queue_arn, FunctionName=lambda_name
-        )
-
-        # add message to SQS, which will trigger the Lambda, resulting in an error
-        payload = {lambda_integration.MSG_BODY_RAISE_ERROR_FLAG: 1}
-        sqs_client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(payload))
-
-        assert poll_condition(
-            lambda: "Messages"
-            in sqs_client.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0),
-            10.0,
-            1.0,
-        )
-        result_recv = sqs_client.receive_message(QueueUrl=dl_queue_url, VisibilityTimeout=0)
-        assert result_recv["Messages"][0]["Body"] == json.dumps(payload)
-
     @pytest.mark.aws_validated
     def test_dead_letter_queue_with_fifo_and_content_based_deduplication(
         self, sqs_client, sqs_create_queue, sqs_queue_arn


### PR DESCRIPTION
This PR fixes how the SQS event source listener deals with DLQs and retry intervals.

There was some very old code left from #1973 that implemented logic that would, for SQS triggered lambdas, put messages into a DLQ manually. This logic is not needed since SQS puts messages into a DLQ automatically when it's being polled (which the event source listener does). I removed all of that code, since it is all handled implicitly in our SQS provider.

For testing I created two new tests that test the basic behavior (which replace the defunct test i removed), and retry with a DLQ (which was the original goal for #5283). The SQS event source mapping does not support `DestinationConfig`, meaning you can't make async lambdas triggered by SQS messages also send lambda results to SQS queues :shrug:. But I needed that to write proper tests, so I wrote a simple new lambda for testing that takes as input a destination queue URL to which the lambda will echo the incoming event.

The `sqs_api()` transformer was causing issue because sometimes the `SenderId` is the same as the account ID, but not always, so I exposed `_resource_name_transformer` through the transformer util so i can build some custom transformations. happy to revise that.

I'll raise a follow-up PR to move the other lambda/sqs integration tests scattered throughout different tests into the new `test_lambda_sqs_integration.py`.

- Fixes #5283