### PR TITLE
Fix region in DynamoDB store lookup to enable access from NoSQL Workbench

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -272,6 +272,9 @@ def get_store(context: RequestContext | None = None) -> DynamoDBStore:
     # todo: create an explicit protocol for to retrieve stores for each provider
     _account_id: str = context.account_id if context else get_aws_account_id()
     _region: str = context.region if context else aws_stack.get_region()
+    # special case: AWS NoSQL Workbench sends "localhost" as region - replace with proper region here
+    if _region == "localhost":
+        _region = aws_stack.get_local_region()
     return dynamodb_stores[_account_id][_region]
 
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1530,6 +1530,19 @@ class TestDynamoDB:
             )
         assert ctx.match("ValidationException")
 
+    @pytest.mark.only_localstack
+    def test_nosql_workbench_localhost_region(self, dynamodb_create_table, dynamodb_client):
+        """Test for AWS NoSQL Workbench, which sends "localhost" as region in header"""
+        table_name = f"t-{short_uid()}"
+        dynamodb_create_table(table_name=table_name, partition_key=PARTITION_KEY)
+        # describe table for default region
+        table = dynamodb_client.describe_table(TableName=table_name)
+        assert table.get("Table")
+        # describe table for "localhost" region
+        client = aws_stack.connect_to_service("dynamodb", region_name="localhost")
+        table = client.describe_table(TableName=table_name)
+        assert table.get("Table")
+
 
 def delete_table(name):
     dynamodb_client = aws_stack.create_external_boto_client("dynamodb")


### PR DESCRIPTION
Fix region in DynamoDB store lookup to enable access from NoSQL Workbench: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.html

Fixes this error:
```
  File ".../localstack/services/dynamodb/provider.py", line 288, in find_global_table_region
    replicas = get_store().REPLICA_UPDATES.get(table_name)
  File ".../localstack/services/dynamodb/provider.py", line 278, in get_store
    return dynamodb_stores[_account_id][_region]
  File ".../localstack/services/stores.py", line 166, in __getitem__
    raise ValueError(
ValueError: 'localhost' is not a valid AWS region name for dynamodb
```

/cc @viren-nadkarni 