### PR TITLE
Making it possible for KMS GetPublicKey to get ENCRYPT_DECRYPT keys.

### DIFF
--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -153,6 +153,10 @@ class TestKMS:
         with pytest.raises(InvalidSignature):
             _verify(result["Signature"] + b"foobar")
 
+    def test_get_public_key(self, kms_client, kms_create_key):
+        key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_2048")["KeyId"]
+        kms_client.get_public_key(KeyId=key_id)
+
     @pytest.mark.aws_validated
     def test_get_and_list_sign_key(self, kms_client, kms_create_key):
         response = kms_create_key(KeyUsage="SIGN_VERIFY", CustomerMasterKeySpec="ECC_NIST_P256")


### PR DESCRIPTION
Addresses https://github.com/localstack/localstack/issues/6605

Currently GetPublicKey succeeds for KeyUsage=SIGN_VERIFY keys, but not for ENCRYPT_DECRYPT asymmetric ones, as
1) moto doesn't have GetPublicKey implemented;
2) we allow moto to deal with ENCRYPT_DECRYPT keys, not storing them ourselves.

This PR makes LocalStack save all keys apart from KeyUsage=ENCRYPT_DECRYPT  + KeySpec=SYMMETRIC_DEFAULT, which makes it possible for GetPublicKey to fetch those keys. We do not store ENCRYPT_DECRYPT  + SYMMETRIC_DEFAULT symmetric keys, as I still have to look into how they are supposed to be handled. But GetPublicKey  in AWS doesn't work for such keys either way.