### PR TITLE
fix CBOR datetime encoding

### DIFF
--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -116,6 +116,10 @@ def dispatch_to_backend(
     return parsed_response
 
 
+# boto config deactivating param validation to forward to backends (backends are responsible for validating params)
+_non_validating_boto_config = BotoConfig(parameter_validation=False)
+
+
 def create_aws_request_context(
     service_name: str,
     action: str,
@@ -153,7 +157,7 @@ def create_aws_request_context(
         service_name,
         endpoint_url=endpoint_url,
         region_name=region,
-        config=BotoConfig(parameter_validation=False),
+        config=_non_validating_boto_config,
     )
     request_context = {
         "client_region": region,

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Mapping, Optional
 from urllib.parse import urlsplit
 
 from botocore.awsrequest import AWSPreparedRequest
+from botocore.config import Config as BotoConfig
 from werkzeug.datastructures import Headers
 
 from localstack import config
@@ -145,9 +146,14 @@ def create_aws_request_context(
     service = load_service(service_name)
     operation = service.operation_model(action)
 
-    # we re-use botocore internals here to serialize the HTTP request, but don't send it
+    # we re-use botocore internals here to serialize the HTTP request,
+    # but deactivate validation (validation errors should be handled by the backend)
+    # and don't send it yet
     client = aws_stack.connect_to_service(
-        service_name, endpoint_url=endpoint_url, region_name=region
+        service_name,
+        endpoint_url=endpoint_url,
+        region_name=region,
+        config=BotoConfig(parameter_validation=False),
     )
     request_context = {
         "client_region": region,

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -18,12 +18,14 @@ default_log_levels = {
     "s3transfer": logging.INFO,
     "urllib3": logging.WARNING,
     "werkzeug": logging.WARNING,
+    "localstack.aws.protocol.serializer": logging.INFO,
     "localstack.aws.serving.wsgi": logging.WARNING,
     "localstack.request": logging.INFO,
     "localstack.request.internal": logging.WARNING,
 }
 
 trace_log_levels = {
+    "localstack.aws.protocol.serializer": logging.DEBUG,
     "localstack.aws.serving.wsgi": logging.DEBUG,
     "localstack.request": logging.DEBUG,
     "localstack.request.internal": logging.INFO,

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -252,6 +252,11 @@ class TestKinesis:
         assert select_attributes(json_records[0], attrs) == select_attributes(
             result["Records"][0], attrs
         )
+        # ensure that the CBOR datetime format is unix timestamp millis
+        assert (
+            int(json_records[0]["ApproximateArrivalTimestamp"].timestamp() * 1000)
+            == result["Records"][0]["ApproximateArrivalTimestamp"]
+        )
 
     def test_get_records_empty_stream(
         self, kinesis_client, kinesis_create_stream, wait_for_stream_ready

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 import cbor2
 import pytest
 import requests
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError
 
 from localstack import config, constants
 from localstack.services.kinesis import provider as kinesis_provider
@@ -37,6 +39,13 @@ def kinesis_snapshot_transformer(snapshot):
 
 
 class TestKinesis:
+    def test_create_stream_without_stream_name_raises(self):
+        boto_config = BotoConfig(parameter_validation=False)
+        kinesis_client = aws_stack.create_external_boto_client("kinesis", config=boto_config)
+        with pytest.raises(ClientError) as e:
+            kinesis_client.create_stream()
+        assert e.value.response["ResponseMetadata"]["HTTPStatusCode"] == 400
+
     @pytest.mark.aws_validated
     def test_create_stream_without_shard_count(
         self, kinesis_client, kinesis_create_stream, wait_for_stream_ready, snapshot


### PR DESCRIPTION
In comparison to the typical JSON datetime format for AWS services (`unixtimestamp`, i.e. the float representation of the current unix timestamp seconds), for CBOR the `unixtimestampmillis` (basically the int representation of `unixtimestamp * 1000`) format is used.

This PR contains the following changes:
- bdd1af3a0b691fc36695b3b40da2bc54f3fc414d: Fixes the CBOR datetime encoding.
- 4b16c7cbe8009f0f92a654baa3431b4cf7847ce8: Fixes an issue with the forwarding of invalid requests. It disables the validation in the botoclient when creating the request which will be forwarded (because the backend should take care of the request parameter validation).
- 3c0d807443bb07e9bfb8190fdb6258154aa1cb1f: Changes the loglevel of the serializer `DEBUG` logs to `TRACE` (since these are a bit verbose, but useful).

This PR fixes #6787.

The following AWS Java SDK snippet has been used to reproduce the issue (based on the issue report of @nicoloboschi):
```
import software.amazon.awssdk.core.SdkBytes;
import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
import software.amazon.awssdk.services.kinesis.model.*;

import java.net.URI;
import java.net.URISyntaxException;
import java.nio.charset.Charset;
import java.util.Random;
import java.util.concurrent.ExecutionException;
import java.util.concurrent.TimeUnit;

class KinesisCBOR {
    public static void main(String[] args) throws ExecutionException, InterruptedException, URISyntaxException {
        try (final KinesisAsyncClient client = KinesisAsyncClient.builder()
                .endpointOverride(new URI("http://localhost.localstack.cloud:4566")).build()) {
            Random rand = new Random();
            String streamName = "Test-Stream-" + rand.nextInt(10000);
            client.createStream(CreateStreamRequest.builder().streamName(streamName).shardCount(1).build()).get();
            TimeUnit.SECONDS.sleep(2);
            client.putRecord(PutRecordRequest.builder()
                    .streamName(streamName)
                    .data(SdkBytes.fromString("DATA", Charset.defaultCharset()))
                    .partitionKey("partitionkey")
                    .build()).get();
            final String shardId = client.listShards(ListShardsRequest.builder().streamName(streamName).build())
                    .get().shards().get(0).shardId();

            final String iterator = client.getShardIterator(GetShardIteratorRequest.builder()
                            .streamName(streamName)
                            .shardId(shardId)
                            .shardIteratorType(ShardIteratorType.TRIM_HORIZON)
                            .build()).get().shardIterator();
            final GetRecordsResponse response = client.getRecords(GetRecordsRequest.builder().shardIterator(iterator)
                                    .build()).get();
            System.out.println(response);
        }
    }
}
```

The fix has been validated with the Java snippet as well as with the extended integration test.