### PR TITLE
SES: Extract and save the source address for raw email messages

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -282,7 +282,11 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         )
 
         save_for_retrospection(
-            message.id, context.region, Source=source, Destination=destinations, RawData=raw_data
+            message.id,
+            context.region,
+            Source=source or message.source,
+            Destination=destinations,
+            RawData=raw_data,
         )
 
         return SendRawEmailResponse(MessageId=message.id)


### PR DESCRIPTION
### Summary

Fixes an issue where raw emails were unfilterable from the retro endpoint. This was because the email source address was not being saved.

### Tests

PR updates integration tests

### Related

Closes: https://github.com/localstack/localstack/issues/6725