### PR TITLE
Fix metrics collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,8 +279,7 @@ jobs:
           name: Parity metric aggregation
           command: |
             source .venv/bin/activate
-            # TODO: remove this - workaround to temporarily unblock the pipeline for now
-            python scripts/metric_aggregator.py . amd64 || true
+            python scripts/metric_aggregator.py . amd64
       - store_artifacts:
           path: parity_metrics/
 

--- a/scripts/metric_aggregator.py
+++ b/scripts/metric_aggregator.py
@@ -149,6 +149,7 @@ def _init_service_metric_counter() -> Dict:
 
     for s, provider in SERVICE_PLUGINS.api_provider_specs.items():
         try:
+            print(f"found service {s}")
             service = load_service(s)
             ops = {}
             service_attributes = {"pro": "pro" in provider, "community": "default" in provider}
@@ -172,7 +173,7 @@ def _init_service_metric_counter() -> Dict:
 
             metric_recorder[s] = ops
         except Exception:
-            LOG.debug(f"cannot load service '{s}'")
+            print(f"cannot load service '{s}'")
     return metric_recorder
 
 

--- a/scripts/metric_aggregator.py
+++ b/scripts/metric_aggregator.py
@@ -83,7 +83,7 @@ def create_simple_html_report(file_name, metrics):
                 tmp += _generate_details_block_html("errors hit", op_details["errors"])
             tmp += "</ul>"
             tmp += "</p>"
-        output += f"<p><details><summary>{operation_tested/operation_counter*100:.2f}% test coverage</summary>\n\n{tmp}\n</details></p>\n"
+        output += f"<p><details><summary>{'-' if not operation_counter else operation_tested/operation_counter*100:.2f}% test coverage</summary>\n\n{tmp}\n</details></p>\n"
 
         with open(file_name, "a") as fd:
             fd.write(f"{output}\n")
@@ -150,9 +150,9 @@ def _load_service_info(service_name: str) -> Dict:
     from localstack.aws.spec import load_service
 
     try:
-        print(f"trying to load service {service_name}")
         info = {}
         service = load_service(service_name)
+        print(f"successfully loaded service {service_name}")
         for op in service.operation_names:
             attributes = {}
             attributes["invoked"] = 0
@@ -178,7 +178,6 @@ def _load_service_info(service_name: str) -> Dict:
 def _init_service_metric_counter() -> Dict:
     metric_recorder = {}
     for s, provider in SERVICE_PLUGINS.api_provider_specs.items():
-        print(f"found service {s}")
         ops = _load_service_info(s)
         service_attributes = {"pro": "pro" in provider, "community": "default" in provider}
         ops["service_attributes"] = service_attributes

--- a/scripts/metric_aggregator.py
+++ b/scripts/metric_aggregator.py
@@ -231,7 +231,9 @@ def aggregate_recorded_raw_data(
                     continue
                 if collect_for_arch and collect_for_arch not in str(path):
                     continue
-
+                if not recorded.get(metric.service):
+                    print(f"could not find service {metric.service}, skipping...")
+                    continue
                 service = recorded[metric.service]
                 ops = service[metric.operation]
 

--- a/scripts/metric_aggregator.py
+++ b/scripts/metric_aggregator.py
@@ -83,7 +83,12 @@ def create_simple_html_report(file_name, metrics):
                 tmp += _generate_details_block_html("errors hit", op_details["errors"])
             tmp += "</ul>"
             tmp += "</p>"
-        output += f"<p><details><summary>{'-' if not operation_counter else operation_tested/operation_counter*100:.2f}% test coverage</summary>\n\n{tmp}\n</details></p>\n"
+        if not operation_counter:
+            print(
+                f"---> error: operation_counter={operation_counter}, operation_tested={operation_tested} for service '{service}'"
+            )
+            operation_counter = 1
+        output += f"<p><details><summary>{operation_tested/operation_counter*100:.2f}% test coverage</summary>\n\n{tmp}\n</details></p>\n"
 
         with open(file_name, "a") as fd:
             fd.write(f"{output}\n")

--- a/scripts/metric_aggregator.py
+++ b/scripts/metric_aggregator.py
@@ -83,11 +83,6 @@ def create_simple_html_report(file_name, metrics):
                 tmp += _generate_details_block_html("errors hit", op_details["errors"])
             tmp += "</ul>"
             tmp += "</p>"
-        if not operation_counter:
-            print(
-                f"---> error: operation_counter={operation_counter}, operation_tested={operation_tested} for service '{service}'"
-            )
-            operation_counter = 1
         output += f"<p><details><summary>{operation_tested/operation_counter*100:.2f}% test coverage</summary>\n\n{tmp}\n</details></p>\n"
 
         with open(file_name, "a") as fd:
@@ -184,6 +179,8 @@ def _init_service_metric_counter() -> Dict:
     metric_recorder = {}
     for s, provider in SERVICE_PLUGINS.api_provider_specs.items():
         ops = _load_service_info(s)
+        if not ops:
+            continue
         service_attributes = {"pro": "pro" in provider, "community": "default" in provider}
         ops["service_attributes"] = service_attributes
         metric_recorder[s] = ops


### PR DESCRIPTION
Fix for the `metric_aggregator.py` script that stopped working, as for some reason `SERVICE_PLUGINS.api_provider_specs` only returns services that are available in pro now.

* removed pro/community details as it only returned pro
* load any service that is "unknown" manually (concerns some services that are only available in community)