### PR TITLE
fix error in deleting lambda configuration keys

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1066,8 +1066,8 @@ def lookup_function(function, region, request_url):
     if lambda_details.package_type == "Image":
         result["Code"] = lambda_details.code
         result["Configuration"]["CodeSize"] = 0
-        del result["Configuration"]["Handler"]
-        del result["Configuration"]["Layers"]
+        result["Configuration"].pop("Handler", None)
+        result["Configuration"].pop("Layers", None)
 
     if lambda_details.concurrency is not None:
         result["Concurrency"] = lambda_details.concurrency


### PR DESCRIPTION
Addresses #6464

When using only community code, but setting the package type to image (which should work until it comes to invocation), the "Layer" key is not available in the "Configuration" dict, when running get-function.
This leads to a 500 error when running get-function.

This PR fixes this by using `pop` instead of `del`, which will not error on missing Keys.