### PR TITLE
fix lambda_sqs_integration region resolution to avoid CI failures

### DIFF
--- a/tests/integration/awslambda/functions/lambda_sqs_integration.py
+++ b/tests/integration/awslambda/functions/lambda_sqs_integration.py
@@ -49,4 +49,7 @@ def create_external_boto_client(service):
         endpoint_url = (
             f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ.get('EDGE_PORT', 4566)}"
         )
-    return boto3.client(service, endpoint_url=endpoint_url)
+    region_name = (
+        os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-east-1"
+    )
+    return boto3.client(service, endpoint_url=endpoint_url, region_name=region_name)


### PR DESCRIPTION
It seems [sometimes in CI](https://app.circleci.com/pipelines/github/localstack/localstack/8346/workflows/c7238f0e-0026-4870-8558-4046b08460b0/jobs/52075), not sure why, the region is not resolved correctly anymore, and the log is full of `You must specify a region` errors. Maybe some test side effects?

For the PR in question, I had originally added using a fallback region, but then removed it. [Here's the discussion](https://github.com/localstack/localstack/pull/6603#discussion_r940465391). So re-adding this fallback code now.

See an excerpt here:
```
tests/integration/awslambda/test_lambda_sqs_integration.py::test_redrive_policy_with_failing_lambda 
-------------------------------- live log call ---------------------------------
2022-08-13T14:44:07.040  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS sqs.CreateQueue => 200
2022-08-13T14:44:07.049  INFO --- [   asgi_gw_2] localstack.request.aws     : AWS sqs.GetQueueUrl => 200
2022-08-13T14:44:07.570  INFO --- [   asgi_gw_5] localstack.request.aws     : AWS lambda.CreateFunction => 200
2022-08-13T14:44:07.585  INFO --- [   asgi_gw_6] localstack.request.aws     : AWS lambda.GetFunction => 200
2022-08-13T14:44:07.595  INFO --- [   asgi_gw_3] localstack.request.aws     : AWS sqs.CreateQueue => 200
2022-08-13T14:44:07.603  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS sqs.GetQueueAttributes => 200
2022-08-13T14:44:07.612  INFO --- [   asgi_gw_4] localstack.request.aws     : AWS sqs.CreateQueue => 200
2022-08-13T14:44:07.621  INFO --- [   asgi_gw_2] localstack.request.aws     : AWS sqs.GetQueueAttributes => 200
2022-08-13T14:44:07.635  INFO --- [   asgi_gw_1] localstack.request.aws     : AWS lambda.CreateEventSourceMapping => 200
2022-08-13T14:44:08.068  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS dynamodb.UpdateItem => 200
2022-08-13T14:44:08.420  INFO --- [   asgi_gw_6] localstack.request.aws     : AWS kinesis.GetRecords => 200
2022-08-13T14:44:09.650  INFO --- [   asgi_gw_4] localstack.request.aws     : AWS lambda.GetEventSourceMapping => 200
2022-08-13T14:44:09.660  INFO --- [   asgi_gw_2] localstack.request.aws     : AWS sqs.SendMessage => 200
2022-08-13T14:44:09.941  INFO --- [   asgi_gw_7] localstack.request.aws     : AWS kinesis.GetRecords => 200
2022-08-13T14:44:10.144  INFO --- [Thread-12065] localstack.services.awslambda.lambda_executors : Error executing Lambda "arn:aws:lambda:*********:000000000000:function:failing-lambda-268c594c": You must specify a region.   File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 1382, in _execute
    process.run()
  File "/usr/local/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 1369, in do_execute
    result = lambda_function_callable(inv_context.event, context)
  File "/var/lib/localstack/tmp/lambda_script_l_8d7eedd6.py", line 42, in handler
    sqs = create_external_boto_client("sqs")
  File "/var/lib/localstack/tmp/lambda_script_l_8d7eedd6.py", line 52, in create_external_boto_client
    return boto3.client(service, endpoint_url=endpoint_url)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/__init__.py", line 92, in client
    return _get_default_session().client(*args, **kwargs)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/session.py", line 299, in client
    return self._session.create_client(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/session.py", line 950, in create_client
    client = client_creator.create_client(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 123, in create_client
    client_args = self._get_client_args(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 466, in _get_client_args
    return args_creator.get_client_args(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py", line 87, in get_client_args
    final_args = self.compute_client_args(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py", line 183, in compute_client_args
    endpoint_config = self._compute_endpoint_config(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py", line 278, in _compute_endpoint_config
    return self._resolve_endpoint(**resolve_endpoint_kwargs)
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py", line 381, in _resolve_endpoint
    return endpoint_bridge.resolve(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py", line 566, in resolve
    resolved = self.endpoint_resolver.construct_endpoint(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/regions.py", line 205, in construct_endpoint
    result = self._endpoint_for_partition(
  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/regions.py", line 253, in _endpoint_for_partition
    raise NoRegionError()

2022-08-13T14:44:10.177  INFO --- [Thread-12065] localstack.utils.threads   : Thread run method <function LambdaExecutor.execute.<locals>.do_execute at 0x7f3f0cb88ee0>(None) failed: {"errorType": "NoRegionError", "errorMessage": "You must specify a region.", "stackTrace": ["  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 1382, in _execute\n    process.run()\n", "  File \"/usr/local/lib/python3.10/multiprocessing/process.py\", line 108, in run\n    self._target(*self._args, **self._kwargs)\n", "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 1369, in do_execute\n    result = lambda_function_callable(inv_context.event, context)\n", "  File \"/var/lib/localstack/tmp/lambda_script_l_8d7eedd6.py\", line 42, in handler\n    sqs = create_external_boto_client(\"sqs\")\n", "  File \"/var/lib/localstack/tmp/lambda_script_l_8d7eedd6.py\", line 52, in create_external_boto_client\n    return boto3.client(service, endpoint_url=endpoint_url)\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/__init__.py\", line 92, in client\n    return _get_default_session().client(*args, **kwargs)\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/session.py\", line 299, in client\n    return self._session.create_client(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/session.py\", line 950, in create_client\n    client = client_creator.create_client(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py\", line 123, in create_client\n    client_args = self._get_client_args(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py\", line 466, in _get_client_args\n    return args_creator.get_client_args(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 87, in get_client_args\n    final_args = self.compute_client_args(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 183, in compute_client_args\n    endpoint_config = self._compute_endpoint_config(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 278, in _compute_endpoint_config\n    return self._resolve_endpoint(**resolve_endpoint_kwargs)\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 381, in _resolve_endpoint\n    return endpoint_bridge.resolve(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py\", line 566, in resolve\n    resolved = self.endpoint_resolver.construct_endpoint(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/regions.py\", line 205, in construct_endpoint\n    result = self._endpoint_for_partition(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/regions.py\", line 253, in _endpoint_for_partition\n    raise NoRegionError()\n"]} Traceback (most recent call last):
  File "/opt/code/localstack/localstack/utils/threads.py", line 39, in run
    result = self.func(self.params, **kwargs)
  File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 443, in do_execute
    return _run(func_arn=func_arn)
  File "/opt/code/localstack/localstack/utils/cloudwatch/cloudwatch_util.py", line 153, in wrapped
    raise e
  File "/opt/code/localstack/localstack/utils/cloudwatch/cloudwatch_util.py", line 149, in wrapped
    result = func(*args, **kwargs)
  File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 430, in _run
    raise e
  File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 426, in _run
    result = self._execute(lambda_function, inv_context)
  File "/opt/code/localstack/localstack/services/awslambda/lambda_executors.py", line 1425, in _execute
    raise InvocationException(result, log_output=log_output, result=result)
localstack.services.awslambda.lambda_executors.InvocationException: {"errorType": "NoRegionError", "errorMessage": "You must specify a region.", "stackTrace": ["  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 1382, in _execute\n    process.run()\n", "  File \"/usr/local/lib/python3.10/multiprocessing/process.py\", line 108, in run\n    self._target(*self._args, **self._kwargs)\n", "  File \"/opt/code/localstack/localstack/services/awslambda/lambda_executors.py\", line 1369, in do_execute\n    result = lambda_function_callable(inv_context.event, context)\n", "  File \"/var/lib/localstack/tmp/lambda_script_l_8d7eedd6.py\", line 42, in handler\n    sqs = create_external_boto_client(\"sqs\")\n", "  File \"/var/lib/localstack/tmp/lambda_script_l_8d7eedd6.py\", line 52, in create_external_boto_client\n    return boto3.client(service, endpoint_url=endpoint_url)\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/__init__.py\", line 92, in client\n    return _get_default_session().client(*args, **kwargs)\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/boto3/session.py\", line 299, in client\n    return self._session.create_client(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/session.py\", line 950, in create_client\n    client = client_creator.create_client(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py\", line 123, in create_client\n    client_args = self._get_client_args(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py\", line 466, in _get_client_args\n    return args_creator.get_client_args(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 87, in get_client_args\n    final_args = self.compute_client_args(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 183, in compute_client_args\n    endpoint_config = self._compute_endpoint_config(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 278, in _compute_endpoint_config\n    return self._resolve_endpoint(**resolve_endpoint_kwargs)\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/args.py\", line 381, in _resolve_endpoint\n    return endpoint_bridge.resolve(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/client.py\", line 566, in resolve\n    resolved = self.endpoint_resolver.construct_endpoint(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/regions.py\", line 205, in construct_endpoint\n    result = self._endpoint_for_partition(\n", "  File \"/opt/code/localstack/.venv/lib/python3.10/site-packages/botocore/regions.py\", line 253, in _endpoint_for_partition\n    raise NoRegionError()\n"]}
```