### PR TITLE
fix service detection for internal service routes

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -171,6 +171,11 @@ def legacy_rules(request: Request) -> Optional[str]:
     if path.startswith("/shell") or path.startswith("/dynamodb/shell"):
         return "dynamodb"
 
+    # TODO Remove once fallback to S3 is disabled (after S3 ASF and Cors rework)
+    # necessary for correct handling of cors for internal endpoints
+    if path == "/health" or path.startswith("/_localstack"):
+        return None
+
     # TODO The remaining rules here are special S3 rules - needs to be discussed how these should be handled.
     #      Some are similar to other rules and not that greedy, others are nearly general fallbacks.
     stripped = path.strip("/")

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -1,3 +1,4 @@
+import pytest
 import requests
 
 from localstack import config
@@ -32,9 +33,10 @@ class TestCSRF:
         assert response.headers["access-control-allow-origin"] == "https://app.localstack.cloud"
         assert "GET" in response.headers["access-control-allow-methods"].split(",")
 
-    def test_internal_route_cors_headers(self):
+    @pytest.mark.parametrize("path", ["/health", "/_localstack/health"])
+    def test_internal_route_cors_headers(self, path):
         headers = {"Origin": "https://app.localstack.cloud"}
-        response = requests.get(f"{config.get_edge_url()}/health", headers=headers)
+        response = requests.get(f"{config.get_edge_url()}{path}", headers=headers)
         assert response.status_code == 200
         assert response.headers["access-control-allow-origin"] == "https://app.localstack.cloud"
         assert "GET" in response.headers["access-control-allow-methods"].split(",")

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -32,6 +32,13 @@ class TestCSRF:
         assert response.headers["access-control-allow-origin"] == "https://app.localstack.cloud"
         assert "GET" in response.headers["access-control-allow-methods"].split(",")
 
+    def test_internal_route_cors_headers(self):
+        headers = {"Origin": "https://app.localstack.cloud"}
+        response = requests.get(f"{config.get_edge_url()}/health", headers=headers)
+        assert response.status_code == 200
+        assert response.headers["access-control-allow-origin"] == "https://app.localstack.cloud"
+        assert "GET" in response.headers["access-control-allow-methods"].split(",")
+
     def test_cors_s3_override(self, s3_client, s3_bucket, monkeypatch):
         monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", True)
 


### PR DESCRIPTION
## Problem
Currently, our service parser interprets internal routes, such as `/health` and `/_localstack/...` as s3 service, which leads to an exemption from cors processing. This leads to localstack not allowing cors requests to /health or internal localstack domains.
```
curl https://localhost.localstack.cloud:4566/health -H "Origin: https://app.localstack.cloud" -v                                        <aws:AWS-daniel>
*   Trying 127.0.0.1:4566...
* Connected to localhost.localstack.cloud (127.0.0.1) port 4566 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=localhost.localstack.cloud
*  start date: Jul  3 07:00:15 2022 GMT
*  expire date: Oct  1 07:00:14 2022 GMT
*  subjectAltName: host "localhost.localstack.cloud" matched cert's "localhost.localstack.cloud"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /health]
* h2h3 [:scheme: https]
* h2h3 [:authority: localhost.localstack.cloud:4566]
* h2h3 [user-agent: curl/7.84.0]
* h2h3 [accept: */*]
* h2h3 [origin: https://app.localstack.cloud]
* Using Stream ID: 1 (easy handle 0x56344390fd30)
> GET /health HTTP/2
> Host: localhost.localstack.cloud:4566
> user-agent: curl/7.84.0
> accept: */*
> origin: https://app.localstack.cloud
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< HTTP/2 200
< content-type: application/json
< content-length: 849
< date: Wed, 31 Aug 2022 14:07:33 GMT
< server: hypercorn-h2
<
* Connection #0 to host localhost.localstack.cloud left intact
{"services": {"acm": "available", "apigateway": "available", "cloudformation": "available", "cloudwatch": "available", "config": "available", "dynamodb": "available", "dynamodbstreams": "available", "ec2": "available", "es": "available", "events": "available", "firehose": "available", "iam": "available", "kinesis": "available", "kms": "available", "lambda": "available", "logs": "available", "opensearch": "available", "redshift": "available", "resource-groups": "available", "resourcegroupstaggingapi": "available", "route53": "available", "route53resolver": "available", "s3": "available", "s3control": "available", "secretsmanager": "available", "ses": "available", "sns": "available", "sqs": "available", "ssm": "available", "stepfunctions": "available", "sts": "available", "support": "available", "swf": "available"}, "version": "1.1.0.dev"}
```

## Proper fix
The fallback to the s3 service has to be removed, and cors handling should be done by the custom routes the services (like apigateway or s3) register.

## Fix for now
Add a hardcoded rule to the service router to stop interpreting internal routes as s3 service, and therefore having proper cors responses:
```
curl https://localhost.localstack.cloud:4566/health -H "Origin: https://app.localstack.cloud" -v                                        <aws:AWS-daniel>
*   Trying 127.0.0.1:4566...
* Connected to localhost.localstack.cloud (127.0.0.1) port 4566 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/certs/ca-certificates.crt
*  CApath: none
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* TLSv1.3 (IN), TLS handshake, Server hello (2):
* TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* TLSv1.3 (IN), TLS handshake, Certificate (11):
* TLSv1.3 (IN), TLS handshake, CERT verify (15):
* TLSv1.3 (IN), TLS handshake, Finished (20):
* TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=localhost.localstack.cloud
*  start date: Jul  3 07:00:15 2022 GMT
*  expire date: Oct  1 07:00:14 2022 GMT
*  subjectAltName: host "localhost.localstack.cloud" matched cert's "localhost.localstack.cloud"
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /health]
* h2h3 [:scheme: https]
* h2h3 [:authority: localhost.localstack.cloud:4566]
* h2h3 [user-agent: curl/7.84.0]
* h2h3 [accept: */*]
* h2h3 [origin: https://app.localstack.cloud]
* Using Stream ID: 1 (easy handle 0x55775a9b6d30)
> GET /health HTTP/2
> Host: localhost.localstack.cloud:4566
> user-agent: curl/7.84.0
> accept: */*
> origin: https://app.localstack.cloud
>
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
< HTTP/2 200
< content-type: application/json
< content-length: 849
< access-control-allow-origin: https://app.localstack.cloud
< access-control-allow-methods: HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH
< access-control-allow-headers: authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request
< access-control-expose-headers: etag,x-amz-version-id
< date: Wed, 31 Aug 2022 14:09:48 GMT
< server: hypercorn-h2
<
* Connection #0 to host localhost.localstack.cloud left intact
{"services": {"acm": "available", "apigateway": "available", "cloudformation": "available", "cloudwatch": "available", "config": "available", "dynamodb": "available", "dynamodbstreams": "available", "ec2": "available", "es": "available", "events": "available", "firehose": "available", "iam": "available", "kinesis": "available", "kms": "available", "lambda": "available", "logs": "available", "opensearch": "available", "redshift": "available", "resource-groups": "available", "resourcegroupstaggingapi": "available", "route53": "available", "route53resolver": "available", "s3": "available", "s3control": "available", "secretsmanager": "available", "ses": "available", "sns": "available", "sqs": "available", "ssm": "available", "stepfunctions": "available", "sts": "available", "support": "available", "swf": "available"}, "version": "1.1.0.dev"}
```

Thanks @alexrashed for discussing where to best place the fix, and @lukqw for mentioning it does not work.