### PR TITLE
fix KeyValueBasedTransformer

### DIFF
--- a/localstack/testing/snapshots/transformer.py
+++ b/localstack/testing/snapshots/transformer.py
@@ -183,10 +183,16 @@ class KeyValueBasedTransformer:
                         ctx, reference_value=match_result, replacement=self.replacement
                     )
                 else:
-                    SNAPSHOT_LOGGER.debug(
-                        f"Replacing value for key '{k}' with '{self.replacement}'. (Original value: {str(v)})"
-                    )
-                    input_data[k] = self.replacement
+                    if isinstance(v, str):
+                        SNAPSHOT_LOGGER.debug(
+                            f"Replacing value for key '{k}': Match result '{match_result}' with '{self.replacement}'. (Original value: {str(v)})"
+                        )
+                        input_data[k] = v.replace(match_result, self.replacement)
+                    else:
+                        SNAPSHOT_LOGGER.debug(
+                            f"Replacing value for key '{k}' with '{self.replacement}'. (Original value: {str(v)})"
+                        )
+                        input_data[k] = self.replacement
             elif isinstance(v, list) and len(v) > 0 and isinstance(v[0], dict):
                 for i in range(0, len(v)):
                     v[i] = self.transform(v[i], ctx=ctx)

--- a/tests/unit/utils/testing/test_snapshots.py
+++ b/tests/unit/utils/testing/test_snapshots.py
@@ -81,3 +81,19 @@ class TestSnapshotManager:
             },
         )
         sm._assert_all()
+
+    def test_replacement_key_value(self):
+        sm = SnapshotSession(scope_key="A", verify=True, file_path="", update=False)
+        sm.add_transformer(
+            KeyValueBasedTransformer(
+                # returns last two characters of value -> only this should be replaced
+                lambda k, v: v[-2:] if k == "aaa" else None,
+                replacement="A",
+                replace_reference=False,
+            )
+        )
+        sm.recorded_state = {
+            "key_a": {"aaa": "hellA", "aab": "this is a test", "b": {"aaa": "another teA"}}
+        }
+        sm.match("key_a", {"aaa": "helloo", "aab": "this is a test", "b": {"aaa": "another test"}})
+        sm._assert_all()


### PR DESCRIPTION
This PR fixes a problem with `KeyValueBasedTransformer`:
If `replace_reference` was set to False, it would replace the entire key.

Fix:
* now it replaces the returned value only (which can be a subset of the value), with the `replacement` string
* behaves similar to `replace_reference=True`
