### PR TITLE
Kinesis: SubscribeToShard session cut after 5min

### DIFF
--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -22,7 +22,7 @@ ACTION_PREFIX = "Kinesis_20131202"
 ACTION_PUT_RECORD = "%s.PutRecord" % ACTION_PREFIX
 ACTION_PUT_RECORDS = "%s.PutRecords" % ACTION_PREFIX
 ACTION_LIST_STREAMS = "%s.ListStreams" % ACTION_PREFIX
-
+MAX_SUBSCRIPTION_SECONDS = 300
 
 class KinesisBackend(RegionBackend):
     def __init__(self):
@@ -296,8 +296,9 @@ def subscribe_to_shard(data, headers):
         yield convert_to_binary_event_payload("", event_type="initial-response")
         iter = iterator
         last_sequence_number = starting_sequence_number
-        # TODO: find better way to run loop up to max 5 minutes (until connection terminates)!
-        for i in range(5 * 60):
+        maximum_duration_subscription_timestamp = now_utc() + MAX_SUBSCRIPTION_SECONDS
+
+        while now_utc() < maximum_duration_subscription_timestamp:
             result = None
             try:
                 result = kinesis.get_records(ShardIterator=iter)

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -24,6 +24,7 @@ ACTION_PUT_RECORDS = "%s.PutRecords" % ACTION_PREFIX
 ACTION_LIST_STREAMS = "%s.ListStreams" % ACTION_PREFIX
 MAX_SUBSCRIPTION_SECONDS = 300
 
+
 class KinesisBackend(RegionBackend):
     def __init__(self):
         # list of stream consumer details

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -321,8 +321,9 @@ def subscribe_to_shard(data, headers):
                 record["Data"] = to_str(base64.b64encode(record["Data"]))
                 last_sequence_number = record["SequenceNumber"]
             if not records:
-                time.sleep(1)
-                continue
+                # on AWS this is approximately 5 sec, however since this is not async, it's a blocking call
+                # putting temporarily to 3 seconds until ASF migration or an async call
+                time.sleep(3)
 
             response = {
                 "ChildShards": [],

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -321,8 +321,9 @@ def subscribe_to_shard(data, headers):
                 record["Data"] = to_str(base64.b64encode(record["Data"]))
                 last_sequence_number = record["SequenceNumber"]
             if not records:
-                # on AWS this is approximately 5 sec, however since this is not async, it's a blocking call
-                # putting temporarily to 3 seconds until ASF migration or an async call
+                # On AWS there is *at least* 1 event every 5 seconds
+                # but this is not possible in this structure.
+                # In order to avoid a 5-second blocking call, we make the compromise of 3 seconds.
                 time.sleep(3)
 
             response = {

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -169,6 +169,29 @@ class TransformerUtility:
         ]
 
     @staticmethod
+    def kinesis_api():
+        """
+        :return: array with Transformers, for s3 api.
+        """
+        return [
+            JsonpathTransformer(
+                jsonpath="$..Records..SequenceNumber",
+                replacement="sequence_number",
+                replace_reference=True,
+            ),
+            TransformerUtility.key_value(
+                "StartingSequenceNumber", "starting_sequence_number", reference_replacement=False
+            ),
+            TransformerUtility.key_value("ShardId", "shard_id", reference_replacement=False),
+            TransformerUtility.key_value(
+                "EndingHashKey", "ending_hash", reference_replacement=False
+            ),
+            TransformerUtility.key_value(
+                "StartingHashKey", "starting_hash", reference_replacement=False
+            ),
+        ]
+
+    @staticmethod
     def sqs_api():
         """
         :return: array with Transformers, for sqs api.

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -171,7 +171,7 @@ class TransformerUtility:
     @staticmethod
     def kinesis_api():
         """
-        :return: array with Transformers, for s3 api.
+        :return: array with Transformers, for kinesis api.
         """
         return [
             JsonpathTransformer(
@@ -179,15 +179,25 @@ class TransformerUtility:
                 replacement="sequence_number",
                 replace_reference=True,
             ),
-            TransformerUtility.key_value(
-                "StartingSequenceNumber", "starting_sequence_number", reference_replacement=False
-            ),
-            TransformerUtility.key_value("ShardId", "shard_id", reference_replacement=False),
+            TransformerUtility.key_value("StartingSequenceNumber", "starting_sequence_number"),
+            TransformerUtility.key_value("ShardId", "shard_id"),
             TransformerUtility.key_value(
                 "EndingHashKey", "ending_hash", reference_replacement=False
             ),
             TransformerUtility.key_value(
                 "StartingHashKey", "starting_hash", reference_replacement=False
+            ),
+            TransformerUtility.key_value(_resource_name_transformer, "ConsumerARN"),
+            RegexTransformer(
+                r"([a-zA-Z0-9-_.]*)?\/consumer:([0-9-_.]*)?",
+                replacement="<stream-consumer>",
+            ),
+            RegexTransformer(
+                r"([a-zA-Z0-9-_.]*)?\/test-stream-([a-zA-Z0-9-_.]*)?",
+                replacement="<stream-name>",
+            ),
+            TransformerUtility.key_value(
+                "ContinuationSequenceNumber", "<continuation_sequence_number>"
             ),
         ]
 

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import re
 import time
@@ -313,8 +312,14 @@ class TestKinesis:
             assert response_record.get("Data").decode("utf-8") in records_data
 
     @pytest.mark.aws_validated
-    def test_subscribe_to_shard_timeout(self, kinesis_client, kinesis_create_stream, wait_for_stream_ready,
-                                        wait_for_consumer_ready, monkeypatch):
+    def test_subscribe_to_shard_timeout(
+        self,
+        kinesis_client,
+        kinesis_create_stream,
+        wait_for_stream_ready,
+        wait_for_consumer_ready,
+        monkeypatch,
+    ):
 
         monkeypatch.setattr(kinesis_listener, "MAX_SUBSCRIPTION_SECONDS", 5)
 
@@ -366,9 +371,7 @@ class TestKinesis:
     @pytest.mark.aws_validated
     def test_add_tags_to_stream(self, kinesis_client, kinesis_create_stream, wait_for_stream_ready):
         stream_name = "test-%s" % short_uid()
-        test_tags = {
-            "Hello": "world"
-        }
+        test_tags = {"Hello": "world"}
 
         # create stream
         kinesis_create_stream(StreamName=stream_name, ShardCount=1)
@@ -380,13 +383,13 @@ class TestKinesis:
         # reading stream tags
         list_tags_response = kinesis_client.list_tags_for_stream(StreamName=stream_name)
 
-        assert list_tags_response['Tags'][0]['Key'] == "Hello"
-        assert list_tags_response['Tags'][0]['Value'] == test_tags["Hello"]
-        assert not list_tags_response['HasMoreTags']
+        assert list_tags_response["Tags"][0]["Key"] == "Hello"
+        assert list_tags_response["Tags"][0]["Value"] == test_tags["Hello"]
+        assert not list_tags_response["HasMoreTags"]
 
     @pytest.mark.aws_validated
     def test_get_records_next_shard_iterator(
-            self, kinesis_client, kinesis_create_stream, wait_for_stream_ready
+        self, kinesis_client, kinesis_create_stream, wait_for_stream_ready
     ):
         stream_name = kinesis_create_stream()
         wait_for_stream_ready(stream_name)

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -295,7 +295,7 @@ class TestKinesis:
         snapshot.match("Records", response_records)
 
     @pytest.mark.aws_validated
-    @patch.object(kinesis_listener, "MAX_SUBSCRIPTION_SECONDS", 5)
+    @patch.object(kinesis_listener, "MAX_SUBSCRIPTION_SECONDS", 3)
     def test_subscribe_to_shard_timeout(
         self,
         kinesis_client,

--- a/tests/integration/test_kinesis.snapshot.json
+++ b/tests/integration/test_kinesis.snapshot.json
@@ -1,0 +1,62 @@
+{
+  "tests/integration/test_kinesis.py::TestKinesis::test_subscribe_to_shard_timeout": {
+    "recorded-date": "25-08-2022, 09:47:30",
+    "recorded-content": {}
+  },
+  "tests/integration/test_kinesis.py::TestKinesis::test_create_stream_without_shard_count": {
+    "recorded-date": "25-08-2022, 09:34:05",
+    "recorded-content": {
+      "Shards": [
+        {
+          "ShardId": "shard_id",
+          "HashKeyRange": {
+            "StartingHashKey": "starting_hash",
+            "EndingHashKey": "ending_hash"
+          },
+          "SequenceNumberRange": {
+            "StartingSequenceNumber": "starting_sequence_number"
+          }
+        },
+        {
+          "ShardId": "shard_id",
+          "HashKeyRange": {
+            "StartingHashKey": "starting_hash",
+            "EndingHashKey": "ending_hash"
+          },
+          "SequenceNumberRange": {
+            "StartingSequenceNumber": "starting_sequence_number"
+          }
+        },
+        {
+          "ShardId": "shard_id",
+          "HashKeyRange": {
+            "StartingHashKey": "starting_hash",
+            "EndingHashKey": "ending_hash"
+          },
+          "SequenceNumberRange": {
+            "StartingSequenceNumber": "starting_sequence_number"
+          }
+        },
+        {
+          "ShardId": "shard_id",
+          "HashKeyRange": {
+            "StartingHashKey": "starting_hash",
+            "EndingHashKey": "ending_hash"
+          },
+          "SequenceNumberRange": {
+            "StartingSequenceNumber": "starting_sequence_number"
+          }
+        }
+      ]
+    }
+  },
+  "tests/integration/test_kinesis.py::TestKinesis::test_add_tags_to_stream": {
+    "recorded-date": "25-08-2022, 08:56:43",
+    "recorded-content": {
+      "Tags": {
+        "Key": "foo",
+        "Value": "bar"
+      }
+    }
+  }
+}

--- a/tests/integration/test_kinesis.snapshot.json
+++ b/tests/integration/test_kinesis.snapshot.json
@@ -1,50 +1,46 @@
 {
-  "tests/integration/test_kinesis.py::TestKinesis::test_subscribe_to_shard_timeout": {
-    "recorded-date": "25-08-2022, 09:47:30",
-    "recorded-content": {}
-  },
   "tests/integration/test_kinesis.py::TestKinesis::test_create_stream_without_shard_count": {
-    "recorded-date": "25-08-2022, 09:34:05",
+    "recorded-date": "26-08-2022, 09:30:59",
     "recorded-content": {
       "Shards": [
         {
-          "ShardId": "shard_id",
+          "ShardId": "<shard_id:1>",
           "HashKeyRange": {
             "StartingHashKey": "starting_hash",
             "EndingHashKey": "ending_hash"
           },
           "SequenceNumberRange": {
-            "StartingSequenceNumber": "starting_sequence_number"
+            "StartingSequenceNumber": "<starting_sequence_number:1>"
           }
         },
         {
-          "ShardId": "shard_id",
+          "ShardId": "<shard_id:2>",
           "HashKeyRange": {
             "StartingHashKey": "starting_hash",
             "EndingHashKey": "ending_hash"
           },
           "SequenceNumberRange": {
-            "StartingSequenceNumber": "starting_sequence_number"
+            "StartingSequenceNumber": "<starting_sequence_number:2>"
           }
         },
         {
-          "ShardId": "shard_id",
+          "ShardId": "<shard_id:3>",
           "HashKeyRange": {
             "StartingHashKey": "starting_hash",
             "EndingHashKey": "ending_hash"
           },
           "SequenceNumberRange": {
-            "StartingSequenceNumber": "starting_sequence_number"
+            "StartingSequenceNumber": "<starting_sequence_number:3>"
           }
         },
         {
-          "ShardId": "shard_id",
+          "ShardId": "<shard_id:4>",
           "HashKeyRange": {
             "StartingHashKey": "starting_hash",
             "EndingHashKey": "ending_hash"
           },
           "SequenceNumberRange": {
-            "StartingSequenceNumber": "starting_sequence_number"
+            "StartingSequenceNumber": "<starting_sequence_number:4>"
           }
         }
       ]
@@ -57,6 +53,131 @@
         "Key": "foo",
         "Value": "bar"
       }
+    }
+  },
+  "tests/integration/test_kinesis.py::TestKinesis::test_record_lifecycle_data_integrity": {
+    "recorded-date": "25-08-2022, 12:39:44",
+    "recorded-content": {
+      "Records": [
+        {
+          "SequenceNumber": "<sequence_number:1>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b''",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:2>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:3>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'test'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:4>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'\\xc3\\xbcnic\\xc3\\xb6d\\xc3\\xa9 \\xe7\\xbb\\x9f\\xe4\\xb8\\x80\\xe7\\xa0\\x81 \\xf0\\x9f\\x92\\xa3\\xf0\\x9f\\x92\\xbb\\xf0\\x9f\\x94\\xa5'",
+          "PartitionKey": "1"
+        }
+      ]
+    }
+  },
+  "tests/integration/test_kinesis.py::TestKinesis::test_subscribe_to_shard_with_sequence_number_as_iterator": {
+    "recorded-date": "26-08-2022, 09:29:21",
+    "recorded-content": {
+      "Records": [
+        {
+          "SequenceNumber": "<sequence_number:1>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_0'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:2>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_1'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:3>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_2'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:4>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_3'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:5>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_4'",
+          "PartitionKey": "1"
+        }
+      ]
+    }
+  },
+  "tests/integration/test_kinesis.py::TestKinesis::test_stream_consumers": {
+    "recorded-date": "26-08-2022, 10:23:46",
+    "recorded-content": {
+      "One_consumer_by_list_stream": [
+        {
+          "ConsumerName": "consumer",
+          "ConsumerARN": "arn:aws:kinesis:<region>:111111111111:<stream-name>/<stream-consumer>",
+          "ConsumerStatus": "ACTIVE",
+          "ConsumerCreationTimestamp": "timestamp"
+        }
+      ],
+      "One_consumer_by_describe_stream": {
+        "ConsumerARN": "arn:aws:kinesis:<region>:111111111111:<stream-name>/<stream-consumer>",
+        "ConsumerCreationTimestamp": "timestamp",
+        "ConsumerName": "consumer",
+        "ConsumerStatus": "ACTIVE",
+        "StreamARN": "arn:aws:kinesis:<region>:111111111111:<stream-name>"
+      }
+    }
+  },
+  "tests/integration/test_kinesis.py::TestKinesis::test_subscribe_to_shard": {
+    "recorded-date": "26-08-2022, 09:33:29",
+    "recorded-content": {
+      "Records": [
+        {
+          "SequenceNumber": "<sequence_number:1>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_0'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:2>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_1'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:3>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_2'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:4>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_3'",
+          "PartitionKey": "1"
+        },
+        {
+          "SequenceNumber": "<sequence_number:5>",
+          "ApproximateArrivalTimestamp": "timestamp",
+          "Data": "b'Hello world_4'",
+          "PartitionKey": "1"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Summary

Fixes an issue where a SubscribeToShard is cut too early - now set to 5min. 
Additionally added aws validated test marks and a basic kinesis stream tags test.

### Test
test_subscribe_to_shard_timeout

### Related
Fixes: #5830 

