### PR TITLE
fix apigateway aws lambda integration invocation

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -12,6 +12,7 @@ from requests import Response
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON, HEADER_CONTENT_TYPE
+from localstack.services.apigateway import helpers
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.helpers import (
     extract_path_params,
@@ -268,6 +269,62 @@ class LambdaProxyIntegration(BackendIntegration):
         invocation_context.response = response
 
         self.response_templates.render(invocation_context)
+        return invocation_context.response
+
+
+class LambdaIntegration(BackendIntegration):
+    def invoke(self, invocation_context: ApiInvocationContext):
+        uri = (
+            invocation_context.integration.get("uri")
+            or invocation_context.integration.get("integrationUri")
+            or ""
+        )
+        func_arn = uri
+        if ":lambda:path" in uri:
+            func_arn = uri.split(":lambda:path")[1].split("functions/")[1].split("/invocations")[0]
+
+        headers = helpers.create_invocation_headers(invocation_context)
+        invocation_context.context = helpers.get_event_request_context(invocation_context)
+        invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
+        if invocation_context.authorizer_type:
+            invocation_context.context["authorizer"] = invocation_context.auth_context
+
+        request_templates = RequestTemplates()
+        payload = request_templates.render(invocation_context)
+
+        invocation_result = lambda_api.run_lambda(
+            func_arn=func_arn,
+            event=payload,
+        )
+        result = invocation_result.result
+
+        if isinstance(result, FlaskResponse):
+            response = flask_to_requests_response(result)
+        elif isinstance(result, Response):
+            response = result
+        else:
+            response = LambdaResponse()
+
+            is_async = headers.get("X-Amz-Invocation-Type", "").strip("'") == "Event"
+
+            if is_async:
+                response._content = ""
+                response.status_code = 200
+            else:
+                parsed_result = (
+                    result if isinstance(result, dict) else json.loads(str(result or "{}"))
+                )
+                parsed_result = common.json_safe(parsed_result)
+                parsed_result = {} if parsed_result is None else parsed_result
+                response.status_code = 200
+                response._content = parsed_result
+
+        # apply custom response template
+        invocation_context.response = response
+
+        response_templates = ResponseTemplates()
+        response_templates.render(invocation_context)
+        invocation_context.response.headers["Content-Length"] = str(len(response.content or ""))
         return invocation_context.response
 
 

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -311,9 +311,22 @@ class LambdaIntegration(BackendIntegration):
                 response._content = ""
                 response.status_code = 200
             else:
-                parsed_result = (
-                    result if isinstance(result, dict) else json.loads(str(result or "{}"))
-                )
+                # depending on the lambda executor sometimes it returns a string and sometimes a dict
+                match result:
+                    case dict():
+                        parsed_result = result
+                    case str():
+                        # try to parse the result as json, if it succeeds we assume it's a valid
+                        # json string and we don't do anything.
+                        if isinstance(json.loads(result or "{}"), dict):
+                            parsed_result = result
+                        else:
+                            # the docker executor returns a string wrapping a json string,
+                            # so we need to remove the outer string
+                            parsed_result = json.loads(result or "{}")
+                    case _:
+                        parsed_result = json.loads(str(result or "{}"))
+
                 parsed_result = common.json_safe(parsed_result)
                 parsed_result = {} if parsed_result is None else parsed_result
                 response.status_code = 200

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Union
 from urllib.parse import urljoin
 
 import requests
-from flask import Response as FlaskResponse
 from jsonschema import ValidationError, validate
 from requests.models import Response
 
@@ -21,6 +20,7 @@ from localstack.services.apigateway.helpers import (
     make_error_response,
 )
 from localstack.services.apigateway.integration import (
+    LambdaIntegration,
     LambdaProxyIntegration,
     MockIntegration,
     RequestTemplates,
@@ -28,17 +28,11 @@ from localstack.services.apigateway.integration import (
     SnsIntegration,
     VtlTemplate,
 )
-from localstack.services.awslambda import lambda_api
 from localstack.services.kinesis import kinesis_listener
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_responses import (
-    LambdaResponse,
-    flask_to_requests_response,
-    request_response_stream,
-    requests_response,
-)
+from localstack.utils.aws.aws_responses import request_response_stream, requests_response
 from localstack.utils.common import camel_to_snake_case, json_safe
 
 # set up logger
@@ -313,8 +307,6 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
     method = invocation_context.method
     data = invocation_context.data
     headers = invocation_context.headers
-    api_id = invocation_context.api_id
-    stage = invocation_context.stage
     resource_path = invocation_context.resource_path
     integration = invocation_context.integration
     integration_response = integration.get("integrationResponses", {})
@@ -341,67 +333,7 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
         if integration_type == "AWS_PROXY":
             return LambdaProxyIntegration().invoke(invocation_context)
         elif integration_type == "AWS":
-            func_arn = uri
-            if ":lambda:path" in uri:
-                func_arn = (
-                    uri.split(":lambda:path")[1].split("functions/")[1].split("/invocations")[0]
-                )
-
-            headers = helpers.create_invocation_headers(invocation_context)
-            invocation_context.context = helpers.get_event_request_context(invocation_context)
-            invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
-            if invocation_context.authorizer_type:
-                invocation_context.context["authorizer"] = invocation_context.auth_context
-
-            request_templates = RequestTemplates()
-            payload = request_templates.render(invocation_context)
-
-            # TODO: change this signature to InvocationContext as well!
-            result = lambda_api.process_apigateway_invocation(
-                func_arn,
-                relative_path,
-                payload,
-                stage,
-                api_id,
-                headers,
-                is_base64_encoded=invocation_context.is_data_base64_encoded,
-                path_params=path_params,
-                query_string_params=query_string_params,
-                method=method,
-                resource_path=resource_path,
-                request_context=invocation_context.context,
-                stage_variables=invocation_context.stage_variables,
-            )
-
-            if isinstance(result, FlaskResponse):
-                response = flask_to_requests_response(result)
-            elif isinstance(result, Response):
-                response = result
-            else:
-                response = LambdaResponse()
-
-                is_async = headers.get("X-Amz-Invocation-Type", "").strip("'") == "Event"
-
-                if is_async:
-                    response._content = ""
-                    response.status_code = 200
-                else:
-                    parsed_result = (
-                        result if isinstance(result, dict) else json.loads(str(result or "{}"))
-                    )
-                    parsed_result = common.json_safe(parsed_result)
-                    parsed_result = {} if parsed_result is None else parsed_result
-                    response.status_code = 200
-                    response._content = parsed_result
-                    update_content_length(response)
-
-            # apply custom response template
-            invocation_context.response = response
-
-            response_templates = ResponseTemplates()
-            response_templates.render(invocation_context)
-            invocation_context.response.headers["Content-Length"] = str(len(response.content or ""))
-            return invocation_context.response
+            return LambdaIntegration().invoke(invocation_context)
 
         raise Exception(
             f'API Gateway integration type "{integration_type}", action "{uri}", method "{method}"'

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -118,8 +118,13 @@ def apply_patches():
         return 400, {}, ""
 
     def apigateway_response_resource_individual(self, request, full_url, headers):
-        if request.method in ["GET", "POST", "DELETE"]:
+        if request.method in ["GET", "DELETE"]:
             return apigateway_response_resource_individual_orig(self, request, full_url, headers)
+        if request.method == "POST":
+            _, _, result = apigateway_response_resource_individual_orig(
+                self, request, full_url, headers
+            )
+            return 201, {}, result
 
         self.setup_class(request, full_url, headers)
         function_id = self.path.replace("/restapis/", "", 1).split("/")[0]
@@ -148,7 +153,7 @@ def apply_patches():
             resource = self.backend.get_resource(function_id, resource_id)
             resource.resource_methods[method_type]["requestParameters"] = request_parameters
             method = resource.resource_methods[method_type]
-            result = 200, {}, json.dumps(method)
+            result = 201, {}, json.dumps(method)
         if len(result) != 3:
             return result
         authorization_type = self._get_param("authorizationType")
@@ -159,7 +164,8 @@ def apply_patches():
                 if "authorizerId" in payload:
                     data["authorizerId"] = payload["authorizerId"]
                     result = result[0], result[1], json.dumps(data)
-        return result
+                    return result
+        return 201, {}, result[2]
 
     def apigateway_response_integrations(self, request, *args, **kwargs):
         result = apigateway_response_integrations_orig(self, request, *args, **kwargs)
@@ -186,7 +192,7 @@ def apply_patches():
             integration["requestParameters"] = request_parameters
             integration["cacheKeyParameters"] = cache_key_parameters
             integration["contentHandling"] = content_handling
-            return 200, {}, json.dumps(integration)
+            return 201, {}, json.dumps(integration)
 
         if self.method == "PATCH":
             patch_operations = self._get_param("patchOperations")
@@ -207,7 +213,7 @@ def apply_patches():
         result = apigateway_response_integration_responses_orig(self, request, *args, **kwargs)
         response_parameters = self._get_param("responseParameters")
 
-        if self.method == "PUT" and response_parameters:
+        if self.method == "PUT":
             url_path_parts = self.path.split("/")
             function_id = url_path_parts[2]
             resource_id = url_path_parts[4]
@@ -217,9 +223,11 @@ def apply_patches():
             integration_response = self.backend.get_integration_response(
                 function_id, resource_id, method_type, status_code
             )
-            integration_response["responseParameters"] = response_parameters
 
-            return 200, {}, json.dumps(integration_response)
+            if response_parameters:
+                integration_response["responseParameters"] = response_parameters
+
+            return 201, {}, json.dumps(integration_response)
 
         return result
 
@@ -227,7 +235,7 @@ def apply_patches():
         result = apigateway_response_resource_method_responses_orig(self, request, *args, **kwargs)
         response_parameters = self._get_param("responseParameters")
 
-        if self.method == "PUT" and response_parameters:
+        if self.method == "PUT":
             url_path_parts = self.path.split("/")
             function_id = url_path_parts[2]
             resource_id = url_path_parts[4]
@@ -238,9 +246,10 @@ def apply_patches():
                 function_id, resource_id, method_type, response_code
             )
 
-            method_response["responseParameters"] = response_parameters
+            if response_parameters:
+                method_response["responseParameters"] = response_parameters
 
-            return 200, {}, json.dumps(method_response)
+            return 201, {}, json.dumps(method_response)
 
         return result
 
@@ -440,7 +449,7 @@ def apply_patches():
             deployment = self.backend.update_deployment(
                 function_id, deployment_id, patch_operations
             )
-            return 200, {}, json.dumps(deployment)
+            return 201, {}, json.dumps(deployment)
         return result
 
     # patch create_rest_api to allow using static API IDs defined via tags
@@ -452,6 +461,18 @@ def apply_patches():
             self.apis.pop(result.id)
             result.id = custom_id
             self.apis[custom_id] = result
+        return result
+
+    def apigateway_response_deployments(self, request, full_url, headers):
+        result = apigateway_response_deployments_orig(self, request, full_url, headers)
+        if self.method == "POST":
+            return 201, {}, result[2]
+        return result
+
+    def apigateway_restapis_stages(self, request, full_url, headers):
+        result = apigateway_restapis_stages_orig(self, request, full_url, headers)
+        if self.method == "POST":
+            return 201, {}, result[2]
         return result
 
     create_rest_api_orig = apigateway_models.APIGatewayBackend.create_rest_api
@@ -472,3 +493,7 @@ def apply_patches():
     apigateway_response_usage_plan_individual_orig = APIGatewayResponse.usage_plan_individual
     APIGatewayResponse.usage_plan_individual = apigateway_response_usage_plan_individual
     apigateway_models.RestAPI.to_dict = apigateway_models_RestAPI_to_dict
+    apigateway_response_deployments_orig = APIGatewayResponse.deployments
+    APIGatewayResponse.deployments = apigateway_response_deployments
+    apigateway_restapis_stages_orig = APIGatewayResponse.restapis_stages
+    APIGatewayResponse.restapis_stages = apigateway_restapis_stages

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -118,8 +118,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
     @handler("CreateRestApi", expand=False)
     def create_rest_api(self, context: RequestContext, request: CreateRestApiRequest) -> RestApi:
-        result = call_moto(context)
-        return result
+        return call_moto(context)
 
     def delete_rest_api(self, context: RequestContext, rest_api_id: String) -> None:
         try:

--- a/tests/integration/apigateway_fixtures.py
+++ b/tests/integration/apigateway_fixtures.py
@@ -123,13 +123,13 @@ def create_base_path_mapping(apigateway_client, **kwargs):
 
 def create_rest_api_deployment(apigateway_client, **kwargs):
     response = apigateway_client.create_deployment(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response.get("id"), response.get("createdDate")
 
 
 def update_rest_api_deployment(apigateway_client, **kwargs):
     response = apigateway_client.update_deployment(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response
 
 

--- a/tests/integration/apigateway_fixtures.py
+++ b/tests/integration/apigateway_fixtures.py
@@ -61,7 +61,7 @@ def delete_rest_api(apigateway_client, **kwargs):
 
 def create_rest_resource(apigateway_client, **kwargs):
     response = apigateway_client.create_resource(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response.get("id"), response.get("parentId")
 
 
@@ -72,7 +72,7 @@ def delete_rest_resource(apigateway_client, **kwargs):
 
 def create_rest_resource_method(apigateway_client, **kwargs):
     response = apigateway_client.put_method(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response.get("httpMethod"), response.get("authorizerId")
 
 
@@ -84,7 +84,7 @@ def create_rest_authorizer(apigateway_client, **kwargs):
 
 def create_rest_api_integration(apigateway_client, **kwargs):
     response = apigateway_client.put_integration(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response.get("uri"), response.get("type")
 
 
@@ -100,13 +100,13 @@ def get_rest_api_integration(apigateway_client, **kwargs):
 
 def create_rest_api_method_response(apigateway_client, **kwargs):
     response = apigateway_client.put_method_response(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response.get("statusCode")
 
 
 def create_rest_api_integration_response(apigateway_client, **kwargs):
     response = apigateway_client.put_integration_response(**kwargs)
-    assert_response_is_200(response)
+    assert_response_is_201(response)
     return response.get("statusCode")
 
 
@@ -131,6 +131,12 @@ def update_rest_api_deployment(apigateway_client, **kwargs):
     response = apigateway_client.update_deployment(**kwargs)
     assert_response_is_200(response)
     return response
+
+
+def create_rest_api_stage(apigateway_client, **kwargs):
+    response = apigateway_client.create_stage(**kwargs)
+    assert_response_is_201(response)
+    return response.get("stageName")
 
 
 def create_cognito_user_pool(cognito_idp, **kwargs):

--- a/tests/integration/awslambda/functions/lambda_aws_proxy.py
+++ b/tests/integration/awslambda/functions/lambda_aws_proxy.py
@@ -1,0 +1,10 @@
+import json
+
+
+def handler(event, context):
+    # Just print the event that was passed to the Lambda
+    print(json.dumps(event))
+    return {
+        "statusCode": 200,
+        "body": json.dumps(event),
+    }

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -82,6 +82,7 @@ TEST_LAMBDA_PYTHON_VERSION = os.path.join(THIS_FOLDER, "functions/lambda_python_
 TEST_LAMBDA_PYTHON_UNHANDLED_ERROR = os.path.join(
     THIS_FOLDER, "functions/lambda_unhandled_error.py"
 )
+TEST_LAMBDA_AWS_PROXY = os.path.join(THIS_FOLDER, "functions/lambda_aws_proxy.py")
 TEST_LAMBDA_PYTHON3 = os.path.join(THIS_FOLDER, "functions/lambda_python3.py")
 TEST_LAMBDA_INTEGRATION_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_integration.js")
 TEST_LAMBDA_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_handler.js")

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -469,7 +469,6 @@ class TestAPIGateway:
 
         delete_rest_api(apigateway_client, apiId=api_id)
 
-
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
     def test_api_gateway_http_integrations(self, int_type, monkeypatch):
         monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1908,7 +1908,7 @@ class TestAPIGateway:
         )
         assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
         assert 200 == response.get("status")
-        assert "response from" in response.get("body").get("body")
+        assert "response from" in json.loads(response.get("body")).get("body")
 
         # run test_invoke_method API #2
         response = client.test_invoke_method(
@@ -1921,8 +1921,8 @@ class TestAPIGateway:
         )
         assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
         assert 200 == response.get("status")
-        assert "response from" in response.get("body").get("body")
-        assert "val123" in response.get("body").get("body")
+        assert "response from" in json.loads(response.get("body")).get("body")
+        assert "val123" in json.loads(response.get("body")).get("body")
 
         # Clean up
         lambda_client.delete_function(FunctionName=fn_name)

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -183,6 +183,7 @@ class TestAPIGateway:
         assert test_id == result["id"]
         assert apigw_name == result["name"]
 
+    @pytest.mark.skip
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
         stream = aws_stack.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
@@ -445,7 +446,7 @@ class TestAPIGateway:
                 "method.response.header.Content-Type": "'text/html'",
             },
         )
-        deployment_id = create_rest_api_deployment(apigateway_client, restApiId=api_id)
+        deployment_id, _ = create_rest_api_deployment(apigateway_client, restApiId=api_id)
         stage = create_rest_api_stage(
             apigateway_client, restApiId=api_id, stageName="local", deploymentId=deployment_id
         )

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -183,7 +183,6 @@ class TestAPIGateway:
         assert test_id == result["id"]
         assert apigw_name == result["name"]
 
-    @pytest.mark.skip
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
         stream = aws_stack.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -50,6 +50,7 @@ from tests.integration.apigateway_fixtures import (
     create_rest_api_integration,
     create_rest_api_integration_response,
     create_rest_api_method_response,
+    create_rest_api_stage,
     create_rest_resource,
     create_rest_resource_method,
     delete_rest_api,
@@ -59,6 +60,7 @@ from tests.integration.awslambda.test_lambda_integration import TEST_STAGE_NAME
 
 from ..unit.test_apigateway import load_test_resource
 from .awslambda.test_lambda import (
+    TEST_LAMBDA_AWS_PROXY,
     TEST_LAMBDA_HTTP_RUST,
     TEST_LAMBDA_LIBS,
     TEST_LAMBDA_NODEJS,
@@ -340,12 +342,13 @@ class TestAPIGateway:
 
     def test_api_gateway_lambda_integration(self, apigateway_client, create_lambda_function):
         """
-        API gateway to lambda integration test returns a response with the same body as the lambda function input.
+        API gateway to lambda integration test returns a response with the same body as the lambda
+        function input event.
         """
         fn_name = f"test-{short_uid()}"
         create_lambda_function(
             func_name=fn_name,
-            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            handler_file=TEST_LAMBDA_AWS_PROXY,
             runtime=LAMBDA_RUNTIME_PYTHON39,
         )
         lambda_arn = aws_stack.lambda_function_arn(fn_name)
@@ -369,7 +372,7 @@ class TestAPIGateway:
             resourceId=resource_id,
             httpMethod="GET",
             integrationHttpMethod="GET",
-            type="AWS",
+            type="AWS_PROXY",
             uri=f"arn:aws:apigateway:{aws_stack.get_region()}:lambda:path//2015-03-31/functions/{lambda_arn}/invocations",
         )
 
@@ -379,6 +382,90 @@ class TestAPIGateway:
 
         # authorizer contains an object that does not contain the authorizer type ('lambda', 'sns')
         assert body.get("requestContext").get("authorizer") == {"context": {}, "identity": {}}
+
+    @pytest.mark.aws_validated
+    def test_api_gateway_lambda_integration_aws_type(
+        self, apigateway_client, create_lambda_function, lambda_client, sts_client
+    ):
+        region_name = apigateway_client._client_config.region_name
+        fn_name = f"test-{short_uid()}"
+        create_lambda_function(
+            func_name=fn_name,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            runtime=LAMBDA_RUNTIME_PYTHON39,
+        )
+        lambda_arn = lambda_client.get_function(FunctionName=fn_name)["Configuration"][
+            "FunctionArn"
+        ]
+
+        api_id, _, root = create_rest_api(apigateway_client, name="aws lambda api")
+        resource_id, _ = create_rest_resource(
+            apigateway_client, restApiId=api_id, parentId=root, pathPart="test"
+        )
+        create_rest_resource_method(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+        )
+        create_rest_api_integration(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            integrationHttpMethod="POST",
+            type="AWS",
+            uri=f"arn:aws:apigateway:{region_name}:lambda:path//2015-03-31/functions/"
+            f"{lambda_arn}/invocations",
+            requestTemplates={
+                "application/json": '#set($allParams = $input.params())\n{\n"body-json" : $input.json("$"),\n"params" : {\n#foreach($type in $allParams.keySet())\n    #set($params = $allParams.get($type))\n"$type" : {\n    #foreach($paramName in $params.keySet())\n    "$paramName" : "$util.escapeJavaScript($params.get($paramName))"\n        #if($foreach.hasNext),#end\n    #end\n}\n    #if($foreach.hasNext),#end\n#end\n},\n"stage-variables" : {\n#foreach($key in $stageVariables.keySet())\n"$key" : "$util.escapeJavaScript($stageVariables.get($key))"\n    #if($foreach.hasNext),#end\n#end\n},\n"context" : {\n    "api-id" : "$context.apiId",\n    "api-key" : "$context.identity.apiKey",\n    "http-method" : "$context.httpMethod",\n    "stage" : "$context.stage",\n    "source-ip" : "$context.identity.sourceIp",\n    "user-agent" : "$context.identity.userAgent",\n    "request-id" : "$context.requestId",\n    "resource-id" : "$context.resourceId",\n    "resource-path" : "$context.resourcePath"\n    }\n}\n'
+            },
+        )
+        create_rest_api_method_response(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+            responseParameters={
+                "method.response.header.Content-Type": False,
+                "method.response.header.Access-Control-Allow-Origin": False,
+            },
+        )
+        create_rest_api_integration_response(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+            responseTemplates={"text/html": "$input.path('$')"},
+            responseParameters={
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Content-Type": "'text/html'",
+            },
+        )
+        deployment_id = create_rest_api_deployment(apigateway_client, restApiId=api_id)
+        stage = create_rest_api_stage(
+            apigateway_client, restApiId=api_id, stageName="local", deploymentId=deployment_id
+        )
+
+        aws_account_id = sts_client.get_caller_identity()["Account"]
+        source_arn = f"arn:aws:execute-api:{region_name}:{aws_account_id}:{api_id}/*/*/test"
+
+        lambda_client.add_permission(
+            FunctionName=lambda_arn,
+            StatementId=str(short_uid()),
+            Action="lambda:InvokeFunction",
+            Principal="apigateway.amazonaws.com",
+            SourceArn=source_arn,
+        )
+
+        url = api_invoke_url(api_id, stage=stage, path="/test")
+        response = requests.post(url, json={"test": "test"})
+
+        assert response.headers["Content-Type"] == "text/html"
+        assert response.headers["Access-Control-Allow-Origin"] == "*"
 
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
     def test_api_gateway_http_integrations(self, int_type, monkeypatch):
@@ -711,7 +798,7 @@ class TestAPIGateway:
             "contentHandling",
             "requestParameters",
         ]
-        assert 200 == rs["ResponseMetadata"]["HTTPStatusCode"]
+        assert 201 == rs["ResponseMetadata"]["HTTPStatusCode"]
         for key in integration_keys:
             assert key in rs
         assert "responseTemplates" not in rs
@@ -731,17 +818,14 @@ class TestAPIGateway:
         response = requests.get(f"{url}?param1=foobar")
         assert response.status_code < 400
         content = response.json()
-        assert '{"param1": "foobar"}' == content.get("body").get("body")
+        assert '{"param1": "foobar"}' == content.get("event")
 
         # additional checks from https://github.com/localstack/localstack/issues/5041
         # pass Signature param
         response = requests.get(f"{url}?param1=foobar&Signature=1")
         assert response.status_code == 200
         content = response.json()
-        assert '{"param1": "foobar"}' == content.get("body").get("body")
-        assert {"Signature": "1", "param1": "foobar"} == content.get("body").get(
-            "queryStringParameters"
-        )
+        assert '{"param1": "foobar"}' == content.get("event")
 
         # delete integration
         rs = apigw_client.delete_integration(

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -467,6 +467,9 @@ class TestAPIGateway:
         assert response.headers["Content-Type"] == "text/html"
         assert response.headers["Access-Control-Allow-Origin"] == "*"
 
+        delete_rest_api(apigateway_client, apiId=api_id)
+
+
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
     def test_api_gateway_http_integrations(self, int_type, monkeypatch):
         monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -467,7 +467,7 @@ class TestAPIGateway:
         assert response.headers["Content-Type"] == "text/html"
         assert response.headers["Access-Control-Allow-Origin"] == "*"
 
-        delete_rest_api(apigateway_client, apiId=api_id)
+        delete_rest_api(apigateway_client, restApiId=api_id)
 
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
     def test_api_gateway_http_integrations(self, int_type, monkeypatch):

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -263,7 +263,7 @@ def test_integration_response(apigateway_client):
         {
             "statusCode": "200",
             "selectionPattern": "foobar",
-            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "ResponseMetadata": {"HTTPStatusCode": 201},
             "responseTemplates": {},  # Note: TF compatibility
         }
     )
@@ -342,7 +342,7 @@ def test_integration_response(apigateway_client):
         {
             "statusCode": "200",
             "selectionPattern": "foobar",
-            "ResponseMetadata": {"HTTPStatusCode": 200},
+            "ResponseMetadata": {"HTTPStatusCode": 201},
             "responseTemplates": {},  # Note: TF compatibility
             "contentHandling": "CONVERT_TO_BINARY",
         }


### PR DESCRIPTION
Adds more parity validations and fixes the AWS lambda integration invocation

* Fixes API responses status codes
* Separates AWS from AWS_TYPE lambda integration.
Fixes https://github.com/localstack/localstack/issues/6462
