### PR TITLE
Extract region from function arn for inter service invokes

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -26,6 +26,7 @@ from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_exec
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import LambdaResponse, requests_response
+from localstack.utils.aws.aws_stack import extract_region_from_arn
 from localstack.utils.collections import remove_attributes
 from localstack.utils.common import make_http_request, to_str
 from localstack.utils.http import canonicalize_headers, parse_request_data
@@ -99,7 +100,9 @@ class SnsIntegration(BackendIntegration):
 
 
 def call_lambda(function_arn: str, event: bytes, asynchronous: bool) -> str:
-    lambda_client = aws_stack.connect_to_service("lambda")
+    lambda_client = aws_stack.connect_to_service(
+        "lambda", region_name=extract_region_from_arn(function_arn)
+    )
     inv_result = lambda_client.invoke(
         FunctionName=function_arn,
         Payload=event,

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -97,6 +97,7 @@ from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_responses import create_sqs_system_attributes
+from localstack.utils.aws.aws_stack import extract_region_from_arn
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
 from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.json import json_safe
@@ -1201,7 +1202,9 @@ def process_sns_notification_to_lambda(
             }
         ]
     }
-    lambda_client = aws_stack.connect_to_service("lambda")
+    lambda_client = aws_stack.connect_to_service(
+        "lambda", region_name=extract_region_from_arn(func_arn)
+    )
     inv_result = lambda_client.invoke(
         FunctionName=func_arn,
         Payload=to_bytes(json.dumps(event)),

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1119,14 +1119,16 @@ def is_change_set_finished(cfn_client):
 
 @pytest.fixture
 def wait_until_lambda_ready(lambda_client):
-    def _wait_until_ready(function_name: str, qualifier: str = None):
+    def _wait_until_ready(function_name: str, qualifier: str = None, client=None):
+        client = client or lambda_client
+
         def _is_not_pending():
             kwargs = {}
             if qualifier:
                 kwargs["Qualifier"] = qualifier
             try:
                 result = (
-                    lambda_client.get_function(FunctionName=function_name)["Configuration"]["State"]
+                    client.get_function(FunctionName=function_name)["Configuration"]["State"]
                     != "Pending"
                 )
                 LOG.debug(f"lambda state result: {result=}")
@@ -1177,12 +1179,13 @@ role_policy = """
 
 @pytest.fixture
 def create_lambda_function(lambda_client, logs_client, iam_client, wait_until_lambda_ready):
-    lambda_arns = []
+    lambda_arns_and_clients = []
     role_names_policy_arns = []
     log_groups = []
 
     def _create_lambda_function(*args, **kwargs):
-        kwargs["client"] = lambda_client
+        client = kwargs.get("client") or lambda_client
+        kwargs["client"] = client
         func_name = kwargs.get("func_name")
         assert func_name
         del kwargs["func_name"]
@@ -1202,8 +1205,8 @@ def create_lambda_function(lambda_client, logs_client, iam_client, wait_until_la
 
         def _create_function():
             resp = testutil.create_lambda_function(func_name, **kwargs)
-            lambda_arns.append(resp["CreateFunctionResponse"]["FunctionArn"])
-            wait_until_lambda_ready(function_name=func_name)
+            lambda_arns_and_clients.append((resp["CreateFunctionResponse"]["FunctionArn"], client))
+            wait_until_lambda_ready(function_name=func_name, client=client)
             log_group_name = f"/aws/lambda/{func_name}"
             log_groups.append(log_group_name)
             return resp
@@ -1214,9 +1217,9 @@ def create_lambda_function(lambda_client, logs_client, iam_client, wait_until_la
 
     yield _create_lambda_function
 
-    for arn in lambda_arns:
+    for arn, client in lambda_arns_and_clients:
         try:
-            lambda_client.delete_function(FunctionName=arn)
+            client.delete_function(FunctionName=arn)
         except Exception:
             LOG.debug(f"Unable to delete function {arn=} in cleanup")
 


### PR DESCRIPTION
## Problem
Sadly, with the refactoring of lambda invokes in the different services, one important thing was missed: the region of the lambda client has to match the region of the lambda invoked. Currently, it will fallback to the default region, which is us-east-1, if it is not executed directly in the context of a request for a different region. Even in the latter case, some services support invoking lambdas in different regions (apigateway for example), which would still not be possible then.

## Fix
We now extract the region of the lambda arn before creating the call, and calling the lambda in the appropriate region.