### PR TITLE
Generalize parameter conversion fallback for SDK calls in CloudFormation

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -625,6 +625,14 @@ class FifoQueue(SqsQueue):
         super().__init__(name, region, account_id, attributes, tags)
         self.deduplication = {}
 
+    def default_attributes(self) -> QueueAttributeMap:
+        return {
+            **super().default_attributes(),
+            QueueAttributeName.ContentBasedDeduplication: "false",
+            QueueAttributeName.DeduplicationScope: "queue",
+            QueueAttributeName.FifoThroughputLimit: "perQueue",
+        }
+
     def update_delay_seconds(self, value: int):
         super(FifoQueue, self).update_delay_seconds(value)
         for message in self.delayed:

--- a/tests/integration/cloudformation/test_cloudformation_engine.py
+++ b/tests/integration/cloudformation/test_cloudformation_engine.py
@@ -1,0 +1,34 @@
+import pytest
+
+#
+TMPL = """
+Resources:
+  blaBE223B94:
+    Type: AWS::SNS::Topic
+  queue276F7297:
+    Type: AWS::SQS::Queue
+    Properties:
+      DelaySeconds: "2"
+      FifoQueue: "true"
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+Outputs:
+  QueueName:
+    Value:
+      Fn::GetAtt:
+        - queue276F7297
+        - QueueName
+  QueueUrl:
+    Value:
+      Ref: queue276F7297
+"""
+
+
+@pytest.mark.aws_validated
+def test_implicit_type_conversion(deploy_cfn_template, cfn_client, sqs_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.sqs_api())
+    stack = deploy_cfn_template(template=TMPL, max_wait=180)
+    queue = sqs_client.get_queue_attributes(
+        QueueUrl=stack.outputs["QueueUrl"], AttributeNames=["All"]
+    )
+    snapshot.match("queue", queue)

--- a/tests/integration/cloudformation/test_cloudformation_engine.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_engine.snapshot.json
@@ -1,0 +1,31 @@
+{
+  "tests/integration/cloudformation/test_cloudformation_engine.py::test_implicit_type_conversion": {
+    "recorded-date": "12-08-2022, 16:14:04",
+    "recorded-content": {
+      "queue": {
+        "Attributes": {
+          "ApproximateNumberOfMessages": "0",
+          "ApproximateNumberOfMessagesDelayed": "0",
+          "ApproximateNumberOfMessagesNotVisible": "0",
+          "ContentBasedDeduplication": "false",
+          "CreatedTimestamp": "timestamp",
+          "DeduplicationScope": "queue",
+          "DelaySeconds": "2",
+          "FifoQueue": "true",
+          "FifoThroughputLimit": "perQueue",
+          "LastModifiedTimestamp": "timestamp",
+          "MaximumMessageSize": "262144",
+          "MessageRetentionPeriod": "345600",
+          "QueueArn": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "ReceiveMessageWaitTimeSeconds": "0",
+          "SqsManagedSseEnabled": "false",
+          "VisibilityTimeout": "30"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a more generalized way to cast parameter values (even nested now) when the first SDK call failed due to invalid parameter types.

Also found minor parity issues for FIFO queue default values along the way. /cc @baermat 


Fixes #5671