### PR TITLE
Fix IAM policy validation and MaxSessionDuration of roles, remove obsolete patches

### DIFF
--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -1,5 +1,4 @@
 import json
-import re
 from datetime import datetime
 from typing import Dict, List
 from urllib.parse import quote
@@ -8,16 +7,17 @@ from moto.iam.models import AWSManagedPolicy, InlinePolicy, Policy
 from moto.iam.models import Role as MotoRole
 from moto.iam.models import aws_managed_policies, filter_items_with_path_prefix
 from moto.iam.models import iam_backends as moto_iam_backends
-from moto.iam.policy_validation import VALID_STATEMENT_ELEMENTS, IAMPolicyDocumentValidator
-from moto.iam.responses import IamResponse
+from moto.iam.policy_validation import VALID_STATEMENT_ELEMENTS
 
 from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.api import CommonServiceException, RequestContext
+from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.iam import (
     ActionNameListType,
     ActionNameType,
     AttachedPermissionsBoundary,
     ContextEntryListType,
+    CreateRoleRequest,
+    CreateRoleResponse,
     CreateServiceLinkedRoleResponse,
     CreateUserResponse,
     DeleteServiceLinkedRoleResponse,
@@ -93,6 +93,18 @@ ADDITIONAL_MANAGED_POLICIES = {
 class IamProvider(IamApi):
     def __init__(self):
         apply_patches()
+
+    @handler("CreateRole", expand=False)
+    def create_role(
+        self, context: RequestContext, request: CreateRoleRequest
+    ) -> CreateRoleResponse:
+        result = call_moto(context)
+
+        if not request.get("MaxSessionDuration") and result["Role"].get("MaxSessionDuration"):
+            role = iam_global_backend().get_role(request["RoleName"])
+            role.max_session_duration = None
+            result["Role"].pop("MaxSessionDuration")
+        return result
 
     @staticmethod
     def build_evaluation_result(
@@ -440,39 +452,6 @@ def apply_patches():
 
     if "Principal" not in VALID_STATEMENT_ELEMENTS:
         VALID_STATEMENT_ELEMENTS.append("Principal")
-
-    @patch(IAMPolicyDocumentValidator._validate_resource_syntax, pass_target=False)
-    def _validate_resource_syntax(statement, *args, **kwargs):
-        # Note: Serverless generates policies without "Resource" section (only "Effect"/"Principal"/"Action"),
-        # which causes several policy validators in moto to fail
-        if statement.get("Resource") in [None, [None]]:
-            statement["Resource"] = ["*"]
-
-    # patch get_user to include tags
-    # TODO: remove this patch in favour of IamProvider.get_user.
-
-    @patch(IamResponse.get_user)
-    def iam_response_get_user(fn, self):
-        result = fn(self)
-        regex = r"(.*<UserName>\s*)([^\s]+)(\s*</UserName>.*)"
-        flags = re.MULTILINE | re.DOTALL
-
-        user_name = re.match(regex, result, flags=flags).group(2)
-        # replace default user id/name in response
-
-        user = iam_global_backend().users.get(user_name)
-        if not user:
-            return result
-        tags = iam_global_backend().tagger.list_tags_for_resource(user.arn)
-        if tags and "<Tags>" not in result:
-            tags_str = "".join(
-                [
-                    "<member><Key>%s</Key><Value>%s</Value></member>" % (t["Key"], t["Value"])
-                    for t in tags["Tags"]
-                ]
-            )
-            result = result.replace("</Arn>", "</Arn><Tags>%s</Tags>" % tags_str)
-        return result
 
     # patch policy __init__ to set document as attribute
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -922,6 +922,7 @@ def deploy_cfn_template(
     is_change_set_finished,
 ):
     state = []
+    specified_max_wait = None
 
     def _deploy(
         *,
@@ -934,6 +935,9 @@ def deploy_cfn_template(
         parameters: Optional[Dict[str, str]] = None,
         max_wait: Optional[int] = None,
     ) -> DeployResult:
+        nonlocal specified_max_wait
+        specified_max_wait = max(specified_max_wait or 0, max_wait or 0)
+
         if is_update:
             assert stack_name
         stack_name = stack_name or f"stack-{short_uid()}"
@@ -980,7 +984,7 @@ def deploy_cfn_template(
                     == "DELETE_COMPLETE"
                 )
 
-            assert wait_until(_await_stack_delete, _max_wait=60)
+            assert wait_until(_await_stack_delete, _max_wait=specified_max_wait or 60)
             # TODO: fix in localstack. stack should only be in DELETE_COMPLETE state after all resources have been deleted
             time.sleep(2)
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -922,7 +922,6 @@ def deploy_cfn_template(
     is_change_set_finished,
 ):
     state = []
-    specified_max_wait = None
 
     def _deploy(
         *,
@@ -935,8 +934,6 @@ def deploy_cfn_template(
         parameters: Optional[Dict[str, str]] = None,
         max_wait: Optional[int] = None,
     ) -> DeployResult:
-        nonlocal specified_max_wait
-        specified_max_wait = max(specified_max_wait or 0, max_wait or 0)
 
         if is_update:
             assert stack_name
@@ -984,7 +981,7 @@ def deploy_cfn_template(
                     == "DELETE_COMPLETE"
                 )
 
-            assert wait_until(_await_stack_delete, _max_wait=specified_max_wait or 60)
+            assert wait_until(_await_stack_delete, _max_wait=max_wait or 60)
             # TODO: fix in localstack. stack should only be in DELETE_COMPLETE state after all resources have been deleted
             time.sleep(2)
 

--- a/tests/integration/templates/statemachine_test.json
+++ b/tests/integration/templates/statemachine_test.json
@@ -71,29 +71,7 @@
                             ]
                         }
                     ]
-                },
-                "Policies": [
-                    {
-                        "PolicyName": "SecretsPermissions",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Action": [
-                                        "secretsmanager:*"
-                                    ],
-                                    "Effect": "Allow",
-                                    "Resource": {
-                                        "Fn::GetAtt": [
-                                            "SMS34SSB",
-                                            "Arn"
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
+                }
             },
             "Metadata": {
                 "AWS::CloudFormation::Designer": {
@@ -124,7 +102,9 @@
         },
         "SFA28OGX": {
             "Type": "AWS::StepFunctions::Activity",
-            "Properties": {},
+            "Properties": {
+                "Name": "activity-SFA28OGX"
+            },
             "Metadata": {
                 "AWS::CloudFormation::Designer": {
                     "id": "c76ef380-8ed9-4566-97dd-49975a40f65d"

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1524,25 +1524,23 @@ class TestCloudFormation:
         stack.destroy()
         _assert(0)
 
+    @pytest.mark.aws_validated
     def test_cfn_statemachine_with_dependencies(self, deploy_cfn_template, stepfunctions_client):
+
         stack = deploy_cfn_template(
-            template_path=os.path.join(THIS_FOLDER, "templates", "statemachine_test.json")
+            template_path=os.path.join(THIS_FOLDER, "templates", "statemachine_test.json"),
+            max_wait=150,
         )
 
         rs = stepfunctions_client.list_state_machines()
-        statemachines = [
-            sm
-            for sm in rs["stateMachines"]
-            if "{}-SFSM22S5Y".format(stack.stack_name) in sm["name"]
-        ]
+        sm_name = "SFSM22S5Y"
+        statemachines = [sm for sm in rs["stateMachines"] if sm_name in sm["name"]]
         assert len(statemachines) == 1
 
         stack.destroy()
 
         rs = stepfunctions_client.list_state_machines()
-        statemachines = [
-            sm for sm in rs["stateMachines"] if f"{stack.stack_name}-SFSM22S5Y" in sm["name"]
-        ]
+        statemachines = [sm for sm in rs["stateMachines"] if sm_name in sm["name"]]
 
         assert not statemachines
 

--- a/tests/integration/test_iam.py
+++ b/tests/integration/test_iam.py
@@ -389,8 +389,8 @@ class TestIAMIntegrations:
         assert actions["s3:GetObjectVersion"]["EvalDecision"] == "allowed"
 
     def test_create_role_with_assume_role_policy(self, iam_client):
-        role_name_1 = "role-{}".format(short_uid())
-        role_name_2 = "role-{}".format(short_uid())
+        role_name_1 = f"role-{short_uid()}"
+        role_name_2 = f"role-{short_uid()}"
 
         assume_role_policy_doc = {
             "Version": "2012-10-17",
@@ -452,9 +452,43 @@ class TestIAMIntegrations:
     def test_service_linked_role_name_should_match_aws(
         self, iam_client, service_name, expected_role
     ):
+        role_name = None
         try:
             service_linked_role = iam_client.create_service_linked_role(AWSServiceName=service_name)
             role_name = service_linked_role["Role"]["RoleName"]
             assert role_name == expected_role
         finally:
-            iam_client.delete_service_linked_role(RoleName=role_name)
+            if role_name:
+                iam_client.delete_service_linked_role(RoleName=role_name)
+
+    @pytest.mark.aws_validated
+    def test_update_assume_role_policy(self, iam_client, snapshot):
+        snapshot.add_transformer(snapshot.transform.iam_api())
+        snapshot.add_transformer(snapshot.transform.resource_name("role_name"))
+        snapshot.add_transformer(snapshot.transform.key_value("RoleId", "role_id"))
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": ["ec2.amazonaws.com"]},
+                    "Action": ["sts:AssumeRole"],
+                }
+            ],
+        }
+
+        role_name = f"role-{short_uid()}"
+        result = iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=json.dumps(policy),
+        )
+        snapshot.match("created_role", result)
+        try:
+            result = iam_client.update_assume_role_policy(
+                RoleName=role_name,
+                PolicyDocument=json.dumps(policy),
+            )
+            snapshot.match("updated_policy", result)
+        finally:
+            iam_client.delete_role(RoleName=role_name)

--- a/tests/integration/test_iam.snapshot.json
+++ b/tests/integration/test_iam.snapshot.json
@@ -1,0 +1,42 @@
+{
+  "tests/integration/test_iam.py::TestIAMIntegrations::test_update_assume_role_policy": {
+    "recorded-date": "25-08-2022, 10:39:48",
+    "recorded-content": {
+      "created_role": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "Role": {
+          "Arn": "arn:aws:iam::111111111111:role/<role_name:1>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ],
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": [
+                    "ec2.amazonaws.com"
+                  ]
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "Path": "/",
+          "RoleId": "<role_id:1>",
+          "RoleName": "<role_name:1>"
+        }
+      },
+      "updated_policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses #6644

* fix IAM policy validation - we were adding a `["*"]` default value for `Resource` in the past (apparently to fix Serverless CFn deployments), which should be no longer required
* fix role `MaxSessionDuration` (set to 3600 by default in moto), which is not how AWS is behaving (i.g., AWS is not returning `MaxSessionDuration` for a role if it hasn't been specified)
* add snapshot test for `update_assume_role_policy`
* remove obsolete patch for `get_user` to include tags, which is fixed upstream in the meantime
* small fix for `test_cfn_statemachine_with_dependencies` with issues detected as part of parity-testing these changes