### PR TITLE
[wip] Update Dockerfile to skip installing node.js by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && \
         # Install dependencies to add additional repos
         apt-get install -y --no-install-recommends ca-certificates curl && \
         # Setup Node 14 Repo
-        curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+        # curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
         # Install Packages
         apt-get update && \
         apt-get install -y --no-install-recommends \
@@ -51,7 +51,8 @@ RUN apt-get update && \
             # Postgres
             postgresql postgresql-client postgresql-plpython3 \
             # NodeJS
-            nodejs && \
+            # nodejs \
+            && \
         apt-get clean && rm -rf /var/lib/apt/lists/*
 
 SHELL [ "/bin/bash", "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN apt-get update && \
             && \
         apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# TODO: tmp. workaround to fix the installation of some plugins that require npm
+RUN ln -s /bin/true /usr/local/bin/npm
+
 SHELL [ "/bin/bash", "-c" ]
 
 # Install Java 11


### PR DESCRIPTION
🚧 **work in progress - do not merge!**

Update Dockerfile to skip installing node.js by default - attempting to resolve a remaining CVE related to our installed node version. This is only a temporary approach that is not supposed to be merged. If and when the build runs through, we can push it under a temporary tag, to make the image available to the users/customer for testing.