### PR TITLE
Add snapshot test for lambda proxy integration

### DIFF
--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -9,6 +9,7 @@ from localstack.testing.snapshots.transformer import (
     RegexTransformer,
     ResponseMetaDataTransformer,
 )
+from localstack.utils.net import IP_REGEX
 
 PATTERN_UUID = re.compile(
     r"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
@@ -107,6 +108,38 @@ class TransformerUtility:
             KeyValueBasedTransformer(
                 _log_stream_name_transformer, "log-stream-name", replace_reference=True
             ),
+        ]
+
+    @staticmethod
+    def apigateway_api():
+        return [
+            TransformerUtility.key_value("id"),
+            TransformerUtility.key_value("name"),
+        ]
+
+    @staticmethod
+    def apigateway_proxy_event():
+        return [
+            TransformerUtility.key_value("extendedRequestId"),
+            TransformerUtility.key_value("resourceId"),
+            TransformerUtility.key_value("sourceIp"),
+            TransformerUtility.jsonpath(
+                "$..headers.CloudFront-Viewer-ASN", value_replacement="cloudfront-asn"
+            ),
+            TransformerUtility.jsonpath(
+                "$..headers.CloudFront-Viewer-Country", value_replacement="cloudfront-country"
+            ),
+            TransformerUtility.jsonpath("$..headers.Via", value_replacement="via"),
+            TransformerUtility.jsonpath("$..headers.X-Amz-Cf-Id", value_replacement="cf-id"),
+            TransformerUtility.jsonpath("$..headers.X-Amzn-Trace-Id", value_replacement="trace-id"),
+            TransformerUtility.jsonpath(
+                "$..requestContext.requestTime", value_replacement="request-time"
+            ),
+            # TODO re-enable once int replacement works
+            # TransformerUtility.jsonpath(
+            #     "$..requestContext.requestTimeEpoch", value_replacement="request-time-epoch"
+            # ),
+            TransformerUtility.regex(IP_REGEX.strip("^$"), "<ip>"),
         ]
 
     @staticmethod

--- a/tests/integration/awslambda/functions/lambda_apigateway_proxy.py
+++ b/tests/integration/awslambda/functions/lambda_apigateway_proxy.py
@@ -1,0 +1,8 @@
+import json
+
+
+def handler(event, context):
+    # Just print the event that was passed to the Lambda
+    print(json.dumps(event))
+    # return the event so we can make assertions about it
+    return {"statusCode": 200, "headers": {}, "isBase64Encoded": False, "body": json.dumps(event)}

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -86,6 +86,7 @@ TEST_LAMBDA_INTEGRATION_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_int
 TEST_LAMBDA_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_handler.js")
 TEST_LAMBDA_NODEJS_ES6 = os.path.join(THIS_FOLDER, "functions/lambda_handler_es6.mjs")
 TEST_LAMBDA_HELLO_WORLD = os.path.join(THIS_FOLDER, "functions/lambda_hello_world.py")
+TEST_LAMBDA_AWS_PROXY = os.path.join(THIS_FOLDER, "functions/lambda_apigateway_proxy.py")
 TEST_LAMBDA_NODEJS_APIGW_INTEGRATION = os.path.join(THIS_FOLDER, "functions/apigw_integration.js")
 TEST_LAMBDA_NODEJS_APIGW_502 = os.path.join(THIS_FOLDER, "functions/apigw_502.js")
 TEST_LAMBDA_GOLANG_ZIP = os.path.join(THIS_FOLDER, "functions/golang/handler.zip")

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -1,10 +1,15 @@
+import json
+import os
+
 import pytest
 import requests
 
+from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.services.apigateway.helpers import path_based_url
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
 from localstack.utils.testutil import create_lambda_function
 from tests.integration.apigateway_fixtures import (
     api_invoke_url,
@@ -13,7 +18,7 @@ from tests.integration.apigateway_fixtures import (
     create_rest_resource,
     create_rest_resource_method,
 )
-from tests.integration.awslambda.test_lambda import TEST_LAMBDA_HELLO_WORLD
+from tests.integration.awslambda.test_lambda import TEST_LAMBDA_AWS_PROXY, TEST_LAMBDA_HELLO_WORLD
 
 
 @pytest.mark.skip_offline
@@ -86,6 +91,104 @@ def test_lambda_aws_integration(apigateway_client):
     url = api_invoke_url(api_id=api_id, stage="local", path="/test")
     response = requests.get(url)
     assert response.json() == {"message": "Hello from Lambda"}
+
+
+def get_apigateway_base_url():
+    return "amazonaws.com" if os.environ.get("TEST_TARGET") == "AWS_CLOUD" else LOCALHOST_HOSTNAME
+
+
+@pytest.mark.aws_validated
+def test_lambda_proxy_integration(
+    apigateway_client,
+    create_lambda_function,
+    lambda_client,
+    create_role,
+    create_policy,
+    iam_client,
+    snapshot,
+):
+    function_name = f"test-function-{short_uid()}"
+    role_name = f"test-role-{short_uid()}"
+    stage_name = "test"
+    snapshot.add_transformer(snapshot.transform.apigateway_api())
+    snapshot.add_transformer(snapshot.transform.apigateway_proxy_event())
+
+    # create lambda
+    create_function_response = create_lambda_function(
+        func_name=function_name,
+        handler_file=TEST_LAMBDA_AWS_PROXY,
+        handler="lambda_apigateway_proxy.handler",
+        runtime=LAMBDA_RUNTIME_PYTHON39,
+    )
+    # create invocation role
+    assume_role_doc = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "apigateway.amazonaws.com"},
+                "Effect": "Allow",
+            }
+        ],
+    }
+    policy_doc = {
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Action": "lambda:InvokeFunction", "Resource": "*"}],
+    }
+    role_arn = create_role(
+        RoleName=role_name, AssumeRolePolicyDocument=json.dumps(assume_role_doc)
+    )["Role"]["Arn"]
+    policy_arn = create_policy(
+        PolicyName=f"test-policy-{short_uid()}", PolicyDocument=json.dumps(policy_doc)
+    )["Policy"]["Arn"]
+    iam_client.attach_role_policy(RoleName=role_name, PolicyArn=policy_arn)
+    lambda_arn = create_function_response["CreateFunctionResponse"]["FunctionArn"]
+
+    # create rest api
+    rest_api_creation_response = apigateway_client.create_rest_api(
+        name=f"test-api-{short_uid()}", description="Integration test API"
+    )
+    snapshot.match("rest-api-creation", rest_api_creation_response)
+    rest_api_id = rest_api_creation_response["id"]
+    try:
+        root_resource_id = apigateway_client.get_resources(restApiId=rest_api_id)["items"][0]["id"]
+        resource_id = apigateway_client.create_resource(
+            restApiId=rest_api_id, parentId=root_resource_id, pathPart="test-path"
+        )["id"]
+        apigateway_client.put_method(
+            restApiId=rest_api_id,
+            resourceId=resource_id,
+            httpMethod="ANY",
+            authorizationType="NONE",
+        )
+        apigateway_client.put_integration(
+            restApiId=rest_api_id,
+            resourceId=resource_id,
+            httpMethod="ANY",
+            type="AWS_PROXY",
+            integrationHttpMethod="POST",
+            uri=f"arn:aws:apigateway:{apigateway_client.meta.region_name}:lambda:path/2015-03-31/functions/{lambda_arn}/invocations",
+            credentials=role_arn,
+        )
+        apigateway_client.create_deployment(restApiId=rest_api_id, stageName=stage_name)
+
+        # invoke rest api
+        invocation_url = f"https://{rest_api_id}.execute-api.{apigateway_client.meta.region_name}.{get_apigateway_base_url()}/{stage_name}/test-path"
+
+        def invoke_api(url):
+            response = requests.get(url, headers={"User-Agent": "python-requests/testing"})
+            assert 200 == response.status_code
+            return response
+
+        # retry is necessary against AWS, probably IAM permission delay
+        response = retry(invoke_api, sleep=2, retries=10, url=invocation_url)
+        snapshot.match("invocation-payload-without-trailing-slash", response.json())
+
+        # invoke rest api with trailing slash
+        response_trailing_slash = retry(invoke_api, sleep=2, retries=10, url=f"{invocation_url}/")
+        snapshot.match("invocation-payload-with-trailing-slash", response_trailing_slash.json())
+    finally:
+        apigateway_client.delete_rest_api(restApiId=rest_api_id)
 
 
 #

--- a/tests/integration/test_apigateway_integrations.snapshot.json
+++ b/tests/integration/test_apigateway_integrations.snapshot.json
@@ -1,0 +1,250 @@
+{
+  "tests/integration/test_apigateway_integrations.py::test_lambda_proxy_integration": {
+    "recorded-date": "10-08-2022, 22:13:01",
+    "recorded-content": {
+      "rest-api-creation": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        },
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "Integration test API",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>"
+      },
+      "invocation-payload-without-trailing-slash": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<id:1>.execute-api.<region>.amazonaws.com",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:1>",
+          "X-Amz-Cf-Id": "<cf-id:1>",
+          "X-Amzn-Trace-Id": "<trace-id:1>",
+          "X-Forwarded-For": "<source-ip:1>, <ip>",
+          "X-Forwarded-Port": "443",
+          "X-Forwarded-Proto": "https"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<id:1>.execute-api.<region>.amazonaws.com"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:1>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:1>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:1>"
+          ],
+          "X-Forwarded-For": [
+            "<source-ip:1>, <ip>"
+          ],
+          "X-Forwarded-Port": [
+            "443"
+          ],
+          "X-Forwarded-Proto": [
+            "https"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path",
+        "pathParameters": null,
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<id:1>",
+          "domainName": "<id:1>.execute-api.<region>.amazonaws.com",
+          "domainPrefix": "<id:1>",
+          "extendedRequestId": "<extended-request-id:1>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:1>",
+          "requestTime": "<request-time:1>",
+          "requestTimeEpoch": 1660162380490,
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/test-path",
+          "stage": "test"
+        },
+        "resource": "/test-path",
+        "stageVariables": null
+      },
+      "invocation-payload-with-trailing-slash": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<id:1>.execute-api.<region>.amazonaws.com",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:2>",
+          "X-Amz-Cf-Id": "<cf-id:2>",
+          "X-Amzn-Trace-Id": "<trace-id:2>",
+          "X-Forwarded-For": "<source-ip:1>, <ip>",
+          "X-Forwarded-Port": "443",
+          "X-Forwarded-Proto": "https"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<id:1>.execute-api.<region>.amazonaws.com"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:2>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:2>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:2>"
+          ],
+          "X-Forwarded-For": [
+            "<source-ip:1>, <ip>"
+          ],
+          "X-Forwarded-Port": [
+            "443"
+          ],
+          "X-Forwarded-Proto": [
+            "https"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path/",
+        "pathParameters": null,
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<id:1>",
+          "domainName": "<id:1>.execute-api.<region>.amazonaws.com",
+          "domainPrefix": "<id:1>",
+          "extendedRequestId": "<extended-request-id:2>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path/",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:2>",
+          "requestTime": "<request-time:1>",
+          "requestTimeEpoch": 1660162380865,
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/test-path",
+          "stage": "test"
+        },
+        "resource": "/test-path",
+        "stageVariables": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
WIP, but test _almost_ is reproducible against AWS.

Currently, int values in keyvaluereplacements will however break the snapshot utility