### PR TITLE
fix crypography with pyopenssl conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ runtime =
     botocore>=1.12.13
     cbor2>=5.2.0
     crontab>=0.22.6
-    cryptography
+    cryptography<38.0.0
     dnslib>=0.9.10
     dnspython>=1.16.0
     docker==5.0.0


### PR DESCRIPTION
cryptography 38.0.0 was released 3h ago, this breaks any run of localstack on host due to a conflict with pyopenssl(not compatible with cryptography 38.0.0

Error trace:
```
Traceback (most recent call last):
  File "/home/runner/.local/bin/localstack", line 23, in <module>
    main()
  File "/home/runner/.local/bin/localstack", line 19, in main
    main.main()
  File "/home/runner/.local/lib/python3.8/site-packages/localstack/cli/main.py", line 3, in main
    from .localstack import create_with_plugins
  File "/home/runner/.local/lib/python3.8/site-packages/localstack/cli/localstack.py", line 7, in <module>
    from localstack import config
  File "/home/runner/.local/lib/python3.8/site-packages/localstack/config.py", line 11, in <module>
    from localstack.constants import (
  File "/home/runner/.local/lib/python3.8/site-packages/localstack/constants.py", line 3, in <module>
    import localstack_client.config
  File "/home/runner/.local/lib/python3.8/site-packages/localstack_client/config.py", line 7, in <module>
    from localstack_client.patch import patch_expand_host_prefix  # noqa
  File "/home/runner/.local/lib/python3.8/site-packages/localstack_client/patch.py", line 3, in <module>
    import boto3
  File "/home/runner/.local/lib/python3.8/site-packages/boto3/__init__.py", line 17, in <module>
    from boto3.session import Session
  File "/home/runner/.local/lib/python3.8/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/session.py", line 26, in <module>
    import botocore.client
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/client.py", line 17, in <module>
    from botocore import waiter, xform_name
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/waiter.py", line 18, in <module>
    from botocore.docs.docstring import WaiterDocstring
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/docs/__init__.py", line 15, in <module>
    from botocore.docs.service import ServiceDocumenter
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/docs/service.py", line 14, in <module>
    from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/docs/client.py", line 14, in <module>
    from botocore.docs.example import ResponseExampleDocumenter
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/docs/example.py", line 13, in <module>
    from botocore.docs.shape import ShapeDocumenter
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/docs/shape.py", line 19, in <module>
    from botocore.utils import is_json_value_header
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/utils.py", line 34, in <module>
    import botocore.httpsession
  File "/home/runner/.local/lib/python3.8/site-packages/botocore/httpsession.py", line 41, in <module>
    from urllib3.contrib.pyopenssl import orig_util_SSLContext as SSLContext
  File "/usr/lib/python3/dist-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```