### PR TITLE
remove publish_invocation decorator from localstack status commands

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -77,7 +77,6 @@ def localstack_status(ctx):
     name="docker", help="Query information about the LocalStack Docker image and runtime"
 )
 @click.option("--format", type=click.Choice(["table", "plain", "dict", "json"]), default="table")
-@publish_invocation
 def cmd_status_docker(format):
     with console.status("Querying Docker status"):
         print_docker_status(format)
@@ -85,7 +84,6 @@ def cmd_status_docker(format):
 
 @localstack_status.command(name="services", help="Query information about running services")
 @click.option("--format", type=click.Choice(["table", "plain", "dict", "json"]), default="table")
-@publish_invocation
 def cmd_status_services(format):
     import requests
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -195,10 +195,8 @@ def test_config_show_dict(runner, monkeypatch):
     "cli_input,expected_cmd,expected_params",
     [
         ("stop", "localstack stop", []),
-        ("status docker", "localstack status docker", ["format"]),
-        ("status", "localstack status docker", ["format"]),
-        ("--debug status docker --format json", "localstack status docker", ["format"]),
-        ("config show --format plain", "localstack config show", ["format"]),
+        ("config show", "localstack config show", ["format"]),
+        ("--debug config show --format plain", "localstack config show", ["format"]),
     ],
 )
 def test_publish_analytics_event_on_command_invocation(
@@ -236,7 +234,7 @@ def test_publish_analytics_event_on_command_invocation(
     "cli_input",
     [
         "invalid",
-        "status invalid",
+        "status services",
         "config show --format invalid",
     ],
 )
@@ -272,7 +270,7 @@ def test_disable_publish_analytics_event_on_command_invocation(runner, monkeypat
 
     with testutil.http_server(handler) as url:
         monkeypatch.setenv("ANALYTICS_API", url)
-        runner.invoke(cli, "status")
+        runner.invoke(cli, ["config", "show"])
         assert (
             len(request_data) == 0
         ), "analytics API should not be invoked when DISABLE_EVENTS is set"
@@ -294,7 +292,7 @@ def test_timeout_publishing_command_invocation(runner, monkeypatch, caplog):
 
     with testutil.http_server(handler) as url:
         monkeypatch.setenv("ANALYTICS_API", url)
-        runner.invoke(cli, "status")
+        runner.invoke(cli, ["config", "show"])
         assert (
             len(request_data) == 0
         ), "analytics event publisher process should time out if request is taking too long"


### PR DESCRIPTION
removes the status command from the list of commands being logged