### PR TITLE
Correctly shutdown kinesis listener once firehose deliverystream is deleted

### DIFF
--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -433,5 +433,13 @@ class TestFirehoseIntegration:
         cleanups.append(
             lambda: firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
         )
-
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        # make sure the stream will come up at some point, for cleaner cleanup
+        def check_stream_state():
+            stream = firehose_client.describe_delivery_stream(
+                DeliveryStreamName=delivery_stream_name
+            )
+            return stream["DeliveryStreamDescription"]["DeliveryStreamStatus"] == "ACTIVE"
+
+        assert poll_condition(check_stream_state, 45, 1)

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -429,9 +429,9 @@ class TestFirehoseIntegration:
                 },
             },
         )
-
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-        firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
-        kinesis_client.delete_stream(StreamName=stream_name)
-        s3_client.delete_bucket(Bucket=s3_bucket)
+        try:
+            assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        finally:
+            firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
+            kinesis_client.delete_stream(StreamName=stream_name)
+            s3_client.delete_bucket(Bucket=s3_bucket)

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -379,6 +379,7 @@ class TestFirehoseIntegration:
         s3_client,
         s3_bucket,
         kinesis_create_stream,
+        cleanups,
     ):
 
         bucket_arn = aws_stack.s3_bucket_arn(s3_bucket)
@@ -429,9 +430,8 @@ class TestFirehoseIntegration:
                 },
             },
         )
-        try:
-            assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        finally:
-            firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
-            kinesis_client.delete_stream(StreamName=stream_name)
-            s3_client.delete_bucket(Bucket=s3_bucket)
+        cleanups.append(
+            lambda: firehose_client.delete_delivery_stream(DeliveryStreamName=delivery_stream_name)
+        )
+
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -1,6 +1,4 @@
 import json
-import logging
-import os
 
 import pytest
 from botocore.exceptions import ClientError
@@ -10,7 +8,6 @@ from localstack.aws.api.iam import Tag
 from localstack.services.iam.provider import ADDITIONAL_MANAGED_POLICIES
 from localstack.testing.aws.util import create_client_with_keys, wait_for_user
 from localstack.utils.common import short_uid
-from localstack.utils.kinesis import kinesis_connector
 from localstack.utils.strings import long_uid
 
 GET_USER_POLICY_DOC = """{
@@ -128,30 +125,6 @@ class TestIAMExtensions:
 
 
 class TestIAMIntegrations:
-
-    # TODO what does this test do?
-    def test_run_kcl_with_iam_assume_role(self):
-        env_vars = {}
-        if os.environ.get("AWS_ASSUME_ROLE_ARN"):
-            env_vars["AWS_ASSUME_ROLE_ARN"] = os.environ.get("AWS_ASSUME_ROLE_ARN")
-            env_vars["AWS_ASSUME_ROLE_SESSION_NAME"] = os.environ.get(
-                "AWS_ASSUME_ROLE_SESSION_NAME"
-            )
-            env_vars["ENV"] = os.environ.get("ENV") or "main"
-
-            def process_records(records):
-                print(records)
-
-            # start Kinesis client
-            stream_name = f"test-foobar-{short_uid()}"
-            kinesis_connector.listen_to_kinesis(
-                stream_name=stream_name,
-                listener_func=process_records,
-                env_vars=env_vars,
-                kcl_log_level=logging.INFO,
-                wait_until_started=True,
-            )
-
     def test_attach_iam_role_to_new_iam_user(self, iam_client):
         test_policy_document = {
             "Version": "2012-10-17",

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -228,7 +228,7 @@ class TestIntegration:
             events.extend(records)
 
         # start the KCL client process in the background
-        kinesis_connector.listen_to_kinesis(
+        process = kinesis_connector.listen_to_kinesis(
             stream_name,
             listener_func=process_records,
             wait_until_started=True,
@@ -236,293 +236,301 @@ class TestIntegration:
         )
 
         LOGGER.info("Kinesis consumer initialized.")
+        try:
+            # create table with stream forwarding config
+            aws_stack.create_dynamodb_table(
+                table_name,
+                partition_key=PARTITION_KEY,
+                stream_view_type="NEW_AND_OLD_IMAGES",
+            )
 
-        # create table with stream forwarding config
-        aws_stack.create_dynamodb_table(
-            table_name,
-            partition_key=PARTITION_KEY,
-            stream_view_type="NEW_AND_OLD_IMAGES",
-        )
+            # list DDB streams and make sure the table stream is there
+            streams = dynamodbstreams.list_streams()
+            ddb_event_source_arn = None
+            for stream in streams["Streams"]:
+                if stream["TableName"] == table_name:
+                    ddb_event_source_arn = stream["StreamArn"]
+            assert ddb_event_source_arn
 
-        # list DDB streams and make sure the table stream is there
-        streams = dynamodbstreams.list_streams()
-        ddb_event_source_arn = None
-        for stream in streams["Streams"]:
-            if stream["TableName"] == table_name:
-                ddb_event_source_arn = stream["StreamArn"]
-        assert ddb_event_source_arn
+            # deploy test lambda connected to DynamoDB Stream
+            testutil.create_lambda_function(
+                handler_file=TEST_LAMBDA_PYTHON,
+                libs=TEST_LAMBDA_LIBS,
+                func_name=lambda_ddb_name,
+                event_source_arn=ddb_event_source_arn,
+                starting_position="TRIM_HORIZON",
+                delete=True,
+            )
 
-        # deploy test lambda connected to DynamoDB Stream
-        testutil.create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON,
-            libs=TEST_LAMBDA_LIBS,
-            func_name=lambda_ddb_name,
-            event_source_arn=ddb_event_source_arn,
-            starting_position="TRIM_HORIZON",
-            delete=True,
-        )
-
-        # submit a batch with writes
-        dynamodb.batch_write_item(
-            RequestItems={
-                table_name: [
-                    {
-                        "PutRequest": {
-                            "Item": {
-                                PARTITION_KEY: {"S": "testId0"},
-                                "data": {"S": "foobar123"},
+            # submit a batch with writes
+            dynamodb.batch_write_item(
+                RequestItems={
+                    table_name: [
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    PARTITION_KEY: {"S": "testId0"},
+                                    "data": {"S": "foobar123"},
+                                }
                             }
+                        },
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    PARTITION_KEY: {"S": "testId1"},
+                                    "data": {"S": "foobar123"},
+                                }
+                            }
+                        },
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    PARTITION_KEY: {"S": "testId2"},
+                                    "data": {"S": "foobar123"},
+                                }
+                            }
+                        },
+                    ]
+                }
+            )
+
+            # submit a batch with writes and deletes
+            dynamodb.batch_write_item(
+                RequestItems={
+                    table_name: [
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    PARTITION_KEY: {"S": "testId3"},
+                                    "data": {"S": "foobar123"},
+                                }
+                            }
+                        },
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    PARTITION_KEY: {"S": "testId4"},
+                                    "data": {"S": "foobar123"},
+                                }
+                            }
+                        },
+                        {
+                            "PutRequest": {
+                                "Item": {
+                                    PARTITION_KEY: {"S": "testId5"},
+                                    "data": {"S": "foobar123"},
+                                }
+                            }
+                        },
+                        {"DeleteRequest": {"Key": {PARTITION_KEY: {"S": "testId0"}}}},
+                        {"DeleteRequest": {"Key": {PARTITION_KEY: {"S": "testId1"}}}},
+                        {"DeleteRequest": {"Key": {PARTITION_KEY: {"S": "testId2"}}}},
+                    ]
+                }
+            )
+
+            # submit a transaction with writes and delete
+            dynamodb.transact_write_items(
+                TransactItems=[
+                    {
+                        "Put": {
+                            "TableName": table_name,
+                            "Item": {
+                                PARTITION_KEY: {"S": "testId6"},
+                                "data": {"S": "foobar123"},
+                            },
                         }
                     },
                     {
-                        "PutRequest": {
+                        "Put": {
+                            "TableName": table_name,
                             "Item": {
-                                PARTITION_KEY: {"S": "testId1"},
+                                PARTITION_KEY: {"S": "testId7"},
                                 "data": {"S": "foobar123"},
-                            }
+                            },
                         }
                     },
                     {
-                        "PutRequest": {
+                        "Put": {
+                            "TableName": table_name,
                             "Item": {
-                                PARTITION_KEY: {"S": "testId2"},
+                                PARTITION_KEY: {"S": "testId8"},
                                 "data": {"S": "foobar123"},
-                            }
+                            },
+                        }
+                    },
+                    {
+                        "Delete": {
+                            "TableName": table_name,
+                            "Key": {PARTITION_KEY: {"S": "testId3"}},
+                        }
+                    },
+                    {
+                        "Delete": {
+                            "TableName": table_name,
+                            "Key": {PARTITION_KEY: {"S": "testId4"}},
+                        }
+                    },
+                    {
+                        "Delete": {
+                            "TableName": table_name,
+                            "Key": {PARTITION_KEY: {"S": "testId5"}},
                         }
                     },
                 ]
-            }
-        )
+            )
 
-        # submit a batch with writes and deletes
-        dynamodb.batch_write_item(
-            RequestItems={
-                table_name: [
+            # submit a batch with a put over existing item
+            dynamodb.transact_write_items(
+                TransactItems=[
                     {
-                        "PutRequest": {
+                        "Put": {
+                            "TableName": table_name,
                             "Item": {
-                                PARTITION_KEY: {"S": "testId3"},
-                                "data": {"S": "foobar123"},
-                            }
+                                PARTITION_KEY: {"S": "testId6"},
+                                "data": {"S": "foobar123_updated1"},
+                            },
                         }
                     },
-                    {
-                        "PutRequest": {
-                            "Item": {
-                                PARTITION_KEY: {"S": "testId4"},
-                                "data": {"S": "foobar123"},
-                            }
-                        }
-                    },
-                    {
-                        "PutRequest": {
-                            "Item": {
-                                PARTITION_KEY: {"S": "testId5"},
-                                "data": {"S": "foobar123"},
-                            }
-                        }
-                    },
-                    {"DeleteRequest": {"Key": {PARTITION_KEY: {"S": "testId0"}}}},
-                    {"DeleteRequest": {"Key": {PARTITION_KEY: {"S": "testId1"}}}},
-                    {"DeleteRequest": {"Key": {PARTITION_KEY: {"S": "testId2"}}}},
                 ]
-            }
-        )
+            )
 
-        # submit a transaction with writes and delete
-        dynamodb.transact_write_items(
-            TransactItems=[
-                {
-                    "Put": {
-                        "TableName": table_name,
-                        "Item": {
-                            PARTITION_KEY: {"S": "testId6"},
-                            "data": {"S": "foobar123"},
-                        },
-                    }
-                },
-                {
-                    "Put": {
-                        "TableName": table_name,
-                        "Item": {
-                            PARTITION_KEY: {"S": "testId7"},
-                            "data": {"S": "foobar123"},
-                        },
-                    }
-                },
-                {
-                    "Put": {
-                        "TableName": table_name,
-                        "Item": {
-                            PARTITION_KEY: {"S": "testId8"},
-                            "data": {"S": "foobar123"},
-                        },
-                    }
-                },
-                {
-                    "Delete": {
-                        "TableName": table_name,
-                        "Key": {PARTITION_KEY: {"S": "testId3"}},
-                    }
-                },
-                {
-                    "Delete": {
-                        "TableName": table_name,
-                        "Key": {PARTITION_KEY: {"S": "testId4"}},
-                    }
-                },
-                {
-                    "Delete": {
-                        "TableName": table_name,
-                        "Key": {PARTITION_KEY: {"S": "testId5"}},
-                    }
-                },
-            ]
-        )
+            # submit a transaction with a put over existing item
+            dynamodb.transact_write_items(
+                TransactItems=[
+                    {
+                        "Put": {
+                            "TableName": table_name,
+                            "Item": {
+                                PARTITION_KEY: {"S": "testId7"},
+                                "data": {"S": "foobar123_updated1"},
+                            },
+                        }
+                    },
+                ]
+            )
 
-        # submit a batch with a put over existing item
-        dynamodb.transact_write_items(
-            TransactItems=[
-                {
-                    "Put": {
-                        "TableName": table_name,
-                        "Item": {
-                            PARTITION_KEY: {"S": "testId6"},
-                            "data": {"S": "foobar123_updated1"},
-                        },
-                    }
-                },
-            ]
-        )
+            # submit a transaction with updates
+            dynamodb.transact_write_items(
+                TransactItems=[
+                    {
+                        "Update": {
+                            "TableName": table_name,
+                            "Key": {PARTITION_KEY: {"S": "testId6"}},
+                            "UpdateExpression": "SET #0 = :0",
+                            "ExpressionAttributeNames": {"#0": "data"},
+                            "ExpressionAttributeValues": {":0": {"S": "foobar123_updated2"}},
+                        }
+                    },
+                    {
+                        "Update": {
+                            "TableName": table_name,
+                            "Key": {PARTITION_KEY: {"S": "testId7"}},
+                            "UpdateExpression": "SET #0 = :0",
+                            "ExpressionAttributeNames": {"#0": "data"},
+                            "ExpressionAttributeValues": {":0": {"S": "foobar123_updated2"}},
+                        }
+                    },
+                    {
+                        "Update": {
+                            "TableName": table_name,
+                            "Key": {PARTITION_KEY: {"S": "testId8"}},
+                            "UpdateExpression": "SET #0 = :0",
+                            "ExpressionAttributeNames": {"#0": "data"},
+                            "ExpressionAttributeValues": {":0": {"S": "foobar123_updated2"}},
+                        }
+                    },
+                ]
+            )
 
-        # submit a transaction with a put over existing item
-        dynamodb.transact_write_items(
-            TransactItems=[
-                {
-                    "Put": {
-                        "TableName": table_name,
-                        "Item": {
-                            PARTITION_KEY: {"S": "testId7"},
-                            "data": {"S": "foobar123_updated1"},
-                        },
-                    }
-                },
-            ]
-        )
+            LOGGER.info("Waiting some time before finishing test.")
+            time.sleep(2)
 
-        # submit a transaction with updates
-        dynamodb.transact_write_items(
-            TransactItems=[
-                {
-                    "Update": {
-                        "TableName": table_name,
-                        "Key": {PARTITION_KEY: {"S": "testId6"}},
-                        "UpdateExpression": "SET #0 = :0",
-                        "ExpressionAttributeNames": {"#0": "data"},
-                        "ExpressionAttributeValues": {":0": {"S": "foobar123_updated2"}},
-                    }
-                },
-                {
-                    "Update": {
-                        "TableName": table_name,
-                        "Key": {PARTITION_KEY: {"S": "testId7"}},
-                        "UpdateExpression": "SET #0 = :0",
-                        "ExpressionAttributeNames": {"#0": "data"},
-                        "ExpressionAttributeValues": {":0": {"S": "foobar123_updated2"}},
-                    }
-                },
-                {
-                    "Update": {
-                        "TableName": table_name,
-                        "Key": {PARTITION_KEY: {"S": "testId8"}},
-                        "UpdateExpression": "SET #0 = :0",
-                        "ExpressionAttributeNames": {"#0": "data"},
-                        "ExpressionAttributeValues": {":0": {"S": "foobar123_updated2"}},
-                    }
-                },
-            ]
-        )
+            num_insert = 9
+            num_modify = 5
+            num_delete = 6
+            num_events = num_insert + num_modify + num_delete
 
-        LOGGER.info("Waiting some time before finishing test.")
-        time.sleep(2)
+            def check_events():
+                if len(events) != num_events:
+                    msg = "DynamoDB updates retrieved (actual/expected): %s/%s" % (
+                        len(events),
+                        num_events,
+                    )
+                    LOGGER.warning(msg)
+                assert len(events) == num_events
+                event_items = [json.loads(base64.b64decode(e["data"])) for e in events]
+                # make sure the we have the right amount of expected event types
+                inserts = [e for e in event_items if e.get("__action_type") == "INSERT"]
+                modifies = [e for e in event_items if e.get("__action_type") == "MODIFY"]
+                removes = [e for e in event_items if e.get("__action_type") == "REMOVE"]
+                assert len(inserts) == num_insert
+                assert len(modifies) == num_modify
+                assert len(removes) == num_delete
 
-        num_insert = 9
-        num_modify = 5
-        num_delete = 6
-        num_events = num_insert + num_modify + num_delete
+                # assert that all inserts were received
 
-        def check_events():
-            if len(events) != num_events:
-                msg = "DynamoDB updates retrieved (actual/expected): %s/%s" % (
-                    len(events),
-                    num_events,
-                )
-                LOGGER.warning(msg)
-            assert len(events) == num_events
-            event_items = [json.loads(base64.b64decode(e["data"])) for e in events]
-            # make sure the we have the right amount of expected event types
-            inserts = [e for e in event_items if e.get("__action_type") == "INSERT"]
-            modifies = [e for e in event_items if e.get("__action_type") == "MODIFY"]
-            removes = [e for e in event_items if e.get("__action_type") == "REMOVE"]
-            assert len(inserts) == num_insert
-            assert len(modifies) == num_modify
-            assert len(removes) == num_delete
+                for i, event in enumerate(inserts):
+                    assert "old_image" not in event
+                    item_id = "testId%d" % i
+                    matching = [i for i in inserts if i["new_image"]["id"] == item_id][0]
+                    assert matching["new_image"] == {"id": item_id, "data": "foobar123"}
 
-            # assert that all inserts were received
+                # assert that all updates were received
 
-            for i, event in enumerate(inserts):
-                assert "old_image" not in event
-                item_id = "testId%d" % i
-                matching = [i for i in inserts if i["new_image"]["id"] == item_id][0]
-                assert matching["new_image"] == {"id": item_id, "data": "foobar123"}
+                def assert_updates(expected_updates, modifies):
+                    def found(update):
+                        for modif in modifies:
+                            if modif["old_image"]["id"] == update["id"]:
+                                assert modif["old_image"] == {
+                                    "id": update["id"],
+                                    "data": update["old"],
+                                }
+                                assert modif["new_image"] == {
+                                    "id": update["id"],
+                                    "data": update["new"],
+                                }
+                                return True
 
-            # assert that all updates were received
+                    for update in expected_updates:
+                        assert found(update)
 
-            def assert_updates(expected_updates, modifies):
-                def found(update):
-                    for modif in modifies:
-                        if modif["old_image"]["id"] == update["id"]:
-                            assert modif["old_image"] == {"id": update["id"], "data": update["old"]}
-                            assert modif["new_image"] == {"id": update["id"], "data": update["new"]}
-                            return True
+                updates1 = [
+                    {"id": "testId6", "old": "foobar123", "new": "foobar123_updated1"},
+                    {"id": "testId7", "old": "foobar123", "new": "foobar123_updated1"},
+                ]
+                updates2 = [
+                    {
+                        "id": "testId6",
+                        "old": "foobar123_updated1",
+                        "new": "foobar123_updated2",
+                    },
+                    {
+                        "id": "testId7",
+                        "old": "foobar123_updated1",
+                        "new": "foobar123_updated2",
+                    },
+                    {"id": "testId8", "old": "foobar123", "new": "foobar123_updated2"},
+                ]
 
-                for update in expected_updates:
-                    assert found(update)
+                assert_updates(updates1, modifies[:2])
+                assert_updates(updates2, modifies[2:])
 
-            updates1 = [
-                {"id": "testId6", "old": "foobar123", "new": "foobar123_updated1"},
-                {"id": "testId7", "old": "foobar123", "new": "foobar123_updated1"},
-            ]
-            updates2 = [
-                {
-                    "id": "testId6",
-                    "old": "foobar123_updated1",
-                    "new": "foobar123_updated2",
-                },
-                {
-                    "id": "testId7",
-                    "old": "foobar123_updated1",
-                    "new": "foobar123_updated2",
-                },
-                {"id": "testId8", "old": "foobar123", "new": "foobar123_updated2"},
-            ]
+                # assert that all removes were received
 
-            assert_updates(updates1, modifies[:2])
-            assert_updates(updates2, modifies[2:])
+                for i, event in enumerate(removes):
+                    assert "new_image" not in event
+                    item_id = "testId%d" % i
+                    matching = [i for i in removes if i["old_image"]["id"] == item_id][0]
+                    assert matching["old_image"] == {"id": item_id, "data": "foobar123"}
 
-            # assert that all removes were received
+            # this can take a long time in CI, make sure we give it enough time/retries
+            retry(check_events, retries=30, sleep=4)
 
-            for i, event in enumerate(removes):
-                assert "new_image" not in event
-                item_id = "testId%d" % i
-                matching = [i for i in removes if i["old_image"]["id"] == item_id][0]
-                assert matching["old_image"] == {"id": item_id, "data": "foobar123"}
-
-        # this can take a long time in CI, make sure we give it enough time/retries
-        retry(check_events, retries=30, sleep=4)
-
-        # clean up
-        testutil.delete_lambda_function(lambda_ddb_name)
+            # clean up
+            testutil.delete_lambda_function(lambda_ddb_name)
+        finally:
+            process.stop()
 
     def test_scheduled_lambda(self, scheduled_test_lambda):
         def check_invocation(*args):


### PR DESCRIPTION
## Problem
Currently, even if we delete the firehose delivery stream, we will not stop the kinesis listener (if kinesis is the source). This leads to a significant resource leak, while at the same time spamming our logs with `dynamodb.Scan` entries (see in [this circleci log](https://app.circleci.com/pipelines/github/localstack/localstack/8606/workflows/b1146cff-6a7d-48bc-b56b-da51547008ea/jobs/53885/parallel-runs/1?filterBy=ALL) for example):
```
2022-08-23T09:42:39.485  INFO --- [  asgi_gw_12] localstack.request.aws     : AWS dynamodb.Scan => 200
2022-08-23T09:42:39.528  INFO --- [   asgi_gw_3] localstack.request.aws     : AWS dynamodb.Scan => 200
2022-08-23T09:42:39.530  INFO --- [   asgi_gw_0] localstack.request.aws     : AWS dynamodb.Scan => 200
2022-08-23T09:42:39.532  INFO --- [  asgi_gw_13] localstack.request.aws     : AWS dynamodb.Scan => 200
```
This can lead to up to 28000 of these unnecessary log lines (and requests) over our integration suite.

## Solution

We should stop the kinesis listener once the delivery stream is cleaned up (in our tests, but also for users).
This PR does this, while also refactoring some tests to use try / finally to make sure they delete the delivery stream or save the process and stop it later if using the kinesis connector directly.
I also deleted 1 test which would never be executed (unless a specific env variable would be set) which would use a kinesis listener directly.