### PR TITLE
upgrade hypercorn to 0.14.2

### DIFF
--- a/localstack/aws/serving/hypercorn.py
+++ b/localstack/aws/serving/hypercorn.py
@@ -42,5 +42,5 @@ def serve(
     for k, v in kwargs.items():
         setattr(config, k, v)
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(serve_hypercorn(AsgiGateway(gateway, event_loop=loop), config))

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -80,6 +80,7 @@ def populate_wsgi_environment(environ: "WSGIEnvironment", scope: "HTTPScope"):
     headers = scope.get("headers")
     environ["asgi.headers"] = headers
     if not isinstance(headers, list):
+        # TODO: apparently dead code with hypercorn>=0.14.1, see https://github.com/localstack/localstack/pull/6778
         try:
             # these are h11 headers from which we extract the raw list
             environ["asgi.headers"] = headers.raw_items()

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -73,19 +73,10 @@ def populate_wsgi_environment(environ: "WSGIEnvironment", scope: "HTTPScope"):
     environ["wsgi.multiprocess"] = False
     environ["wsgi.run_once"] = False
 
-    # asgi.headers: a custom key to allow downstream applications to circumvent WSGI header processing. we try to map
-    # asgi.headers to a List[Tuple[byte, byte]]. in our case the headers typically come from hypercorn which uses
-    # h11/h2 as protocol library. in the case of h2, the headers will be simply a List[Tuple[byte, byte]],
-    # and in the case of h11, it will be a Headers object that we can extract the list of raw headers from.
+    # asgi.headers: a custom key to allow downstream applications to circumvent WSGI header processing. these headers
+    # should preserve the original casing as the client sends them.
     headers = scope.get("headers")
     environ["asgi.headers"] = headers
-    if not isinstance(headers, list):
-        # TODO: apparently dead code with hypercorn>=0.14.1, see https://github.com/localstack/localstack/pull/6778
-        try:
-            # these are h11 headers from which we extract the raw list
-            environ["asgi.headers"] = headers.raw_items()
-        except AttributeError:
-            environ["asgi.headers"] = headers
 
 
 async def to_async_generator(

--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -4,7 +4,7 @@ from asyncio import AbstractEventLoop
 
 from hypercorn import Config
 from hypercorn.asyncio import serve
-from hypercorn.typing import ASGI3Framework
+from hypercorn.typing import ASGIFramework
 
 from localstack.utils.serving import Server
 
@@ -14,7 +14,7 @@ class HypercornServer(Server):
     A sync wrapper around Hypercorn that implements the ``Server`` interface.
     """
 
-    def __init__(self, app: ASGI3Framework, config: Config, loop: AbstractEventLoop = None):
+    def __init__(self, app: ASGIFramework, config: Config, loop: AbstractEventLoop = None):
         """
         Create a new Hypercorn server instance. Note that, if you pass an event loop to the constructor,
         you are yielding control of that event loop to the server, as it will invoke `run_until_complete` and

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1100,7 +1100,7 @@ def handle_lambda_url_invocation(
         return response
 
     event = event_for_lambda_url(
-        api_id, request.full_path, request.data, dict(request.headers), request.method
+        api_id, request.full_path, request.data, request.headers, request.method
     )
 
     try:

--- a/localstack/utils/http.py
+++ b/localstack/utils/http.py
@@ -60,7 +60,7 @@ def canonicalize_headers(headers: Union[Dict, CaseInsensitiveDict]) -> Dict:
     def _normalize(name):
         if name.lower().startswith(ACCEPT):
             return name.lower()
-        return name
+        return name.title()
 
     result = {_normalize(k): v for k, v in headers.items()}
     return result

--- a/localstack/utils/http.py
+++ b/localstack/utils/http.py
@@ -60,7 +60,7 @@ def canonicalize_headers(headers: Union[Dict, CaseInsensitiveDict]) -> Dict:
     def _normalize(name):
         if name.lower().startswith(ACCEPT):
             return name.lower()
-        return name.title()
+        return name
 
     result = {_normalize(k): v for k, v in headers.items()}
     return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ runtime =
     flask==2.1.3
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
-    hypercorn==0.13.2
+    hypercorn>=0.14.1
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.1.1.dev,<1.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ runtime =
     flask==2.1.3
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
-    hypercorn>=0.14.1
+    hypercorn>=0.14.2
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.1.1.dev,<1.2

--- a/tests/unit/aws/test_gateway.py
+++ b/tests/unit/aws/test_gateway.py
@@ -1,0 +1,64 @@
+import asyncio
+
+import pytest
+import requests
+from hypercorn import Config
+
+from localstack.aws.api import RequestContext
+from localstack.aws.chain import HandlerChain
+from localstack.aws.gateway import Gateway
+from localstack.aws.serving.asgi import AsgiGateway
+from localstack.http import Response
+from localstack.http.hypercorn import HypercornServer
+from localstack.utils import net
+from localstack.utils.sync import poll_condition
+
+
+@pytest.fixture
+def serve_gateway_hypercorn():
+    _servers = []
+
+    def _create(gateway: Gateway) -> HypercornServer:
+        config = Config()
+        config.bind = f"localhost:{net.get_free_tcp_port()}"
+        loop = asyncio.new_event_loop()
+        srv = HypercornServer(AsgiGateway(gateway, event_loop=loop), config, loop=loop)
+        _servers.append(srv)
+        srv.start()
+        assert srv.wait_is_up(timeout=10), "gave up waiting for server to start up"
+        return srv
+
+    yield _create
+
+    for server in _servers:
+        server.shutdown()
+        assert poll_condition(
+            lambda: not server.is_up(), timeout=10
+        ), "gave up waiting for server to shut down"
+
+
+def test_gateway_served_through_hypercorn_preserves_client_headers(serve_gateway_hypercorn):
+    def echo_request_headers(chain: HandlerChain, context: RequestContext, response: Response):
+        response.set_json({"headers": [(k, v) for k, v in context.request.headers.items()]})
+        chain.stop()
+
+    gateway = Gateway()
+    gateway.request_handlers.append(echo_request_headers)
+
+    server = serve_gateway_hypercorn(gateway=gateway)
+
+    response = requests.get(
+        server.url,
+        headers={
+            "x-my-header": "value1",
+            "Some-Title-Case-Header": "value2",
+            "X-UPPER": "value3",
+            "KEEPS__underscores_-": "value4",
+        },
+    )
+    headers = response.json()["headers"]
+
+    assert ["x-my-header", "value1"] in headers
+    assert ["Some-Title-Case-Header", "value2"] in headers
+    assert ["X-UPPER", "value3"] in headers
+    assert ["KEEPS__underscores_-", "value4"] in headers

--- a/tests/unit/http_/conftest.py
+++ b/tests/unit/http_/conftest.py
@@ -4,7 +4,7 @@ from asyncio import AbstractEventLoop
 
 import pytest
 from hypercorn import Config
-from hypercorn.typing import ASGI3Framework
+from hypercorn.typing import ASGIFramework
 
 from localstack.http.asgi import ASGIAdapter
 from localstack.http.hypercorn import HypercornServer
@@ -19,7 +19,7 @@ def serve_asgi_app():
     _servers = []
 
     def _create(
-        app: ASGI3Framework, config: Config = None, event_loop: AbstractEventLoop = None
+        app: ASGIFramework, config: Config = None, event_loop: AbstractEventLoop = None
     ) -> HypercornServer:
         if not config:
             config = Config()


### PR DESCRIPTION
This PR fixes an import error that occurred with a change in hypercorn https://github.com/pgjones/hypercorn/commit/c2608a0ab1133a11a2a8eeb659388c8dd13bc9b1.

I renamed the affected imports and also added an explicit dependency to the latest hypercorn version.

Side note: Hypercorn now supports serving WSGI apps. Looks like the ASGI/WSGI bridge isn't as mature as ours yet, but looks promising! Maybe we can get rid of some code soon.

**Update**: Looks like hypercorn is now also lowercasing the raw headers. there seems to be no way to restore the original header casings, which, however, some cases rely on, such as #4532.

**Update**: specifically, it seems h11 is no longer returning a `h11.Headers` object #6413, and it's now just a tuple of lower-case header name and value. https://github.com/localstack/localstack/blob/7c02200e449380b6d5198eb09f0da14968bb49b6/localstack/http/asgi.py#L78-L82

there seems to be no way to restore the original header casing, which means that, if AWS lambda expects headers to be cased a certain way, we'll have to first title-case and then run canonicalize_headers.

**Update**: now with hypercorn 0.14.2, the headers are correctly preserved