### PR TITLE
Update CLA Github action to not lock PR threads after merge

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,3 +27,4 @@ jobs:
           path-to-document: "https://github.com/localstack/localstack/blob/master/.github/CLA.md"
           branch: "cla-signatures"
           allowlist: "localstack-bot,renovate-bot,renovate"
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
Update CLA Github action to not lock PRs after merge. Currently, the default setting for the CLA bot is to lock threads after PRs are merged - meaning that it is not possible to interact with the PR in any way - no comments, no follow-up questions, no emoji upvotes! ;) , etc.

<img width="577" alt="image" src="https://user-images.githubusercontent.com/2807888/185744987-f72b5670-0491-457d-a22c-613cc1ee567e.png">


The main motivation for having `lock-pullrequest-aftermerge` as `true` by default is the following:
> It is highly recommended to lock the Pull Request after merging so that the Contributors won't be able to revoke their signature comments after merge

This should not be an issue, as we still have the paper trail of signatures in the `cla-signatures` branch. The benefit of being able to interact on PRs after merge arguably outweighs the potential risk of contributors revoking their signature (which I don't think is a realistic risk anyway).

/cc @HarshCasper @thrau @alexrashed @dominikschubert 