### PR TITLE
remove extensions api from coverage collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ source = [
 omit = [
     "localstack/infra/",
     "localstack/node_modules",
-    "localstack/aws/api"
+    "localstack/aws/api",
+    "localstack/extensions/api",
 ]
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
Remvoes localstack.extensions.api, which is just a set of import statements, from the coverage metrics. Extensions will be tested as part of pro