### PR TITLE
SNS - fix publish_batch to invalid topic

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -472,6 +472,12 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                         "Invalid parameter: The topic should either have ContentBasedDeduplication enabled or MessageDeduplicationId provided explicitly",
                     )
 
+        sns_backend = SNSBackend.get()
+        if topic_arn not in sns_backend.sns_subscriptions:
+            raise NotFoundException(
+                "Topic does not exist",
+            )
+
         response = {"Successful": [], "Failed": []}
         for entry in publish_batch_request_entries:
             message_id = str(uuid.uuid4())

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2015,5 +2015,21 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_publish_batch_messages_without_topic": {
+    "recorded-date": "01-09-2022, 20:49:54",
+    "recorded-content": {
+      "publish-batch-no-topic": {
+        "Error": {
+          "Code": "NotFound",
+          "Message": "Topic does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR fixes #6784 
We did not check when calling `publish_batch` if the topic was valid or existing. Added the check + AWS validated test