### PR TITLE
Remove xfail flag for test to run container as non-root

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -59,8 +59,4 @@ jobs:
         env:
           PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -s"
         run: |
-          # make sure that the logs dir is writable by a non-root user (required by the tests)
-          logs_dir=/home/runner/.cache/localstack/volume/logs; \
-            mkdir -p $logs_dir; \
-            sudo chmod -R 777 $logs_dir
           python -m pytest tests/bootstrap/

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -59,4 +59,8 @@ jobs:
         env:
           PYTEST_ADDOPTS: "-p no:localstack.testing.pytest.fixtures -p no:localstack.testing.pytest.snapshot -p no:localstack.testing.pytest.filters -p no:localstack.testing.pytest.fixture_conflicts -s"
         run: |
+          # make sure that the logs dir is writable by a non-root user (required by the tests)
+          logs_dir=/home/runner/.cache/localstack/volume/logs; \
+            mkdir -p $logs_dir; \
+            sudo chmod -R 777 $logs_dir
           python -m pytest tests/bootstrap/

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -163,11 +163,6 @@ class TestCliContainerLifecycle:
         user = "localstack"
         monkeypatch.setattr(config, "DOCKER_FLAGS", f"--user={user}")
 
-        if in_ci() and os.path.exists("/home/runner"):
-            logs_dir = "/home/runner/.cache/localstack/volume/logs"
-            mkdir(logs_dir)
-            run(["sudo", "chmod", "-R", "777", logs_dir])
-
         runner.invoke(cli, ["start", "-d"])
         runner.invoke(cli, ["wait", "-t", "60"])
 

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import os.path
 
 import pytest
 import requests
@@ -8,8 +9,10 @@ import localstack.utils.container_utils.docker_cmd_client
 from localstack import config, constants
 from localstack.cli.localstack import localstack as cli
 from localstack.config import DOCKER_SOCK, get_edge_url, in_docker
+from localstack.utils.bootstrap import in_ci
 from localstack.utils.common import poll_condition
-from localstack.utils.run import to_str
+from localstack.utils.files import mkdir
+from localstack.utils.run import run, to_str
 
 
 @pytest.fixture
@@ -159,6 +162,11 @@ class TestCliContainerLifecycle:
     def test_container_starts_non_root(self, runner, monkeypatch, container_client):
         user = "localstack"
         monkeypatch.setattr(config, "DOCKER_FLAGS", f"--user={user}")
+
+        if in_ci() and os.path.exists("/home/runner"):
+            logs_dir = "/home/runner/.cache/localstack/volume/logs"
+            mkdir(logs_dir)
+            run(["sudo", "chmod", "-R", "777", logs_dir])
 
         runner.invoke(cli, ["start", "-d"])
         runner.invoke(cli, ["wait", "-t", "60"])

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -156,10 +156,6 @@ class TestCliContainerLifecycle:
         binds = inspect["HostConfig"]["Binds"]
         assert f"{volume_dir}:{constants.DEFAULT_VOLUME_DIR}" in binds
 
-    # TODO: remove xfail marker as soon as new Docker image is published and test passes
-    @pytest.mark.xfail(
-        reason="Test should pass once the new Docker image is available after fixes in #6785"
-    )
     def test_container_starts_non_root(self, runner, monkeypatch, container_client):
         user = "localstack"
         monkeypatch.setattr(config, "DOCKER_FLAGS", f"--user={user}")

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -163,6 +163,11 @@ class TestCliContainerLifecycle:
         user = "localstack"
         monkeypatch.setattr(config, "DOCKER_FLAGS", f"--user={user}")
 
+        if in_ci() and os.path.exists("/home/runner"):
+            logs_dir = "/home/runner/.cache/localstack/volume/logs"
+            mkdir(logs_dir)
+            run(["sudo", "chmod", "-R", "777", logs_dir])
+
         runner.invoke(cli, ["start", "-d"])
         runner.invoke(cli, ["wait", "-t", "60"])
 


### PR DESCRIPTION
Remove xfail flag for test to run container as non-root. Follow-up / cleanup for PR #6785

Note: Had to add a `chmod` command to enable open permissions for the host directory that's mounted into `/var/lib/localstack/logs` - avoiding this error:
```
2022-09-01T17:45:57.270 ERROR --- [   Thread-12] localstack.utils.bootstrap : Error while starting LocalStack container: Docker process returned with errorcode 1
/usr/local/bin/docker-entrypoint.sh: line 73: /var/lib/localstack/logs/localstack_infra.log: Permission denied
```

I think it's a fair assumption that the user needs to take care of giving the Docker container user write access to the LocalStack internal filesystem. Additionally, we could also make the log file creation more resilient - adding a fallback to swallow permission errors when creating the `localstack_infra.log` log file.