### PR TITLE
add service-specific response handler for dynamodb

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -56,6 +56,7 @@ class LocalstackAwsGateway(Gateway):
         # response post-processing
         self.response_handlers.extend(
             [
+                handlers.modify_service_response,
                 handlers.parse_service_response,
                 handlers.set_close_connection_header,
                 handlers.run_custom_response_handlers,

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -19,6 +19,7 @@ handle_internal_failure = fallback.InternalFailureHandler()
 serve_custom_service_request_handlers = chain.CompositeHandler()
 serve_localstack_resources = internal.LocalstackResourceHandler()
 run_custom_response_handlers = chain.CompositeResponseHandler()
+modify_service_response = service.ServiceResponseHandlers()
 parse_service_response = service.ServiceResponseParser()
 # legacy compatibility handlers
 serve_edge_router_rules = legacy.EdgeRouterHandler()

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -5,12 +5,14 @@ import random
 import re
 import time
 import traceback
+from binascii import crc32
 from typing import Dict, List
 
 import requests
 import werkzeug
 
 from localstack import config, constants
+from localstack.aws import handlers
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import (
     CommonServiceException,
@@ -261,30 +263,10 @@ class ValidationException(CommonServiceException):
 
 class DynamoDBApiListener(AwsApiListener):
     def __init__(self, provider=None):
+        # TODO: remove once localstack-ext is refactored
         provider = provider or DynamoDBProvider()
         self.provider = provider
         super().__init__("dynamodb", HttpFallbackDispatcher(provider, provider.get_forward_url))
-
-    def return_response(self, method, path, data, headers, response):
-        if response._content:
-            response_content = to_str(response._content)
-            # fix the table and latest stream ARNs (DynamoDBLocal hardcodes "ddblocal" as the region)
-            content_replaced = re.sub(
-                r'("TableArn"|"LatestStreamArn"|"StreamArn")\s*:\s*"arn:([a-z-]+):dynamodb:ddblocal:([^"]+)"',
-                rf'\1: "arn:\2:dynamodb:{aws_stack.get_region()}:\3"',
-                response_content,
-            )
-            if content_replaced != response_content:
-                response._content = content_replaced
-
-        # set x-amz-crc32 headers required by some client
-        fix_headers_for_updated_response(response)
-
-        # update table definitions
-        data = json.loads(to_str(data))
-        if data and "TableName" in data and "KeySchema" in data:
-            table_definitions = get_store().table_definitions
-            table_definitions[data["TableName"]] = data
 
 
 def get_store(context: RequestContext | None = None) -> DynamoDBStore:
@@ -299,6 +281,10 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         self.request_forwarder = get_request_forwarder_http(self.get_forward_url)
 
     def on_after_init(self):
+        # add response processor specific to ddblocal
+        handlers.modify_service_response.append(self.service, self._modify_ddblocal_arns)
+
+        # routes for the shell ui
         ROUTER.add(
             path="/shell",
             endpoint=self.handle_shell_ui_redirect,
@@ -308,6 +294,24 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             path="/shell/<regex('.*'):req_path>",
             endpoint=self.handle_shell_ui_request,
         )
+
+    def _modify_ddblocal_arns(self, chain, context: RequestContext, response: Response):
+        """A service response handler that modifies the dynamodb backend response."""
+        if response_content := response.get_data(as_text=True):
+            # fix the table and latest stream ARNs (DynamoDBLocal hardcodes "ddblocal" as the region)
+            content_replaced = re.sub(
+                r'("TableArn"|"LatestStreamArn"|"StreamArn")\s*:\s*"arn:([a-z-]+):dynamodb:ddblocal:([^"]+)"',
+                rf'\1: "arn:\2:dynamodb:{aws_stack.get_region()}:\3"',
+                response_content,
+            )
+            if content_replaced != response_content:
+                response.data = content_replaced
+                context.service_response = (
+                    None  # make sure the service response is parsed again later
+                )
+
+        # update x-amz-crc32 header required by some clients
+        response.headers["x-amz-crc32"] = crc32(response.data) & 0xFFFFFFFF
 
     def forward_request(
         self, context: RequestContext, service_request: ServiceRequest = None

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -97,7 +97,6 @@ from localstack.services.dynamodb.utils import (
     ItemFinder,
     ItemSet,
     SchemaExtractor,
-    calculate_crc32,
     extract_table_name_from_partiql_update,
 )
 from localstack.services.dynamodbstreams import dynamodbstreams_api
@@ -1364,11 +1363,6 @@ def get_updated_records(table_name: str, existing_items: List) -> List:
     for item in before.items_list:
         _add_record(item, after)
     return result
-
-
-def fix_headers_for_updated_response(response):
-    response.headers["Content-Length"] = len(to_bytes(response.content))
-    response.headers["x-amz-crc32"] = calculate_crc32(response)
 
 
 def create_dynamodb_stream(data, latest_stream_label):

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from binascii import crc32
 from typing import Dict, List, Optional
 
 from cachetools import TTLCache
@@ -8,7 +7,6 @@ from moto.core.exceptions import JsonRESTError
 
 from localstack.utils.aws import aws_stack
 from localstack.utils.json import canonical_json
-from localstack.utils.strings import to_bytes
 from localstack.utils.testutil import list_all_resources
 
 LOG = logging.getLogger(__name__)
@@ -154,7 +152,3 @@ def extract_table_name_from_partiql_update(statement: str) -> Optional[str]:
     regex = r"^\s*(UPDATE|INSERT\s+INTO|DELETE\s+FROM)\s+([^\s]+).*"
     match = re.match(regex, statement, flags=re.IGNORECASE | re.MULTILINE)
     return match and match.group(2)
-
-
-def calculate_crc32(response):
-    return crc32(to_bytes(response.content)) & 0xFFFFFFFF

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -69,13 +69,18 @@ def cloudwatch():
 
 @aws_provider()
 def dynamodb():
-    from localstack.services.dynamodb.provider import DynamoDBApiListener
+    from localstack.aws.forwarder import HttpFallbackDispatcher
+    from localstack.services.dynamodb.provider import DynamoDBProvider
 
-    listener = DynamoDBApiListener()
+    provider = DynamoDBProvider()
+    listener = AwsApiListener(
+        "dynamodb", HttpFallbackDispatcher(provider, provider.get_forward_url)
+    )
+
     return Service(
         "dynamodb",
         listener=listener,
-        lifecycle_hook=listener.provider,
+        lifecycle_hook=provider,
     )
 
 


### PR DESCRIPTION
This PR
* adds service-specific response handlers that allow services to modify responses *before* it is parsed. this is useful for cases when you want a catch-all modification of responses as they are returned by a backend
* refactors the DynamoDBApiListener to make use of the new construct
* removes the obsolete "update table definitions" code (already handled in `create_table`, and it's the only operation that the if condition matches, i double checked against the specs)

ext should work, but needs to be refactored once this is merged to also remove the custom AwsApiListener

- part of #6668 