### PR TITLE
Fix fifo queue creation with attribute validation

### DIFF
--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -447,6 +447,7 @@ class TestSqsProvider:
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
         assert sqs_create_queue(QueueName=queue_name) == queue_url
 
+    @pytest.mark.aws_validated
     def test_create_fifo_queue_with_same_attributes_is_idempotent(self, sqs_create_queue):
         queue_name = f"queue-{short_uid()}.fifo"
         attributes = {"FifoQueue": "true"}

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -447,6 +447,12 @@ class TestSqsProvider:
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
         assert sqs_create_queue(QueueName=queue_name) == queue_url
 
+    def test_create_fifo_queue_with_same_attributes_is_idempotent(self, sqs_create_queue):
+        queue_name = f"queue-{short_uid()}.fifo"
+        attributes = {"FifoQueue": "true"}
+        queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
+        assert sqs_create_queue(QueueName=queue_name, Attributes=attributes) == queue_url
+
     @pytest.mark.aws_validated
     def test_create_queue_with_different_attributes_raises_exception(
         self, sqs_client, sqs_create_queue, snapshot


### PR DESCRIPTION
This small PR fixes queue attribute validation for fifo queues when they get "created again" (=create_queue with the same attributes, including FifoQueue=true)
fixes #6620 
