### PR TITLE
add support for ReportBatchItemFailures in Lambda SQS event source mappings 

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -231,7 +231,10 @@ def parse_batch_item_failures(result: InvocationResult, valid_message_ids: List[
     if not result or not result.result:
         return []
 
-    partial_batch_failure = json.loads(result.result)
+    if isinstance(result.result, dict):
+        partial_batch_failure = result.result
+    else:
+        partial_batch_failure = json.loads(result.result)
 
     if not partial_batch_failure:
         return []

--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -224,7 +224,7 @@ def parse_batch_item_failures(result: InvocationResult, valid_message_ids: List[
 
     :param result: the lambda invocation result
     :param valid_message_ids: the list of valid message ids in the batch
-    :raises ValueError: if the item
+    :raises KeyError: if the itemIdentifier value is missing or not in the batch
     :raises Exception: any other exception related to parsing (e.g., JSON parser error)
     :return: a list of message IDs that are part of a failure and should not be deleted from the queue
     """
@@ -245,7 +245,7 @@ def parse_batch_item_failures(result: InvocationResult, valid_message_ids: List[
         return []
 
     messages_to_keep = []
-    for item in partial_batch_failure["batchItemFailures"]:
+    for item in batch_item_failures:
         if "itemIdentifier" not in item:
             raise KeyError(f"missing itemIdentifier in batchItemFailure record {item}")
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -239,6 +239,9 @@ def build_mapping_obj(data) -> Dict:
     if data.get("DestinationConfig"):
         mapping["DestinationConfig"] = data.get("DestinationConfig")
 
+    if data.get("FunctionResponseTypes"):
+        mapping["FunctionResponseTypes"] = data.get("FunctionResponseTypes")
+
     return mapping
 
 

--- a/tests/integration/awslambda/functions/lambda_sqs_batch_item_failure.py
+++ b/tests/integration/awslambda/functions/lambda_sqs_batch_item_failure.py
@@ -19,10 +19,6 @@ import boto3
 def handler(event, context):
     sqs = create_external_boto_client("sqs")
 
-    destination_queue_url = os.environ.get("DESTINATION_QUEUE_URL")
-    if not destination_queue_url:
-        raise ValueError("no destination queue passed to lambda")
-
     print("incoming event:")
     print(json.dumps(event))
 
@@ -47,10 +43,12 @@ def handler(event, context):
         ]
     }
 
-    sqs.send_message(
-        QueueUrl=destination_queue_url,
-        MessageBody=json.dumps({"event": event, "result": result}),
-    )
+    destination_queue_url = os.environ.get("DESTINATION_QUEUE_URL")
+    if destination_queue_url:
+        sqs.send_message(
+            QueueUrl=destination_queue_url,
+            MessageBody=json.dumps({"event": event, "result": result}),
+        )
 
     return result
 

--- a/tests/integration/awslambda/functions/lambda_sqs_batch_item_failure.py
+++ b/tests/integration/awslambda/functions/lambda_sqs_batch_item_failure.py
@@ -1,0 +1,67 @@
+"""This lambda is used for lambda/sqs integration tests. Since SQS event source mappings don't allow
+DestinationConfigurations that send lambda results to other source (like SQS queues), that can be used to verify
+invocations, this lambda does this manually. You can pass in an event that looks like this::
+
+    {
+        "destination": "<queue_url>",
+        "fail_attempts": 2
+    }
+
+Which will cause the lambda to mark that record as failure twice (comparing the "ApproximateReceiveCount" of the SQS
+event triggering the lambda). The lambda returns a batchItemFailures list that contains every failed record. All
+other records are sent to the destination queue as successfully processed."""
+import json
+import os
+
+import boto3
+
+
+def handler(event, context):
+    sqs = create_external_boto_client("sqs")
+
+    destination_queue_url = os.environ.get("DESTINATION_QUEUE_URL")
+    if not destination_queue_url:
+        raise ValueError("no destination queue passed to lambda")
+
+    print("incoming event:")
+    print(json.dumps(event))
+
+    # this lambda expects inputs from an SQS event source mapping
+    if not event.get("Records"):
+        raise ValueError("no records passed to event")
+
+    batch_item_failures_ids = []
+
+    for record in event["Records"]:
+        message = json.loads(record["body"])
+
+        if message.get("fail_attempts") is None:
+            raise ValueError("no fail_attempts for the event given")
+
+        if message["fail_attempts"] >= int(record["attributes"]["ApproximateReceiveCount"]):
+            batch_item_failures_ids.append(record["messageId"])
+
+    result = {
+        "batchItemFailures": [
+            {"itemIdentifier": message_id} for message_id in batch_item_failures_ids
+        ]
+    }
+
+    sqs.send_message(
+        QueueUrl=destination_queue_url,
+        MessageBody=json.dumps({"event": event, "result": result}),
+    )
+
+    return result
+
+
+def create_external_boto_client(service):
+    endpoint_url = None
+    if os.environ.get("LOCALSTACK_HOSTNAME"):
+        endpoint_url = (
+            f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ.get('EDGE_PORT', 4566)}"
+        )
+    region_name = (
+        os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-east-1"
+    )
+    return boto3.client(service, endpoint_url=endpoint_url, region_name=region_name)

--- a/tests/integration/awslambda/test_lambda_sqs_integration.py
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.py
@@ -373,7 +373,7 @@ def test_report_batch_item_failures(
 
     # timeout in seconds, used for both the lambda and the queue visibility timeout.
     # increase to 10 if testing against AWS fails.
-    retry_timeout = 6
+    retry_timeout = 8
     retries = 2
 
     # set up lambda function

--- a/tests/integration/awslambda/test_lambda_sqs_integration.py
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.py
@@ -665,7 +665,7 @@ def test_report_batch_item_failures_invalid_result_json_batch_fails(
     assert "Messages" in first_invocation
     snapshot.match("first_invocation", first_invocation)
 
-    # now wait for the second invocation result which
+    # now wait for the second invocation result, which should be a retry of the first
     second_invocation = sqs_client.receive_message(
         QueueUrl=destination_url, WaitTimeSeconds=15, MaxNumberOfMessages=1
     )

--- a/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
@@ -527,5 +527,27 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_sqs_integration.py::test_report_batch_item_failures_on_lambda_error": {
+    "recorded-date": "08-08-2022, 21:24:21",
+    "recorded-content": {
+      "dlq_messages": [
+        {
+          "MessageId": "<uuid:1>",
+          "ReceiptHandle": "<receipt-handle:1>",
+          "MD5OfBody": "<m-d5-of-body:1>",
+          "Body": "{not a json body"
+        },
+        {
+          "MessageId": "<uuid:2>",
+          "ReceiptHandle": "<receipt-handle:2>",
+          "MD5OfBody": "<m-d5-of-body:2>",
+          "Body": {
+            "message": 2,
+            "fail_attempts": 0
+          }
+        }
+      ]
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
@@ -237,5 +237,295 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_sqs_integration.py::test_report_batch_item_failures": {
+    "recorded-date": "07-08-2022, 19:18:36",
+    "recorded-content": {
+      "get_destination_queue_url": {
+        "QueueUrl": "<queue-url:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "send_message_batch": {
+        "Successful": [
+          {
+            "Id": "message-1",
+            "MessageId": "<uuid:1>",
+            "MD5OfMessageBody": "<md5-of-body:1>",
+            "SequenceNumber": "<sequence-number:1>"
+          },
+          {
+            "Id": "message-2",
+            "MessageId": "<uuid:2>",
+            "MD5OfMessageBody": "<md5-of-body:2>",
+            "SequenceNumber": "<sequence-number:2>"
+          },
+          {
+            "Id": "message-3",
+            "MessageId": "<uuid:3>",
+            "MD5OfMessageBody": "<md5-of-body:3>",
+            "SequenceNumber": "<sequence-number:3>"
+          },
+          {
+            "Id": "message-4",
+            "MessageId": "<uuid:4>",
+            "MD5OfMessageBody": "<m-d5-of-body:3>",
+            "SequenceNumber": "<sequence-number:4>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_event_source_mapping": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        },
+        "UUID": "<uuid:5>",
+        "BatchSize": 10,
+        "MaximumBatchingWindowInSeconds": 0,
+        "EventSourceArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>",
+        "LastModified": "datetime",
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "FunctionResponseTypes": [
+          "ReportBatchItemFailures"
+        ]
+      },
+      "first_invocation": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:6>",
+            "ReceiptHandle": "<receipt-handle:1>",
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "Body": {
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:1>",
+                    "receiptHandle": "<receipt-handle:4>",
+                    "body": {
+                      "message": 1,
+                      "fail_attempts": 0
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:1>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-1",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:1>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  },
+                  {
+                    "messageId": "<uuid:2>",
+                    "receiptHandle": "<receipt-handle:5>",
+                    "body": {
+                      "message": 2,
+                      "fail_attempts": 1
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:2>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-2",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:2>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  },
+                  {
+                    "messageId": "<uuid:3>",
+                    "receiptHandle": "<receipt-handle:6>",
+                    "body": {
+                      "message": 3,
+                      "fail_attempts": 1
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:3>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-3",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  },
+                  {
+                    "messageId": "<uuid:4>",
+                    "receiptHandle": "<receipt-handle:7>",
+                    "body": {
+                      "message": 4,
+                      "fail_attempts": 2
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:4>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-4",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<m-d5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              },
+              "result": {
+                "batchItemFailures": [
+                  {
+                    "itemIdentifier": "<uuid:2>"
+                  },
+                  {
+                    "itemIdentifier": "<uuid:3>"
+                  },
+                  {
+                    "itemIdentifier": "<uuid:4>"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_invocation": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:7>",
+            "ReceiptHandle": "<receipt-handle:2>",
+            "MD5OfBody": "<m-d5-of-body:2>",
+            "Body": {
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:2>",
+                    "receiptHandle": "<receipt-handle:8>",
+                    "body": {
+                      "message": 2,
+                      "fail_attempts": 1
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "2",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:2>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-2",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:2>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  },
+                  {
+                    "messageId": "<uuid:3>",
+                    "receiptHandle": "<receipt-handle:9>",
+                    "body": {
+                      "message": 3,
+                      "fail_attempts": 1
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "2",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:3>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-3",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  },
+                  {
+                    "messageId": "<uuid:4>",
+                    "receiptHandle": "<receipt-handle:10>",
+                    "body": {
+                      "message": 4,
+                      "fail_attempts": 2
+                    },
+                    "attributes": {
+                      "ApproximateReceiveCount": "2",
+                      "SentTimestamp": "timestamp",
+                      "SequenceNumber": "<sequence-number:4>",
+                      "MessageGroupId": "1",
+                      "SenderId": "sender-id",
+                      "MessageDeduplicationId": "dedup-4",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<m-d5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              },
+              "result": {
+                "batchItemFailures": [
+                  {
+                    "itemIdentifier": "<uuid:4>"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dlq_response": {
+        "Messages": [
+          {
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:3>",
+            "MD5OfBody": "<m-d5-of-body:3>",
+            "Body": {
+              "message": 4,
+              "fail_attempts": 2
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_sqs_integration.snapshot.json
@@ -549,5 +549,166 @@
         }
       ]
     }
+  },
+  "tests/integration/awslambda/test_lambda_sqs_integration.py::test_report_batch_item_failures_invalid_result_json_batch_fails": {
+    "recorded-date": "12-08-2022, 23:58:04",
+    "recorded-content": {
+      "get_destination_queue_url": {
+        "QueueUrl": "<queue-url:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_invocation": {
+        "Messages": [
+          {
+            "Body": {
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:1>",
+                    "receiptHandle": "<receipt-handle:4>",
+                    "body": "{\"message\": 1, \"fail_attempts\": 0}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<m-d5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              },
+              "result": {
+                "batchItemFailures": [
+                  {
+                    "foo": "notvalid"
+                  }
+                ]
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_invocation": {
+        "Messages": [
+          {
+            "Body": {
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:1>",
+                    "receiptHandle": "<receipt-handle:5>",
+                    "body": "{\"message\": 1, \"fail_attempts\": 0}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "2",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<m-d5-of-body:3>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              },
+              "result": {
+                "batchItemFailures": [
+                  {
+                    "foo": "notvalid"
+                  }
+                ]
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:2>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "dlq_response": {
+        "Messages": [
+          {
+            "Body": {
+              "message": 1,
+              "fail_attempts": 0
+            },
+            "MD5OfBody": "<m-d5-of-body:3>",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_sqs_integration.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
+    "recorded-date": "13-08-2022, 00:52:53",
+    "recorded-content": {
+      "get_destination_queue_url": {
+        "QueueUrl": "<queue-url:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_invocation": {
+        "Messages": [
+          {
+            "Body": {
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:1>",
+                    "receiptHandle": "<receipt-handle:2>",
+                    "body": "{\"message\": 1, \"fail_attempts\": 0}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {},
+                    "md5OfBody": "<md5-of-body:1>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              },
+              "result": {}
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds support for reporting batch item failures](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#services-sqs-batchfailurereporting) when using Lambda SQS event source mappings.

* Lambda changes: just for the API to accept and store the `FunctionResponseTypes` attribute
* `sqs_event_source_listener.py`: Just needed to add a control path for when `ReportBatchItemFailures` is set, in which the listener interprets the lambda `batchItemFailures` result according to the spec (see the "Success and failure conditions" in the docs I linked), and calls sqs delete batch with only the messages that should be deleted according to the result.
* Tests: The most complicated part of this PR are i think the tests, which also introduce a new lambda that can be configured to return specific expected or unexpected results (see the TODO list below which test cases are covered). The tests are very similar to each other, but IMO not enough to generalize something out of them without becoming confusing. I'd rather keep the code duplicated.

- Fixes #5301 

## TODOs

- [x] write proper PR description
- [x] basic happy path test case
- [x] test case: lambda fails -> entire batch fails
- [x] test case: lambda returns faulty batchItemFailures json -> entire batch fails
- [x] test case: lambda returns nothing -> entire batch succeeds
- [x] rebase when merged #6603
- [ ] add user docs