### PR TITLE
Switch to new Lambda provider implementation

### DIFF
--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -168,7 +168,7 @@ def kms():
     return Service("kms", listener=AwsApiListener("kms", MotoFallbackDispatcher(provider)))
 
 
-@aws_provider(api="lambda")
+@aws_provider(api="lambda", name="legacy")
 def awslambda():
     from localstack.services.awslambda import lambda_starter
 
@@ -180,7 +180,7 @@ def awslambda():
     )
 
 
-@aws_provider(api="lambda", name="asf")
+@aws_provider(api="lambda")
 def awslambda_asf():
     from localstack.aws.proxy import AwsApiListener
     from localstack.services.awslambda.provider import LambdaProvider


### PR DESCRIPTION
## Summary
This PR should remain minimal in terms of code changes, and is mostly used for keeping track of the PRs regarding the new lambda provider going directly into master and for tracking test failure rates against the new provider.

## PRs
The following PRs have been created to fully implement the new Lambda provider:
* #5306

## Tasks
- [ ] Initial core runtime implementation of the new provider
- [ ] Refactor package imports
- [ ] replace run_lambda calls by botocore invocations / common interface
- [ ] extend integration tests for full API coverage
- [ ] Version & Alias CRUD
- [ ] Full API CRUD
- [ ] Alias routing
- [ ] Lambda URL port