### PR TITLE
Add ability to set custom expiry for reserved ports in PortRange TTL cache

### DIFF
--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -622,6 +622,15 @@ class TestExternalServicePortsManager:
         with pytest.raises(PortNotAvailableException):
             external_service_ports_manager.reserve_port(config.EXTERNAL_SERVICE_PORTS_START)
 
+    def test_reserve_custom_expiry(
+        self, external_service_ports_manager: ExternalServicePortsManager
+    ):
+        external_service_ports_manager.reserve_port(config.EXTERNAL_SERVICE_PORTS_START, duration=1)
+        with pytest.raises(PortNotAvailableException):
+            external_service_ports_manager.reserve_port(config.EXTERNAL_SERVICE_PORTS_START)
+        time.sleep(1)
+        external_service_ports_manager.reserve_port(config.EXTERNAL_SERVICE_PORTS_START)
+
 
 @pytest.fixture()
 def paginated_list():


### PR DESCRIPTION
Add ability to set custom expiry for reserved ports in `PortRange` TTL cache. 

This surfaced while working on a fix for #6798 - some services need a bit more time to start up, so it will come in handy if we have a way to reserve service ports for an extended period of time (beyond the default 6 seconds).

Summary of changes:
* introduce a `CustomExpiryTTLCache` class that provides a `set_expiry(..)` method to set the expiry for a single key
* allow passing in an optional `duration` parameter to `reserve_port(..)`, to reserve a port for the given duration
* add a small test to assert the custom port reservation duration