### PR TITLE
fix SNS msg attrs when sending to SQS DLQ

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1813,7 +1813,12 @@ class TestSNSProvider:
         }
         sns_client.publish(TopicArn=topic_arn, Message=message, MessageAttributes=message_attr)
 
-        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        response = sqs_client.receive_message(
+            QueueUrl=dlq_url,
+            WaitTimeSeconds=10,
+            AttributeNames=["All"],
+            MessageAttributeNames=["All"],
+        )
         snapshot.match("messages", response)
 
     @pytest.mark.aws_validated

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -836,16 +836,13 @@ class TestSNSProvider:
         sns_client.publish(
             TopicArn=topic_arn,
             Message="test_redrive_policy",
+            MessageAttributes={"attr1": {"DataType": "Number", "StringValue": "1"}},
         )
 
-        response = sqs_client.receive_message(QueueUrl=dlq_url, WaitTimeSeconds=10)
+        response = sqs_client.receive_message(
+            QueueUrl=dlq_url, WaitTimeSeconds=10, MessageAttributeNames=["All"]
+        )
         snapshot.match("messages", response)
-        assert (
-            len(response["Messages"]) == 1
-        ), f"invalid number of messages in DLQ response {response}"
-        message = json.loads(response["Messages"][0]["Body"])
-        assert message["Type"] == "Notification"
-        assert message["Message"] == "test_redrive_policy"
 
     @pytest.mark.aws_validated
     def test_publish_with_empty_subject(self, sns_client, sns_create_topic, snapshot):

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -56,13 +56,30 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[True]": {
-    "recorded-date": "09-08-2022, 11:36:01",
+    "recorded-date": "10-08-2022, 11:36:11",
     "recorded-content": {
       "messages": {
         "Messages": [
           {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
             "Body": "test_dlq_after_sqs_endpoint_deleted",
             "MD5OfBody": "<md5-hash>",
+            "MD5OfMessageAttributes": "<md5-hash>",
+            "MessageAttributes": {
+              "attr1": {
+                "DataType": "Number",
+                "StringValue": "111"
+              },
+              "attr2": {
+                "BinaryValue": "b'\\x02\\x03\\x04'",
+                "DataType": "Binary"
+              }
+            },
             "MessageId": "<uuid:1>",
             "ReceiptHandle": "<receipt-handle:1>"
           }
@@ -75,11 +92,17 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_sqs_queue_subscription[False]": {
-    "recorded-date": "09-08-2022, 11:36:04",
+    "recorded-date": "10-08-2022, 11:36:14",
     "recorded-content": {
       "messages": {
         "Messages": [
           {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "SenderId": "<sender-id>",
+              "SentTimestamp": "timestamp"
+            },
             "Body": {
               "Type": "Notification",
               "MessageId": "<uuid:1>",

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -689,7 +689,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_redrive_policy_lambda_subscription": {
-    "recorded-date": "09-08-2022, 11:34:55",
+    "recorded-date": "11-08-2022, 14:36:27",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -722,7 +722,13 @@
               "SignatureVersion": "1",
               "Signature": "<signature>",
               "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
-              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:3>"
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:4>:<resource:3>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "1"
+                }
+              }
             },
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:2>",


### PR DESCRIPTION
Fix #6639
This was discovered by accident while augmenting the snapshots, adding more attributes to the response before fixing another bug.

The format was wrong, we would add and even override `MessagesAttributes` with error coded one when AWS doesn't do it. The code to check if we send the attributes is a bit messy, there are check all over the place and the provider will need a good clean up/refactor.