### PR TITLE
S3 migration - set s3 v2 provider as default

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -76,48 +76,9 @@ cat /dev/null > ${LOG_DIR}/localstack_infra.err
 # run modern runtime init scripts before starting localstack
 test -d /etc/localstack/init/boot.d && /opt/code/localstack/.venv/bin/python -m localstack.runtime.init BOOT
 
+# TODO: maybe we can simplify this by making supervisord block the main process?
 supervisord -c /etc/supervisord.conf &
 suppid="$!"
-
-
-# FIXME: remove with 2.0
-if [[ ! $INIT_SCRIPTS_PATH ]]
-then
-  INIT_SCRIPTS_PATH=/docker-entrypoint-initaws.d
-fi
-# check if the init script directory exists (by default it does not)
-if [ -d "$INIT_SCRIPTS_PATH" ]; then
-    # unless LEGACY_INIT_DIR is explicitly set to 1 print a prominent warning
-    if [[ -z ${LEGACY_INIT_DIR} ]] || [[ ${LEGACY_INIT_DIR} == "0" ]]; then
-        echo "WARNING"
-        echo "============================================================================"
-        echo "  It seems you are using an init script in $INIT_SCRIPTS_PATH."
-        echo "  The INIT_SCRIPTS_PATH have been deprecated with v1.1.0 and will be removed in future releases"
-        echo "  of LocalStack. Please use /etc/localstack/init/ready.d instead."
-        echo "  You can suppress this warning by setting LEGACY_INIT_DIR=1."
-        echo ""
-        echo "  See: https://github.com/localstack/localstack/issues/7257"
-        echo "============================================================================"
-        echo ""
-    fi
-fi
-function run_startup_scripts {
-  until grep -q '^Ready.' ${LOG_DIR}/localstack_infra.log >/dev/null 2>&1 ; do
-    echo "Waiting for all LocalStack services to be ready"
-    sleep 7
-  done
-
-  curl -XPUT -s -H "Content-Type: application/json" -d '{"features:initScripts":"initializing"}' "http://localhost:$EDGE_PORT/_localstack/health" > /dev/null
-  for f in $INIT_SCRIPTS_PATH/*; do
-    case "$f" in
-      *.sh)     echo "$0: running $f"; . "$f" ;;
-      *)        echo "$0: ignoring $f" ;;
-    esac
-    echo
-  done
-  curl -XPUT -s -H "Content-Type: application/json" -d '{"features:initScripts":"initialized"}' "http://localhost:$EDGE_PORT/_localstack/health" > /dev/null
-}
-run_startup_scripts &
 
 # Run tail on the localstack log files forever until we are told to terminate
 if [ "$DISABLE_TERM_HANDLER" == "" ]; then

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -35,25 +35,6 @@ elif [[ -f /usr/lib/localstack/.light-version ]] || [[ -f /usr/lib/localstack/.f
     echo ""
 fi
 
-# FIXME: remove with 2.0
-# the Dockerfile creates .marker file that will be overwritten if a volume is mounted into /tmp/localstack
-if [ ! -f /tmp/localstack/.marker ]; then
-    # unless LEGACY_DIRECTORIES is explicitly set to 1, print an error message and exit with a non-zero exit code
-    if [[ -z ${LEGACY_DIRECTORIES} ]] || [[ ${LEGACY_DIRECTORIES} == "0" ]]; then
-        echo "ERROR"
-        echo "============================================================================"
-        echo "  It seems you are mounting the LocalStack volume into /tmp/localstack."
-        echo "  This will break the LocalStack container! Please update your volume mount"
-        echo "  destination to /var/lib/localstack."
-        echo "  You can suppress this error by setting LEGACY_DIRECTORIES=1."
-        echo ""
-        echo "  See: https://github.com/localstack/localstack/issues/6398"
-        echo "============================================================================"
-        echo ""
-        exit 1
-    fi
-fi
-
 # This stores the PID of supervisord for us after forking
 suppid=0
 
@@ -91,10 +72,6 @@ test -d ${LOG_DIR} || mkdir -p ${LOG_DIR}
 
 cat /dev/null > ${LOG_DIR}/localstack_infra.log
 cat /dev/null > ${LOG_DIR}/localstack_infra.err
-
-# FIXME for backwards compatibility with LEGACY_DIRECTORIES=1
-test -f /tmp/localstack_infra.log || ln -s ${LOG_DIR}/localstack_infra.log /tmp/localstack_infra.log
-test -f /tmp/localstack_infra.err || ln -s ${LOG_DIR}/localstack_infra.err /tmp/localstack_infra.err
 
 # run modern runtime init scripts before starting localstack
 test -d /etc/localstack/init/boot.d && /opt/code/localstack/.venv/bin/python -m localstack.runtime.init BOOT

--- a/localstack/__init__.py
+++ b/localstack/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.4.1.dev"
+__version__ = "2.0.0.dev"

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -282,15 +282,14 @@ def resolve_conflicts(candidates: Set[str], request: Request):
         return "rds"
 
 
-def determine_aws_service_name(
-    request: Request, services: ServiceCatalog = get_service_catalog()
-) -> Optional[str]:
+def determine_aws_service_name(request: Request, services: ServiceCatalog = None) -> Optional[str]:
     """
     Tries to determine the name of the AWS service an incoming request is targeting.
     :param request: to determine the target service name of
     :param services: service catalog (can be handed in for caching purposes)
     :return: service name string (or None if the targeting service could not be determined exactly)
     """
+    services = services or get_service_catalog()
     signing_name, target_prefix, operation, host, path = _extract_service_indicators(request)
     candidates = set()
 

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -53,7 +53,7 @@ def localstack(debug, profile):
     from localstack.utils.files import cache_dir
 
     # overwrite the config variable here to defer import of cache_dir
-    if not config.LEGACY_DIRECTORIES and not os.environ.get("LOCALSTACK_VOLUME_DIR", "").strip():
+    if not os.environ.get("LOCALSTACK_VOLUME_DIR", "").strip():
         config.VOLUME_DIR = str(cache_dir() / "volume")
 
 

--- a/localstack/cli/main.py
+++ b/localstack/cli/main.py
@@ -1,5 +1,11 @@
+import os
+
+
 def main():
-    # config profiles are the first thing that need to be loaded
+    # indicate to the environment we are starting from the CLI
+    os.environ["LOCALSTACK_CLI"] = "1"
+
+    # config profiles are the first thing that need to be loaded (especially before localstack.config!)
     from .profiles import set_profile_from_sys_argv
 
     set_profile_from_sys_argv()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -370,6 +370,11 @@ USE_SSL = is_env_true("USE_SSL")
 # whether to use the legacy edge proxy or the newer Gateway/HandlerChain framework
 LEGACY_EDGE_PROXY = is_env_true("LEGACY_EDGE_PROXY")
 
+# Forces to use S3 ASF provider, while not loading -ext (does not have asf provider)
+# TODO: will need to discuss the best way to do this with -ext, this is temporary for testing
+if not os.environ.get("PROVIDER_OVERRIDE_S3"):
+    os.environ["PROVIDER_OVERRIDE_S3"] = "asf"
+
 # whether legacy s3 is enabled
 # TODO change when asf becomes default: os.environ.get("PROVIDER_OVERRIDE_S3", "") == 'legacy'
 LEGACY_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") not in (

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -376,13 +376,7 @@ if not os.environ.get("PROVIDER_OVERRIDE_S3"):
     os.environ["PROVIDER_OVERRIDE_S3"] = "asf"
 
 # whether legacy s3 is enabled
-# TODO change when asf becomes default: os.environ.get("PROVIDER_OVERRIDE_S3", "") == 'legacy'
-LEGACY_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") not in (
-    "asf",
-    "asf_pro",
-    "v2",
-    "v2_pro",
-)
+LEGACY_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") == "legacy"
 
 # Whether to report internal failures as 500 or 501 errors.
 FAIL_FAST = is_env_true("FAIL_FAST")

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -154,8 +154,7 @@ API_ENDPOINT = os.environ.get("API_ENDPOINT") or "https://api.localstack.cloud/v
 # new analytics API endpoint
 ANALYTICS_API = os.environ.get("ANALYTICS_API") or "https://analytics.localstack.cloud/v1"
 
-# environment variable to indicates that this process is running the Web UI
-LOCALSTACK_WEB_PROCESS = "LOCALSTACK_WEB_PROCESS"
+# environment variable to indicates this process should run the localstack infrastructure
 LOCALSTACK_INFRA_PROCESS = "LOCALSTACK_INFRA_PROCESS"
 
 # default AWS region us-east-1

--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -57,17 +57,6 @@ def start_lambda(port=None, asynchronous=False):
             lambda_utils.get_executor_mode(),
         )
 
-    if (
-        config.is_in_docker
-        and not config.LAMBDA_REMOTE_DOCKER
-        and not config.dirs.functions
-        and config.LEGACY_DIRECTORIES
-    ):
-        LOG.warning(
-            "!WARNING! - Looks like you have configured $LAMBDA_REMOTE_DOCKER=0 - "
-            "please make sure to configure $HOST_TMP_FOLDER to point to your host's $TMPDIR"
-        )
-
     port = port or config.service_port("lambda")
     return start_local_api(
         "Lambda", port, api="lambda", method=lambda_api.serve, asynchronous=asynchronous

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -354,14 +354,9 @@ def is_trace_logging_enabled(headers) -> bool:
 
 
 def do_start_edge(bind_address, port, use_ssl, asynchronous=False):
-    if config.LEGACY_EDGE_PROXY:
-        serve = do_start_edge_proxy
-    else:
-        from localstack.aws.serving.edge import serve_gateway
+    from localstack.aws.serving.edge import serve_gateway
 
-        serve = serve_gateway
-
-    return serve(bind_address, port, use_ssl, asynchronous)
+    return serve_gateway(bind_address, port, use_ssl, asynchronous)
 
 
 def do_start_edge_proxy(bind_address, port, use_ssl, asynchronous=False):

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -221,7 +221,7 @@ def route53resolver():
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
-@aws_provider(api="s3", name="default")
+@aws_provider(api="s3", name="legacy")
 def s3():
     from localstack.services.s3 import s3_listener, s3_starter
 
@@ -247,7 +247,7 @@ def s3_asf():
     return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
-@aws_provider(api="s3", name="v2")
+@aws_provider(api="s3", name="default")
 def s3_v2():
     from localstack.services.s3.provider import S3Provider
 

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -184,10 +184,6 @@ class BackendState:
         backend = get_s3_backend()
         bucket = backend.buckets.get(bucket_name)
         if not bucket:
-            # note: adding a switch here to be able to handle both, moto's MissingBucket with the
-            # legacy edge proxy, as well as our custom CommonServiceException with the new Gateway.
-            if config.LEGACY_EDGE_PROXY:
-                raise MissingBucket()
             raise NoSuchBucket()
         return bucket
 

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -83,8 +83,7 @@ def start_s3(port=None, backend_port=None, asynchronous=None, update_listener=No
 
     apply_patches()
 
-    if not config.LEGACY_EDGE_PROXY:
-        add_gateway_compatibility_handlers()
+    add_gateway_compatibility_handlers()
 
     return start_moto_server(
         key="s3",

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -10,7 +10,6 @@ from functools import wraps
 from typing import Dict, Iterable, List, Optional, Set
 
 from localstack import config, constants
-from localstack.config import Directories
 from localstack.constants import DEFAULT_VOLUME_DIR
 from localstack.runtime import hooks
 from localstack.utils.container_networking import get_main_container_name
@@ -580,30 +579,7 @@ def configure_container(container: LocalstackContainer):
 
 
 def configure_volume_mounts(container: LocalstackContainer):
-    if not config.LEGACY_DIRECTORIES:
-        container.volumes.add(VolumeBind(config.VOLUME_DIR, DEFAULT_VOLUME_DIR))
-        return
-
-    source_dirs = config.dirs
-    target_dirs = Directories.legacy_for_container()
-
-    # default shared directories
-    for name in Directories.default_bind_mounts:
-        src = getattr(source_dirs, name, None)
-        target = getattr(target_dirs, name, None)
-        if src and target:
-            container.volumes.add(VolumeBind(src, target))
-
-    # shared tmp folder
-    container.volumes.add(VolumeBind(source_dirs.tmp, target_dirs.tmp))
-
-    # set the HOST_TMP_FOLDER for the legacy dirs / legacy lambda function mounting
-    container.env_vars["HOST_TMP_FOLDER"] = source_dirs.functions
-
-    # data_dir mounting and environment variables
-    if source_dirs.data:
-        container.volumes.add(VolumeBind(source_dirs.data, target_dirs.data))
-        container.env_vars["DATA_DIR"] = target_dirs.data
+    container.volumes.add(VolumeBind(config.VOLUME_DIR, DEFAULT_VOLUME_DIR))
 
 
 @log_duration()

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -22,7 +22,7 @@ from localstack.utils.container_utils.container_client import (
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
-from localstack.utils.files import cache_dir, chmod_r, mkdir
+from localstack.utils.files import cache_dir, mkdir
 from localstack.utils.functions import call_safe
 from localstack.utils.run import run, to_str
 from localstack.utils.serving import Server
@@ -54,13 +54,6 @@ API_COMPOSITES = {
     ],
     "cognito": ["cognito-idp", "cognito-identity"],
 }
-
-# main container name determined via "docker inspect"
-MAIN_CONTAINER_NAME_CACHED = None
-
-# environment variable that indicates that we're executing in
-# the context of the script that starts the Docker container
-ENV_SCRIPT_STARTING_DOCKER = "LS_SCRIPT_STARTING_DOCKER"
 
 
 def log_duration(name=None, min_ms=500):
@@ -516,21 +509,6 @@ def prepare_docker_start():
 
     if DOCKER_CLIENT.is_container_running(container_name):
         raise ContainerExists('LocalStack container named "%s" is already running' % container_name)
-    if config.dirs.tmp != config.dirs.functions and not config.LAMBDA_REMOTE_DOCKER:
-        # Logger is not initialized at this point, so the warning is displayed via print
-        print(
-            f"WARNING: The detected temp folder for localstack ({config.dirs.tmp}) is not equal to the "
-            f"HOST_TMP_FOLDER environment variable set ({config.dirs.functions})."
-        )
-
-    os.environ[ENV_SCRIPT_STARTING_DOCKER] = "1"
-
-    # make sure temp folder exists
-    mkdir(config.dirs.tmp)
-    try:
-        chmod_r(config.dirs.tmp, 0o777)
-    except Exception:
-        pass
 
 
 def configure_container(container: LocalstackContainer):

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import platform
 import random
-import re
 from typing import List, Optional
 
 from localstack import config
@@ -102,9 +101,6 @@ def get_host_path_for_path_in_docker(path):
     :param path: Path to be replaced (subpath of DEFAULT_VOLUME_DIR)
     :return: Path on the host
     """
-    if config.LEGACY_DIRECTORIES:
-        return re.sub(r"^%s/(.*)$" % config.dirs.tmp, r"%s/\1" % config.dirs.functions, path)
-
     if config.is_in_docker:
         volume = get_default_volume_dir_mount()
 

--- a/tests/integration/aws/test_app.py
+++ b/tests/integration/aws/test_app.py
@@ -72,6 +72,4 @@ class TestExceptionHandlers:
         # FIXME: this is because unknown routes have to be interpreted as s3 requests
         response = requests.get(get_edge_url() + "/_raise_error")
         assert response.status_code == 404
-        assert response.text.startswith(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>NoSuchBucket</Code>'
-        )
+        assert "<Error><Code>NoSuchBucket</Code>" in response.text

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2269,8 +2269,9 @@ class TestS3:
                 snapshot.transform.regex(rf"{bucket_2}", "<bucket-name:2>"),
                 snapshot.transform.key_value("x-amz-id-2", reference_replacement=False),
                 snapshot.transform.key_value("x-amz-request-id", reference_replacement=False),
-                snapshot.transform.regex(r"s3\.amazonaws\.com", "host"),
-                snapshot.transform.regex(r"s3\.localhost\.localstack\.cloud:4566", "host"),
+                snapshot.transform.regex(r"s3\.amazonaws\.com", "<host>"),
+                snapshot.transform.regex(r"s3\.localhost\.localstack\.cloud:4566", "<host>"),
+                snapshot.transform.regex(r"s3\.localhost\.localstack\.cloud:443", "<host>"),
             ]
         )
 
@@ -2298,10 +2299,11 @@ class TestS3:
                 _filter_header(response["ResponseMetadata"]["HTTPHeaders"]),
             )
 
-            # TODO aws returns 403, LocalStack 404
-            # with pytest.raises(ClientError) as e:
-            #     response = s3_client.head_bucket(Bucket="does-not-exist")
-            # snapshot.match("head_bucket_not_exist", e.value.response)
+            with pytest.raises(ClientError) as e:
+                response = s3_client.head_bucket(
+                    Bucket=f"does-not-exist-{short_uid()}-{short_uid()}"
+                )
+            snapshot.match("head_bucket_not_exist", e.value.response)
         finally:
             s3_client.delete_bucket(Bucket=bucket_1)
             s3_client.delete_bucket(Bucket=bucket_2)

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -1748,7 +1748,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
-    "recorded-date": "21-09-2022, 13:38:23",
+    "recorded-date": "22-03-2023, 16:45:10",
     "recorded-content": {
       "create_bucket": {
         "Location": "/<bucket-name:1>",
@@ -1758,7 +1758,7 @@
         }
       },
       "create_bucket_location_constraint": {
-        "Location": "http://<bucket-name:2>.host/",
+        "Location": "http://<bucket-name:2>.<host>/",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1789,6 +1789,16 @@
         "x-amz-bucket-region": "us-west-1",
         "x-amz-id-2": "x-amz-id-2",
         "x-amz-request-id": "x-amz-request-id"
+      },
+      "head_bucket_not_exist": {
+        "Error": {
+          "Code": "404",
+          "Message": "Not Found"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary
This PR should remain minimal in terms of code changes, and is mostly used for keeping track of the PRs regarding the new s3 provider going directly into master and for tracking test failure rates against the new provider.

## PRs
The following PRs have been created to fully implement the new s3 provider:
* #6552
* #6629
* #6836
* #6829 
* #6812 
* #6839
* #6859
* #6868 
* #6875 
* #6846
* #6903 
* #6906
* #6908
* #6937 
* #6959
* #6980
* #6987
* #7001
* #7027
* #7065
* #7070
* #7081
* #7152
* #7173

## Tasks
- [x] Migrate all s3 tests to pytest and validates them against AWS
- [X] Create the new ASF provider
- [X] Allow patching of botocore specs to match actual AWS behaviour
- [X] Reroute virtual host addressed requests as path addressed ones to take advantage of the builtin ASF routing
- [x] Implement major S3 features:
  - [X] S3 notifications
  - [X] All major basic OPs (GetObject, GetBucket, etc)
  - [X] Pre-signed URLs
  - [X] Pre-signed POST
  - [X] S3 Static Website Hosting
  - [x] CORS

- [x] Fix ongoing issues with current provider not tackled in above major features
  - [X] VersionId and Expires always present
  - [X] GetObjectAttributes not implemented
  - [X] Empty tagging lists
  - [X] Delete versioned objects
  - [X] Fix Terraform tests (fixed in #7027 + full test run green [here](https://github.com/localstack/localstack/actions/runs/3322125332/jobs/5490831947))
  - [x] remove legacy VirtualHostRewriter
  - [x] Fix issues with presigned urls

- [x] Implement the Pro provider

- [x] Implement S3 ASF test job for CircleCI