### PR TITLE
fix terraform AWS provider patch for terraform tests

### DIFF
--- a/etc/tf-patch/0001-endpoints.patch
+++ b/etc/tf-patch/0001-endpoints.patch
@@ -1,11 +1,11 @@
 diff --git a/internal/conns/config.go b/internal/conns/config.go
-index 7bfd3100fd..3258372938 100644
+index 2737b0b2f8..95259e3126 100644
 --- a/internal/conns/config.go
 +++ b/internal/conns/config.go
-@@ -78,8 +78,22 @@ type Config struct {
+@@ -84,8 +84,22 @@ type Config struct {
  	UseFIPSEndpoint                bool
  }
- 
+
 +func GetLocalEndpoints() map[string]string {
 +	const localEndpoint = "http://localhost:4566"
 +	var localEndpoints = map[string]string{}
@@ -19,22 +19,22 @@ index 7bfd3100fd..3258372938 100644
 +	return localEndpoints
 +}
 +
- // Client configures and returns a fully initialized AWSClient
- func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
+ // ConfigureProvider configures the provided provider Meta (instance data).
+ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWSClient, diag.Diagnostics) {
 +	c.Endpoints = GetLocalEndpoints()
  	awsbaseConfig := awsbase.Config{
  		AccessKey:                     c.AccessKey,
  		APNInfo:                       StdUserAgentProducts(c.TerraformVersion),
 diff --git a/internal/provider/provider.go b/internal/provider/provider.go
-index c24f096fb7..44887ea1fc 100644
+index a0af64476f..dcb74c0e5a 100644
 --- a/internal/provider/provider.go
 +++ b/internal/provider/provider.go
-@@ -2113,7 +2113,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
+@@ -2184,7 +2184,7 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
  		CustomCABundle:                 d.Get("custom_ca_bundle").(string),
  		EC2MetadataServiceEndpoint:     d.Get("ec2_metadata_service_endpoint").(string),
  		EC2MetadataServiceEndpointMode: d.Get("ec2_metadata_service_endpoint_mode").(string),
 -		Endpoints:                      make(map[string]string),
 +		Endpoints:                      conns.GetLocalEndpoints(),
  		HTTPProxy:                      d.Get("http_proxy").(string),
- 		IgnoreTagsConfig:               expandProviderIgnoreTags(d.Get("ignore_tags").([]interface{})),
  		Insecure:                       d.Get("insecure").(bool),
+ 		MaxRetries:                     25, // Set default here, not in schema (muxing with v6 provider).


### PR DESCRIPTION
With https://github.com/localstack/localstack/commit/3baefea6df1e590c426bd8458d6d2564f2dabf92, @macnev2013 introduced an automation which automatically executes a set of terraform tests (created by the terraform community) against localstack.
The testing infrastructure depends on a small patch which is applied on top of https://github.com/hashicorp/terraform-provider-aws. Unfortunately, the patch broke with https://github.com/hashicorp/terraform-provider-aws/commit/2b217fc97c080aa193516f1c2249a1ba3571154a.

This PR fixes the patch for now. In another iteration, we could make the testing infrastructure more resilient by:
- Maybe get the terraform team to allow configuring the endpoints when executing the tests (that would be awesome).
- Use a pinned version of the repo (i.e. a tag) which is automatically updated by some kind of "dependency bot" like renovate.