### PR TITLE
fix coverage exclusions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,8 @@ source = [
     "localstack/"
 ]
 omit = [
-    "localstack/infra/",
-    "localstack/node_modules",
-    "localstack/aws/api",
-    "localstack/extensions/api",
+    "localstack/aws/api/*",
+    "localstack/extensions/api/*",
 ]
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
This PR fixes the `coverage` config to:
- Properly exclude the generated ASF APIs and the extensions API (see https://github.com/localstack/localstack/pull/6715 and https://github.com/localstack/localstack/pull/6829).
- Remove the exclusion of `localstack/infra` and `localstack/node_modules`, since these directories are not used anymore (since https://github.com/localstack/localstack/pull/6302).

I verified the settings with the following commands locally:
```
TEST_PATH="tests/integration/test_sqs.py" make test-coverage
coverage combine
coverage html
```

**This PR will unfortunately lower the code coverage percentage quite a lot**, since the generated APIs had a high coverage:
- They only contain the method and type signatures where loading them is a coverage hit.
- They increase the total number of lines quite a lot (the generated code is quite big).

However, we don't want to green-wash our results. Once this PR is merged we can substantially increase the code coverage by identifying currently uncovered code and either removing it (if it's dead code), or write tests for these uncovered sections.

/cc @bentsku @thrau 