### PR TITLE
Add parity tests and refactor logic for CFn stack resource updates

### DIFF
--- a/localstack/services/cloudformation/models/cdk.py
+++ b/localstack/services/cloudformation/models/cdk.py
@@ -1,4 +1,6 @@
 from localstack.services.cloudformation.service_models import GenericBaseModel
+from localstack.utils.json import canonical_json
+from localstack.utils.strings import md5
 
 
 class CDKMetadata(GenericBaseModel):
@@ -8,8 +10,19 @@ class CDKMetadata(GenericBaseModel):
     def cloudformation_type():
         return "AWS::CDK::Metadata"
 
+    def fetch_state(self, stack_name, resources):
+        return self.props
+
+    def get_physical_resource_id(self, attribute=None, **kwargs):
+        # return a synthetic ID here, as some parts of the CFn engine depend on PhysicalResourceId being resolvable
+        return md5(canonical_json(self.props))
+
     @staticmethod
     def get_deploy_templates():
+        def _no_op(*args, **kwargs):
+            pass
+
         return {
-            "create": {},
+            "create": {"function": _no_op},
+            "delete": {"function": _no_op},
         }

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -43,7 +43,7 @@ class EC2RouteTable(GenericBaseModel):
             },
             "delete": {
                 "function": "delete_route_table",
-                "parameters": {"RouteTableId": "RouteTableId"},
+                "parameters": {"RouteTableId": "PhysicalResourceId"},
             },
         }
 

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -8,11 +8,10 @@ import yaml
 from localstack.testing.aws.cloudformation_utils import load_template_file
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
-
-# TODO: refactor file and remove this compatibility fn
 from localstack.utils.sync import retry
 
 
+# TODO: refactor file and remove this compatibility fn
 def load_template_raw(file_name: str):
     return load_template_file(os.path.join(os.path.dirname(__file__), "../templates", file_name))
 

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import jinja2
@@ -8,8 +9,10 @@ from localstack.testing.aws.cloudformation_utils import load_template_file
 from localstack.utils.common import short_uid
 from localstack.utils.generic.wait_utils import wait_until
 
-
 # TODO: refactor file and remove this compatibility fn
+from localstack.utils.sync import retry
+
+
 def load_template_raw(file_name: str):
     return load_template_file(os.path.join(os.path.dirname(__file__), "../templates", file_name))
 
@@ -68,7 +71,7 @@ def test_list_stack_resources_for_removed_resource(
     resources_before = len(resources)
     assert resources_before == 3
     statuses = set([res["ResourceStatus"] for res in resources])
-    assert statuses == {"CREATE_COMPLETE", "UPDATE_COMPLETE"}
+    assert statuses == {"CREATE_COMPLETE"}
 
     # remove one resource from the template, then update stack (via change set)
     template_dict = yaml.load(template)
@@ -86,7 +89,7 @@ def test_list_stack_resources_for_removed_resource(
     resources = cfn_client.list_stack_resources(StackName=stack_name)["StackResourceSummaries"]
     assert len(resources) == resources_before - 1
     statuses = set([res["ResourceStatus"] for res in resources])
-    assert statuses == {"CREATE_COMPLETE", "UPDATE_COMPLETE"}
+    assert statuses == {"UPDATE_COMPLETE"}
 
 
 @pytest.mark.xfail(reason="outputs don't behave well in combination with conditions")
@@ -269,3 +272,56 @@ def test_get_template(cfn_client, deploy_cfn_template, snapshot, fileformat):
         StackName=stack.stack_id, TemplateStage="Processed"
     )
     snapshot.match("template_processed", template_processed)
+
+
+@pytest.mark.aws_validated
+@pytest.mark.skip_snapshot_verify(paths=["$..ParameterValue", "$..PhysicalResourceId"])
+def test_stack_update_resources(
+    cfn_client,
+    deploy_cfn_template,
+    is_change_set_finished,
+    is_change_set_created_and_available,
+    snapshot,
+):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.key_value("PhysicalResourceId"))
+
+    def _get_stack_details():
+        result = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0]
+        assert result["StackStatus"] in ["CREATE_COMPLETE", "UPDATE_COMPLETE"]
+        return result
+
+    api_name = f"test_{short_uid()}"
+    template_path = os.path.join(os.path.dirname(__file__), "../templates/simple_api.yaml")
+
+    # create stack
+    deployed = deploy_cfn_template(template_path=template_path, parameters={"ApiName": api_name})
+    stack_name = deployed.stack_name
+    stack_id = deployed.stack_id
+
+    # assert snapshot of created stack
+    result = retry(_get_stack_details, sleep=1, retries=10)
+    snapshot.match("stack_created", result)
+
+    # update stack, with one additional resource
+    api_name = f"test_{short_uid()}"
+    template_body = yaml.safe_load(load_template_file(template_path))
+    template_body["Resources"]["Bucket"] = {"Type": "AWS::S3::Bucket"}
+    response = cfn_client.create_change_set(
+        StackName=stack_name,
+        ChangeSetName="cs1",
+        TemplateBody=json.dumps(template_body),
+        Parameters=[{"ParameterKey": "ApiName", "ParameterValue": api_name}],
+    )
+    change_set_id = response["Id"]
+    wait_until(is_change_set_created_and_available(change_set_id))
+    cfn_client.execute_change_set(ChangeSetName=change_set_id)
+    wait_until(is_change_set_finished(change_set_id))
+
+    # assert snapshot of updated stack
+    result = retry(_get_stack_details, sleep=1, retries=10)
+    snapshot.match("stack_updated", result)
+
+    # describe stack resources
+    resources = cfn_client.describe_stack_resources(StackName=stack_name)
+    snapshot.match("stack_resources", resources)

--- a/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.snapshot.json
@@ -181,5 +181,91 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/test_cloudformation_stacks.py::test_stack_update_resources": {
+    "recorded-date": "30-08-2022, 00:13:26",
+    "recorded-content": {
+      "stack_created": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "ApiName",
+            "ParameterValue": "test_12395eb4"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "stack_updated": {
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "ApiName",
+            "ParameterValue": "test_5a3df175"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "UPDATE_COMPLETE",
+        "Tags": []
+      },
+      "stack_resources": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StackResources": [
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "Api",
+            "PhysicalResourceId": "<physical-resource-id:1>",
+            "ResourceStatus": "UPDATE_COMPLETE",
+            "ResourceType": "AWS::ApiGateway::RestApi",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "DriftInformation": {
+              "StackResourceDriftStatus": "NOT_CHECKED"
+            },
+            "LogicalResourceId": "Bucket",
+            "PhysicalResourceId": "<stack-name:1>-bucket-10xf2vf1pqap8",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::S3::Bucket",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/integration/templates/template36.yaml
+++ b/tests/integration/templates/template36.yaml
@@ -39,12 +39,21 @@ Resources:
       - Key: env
         Value: qa
 
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
   PublicRoute:
     Type: AWS::EC2::Route
     Properties:
       DestinationCidrBlock: 0.0.0.0/0
-      RouteTableId:
-        Ref: RouteTableProduction
+      RouteTableId: !Ref RouteTableProduction
+      GatewayId: !Ref InternetGateway
 
 Outputs:
   PublicRoute:
@@ -52,3 +61,6 @@ Outputs:
       Ref: PublicRoute
     Export:
       Name: 'publicRoute-identify'
+  VPC:
+    Value:
+      Ref: VPC

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1781,19 +1781,16 @@ class TestCloudFormation:
         new_role = [role for role in list_roles if role.get("RoleName") == lambda_role_name_new]
         assert len(new_role) == 1
 
+    @pytest.mark.aws_validated
     def test_cfn_with_multiple_route_tables(self, ec2_client, deploy_cfn_template):
-        resp = ec2_client.describe_vpcs()
-        # TODO: remove/change assertion, to make tests parallelizable!
-        vpcs_before = [vpc["VpcId"] for vpc in resp["Vpcs"]]
 
-        deploy_cfn_template(template_path=os.path.join(THIS_FOLDER, "templates/template36.yaml"))
+        result = deploy_cfn_template(
+            template_path=os.path.join(THIS_FOLDER, "templates/template36.yaml"), max_wait=180
+        )
+        vpc_id = result.outputs["VPC"]
 
-        resp = ec2_client.describe_vpcs()
-        vpcs = [vpc["VpcId"] for vpc in resp["Vpcs"] if vpc["VpcId"] not in vpcs_before]
-        assert len(vpcs) == 1
-
-        resp = ec2_client.describe_route_tables(Filters=[{"Name": "vpc-id", "Values": [vpcs[0]]}])
-        # CloudFormation will create more than one route table: 3 in template + default = 4
+        resp = ec2_client.describe_route_tables(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
+        # 4 route tables being created (validated against AWS): 3 in template + 1 default = 4
         assert len(resp["RouteTables"]) == 4
 
     def test_cfn_with_multiple_route_table_associations(self, ec2_client, deploy_cfn_template):

--- a/tests/integration/test_cloudformation.py
+++ b/tests/integration/test_cloudformation.py
@@ -1793,8 +1793,8 @@ class TestCloudFormation:
         assert len(vpcs) == 1
 
         resp = ec2_client.describe_route_tables(Filters=[{"Name": "vpc-id", "Values": [vpcs[0]]}])
-        # CloudFormation will create more than one route table 2 in template + default
-        assert len(resp["RouteTables"]) == 3
+        # CloudFormation will create more than one route table: 3 in template + default = 4
+        assert len(resp["RouteTables"]) == 4
 
     def test_cfn_with_multiple_route_table_associations(self, ec2_client, deploy_cfn_template):
         stack = deploy_cfn_template(


### PR DESCRIPTION
Add parity tests and add a number of smaller fixes in the logic for CloudFormation stack resource updates. Addresses #6155

The main issue with the sample shared by the user is that SAM deployment was hanging, as the stack/resource status was incorrectly reported as `CREATE_COMPLETE` instead of `UPDATE_COMPLETE`. This led to the discovery of a few more issues, which are now fixed, and covered by parity tests.

Summary of changes:
* properly set the status of stack resources as `CREATE_COMPLETE` or `UPDATE_COMPLETE`, depending on the operation and prior existence of resources within the stack
* add a parity/snapshot test for the point above (which is essentially what caused SAM/`samlocal` to hang when deploying the sample in #6155)
* ensure that `Parameter` instances are not being returned from the list of stack resources in `DescribeStackResources`
* remove a few attributes in API response messages to avoid ASF response serializer warnings
* minor simplifications, e.g., removing `stack_name` from `apply_changes(..)` method
* add missing resource methods to CDK::Metadata model, returning synthetic data (surfaced as being required when testing the changes)
* fix an assertion in `test_cfn_with_multiple_route_tables` and parity test it against AWS - previously we were creating/asserting 3 route tables instead of 4 (validated against AWS)

Note: part of the changes in the PR is to avoid us changing the resource action (from `"Modify"` to `"Add"`), and instead introducing a `"_deployed"` attribute that allows us to determine whether the resource needs to be created or updated - see `TODO` in the code. This is only a workaround for now, and should be fixed as part of a larger refactoring after introducing model classes for the state of the resources in a stack (e.g., using a cached property). To be discussed in more detail @dominikschubert ... 👍