### PR TITLE
Fix idempotence of DDB/SFN installer logic to enable running as non-root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,8 @@ jobs:
   itest-lambda-docker:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
+    environment:
+      LOCALSTACK_API_KEY=test
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,6 @@ jobs:
   itest-lambda-docker:
     executor: ubuntu-machine-amd64
     working_directory: /tmp/workspace/repo
-    environment:
-      LOCALSTACK_API_KEY=test
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -307,7 +307,9 @@ class FilterCriteria(TypedDict):
     Filters: List[Dict[str, any]]
 
 
-def parse_and_apply_numeric_filter(record_value: Dict, numeric_filter: List[str | int]) -> bool:
+def parse_and_apply_numeric_filter(
+    record_value: Dict, numeric_filter: List[Union[str, int]]
+) -> bool:
     if len(numeric_filter) % 2 > 0:
         LOG.warn("Invalid numeric lambda filter given")
         return True

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -613,7 +613,7 @@ def update_jar_manifest(
         run(["unzip", "-o", jar_path, manifest_file_path], cwd=tmp_dir)
         manifest = load_file(tmp_manifest_file)
 
-    # check if the search pattern matches (to make the logic idempotent), then replace the content
+    # return if the search pattern does not match (to make the logic idempotent), otherwise replace the content
     if isinstance(search, re.Pattern):
         if not search.match(manifest):
             return

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -613,7 +613,7 @@ def update_jar_manifest(
         run(["unzip", "-o", jar_path, manifest_file_path], cwd=tmp_dir)
         manifest = load_file(tmp_manifest_file)
 
-    # return if the search pattern does not match (to make the logic idempotent), otherwise replace the content
+    # return if the search pattern does not match (for idempotence, to avoid file permission issues further below)
     if isinstance(search, re.Pattern):
         if not search.search(manifest):
             return

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -615,7 +615,7 @@ def update_jar_manifest(
 
     # return if the search pattern does not match (to make the logic idempotent), otherwise replace the content
     if isinstance(search, re.Pattern):
-        if not search.match(manifest):
+        if not search.search(manifest):
             return
         manifest = search.sub(replace, manifest, 1)
     else:

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -536,7 +536,7 @@ def install_stepfunctions_local():
     update_jar_manifest(
         "StepFunctionsLocal.jar",
         INSTALL_DIR_STEPFUNCTIONS,
-        re.compile("Main-Class: .+"),
+        re.compile(r"Main-Class: com\.amazonaws.+"),
         "Main-Class: cloud.localstack.StepFunctionsStarter",
     )
 
@@ -586,7 +586,7 @@ def install_dynamodb_local():
       </Loggers>
     </Configuration>"""
     log4j2_file = os.path.join(INSTALL_DIR_DDB, "log4j2.xml")
-    save_file(log4j2_file, log4j2_config)
+    run_safe(lambda: save_file(log4j2_file, log4j2_config))
     run_safe(lambda: run(["zip", "-u", "DynamoDBLocal.jar", "log4j2.xml"], cwd=INSTALL_DIR_DDB))
 
     # download agent JAR
@@ -599,7 +599,7 @@ def install_dynamodb_local():
 
     # ensure that javassist.jar is in the manifest classpath
     update_jar_manifest(
-        "DynamoDBLocal.jar", INSTALL_DIR_DDB, "Class-Path:", "Class-Path: javassist.jar"
+        "DynamoDBLocal.jar", INSTALL_DIR_DDB, "Class-Path: .", "Class-Path: javassist.jar ."
     )
 
 
@@ -607,17 +607,25 @@ def update_jar_manifest(
     jar_file_name: str, parent_dir: str, search: Union[str, re.Pattern], replace: str
 ):
     manifest_file_path = "META-INF/MANIFEST.MF"
-    run(["unzip", "-o", jar_file_name, manifest_file_path], cwd=parent_dir)
+    jar_path = os.path.join(parent_dir, jar_file_name)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_manifest_file = os.path.join(tmp_dir, manifest_file_path)
+        run(["unzip", "-o", jar_path, manifest_file_path], cwd=tmp_dir)
+        manifest = load_file(tmp_manifest_file)
+
+    # check if the search pattern matches (to make the logic idempotent), then replace the content
+    if isinstance(search, re.Pattern):
+        if not search.match(manifest):
+            return
+        manifest = search.sub(replace, manifest, 1)
+    else:
+        if search not in manifest:
+            return
+        manifest = manifest.replace(search, replace, 1)
+
     manifest_file = os.path.join(parent_dir, manifest_file_path)
-    manifest = load_file(manifest_file)
-    if replace not in manifest:
-        if isinstance(search, re.Pattern):
-            manifest = search.sub(replace, manifest, 1)
-        else:
-            manifest = manifest.replace(search, replace, 1)
-        save_file(manifest_file, manifest)
-        run(["zip", jar_file_name, manifest_file_path], cwd=parent_dir)
-    os.remove(manifest_file)
+    save_file(manifest_file, manifest)
+    run(["zip", jar_file_name, manifest_file_path], cwd=parent_dir)
 
 
 def upgrade_jar_file(base_dir: str, file_glob: str, maven_asset: str):

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -152,3 +152,7 @@ class TestCliContainerLifecycle:
         inspect = container_client.inspect_container(config.MAIN_CONTAINER_NAME)
         binds = inspect["HostConfig"]["Binds"]
         assert f"{volume_dir}:{constants.DEFAULT_VOLUME_DIR}" in binds
+
+    def test_container_starts_non_root(self, runner):
+        # TODO: add test to start container with non-root user, as soon as new Docker image is published
+        pass

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1390,7 +1390,7 @@ class TestAPIGateway:
         sfn_client = aws_stack.create_external_boto_client("stepfunctions")
         lambda_client = aws_stack.create_external_boto_client("lambda")
 
-        state_machine_name = "test"
+        state_machine_name = f"test-{short_uid()}"
         state_machine_def = {
             "Comment": "Hello World example",
             "StartAt": "step1",
@@ -1400,7 +1400,7 @@ class TestAPIGateway:
         }
 
         # create state machine
-        fn_name = "test-stepfunctions-apigw"
+        fn_name = f"sfn-apigw-{short_uid()}"
         testutil.create_lambda_function(
             handler_file=TEST_LAMBDA_PYTHON_ECHO,
             func_name=fn_name,


### PR DESCRIPTION
Fix idempotence of DynamoDB/StepFunctions installer logic to ensure running as non-root. First step towards addressing #5396

Currently, there are a few issues (i.e., false positives) with the way how we're determining whether to replace the content of certain JAR manifest files. This results in issues when attempting to run the Docker container as a non-root user, as we're trying to overwrite the files owned by `root`.

(This will also require a small change in the upstream repo in -ext.)

Tested the changes manually/locally so far - also added a test skeleton / `TODO` for a CLI test that we can add in a follow-up PR, once the `latest` Docker image has been built and published with the latest changes. 👍 

---
Update: After consulting with @alexrashed , we can add a test already now that `xfail`s for now. The test would essentially start up LS like this (will update the PR shortly..): 
```
DOCKER_FLAGS='--user=localstack' localstack start
```