### PR TITLE
add caching for service catalog indexes

### DIFF
--- a/localstack/aws/spec.py
+++ b/localstack/aws/spec.py
@@ -1,5 +1,6 @@
+import dataclasses
 from collections import defaultdict
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import Dict, Generator, List, Optional, Tuple
 
 from botocore.loaders import create_loader
@@ -36,48 +37,7 @@ def iterate_service_operations() -> Generator[Tuple[ServiceModel, OperationModel
 
 class ServiceCatalog:
     def get(self, name: ServiceName) -> Optional[ServiceModel]:
-        return self.services.get(name)
-
-    @cached_property
-    def services(self) -> Dict[ServiceName, ServiceModel]:
-        return {service.service_name: service for service in list_services()}
-
-    @cached_property
-    def service_names(self) -> List[ServiceName]:
-        return list(self.services.keys())
-
-    @cached_property
-    def target_prefix_index(self) -> Dict[str, List[ServiceName]]:
-        result = defaultdict(list)
-        for service in self.services.values():
-            target_prefix = service.metadata.get("targetPrefix")
-            if target_prefix:
-                result[target_prefix].append(service.service_name)
-        return dict(result)
-
-    @cached_property
-    def signing_name_index(self) -> Dict[str, List[ServiceName]]:
-        result = defaultdict(list)
-        for service in self.services.values():
-            result[service.signing_name].append(service.service_name)
-        return dict(result)
-
-    @cached_property
-    def operations_index(self) -> Dict[str, List[ServiceName]]:
-        result = defaultdict(list)
-        for service in self.services.values():
-            operations = service.operation_names
-            if operations:
-                for operation in operations:
-                    result[operation].append(service.service_name)
-        return dict(result)
-
-    @cached_property
-    def endpoint_prefix_index(self) -> Dict[str, List[ServiceName]]:
-        result = defaultdict(list)
-        for service in self.services.values():
-            result[service.endpoint_prefix].append(service.service_name)
-        return dict(result)
+        return self._services.get(name)
 
     def by_target_prefix(self, target_prefix: str) -> List[ServiceName]:
         return self.target_prefix_index.get(target_prefix, [])
@@ -87,3 +47,125 @@ class ServiceCatalog:
 
     def by_operation(self, operation_name: str) -> List[ServiceName]:
         return self.operations_index.get(operation_name, [])
+
+    @cached_property
+    def service_names(self) -> List[ServiceName]:
+        return list(self._services.keys())
+
+    @cached_property
+    def target_prefix_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self._services.values():
+            target_prefix = service.metadata.get("targetPrefix")
+            if target_prefix:
+                result[target_prefix].append(service.service_name)
+        return dict(result)
+
+    @cached_property
+    def signing_name_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self._services.values():
+            result[service.signing_name].append(service.service_name)
+        return dict(result)
+
+    @cached_property
+    def operations_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self._services.values():
+            operations = service.operation_names
+            if operations:
+                for operation in operations:
+                    result[operation].append(service.service_name)
+        return dict(result)
+
+    @cached_property
+    def endpoint_prefix_index(self) -> Dict[str, List[ServiceName]]:
+        result = defaultdict(list)
+        for service in self._services.values():
+            result[service.endpoint_prefix].append(service.service_name)
+        return dict(result)
+
+    @cached_property
+    def _services(self) -> Dict[ServiceName, ServiceModel]:
+        # since index creation requires all services to be loaded, we implement this method here
+        # to load and cache all services up front, and then let .get access this cache as well.
+        return {service.service_name: service for service in list_services()}
+
+
+@dataclasses.dataclass
+class ServiceCatalogIndex:
+    service_names: List[ServiceName]
+    endpoint_prefix_index: Dict[str, List[ServiceName]]
+    operations_index: Dict[str, List[ServiceName]]
+    signing_name_index: Dict[str, List[ServiceName]]
+    target_prefix_index: Dict[str, List[ServiceName]]
+
+
+class CachedServiceCatalog(ServiceCatalog):
+    """
+    A ServiceCatalog that uses a pre-built ServiceCatalogIndex instead of resolving the indices
+    lazily at runtime from the specifications.
+    """
+
+    index: ServiceCatalogIndex
+
+    def __init__(self, index: ServiceCatalogIndex):
+        self.index = index
+
+    @lru_cache(maxsize=512)
+    def get(self, name: ServiceName) -> Optional[ServiceModel]:
+        return load_service(name)
+
+    @property
+    def service_names(self) -> List[ServiceName]:
+        return self.index.service_names
+
+    @property
+    def target_prefix_index(self) -> Dict[str, List[ServiceName]]:
+        return self.index.target_prefix_index
+
+    @property
+    def signing_name_index(self) -> Dict[str, List[ServiceName]]:
+        return self.index.signing_name_index
+
+    @property
+    def operations_index(self) -> Dict[str, List[ServiceName]]:
+        return self.index.operations_index
+
+    @property
+    def endpoint_prefix_index(self) -> Dict[str, List[ServiceName]]:
+        return self.index.endpoint_prefix_index
+
+
+def save_service_index_cache(catalog: ServiceCatalog, file_path: str) -> ServiceCatalogIndex:
+    """
+    Extracts from the given ServiceCatalog a ServiceCatalogIndex and pickles that into the given file.
+    :param catalog: the catalog that creates the service-operation indexes.
+    :param file_path: the path to pickle to
+    :return: the created ServiceCatalogIndex
+    """
+    import pickle
+
+    cache = ServiceCatalogIndex(
+        catalog.service_names,
+        catalog.endpoint_prefix_index,
+        catalog.operations_index,
+        catalog.signing_name_index,
+        catalog.target_prefix_index,
+    )
+    with open(file_path, "wb") as fd:
+        pickle.dump(cache, fd)
+    return cache
+
+
+def load_service_index_cache(file: str) -> ServiceCatalogIndex:
+    """
+    Loads from the given file the pickled ServiceCatalogIndex.
+
+    :param file: the file to load from
+    :return: the loaded ServiceCatalogIndex
+    """
+    import pickle
+
+    with open(file, "rb") as fd:
+        return pickle.load(fd)

--- a/localstack/aws/spec.py
+++ b/localstack/aws/spec.py
@@ -35,18 +35,23 @@ def iterate_service_operations() -> Generator[Tuple[ServiceModel, OperationModel
             yield service, service.operation_model(op_name)
 
 
-class ServiceCatalog:
-    def get(self, name: ServiceName) -> Optional[ServiceModel]:
-        return self._services.get(name)
+@dataclasses.dataclass
+class ServiceCatalogIndex:
+    """
+    The ServiceCatalogIndex enables fast lookups for common operations to determine a service from service indicators.
+    """
 
-    def by_target_prefix(self, target_prefix: str) -> List[ServiceName]:
-        return self.target_prefix_index.get(target_prefix, [])
+    service_names: List[ServiceName]
+    target_prefix_index: Dict[str, List[ServiceName]]
+    signing_name_index: Dict[str, List[ServiceName]]
+    operations_index: Dict[str, List[ServiceName]]
+    endpoint_prefix_index: Dict[str, List[ServiceName]]
 
-    def by_signing_name(self, signing_name: str) -> List[ServiceName]:
-        return self.signing_name_index.get(signing_name, [])
 
-    def by_operation(self, operation_name: str) -> List[ServiceName]:
-        return self.operations_index.get(operation_name, [])
+class LazyServiceCatalogIndex:
+    """
+    A ServiceCatalogIndex that builds indexes in-memory from the spec.
+    """
 
     @cached_property
     def service_names(self) -> List[ServiceName]:
@@ -87,30 +92,14 @@ class ServiceCatalog:
 
     @cached_property
     def _services(self) -> Dict[ServiceName, ServiceModel]:
-        # since index creation requires all services to be loaded, we implement this method here
-        # to load and cache all services up front, and then let .get access this cache as well.
         return {service.service_name: service for service in list_services()}
 
 
-@dataclasses.dataclass
-class ServiceCatalogIndex:
-    service_names: List[ServiceName]
-    endpoint_prefix_index: Dict[str, List[ServiceName]]
-    operations_index: Dict[str, List[ServiceName]]
-    signing_name_index: Dict[str, List[ServiceName]]
-    target_prefix_index: Dict[str, List[ServiceName]]
-
-
-class CachedServiceCatalog(ServiceCatalog):
-    """
-    A ServiceCatalog that uses a pre-built ServiceCatalogIndex instead of resolving the indices
-    lazily at runtime from the specifications.
-    """
-
+class ServiceCatalog:
     index: ServiceCatalogIndex
 
-    def __init__(self, index: ServiceCatalogIndex):
-        self.index = index
+    def __init__(self, index: ServiceCatalogIndex = None):
+        self.index = index or LazyServiceCatalogIndex()
 
     @lru_cache(maxsize=512)
     def get(self, name: ServiceName) -> Optional[ServiceModel]:
@@ -136,26 +125,24 @@ class CachedServiceCatalog(ServiceCatalog):
     def endpoint_prefix_index(self) -> Dict[str, List[ServiceName]]:
         return self.index.endpoint_prefix_index
 
+    def by_target_prefix(self, target_prefix: str) -> List[ServiceName]:
+        return self.target_prefix_index.get(target_prefix, [])
 
-def save_service_index_cache(catalog: ServiceCatalog, file_path: str) -> ServiceCatalogIndex:
+    def by_signing_name(self, signing_name: str) -> List[ServiceName]:
+        return self.signing_name_index.get(signing_name, [])
+
+    def by_operation(self, operation_name: str) -> List[ServiceName]:
+        return self.operations_index.get(operation_name, [])
+
+
+def build_service_index_cache(file_path: str) -> ServiceCatalogIndex:
     """
-    Extracts from the given ServiceCatalog a ServiceCatalogIndex and pickles that into the given file.
-    :param catalog: the catalog that creates the service-operation indexes.
+    Creates a new ServiceCatalogIndex and stores it into the given file_path.
+
     :param file_path: the path to pickle to
     :return: the created ServiceCatalogIndex
     """
-    import pickle
-
-    cache = ServiceCatalogIndex(
-        catalog.service_names,
-        catalog.endpoint_prefix_index,
-        catalog.operations_index,
-        catalog.signing_name_index,
-        catalog.target_prefix_index,
-    )
-    with open(file_path, "wb") as fd:
-        pickle.dump(cache, fd)
-    return cache
+    return save_service_index_cache(LazyServiceCatalogIndex(), file_path)
 
 
 def load_service_index_cache(file: str) -> ServiceCatalogIndex:
@@ -169,3 +156,26 @@ def load_service_index_cache(file: str) -> ServiceCatalogIndex:
 
     with open(file, "rb") as fd:
         return pickle.load(fd)
+
+
+def save_service_index_cache(index: LazyServiceCatalogIndex, file_path: str) -> ServiceCatalogIndex:
+    """
+    Creates from the given LazyServiceCatalogIndex a ``ServiceCatalogIndex`, pickles its contents into the given file,
+    and then returns the newly created index.
+
+    :param index: the LazyServiceCatalogIndex to store the index from.
+    :param file_path: the path to pickle to
+    :return: the created ServiceCatalogIndex
+    """
+    import pickle
+
+    cache = ServiceCatalogIndex(
+        service_names=index.service_names,
+        endpoint_prefix_index=index.endpoint_prefix_index,
+        operations_index=index.operations_index,
+        signing_name_index=index.signing_name_index,
+        target_prefix_index=index.target_prefix_index,
+    )
+    with open(file_path, "wb") as fd:
+        pickle.dump(cache, fd)
+    return cache

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -19,7 +19,8 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
     Collects all service<>operation combinations to test.
     """
     service_catalog = get_service_catalog()
-    for service in service_catalog.services.values():
+    for service_name in service_catalog.service_names:
+        service = service_catalog.get(service_name)
         for operation_name in service.operation_names:
             # FIXME try to support more and more services, get these exclusions down!
             # Exclude all operations for the following, currently _not_ supported services

--- a/tests/unit/aws/test_spec.py
+++ b/tests/unit/aws/test_spec.py
@@ -1,0 +1,20 @@
+from localstack.aws.spec import (
+    LazyServiceCatalogIndex,
+    load_service_index_cache,
+    save_service_index_cache,
+)
+
+
+def test_pickled_index_equals_lazy_index(tmp_path):
+    file_path = tmp_path / "index-cache.pickle"
+
+    lazy_index = LazyServiceCatalogIndex()
+
+    save_service_index_cache(lazy_index, str(file_path))
+    cached_index = load_service_index_cache(str(file_path))
+
+    assert cached_index.service_names == lazy_index.service_names
+    assert cached_index.target_prefix_index == lazy_index.target_prefix_index
+    assert cached_index.signing_name_index == lazy_index.signing_name_index
+    assert cached_index.operations_index == lazy_index.operations_index
+    assert cached_index.endpoint_prefix_index == lazy_index.endpoint_prefix_index


### PR DESCRIPTION
This PR adds caching of the indexes created in the `ServiceCatalog`.

## Problem

The `ServiceCatalog` is what powers the `ServiceNameParser` by providing indexes that allow fast lookup of service indicators to services (e.g., finding the service by its signing name or endpoint prefix). Creating the indexes involves loading all 300-something services, and iterating over all 11k-something operations. This takes around 1500 ms on my machine. This happens the first time an HTTP call is made that triggers the `ServiceNameParser`, making the first call take at least 1500ms.

## Solution

@alexrashed raised some concerns in the past about shipping an index pre-built with the distribution, which was a valid point since that would involve an error-prone build step. So instead I opportunistically create the cache and store it in the localstack volume directory cache. I restructured the service catalog a bit to separate concerns (providing access to the index, vs actually holding the data). I added both the localstack and botocore version identifier to the file name so we always re-load the cache on new versions.

## Result

Loading the cache takes 8ms vs. creating it lazily which takes about 1500ms. This has a dramatic effect on cold starts, specifically the first invocation of a service now only loads the service model, which is much faster (previously we would also load *all* service models to build the index).

Here's me executing `awslocal opensearch list-domains`. "process" is the end-to-end server latency (timer around `Gateway.process`, and `by_signing_name` is what's being executed to look up the service):

Without caching:
```
# first invocation
Execution of "by_signing_name" took 1458.67ms
Execution of "process" took 1562.29ms
# second invocation
Execution of "by_signing_name" took 0.00ms
Execution of "process" took 23.25ms
```

With caching:
```
# first invocation
Execution of "by_signing_name" took 0.01ms
Execution of "process" took 127.29ms
# second invocation
Execution of "by_signing_name" took 0.00ms
Execution of "process" took 22.81ms
```

I also tried cold-starting several different services in a row. There's only a measurable effect for the first one. 
But a pretty dramatic one: 10x speedup for the first cold start.

### Drawbacks/Limitations

The index obviously has to be computed at some point. Previously we would do that on the first invocation of any HTTP request for *every* localstack run. Now we do it *once* when localstack starts up for the very first time. Any subsequent localstack runs will have no startup delay. This means that this PR has no effect on ephemeral instances of localstack (e.g., in CI environments). For that we would have to ship the index with the distribution.