### PR TITLE
add ability to patch botocore specs

### DIFF
--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -1,0 +1,6 @@
+{
+  "s3/2006-03-01/service-2": [
+    {"op": "add", "path": "/shapes/NoSuchBucket/members/BucketName", "value": {"shape": "BucketName"}},
+    {"op": "add", "path": "/shapes/NoSuchBucket/error", "value": {"httpStatusCode": 404}}
+  ]
+}

--- a/tests/unit/aws/test_spec.py
+++ b/tests/unit/aws/test_spec.py
@@ -1,5 +1,8 @@
+from botocore.model import ServiceModel, StringShape
+
 from localstack.aws.spec import (
     LazyServiceCatalogIndex,
+    PatchingLoader,
     load_service_index_cache,
     save_service_index_cache,
 )
@@ -18,3 +21,42 @@ def test_pickled_index_equals_lazy_index(tmp_path):
     assert cached_index.signing_name_index == lazy_index.signing_name_index
     assert cached_index.operations_index == lazy_index.operations_index
     assert cached_index.endpoint_prefix_index == lazy_index.endpoint_prefix_index
+
+
+def test_patching_loaders():
+    # first test that specs remain intact
+    loader = PatchingLoader({})
+    description = loader.load_service_model("s3", "service-2")
+
+    model = ServiceModel(description, "s3")
+
+    shape = model.shape_for("NoSuchBucket")
+    # by default, the s3 error shapes have no members, but AWS will actually return additional attributes
+    assert not shape.members
+    assert shape.metadata.get("exception")
+
+    # now try it with a patch
+    loader = PatchingLoader(
+        {
+            "s3/2006-03-01/service-2": [
+                {
+                    "op": "add",
+                    "path": "/shapes/NoSuchBucket/members/BucketName",
+                    "value": {"shape": "BucketName"},
+                },
+                {
+                    "op": "add",
+                    "path": "/shapes/NoSuchBucket/error",
+                    "value": {"httpStatusCode": 404},
+                },
+            ],
+        }
+    )
+    description = loader.load_service_model("s3", "service-2", "2006-03-01")
+    model = ServiceModel(description, "s3")
+
+    shape = model.shape_for("NoSuchBucket")
+    assert "BucketName" in shape.members
+    assert isinstance(shape.members["BucketName"], StringShape)
+    assert shape.metadata["error"]["httpStatusCode"] == 404
+    assert shape.metadata.get("exception")


### PR DESCRIPTION
This PR adds a `PatchingLoader` to ASF, which allows dynamic patching of botocore specs using jsonpatch.

This is mainly needed for s3 exception and response types, where the status codes defined in the spec often missing or differ from what AWS actually returns.

Patches are collected  into `spec-patches.json` which is just a dictionary of botocore spec path -> jsonpatch document for that spec.
I also added an example patch to demonstrate how to use it.

@alexrashed i hope you find this to be an acceptable compromise between the two extremes of patching botocore objects vs providing our own spec files. :slightly_smiling_face:  by adding patched services to `test_generated_code_compiles`, we make sure that the patches are actually compatible with the spec, so that, should the spec diverge, we immediately get notified.