### PR TITLE
fix delay seconds=0 for fifo queues

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -638,8 +638,8 @@ class FifoQueue(SqsQueue):
         message_group_id: str = None,
         delay_seconds: int = None,
     ):
-        if delay_seconds is not None:
-            # in fifo queues, delay is only applied on queue level
+        if delay_seconds:
+            # in fifo queues, delay is only applied on queue level. However, explicitly setting delay_seconds=0 is valid
             raise InvalidParameterValue(
                 f"Value {delay_seconds} for parameter DelaySeconds is invalid. Reason: The request include parameter "
                 f"that is not valid for this queue type."

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -455,6 +455,24 @@ class TestSqsProvider:
         assert sqs_create_queue(QueueName=queue_name, Attributes=attributes) == queue_url
 
     @pytest.mark.aws_validated
+    def test_send_message_with_delay_0_works_for_fifo(self, sqs_client, sqs_create_queue):
+        # see https://github.com/localstack/localstack/issues/6612
+        queue_name = f"queue-{short_uid()}.fifo"
+        attributes = {"FifoQueue": "true"}
+        queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
+        message_sent_hash = sqs_client.send_message(
+            QueueUrl=queue_url,
+            DelaySeconds=0,
+            MessageBody="Hello World!",
+            MessageGroupId="test",
+            MessageDeduplicationId="42",
+        )["MD5OfMessageBody"]
+        message_receive_hash = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)[
+            "Messages"
+        ][0]["MD5OfBody"]
+        assert message_sent_hash == message_receive_hash
+
+    @pytest.mark.aws_validated
     def test_create_queue_with_different_attributes_raises_exception(
         self, sqs_client, sqs_create_queue, snapshot
     ):

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -456,7 +456,7 @@ class TestSqsProvider:
 
     @pytest.mark.aws_validated
     def test_send_message_with_delay_0_works_for_fifo(self, sqs_client, sqs_create_queue):
-        # see https://github.com/localstack/localstack/issues/6612
+        # see issue https://github.com/localstack/localstack/issues/6612
         queue_name = f"queue-{short_uid()}.fifo"
         attributes = {"FifoQueue": "true"}
         queue_url = sqs_create_queue(QueueName=queue_name, Attributes=attributes)
@@ -467,10 +467,10 @@ class TestSqsProvider:
             MessageGroupId="test",
             MessageDeduplicationId="42",
         )["MD5OfMessageBody"]
-        message_receive_hash = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)[
+        message_received_hash = sqs_client.receive_message(QueueUrl=queue_url, VisibilityTimeout=0)[
             "Messages"
         ][0]["MD5OfBody"]
-        assert message_sent_hash == message_receive_hash
+        assert message_sent_hash == message_received_hash
 
     @pytest.mark.aws_validated
     def test_create_queue_with_different_attributes_raises_exception(


### PR DESCRIPTION
Even though DelaySeconds is not valid for fifo queues in a send_message operation, sending it with the value 0 is allowed.
fixes #6612 
