### PR TITLE
fix snapshot-report: return error for 'type_changes'

### DIFF
--- a/localstack/testing/snapshots/report.py
+++ b/localstack/testing/snapshots/report.py
@@ -79,7 +79,7 @@ def render_report(result: SnapshotMatchResult):
             return [(change_path, f"[remove](-)[/remove] {change_path} ( {expected!r} )")]
         elif c.report_type in ["dictionary_item_added", "iterable_item_added"]:
             return [(change_path, f"[add](+)[/add] {change_path} ( {actual!r} )")]
-        elif c.report_type in ["values_changed"]:
+        elif c.report_type in ["values_changed", "type_changes"]:
             # TODO: more fancy change detection and visualization (e.g. parts of a string)
             return [
                 (
@@ -88,9 +88,14 @@ def render_report(result: SnapshotMatchResult):
                 )
             ]
         else:
-            LOG.warning(
-                f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support. {expected=} | {actual=}"
-            )
+            resp = f"Unsupported diff mismatch reason: {c.report_type}. Please report this to the team so we can add support. {expected=} | {actual=}"
+            LOG.warning(resp)
+            return [
+                (
+                    change_path,
+                    resp,
+                )
+            ]
         return []
 
     lines = []


### PR DESCRIPTION
When the type for the value comparison changes, the match would silently succeed. Only a warning is logged, but this is likely to be overseen.

For example the snapshot contains a string:
`"list-objects-next_marker": "test"` and the actual response contains a dict, the following warning would be logged, but the comparison would not show any error:
`Unsupported diff mismatch reason: type_changes. Please report this to the team so we can add support. expected='test' | actual={'Contents': [{'ETag': '"469aa468e8b397232fe0754ba11ba9f3"', 'Key': 'test-key-990', …………….. }]}`

Fix in this PR:

- As the `report_type` in this case is `type_changes` we can simply filter for it, and return a response similar to `values_changed`.
- Also added a dummy-return value in case another unknown `report_type` is encountered. The report will simply return the message we already log as warning, but the snapshot matching will fail.

