### PR TITLE
fix sqs purge queue operation to match AWS behavior

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -585,6 +585,9 @@ DYNAMODB_SHARE_DB = int(os.environ.get("DYNAMODB_SHARE_DB") or 0)
 # Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it
 SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
 
+# Used to toggle PurgeInProgress exceptions when calling purge within 60 seconds
+SQS_DELAY_PURGE_RETRY = is_env_true("SQS_DELAY_PURGE_RETRY")
+
 # expose SQS on a specific port externally
 SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -582,11 +582,11 @@ DYNAMODB_HEAP_SIZE = os.environ.get("DYNAMODB_HEAP_SIZE", "").strip() or "256m"
 # single DB instance across multiple credentials are regions
 DYNAMODB_SHARE_DB = int(os.environ.get("DYNAMODB_SHARE_DB") or 0)
 
-# Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it
-SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
-
 # Used to toggle PurgeInProgress exceptions when calling purge within 60 seconds
 SQS_DELAY_PURGE_RETRY = is_env_true("SQS_DELAY_PURGE_RETRY")
+
+# Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it
+SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
 
 # expose SQS on a specific port externally
 SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
@@ -763,6 +763,7 @@ CONFIG_ENV_VARS = [
     "SERVICES",
     "SKIP_INFRA_DOWNLOADS",
     "SKIP_SSL_CERT_DOWNLOAD",
+    "SQS_DELAY_PURGE_RETRY",
     "SQS_DELAY_RECENTLY_DELETED",
     "SQS_ENDPOINT_STRATEGY",
     "SQS_PORT_EXTERNAL",

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -418,10 +418,6 @@
       }
     }
   },
-  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_sequence_number_increases": {
-    "recorded-date": "21-08-2022, 00:36:25",
-    "recorded-content": {}
-  },
   "tests/integration/test_sqs.py::TestSqsProvider::test_invalid_dead_letter_arn_rejected_before_lookup": {
     "recorded-date": "21-08-2022, 00:54:10",
     "recorded-content": {
@@ -435,6 +431,23 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_successive_purge_calls_fail": {
+    "recorded-date": "22-08-2022, 21:28:31",
+    "recorded-content": {
+      "purge_queue_error": {
+        "Error": {
+          "Code": "AWS.SimpleQueueService.PurgeQueueInProgress",
+          "Detail": null,
+          "Message": "Only one PurgeQueue operation on <queue-name> is allowed every 60 seconds.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
         }
       }
     }


### PR DESCRIPTION
This PR fixes the SQS purge_queue operation.

* correctly delete inflight and delayed messages (as AWS does)
* I also added a feature flag `SQS_DELAY_PURGE_RETRY` to enable the behavior to raise `PurgeInProgress` errors within a 60 second internval, which is how AWS managed purge queue.

- Related to #6695