### PR TITLE
Add default logging configuration for state machine

### DIFF
--- a/localstack/services/stepfunctions/provider.py
+++ b/localstack/services/stepfunctions/provider.py
@@ -5,6 +5,8 @@ from localstack.aws.api.stepfunctions import (
     CreateStateMachineOutput,
     DeleteStateMachineInput,
     DeleteStateMachineOutput,
+    LoggingConfiguration,
+    LogLevel,
     StepfunctionsApi,
 )
 from localstack.aws.forwarder import HttpFallbackDispatcher, get_request_forwarder_http
@@ -42,6 +44,11 @@ class StepFunctionsProvider(StepfunctionsApi, ServiceLifecycleHook):
     def create_state_machine(
         self, context: RequestContext, request: CreateStateMachineInput
     ) -> CreateStateMachineOutput:
+        # set default logging configuration
+        if not request.get("loggingConfiguration"):
+            request["loggingConfiguration"] = LoggingConfiguration(
+                level=LogLevel.OFF, includeExecutionData=False
+            )
         result = self.forward_request(context, request)
         event_publisher.fire_event(
             event_publisher.EVENT_STEPFUNCTIONS_CREATE_SM,

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -603,7 +603,6 @@ def test_default_logging_configuration(
     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
     result = stepfunctions_client.describe_state_machine(stateMachineArn=result["stateMachineArn"])
     assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
-    assert result["loggingConfiguration"]
     assert result["loggingConfiguration"] == {"level": "OFF", "includeExecutionData": False}
 
     # clean up


### PR DESCRIPTION
Should address #6486. 
Passing an empty dictionary as `loggingConfiguration`, while being a valid AWS request, as shown in the ticker messes up with persistence. This PR adds the default configuration as the real AWS. 