### PR TITLE
Fixing BatchWriteItem with key element not matching the schema

### DIFF
--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1428,8 +1428,9 @@ class TestDynamoDB:
         _transact_write({"id": {"S": "id1"}, "name": {"S": "name1"}})
         _transact_write({"name": {"S": "name1"}, "id": {"S": "id1"}})
 
+    @pytest.mark.aws_validated
     def test_batch_write_not_matching_schema(
-        self, dynamodb_client, dynamodb_create_table_with_parameters
+        self, dynamodb_client, dynamodb_create_table_with_parameters, dynamodb_wait_for_table_active
     ):
         table_name = f"ddb-table-{short_uid()}"
 
@@ -1445,6 +1446,7 @@ class TestDynamoDB:
             ],
             ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
         )
+        dynamodb_wait_for_table_active(table_name)
 
         faulty_item = {"Item": {"nonKey": {"S": "hello"}}}
         with pytest.raises(Exception) as ctx:

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1428,6 +1428,31 @@ class TestDynamoDB:
         _transact_write({"id": {"S": "id1"}, "name": {"S": "name1"}})
         _transact_write({"name": {"S": "name1"}, "id": {"S": "id1"}})
 
+    def test_batch_write_not_matching_schema(
+        self, dynamodb_client, dynamodb_create_table_with_parameters
+    ):
+        table_name = f"ddb-table-{short_uid()}"
+
+        dynamodb_create_table_with_parameters(
+            TableName=table_name,
+            KeySchema=[
+                {"AttributeName": "id", "KeyType": "HASH"},
+                {"AttributeName": "sortKey", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "id", "AttributeType": "S"},
+                {"AttributeName": "sortKey", "AttributeType": "S"},
+            ],
+            ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
+        )
+
+        faulty_item = {"Item": {"nonKey": {"S": "hello"}}}
+        with pytest.raises(Exception) as ctx:
+            dynamodb_client.batch_write_item(
+                RequestItems={table_name: [{"PutRequest": faulty_item}]}
+            )
+        assert ctx.match("ValidationException")
+
 
 def delete_table(name):
     dynamodb_client = aws_stack.create_external_boto_client("dynamodb")


### PR DESCRIPTION
This PR addresses #6290 and adds an integration test.

Sneak peek: in an upcoming PR I am embedding `dynamodb_wait_for_table_active` into the creation fixture (and validating many DynamoDB tests).