### PR TITLE
fix failing circle-ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,8 +279,7 @@ jobs:
           name: Parity metric aggregation
           command: |
             source .venv/bin/activate
-            # TODO: remove this - workaround to temporarily unblock the pipeline for now
-            python scripts/metric_aggregator.py . amd64 || true
+            python -m scripts.metric_aggregator . amd64
       - store_artifacts:
           path: parity_metrics/
 


### PR DESCRIPTION
Fix for the failing `metric_aggregator` script in the `report` step of CircleCI.
Running the script as module seems to work fine and makes PR https://github.com/localstack/localstack/pull/6680 obsolete.
