### PR TITLE
fix sqs fifo message sequence number generation

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -3,6 +3,7 @@ import copy
 import hashlib
 import heapq
 import inspect
+import itertools
 import json
 import logging
 import re
@@ -125,11 +126,9 @@ class MissingParameter(CommonServiceException):
 @singleton_factory
 def global_message_sequence():
     # creates a 20-digit number used as the start for the global sequence
-    counter = int(time.time()) << 33
-
-    while True:
-        counter += 1
-        yield counter
+    start = int(time.time()) << 33
+    # itertools.count is thread safe over the GIL since its getAndIncrement operation is a single python bytecode op
+    return itertools.count(start)
 
 
 def generate_message_id():

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -5,9 +5,7 @@ import heapq
 import inspect
 import json
 import logging
-import random
 import re
-import string
 import threading
 import time
 from queue import Empty, PriorityQueue
@@ -69,9 +67,12 @@ from localstack.config import external_service_url
 from localstack.services.generic_proxy import RegionBackend
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws.aws_stack import parse_arn
-from localstack.utils.common import long_uid, md5, now, start_thread
+from localstack.utils.objects import singleton_factory
 from localstack.utils.run import FuncThread
 from localstack.utils.scheduler import Scheduler
+from localstack.utils.strings import long_uid, md5
+from localstack.utils.threads import start_thread
+from localstack.utils.time import now
 
 LOG = logging.getLogger(__name__)
 
@@ -119,6 +120,16 @@ class InvalidAttributeValue(CommonServiceException):
 class MissingParameter(CommonServiceException):
     def __init__(self, message):
         super().__init__("MissingParameter", message, 400, True)
+
+
+@singleton_factory
+def global_message_sequence():
+    # creates a 20-digit number used as the start for the global sequence
+    counter = int(time.time()) << 33
+
+    while True:
+        counter += 1
+        yield counter
 
 
 def generate_message_id():
@@ -191,6 +202,7 @@ class SqsMessage:
     priority: float
     message_deduplication_id: str
     message_group_id: str
+    sequence_number: str
 
     def __init__(
         self,
@@ -198,6 +210,7 @@ class SqsMessage:
         message: Message,
         message_deduplication_id: str = None,
         message_group_id: str = None,
+        sequence_number: str = None,
     ) -> None:
         self.created = time.time()
         self.message = message
@@ -209,12 +222,15 @@ class SqsMessage:
         self.first_received = None
         self.deleted = False
         self.priority = priority
+        self.sequence_number = sequence_number
 
         attributes = {}
         if message_group_id is not None:
             attributes["MessageGroupId"] = message_group_id
         if message_deduplication_id is not None:
             attributes["MessageDeduplicationId"] = message_deduplication_id
+        if sequence_number is not None:
+            attributes["SequenceNumber"] = sequence_number
 
         if self.message.get("Attributes"):
             self.message["Attributes"].update(attributes)
@@ -473,7 +489,7 @@ class SqsQueue:
         message_deduplication_id: str = None,
         message_group_id: str = None,
         delay_seconds: int = None,
-    ):
+    ) -> SqsMessage:
         raise NotImplementedError
 
     def get(self, block=True, timeout=None, visibility_timeout: int = None) -> SqsMessage:
@@ -574,9 +590,6 @@ class SqsQueue:
             if k not in valid:
                 raise InvalidAttributeName(f"Unknown Attribute {k}.")
 
-    def generate_sequence_number(self):
-        return None
-
 
 class StandardQueue(SqsQueue):
     def put(
@@ -615,6 +628,8 @@ class StandardQueue(SqsQueue):
             self.delayed.add(standard_message)
         else:
             self.visible.put_nowait(standard_message)
+
+        return standard_message
 
 
 class FifoQueue(SqsQueue):
@@ -672,6 +687,7 @@ class FifoQueue(SqsQueue):
             message,
             message_deduplication_id=dedup_id,
             message_group_id=message_group_id,
+            sequence_number=str(self.next_sequence_number()),
         )
         if visibility_timeout is not None:
             fifo_message.visibility_timeout = visibility_timeout
@@ -705,6 +721,8 @@ class FifoQueue(SqsQueue):
                 self.deduplication[message_group_id] = {}
             self.deduplication[message_group_id][dedup_id] = fifo_message
 
+        return fifo_message
+
     def _assert_queue_name(self, name):
         if not name.endswith(".fifo"):
             raise InvalidParameterValue(
@@ -731,10 +749,8 @@ class FifoQueue(SqsQueue):
                 "Invalid value for the parameter FifoQueue. Reason: Modifying queue type is not supported."
             )
 
-    # TODO: If we ever actually need to do something with this number, it needs to be part of
-    #   SQSMessage. This means changing all *put*() signatures to return the saved message.
-    def generate_sequence_number(self):
-        return _create_mock_sequence_number()
+    def next_sequence_number(self):
+        return next(global_message_sequence())
 
 
 class QueueUpdateWorker:
@@ -1121,7 +1137,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
     ) -> SendMessageResult:
         queue = self._resolve_queue(context, queue_url=queue_url)
 
-        message = self._put_message(
+        queue_item = self._put_message(
             queue,
             context,
             message_body,
@@ -1131,11 +1147,12 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             message_deduplication_id,
             message_group_id,
         )
+        message = queue_item.message
         return SendMessageResult(
             MessageId=message["MessageId"],
             MD5OfMessageBody=message["MD5OfBody"],
             MD5OfMessageAttributes=message.get("MD5OfMessageAttributes"),
-            SequenceNumber=queue.generate_sequence_number(),
+            SequenceNumber=queue_item.sequence_number,
             MD5OfMessageSystemAttributes=_create_message_attribute_hash(message_system_attributes),
         )
 
@@ -1152,7 +1169,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         with queue.mutex:
             for entry in entries:
                 try:
-                    message = self._put_message(
+                    queue_item = self._put_message(
                         queue,
                         context,
                         message_body=entry.get("MessageBody"),
@@ -1162,6 +1179,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                         message_deduplication_id=entry.get("MessageDeduplicationId"),
                         message_group_id=entry.get("MessageGroupId"),
                     )
+                    message = queue_item.message
 
                     successful.append(
                         SendMessageBatchResultEntry(
@@ -1172,7 +1190,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                             MD5OfMessageSystemAttributes=_create_message_attribute_hash(
                                 message.get("message_system_attributes")
                             ),
-                            SequenceNumber=queue.generate_sequence_number(),
+                            SequenceNumber=queue_item.sequence_number,
                         )
                     )
                 except Exception as e:
@@ -1200,7 +1218,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         message_system_attributes: MessageBodySystemAttributeMap = None,
         message_deduplication_id: String = None,
         message_group_id: String = None,
-    ) -> Message:
+    ) -> SqsMessage:
         check_message_content(message_body)
         check_attributes(message_attributes)
         check_attributes(message_system_attributes)
@@ -1216,14 +1234,12 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             MessageAttributes=message_attributes,
         )
 
-        queue.put(
+        return queue.put(
             message=message,
             message_deduplication_id=message_deduplication_id,
             message_group_id=message_group_id,
             delay_seconds=int(delay_seconds) if delay_seconds is not None else None,
         )
-
-        return message
 
     def receive_message(
         self,
@@ -1514,10 +1530,6 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                 raise BatchEntryIdsNotDistinct()
             else:
                 visited.add(entry["Id"])
-
-
-def _create_mock_sequence_number():
-    return "".join(random.choice(string.digits) for _ in range(20))
 
 
 # Method from moto's attribute_md5 of moto/sqs/models.py, separated from the Message Object

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -176,6 +176,7 @@ class TransformerUtility:
         return [
             TransformerUtility.key_value("ReceiptHandle"),
             TransformerUtility.key_value("SenderId"),
+            TransformerUtility.key_value("SequenceNumber"),
             TransformerUtility.jsonpath("$..MessageAttributes.RequestID.StringValue", "request-id"),
             KeyValueBasedTransformer(_resource_name_transformer, "resource"),
         ]

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -357,5 +357,86 @@
       "create_queue_01": "An error occurred (QueueAlreadyExists) when calling the CreateQueue operation: A queue already exists with the same name and a different value for attribute DelaySeconds",
       "create_queue_02": "An error occurred (QueueAlreadyExists) when calling the CreateQueue operation: A queue already exists with the same name and a different value for attribute DelaySeconds"
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_message_attributes": {
+    "recorded-date": "21-08-2022, 00:35:54",
+    "recorded-content": {
+      "send_message": {
+        "MD5OfMessageBody": "19c9e282d65f9733bc6b35d50062c7ee",
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "SequenceNumber": "<sequence-number:1>"
+      },
+      "receive_message_0": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "1",
+              "MessageDeduplicationId": "dedup-1",
+              "MessageGroupId": "group-1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "message-body-1",
+            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "receive_message_1": {
+        "Messages": [
+          {
+            "Attributes": {
+              "ApproximateFirstReceiveTimestamp": "timestamp",
+              "ApproximateReceiveCount": "2",
+              "MessageDeduplicationId": "dedup-1",
+              "MessageGroupId": "group-1",
+              "SenderId": "<sender-id:1>",
+              "SentTimestamp": "timestamp",
+              "SequenceNumber": "<sequence-number:1>"
+            },
+            "Body": "message-body-1",
+            "MD5OfBody": "19c9e282d65f9733bc6b35d50062c7ee",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_fifo_sequence_number_increases": {
+    "recorded-date": "21-08-2022, 00:36:25",
+    "recorded-content": {}
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_invalid_dead_letter_arn_rejected_before_lookup": {
+    "recorded-date": "21-08-2022, 00:54:10",
+    "recorded-content": {
+      "error_response": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value {\"deadLetterTargetArn\": \"dummy\", \"maxReceiveCount\": 42} for parameter RedrivePolicy is invalid. Reason: Invalid value for deadLetterTargetArn.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR corrects the way the `SequenceNumber` is generated and passed through to API call results. We now generate the sequence number once, and keep it in the message. I had to change the internal API to make `put` actually return the `SqsMessage` object which holds the sequence number, since we return the sequence number both in `SendMessage` and `ReceiveMessage`.

The sequence numbers are 20 digit numbers that are non-consecutive, but monotonically increasing. Other than that there seem to be no guarantees associated with the sequence numbers. So I simply used the unix timestamp (which is 10 digits, at least for the next 264 years), shifted it to be 20 digits, and then use that number as a basis.

I also refactored an unrelated test to use snapshot testing.

- Fixes #6674