### PR TITLE
Extend CLI to run container from within Docker using SDK client

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -21,7 +21,6 @@ from localstack.utils.container_utils.container_client import (
     VolumeBind,
     VolumeMappings,
     get_docker_client,
-    pull_image_if_not_available,
 )
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cache_dir, chmod_r, mkdir
@@ -431,9 +430,6 @@ class LocalstackContainer:
         client.default_run_outfile = self.logfile
 
         try:
-            # pull image if not available
-            pull_image_if_not_available(self.image_name, client=client)
-            # run main container
             return client.run_container(
                 image_name=self.image_name,
                 stdin=self.stdin,

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -23,7 +23,6 @@ from localstack.utils.container_utils.container_client import (
     VolumeMappings,
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
-from localstack.utils.container_utils.docker_sdk_client import SdkDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cache_dir, chmod_r, mkdir
 from localstack.utils.functions import call_safe
@@ -745,4 +744,7 @@ def get_docker_client() -> ContainerClient:
     """Get a Docker client - either using the `docker` binary (if available), or using the Python SDK"""
     if is_command_available(config.DOCKER_CMD):
         return CmdDockerClient()
+
+    from localstack.utils.container_utils.docker_sdk_client import SdkDockerClient
+
     return SdkDockerClient()

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -20,8 +20,8 @@ from localstack.utils.container_utils.container_client import (
     SimpleVolumeBind,
     VolumeBind,
     VolumeMappings,
-    get_docker_client,
 )
+from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import cache_dir, chmod_r, mkdir
 from localstack.utils.functions import call_safe
@@ -426,11 +426,11 @@ class LocalstackContainer:
         return mount_volumes
 
     def run(self):
-        client = get_docker_client()
-        client.default_run_outfile = self.logfile
+        if isinstance(DOCKER_CLIENT, CmdDockerClient):
+            DOCKER_CLIENT.default_run_outfile = self.logfile
 
         try:
-            return client.run_container(
+            return DOCKER_CLIENT.run_container(
                 image_name=self.image_name,
                 stdin=self.stdin,
                 name=self.name,
@@ -502,7 +502,7 @@ class LocalstackContainerServer(Server):
 
     def do_shutdown(self):
         try:
-            get_docker_client().stop_container(
+            DOCKER_CLIENT.stop_container(
                 self.container.name, timeout=10
             )  # giving the container some time to stop
         except Exception as e:

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -676,6 +676,7 @@ class ContainerClient(metaclass=ABCMeta):
             dns=container_config.dns,
             additional_flags=container_config.additional_flags,
             workdir=container_config.workdir,
+            privileged=container_config.privileged
         )
 
     @abstractmethod

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -272,6 +272,7 @@ class PortMappings:
         return f"<PortMappings: {self.to_dict()}>"
 
 
+"""Type alias for a simple version of VolumeBind"""
 SimpleVolumeBind = Tuple[str, str]
 
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -698,6 +698,7 @@ class ContainerClient(metaclass=ABCMeta):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        privileged: Optional[bool] = None,
     ) -> str:
         """Creates a container with the given image
 
@@ -729,6 +730,7 @@ class ContainerClient(metaclass=ABCMeta):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        privileged: Optional[bool] = None,
     ) -> Tuple[bytes, bytes]:
         """Creates and runs a given docker container
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -274,8 +274,8 @@ class PortMappings:
         return f"<PortMappings: {self.to_dict()}>"
 
 
-"""Type alias for a simple version of VolumeBind"""
 SimpleVolumeBind = Tuple[str, str]
+"""Type alias for a simple version of VolumeBind"""
 
 
 @dataclasses.dataclass
@@ -676,7 +676,7 @@ class ContainerClient(metaclass=ABCMeta):
             dns=container_config.dns,
             additional_flags=container_config.additional_flags,
             workdir=container_config.workdir,
-            privileged=container_config.privileged
+            privileged=container_config.privileged,
         )
 
     @abstractmethod
@@ -982,28 +982,12 @@ class Util:
         return dockerfile_path
 
 
-def pull_image_if_not_available(image_name: str, client: ContainerClient = None):
-    """Pull the given Docker image if it is not yet available locally"""
-    client = client or get_docker_client()
-    if not image_exists_locally(image_name, client=client):
-        client.pull_image(image_name)
-
-
-def image_exists_locally(image_name: str, client: ContainerClient = None) -> bool:
-    """Return whether the given Docker image exists locally"""
-    try:
-        client = client or get_docker_client()
-        details = client.inspect_image(image_name)
-        return True if details else False
-    except NoSuchImage:
-        return False
-
-
 def get_docker_client() -> ContainerClient:
     """Get a Docker client - either using the `docker` binary (if available), or using the Python SDK"""
-    from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 
     if is_command_available(config.DOCKER_CMD):
+        from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
+
         return CmdDockerClient()
 
     from localstack.utils.container_utils.docker_sdk_client import SdkDockerClient

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -13,8 +13,6 @@ from enum import Enum, unique
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
-from localstack.utils.run import is_command_available
-
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, get_args
 else:
@@ -980,16 +978,3 @@ class Util:
         if os.path.isdir(dockerfile_path) and os.path.exists(rel_path):
             return rel_path
         return dockerfile_path
-
-
-def get_docker_client() -> ContainerClient:
-    """Get a Docker client - either using the `docker` binary (if available), or using the Python SDK"""
-
-    if is_command_available(config.DOCKER_CMD):
-        from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
-
-        return CmdDockerClient()
-
-    from localstack.utils.container_utils.docker_sdk_client import SdkDockerClient
-
-    return SdkDockerClient()

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -600,6 +600,7 @@ class CmdDockerClient(ContainerClient):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        privileged: Optional[bool] = None,
     ) -> Tuple[List[str], str]:
         env_file = None
         cmd = self._docker_cmd() + [action]
@@ -609,6 +610,8 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--name", name]
         if entrypoint is not None:  # empty string entrypoint can be intentional
             cmd += ["--entrypoint", entrypoint]
+        if privileged:
+            cmd += ["--privileged"]
         if mount_volumes:
             cmd += [
                 volume

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -505,6 +505,7 @@ class SdkDockerClient(ContainerClient):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        privileged: Optional[bool] = None,
     ) -> str:
         LOG.debug("Creating container with attributes: %s", locals())
         extra_hosts = None
@@ -526,6 +527,8 @@ class SdkDockerClient(ContainerClient):
                 kwargs["ports"] = ports.to_dict()
             if workdir:
                 kwargs["working_dir"] = workdir
+            if privileged:
+                kwargs["privileged"] = True
             mounts = None
             if mount_volumes:
                 mounts = Util.convert_mount_list_to_dict(mount_volumes)
@@ -582,6 +585,7 @@ class SdkDockerClient(ContainerClient):
         dns: Optional[str] = None,
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
+        privileged: Optional[bool] = None,
     ) -> Tuple[bytes, bytes]:
         LOG.debug("Running container with image: %s", image_name)
         container = None
@@ -606,6 +610,7 @@ class SdkDockerClient(ContainerClient):
                 dns=dns,
                 additional_flags=additional_flags,
                 workdir=workdir,
+                privileged=privileged,
             )
             result = self.start_container(
                 container_name_or_id=container,

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -8,8 +8,6 @@ from localstack import config
 from localstack.constants import DEFAULT_VOLUME_DIR
 from localstack.utils.container_utils.container_client import ContainerClient, VolumeInfo
 
-"""Type alias for a simple version of VolumeBind"""
-
 LOG = logging.getLogger(__name__)
 
 

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -179,10 +179,9 @@ class TestCliContainerLifecycle:
         output = container_client.exec_in_container(config.MAIN_CONTAINER_NAME, ["ps", "-u", user])
         assert "supervisord" in to_str(output[0])
 
-    # TODO: remove marker
-    @pytest.mark.xfail(reason="tests should run after a full rebuild of the Docker image")
+    # TODO: enable test in next iteration, after a full rebuild of the Docker image
+    @pytest.mark.skip
     def test_start_cli_within_container(self, runner, container_client):
-
         output = container_client.run_container(
             "localstack/localstack",
             remove=True,

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -9,6 +9,7 @@ import localstack.utils.container_utils.docker_cmd_client
 from localstack import config, constants
 from localstack.cli.localstack import localstack as cli
 from localstack.config import DOCKER_SOCK, get_edge_url, in_docker
+from localstack.constants import MODULE_MAIN_PATH
 from localstack.utils.bootstrap import in_ci
 from localstack.utils.common import poll_condition
 from localstack.utils.files import mkdir
@@ -179,15 +180,16 @@ class TestCliContainerLifecycle:
         output = container_client.exec_in_container(config.MAIN_CONTAINER_NAME, ["ps", "-u", user])
         assert "supervisord" in to_str(output[0])
 
-    # TODO: enable test in next iteration, after a full rebuild of the Docker image
-    @pytest.mark.skip
     def test_start_cli_within_container(self, runner, container_client):
         output = container_client.run_container(
             "localstack/localstack",
             remove=True,
             entrypoint="",
             command=["bin/localstack", "start", "-d"],
-            mount_volumes=[("/var/run/docker.sock", "/var/run/docker.sock")],
+            mount_volumes=[
+                ("/var/run/docker.sock", "/var/run/docker.sock"),
+                (MODULE_MAIN_PATH, "/opt/code/localstack/localstack"),
+            ],
             env_vars={"LOCALSTACK_VOLUME_DIR": "/tmp/ls-volume"},
         )
         stdout = to_str(output[0])

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -38,10 +38,6 @@ def container_client():
         client.stop_container(config.MAIN_CONTAINER_NAME, timeout=5)
     except Exception:
         pass
-    try:
-        client.remove_container(config.MAIN_CONTAINER_NAME, force=True)
-    except Exception:
-        pass
 
     # wait until container has been removed
     assert poll_condition(


### PR DESCRIPTION
Extend CLI to run container from within Docker using SDK client. 

The starting point for this PR is a [Docker Extension](https://www.docker.com/products/extensions/) PoC for LocalStack - these extensions do not allow us to run native commands on the host, but only spawn Docker containers. Hence, in order to be able to reuse the full power of the CLI, this PR adds a few small adjustments to allow us to run the CLI (and `localstack start`) from within a Docker container.

Essentially, we'd like to be able to run this command:
```
docker run --rm -it --entrypoint= -v /var/run/docker.sock:/var/run/docker.sock localstack/localstack bin/localstack start -d
```

... which currently fails, because we're always using the `CmdDockerClient` (and `docker` is not available in the image):
```
  File "/opt/code/localstack/localstack/utils/container_utils/docker_cmd_client.py", line 492, in run_container
    result = self._run_async_cmd(cmd, stdin, kwargs.get("name") or "", image_name)
  File "/opt/code/localstack/localstack/utils/container_utils/docker_cmd_client.py", line 559, in _run_async_cmd
    process = run(cmd, **kwargs)
  File "/opt/code/localstack/localstack/utils/run.py", line 87, in run
    process = subprocess.Popen(
  File "/usr/local/lib/python3.10/subprocess.py", line 969, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.10/subprocess.py", line 1845, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'docker'
```

The main change in the PR is to make a switch in `bootstrap.py` to use `SdkDockerClient` in case the `docker` command is not available. Additionally, a small refactoring is introduced to allow passing in the `--privileged` flag for both, the `create_container(..)` and `run_container(..)` commands.

~The `test_start_cli_within_container(..)` test is currently still marked as `skip` - it should pass once we've done a full roundtrip of building the Docker image (then we can remove the marker).~