### PR TITLE
refactor stepfunctions installer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,6 @@
 .venv*
 
 .filesystem
-# these files are required to be in the build context (see Dockerfile)
-!.filesystem/usr/lib/localstack/stepfunctions
-!.filesystem/usr/lib/localstack/localstack-*.jar
 
 # ignore files generated in CI build
 tests/integration/**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,9 +233,6 @@ RUN mkdir -p /.npm && \
 # Install the latest version of awslocal globally
 RUN pip3 install --upgrade awscli awscli-local requests
 
-# Adds the results of `make init` that are explicitly include in .dockerignore to the image.
-# `make init` needs to be executed before building the image, because some package installers need docker themselves.
-ADD .filesystem/usr/lib/localstack /usr/lib/localstack
 # Add the code in the last step
 ADD localstack/ localstack/
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ DOCKER_BUILD_FLAGS ?= "--load"
 DOCKERFILE ?= "./Dockerfile"
 docker-build: 			  ## Build Docker image
 	# prepare
-	# test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
+	test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
 	# start build
 	# --add-host: Fix for Centos host OS
 	# --build-arg BUILDKIT_INLINE_CACHE=1: Instruct buildkit to inline the caching information into the image

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ DOCKER_BUILD_FLAGS ?= "--load"
 DOCKERFILE ?= "./Dockerfile"
 docker-build: 			  ## Build Docker image
 	# prepare
-	test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
+	# test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
 	# start build
 	# --add-host: Fix for Centos host OS
 	# --build-arg BUILDKIT_INLINE_CACHE=1: Instruct buildkit to inline the caching information into the image

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,6 @@ TAG ?= $(IMAGE_NAME_FULL)
 DOCKER_BUILD_FLAGS ?= "--load"
 DOCKERFILE ?= "./Dockerfile"
 docker-build: 			  ## Build Docker image
-	# prepare
-	# test -e 'localstack/infra/stepfunctions/StepFunctionsLocal.jar' || make init
 	# start build
 	# --add-host: Fix for Centos host OS
 	# --build-arg BUILDKIT_INLINE_CACHE=1: Instruct buildkit to inline the caching information into the image


### PR DESCRIPTION
This PR is the first step of the bigger installer refactoring. It changes the following

- Get rid of make init on the host: This is a major pain point and blocker because it pulls and runs a container image via docker, and therefore needs to be removed for any work to be continued. 

The make init command on the host is essentially a convenient but inefficient way to get to the necessary JAR files of a specific version we need for the stepfuntions implementation. They are necessary because we need a pinned version, which AWS does not provide.
This PR should not impact any actual customer facing localstack functionality. It only changes how the necessary JAR files are fetched: we now download the necessary stepfunctions jars from the specific **_layer_** from the wanted image without docker, but directly via http. This makes the make init call for stepfunctions obsolete.
The layer is addressed via its digest. This digest does not change as far as we can tell, and is therefore suitable.