### PR TITLE
fix SNS subscription deleted when SQS endpoint was deleted

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -991,12 +991,10 @@ async def message_to_subscriber(
             store_delivery_log(subscriber, False, message, message_id)
             sns_error_to_dead_letter_queue(subscriber, message_body, str(exc))
             if "NonExistentQueue" in str(exc):
-                LOG.info(
-                    'Removing non-existent queue "%s" subscribed to topic "%s"',
-                    queue_url,
-                    topic_arn,
-                )
-                subscriptions.remove(subscriber)
+                LOG.debug("The SQS queue endpoint does not exist anymore")
+                # todo: if the queue got deleted, even if we recreate a queue with the same name/url
+                #  AWS won't send to it anymore. Would need to unsub/resub.
+                #  We should mark this subscription as "broken"
         return
 
     elif subscriber["Protocol"] == "lambda":

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -1668,5 +1668,132 @@
   "tests/integration/test_sns.py::TestSNSProvider::test_publish_sqs_from_sns_with_xray_propagation": {
     "recorded-date": "09-08-2022, 11:35:46",
     "recorded-content": {}
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_subscription_after_failure_to_deliver": {
+    "recorded-date": "10-08-2022, 17:04:52",
+    "recorded-content": {
+      "subscriptions-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-before-delete": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "Message": "test_dlq_before_sqs_endpoint_deleted",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscriptions": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "Subscriptions": [
+          {
+            "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+            "Owner": "111111111111",
+            "Protocol": "sqs",
+            "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+          }
+        ]
+      },
+      "subscriptions-attrs-with-redrive": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "RedrivePolicy": {
+            "deadLetterTargetArn": "arn:aws:sqs:<region>:111111111111:<resource:4>"
+          },
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "message-0-after-delete": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "Message": "test_dlq_after_sqs_endpoint_deleted_0",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "message-1-after-delete": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:5>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "Message": "test_dlq_after_sqs_endpoint_deleted_1",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:6>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR fixes the scenario where we would delete an SNS subscription (we would actually only delete the logic/publish part but not the resource in moto, which could be listed) when its SQS endpoint was deleted. It would send a message to the DLQ once if configured then delete the subscription.
AWS does not do this, it keeps the subscription and you can even set a RedrivePolicy afterwards.

I wrote a new AWS validated and snapshotted test to validate the behaviour.

There was an old PR fixing this #6160, which had a lot of merge conflicts from all the changes since.

_fixes #5459_