### PR TITLE
Correctly extract auth info context from authorizer payload

### DIFF
--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -129,8 +129,7 @@ class ApiInvocationContext:
             context = self.auth_info.setdefault("context", {})
             if principal := self.auth_info.get("principalId"):
                 context["principalId"] = principal
-                return context
-            return self.auth_info
+            return context
 
     @property
     def auth_identity(self) -> Optional[Dict]:


### PR DESCRIPTION
## Problem
Currently, we only use the "context" variable if the principal id is set, but we have to do this in all the cases  (otherwise we would turn over the complete authorizer payload to the lambda, not just the context variables)
## Solution
Make "return context" not dependent on the presence of some variable.