### PR TITLE
Validate a bunch of DynamoDB tests against AWS

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -345,9 +345,9 @@ def dynamodb_create_table_with_parameters(dynamodb_client, dynamodb_wait_for_tab
             kwargs["TableName"] = f"test-table-{short_uid()}"
 
         tables.append(kwargs["TableName"])
-        fn = dynamodb_client.create_table(**kwargs)
+        response = dynamodb_client.create_table(**kwargs)
         dynamodb_wait_for_table_active(kwargs["TableName"])
-        return fn
+        return response
 
     yield factory
 
@@ -375,9 +375,7 @@ def dynamodb_create_table(dynamodb_client, dynamodb_wait_for_table_active):
 
         tables.append(kwargs["table_name"])
 
-        fn = create_dynamodb_table(**kwargs)
-        dynamodb_wait_for_table_active(kwargs["table_name"])
-        return fn
+        return create_dynamodb_table(**kwargs)
 
     yield factory
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -342,10 +342,12 @@ def dynamodb_create_table_with_parameters(dynamodb_client, dynamodb_wait_for_tab
 
     def factory(**kwargs):
         if "TableName" not in kwargs:
-            kwargs["TableName"] = "test-table-%s" % short_uid()
+            kwargs["TableName"] = f"test-table-{short_uid()}"
 
         tables.append(kwargs["TableName"])
-        return dynamodb_client.create_table(**kwargs)
+        fn = dynamodb_client.create_table(**kwargs)
+        dynamodb_wait_for_table_active(kwargs["TableName"])
+        return fn
 
     yield factory
 
@@ -373,7 +375,9 @@ def dynamodb_create_table(dynamodb_client, dynamodb_wait_for_table_active):
 
         tables.append(kwargs["table_name"])
 
-        return create_dynamodb_table(**kwargs)
+        fn = create_dynamodb_table(**kwargs)
+        dynamodb_wait_for_table_active(kwargs["table_name"])
+        return fn
 
     yield factory
 


### PR DESCRIPTION
This PR:

- embed the fixture used to wait for a table to be active into the fixtures we use to create DynamoDB tables; this unlocks the possibility of starting verifying DynamoDB tests against AWS;
- started verifying a bunch of integration tests against AWS (the easiest ones, for the moment; a second bunch will come);

Generally, for DynamoDB we have three different ways to create resources, i.e., tables, that we might think of standardizing.
- `dynamodb_create_table_with_parameters` fixture, where we simply pass a dictionary of parameters and create the table with the client's API;
- `dynamodb_create_table` fixture, with similar behavior to the one above but it then actually calls the `create_dynamodb_table` in `aws_stack.py`;
- via [`DynamoDBServiceResource`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.ServiceResource) to abstract the creation of resources.