### PR TITLE
fix create-bucket: exclude LocationConstraint for us-east-1

### DIFF
--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -164,11 +164,15 @@ class S3Bucket(GenericBaseModel):
             except ClientError as e:
                 if e.response["Error"]["Message"] == "Not Found":
                     bucket_name = props.get("BucketName")
-                    s3_client.create_bucket(
-                        Bucket=bucket_name,
-                        ACL=convert_acl_cf_to_s3(props.get("AccessControl", "PublicRead")),
-                        CreateBucketConfiguration={"LocationConstraint": aws_stack.get_region()},
-                    )
+                    params = {
+                        "Bucket": bucket_name,
+                        "ACL": convert_acl_cf_to_s3(props.get("AccessControl", "PublicRead")),
+                    }
+                    if aws_stack.get_region() != "us-east-1":
+                        params["CreateBucketConfiguration"] = {
+                            "LocationConstraint": aws_stack.get_region()
+                        }
+                    s3_client.create_bucket(**params)
 
         result = {
             "create": [


### PR DESCRIPTION
This is a preparation for ASF S3 migration. The [old provider, filters `LocationConstraint`](https://github.com/localstack/localstack/blob/master/localstack/services/s3/s3_listener.py#L1465-L1471) for `create-bucket`:
```
 # TODO: For some reason, moto doesn't allow us to put a location constraint on us-east-1
        to_find1 = to_bytes("<LocationConstraint>us-east-1</LocationConstraint>")
        to_find2 = to_bytes("<CreateBucketConfiguration")
        if data and data.startswith(to_bytes("<")) and to_find1 in data and to_find2 in data:
            # Note: with the latest version, <CreateBucketConfiguration> must either
            # contain a valid <LocationConstraint>, or not be present at all in the body.
            modified_data = b""
```

With the new ASF S3 provider, we will have the same behavior as AWS:
`LocationConstraint` for bucket creation should only be included if the location is not the default location (e.g. not us-east-1). Otherwise it will thrown an `IllegalLocationConstraintException`.

[According to the API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#API_CreateBucket_RequestSyntax), `us-east-1` is not a valid identifier for `LocationConstraint`

There was previously a check, but it was removed with PR https://github.com/localstack/localstack/pull/6171.

