### PR TITLE
add rules for ASF S3 virtual host urls

### DIFF
--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -110,6 +110,11 @@
       "op": "add",
       "path": "/operations/PutBucketPolicy/http/responseCode",
       "value": 204
+    },
+    {
+      "op": "add",
+      "path": "/shapes/GetBucketLocationOutput/payload",
+      "value": "LocationConstraint"
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1,12 +1,10 @@
 import copy
 import logging
 import os
-from typing import Tuple
 from urllib.parse import SplitResult, quote, urlsplit, urlunsplit
 
 import moto.s3.models as moto_s3_models
 import moto.s3.responses as moto_s3_responses
-import requests
 from moto.s3 import s3_backends as moto_s3_backends
 
 from localstack.aws.accounts import get_aws_account_id
@@ -33,7 +31,7 @@ from localstack.aws.api.s3 import (
 from localstack.config import get_edge_port_http, get_protocol
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.http import Request, Response
-from localstack.services.apigateway.router_asf import convert_response
+from localstack.http.proxy import forward
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
@@ -53,6 +51,10 @@ os.environ[
 
 def get_moto_s3_backend(context: RequestContext) -> moto_s3_models.S3Backend:
     return moto_s3_backends[context.account_id]["global"]
+
+
+def get_full_default_bucket_location(bucket_name):
+    return f"{get_protocol()}://{bucket_name}.s3.{LOCALHOST_HOSTNAME}:{get_edge_port_http()}/"
 
 
 class S3Provider(S3Api, ServiceLifecycleHook):
@@ -77,9 +79,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if request.get("CreateBucketConfiguration"):
             location = request["CreateBucketConfiguration"].get("LocationConstraint")
             if location and location != "us-east-1":
-                response[
-                    "Location"
-                ] = f"{get_protocol()}://{bucket_name}.s3.{LOCALHOST_HOSTNAME}:{get_edge_port_http()}/"
+                response["Location"] = get_full_default_bucket_location(bucket_name)
         if "Location" not in response:
             response["Location"] = f"/{bucket_name}"
         return response
@@ -205,23 +205,31 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, request: Request, bucket: str, path: str, region: str, port: str
     ) -> Response:
         # TODO region pattern currently not working -> removing it from url
-        host, rewritten_url = self.rewrite_url(request.url, bucket, region)
-        LOG.debug(
-            f"Rewritten original virtual host url: {request.url} to path-style url: {rewritten_url}"
-        )
+        rewritten_url = self.rewrite_url(request.url, bucket, region)
+
+        LOG.debug(f"Rewritten original host url: {request.url} to path-style url: {rewritten_url}")
+
+        splitted = urlsplit(rewritten_url)
         copied_headers = copy.deepcopy(request.headers)
-        # TODO is_internal_call_context
-        original_host = copied_headers["Host"]
-        copied_headers["Host"] = host
-        params = {"data": request.data, "headers": copied_headers}
-        response = requests.request(method=request.method, url=rewritten_url, **params)
+        copied_headers["Host"] = splitted.netloc
+        return forward(
+            request, f"{splitted.scheme}://{splitted.netloc}", splitted.path, copied_headers
+        )
 
-        response.request.headers["Host"] = original_host
-        response.request.url = request.url
-        ls_response = convert_response(response)
-        return ls_response
+    def rewrite_url(self, url: str, bucket: str, region: str) -> str:
+        """
+        Rewrites the url so that it can be forwarded to moto. Used for vhost-style and for any url that contains the region.
 
-    def rewrite_url(self, url: str, bucket: str, region: str) -> Tuple[str, str]:
+        For vhost style: removes the bucket-name from the host-name and adds it as path
+        E.g. http://my-bucket.s3.localhost.localstack.cloud:4566 -> http://s3.localhost.localstack.cloud:4566/my-bucket
+
+        If the region is contained in the host-name we remove it (for now) as moto cannot handle the region correctly
+
+        :param url: the original url
+        :param bucket: the bucket name
+        :param region: the region name
+        :return: re-written url as string
+        """
         splitted = urlsplit(url)
         if splitted.netloc.startswith(f"{bucket}."):
             netloc = splitted.netloc.replace(f"{bucket}.", "")
@@ -234,7 +242,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if region:
             netloc = netloc.replace(f"{region}", "")
 
-        return netloc, urlunsplit(
+        return urlunsplit(
             SplitResult(splitted.scheme, netloc, path, splitted.query, splitted.fragment)
         )
 

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -2164,5 +2164,136 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_bucket_does_not_exist": {
+    "recorded-date": "15-09-2022, 18:54:54",
+    "recorded-content": {
+      "list_object": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "list_object_vhost": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_bucket_name_with_dots": {
+    "recorded-date": "16-09-2022, 11:57:35",
+    "recorded-content": {
+      "list_objects": {
+        "Contents": [
+          {
+            "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+            "Key": "my-content",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 9,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "Marker": "",
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_objects_headers": {
+        "content-type": "application/xml",
+        "date": "date",
+        "server": "AmazonS3",
+        "transfer-encoding": "chunked",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      },
+      "request_vhost_url_content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name><bucket-name:1></Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>my-content</Key><LastModified>date</LastModified><ETag>&quot;437b930db84b8079c2dd804a71936b5f&quot;</ETag><Size>9</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>",
+      "request_vhost_headers": {
+        "Content-Type": "application/xml",
+        "Date": "date",
+        "Server": "AmazonS3",
+        "Transfer-Encoding": "chunked",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      },
+      "request_path_url_content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name><bucket-name:1></Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>my-content</Key><LastModified>date</LastModified><ETag>&quot;437b930db84b8079c2dd804a71936b5f&quot;</ETag><Size>9</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>",
+      "request_path_headers": {
+        "Content-Type": "application/xml",
+        "Date": "date",
+        "Server": "AmazonS3",
+        "Transfer-Encoding": "chunked",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
+    "recorded-date": "16-09-2022, 12:00:07",
+    "recorded-content": {
+      "create_bucket": {
+        "Location": "/<bucket-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_bucket_location_constraint": {
+        "Location": "http://<bucket-name:2>.host/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_bucket": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_bucket_filtered_header": {
+        "content-type": "application/xml",
+        "x-amz-access-point-alias": "false",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      },
+      "head_bucket_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_bucket_2_filtered_header": {
+        "content-type": "application/xml",
+        "x-amz-access-point-alias": "false",
+        "x-amz-bucket-region": "us-west-1",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      }
+    }
   }
 }


### PR DESCRIPTION
Buckets can be addressed either in path-style `s3.<region>.localhost.localstack.cloud:4566/mybucket` or virtual host-style `mybucket.<region>.localhost.localstack.cloud:4566`.

Path style (without region) is covered by moto.
* Added routes for vhost-style 
* Added more specific routes for buckets that contain dot(s) in the name -> this is a special case as it changes the domain
  * put requests for such buckets will currently not work
* Added route to match path-style urls that contain a region
  * currently only strips the region, and re-sends the request

Note: AWS works a bit differently (also compared to the old provider): if bucket is created with a location constraint and the path-style contains another region, it would respond with 301 (for any region other than `us-east-1`), or 307 (for `us-east-1`). see test `test_access_bucket_different_region`
