### PR TITLE
set CONFIG_PROFILE correctly into config variable with localstack CLI

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -47,6 +47,7 @@ def _setup_cli_debug():
 def localstack(debug, profile):
     if profile:
         os.environ["CONFIG_PROFILE"] = profile
+        config.CONFIG_PROFILE = profile
     if debug:
         _setup_cli_debug()
 


### PR DESCRIPTION
this PR modifies the localstack CLI command to correctly set the `config.CONFIG_PROFILE` value to whatever is passed to `--profile`. previously we would only set the environment variable, but the config was already loaded before the env var was set.