### PR TITLE
POC of global tables version 2019

### DIFF
--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -84,7 +84,7 @@ class RegionContextModifier(ContextModifier):
         self.region = region
 
     def modify_context(self, context: RequestContext) -> RequestContext:
-        _context = copy.deepcopy(context)
+        _context = copy.copy(context)
         _context.region = self.region
         _headers = _context.request.headers
 

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -2,7 +2,9 @@
 This module contains utilities to call a backend (e.g., an external service process like
 DynamoDBLocal) from a service provider.
 """
-from typing import Any, Callable, Mapping, Optional
+import copy
+import re
+from typing import Any, Callable, Mapping, Optional, Protocol
 from urllib.parse import urlsplit
 
 from botocore.awsrequest import AWSPreparedRequest
@@ -63,6 +65,36 @@ def _wrap_with_fallthrough(
 
 def HttpFallbackDispatcher(provider: object, forward_url_getter: Callable[[], str]):
     return ForwardingFallbackDispatcher(provider, get_request_forwarder_http(forward_url_getter))
+
+
+class ContextModifier(Protocol):
+    """
+    This protocol is used to apply a specific modification to a request context.
+    It does not modify the original context; it creates a newly one instead.
+    """
+
+    def modify_context(self, context: RequestContext) -> RequestContext:
+        ...
+
+
+class RegionContextModifier(ContextModifier):
+    """It modifies a `RequestContext` by changing its region."""
+
+    def __init__(self, region: str):
+        self.region = region
+
+    def modify_context(self, context: RequestContext) -> RequestContext:
+        _context = copy.deepcopy(context)
+        _context.region = self.region
+        _headers = _context.request.headers
+
+        _headers["Authorization"] = re.sub(
+            r"Credential=([^/]+/[^/]+)/(.*?)/",
+            rf"Credential=\1/{self.region}/",
+            _headers.get("Authorization") or "",
+            flags=re.IGNORECASE,
+        )
+        return _context
 
 
 def get_request_forwarder_http(forward_url_getter: Callable[[], str]) -> ServiceRequestHandler:

--- a/localstack/services/dynamodb/models.py
+++ b/localstack/services/dynamodb/models.py
@@ -20,7 +20,6 @@ class DynamoDBStore(BaseStore):
     # maps table names to cached table definitions
     table_definitions: Dict[str, Dict] = LocalAttribute(default=dict)
     # maps table names to additional table properties that are not stored upstream (e.g., ReplicaUpdates)
-    # TODO: replicas are out of here!!
     table_properties: Dict[str, Dict] = LocalAttribute(default=dict)
     # maps the replicas for the v.2019 tables
     REPLICA_UPDATES: Dict[TableName, Replica] = CrossRegionAttribute(default=dict)

--- a/localstack/services/dynamodb/models.py
+++ b/localstack/services/dynamodb/models.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Set
 
 from localstack.services.stores import (
     AccountRegionBundle,
@@ -6,6 +6,10 @@ from localstack.services.stores import (
     CrossRegionAttribute,
     LocalAttribute,
 )
+
+TableName = str
+Region = str
+Replica = Dict[Region, Set[Region]]
 
 
 class DynamoDBStore(BaseStore):
@@ -16,7 +20,10 @@ class DynamoDBStore(BaseStore):
     # maps table names to cached table definitions
     table_definitions: Dict[str, Dict] = LocalAttribute(default=dict)
     # maps table names to additional table properties that are not stored upstream (e.g., ReplicaUpdates)
+    # TODO: replicas are out of here!!
     table_properties: Dict[str, Dict] = LocalAttribute(default=dict)
+    # maps the replicas for the v.2019 tables
+    REPLICA_UPDATES: Dict[TableName, Replica] = CrossRegionAttribute(default=dict)
     # maps table names to TTL specifications
     ttl_specifications: Dict[str, Dict] = LocalAttribute(default=dict)
 

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -293,7 +293,7 @@ def get_global_table_region(table_name: str, target_region: str | None = None) -
 def look_for_global_table(
     context: RequestContext, table_name: str, region: str | None = None
 ) -> None:
-    region: str | None = get_global_table_region(table_name=table_name, target_region=region)
+    region = get_global_table_region(table_name=table_name, target_region=region)
     if region:
         # modify the context to query the original region where the table has been created
         context.region = region

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -457,7 +457,6 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         result = self.forward_request(context)
 
         # update response with additional props
-        # TODO: This description needs to be updated too! (replicas)
         table_props = get_store(context).table_properties.get(table_name)
         if table_props:
             result.get("Table", {}).update(table_props)

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -324,12 +324,11 @@ def route53_client() -> "Route53Client":
 
 @pytest.fixture
 def dynamodb_wait_for_table_active(dynamodb_client):
-    def wait_for_table_active(table_name: str):
+    def wait_for_table_active(table_name: str, client=None):
         def wait():
-            return (
-                dynamodb_client.describe_table(TableName=table_name)["Table"]["TableStatus"]
-                == "ACTIVE"
-            )
+            return (client or dynamodb_client).describe_table(TableName=table_name)["Table"][
+                "TableStatus"
+            ] == "ACTIVE"
 
         poll_condition(wait, timeout=30)
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -869,74 +869,70 @@ class TestDynamoDB:
         delete_table(table_name)
         kinesis.delete_stream(StreamName="kinesis_dest_stream")
 
-    def test_global_tables_version_2019(self):
+    def test_global_tables_version_2019(
+        self, create_boto_client, cleanups, dynamodb_wait_for_table_active
+    ):
         # following https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables.tutorial.html
 
         # create clients
-        dynamodb_us_east_2 = aws_stack.create_external_boto_client(
-            "dynamodb", region_name="us-east-2"
-        )
-        dynamodb_eu_west_1 = aws_stack.create_external_boto_client(
-            "dynamodb", region_name="eu-west-1"
-        )
-        dynamodb_us_east_1 = aws_stack.create_external_boto_client(
-            "dynamodb", region_name="us-east-1"
-        )
+        dynamodb_us_east_1 = create_boto_client("dynamodb", region_name="us-east-1")
+        dynamodb_eu_west_1 = create_boto_client("dynamodb", region_name="eu-west-1")
+        dynamodb_us_east_2 = create_boto_client("dynamodb", region_name="us-east-2")
 
-        try:
-            # create table on us_east_2
-            table_name = f"table-{short_uid()}"
-            dynamodb_us_east_2.create_table(
-                TableName=table_name,
-                KeySchema=[
-                    {"AttributeName": "Artist", "KeyType": "HASH"},
-                    {"AttributeName": "SongTitle", "KeyType": "RANGE"},
-                ],
-                AttributeDefinitions=[
-                    {"AttributeName": "Artist", "AttributeType": "S"},
-                    {"AttributeName": "SongTitle", "AttributeType": "S"},
-                ],
-                ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
-            )
-            # replica table on us-east-1
-            dynamodb_us_east_2.update_table(
-                TableName=table_name, ReplicaUpdates=[{"Create": {"RegionName": "us-east-1"}}]
-            )
-            # replica table on eu-west-1
-            dynamodb_us_east_2.update_table(
-                TableName=table_name, ReplicaUpdates=[{"Create": {"RegionName": "eu-west-1"}}]
-            )
-            response = dynamodb_us_east_2.describe_table(TableName=table_name)
-            assert len(response["Table"]["Replicas"]) == 2
+        # create table on us-east-1
+        table_name = f"table-{short_uid()}"
+        dynamodb_us_east_2.create_table(
+            TableName=table_name,
+            KeySchema=[
+                {"AttributeName": "Artist", "KeyType": "HASH"},
+                {"AttributeName": "SongTitle", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "Artist", "AttributeType": "S"},
+                {"AttributeName": "SongTitle", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        dynamodb_wait_for_table_active(table_name=table_name, client=dynamodb_us_east_2)
+        # replica table on us-east-1
+        dynamodb_us_east_2.update_table(
+            TableName=table_name, ReplicaUpdates=[{"Create": {"RegionName": "us-east-1"}}]
+        )
+        # replica table on eu-west-1
+        dynamodb_us_east_2.update_table(
+            TableName=table_name, ReplicaUpdates=[{"Create": {"RegionName": "eu-west-1"}}]
+        )
+        response = dynamodb_us_east_2.describe_table(TableName=table_name)
 
-            # put item on us-east-2
-            dynamodb_us_east_2.put_item(
-                TableName=table_name,
-                Item={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
-            )
-            # check the item on us-east-1 and eu-west-1
-            item_us_east = dynamodb_us_east_1.get_item(
+        assert len(response["Table"]["Replicas"]) == 2
+
+        # put item on us-east-2
+        dynamodb_us_east_2.put_item(
+            TableName=table_name,
+            Item={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
+        )
+        # check the item on us-east-1 and eu-west-1
+        item_us_east = dynamodb_us_east_1.get_item(
+            TableName=table_name,
+            Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
+        )["Item"]
+        assert item_us_east
+        item_eu_west = dynamodb_eu_west_1.get_item(
+            TableName=table_name,
+            Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
+        )["Item"]
+        assert item_eu_west
+        # delete replica on us-west-1
+        dynamodb_us_east_2.update_table(
+            TableName=table_name, ReplicaUpdates=[{"Delete": {"RegionName": "eu-west-1"}}]
+        )
+        with pytest.raises(Exception) as ctx:
+            dynamodb_eu_west_1.get_item(
                 TableName=table_name,
                 Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
-            )["Item"]
-            assert item_us_east
-            item_eu_west = dynamodb_eu_west_1.get_item(
-                TableName=table_name,
-                Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
-            )["Item"]
-            assert item_eu_west
-            # delete replica on us-west-1
-            dynamodb_us_east_2.update_table(
-                TableName=table_name, ReplicaUpdates=[{"Delete": {"RegionName": "eu-west-1"}}]
             )
-            with pytest.raises(Exception) as ctx:
-                dynamodb_eu_west_1.get_item(
-                    TableName=table_name,
-                    Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
-                )
-            ctx.match("ResourceNotFoundException")
-        finally:
-            dynamodb_us_east_2.delete_table(TableName=table_name)
+        ctx.match("ResourceNotFoundException")
+        cleanups.append(lambda: dynamodb_us_east_2.delete_table(TableName=table_name))
 
     def test_global_tables(self):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -893,6 +893,7 @@ class TestDynamoDB:
             ],
             BillingMode="PAY_PER_REQUEST",
         )
+        cleanups.append(lambda: dynamodb_us_east_2.delete_table(TableName=table_name))
         dynamodb_wait_for_table_active(table_name=table_name, client=dynamodb_us_east_2)
         # replica table on us-east-1
         dynamodb_us_east_2.update_table(
@@ -932,7 +933,6 @@ class TestDynamoDB:
                 Key={"Artist": {"S": "item_1"}, "SongTitle": {"S": "Song Value 1"}},
             )
         ctx.match("ResourceNotFoundException")
-        cleanups.append(lambda: dynamodb_us_east_2.delete_table(TableName=table_name))
 
     def test_global_tables(self):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)


### PR DESCRIPTION
This PR introduces initial support for DynamoDB global tables version 2019.

We simulate replicas as follows:
- We store information about the replicas in a cross-region attribute; this step is done when the user updates a table. The region for this call is going to the "original region" where the table effectively lives. De-facto, we have created a global table with this step.
- We can now call operations (only `PutItem` and `GetItem` at the moment) on the created global table from other regions. Before forwarding the call to DDB local, we inspect our cross-region attribute to see if this is a global table and if in the current regions there is a valid replica. If so, we change the context of the call and the credentials in the header to perform a call against the original region (where the table effectively lives) and not to the replica (DDB local won't find it).

Such an approach is still rudimental and probably it does not cover a lot of corner cases, but we are able to replicate the example in the [docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables.tutorial.html#V2creategt_cli) in an integration test.