### PR TITLE
Add semantic names to threads to simplify detection of thread leaks

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -38,7 +38,9 @@ class SQSEventSourceListener(EventSourceListener):
             return
 
         LOG.debug("Starting SQS message polling thread for Lambda API")
-        self.SQS_LISTENER_THREAD["_thread_"] = thread = FuncThread(self._listener_loop)
+        self.SQS_LISTENER_THREAD["_thread_"] = thread = FuncThread(
+            self._listener_loop, name="sqs-event-source-listener"
+        )
         thread.start()
 
     def get_matching_event_sources(self) -> List[Dict]:

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -489,7 +489,7 @@ class LambdaExecutor:
             LOG.debug(
                 "Lambda executed in Event (asynchronous) mode, no response will be returned to caller"
             )
-            FuncThread(do_execute).start()
+            FuncThread(do_execute, name="lambda-execute-async").start()
             return InvocationResult(None, log_output="Lambda executed asynchronously.")
 
         return do_execute()

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -86,6 +86,7 @@ class DynamodbServer(Server):
             strip_color=True,
             log_listener=self._log_listener,
             auto_restart=True,
+            name="dynamodb-server",
         )
         TMP_THREADS.append(t)
         t.start()

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -492,7 +492,9 @@ def run_process_as_sudo(component, port, asynchronous=False, env_vars=None):
         run(shell_cmd, outfile=subprocess.PIPE, print_error=False, env_vars=env_vars)
 
     LOG.debug("Running command as sudo: %s", shell_cmd)
-    result = start_thread(run_command, quiet=True) if asynchronous else run_command()
+    result = (
+        start_thread(run_command, quiet=True, name="sudo-edge") if asynchronous else run_command()
+    )
     return result
 
 

--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -29,7 +29,7 @@ class Job:
         return delay_secs is not None and delay_secs < 60
 
     def do_run(self):
-        FuncThread(self.job_func).start()
+        FuncThread(self.job_func, name="events-job-run").start()
 
 
 class JobScheduler:
@@ -73,7 +73,7 @@ class JobScheduler:
             self._stop_event.wait(timeout=59.9)
 
     def start_loop(self):
-        self.thread = FuncThread(self.loop)
+        self.thread = FuncThread(self.loop, name="events-jobscheduler-loop")
         self.thread.start()
 
     @classmethod

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -1126,5 +1126,5 @@ def serve_flask_app(app, port, host=None, cors=True, asynchronous=False):
         return app
 
     if asynchronous:
-        return start_thread(_run)
+        return start_thread(_run, name="flaskapp")
     return _run()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -162,6 +162,7 @@ def do_run(
             env_vars=env_vars,
             auto_restart=auto_restart,
             strip_color=strip_color,
+            name="todo_dorun",
         )
         t.start()
         TMP_THREADS.append(t)
@@ -271,7 +272,7 @@ def start_local_api(name, port, api, method, asynchronous=False, listener=None):
         port = get_free_tcp_port()
         PROXY_LISTENERS[api] = (api, port, listener)
     if asynchronous:
-        thread = start_thread(method, port, quiet=True)
+        thread = start_thread(method, port, quiet=True, name=f"aws-api-{api}")
         return thread
     else:
         method(port)

--- a/localstack/services/kinesis/kinesalite_server.py
+++ b/localstack/services/kinesis/kinesalite_server.py
@@ -40,6 +40,7 @@ class KinesaliteServer(Server):
             strip_color=True,
             log_listener=self._log_listener,
             auto_restart=True,
+            name="kinesis-kinesalite",
         )
         TMP_THREADS.append(t)
         t.start()

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -47,6 +47,7 @@ class KinesisMockServer(Server):
             env_vars=env_vars,
             log_listener=self._log_listener,
             auto_restart=True,
+            name="kinesis-mock",
         )
         TMP_THREADS.append(t)
         t.start()

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -174,6 +174,7 @@ class OpensearchCluster(Server):
             env_vars=env_vars,
             strip_color=True,
             log_listener=self._log_listener,
+            name="opensearch-cluster",
         )
         t.start()
         return t

--- a/localstack/services/opensearch/cluster_manager.py
+++ b/localstack/services/opensearch/cluster_manager.py
@@ -262,7 +262,7 @@ class MultiplexingClusterManager(ClusterManager):
                     LOG.info("starting %s on %s", type(self.cluster), self.cluster.url)
                     self.cluster.start()  # start may block during install
 
-                start_thread(_start_async)
+                start_thread(_start_async, name="opensearch-multiplex")
             cluster_endpoint = ClusterEndpoint(self.cluster, EndpointProxy(url, self.cluster.url))
             self.clusters[arn] = cluster_endpoint
             return cluster_endpoint

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -163,7 +163,8 @@ def publish_message(
                 message_structure,
                 endpoint_attributes,
                 platform_app,
-            )
+            ),
+            name="sns-message_to_endpoint",
         )
         return message_id
 
@@ -179,7 +180,8 @@ def publish_message(
             subscription_arn,
             skip_checks,
             message_attributes,
-        )
+        ),
+        name="sns-message_to_subscribers",
     )
 
     return message_id

--- a/localstack/services/sqs/legacy/elasticmq.py
+++ b/localstack/services/sqs/legacy/elasticmq.py
@@ -72,6 +72,7 @@ class ElasticMQSerer(Server):
             strip_color=True,
             log_listener=self._log_listener,
             auto_restart=True,
+            name="elasticmq-server",
         )
         TMP_THREADS.append(t)
         t.start()

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -156,7 +156,7 @@ class QueueUpdateWorker:
             def _run(*_args):
                 self.scheduler.run()
 
-            self.thread = start_thread(_run)
+            self.thread = start_thread(_run, name="sqs-queue-update-worker")
 
     def stop(self):
         with self.mutex:

--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -121,7 +121,7 @@ class PublisherBuffer(EventHandler):
             self.checked_flush()
 
     def run(self, *_):
-        flush_scheduler = start_thread(self._run_flush_schedule)
+        flush_scheduler = start_thread(self._run_flush_schedule, name="analytics-publishbuffer")
 
         try:
             while True:
@@ -258,7 +258,7 @@ class GlobalAnalyticsBus(PublisherBuffer):
         finally:
             self._startup_complete = True
 
-        start_thread(self.run)
+        start_thread(self.run, name="global-analytics-bus")
 
         def _do_close():
             self.close_sync(timeout=2)

--- a/localstack/utils/asyncio.py
+++ b/localstack/utils/asyncio.py
@@ -51,7 +51,7 @@ class AsyncThread(FuncThread):
     def __init__(self, async_func_gen=None, loop=None):
         """Pass a function that receives an event loop instance and a shutdown event,
         and returns an async function."""
-        FuncThread.__init__(self, self.run_func, None)
+        FuncThread.__init__(self, self.run_func, None, name="asyncio-thread")
         self.async_func_gen = async_func_gen
         self.loop = loop
         self.shutdown_event = None

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -135,7 +135,12 @@ class KinesisProcessorThread(ShellCommandThread):
         env = aws_stack.get_environment()
         quiet = aws_stack.is_local_env(env)
         ShellCommandThread.__init__(
-            self, cmd, outfile=params["log_file"], env_vars=env_vars, quiet=quiet
+            self,
+            cmd,
+            outfile=params["log_file"],
+            env_vars=env_vars,
+            quiet=quiet,
+            name="kinesis-processor",
         )
 
     @staticmethod
@@ -147,7 +152,7 @@ class KinesisProcessorThread(ShellCommandThread):
 
 class OutputReaderThread(FuncThread):
     def __init__(self, params):
-        FuncThread.__init__(self, self.start_reading, params)
+        FuncThread.__init__(self, self.start_reading, params, name="kinesis-output-reader")
         self.buffer = []
         self.params = params
         # number of lines that make up a single log entry

--- a/localstack/utils/kinesis/kinesis_util.py
+++ b/localstack/utils/kinesis/kinesis_util.py
@@ -13,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 class EventFileReaderThread(FuncThread):
     def __init__(self, events_file, callback, ready_mutex=None, fh_d_stream=None):
-        FuncThread.__init__(self, self.retrieve_loop, None)
+        FuncThread.__init__(self, self.retrieve_loop, None, name="kinesis-event-file-reader")
         self.events_file = events_file
         self.callback = callback
         self.ready_mutex = ready_mutex
@@ -28,7 +28,9 @@ class EventFileReaderThread(FuncThread):
         while self.running:
             try:
                 conn, client_addr = sock.accept()
-                thread = FuncThread(self.handle_connection, conn)
+                thread = FuncThread(
+                    self.handle_connection, conn, name="kinesis-event-file-reader-connectionhandler"
+                )
                 thread.start()
             except Exception as e:
                 LOG.error("Error dispatching client request: %s %s", e, traceback.format_exc())

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -109,7 +109,7 @@ def run(
                         if o:
                             os.write(sys.stdout.fileno(), o)
 
-            FuncThread(pipe_streams).start()
+            FuncThread(pipe_streams, name="pipe-streams").start()
 
         return process
     except subprocess.CalledProcessError as e:
@@ -213,6 +213,7 @@ class ShellCommandThread(FuncThread):
         log_listener: Callable = None,
         stop_listener: Callable = None,
         strip_color: bool = False,
+        name: Optional[str] = None,
     ):
         params = params if params is not None else {}
         env_vars = env_vars if env_vars is not None else {}
@@ -229,7 +230,9 @@ class ShellCommandThread(FuncThread):
         self.stop_listener = stop_listener
         self.strip_color = strip_color
         self.started = threading.Event()
-        FuncThread.__init__(self, self.run_cmd, params, quiet=quiet)
+        FuncThread.__init__(
+            self, self.run_cmd, params, quiet=quiet, name=(name or "shell-cmd-thread")
+        )
 
     def run_cmd(self, params):
         while True:

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -283,7 +283,7 @@ def run_server(
 
     class ProxyThread(FuncThread):
         def __init__(self):
-            FuncThread.__init__(self, self.run_proxy, None, name="proxy-thread")  # TODO
+            FuncThread.__init__(self, self.run_proxy, None, name="proxy-thread")
             self.shutdown_event = None
             self.loop = None
 

--- a/localstack/utils/server/http2_server.py
+++ b/localstack/utils/server/http2_server.py
@@ -283,7 +283,7 @@ def run_server(
 
     class ProxyThread(FuncThread):
         def __init__(self):
-            FuncThread.__init__(self, self.run_proxy, None)
+            FuncThread.__init__(self, self.run_proxy, None, name="proxy-thread")  # TODO
             self.shutdown_event = None
             self.loop = None
 

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -113,7 +113,7 @@ def start_ssl_proxy(
 
     if not asynchronous:
         return _run()
-    proxy = FuncThread(_run)
+    proxy = FuncThread(_run, name="ssl-proxy")
     TMP_THREADS.append(proxy)
     proxy.start()
     return proxy

--- a/localstack/utils/serving.py
+++ b/localstack/utils/serving.py
@@ -171,7 +171,7 @@ class Server(abc.ABC):
             finally:
                 self._stopped.set()
 
-        return start_thread(_run)
+        return start_thread(_run, name=f"server-{self.__class__.__name__}")
 
     def do_run(self):
         """

--- a/localstack/utils/tail.py
+++ b/localstack/utils/tail.py
@@ -65,7 +65,10 @@ class FileListener:
             raise FileNotFoundError
 
         return ShellCommandThread(
-            cmd=["tail", "-f", self.file_path], quiet=False, log_listener=_log_listener
+            cmd=["tail", "-f", self.file_path],
+            quiet=False,
+            log_listener=_log_listener,
+            name="file-listener-tail",
         )
 
     def _create_tailer_thread(self) -> FuncThread:
@@ -84,4 +87,4 @@ class FileListener:
             finally:
                 tailer.close()
 
-        return FuncThread(func=_run_follow, on_stop=lambda *_: tailer.close())
+        return FuncThread(func=_run_follow, on_stop=lambda *_: tailer.close(), name="lambda-tailer")

--- a/localstack/utils/tail.py
+++ b/localstack/utils/tail.py
@@ -1,6 +1,6 @@
 import os
-import threading
 import pathlib
+import threading
 from typing import Callable, Optional
 
 from .platform import is_windows

--- a/localstack/utils/tail.py
+++ b/localstack/utils/tail.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import pathlib
 from typing import Callable, Optional
 
 from .platform import is_windows
@@ -64,11 +65,13 @@ class FileListener:
         if not os.path.isfile(self.file_path):
             raise FileNotFoundError
 
+        file_name = pathlib.Path(self.file_path).name
+
         return ShellCommandThread(
             cmd=["tail", "-f", self.file_path],
             quiet=False,
             log_listener=_log_listener,
-            name="file-listener-tail",
+            name=f"file-listener-tail-{file_name}",
         )
 
     def _create_tailer_thread(self) -> FuncThread:

--- a/localstack/utils/threads.py
+++ b/localstack/utils/threads.py
@@ -92,8 +92,8 @@ class FuncThread(threading.Thread):
 def start_thread(method, *args, **kwargs) -> FuncThread:  # TODO: find all usages and add names...
     """Start the given method in a background thread, and add the thread to the TMP_THREADS shutdown hook"""
     _shutdown_hook = kwargs.pop("_shutdown_hook", True)
-    # if not kwargs.get("name"):
-    #     print("oh no")
+    if not kwargs.get("name"):
+        LOG.debug("start_thread called without providing a custom name") # technically we should add a new level here for *internal* warnings
     kwargs.setdefault("name", method.__name__)
     thread = FuncThread(method, *args, **kwargs)
     thread.start()

--- a/localstack/utils/threads.py
+++ b/localstack/utils/threads.py
@@ -93,7 +93,9 @@ def start_thread(method, *args, **kwargs) -> FuncThread:  # TODO: find all usage
     """Start the given method in a background thread, and add the thread to the TMP_THREADS shutdown hook"""
     _shutdown_hook = kwargs.pop("_shutdown_hook", True)
     if not kwargs.get("name"):
-        LOG.debug("start_thread called without providing a custom name") # technically we should add a new level here for *internal* warnings
+        LOG.debug(
+            "start_thread called without providing a custom name"
+        )  # technically we should add a new level here for *internal* warnings
     kwargs.setdefault("name", method.__name__)
     thread = FuncThread(method, *args, **kwargs)
     thread.start()

--- a/localstack/utils/threads.py
+++ b/localstack/utils/threads.py
@@ -5,7 +5,7 @@ import threading
 import traceback
 from concurrent.futures import Future
 from multiprocessing.dummy import Pool
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 LOG = logging.getLogger(__name__)
 
@@ -13,14 +13,33 @@ LOG = logging.getLogger(__name__)
 TMP_THREADS = []
 TMP_PROCESSES = []
 
+counter_lock = threading.Lock()
+counter = 0
+
 
 class FuncThread(threading.Thread):
     """Helper class to run a Python function in a background thread."""
 
     def __init__(
-        self, func, params=None, quiet=False, on_stop: Callable[["FuncThread"], None] = None
+        self,
+        func,
+        params=None,
+        quiet=False,
+        on_stop: Callable[["FuncThread"], None] = None,
+        name: Optional[str] = None,
     ):
-        threading.Thread.__init__(self)
+        global counter
+        global counter_lock
+
+        if name:
+            with counter_lock:
+                counter += 1
+                thread_counter_current = counter
+
+            threading.Thread.__init__(self, name=f"{name}-functhread{thread_counter_current}")
+        else:
+            threading.Thread.__init__(self)
+
         self.daemon = True
         self.params = params
         self.func = func
@@ -70,9 +89,12 @@ class FuncThread(threading.Thread):
                 LOG.warning("error while calling on_stop callback: %s", e)
 
 
-def start_thread(method, *args, **kwargs) -> FuncThread:
+def start_thread(method, *args, **kwargs) -> FuncThread:  # TODO: find all usages and add names...
     """Start the given method in a background thread, and add the thread to the TMP_THREADS shutdown hook"""
     _shutdown_hook = kwargs.pop("_shutdown_hook", True)
+    # if not kwargs.get("name"):
+    #     print("oh no")
+    kwargs.setdefault("name", method.__name__)
     thread = FuncThread(method, *args, **kwargs)
     thread.start()
     if _shutdown_hook:
@@ -81,6 +103,7 @@ def start_thread(method, *args, **kwargs) -> FuncThread:
 
 
 def start_worker_thread(method, *args, **kwargs):
+    kwargs.setdefault("name", "start_worker_thread")
     return start_thread(method, *args, _shutdown_hook=False, **kwargs)
 
 


### PR DESCRIPTION
Changes

* Thread utils now have optional name parameters that when set determine the resulting thread name to facilitate the identification of threads when debugging (e.g. when trying to find leaks)
* Semantic names have been added where appropriate. Might still need some adjustment in the future though and not all might be covered atm.