### PR TITLE
increase max number of http request threads

### DIFF
--- a/localstack/aws/serving/asgi.py
+++ b/localstack/aws/serving/asgi.py
@@ -15,7 +15,7 @@ class AsgiGateway:
     gateway: Gateway
 
     def __init__(
-        self, gateway: Gateway, event_loop: Optional[AbstractEventLoop] = None, threads: int = 100
+        self, gateway: Gateway, event_loop: Optional[AbstractEventLoop] = None, threads: int = 1000
     ) -> None:
         self.gateway = gateway
 


### PR DESCRIPTION
This PR increases the number of concurrent requests that can be served when running the LocalStack gateway through hypercorn. There's no impact die normal usage, it's just the size of the thread pool used for spawning request handlers. Should fix #6792 but need to double check with the user.