### PR TITLE
Add sorting transformer for snapshots

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -40,6 +40,11 @@
 # Analytics client
 /localstack/utils/analytics/ @thrau
 
+# Snapshot testing
+/localstack/testing/snapshots/ @dominikschubert @steffyP
+/localstack/testing/pytest/ @dominikschubert
+/localstack/testing/pytest/snapshot.py @dominikschubert @steffyP
+
 ######################
 ### SERVICE OWNERS ###
 ######################

--- a/tests/unit/utils/testing/test_snapshots.py
+++ b/tests/unit/utils/testing/test_snapshots.py
@@ -1,7 +1,7 @@
 import pytest
 
 from localstack.testing.snapshots import SnapshotSession
-from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
+from localstack.testing.snapshots.transformer import KeyValueBasedTransformer, SortingTransformer
 from localstack.testing.snapshots.transformer_utility import _resource_name_transformer
 
 
@@ -119,3 +119,34 @@ class TestSnapshotManager:
 
         skip_path_escaped = ["$..aab", "$..b.'a.aa'"]
         sm._assert_all(skip_verification_paths=skip_path_escaped)
+
+
+def test_sorting_transformer():
+    original_dict = {
+        "a": {
+            "b": [
+                {"name": "c-123"},
+                {"name": "a-123"},
+                {"name": "b-123"},
+            ]
+        },
+        "a2": {
+            "b": [
+                {"name": "b-123"},
+                {"name": "a-123"},
+                {"name": "c-123"},
+            ]
+        },
+    }
+
+    sorted_items = [
+        {"name": "a-123"},
+        {"name": "b-123"},
+        {"name": "c-123"},
+    ]
+
+    transformer = SortingTransformer("b", lambda x: x["name"])
+    transformed_dict = transformer.transform(original_dict)
+
+    assert transformed_dict["a"]["b"] == sorted_items
+    assert transformed_dict["a2"]["b"] == sorted_items


### PR DESCRIPTION
Makes it easier to reliably compare lists via snapshots by sorting them via a transformer instead of having to manually sorting the object before calling `match`.

Usage: 
```python
snapshot.add_transformer(SortingTransformer("Aliases", lambda x: x["Name"]))
 ```
