### PR TITLE
update CODEOWNERS, set default reviewer for ASF Update PRs

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -84,3 +84,4 @@ jobs:
           commit-message: "update generated ASF APIs to latest version"
           labels: "area: asf"
           token: ${{ secrets.PRO_ACCESS_TOKEN }}
+          reviewers: alexrashed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,7 +44,20 @@
 ### SERVICE OWNERS ###
 ######################
 
+# ACM
+/localstack/aws/api/acm/ @alexrashed
+/localstack/services/acm/ @alexrashed
+/tests/integration/test_acm.py @alexrashed
+
+# API Gateway
+/localstack/aws/api/apigateway/ @calvernaz
+/localstack/services/apigateway/ @calvernaz
+/localstack/services/cloudformation/models/apigateway.py @calvernaz
+/tests/integration/test_apigateway*.py @calvernaz
+/tests/unit/test_apigateway.py @calvernaz
+
 # Cloudformation
+/localstack/aws/api/cloudformation/ @dominikschubert
 /localstack/services/cloudformation/ @dominikschubert
 /localstack/utils/cloudformation/ @dominikschubert
 /tests/integration/cloudformation/ @dominikschubert
@@ -55,71 +68,101 @@
 /localstack/services/cloudformation/models/cloudformation.py @dominikschubert
 
 # Cloudwatch
-/localstack/services/cloudwatch/ @silv-io
-/tests/integration/test_cloudwatch.py @silv-io
+/localstack/aws/api/cloudwatch/ @steffyP
+/localstack/services/cloudwatch/ @steffyP
+/localstack/services/cloudformation/models/cloudwatch.py @steffyP
+/tests/integration/test_cloudwatch.py @steffyP
 
 # EC2
+/localstack/aws/api/ec2/ @viren-nadkarni
 /localstack/services/ec2/ @viren-nadkarni
+/localstack/services/cloudformation/models/ec2.py @viren-nadkarni
 /tests/integration/test_ec2.py @viren-nadkarni
 
 # ElasticSearch
+/localstack/aws/api/es/ @alexrashed
 /localstack/services/es/ @alexrashed
 /localstack/services/cloudformation/models/elasticsearch.py @alexrashed
 /tests/integration/test_es.py @alexrashed
 
 # Events / EventBridge
+/localstack/aws/api/events/ @dominikschubert @dfangl
 /localstack/services/events/ @dominikschubert @dfangl
 /localstack/services/cloudformation/models/events.py @dominikschubert @dfangl
 /tests/integration/test_events.py @dominikschubert @dfangl
 
-# OpenSearch
-/localstack/services/opensearch/ @alexrashed
-/tests/integration/test_opensearch.py @alexrashed
-/tests/unit/services/opensearch/test_s3.py @alexrashed
-
 # IAM
-/localstack/services/iam/ @dominikschubert
-/localstack/services/cloudformation/models/iam.py @dominikschubert
-/tests/integration/test_iam.py @dominikschubert
+/localstack/aws/api/iam/ @dfangl
+/localstack/services/iam/ @dfangl
+/localstack/services/cloudformation/models/iam.py @dfangl
+/tests/integration/test_iam.py @dfangl
 
 # Lambda
+/localstack/aws/api/lambda_/ @dfangl @dominikschubert
 /localstack/services/awslambda/ @dfangl @dominikschubert
 /localstack/services/cloudformation/models/awslambda.py @dfangl @dominikschubert
 /tests/integration/awslambda/ @dfangl @dominikschubert
 
+# Logs
+/localstack/aws/api/logs/ @steffyP
+/localstack/services/logs/ @steffyP
+/localstack/services/cloudformation/models/logs.py @steffyP
+/tests/integration/test_logs.py @steffyP
+/tests/unit/test_logs.py @steffyP
+
+# OpenSearch
+/localstack/aws/api/opensearch/ @alexrashed
+/localstack/services/opensearch/ @alexrashed
+/localstack/services/cloudformation/models/opensearch.py @alexrashed
+/tests/integration/test_opensearch.py @alexrashed
+/tests/unit/services/opensearch/ @alexrashed
+
+# Route53
+/localstack/aws/api/route53/ @giograno
+/localstack/services/route53/ @giograno
+/localstack/services/cloudformation/models/route53.py @giograno
+/tests/integration/test_route53.py @giograno
+
+# S3
+/localstack/aws/api/s3/ @thrau
+/localstack/services/s3/ @thrau
+/localstack/services/cloudformation/models/s3.py @thrau
+/tests/integration/test_s3.py @thrau
+/tests/unit/test_s3.py @thrau
+
 # Secretsmanager
+/localstack/aws/api/secretsmanager/ @dominikschubert
 /localstack/services/secretsmanager/ @dominikschubert
 /localstack/services/cloudformation/models/secretsmanager.py @dominikschubert
 /tests/integration/test_secretsmanager.py @dominikschubert
 
-# Stepfunctions
-/localstack/services/stepfunctions/ @dominikschubert
-/localstack/services/cloudformation/models/stepfunctions.py @dominikschubert
-/tests/integration/test_stepfunctions.py @dominikschubert
-
 # SES
+/localstack/aws/api/ses/ @viren-nadkarni
 /localstack/services/ses/ @viren-nadkarni
 /tests/integration/test_ses.py @viren-nadkarni
 
-# SSM
-/localstack/services/ssm/ @dominikschubert
-/localstack/services/cloudformation/models/ssm.py @dominikschubert
-/tests/integration/test_ssm.py @dominikschubert
-
-# SQS
-/localstack/services/sqs/ @thrau
-/localstack/services/cloudformation/models/sqs.py @thrau
-/tests/integration/test_sqs.py @thrau
-/tests/unit/test_sqs.py @thrau
-
 # SNS
+/localstack/aws/api/sns/ @bentsku
 /localstack/services/sns/ @bentsku
 /localstack/services/cloudformation/models/sns.py @bentsku
 /tests/integration/test_sns.py @bentsku
 /tests/unit/test_sns.py @bentsku
 
-# S3
-/localstack/services/s3/ @thrau
-/localstack/services/cloudformation/models/s3.py @thrau
-/tests/integration/test_s3.py @thrau
-/tests/unit/test_s3.py @thrau
+# SQS
+/localstack/aws/api/sqs/ @thrau
+/localstack/services/sqs/ @thrau
+/localstack/services/cloudformation/models/sqs.py @thrau
+/tests/integration/test_sqs.py @thrau
+/tests/unit/test_sqs.py @thrau
+
+# SSM
+/localstack/aws/api/ssm/ @dominikschubert
+/localstack/services/ssm/ @dominikschubert
+/localstack/services/cloudformation/models/ssm.py @dominikschubert
+/tests/integration/test_ssm.py @dominikschubert
+
+# Stepfunctions
+/localstack/aws/api/stepfunctions/ @dominikschubert
+/localstack/services/stepfunctions/ @dominikschubert
+/localstack/services/cloudformation/models/stepfunctions.py @dominikschubert
+/tests/integration/test_stepfunctions.py @dominikschubert


### PR DESCRIPTION
This PR updates the `CODEOWNERS` file:
- Orders the service owners alphabetically.
- Adds missing service sections which have an owner (ACM / @alexrashed, Api Gateway / @calvernaz, Logs / @steffyP, Route53 / @giograno).
- Changed codeowner of IAM from @dominikschubert to @dfangl.
- Changed codeowner of CloudWatch from @silv-io to @steffyP.
- Adds the cloudformation models to some of the sections.
- Adds the generated API code (`localstack.aws.api.<service>`) to each section (i.e. codeowners will be added to ASF Update PRs automatically if anything changes for their service).

I changed this proactively once I realized that some parts are outdated. Please let me know if any of the sections should be set differently (as a comment or in a DM).

In addition, I added myself as a default reviewer for PRs created by the ASF Update Action.