### PR TITLE
A valid skip condition without paths should skip the whole snapshot

### DIFF
--- a/localstack/testing/pytest/snapshot.py
+++ b/localstack/testing/pytest/snapshot.py
@@ -81,6 +81,14 @@ def pytest_runtest_call(item: Item) -> None:
                     if not callable(skip_condition):
                         raise ValueError("condition must be a callable")
 
+                    # special case where one of the marks has a skip condition but no paths
+                    # since we interpret a missing paths key as "all paths",
+                    # this should skip all paths, no matter what the other marks say
+                    if skip_condition() and not skip_paths:
+                        verify = False
+                        paths.clear()  # in case some other marker already added paths
+                        break
+
                     if not skip_condition():
                         continue  # don't skip
 


### PR DESCRIPTION
Minor fix for a bug that occurs when there are multiple `@pytest.mark.skip_snapshot_verify(condition=...)` markers.

If there's one where `condition` evaluates to True and it doesn't include a `paths` key, the affected snapshots should be skipped entirely, no matter in what order the marks are evaluated. Previously the paths were still added to the list and thus, not everything was skipped.
