### PR TITLE
Avoid import rest api from openapi skipping 'parameters'

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -646,7 +646,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                 "description",
                 "summary",
                 "$ref",
-            ] and not isinstance(field_schema, dict):
+            ] or not isinstance(field_schema, dict):
                 LOG.warning("Ignoring unsupported field %s in path %s", field, rel_path)
                 continue
 

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -551,6 +551,11 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
     """Import an API from an OpenAPI spec document"""
 
     resolved_schema = resolve_references(body)
+
+    # TODO:
+    # 1. validate the "mode" property of the spec document, "merge" or "overwrite"
+    # 2. validate the document type, "swagger" or "openapi"
+
     # XXX for some reason this makes cf tests fail that's why is commented.
     # test_cfn_handle_serverless_api_resource
     # rest_api.name = resolved_schema.get("info", {}).get("title")
@@ -616,7 +621,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
         ]:
             return existing[0]
 
-        # construct relative path (without base path), then add method resources for this path
+        # construct relative path (without base path), then add field resources for this path
         rel_path = abs_path.removeprefix(base_path)
         return add_path_methods(rel_path, parts, parent_id=parent_id)
 
@@ -634,13 +639,16 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
 
         paths_dict = resolved_schema["paths"]
         method_paths = paths_dict.get(rel_path, {})
-        for method, method_schema in method_paths.items():
-            method = method.upper()
+        for field, field_schema in method_paths.items():
+            if field in ["parameters", "servers", "description", "summary", "$ref"]:
+                continue
 
-            method_integration = method_schema.get("x-amazon-apigateway-integration", {})
-            method_resource = create_method_resource(resource, method, method_schema)
+            field = field.upper()
+
+            method_integration = field_schema.get("x-amazon-apigateway-integration", {})
+            method_resource = create_method_resource(resource, field, field_schema)
             method_resource["requestParameters"] = method_integration.get("requestParameters")
-            responses = method_schema.get("responses", {})
+            responses = field_schema.get("responses", {})
             for status_code in responses:
                 response_model = None
                 if model_schema := responses.get(status_code, {}).get("schema", {}):
@@ -658,7 +666,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                 )
 
             integration = Integration(
-                http_method=method,
+                http_method=field,
                 uri=method_integration.get("uri"),
                 integration_type=method_integration.get("type"),
                 passthrough_behavior=method_integration.get("passthroughBehavior"),
@@ -675,7 +683,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                 .get("responseTemplates", None),
                 content_handling=None,
             )
-            resource.resource_methods[method]["methodIntegration"] = integration
+            resource.resource_methods[field]["methodIntegration"] = integration
 
         rest_api.resources[child_id] = resource
         return resource

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -640,7 +640,14 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
         paths_dict = resolved_schema["paths"]
         method_paths = paths_dict.get(rel_path, {})
         for field, field_schema in method_paths.items():
-            if field in ["parameters", "servers", "description", "summary", "$ref"]:
+            if field in [
+                "parameters",
+                "servers",
+                "description",
+                "summary",
+                "$ref",
+            ] and not isinstance(field_schema, dict):
+                LOG.warning("Ignoring unsupported field %s in path %s", field, rel_path)
                 continue
 
             field = field.upper()

--- a/tests/integration/apigateway_fixtures.py
+++ b/tests/integration/apigateway_fixtures.py
@@ -63,6 +63,12 @@ def get_rest_api(apigateway_client, **kwargs):
     return response.get("id"), response.get("name")
 
 
+def put_rest_api(apigateway_client, **kwargs):
+    response = apigateway_client.put_rest_api(**kwargs)
+    assert_response_is_200(response)
+    return response.get("id"), response.get("name")
+
+
 def get_rest_apis(apigateway_client, **kwargs):
     response = apigateway_client.get_rest_apis(**kwargs)
     assert_response_is_200(response)
@@ -101,6 +107,12 @@ def create_rest_api_integration(apigateway_client, **kwargs):
     response = apigateway_client.put_integration(**kwargs)
     assert_response_is_201(response)
     return response.get("uri"), response.get("type")
+
+
+def get_rest_api_resources(apigateway_client, **kwargs):
+    response = apigateway_client.get_resources(**kwargs)
+    assert_response_is_200(response)
+    return response.get("items")
 
 
 def delete_rest_api_integration(apigateway_client, **kwargs):

--- a/tests/integration/files/pets.json
+++ b/tests/integration/files/pets.json
@@ -1,7 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "title": "Simple PetStore (Swagger)"
+    "title": "Simple PetStore (Swagger)",
+    "version": "1.0.0"
   },
   "schemes": [
     "https"

--- a/tests/integration/files/swagger.json
+++ b/tests/integration/files/swagger.json
@@ -1,20 +1,10 @@
 {
-  "openapi": "3.0.1",
+  "swagger": "2.0",
   "info": {
     "title": "test",
-    "version": "2020-07-23T23:02:57Z"
+    "version": "2"
   },
   "basePath": "/base",
-  "servers": [
-    {
-      "url": "https://rei6t36l9d.execute-api.us-east-1.amazonaws.com/{basePath}",
-      "variables": {
-        "basePath": {
-          "default": "/test"
-        }
-      }
-    }
-  ],
   "paths": {
     "/test": {
       "get": {
@@ -28,16 +18,7 @@
             "description": "200 response",
             "headers": {
               "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Empty"
-                }
+                "type": "string"
               }
             }
           }
@@ -66,31 +47,18 @@
         ],
         "responses": {
           "200": {
-            "description": "200 response",
             "headers": {
               "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
+                "type": "string"
               },
               "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
+                "type": "string"
               },
               "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
+                "type": "string"
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Empty"
-                }
-              }
-            }
+            "description": ""
           }
         },
         "x-amazon-apigateway-integration": {
@@ -113,12 +81,10 @@
       }
     }
   },
-  "components": {
-    "schemas": {
-      "Empty": {
-        "title": "Empty Schema",
-        "type": "object"
-      }
+  "definitions": {
+    "Empty": {
+      "title": "Empty Schema",
+      "type": "object"
     }
   },
   "securityDefinitions": {

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -62,6 +62,9 @@ from tests.integration.apigateway_fixtures import (
     create_rest_resource_method,
     delete_rest_api,
     get_rest_api,
+    get_rest_api_resources,
+    import_rest_api,
+    put_rest_api,
     update_rest_api_deployment,
 )
 
@@ -1968,6 +1971,66 @@ class TestAPIGateway:
         # Clean up
         lambda_client.delete_function(FunctionName=fn_name)
 
+
+    @pytest.mark.parametrize("base_path_type", ["ignore", "prepend", "split"])
+    def test_import_rest_api(self, base_path_type, apigateway_client):
+        rest_api_name = f"restapi-{short_uid()}"
+        rest_api_id, _, _ = create_rest_api(apigateway_client, name=rest_api_name)
+
+        spec_file = load_file(TEST_SWAGGER_FILE_JSON)
+        api_params = {"basepath": base_path_type}
+        put_rest_api(
+            apigateway_client,
+            restApiId=rest_api_id,
+            body=spec_file,
+            mode="overwrite",
+            parameters=api_params,
+        )
+
+        resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
+        for rv in resources:
+            for method in rv.get("resourceMethods", {}).values():
+                assert method.get("authorizationType") == "request"
+                assert method.get("authorizerId") is not None
+
+        spec_file = load_file(TEST_SWAGGER_FILE_YAML)
+        put_rest_api(
+            apigateway_client,
+            restApiId=rest_api_id,
+            body=spec_file,
+            mode="overwrite",
+            parameters=api_params,
+        )
+
+        rs = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
+        expected_resources = 2 if base_path_type == "ignore" else 3
+        assert len(rs) == expected_resources
+
+        abs_path = "/test" if base_path_type == "ignore" else "/base/test"
+        resource = [res for res in rs if res["path"] == abs_path][0]
+        assert "GET" in resource["resourceMethods"]
+        assert "requestParameters" in resource["resourceMethods"]["GET"]
+        assert {"integration.request.header.X-Amz-Invocation-Type": "'Event'"} == resource[
+            "resourceMethods"
+        ]["GET"]["requestParameters"]
+
+        url = path_based_url(api_id=rest_api_id, stage_name="dev", path=abs_path)
+        response = requests.get(url)
+        assert 200 == response.status_code
+
+        # clean up
+        delete_rest_api(apigateway_client, restApiId=rest_api_id)
+
+        spec_file = load_file(TEST_IMPORT_REST_API_FILE)
+        rest_api_id, _ = import_rest_api(apigateway_client, body=spec_file, parameters=api_params)
+        resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
+        paths = [res["path"] for res in resources]
+        assert "/" in paths
+        assert "/pets" in paths
+        assert "/pets/{petId}" in paths
+
+        # clean up
+        delete_rest_api(apigateway_client, restApiId=rest_api_id)
     @staticmethod
     def start_http_backend(test_port):
         # test listener for target HTTP backend
@@ -2046,6 +2109,66 @@ class TestAPIGateway:
 
         apigw_client.create_deployment(restApiId=api_id, stageName="staging")
         return api_id
+
+    @pytest.mark.parametrize("base_path_type", ["ignore", "prepend", "split"])
+    def test_import_rest_apis(self, base_path_type, apigateway_client):
+        rest_api_name = f"restapi-{short_uid()}"
+        rest_api_id, _, _ = create_rest_api(apigateway_client, name=rest_api_name)
+
+        spec_file = load_file(TEST_SWAGGER_FILE_JSON)
+        api_params = {"basepath": base_path_type}
+        rest_api_id, _ = put_rest_api(
+            apigateway_client,
+            restApiId=rest_api_id,
+            body=spec_file,
+            mode="overwrite",
+            parameters=api_params,
+        )
+
+        resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
+        for rv in resources:
+            for method in rv.get("resourceMethods", {}).values():
+                assert method.get("authorizationType") == "request"
+                assert method.get("authorizerId") is not None
+
+        spec_file = load_file(TEST_SWAGGER_FILE_YAML)
+        rest_api_id, _ = put_rest_api(
+            apigateway_client,
+            restApiId=rest_api_id,
+            body=spec_file,
+            mode="overwrite",
+            parameters=api_params,
+        )
+
+        rs = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
+        expected_resources = 2 if base_path_type == "ignore" else 3
+        assert len(rs) == expected_resources
+
+        abs_path = "/test" if base_path_type == "ignore" else "/base/test"
+        resource = [res for res in rs if res["path"] == abs_path][0]
+        assert "GET" in resource["resourceMethods"]
+        assert "requestParameters" in resource["resourceMethods"]["GET"]
+        assert {"integration.request.header.X-Amz-Invocation-Type": "'Event'"} == resource[
+            "resourceMethods"
+        ]["GET"]["requestParameters"]
+
+        url = path_based_url(api_id=rest_api_id, stage_name="dev", path=abs_path)
+        response = requests.get(url)
+        assert 200 == response.status_code
+
+        # clean up
+        delete_rest_api(apigateway_client, restApiId=rest_api_id)
+
+        spec_file = load_file(TEST_IMPORT_REST_API_FILE)
+        rest_api_id, _ = import_rest_api(apigateway_client, body=spec_file, parameters=api_params)
+        resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
+        paths = [res["path"] for res in resources]
+        assert "/" in paths
+        assert "/pets" in paths
+        assert "/pets/{petId}" in paths
+
+        # clean up
+        delete_rest_api(apigateway_client, restApiId=rest_api_id)
 
 
 def test_import_swagger_api(apigateway_client):

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -63,7 +63,6 @@ from tests.integration.apigateway_fixtures import (
     delete_rest_api,
     get_rest_api,
     get_rest_api_resources,
-    import_rest_api,
     put_rest_api,
     update_rest_api_deployment,
 )
@@ -2051,9 +2050,11 @@ class TestAPIGateway:
         return api_id
 
     @pytest.mark.parametrize("base_path_type", ["ignore", "prepend", "split"])
-    def test_import_rest_apis(self, base_path_type, apigateway_client):
+    def test_import_rest_apis(
+        self, base_path_type, apigateway_client, create_rest_apigw, import_apigw
+    ):
         rest_api_name = f"restapi-{short_uid()}"
-        rest_api_id, _, _ = create_rest_api(apigateway_client, name=rest_api_name)
+        rest_api_id, _, _ = create_rest_apigw(name=rest_api_name)
 
         spec_file = load_file(TEST_SWAGGER_FILE_JSON)
         api_params = {"basepath": base_path_type}
@@ -2096,19 +2097,13 @@ class TestAPIGateway:
         response = requests.get(url)
         assert 200 == response.status_code
 
-        # clean up
-        delete_rest_api(apigateway_client, restApiId=rest_api_id)
-
         spec_file = load_file(TEST_IMPORT_REST_API_FILE)
-        rest_api_id, _ = import_rest_api(apigateway_client, body=spec_file, parameters=api_params)
+        rest_api_id, _, _ = import_apigw(body=spec_file, parameters=api_params)
         resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
         paths = [res["path"] for res in resources]
         assert "/" in paths
         assert "/pets" in paths
         assert "/pets/{petId}" in paths
-
-        # clean up
-        delete_rest_api(apigateway_client, restApiId=rest_api_id)
 
 
 def test_import_swagger_api(apigateway_client):

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1971,7 +1971,6 @@ class TestAPIGateway:
         # Clean up
         lambda_client.delete_function(FunctionName=fn_name)
 
-
     @pytest.mark.parametrize("base_path_type", ["ignore", "prepend", "split"])
     def test_import_rest_api(self, base_path_type, apigateway_client):
         rest_api_name = f"restapi-{short_uid()}"
@@ -2031,6 +2030,7 @@ class TestAPIGateway:
 
         # clean up
         delete_rest_api(apigateway_client, restApiId=rest_api_id)
+
     @staticmethod
     def start_http_backend(test_port):
         # test listener for target HTTP backend

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1971,66 +1971,6 @@ class TestAPIGateway:
         # Clean up
         lambda_client.delete_function(FunctionName=fn_name)
 
-    @pytest.mark.parametrize("base_path_type", ["ignore", "prepend", "split"])
-    def test_import_rest_api(self, base_path_type, apigateway_client):
-        rest_api_name = f"restapi-{short_uid()}"
-        rest_api_id, _, _ = create_rest_api(apigateway_client, name=rest_api_name)
-
-        spec_file = load_file(TEST_SWAGGER_FILE_JSON)
-        api_params = {"basepath": base_path_type}
-        put_rest_api(
-            apigateway_client,
-            restApiId=rest_api_id,
-            body=spec_file,
-            mode="overwrite",
-            parameters=api_params,
-        )
-
-        resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
-        for rv in resources:
-            for method in rv.get("resourceMethods", {}).values():
-                assert method.get("authorizationType") == "request"
-                assert method.get("authorizerId") is not None
-
-        spec_file = load_file(TEST_SWAGGER_FILE_YAML)
-        put_rest_api(
-            apigateway_client,
-            restApiId=rest_api_id,
-            body=spec_file,
-            mode="overwrite",
-            parameters=api_params,
-        )
-
-        rs = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
-        expected_resources = 2 if base_path_type == "ignore" else 3
-        assert len(rs) == expected_resources
-
-        abs_path = "/test" if base_path_type == "ignore" else "/base/test"
-        resource = [res for res in rs if res["path"] == abs_path][0]
-        assert "GET" in resource["resourceMethods"]
-        assert "requestParameters" in resource["resourceMethods"]["GET"]
-        assert {"integration.request.header.X-Amz-Invocation-Type": "'Event'"} == resource[
-            "resourceMethods"
-        ]["GET"]["requestParameters"]
-
-        url = path_based_url(api_id=rest_api_id, stage_name="dev", path=abs_path)
-        response = requests.get(url)
-        assert 200 == response.status_code
-
-        # clean up
-        delete_rest_api(apigateway_client, restApiId=rest_api_id)
-
-        spec_file = load_file(TEST_IMPORT_REST_API_FILE)
-        rest_api_id, _ = import_rest_api(apigateway_client, body=spec_file, parameters=api_params)
-        resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
-        paths = [res["path"] for res in resources]
-        assert "/" in paths
-        assert "/pets" in paths
-        assert "/pets/{petId}" in paths
-
-        # clean up
-        delete_rest_api(apigateway_client, restApiId=rest_api_id)
-
     @staticmethod
     def start_http_backend(test_port):
         # test listener for target HTTP backend


### PR DESCRIPTION
OpenAPI supports the "parameters" field that is applied to all methods of the path, however, we don't offer particular support for it.

This PR skips the "parameters" and others like, e.g "servers", "description", "summary", "$ref", from the OpenAPI spec to avoid errors. 

Fix downstream to enable the construction of the Method model with request parameters.
https://github.com/spulec/moto/pull/5425

Unblocks https://github.com/localstack/localstack/issues/6747