### PR TITLE
Fix Lambda URL building

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1564,7 +1564,8 @@ def create_url_config(function):
 
     custom_id = md5(str(random()))
     region = LambdaRegion.get_current_request_region()
-    url = f"http://{custom_id}.lambda-url.{region}.{LOCALHOST_HOSTNAME}:{config.EDGE_PORT}/"
+    url = f"http://{custom_id}.lambda-url.{region}.{LOCALHOST_HOSTNAME}:{config.EDGE_PORT_HTTP or config.EDGE_PORT}/"
+    # TODO: HTTPS support
 
     data = json.loads(to_str(request.data))
     url_config = {

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -2463,7 +2463,6 @@ class TestLambdaBehavior:
 
 
 class TestLambdaURL:
-    # testing
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -2463,6 +2463,7 @@ class TestLambdaBehavior:
 
 
 class TestLambdaURL:
+    # testing
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[


### PR DESCRIPTION
Fixes a small issue where the function URL was returned as `http://<...>:{EDGE_PORT}` but since PRO by default sets the EDGE_PORT to 443, this lead to the tests misbehaving.

Still need to add HTTPS support for this at a later point but this should at least unblock the PRO tests in CI.