### PR TITLE
Add githook script to alert on changes that require re-installs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,13 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: check_deps_changes
+        name: Check for dependency changes
+        entry: python -m scripts.githook_deps_check
+        language: system
+        always_run: true
+        stages: [post-checkout, post-merge]
+        verbose: true

--- a/Makefile
+++ b/Makefile
@@ -274,8 +274,11 @@ format:            		  ## Run black and isort code formatter
 format-modified:   		  ## Run black and isort code formatter on modified files
 	($(VENV_RUN); python -m isort `git ls-files -m | grep '\.py$$' | xargs`; python -m black `git ls-files -m | grep '\.py$$' | xargs` )
 
-init-precommit:    		  ## install te pre-commit hook into your local git repository
+init-precommit:    		  ## install the pre-commit hook into your local git repository
 	($(VENV_RUN); pre-commit install)
+
+init-githooks:    		  ## install all githooks into your local git repository
+	($(VENV_RUN); pre-commit install -t pre-commit -t post-checkout -t post-merge)
 
 clean:             		  ## Clean up (npm dependencies, downloaded infrastructure code, compiled Java classes)
 	rm -rf .filesystem

--- a/scripts/githook_deps_check.py
+++ b/scripts/githook_deps_check.py
@@ -1,0 +1,49 @@
+"""
+Git hook that checks if there's been any updates to a set of predefined files
+
+This is for example useful to be alerted if there might be a need to reinstall the project
+"""
+
+import os
+import subprocess
+
+from rich.console import Console
+
+c = Console()
+
+DISABLE_CHECKS_ENV_VAR = "GITHOOK_DISABLE_DEPS_CHECK"
+
+# basically anything that might lead to issues with an existing local setup
+files_to_watch = ["setup.py", "setup.cfg", "requirements.txt", "Makefile", "pyproject.toml"]
+
+# TODO: alert on rebase
+# TODO: alert on pull
+# TODO: compare providers
+# TODO: compare plugins
+
+
+if __name__ == "__main__":
+    if os.environ.get(DISABLE_CHECKS_ENV_VAR, "0") == "1":
+        exit(0)
+
+    envs = {k: v for k, v in os.environ.items() if k.startswith("PRE_COMMIT")}
+
+    # checkout
+    from_commit = envs.get("PRE_COMMIT_FROM_REF")
+    to_commit = envs.get("PRE_COMMIT_TO_REF")
+
+    if from_commit and to_commit:
+        r = subprocess.run(
+            ["git", "diff", "--name-only", from_commit, to_commit], capture_output=True
+        )
+
+        files = r.stdout.decode().splitlines()
+
+        for file in files_to_watch:
+            if file in files:
+                c.print(
+                    f"[red]ATTENTION![/red] Found a change in file [red]{file}[/red] during the checkout."
+                )
+                c.print(
+                    f"\t>> show changes: [bold]git diff {from_commit[:8]}:{file} {to_commit[:8]}:{file}[/bold]\n"
+                )


### PR DESCRIPTION
Uses pre-commit to register a local python script that will be executed after running `git checkout`, i.e. when switching branches. It contains a list of files and if the diff between the two commits includes a change in these files, it will output a warning.

How to use:
Run `make init-githooks` to set up the hooks for your current repository.
You can trigger the behavior by switching to any branch with some change in any of the files that are listed in the script.


 Some things that I think should still be included before an initial merge:

- [ ] warn on rebase
- [ ] warn on pull
- [ ] check changes in providers
- [ ] check changes in plugins



References:
- https://git-scm.com/docs/githooks
- https://github.com/pre-commit/pre-commit