### PR TITLE
Bump Node.js binary to version 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ ARG TARGETARCH
 RUN apt-get update && \
         # Install dependencies to add additional repos
         apt-get install -y --no-install-recommends ca-certificates curl && \
-        # Setup Node 14 Repo
-        curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+        # Setup Node 18 Repo
+        curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
         # Install Packages
         apt-get update && \
         apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Bump Node.js binary to version 18. This addresses a few security vulnerabilities (CVEs) that have been reported by scanners like Aquasec/[Trivy](https://github.com/aquasecurity/trivy), or the Docker built-in scanner by Snyk (incl     CVE-2022-32213, CVE-2022-32214, CVE-2022-32215). Current LTS version is v16, but versions 14/16/17 were unfortunately all exposing these CVEs in the scan results, hence the easiest is for us to go with the latest version, 18.

The main impact of this will be on the local Lambda executor mode (`LAMBDA_EXECUTOR=local`) - specifically, if users are depending on [Node.js APIs that have been deprecated](https://nodejs.org/api/deprecations.html) . Still planning to prepare a small docs PR to highlight this point to our customers - also, with the new Lambda provider, the local executor will likely become obsolete / get phased out over time. /cc @dominikschubert @dfangl 

We can merge this post v1.1 (no urgency to get it out with the 1.1 release in particular) - we could then wait for the next patch version for customers who need to pin to a specific version tag. 👍 

TODO:
- [ ] Update Lambda docs for local executor with new Node.js version