### PR TITLE
Extend valid regions for Stores to include extended AWS partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ api_states
 /integration/lambdas/golang/handler.zip
 /tests/integration/lambdas/golang/handler.zip
 tmp/
+
+volume/

--- a/localstack/services/stores.py
+++ b/localstack/services/stores.py
@@ -28,7 +28,7 @@ from collections.abc import Callable
 from threading import RLock
 from typing import Any, Type, TypeVar, Union
 
-from boto3 import Session
+from localstack.utils.aws.aws_stack import get_valid_regions_for_service
 
 LOCAL_ATTR_PREFIX = "attr_"
 
@@ -155,7 +155,7 @@ class RegionBundle(dict):
         self.validate = validate
         self.lock = lock or RLock()
 
-        self.valid_regions = Session().get_available_regions(service_name)
+        self.valid_regions = get_valid_regions_for_service(service_name)
 
         # Keeps track of all cross-region attributes
         self._global = {}

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest import fixture
 
 from localstack.services.stores import (
@@ -119,3 +120,20 @@ class TestStores:
             == id(sample_stores[account2]._global)
             != id(backend1_ap._global)
         )
+
+    def test_valid_regions(self):
+        class SampleStore(BaseStore):
+            pass
+
+        stores = AccountRegionBundle("sns", SampleStore)
+        account1 = "696969696969"
+
+        # assert regular regions work
+        assert stores[account1]["us-east-1"]
+        # assert extended regions work
+        assert stores[account1]["cn-north-1"]
+        assert stores[account1]["us-gov-west-1"]
+        # assert invalid regions don't pass validation
+        with pytest.raises(Exception) as exc:
+            assert stores[account1]["invalid-region"]
+        exc.match("not a valid AWS region")


### PR DESCRIPTION
Extend valid regions for Stores to include extended AWS partitions. Currently, store creation fails when creating them for a region within one of the extended AWS partitions, e.g., `us-gov-west-1`