### PR TITLE
expose internal SNS data platform_endpoint_messages

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -93,6 +93,7 @@ from localstack.aws.api.sns import (
 from localstack.config import external_service_url
 from localstack.services.awslambda import lambda_api
 from localstack.services.generic_proxy import RegionBackend
+from localstack.services.internal import get_internal_apis
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.analytics import event_publisher
@@ -118,6 +119,12 @@ SNS_PROTOCOLS = [
     "firehose",
 ]
 
+# Endpoint to access all the PlatformEndpoint sent Messages
+# (relative to LocalStack internal HTTP resources base endpoint)
+PLATFORM_ENDPOINT_MSGS_ENDPOINT = "/sns/platform-endpoint-messages"
+_PLATFORM_ENDPOINT_MSGS_ENDPOINT_REGISTERED = False
+
+
 # set up logger
 LOG = logging.getLogger(__name__)
 
@@ -131,7 +138,7 @@ class SNSBackend(RegionBackend):
     subscription_status: Dict[str, Dict]
     # maps topic ARN to list of tags
     sns_tags: Dict[str, List[Dict]]
-    # cache of topic ARN to platform endpoint messages (used primarily for testing)
+    # cache of endpoint ARN to platform endpoint messages (used primarily for testing)
     platform_endpoint_messages: Dict[str, List[Dict]]
 
     # list of sent SMS messages - TODO: expose via internal API
@@ -292,6 +299,10 @@ def send_message_to_GCM(app_attributes, endpoint_attributes, message):
 
 
 class SnsProvider(SnsApi, ServiceLifecycleHook):
+    def on_after_init(self):
+        # Allow sent platform endpoint messages to be retrieved from the SNS endpoint
+        register_sns_api_resource()
+
     def add_permission(
         self,
         context: RequestContext,
@@ -1422,3 +1433,43 @@ def unsubscribe_sqs_queue(queue_url):
             sub_url = subscriber.get("sqs_queue_url") or subscriber["Endpoint"]
             if queue_url == sub_url:
                 subscriptions.remove(subscriber)
+
+
+def register_sns_api_resource():
+    """Register the platform endpointmessages retrospection endpoint as an internal LocalStack endpoint."""
+    # Use a global to indicate whether the resource has already been registered
+    # This is cheaper than iterating over the registered routes in the Router object
+    global _PLATFORM_ENDPOINT_MSGS_ENDPOINT_REGISTERED
+
+    if not _PLATFORM_ENDPOINT_MSGS_ENDPOINT_REGISTERED:
+        get_internal_apis().add(
+            PLATFORM_ENDPOINT_MSGS_ENDPOINT, SNSServicePlatformEndpointMessagesApiResource()
+        )
+        _PLATFORM_ENDPOINT_MSGS_ENDPOINT_REGISTERED = True
+
+
+class SNSServicePlatformEndpointMessagesApiResource:
+    """Provides a REST API for retrospective access to platform endpoint messages sent via SNS.
+
+    This is registered as a LocalStack internal HTTP resource.
+
+    This endpoint accepts:
+    - GET param `region`: selector for AWS `region`. If not specified, return default "us-east-1"
+    - GET param `topicArn`: filter for `topicArn` resource in SNS
+    """
+
+    def on_get(self, request):
+        region = request.args.get("region", "us-east-1")
+        filter_endpoint_arn = request.args.get("endpointArn")
+        backend = SNSBackend.get(region=region)
+        if filter_endpoint_arn:
+            messages = backend.platform_endpoint_messages.get(filter_endpoint_arn, [])
+            return {
+                "platform_endpoint_messages": {filter_endpoint_arn: messages},
+                "region": region,
+            }
+
+        return {
+            "platform_endpoint_messages": backend.platform_endpoint_messages,
+            "region": region,
+        }

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -14,8 +14,9 @@ from werkzeug import Response
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
+from localstack.constants import INTERNAL_RESOURCE_PATH
 from localstack.services.install import SQS_BACKEND_IMPL
-from localstack.services.sns.provider import SNSBackend
+from localstack.services.sns.provider import PLATFORM_ENDPOINT_MSGS_ENDPOINT, SNSBackend
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils import testutil
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
@@ -462,10 +463,7 @@ class TestSNSProvider:
         snapshot.match("messages", response)
 
     @pytest.mark.only_localstack
-    def test_subscribe_platform_endpoint(
-        self, sns_client, sqs_create_queue, sns_create_topic, sns_subscription
-    ):
-
+    def test_subscribe_platform_endpoint(self, sns_client, sns_create_topic, sns_subscription):
         sns_backend = SNSBackend.get()
         topic_arn = sns_create_topic()["TopicArn"]
 
@@ -2204,3 +2202,63 @@ class TestSNSProvider:
             )
 
             snapshot.match(f"message-{i}-after-delete", response)
+
+    @pytest.mark.only_localstack
+    def test_publish_to_platform_endpoint_can_retrospect(
+        self, sns_client, sns_create_topic, sns_subscription
+    ):
+        sns_backend = SNSBackend.get()
+        topic_arn = sns_create_topic()["TopicArn"]
+        application_platform_name = f"app-platform-{short_uid()}"
+
+        app_arn = sns_client.create_platform_application(
+            Name=application_platform_name, Platform="p1", Attributes={}
+        )["PlatformApplicationArn"]
+
+        endpoint_arn = sns_client.create_platform_endpoint(
+            PlatformApplicationArn=app_arn, Token=short_uid()
+        )["EndpointArn"]
+
+        endpoint_arn_2 = sns_client.create_platform_endpoint(
+            PlatformApplicationArn=app_arn, Token=short_uid()
+        )["EndpointArn"]
+
+        sns_subscription(
+            TopicArn=topic_arn,
+            Protocol="application",
+            Endpoint=endpoint_arn,
+        )
+
+        message = "This is a test message"
+        sns_client.publish(TopicArn=topic_arn, Message=message)
+        sns_client.publish(TargetArn=endpoint_arn_2, Message=message)
+
+        # assert that message has been received
+        def check_message():
+            assert len(sns_backend.platform_endpoint_messages[endpoint_arn]) > 0
+
+        retry(check_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
+
+        msgs_url = config.get_edge_url() + INTERNAL_RESOURCE_PATH + PLATFORM_ENDPOINT_MSGS_ENDPOINT
+        api_contents = requests.get(msgs_url).json()
+
+        assert len(api_contents["platform_endpoint_messages"]) == 2
+        assert len(api_contents["platform_endpoint_messages"][endpoint_arn]) == 1
+        assert len(api_contents["platform_endpoint_messages"][endpoint_arn_2]) == 1
+        assert api_contents["region"] == "us-east-1"
+        assert api_contents["platform_endpoint_messages"][endpoint_arn][0]["Message"][0] == message
+
+        # Ensure messages can be filtered by EndpointArn
+        msg_with_endpoint = requests.get(msgs_url, params={"endpointArn": endpoint_arn}).json()
+        assert len(msg_with_endpoint["platform_endpoint_messages"]) == 1
+        assert len(msg_with_endpoint["platform_endpoint_messages"][endpoint_arn]) == 1
+        assert api_contents["region"] == "us-east-1"
+
+        # Ensure you can select the region
+        msg_with_region = requests.get(msgs_url, params={"region": "eu-west-1"}).json()
+        assert len(msg_with_region["platform_endpoint_messages"]) == 0
+        assert msg_with_region["region"] == "eu-west-1"
+
+        sns_client.delete_endpoint(EndpointArn=endpoint_arn)
+        sns_client.delete_endpoint(EndpointArn=endpoint_arn_2)
+        sns_client.delete_platform_application(PlatformApplicationArn=app_arn)


### PR DESCRIPTION
This is a feature request here: #6360
Taking example on the SES provider, I used the same utility to expose the messages.
This is a first draft, as I don't like the formatting of the messages that we store and would prefer to use the ASF message model instead. I can do a separate PR to remove traces of the old legacy provider first, but I would like feedback on the mechanism used to expose the data.

\cc @thrau 
