### PR TITLE
Fix CloudFormation GetTemplate response and multiple cdk deployments

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -581,7 +581,7 @@ class CloudformationProvider(CloudformationApi):
         template_deployer.prepare_template_body(request)  # TODO: avoid mutating request directly
         template = template_preparer.parse_template(request["TemplateBody"])
         stack_name = template["StackName"] = request.get("StackName")
-        stack = Stack(request, template)
+        stack = Stack(request, template)  # TODO: proper body handling like in create_change_set
 
         # find existing stack with same name, and remove it if this stack is in DELETED state
         existing = ([s for s in state.stacks.values() if s.stack_name == stack_name] or [None])[0]

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -967,6 +967,11 @@ class CloudformationProvider(CloudformationApi):
 
         # only relevant if change_set_name isn't an ARN
         if not ARN_CHANGESET_REGEX.match(change_set_name):
+            if not stack_name:
+                raise ValidationError(
+                    "StackName must be specified if ChangeSetName is not specified as an ARN."
+                )
+
             stack = find_stack(stack_name)
             if not stack:
                 raise ValidationError(f"Stack [{stack_name}] does not exist")
@@ -984,7 +989,17 @@ class CloudformationProvider(CloudformationApi):
         change_set_name: ChangeSetNameOrId,
         stack_name: StackNameOrId = None,
     ) -> DeleteChangeSetOutput:
-        # TODO: change_set_name can be an ARN
+
+        # only relevant if change_set_name isn't an ARN
+        if not ARN_CHANGESET_REGEX.match(change_set_name):
+            if not stack_name:
+                raise ValidationError(
+                    "StackName must be specified if ChangeSetName is not specified as an ARN."
+                )
+
+            stack = find_stack(stack_name)
+            if not stack:
+                raise ValidationError(f"Stack [{stack_name}] does not exist")
 
         change_set = find_change_set(change_set_name, stack_name=stack_name)
         if not change_set:

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -1007,7 +1007,7 @@ class CloudformationProvider(CloudformationApi):
         change_set.stack.change_sets = [
             cs
             for cs in change_set.stack.change_sets
-            if (cs.change_set_name != change_set_name and cs.change_set_id != change_set_name)
+            if change_set_name not in (cs.change_set_name, cs.change_set_id)
         ]
         return DeleteChangeSetOutput()
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1034,9 +1034,13 @@ def _has_stack_status(cfn_client, statuses: List[str]):
 
 @pytest.fixture
 def is_change_set_finished(cfn_client):
-    def _is_change_set_finished(change_set_id: str):
+    def _is_change_set_finished(change_set_id: str, stack_name: Optional[str] = None):
         def _inner():
-            check_set = cfn_client.describe_change_set(ChangeSetName=change_set_id)
+            kwargs = {"ChangeSetName": change_set_id}
+            if stack_name:
+                kwargs["StackName"] = stack_name
+
+            check_set = cfn_client.describe_change_set(**kwargs)
             return check_set.get("ExecutionStatus") == "EXECUTE_COMPLETE"
 
         return _inner

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -54,6 +54,7 @@ class TransformerUtility:
     def resource_name(replacement_name: str = "resource"):
         """Creates a new KeyValueBasedTransformer for the resource name.
 
+        :param replacement_name ARN of a resource to extract name from
         :return: KeyValueBasedTransformer
         """
         return KeyValueBasedTransformer(_resource_name_transformer, replacement_name)
@@ -115,10 +116,11 @@ class TransformerUtility:
         :return: array with Transformers, for cloudformation api.
         """
         return [
-            TransformerUtility.key_value("ChangeSetName"),
-            TransformerUtility.key_value("StackName"),
             KeyValueBasedTransformer(_resource_name_transformer, "resource"),
             KeyValueBasedTransformer(_change_set_id_transformer, "change-set-id"),
+            TransformerUtility.key_value("ChangeSetName"),
+            TransformerUtility.key_value("ChangeSetId"),
+            TransformerUtility.key_value("StackName"),
         ]
 
     @staticmethod

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1362,17 +1362,22 @@ class TemplateDeployer:
         return physical_id
 
     def get_change_config(self, action, resource, change_set_id=None):
-        return {
+        result = {
             "Type": "Resource",
             "ResourceChange": {
                 "Action": action,
                 "LogicalResourceId": resource.get("LogicalResourceId"),
                 "PhysicalResourceId": resource.get("PhysicalResourceId"),
                 "ResourceType": resource.get("Type"),
-                "Replacement": "False",
-                "ChangeSetId": change_set_id,
+                # TODO ChangeSetId is only set for *nested* change sets
+                # "ChangeSetId": change_set_id,
+                "Scope": [],  # TODO
+                "Details": [],  # TODO
             },
         }
+        if action == "Modify":
+            result["ResourceChange"]["Replacement"] = "False"
+        return result
 
     def resource_config_differs(self, resource_new):
         """Return whether the given resource properties differ from the existing config (for stack updates)."""

--- a/localstack/utils/cloudformation/template_preparer.py
+++ b/localstack/utils/cloudformation/template_preparer.py
@@ -60,7 +60,7 @@ def transform_template(req_data) -> Optional[str]:
                 os.environ["AWS_DEFAULT_REGION"] = region_before
 
 
-def prepare_template_body(req_data) -> Optional[str]:  # TODO: mutating and returning
+def prepare_template_body(req_data) -> str | bytes | None:  # TODO: mutating and returning
     template_url = req_data.get("TemplateURL")
     if template_url:
         req_data["TemplateURL"] = convert_s3_to_local_url(template_url)
@@ -139,7 +139,7 @@ def get_template_body(req_data):
             raise Exception(
                 "Unable to fetch template body (code %s) from URL %s" % (status_code, url)
             )
-        return response.content
+        return to_str(response.content)
     raise Exception("Unable to get template body from input: %s" % req_data)
 
 

--- a/tests/integration/cloudformation/test_cloudformation_cdk.py
+++ b/tests/integration/cloudformation/test_cloudformation_cdk.py
@@ -50,7 +50,9 @@ class TestCdkInit:
                 requests.request(method=op["method"], url=url, headers=headers, data=data)
                 if "Action=ExecuteChangeSet" in data:
                     assert wait_until(
-                        is_change_set_finished(change_set_name), _max_wait=20, strategy="linear"
+                        is_change_set_finished(change_set_name, stack_name=stack_name),
+                        _max_wait=20,
+                        strategy="linear",
                     )
         finally:
             # clean up

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -305,11 +305,11 @@ def test_create_change_set_with_ssm_parameter(
         cleanup_stacks([stack_id])
 
 
-def test_describe_change_set_nonexisting(cfn_client):
+@pytest.mark.aws_validated
+def test_describe_change_set_nonexisting(cfn_client, snapshot):
     with pytest.raises(Exception) as ex:
-        cfn_client.describe_change_set(ChangeSetName="DoesNotExist")
-
-    assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
+        cfn_client.describe_change_set(StackName="somestack", ChangeSetName="DoesNotExist")
+    snapshot.match("exception", ex.value)
 
 
 def test_execute_change_set(
@@ -516,7 +516,9 @@ def test_empty_changeset(cfn_client, snapshot, cleanups):
     snapshot.match("error_execute_failed", e.value)
 
 
+@pytest.mark.aws_validated
 def test_deleted_changeset(cfn_client, snapshot, cleanups):
+    """simple case verifying that proper exception is thrown when trying to get a deleted changeset"""
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
 
     changeset_name = f"changeset-{short_uid()}"

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -377,11 +377,16 @@ def test_execute_change_set(
         cleanup_stacks([stack_id])
 
 
-def test_delete_change_set_nonexisting(cfn_client):
-    with pytest.raises(Exception) as ex:
-        cfn_client.delete_change_set(ChangeSetName="DoesNotExist")
+@pytest.mark.aws_validated
+def test_delete_change_set_exception(cfn_client, snapshot):
+    """test error cases when trying to delete a change set"""
+    with pytest.raises(Exception) as e1:
+        cfn_client.delete_change_set(StackName="nostack", ChangeSetName="DoesNotExist")
+    snapshot.match("e1", e1)
 
-    assert ex.value.response["Error"]["Code"] == "ResourceNotFoundException"
+    with pytest.raises(Exception) as e2:
+        cfn_client.delete_change_set(ChangeSetName="DoesNotExist")
+    snapshot.match("e2", e2)
 
 
 @pytest.mark.aws_validated

--- a/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
@@ -150,5 +150,19 @@
       },
       "error_execute_failed": "An error occurred (InvalidChangeSetStatus) when calling the ExecuteChangeSet operation: ChangeSet [arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>] cannot be executed in its current status of [FAILED]"
     }
+  },
+  "tests/integration/cloudformation/test_cloudformation_changesets.py::test_deleted_changeset": {
+    "recorded-date": "11-08-2022, 11:11:47",
+    "recorded-content": {
+      "create": {
+        "Id": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name>/<resource:2>"
+      },
+      "postdelete_changeset_notfound": "An error occurred (ChangeSetNotFound) when calling the DescribeChangeSet operation: ChangeSet [arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>] does not exist"
+    }
   }
 }

--- a/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
@@ -170,5 +170,12 @@
     "recorded-content": {
       "exception": "An error occurred (ValidationError) when calling the DescribeChangeSet operation: Stack [somestack] does not exist"
     }
+  },
+  "tests/integration/cloudformation/test_cloudformation_changesets.py::test_delete_change_set_exception": {
+    "recorded-date": "11-08-2022, 14:07:38",
+    "recorded-content": {
+      "e1": "<ExceptionInfo ClientError('An error occurred (ValidationError) when calling the DeleteChangeSet operation: Stack [nostack] does not exist') tblen=3>",
+      "e2": "<ExceptionInfo ClientError('An error occurred (ValidationError) when calling the DeleteChangeSet operation: StackName must be specified if ChangeSetName is not specified as an ARN.') tblen=3>"
+    }
   }
 }

--- a/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
@@ -164,5 +164,11 @@
       },
       "postdelete_changeset_notfound": "An error occurred (ChangeSetNotFound) when calling the DescribeChangeSet operation: ChangeSet [arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>] does not exist"
     }
+  },
+  "tests/integration/cloudformation/test_cloudformation_changesets.py::test_describe_change_set_nonexisting": {
+    "recorded-date": "11-08-2022, 13:22:01",
+    "recorded-content": {
+      "exception": "An error occurred (ValidationError) when calling the DescribeChangeSet operation: Stack [somestack] does not exist"
+    }
   }
 }

--- a/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.snapshot.json
@@ -72,5 +72,83 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/test_cloudformation_changesets.py::test_empty_changeset": {
+    "recorded-date": "10-08-2022, 10:52:55",
+    "recorded-content": {
+      "first_changeset": {
+        "Id": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>"
+      },
+      "describe_first_cs": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "ChangeSetName": "<change-set-id:1>",
+        "Changes": [
+          {
+            "ResourceChange": {
+              "Action": "Add",
+              "Details": [],
+              "LogicalResourceId": "CDKMetadata",
+              "ResourceType": "AWS::CDK::Metadata",
+              "Scope": []
+            },
+            "Type": "Resource"
+          }
+        ],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "AVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "CREATE_COMPLETE"
+      },
+      "nochange_changeset": {
+        "Id": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>"
+      },
+      "describe_nochange": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "ChangeSetName": "<change-set-id:2>",
+        "Changes": [],
+        "CreationTime": "datetime",
+        "ExecutionStatus": "UNAVAILABLE",
+        "IncludeNestedStacks": false,
+        "NotificationARNs": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "Status": "FAILED",
+        "StatusReason": "The submitted information didn't contain changes. Submit different information to create a change set."
+      },
+      "error_execute_failed": "An error occurred (InvalidChangeSetStatus) when calling the ExecuteChangeSet operation: ChangeSet [arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>] cannot be executed in its current status of [FAILED]"
+    }
   }
 }

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -249,11 +249,14 @@ Outputs:
 @pytest.mark.parametrize("fileformat", ["yaml", "json"])
 def test_get_template(cfn_client, deploy_cfn_template, snapshot, fileformat):
     snapshot.add_transformer(snapshot.transform.cloudformation_api())
+
     stack = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), f"../templates/sns_topic_template.{fileformat}"
         )
     )
+    topic_name = stack.outputs["TopicName"]
+    snapshot.add_transformer(snapshot.transform.regex(topic_name, "<topic-name>"), priority=-1)
 
     describe_stacks = cfn_client.describe_stacks(StackName=stack.stack_id)
     snapshot.match("describe_stacks", describe_stacks)

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -244,3 +244,24 @@ Outputs:
     test_tag = [tag for tag in tagging["TagSet"] if tag["Key"] == "test"]
     assert test_tag
     assert test_tag[0]["Value"] == bucket_name1
+
+@pytest.mark.aws_validated
+@pytest.mark.parametrize("fileformat", ["yaml", "json"])
+def test_get_template(cfn_client, deploy_cfn_template, snapshot, fileformat):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), f"../templates/sns_topic_template.{fileformat}"
+        )
+    )
+
+    describe_stacks = cfn_client.describe_stacks(StackName=stack.stack_id)
+    snapshot.match("describe_stacks", describe_stacks)
+
+    template_original = cfn_client.get_template(StackName=stack.stack_id, TemplateStage="Original")
+    snapshot.match("template_original", template_original)
+
+    template_processed = cfn_client.get_template(
+        StackName=stack.stack_id, TemplateStage="Processed"
+    )
+    snapshot.match("template_processed", template_processed)

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -245,6 +245,7 @@ Outputs:
     assert test_tag
     assert test_tag[0]["Value"] == bucket_name1
 
+
 @pytest.mark.aws_validated
 @pytest.mark.parametrize("fileformat", ["yaml", "json"])
 def test_get_template(cfn_client, deploy_cfn_template, snapshot, fileformat):

--- a/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
@@ -27,7 +27,7 @@
     }
   },
   "tests/integration/cloudformation/test_cloudformation_stacks.py::test_get_template[yaml]": {
-    "recorded-date": "10-08-2022, 10:53:30",
+    "recorded-date": "11-08-2022, 10:55:10",
     "recorded-content": {
       "describe_stacks": {
         "ResponseMetadata": {
@@ -53,7 +53,7 @@
             "Outputs": [
               {
                 "OutputKey": "TopicName",
-                "OutputValue": "<stack-name:1>-topic69831491-1HT7YTYGJ865N"
+                "OutputValue": "<topic-name>"
               }
             ],
             "RollbackConfiguration": {},
@@ -73,7 +73,7 @@
           "Original",
           "Processed"
         ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName"
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
       },
       "template_processed": {
         "ResponseMetadata": {
@@ -84,12 +84,12 @@
           "Original",
           "Processed"
         ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName"
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
       }
     }
   },
   "tests/integration/cloudformation/test_cloudformation_stacks.py::test_get_template[json]": {
-    "recorded-date": "10-08-2022, 10:53:54",
+    "recorded-date": "11-08-2022, 10:55:35",
     "recorded-content": {
       "describe_stacks": {
         "ResponseMetadata": {
@@ -115,7 +115,7 @@
             "Outputs": [
               {
                 "OutputKey": "TopicName",
-                "OutputValue": "<stack-name:1>-topic69831491-1R0GSRI7LFP31"
+                "OutputValue": "<topic-name>"
               }
             ],
             "RollbackConfiguration": {},

--- a/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
@@ -25,5 +25,161 @@
         "Tags": []
       }
     }
+  },
+  "tests/integration/cloudformation/test_cloudformation_stacks.py::test_get_template[yaml]": {
+    "recorded-date": "10-08-2022, 10:53:30",
+    "recorded-content": {
+      "describe_stacks": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "OutputKey": "TopicName",
+                "OutputValue": "<stack-name:1>-topic69831491-1HT7YTYGJ865N"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ]
+      },
+      "template_original": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName"
+      },
+      "template_processed": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName"
+      }
+    }
+  },
+  "tests/integration/cloudformation/test_cloudformation_stacks.py::test_get_template[json]": {
+    "recorded-date": "10-08-2022, 10:53:54",
+    "recorded-content": {
+      "describe_stacks": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Outputs": [
+              {
+                "OutputKey": "TopicName",
+                "OutputValue": "<stack-name:1>-topic69831491-1R0GSRI7LFP31"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ]
+      },
+      "template_original": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": {
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          }
+        }
+      },
+      "template_processed": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": {
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/cdkmetadata.yaml
+++ b/tests/integration/templates/cdkmetadata.yaml
@@ -1,0 +1,7 @@
+Resources:
+  CDKMetadata:
+    Type: AWS::CDK::Metadata
+    Properties:
+      Analytics: v2:deflate64:H4sIAAAAAAAA/zPSMzbTM1BMLC/WTU7J1s3JTNKrDi5JTM7WcU7LC0otzi8tSk4FsZ3z81IySzLz82p18vJTUvWyivXLDM30DE30jBSzijMzdYtK80oyc1P1giA0AExi6LdZAAAA
+    Metadata:
+      aws:cdk:path: CdkTestStack/CDKMetadata/Default

--- a/tests/integration/templates/sns_topic_template.json
+++ b/tests/integration/templates/sns_topic_template.json
@@ -1,0 +1,17 @@
+{
+ "Resources": {
+  "topic69831491": {
+   "Type": "AWS::SNS::Topic"
+  }
+ },
+ "Outputs": {
+  "TopicName": {
+   "Value": {
+    "Fn::GetAtt": [
+     "topic69831491",
+     "TopicName"
+    ]
+   }
+  }
+ }
+}

--- a/tests/integration/templates/sns_topic_template.yaml
+++ b/tests/integration/templates/sns_topic_template.yaml
@@ -1,0 +1,9 @@
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName


### PR DESCRIPTION
Previously  there was some weird behavior in CDK:

1. Deploy Stack A (new) => success
2. Deploy Stack A (no changes) => success (but still created a change set)
3. Deploy Stack A (no changes) => fail (resource not found)
4. go to 3


We didn't save the "raw" template string when creating a stack and therefore returned invalid data in `GetTemplate`. This is important because CDK uses it to compare the new template against and if they match, it won't even try to create a change set (by default, can be disabled with `deploy --force`)
