### PR TITLE
fix ext compatibility for mergable sqs queue

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -344,7 +344,7 @@ class SqsQueue:
 
     def default_attributes(self) -> QueueAttributeMap:
         return {
-            QueueAttributeName.ApproximateNumberOfMessages: self.visible._qsize,
+            QueueAttributeName.ApproximateNumberOfMessages: lambda: self.visible._qsize(),
             QueueAttributeName.ApproximateNumberOfMessagesNotVisible: lambda: len(self.inflight),
             QueueAttributeName.ApproximateNumberOfMessagesDelayed: lambda: len(self.delayed),
             QueueAttributeName.CreatedTimestamp: str(now()),


### PR DESCRIPTION
This PR fixes an issue that was introduced by the SQS patches from ext related to merging of SQS queues.

The issue was that `self.visible` was overwritten by the patch, while the attribute getter of `ApproximateNumberOfMessages` was set to `self.visible._qsize` (the function reference) _before_ `self.visible` was overwritten, causing `ApproximateNumberOfMessages` to always be 0 since it was referencing the old queue. The fix was to make a lambda out of it so we always resolve the current `self.visible`, allowing a later overwrite.

The PR also adds a `timeout` argument to the `poll_condition` calls in the SQS tests to avoid the build pipeline to block until the timeout.