### PR TITLE
adds small utility to do atomic writes

### DIFF
--- a/localstack/utils/files.py
+++ b/localstack/utils/files.py
@@ -284,6 +284,6 @@ class safe_open:
         if exc_type is None:
             os.rename(self._file.name, self._target)
             if self._permissions:
-                os.chmod(self._file.name, self._permissions)
+                os.chmod(self._target, self._permissions)
         else:
             os.unlink(self._file.name)

--- a/localstack/utils/files.py
+++ b/localstack/utils/files.py
@@ -53,9 +53,15 @@ def cache_dir() -> Path:
 def save_file(file, content, append=False, permissions=None):
     mode = "a" if append else "w+"
     if not isinstance(content, str):
-        mode += "b"
+        mode = mode + "b"
+
+    def _opener(path, flags):
+        return os.open(path, flags, permissions)
+
+    # make sure that the parent dir exsits
     mkdir(os.path.dirname(file))
-    with safe_open(file, mode, permissions) as f:
+    # store file contents
+    with open(file, mode, opener=_opener if permissions else None) as f:
         f.write(content)
         f.flush()
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -534,10 +534,9 @@ class TestCommonFileOperations:
 
 
 def test_save_load_file(tmp_path):
-    file_name = tmp_path / ("normal_permissions_%s" % short_uid())
-    content = "some_content_%s" % short_uid()
-    more_content = "some_more_content_%s" % short_uid()
-
+    file_name = tmp_path / f"normal_permissions_{short_uid()}"
+    content = f"some_content_{short_uid()}"
+    more_content = f"some_more_content_{short_uid()}"
     save_file(file_name, content)
     assert content == load_file(file_name)
     save_file(file_name, more_content, append=True)
@@ -545,35 +544,31 @@ def test_save_load_file(tmp_path):
 
 
 def test_save_load_file_with_permissions(tmp_path):
-    file_name = tmp_path / ("special_permissions_%s" % short_uid())
-    content = "some_content_%s" % short_uid()
-    more_content = "some_more_content_%s" % short_uid()
-    permissions = 0o600
-
+    file_name = tmp_path / f"special_permissions_{short_uid()}"
+    content = f"some_content_{short_uid()}"
+    more_content = f"some_more_content_{short_uid()}"
+    permissions = 384
     save_file(file_name, content, permissions=permissions)
-    assert permissions == os.stat(file_name).st_mode & 0o777
+    assert permissions == os.stat(file_name).st_mode & 511
     assert content == load_file(file_name)
     save_file(file_name, more_content, append=True)
-    assert permissions == os.stat(file_name).st_mode & 0o777
+    assert permissions == os.stat(file_name).st_mode & 511
     assert content + more_content == load_file(file_name)
 
 
 def test_save_load_file_with_changing_permissions(tmp_path):
-    file_name = tmp_path / ("changing_permissions_%s" % short_uid())
-    content = "some_content_%s" % short_uid()
-    more_content = "some_more_content_%s" % short_uid()
-    permissions = 0o600
-
+    file_name = tmp_path / f"changing_permissions_{short_uid()}"
+    content = f"some_content_{short_uid()}"
+    more_content = f"some_more_content_{short_uid()}"
+    permissions = 384
     save_file(file_name, content)
-    assert permissions != os.stat(file_name).st_mode & 0o777
+    assert permissions != os.stat(file_name).st_mode & 511
     assert content == load_file(file_name)
-    # setting the permissions on append should not change the permissions
     save_file(file_name, more_content, append=True, permissions=permissions)
-    assert permissions != os.stat(file_name).st_mode & 0o777
+    assert permissions != os.stat(file_name).st_mode & 511
     assert content + more_content == load_file(file_name)
-    # overwriting the file also will not change the permissions
     save_file(file_name, content, permissions=permissions)
-    assert permissions != os.stat(file_name).st_mode & 0o777
+    assert permissions != os.stat(file_name).st_mode & 511
     assert content == load_file(file_name)
 
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -534,9 +534,10 @@ class TestCommonFileOperations:
 
 
 def test_save_load_file(tmp_path):
-    file_name = tmp_path / f"normal_permissions_{short_uid()}"
-    content = f"some_content_{short_uid()}"
-    more_content = f"some_more_content_{short_uid()}"
+    file_name = tmp_path / ("normal_permissions_%s" % short_uid())
+    content = "some_content_%s" % short_uid()
+    more_content = "some_more_content_%s" % short_uid()
+
     save_file(file_name, content)
     assert content == load_file(file_name)
     save_file(file_name, more_content, append=True)
@@ -544,31 +545,35 @@ def test_save_load_file(tmp_path):
 
 
 def test_save_load_file_with_permissions(tmp_path):
-    file_name = tmp_path / f"special_permissions_{short_uid()}"
-    content = f"some_content_{short_uid()}"
-    more_content = f"some_more_content_{short_uid()}"
-    permissions = 384
+    file_name = tmp_path / ("special_permissions_%s" % short_uid())
+    content = "some_content_%s" % short_uid()
+    more_content = "some_more_content_%s" % short_uid()
+    permissions = 0o600
+
     save_file(file_name, content, permissions=permissions)
-    assert permissions == os.stat(file_name).st_mode & 511
+    assert permissions == os.stat(file_name).st_mode & 0o777
     assert content == load_file(file_name)
     save_file(file_name, more_content, append=True)
-    assert permissions == os.stat(file_name).st_mode & 511
+    assert permissions == os.stat(file_name).st_mode & 0o777
     assert content + more_content == load_file(file_name)
 
 
 def test_save_load_file_with_changing_permissions(tmp_path):
-    file_name = tmp_path / f"changing_permissions_{short_uid()}"
-    content = f"some_content_{short_uid()}"
-    more_content = f"some_more_content_{short_uid()}"
-    permissions = 384
+    file_name = tmp_path / ("changing_permissions_%s" % short_uid())
+    content = "some_content_%s" % short_uid()
+    more_content = "some_more_content_%s" % short_uid()
+    permissions = 0o600
+
     save_file(file_name, content)
-    assert permissions != os.stat(file_name).st_mode & 511
+    assert permissions != os.stat(file_name).st_mode & 0o777
     assert content == load_file(file_name)
+    # setting the permissions on append should not change the permissions
     save_file(file_name, more_content, append=True, permissions=permissions)
-    assert permissions != os.stat(file_name).st_mode & 511
+    assert permissions != os.stat(file_name).st_mode & 0o777
     assert content + more_content == load_file(file_name)
+    # overwriting the file also will not change the permissions
     save_file(file_name, content, permissions=permissions)
-    assert permissions != os.stat(file_name).st_mode & 511
+    assert permissions != os.stat(file_name).st_mode & 0o777
     assert content == load_file(file_name)
 
 

--- a/tests/unit/utils/generic/test_file_utils.py
+++ b/tests/unit/utils/generic/test_file_utils.py
@@ -72,7 +72,7 @@ def test_write_file_atomically():
     assert open(tf.name, "r").read() == "Replace the hello world, "
 
     # let's do the same thing, but this time, using the safe_open call.
-    # writes, but because an exception is thrown, the file will be rolled back.
+    # given an exception is thrown, the content of the file will be rolled back.
     with contextlib.suppress(Exception):
         with safe_open(tf.name) as f:
             f.write(b"This wont be written, ")

--- a/tests/unit/utils/generic/test_file_utils.py
+++ b/tests/unit/utils/generic/test_file_utils.py
@@ -50,7 +50,7 @@ def test_parse_config_file(input_type, sections):
             assert expected == section
 
 
-def test_write_file_atomically():
+def test_write_to_file_atomically():
 
     # open a temporary file and writes to it, so far nothing new
     tf = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
This little function will give us the ability to write to files and make sure there are no partial writes in case of an exception.

The intent was to ensure our persistence files were not corrupted in case of failure, however, this doesn't work for "append" to file writes; therefore it can't be used inside `save_file`. 

I can leave the utility there for cases where we know it's a one-off write. There is a test example that should be clear enough explaining what it does and how it works

/cc @giograno 



