### PR TITLE
fix scaffold by handling Union as special keyword

### DIFF
--- a/localstack/aws/scaffold.py
+++ b/localstack/aws/scaffold.py
@@ -24,7 +24,7 @@ from localstack.aws.spec import load_service
 from localstack.utils.common import camel_to_snake_case, snake_to_camel_case
 
 # Some minification packages might treat "type" as a keyword, some specs define shapes called like the type "Optional"
-KEYWORDS = list(keyword.kwlist) + ["type", "Optional"]
+KEYWORDS = list(keyword.kwlist) + ["type", "Optional", "Union"]
 is_keyword = KEYWORDS.__contains__
 
 

--- a/tests/unit/aws/test_scaffold.py
+++ b/tests/unit/aws/test_scaffold.py
@@ -9,9 +9,12 @@ from localstack.aws.scaffold import generate
 @pytest.mark.skip_offline
 @pytest.mark.parametrize(
     "service",
-    ["apigateway", "autoscaling", "cloudformation", "kafka", "dynamodb", "sqs", "kinesis"],
+    ["apigateway", "autoscaling", "cloudformation", "dynamodb", "glue", "kafka", "kinesis", "sqs"],
 )
-def test_generated_code_compiles(service):
+def test_generated_code_compiles(service, caplog):
+    # Deactivate logging on CLI (https://github.com/pallets/click/issues/824#issuecomment-562581313)
+    caplog.set_level(100000)
+
     runner = CliRunner()
     result = runner.invoke(generate, [service, "--no-doc", "--print"])
     assert result.exit_code == 0


### PR DESCRIPTION
AWS just recently introduced some changes to the AWS Glue API which introduces a type called `Union` in the service specification. The scaffold didn't properly escape the keyword yet, which caused issues with our code generation (since it wouldn't pass our linting rules):
```
. .venv/bin/activate; python -m pflake8 --show-source
aws/api/glue/__init__.py:1[8]10:1: F811 redefinition of unused 'Union' from line 3
class Union(TypedDict, total=False):
^
```

This PR adds `Union` to the list of reserved keywords (which causes the scaffold to escape the type name with a trailing underscore: `Union_`).
In addition, I added a small fix to deactivate logging in the scaffold unit tests due to issues with stdout logs and Click in pytest.