### PR TITLE
Implement more ASF S3 operations in provider

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1350,6 +1350,8 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
     serialization.
     """
 
+    SUPPORTED_MIME_TYPES = [TEXT_XML, APPLICATION_XML]
+
     def _serialize_error(
         self,
         error: ServiceException,
@@ -1370,6 +1372,18 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         self._add_additional_error_tags(error, root, shape, mime_type)
 
         response.set_response(self._encode_payload(self._node_to_string(root, mime_type)))
+
+    def _prepare_additional_traits_in_response(
+        self, response: HttpResponse, operation_model: OperationModel
+    ):
+        """Adds the request ID to the headers (in contrast to the body - as in the Query protocol)."""
+        response = super()._prepare_additional_traits_in_response(response, operation_model)
+        request_id = gen_amzn_requestid_long()
+        response.headers["x-amz-request-id"] = request_id
+        response.headers[
+            "x-amz-id-2"
+        ] = f"MzRISOwyjmnup{request_id}7/JypPGXLh0OVFGcJaaO3KW/hRAqKOpIEEp"
+        return response
 
 
 class SqsResponseSerializer(QueryResponseSerializer):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -115,6 +115,146 @@
       "op": "add",
       "path": "/shapes/GetBucketLocationOutput/payload",
       "value": "LocationConstraint"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/BucketAlreadyOwnedByYou/members/BucketName",
+      "value": {
+        "shape": "BucketName"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/GetObjectOutput/members/StatusCode",
+      "value": {
+        "shape": "GetObjectResponseStatusCode",
+        "location": "statusCode"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchKey/members/Key",
+      "value": {
+        "shape": "ObjectKey"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchKey/error",
+      "value": {
+        "httpStatusCode": 404
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/PreconditionFailed",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Condition": {
+            "shape": "IfCondition"
+          }
+        },
+        "error": {
+          "httpStatusCode": 412
+        },
+        "documentation": "<p>At least one of the pre-conditions you specified did not hold</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/IfCondition",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidRange",
+      "value": {
+        "type": "structure",
+        "members": {
+          "ActualObjectSize": {
+            "shape": "ObjectSize"
+          },
+          "RangeRequested": {
+            "shape": "ContentRange"
+          }
+        },
+        "error": {
+          "httpStatusCode": 416
+        },
+        "documentation": "<p>The requested range is not satisfiable</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/HeadObjectOutput/members/Expires",
+      "value": {
+        "shape": "Expires",
+        "documentation": "<p>The date and time at which the object is no longer cacheable.</p>",
+        "location": "header",
+        "locationName": "expires"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/GetObjectOutput/members/Expires",
+      "value": {
+        "shape": "Expires",
+        "documentation": "<p>The date and time at which the object is no longer cacheable.</p>",
+        "location": "header",
+        "locationName": "expires"
+      }
+    },
+    {
+      "op": "remove",
+      "path": "/shapes/DeleteObjectsOutput"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/DeleteResult",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Deleted": {
+            "shape": "DeletedObjects",
+            "documentation": "<p>Container element for a successful delete. It identifies the object that was successfully deleted.</p>"
+          },
+          "RequestCharged": {
+            "shape": "RequestCharged",
+            "location": "header",
+            "locationName": "x-amz-request-charged"
+          },
+          "Errors": {
+            "shape": "Errors",
+            "documentation": "<p>Container for a failed delete action that describes the object that Amazon S3 attempted to delete and the error it encountered.</p>",
+            "locationName": "Error"
+          }
+        }
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/operations/DeleteObjects/output/shape",
+      "value": "DeleteResult"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/RestoreObjectOutputStatusCode",
+      "value": {
+        "type": "integer"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/RestoreObjectOutput/members/StatusCode",
+      "value": {
+        "shape": "RestoreObjectOutputStatusCode",
+        "location": "statusCode"
+      }
     }
   ]
 }

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from localstack.aws.api.s3 import (
+    BucketLifecycleConfiguration,
     BucketName,
     CORSConfiguration,
     NotificationConfiguration,
@@ -20,6 +21,12 @@ class S3Store(BaseStore):
 
     # maps bucket name to bucket's replication settings
     bucket_replication: Dict[BucketName, ReplicationConfiguration] = LocalAttribute(default=dict)
+
+    # maps bucket name to bucket's lifecycle configuration
+    # TODO: need to check "globality" of parameters / redirect
+    bucket_lifecycle_configuration: Dict[BucketName, BucketLifecycleConfiguration] = LocalAttribute(
+        default=dict
+    )
 
 
 s3_stores = AccountRegionBundle("s3", S3Store)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -6,15 +6,20 @@ from urllib.parse import SplitResult, quote, urlsplit, urlunsplit
 import moto.s3.models as moto_s3_models
 import moto.s3.responses as moto_s3_responses
 from moto.s3 import s3_backends as moto_s3_backends
+from moto.s3.exceptions import MissingBucket
 
 from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.api import RequestContext, handler
+from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.s3 import (
     AccountId,
     BucketName,
     CreateBucketOutput,
     CreateBucketRequest,
+    GetBucketLifecycleConfigurationOutput,
+    GetBucketLifecycleOutput,
     GetBucketLocationOutput,
+    GetBucketRequestPaymentOutput,
+    GetBucketRequestPaymentRequest,
     GetObjectOutput,
     GetObjectRequest,
     HeadObjectOutput,
@@ -24,6 +29,13 @@ from localstack.aws.api.s3 import (
     ListObjectsRequest,
     ListObjectsV2Output,
     ListObjectsV2Request,
+    NoSuchBucket,
+    NoSuchKey,
+    NoSuchLifecycleConfiguration,
+    ObjectKey,
+    PutBucketLifecycleConfigurationRequest,
+    PutBucketLifecycleRequest,
+    PutBucketRequestPaymentRequest,
     PutObjectOutput,
     PutObjectRequest,
     S3Api,
@@ -36,7 +48,7 @@ from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3.models import S3Store, s3_stores
-from localstack.services.s3.utils import verify_checksum
+from localstack.services.s3.utils import is_bucket_name_valid, is_key_expired, verify_checksum
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.request_context import AWS_REGION_REGEX
 from localstack.utils.objects import singleton_factory
@@ -47,6 +59,11 @@ LOG = logging.getLogger(__name__)
 os.environ[
     "MOTO_S3_CUSTOM_ENDPOINTS"
 ] = "s3.localhost.localstack.cloud:4566,s3.localhost.localstack.cloud"
+
+
+class MalformedXML(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("MalformedXML", status_code=400, message=message)
 
 
 def get_moto_s3_backend(context: RequestContext) -> moto_s3_models.S3Backend:
@@ -83,6 +100,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if "Location" not in response:
             response["Location"] = f"/{bucket_name}"
         return response
+
+    def delete_bucket(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> None:
+        call_moto(context)
+        store = self.get_store()
+        # TODO: create a helper method for cleaning up the store, already done in next PR
+        store.bucket_lifecycle_configuration.pop(bucket, None)
 
     def get_bucket_location(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
@@ -155,6 +180,14 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
     @handler("GetObject", expand=False)
     def get_object(self, context: RequestContext, request: GetObjectRequest) -> GetObjectOutput:
+        key = request.get("Key", "")
+        if is_object_expired(context, bucket=request.get("Bucket", ""), key=key):
+            # TODO: old behaviour was deleting key instantly if expired. AWS cleans up only once a day generally
+            # see if we need to implement a feature flag
+            # but you can still HeadObject on it and you get the expiry time
+            ex = NoSuchKey("The specified key does not exist.")
+            ex.Key = key
+            raise ex
         response: GetObjectOutput = call_moto(context)
         response["AcceptRanges"] = "bytes"
         return response
@@ -169,7 +202,105 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             verify_checksum(checksum_algorithm, context.request.data, request)
 
         response: PutObjectOutput = call_moto(context)
+
+        if expires := request.get("Expires"):
+            moto_backend = get_moto_s3_backend(context)
+            bucket = get_bucket_from_moto(moto_backend, bucket=request.get("Bucket", ""))
+            key = request.get("Key", "")
+            key_object = get_key_from_moto_bucket(bucket, key=key)
+            key_object.set_expiry(expires)
+
         return response
+
+    @handler("PutBucketRequestPayment", expand=False)
+    def put_bucket_request_payment(
+        self,
+        context: RequestContext,
+        request: PutBucketRequestPaymentRequest,
+    ) -> None:
+        bucket_name = request.get("Bucket", "")
+        payer = request.get("RequestPaymentConfiguration", {}).get("Payer")
+        if payer not in ["Requester", "BucketOwner"]:
+            raise MalformedXML(
+                message="The XML you provided was not well-formed or did not validate against our published schema"
+            )
+
+        moto_backend = get_moto_s3_backend(context)
+        bucket = get_bucket_from_moto(moto_backend, bucket=bucket_name)
+        bucket.payer = payer
+
+    @handler("GetBucketRequestPayment", expand=False)
+    def get_bucket_request_payment(
+        self,
+        context: RequestContext,
+        request: GetBucketRequestPaymentRequest,
+    ) -> GetBucketRequestPaymentOutput:
+        bucket_name = request.get("Bucket", "")
+        moto_backend = get_moto_s3_backend(context)
+        bucket = get_bucket_from_moto(moto_backend, bucket=bucket_name)
+        return GetBucketRequestPaymentOutput(Payer=bucket.payer)
+
+    def get_bucket_lifecycle(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> GetBucketLifecycleOutput:
+        # deprecated for older rules created. Not sure what to do with this?
+        response = self.get_bucket_lifecycle_configuration(context, bucket, expected_bucket_owner)
+        return GetBucketLifecycleOutput(**response)
+
+    def get_bucket_lifecycle_configuration(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> GetBucketLifecycleConfigurationOutput:
+        # test if bucket exists in moto
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket=bucket)
+
+        store = self.get_store()
+        bucket_lifecycle = store.bucket_lifecycle_configuration.get(bucket)
+        if not bucket_lifecycle:
+            ex = NoSuchLifecycleConfiguration("The lifecycle configuration does not exist")
+            ex.BucketName = bucket
+            raise ex
+
+        return GetBucketLifecycleConfigurationOutput(Rules=bucket_lifecycle["Rules"])
+
+    @handler("PutBucketLifecycle", expand=False)
+    def put_bucket_lifecycle(
+        self,
+        context: RequestContext,
+        request: PutBucketLifecycleRequest,
+    ) -> None:
+        # deprecated for older rules created. Not sure what to do with this?
+        # same URI as PutBucketLifecycleConfiguration
+        self.put_bucket_lifecycle_configuration(context, request)
+
+    @handler("PutBucketLifecycleConfiguration", expand=False)
+    def put_bucket_lifecycle_configuration(
+        self,
+        context: RequestContext,
+        request: PutBucketLifecycleConfigurationRequest,
+    ) -> None:
+        """This is technically supported in moto, however moto does not support multiple transitions action
+        It will raise an TypeError trying to get dict attributes on a list. It would need a bigger rework on moto's side
+        Moto has quite a good validation for the other Lifecycle fields, so it would be nice to be able to use it
+        somehow. For now the behaviour is the same as before, aka no validation
+        """
+        # test if bucket exists in moto
+        bucket = request.get("Bucket", "")
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket=bucket)
+        store = self.get_store()
+        # TODO: add validation on the BucketLifecycleConfiguration
+        store.bucket_lifecycle_configuration[bucket] = request.get("LifecycleConfiguration")
+
+    def delete_bucket_lifecycle(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> None:
+        # test if bucket exists in moto
+        moto_backend = get_moto_s3_backend(context)
+        get_bucket_from_moto(moto_backend, bucket=bucket)
+
+        store = self.get_store()
+        store.bucket_lifecycle_configuration.pop(bucket, None)
 
     def add_custom_routes(self):
         # virtual-host style: https://bucket-name.s3.region-code.amazonaws.com/key-name
@@ -248,8 +379,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
 
 def validate_bucket_name(bucket: BucketName):
-    # TODO: add rules to validate bucket name
-    if not bucket.islower():
+    """
+    Validate s3 bucket name based on the documentation
+    ref. https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    """
+    if not is_bucket_name_valid(bucket_name=bucket):
         ex = InvalidBucketName("The specified bucket is not valid.")
         ex.BucketName = bucket
         raise ex
@@ -258,16 +392,50 @@ def validate_bucket_name(bucket: BucketName):
 def get_bucket_from_moto(
     moto_backend: moto_s3_models.S3Backend, bucket: BucketName
 ) -> moto_s3_models.FakeBucket:
-    return moto_backend.get_bucket(bucket_name=bucket)
+    # TODO: check authorization for buckets as well?
+    try:
+        return moto_backend.get_bucket(bucket_name=bucket)
+    except MissingBucket:
+        ex = NoSuchBucket("The specified bucket does not exist")
+        ex.BucketName = bucket
+        raise ex
+
+
+def get_key_from_moto_bucket(
+    moto_bucket: moto_s3_models.FakeBucket, key: ObjectKey
+) -> moto_s3_models.FakeKey:
+    fake_key = moto_bucket.keys.get(key)
+    if not fake_key:
+        ex = NoSuchKey("The specified key does not exist.")
+        ex.Key = key
+        raise ex
+
+    return fake_key
+
+
+def is_object_expired(context: RequestContext, bucket: BucketName, key: ObjectKey) -> bool:
+    moto_backend = get_moto_s3_backend(context)
+    moto_bucket = get_bucket_from_moto(moto_backend, bucket)
+    key_object = get_key_from_moto_bucket(moto_bucket, key)
+    return is_key_expired(key_object=key_object)
 
 
 @singleton_factory
 def apply_moto_patches():
+    # importing here in case we need InvalidObjectState from `localstack.aws.api.s3`
+    from moto.s3.exceptions import InvalidObjectState
+
     @patch(moto_s3_responses.S3Response.key_response)
     def _fix_key_response(fn, self, *args, **kwargs):
         """Change casing of Last-Modified headers to be picked by the parser"""
         status_code, resp_headers, key_value = fn(self, *args, **kwargs)
-        for low_case_header in ["last-modified", "content-type", "content-length"]:
+        for low_case_header in [
+            "last-modified",
+            "content-type",
+            "content-length",
+            "content-range",
+            "content-encoding",
+        ]:
             if header_value := resp_headers.pop(low_case_header, None):
                 header_name = _capitalize_header_name_from_snake_case(low_case_header)
                 resp_headers[header_name] = header_value
@@ -275,11 +443,21 @@ def apply_moto_patches():
         return status_code, resp_headers, key_value
 
     @patch(moto_s3_responses.S3Response._bucket_response_head)
-    def _bucket_response_head(fn, self, bucket_name, *args, **kwargs):
+    def _fix_bucket_response_head(fn, self, bucket_name, *args, **kwargs):
         code, headers, body = fn(self, bucket_name, *args, **kwargs)
         bucket = self.backend.get_bucket(bucket_name)
         headers["x-amz-bucket-region"] = bucket.region_name
         headers["content-type"] = "application/xml"
+        return code, headers, body
+
+    @patch(moto_s3_responses.S3Response._key_response_get)
+    def _fix_key_response_get(fn, *args, **kwargs):
+        code, headers, body = fn(*args, **kwargs)
+        storage_class = headers.get("x-amz-storage-class")
+
+        if storage_class == "DEEP_ARCHIVE" and not headers.get("x-amz-restore"):
+            raise InvalidObjectState(storage_class=storage_class)
+
         return code, headers, body
 
 

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -1,10 +1,18 @@
-from typing import Type, TypedDict
+import datetime
+import re
+
+from moto.s3.models import FakeKey
 
 from localstack.aws.api import ServiceException
 from localstack.aws.api.s3 import ChecksumAlgorithm, PutObjectRequest
 from localstack.utils.strings import checksum_crc32, checksum_crc32c, hash_sha1, hash_sha256
 
 checksum_keys = ["ChecksumSHA1", "ChecksumSHA256", "ChecksumCRC32", "ChecksumCRC32C"]
+
+BUCKET_NAME_REGEX = (
+    r"(?=^.{3,63}$)(?!^(\d+\.)+\d+$)"
+    + r"(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)"
+)
 
 
 class InvalidRequest(ServiceException):
@@ -13,10 +21,6 @@ class InvalidRequest(ServiceException):
     code: str = "InvalidRequest"
     sender_fault: bool = False
     status_code: int = 400
-
-
-def get_all_typed_dict_keys(typed_dict: Type[TypedDict]):
-    return [*typed_dict.__required_keys__, *typed_dict.__optional_keys__]
 
 
 def verify_checksum(checksum_algorithm: str, data: bytes, request: PutObjectRequest):
@@ -44,3 +48,16 @@ def verify_checksum(checksum_algorithm: str, data: bytes, request: PutObjectRequ
         raise InvalidRequest(
             f"Value for x-amz-checksum-{checksum_algorithm.lower()} header is invalid."
         )
+
+
+def is_key_expired(key_object: FakeKey) -> bool:
+    if not key_object or not key_object._expiry:
+        return False
+    return key_object._expiry <= datetime.datetime.now(key_object._expiry.tzinfo)
+
+
+def is_bucket_name_valid(bucket_name: str) -> bool:
+    """
+    ref. https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    """
+    return bucket_name.islower() and re.match(BUCKET_NAME_REGEX, bucket_name)

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -1,314 +1,328 @@
 {
-  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_utf8_key": {
-    "recorded-date": "02-06-2022, 11:43:43",
+  "tests/integration/s3/test_s3.py::TestS3::test_region_header_exists": {
+    "recorded-date": "21-09-2022, 13:34:35",
     "recorded-content": {
-      "put-object": {
+      "head_bucket": {
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "ETag": "\"e99a18c428cb38d5f260853678922e03\""
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
-      "get-object": {
+      "list_objects_v2": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 0,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "AcceptRanges": "bytes",
-        "LastModified": "datetime",
-        "ContentLength": 6,
-        "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
-        "ContentType": "binary/octet-stream",
-        "Metadata": {},
-        "Body": ""
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_metadata_header_character_decoding": {
-    "recorded-date": "31-05-2022, 09:37:56",
-    "recorded-content": {
-      "head-object": {
-        "test_meta_1": "foo",
-        "__meta_2": "bar"
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_with_content": {
-    "recorded-date": "31-05-2022, 09:36:16",
+    "recorded-date": "21-09-2022, 13:34:41",
     "recorded-content": {
       "list-objects": {
-        "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "IsTruncated": false,
-        "Marker": "",
         "Contents": [
           {
+            "ETag": "\"86639701cdcc5b39438a5f009bd74cb1\"",
             "Key": "test-key-0",
             "LastModified": "datetime",
-            "ETag": "\"86639701cdcc5b39438a5f009bd74cb1\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"70a37754eb5a2e7db8cd887aaf11cda7\"",
             "Key": "test-key-1",
             "LastModified": "datetime",
-            "ETag": "\"70a37754eb5a2e7db8cd887aaf11cda7\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"282ff2cb3d9dadeb831bb3ba0128f2f4\"",
             "Key": "test-key-2",
             "LastModified": "datetime",
-            "ETag": "\"282ff2cb3d9dadeb831bb3ba0128f2f4\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"2b61ddda48445374b35a927b6ae2cd6d\"",
             "Key": "test-key-3",
             "LastModified": "datetime",
-            "ETag": "\"2b61ddda48445374b35a927b6ae2cd6d\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"f533f549a84b9d7a381a7ed55c4f46b9\"",
             "Key": "test-key-4",
             "LastModified": "datetime",
-            "ETag": "\"f533f549a84b9d7a381a7ed55c4f46b9\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"0efcf24eb64fa875c294d05703096b0d\"",
             "Key": "test-key-5",
             "LastModified": "datetime",
-            "ETag": "\"0efcf24eb64fa875c294d05703096b0d\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"7b1b88bb19a8c5a6a1d53eaa75108b80\"",
             "Key": "test-key-6",
             "LastModified": "datetime",
-            "ETag": "\"7b1b88bb19a8c5a6a1d53eaa75108b80\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"698fbf838fdda3065e058190398514f8\"",
             "Key": "test-key-7",
             "LastModified": "datetime",
-            "ETag": "\"698fbf838fdda3065e058190398514f8\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"96c2178517e273d4001ab7f68fdde969\"",
             "Key": "test-key-8",
             "LastModified": "datetime",
-            "ETag": "\"96c2178517e273d4001ab7f68fdde969\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           },
           {
+            "ETag": "\"da51d6e22a1ae095154e69b07eef731b\"",
             "Key": "test-key-9",
             "LastModified": "datetime",
-            "ETag": "\"da51d6e22a1ae095154e69b07eef731b\"",
-            "Size": 6,
-            "StorageClass": "STANDARD",
             "Owner": {
               "DisplayName": "<display-name>",
               "ID": "<owner-id>"
-            }
+            },
+            "Size": 6,
+            "StorageClass": "STANDARD"
           }
         ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "Marker": "",
+        "MaxKeys": 100,
         "Name": "<bucket-name:1>",
         "Prefix": "",
-        "MaxKeys": 100,
-        "EncodingType": "url"
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "list-buckets": {
-        "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "Buckets": [],
+        "Buckets": [
+          {
+            "CreationDate": "datetime",
+            "Name": "<bucket-name:2>"
+          }
+        ],
         "Owner": {
           "DisplayName": "<display-name>",
           "ID": "<owner-id>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_region_header_exists": {
-    "recorded-date": "02-06-2022, 11:23:16",
+  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_utf8_key": {
+    "recorded-date": "21-09-2022, 13:34:43",
     "recorded-content": {
-      "head_bucket": {
+      "put-object": {
+        "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
-      "list_objects_v2": {
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ContentLength": 6,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
+        "LastModified": "datetime",
+        "Metadata": {},
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "IsTruncated": false,
-        "Name": "<bucket-name:1>",
-        "Prefix": "",
-        "MaxKeys": 1000,
-        "EncodingType": "url",
-        "KeyCount": 0
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_metadata_header_character_decoding": {
+    "recorded-date": "21-09-2022, 13:34:49",
+    "recorded-content": {
+      "head-object": {
+        "__meta_2": "bar",
+        "test_meta_1": "foo"
       }
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_upload_file_multipart": {
-    "recorded-date": "02-06-2022, 11:52:47",
+    "recorded-date": "21-09-2022, 13:34:53",
     "recorded-content": {
       "get_object": {
-        "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
         "AcceptRanges": "bytes",
-        "LastModified": "datetime",
+        "Body": "",
         "ContentLength": 6144,
+        "ContentType": "binary/octet-stream",
         "ETag": "\"8eabe9d6b43316e840b079170916c079-1\"",
-        "ContentType": "binary/octet-stream",
-        "Metadata": {},
-        "Body": ""
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object": {
-    "recorded-date": "02-06-2022, 11:55:55",
-    "recorded-content": {
-      "get_object": {
-        "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "AcceptRanges": "bytes",
         "LastModified": "datetime",
-        "ContentLength": 9,
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "ContentType": "binary/octet-stream",
         "Metadata": {},
-        "Body": ""
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_url_metadata": {
-    "recorded-date": "02-06-2022, 12:05:29",
-    "recorded-content": {
-      "head_object": {
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        },
-        "AcceptRanges": "bytes",
-        "LastModified": "datetime",
-        "ContentLength": 11,
-        "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-        "ContentType": "binary/octet-stream",
-        "Metadata": {
-          "foo": "bar"
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_hash_prefix": {
-    "recorded-date": "26-07-2022, 15:37:04",
+  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_with_prefix[/]": {
+    "recorded-date": "21-09-2022, 13:34:55",
     "recorded-content": {
-      "put-object": {
+      "list-objects": {
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/foo/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "Marker": "",
+        "MaxKeys": 1,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "ETag": "\"39d0d586a701e199389d954f2d592720\""
-      },
-      "get-object": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "AcceptRanges": "bytes",
-        "LastModified": "datetime",
-        "ContentLength": 8,
-        "ETag": "\"39d0d586a701e199389d954f2d592720\"",
-        "ContentType": "binary/octet-stream",
-        "Metadata": {},
-        "Body": ""
+        }
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_object_tagging_empty_list": {
-    "recorded-date": "09-08-2022, 15:20:21",
+  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_with_prefix[%2F]": {
+    "recorded-date": "21-09-2022, 13:34:58",
     "recorded-content": {
-      "created-object-tags": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TagSet": []
-      },
-      "updated-object-tags": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "TagSet": [
+      "list-objects": {
+        "Contents": [
           {
-            "Key": "tag1",
-            "Value": "tag1"
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 11,
+            "StorageClass": "STANDARD"
           }
-        ]
-      },
-      "deleted-object-tags": {
+        ],
+        "Delimiter": "%252F",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "Marker": "",
+        "MaxKeys": 1,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_get_object_no_such_bucket": {
+    "recorded-date": "21-09-2022, 13:34:59",
+    "recorded-content": {
+      "expected_error": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
         },
-        "TagSet": []
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_no_such_bucket": {
+    "recorded-date": "21-09-2022, 13:35:00",
+    "recorded-content": {
+      "expected_error": {
+        "Error": {
+          "BucketName": "does-not-exist-7a2b1426",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_get_bucket_notification_configuration_no_such_bucket": {
+    "recorded-date": "21-09-2022, 13:35:00",
+    "recorded-content": {
+      "expected_error": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
       }
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_attributes": {
-    "recorded-date": "09-08-2022, 15:35:20",
+    "recorded-date": "21-09-2022, 13:35:02",
     "recorded-content": {
       "object-attrs": {
         "ETag": "e92499db864217242396e8ef766079a9",
@@ -322,14 +336,22 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_head_object_fields": {
-    "recorded-date": "09-08-2022, 16:38:09",
+  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_hash_prefix": {
+    "recorded-date": "21-09-2022, 13:35:04",
     "recorded-content": {
-      "head-object": {
+      "put-object": {
+        "ETag": "\"39d0d586a701e199389d954f2d592720\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object": {
         "AcceptRanges": "bytes",
+        "Body": "",
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"e8dc4081b13434b45189a720b77b6818\"",
+        "ETag": "\"39d0d586a701e199389d954f2d592720\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ResponseMetadata": {
@@ -339,8 +361,102 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3::test_invalid_range_error": {
+    "recorded-date": "21-09-2022, 13:35:07",
+    "recorded-content": {
+      "exc": {
+        "Error": {
+          "ActualObjectSize": "8",
+          "Code": "InvalidRange",
+          "Message": "The requested range is not satisfiable",
+          "RangeRequested": "bytes=1024-4096"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 416
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_range_key_not_exists": {
+    "recorded-date": "21-09-2022, 13:35:09",
+    "recorded-content": {
+      "exc": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "my-key",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_bucket_policy": {
+    "recorded-date": "21-09-2022, 13:35:13",
+    "recorded-content": {
+      "put-bucket-policy": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-bucket-policy": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "*"
+              },
+              "Action": "s3:GetObject",
+              "Resource": "<resource:1>"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_tagging_empty_list": {
+    "recorded-date": "21-09-2022, 13:35:15",
+    "recorded-content": {
+      "created-object-tags": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "updated-object-tags": {
+        "TagSet": [
+          {
+            "Key": "tag1",
+            "Value": "tag1"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "deleted-object-tags": {
+        "TagSet": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_after_deleted_in_versioned_bucket": {
-    "recorded-date": "09-08-2022, 17:23:32",
+    "recorded-date": "21-09-2022, 13:35:18",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -350,7 +466,7 @@
         "ETag": "\"e8dc4081b13434b45189a720b77b6818\"",
         "LastModified": "datetime",
         "Metadata": {},
-        "VersionId": "dHbAQTgztqVidv2H01dsECtk0x7LN0CJ",
+        "VersionId": "tJEw7LZJ5OQQyUBbur6az2mmK7NnO1sy",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -369,8 +485,132 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32]": {
+    "recorded-date": "21-09-2022, 13:35:21",
+    "recorded-content": {
+      "put-wrong-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-crc32 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-generated": {
+        "ChecksumCRC32": "cZWHwQ==",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-autogenerated": {
+        "ChecksumCRC32": "cZWHwQ==",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32C]": {
+    "recorded-date": "21-09-2022, 13:35:24",
+    "recorded-content": {
+      "put-wrong-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-crc32c header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-generated": {
+        "ChecksumCRC32C": "Pf4upw==",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-autogenerated": {
+        "ChecksumCRC32C": "Pf4upw==",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[SHA1]": {
+    "recorded-date": "21-09-2022, 13:35:27",
+    "recorded-content": {
+      "put-wrong-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-sha1 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-generated": {
+        "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-autogenerated": {
+        "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
+    "recorded-date": "21-09-2022, 13:35:29",
+    "recorded-content": {
+      "put-wrong-checksum": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Value for x-amz-checksum-sha256 header is invalid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-object-generated": {
+        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-autogenerated": {
+        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
+        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_metadata_replace": {
-    "recorded-date": "18-08-2022, 17:31:08",
+    "recorded-date": "21-09-2022, 13:35:32",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -420,7 +660,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_copy_content_type_and_metadata": {
-    "recorded-date": "18-08-2022, 17:52:12",
+    "recorded-date": "21-09-2022, 13:35:36",
     "recorded-content": {
       "put_object": {
         "ETag": "\"88bac95f31528d13a072c05f2a1cf371\"",
@@ -494,7 +734,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_multipart_upload_acls": {
-    "recorded-date": "19-08-2022, 16:57:09",
+    "recorded-date": "21-09-2022, 13:35:40",
     "recorded-content": {
       "bucket-acl": {
         "Grants": [
@@ -600,7 +840,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_object_expiry": {
-    "recorded-date": "22-08-2022, 18:02:13",
+    "recorded-date": "21-09-2022, 13:35:46",
     "recorded-content": {
       "head-object-expired": {
         "AcceptRanges": "bytes",
@@ -631,35 +871,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_bucket_availability": {
-    "recorded-date": "22-08-2022, 20:06:27",
-    "recorded-content": {
-      "bucket-lifecycle": {
-        "Error": {
-          "BucketName": "test-bucket-lifecycle",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "bucket-replication": {
-        "Error": {
-          "BucketName": "test-bucket-lifecycle",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
   "tests/integration/s3/test_s3.py::TestS3::test_upload_file_with_xml_preamble": {
-    "recorded-date": "23-08-2022, 12:03:04",
+    "recorded-date": "21-09-2022, 13:35:48",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -676,8 +889,35 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3::test_bucket_availability": {
+    "recorded-date": "21-09-2022, 13:35:50",
+    "recorded-content": {
+      "bucket-lifecycle": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "bucket-replication": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "23-08-2022, 18:45:59",
+    "recorded-date": "21-09-2022, 13:35:57",
     "recorded-content": {
       "get_bucket_location_bucket_1": {
         "LocationConstraint": null,
@@ -720,7 +960,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_with_anon_credentials": {
-    "recorded-date": "24-08-2022, 11:01:27",
+    "recorded-date": "21-09-2022, 13:36:04",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -738,7 +978,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_putobject_with_multiple_keys": {
-    "recorded-date": "24-08-2022, 19:09:22",
+    "recorded-date": "21-09-2022, 13:36:06",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -756,7 +996,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_lifecycle_configuration": {
-    "recorded-date": "08-09-2022, 20:59:00",
+    "recorded-date": "21-09-2022, 13:36:09",
     "recorded-content": {
       "get-bucket-lifecycle-exc-1": {
         "Error": {
@@ -767,6 +1007,12 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      },
+      "delete-bucket-lifecycle-no-bucket": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       },
       "get-bucket-lifecycle-conf": {
@@ -801,7 +1047,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_lifecycle_configuration_on_bucket_deletion": {
-    "recorded-date": "25-08-2022, 17:12:56",
+    "recorded-date": "21-09-2022, 13:36:12",
     "recorded-content": {
       "get-bucket-lifecycle-conf": {
         "Rules": [
@@ -834,8 +1080,56 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3::test_bucket_lifecycle_configuration_object_expiry": {
+    "recorded-date": "21-09-2022, 13:36:14",
+    "recorded-content": {
+      "get-bucket-lifecycle-conf": {
+        "Rules": [
+          {
+            "Expiration": "<expiration>",
+            "Filter": {
+              "Prefix": ""
+            },
+            "ID": "wholebucket",
+            "Status": "Enabled"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head-object-expiry": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-expiry": {
+        "AcceptRanges": "bytes",
+        "Body": "test",
+        "ContentLength": 4,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "Expiration": "<expiration>",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3::test_range_header_body_length": {
-    "recorded-date": "25-08-2022, 18:02:59",
+    "recorded-date": "21-09-2022, 13:36:17",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -843,7 +1137,7 @@
         "ContentLength": 1024,
         "ContentRange": "bytes 0-1023/2048",
         "ContentType": "binary/octet-stream",
-        "ETag": "\"7be4229686e4047603196e6edb58692d\"",
+        "ETag": "\"a407c5edc8840c22ec42a82609f4b5ee\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ResponseMetadata": {
@@ -854,7 +1148,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_object_tagging": {
-    "recorded-date": "26-08-2022, 01:29:53",
+    "recorded-date": "21-09-2022, 13:36:22",
     "recorded-content": {
       "get-obj": {
         "AcceptRanges": "bytes",
@@ -884,112 +1178,30 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3Cors::test_cors_with_allowed_origins": {
-    "recorded-date": "26-08-2022, 15:10:47",
+  "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys": {
+    "recorded-date": "21-09-2022, 13:36:25",
     "recorded-content": {
-      "raw-response-headers": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4200",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-2": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4200",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-3": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4200",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-4": {
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "https://localhost:4201",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "0",
-        "Date": "<date>",
-        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3Cors::test_cors_configurations": {
-    "recorded-date": "26-08-2022, 16:34:52",
-    "recorded-content": {
-      "raw-response-headers": {
-        "Accept-Ranges": "bytes",
-        "Access-Control-Allow-Credentials": "true",
-        "Access-Control-Allow-Methods": "GET, PUT",
-        "Access-Control-Allow-Origin": "http://localhost:4566",
-        "Access-Control-Max-Age": "3000",
-        "Content-Length": "16",
-        "Content-Type": "binary/octet-stream",
-        "Date": "<date>",
-        "ETag": "\"aa4315fde513528bf6580028d3341f0b\"",
-        "Last-Modified": "<date>",
-        "Server": "<server>",
-        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      },
-      "raw-response-headers-2": {
-        "Accept-Ranges": "bytes",
-        "Content-Length": "16",
-        "Content-Type": "binary/octet-stream",
-        "Date": "<date>",
-        "ETag": "\"aa4315fde513528bf6580028d3341f0b\"",
-        "Last-Modified": "<date>",
-        "Server": "<server>",
-        "x-amz-id-2": "<id>",
-        "x-amz-request-id": "<request-id>"
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_precondition_failed_error": {
-    "recorded-date": "26-08-2022, 17:06:05",
-    "recorded-content": {
-      "get-object-if-match": {
-        "Error": {
-          "Code": "PreconditionFailed",
-          "Condition": "If-Match",
-          "Message": "At least one of the pre-conditions you specified did not hold"
-        },
+      "deleted-resp": {
+        "Deleted": [
+          {
+            "Key": "dummy1"
+          },
+          {
+            "Key": "dummy2"
+          },
+          {
+            "Key": "test-key-nonexistent"
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 412
+          "HTTPStatusCode": 200
         }
       }
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys_in_non_existing_bucket": {
-    "recorded-date": "26-08-2022, 15:41:56",
+    "recorded-date": "21-09-2022, 13:36:26",
     "recorded-content": {
       "error-non-existent-bucket": {
         "Error": {
@@ -1005,7 +1217,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_request_payer": {
-    "recorded-date": "26-08-2022, 15:48:13",
+    "recorded-date": "21-09-2022, 13:36:27",
     "recorded-content": {
       "put-bucket-request-payment": {
         "ResponseMetadata": {
@@ -1022,8 +1234,23 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_request_payer_exceptions": {
+    "recorded-date": "21-09-2022, 13:36:28",
+    "recorded-content": {
+      "wrong-payer-type": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3::test_bucket_exists": {
-    "recorded-date": "26-08-2022, 15:53:56",
+    "recorded-date": "21-09-2022, 13:36:31",
     "recorded-content": {
       "get-bucket-cors": {
         "CORSRules": [
@@ -1078,7 +1305,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_uppercase_key_names": {
-    "recorded-date": "26-08-2022, 16:13:42",
+    "recorded-date": "21-09-2022, 13:36:33",
     "recorded-content": {
       "response": {
         "AcceptRanges": "bytes",
@@ -1106,45 +1333,24 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys": {
-    "recorded-date": "29-08-2022, 10:23:50",
+  "tests/integration/s3/test_s3.py::TestS3::test_precondition_failed_error": {
+    "recorded-date": "21-09-2022, 13:37:08",
     "recorded-content": {
-      "deleted-resp": {
-        "Deleted": [
-          {
-            "Key": "dummy1"
-          },
-          {
-            "Key": "dummy2"
-          },
-          {
-            "Key": "test-key-nonexistent"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_copy_md5": {
-    "recorded-date": "29-08-2022, 12:07:36",
-    "recorded-content": {
-      "copy-obj": {
-        "CopyObjectResult": {
-          "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-          "LastModified": "datetime"
+      "get-object-if-match": {
+        "Error": {
+          "Code": "PreconditionFailed",
+          "Condition": "If-Match",
+          "Message": "At least one of the pre-conditions you specified did not hold"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPStatusCode": 412
         }
       }
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_invalid_content_md5": {
-    "recorded-date": "29-08-2022, 12:15:05",
+    "recorded-date": "21-09-2022, 13:37:13",
     "recorded-content": {
       "md5-error-0": {
         "Error": {
@@ -1193,10 +1399,10 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_upload_download_gzip": {
-    "recorded-date": "29-08-2022, 12:18:22",
+    "recorded-date": "21-09-2022, 13:37:15",
     "recorded-content": {
       "put-object": {
-        "ETag": "\"f84006d978dfac9da356af8c41b83150\"",
+        "ETag": "\"8b168421e12cb36daa65760e4d8660bc\"",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -1208,7 +1414,7 @@
         "ContentEncoding": "gzip",
         "ContentLength": 41,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"f84006d978dfac9da356af8c41b83150\"",
+        "ETag": "\"8b168421e12cb36daa65760e4d8660bc\"",
         "LastModified": "datetime",
         "Metadata": {},
         "ResponseMetadata": {
@@ -1219,7 +1425,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_multipart_copy_object_etag": {
-    "recorded-date": "29-08-2022, 12:32:37",
+    "recorded-date": "21-09-2022, 13:37:17",
     "recorded-content": {
       "multipart-upload": {
         "Bucket": "<bucket:1>",
@@ -1244,7 +1450,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_set_external_hostname": {
-    "recorded-date": "29-08-2022, 15:12:54",
+    "recorded-date": "21-09-2022, 13:37:21",
     "recorded-content": {
       "multipart-upload": {
         "Bucket": "<bucket:1>",
@@ -1268,33 +1474,155 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_get_deep_archive_object_restore": {
-    "recorded-date": "02-09-2022, 12:16:13",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_lambda_integration": {
+    "recorded-date": "21-09-2022, 13:38:03",
     "recorded-content": {
-      "get_object_invalid_state": {
-        "Error": {
-          "Code": "InvalidObjectState",
-          "Message": "The operation is not valid for the object's storage class",
-          "StorageClass": "DEEP_ARCHIVE"
-        },
-        "StorageClass": "DEEP_ARCHIVE",
+      "head_object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 0,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+        "LastModified": "datetime",
+        "Metadata": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
-          "HTTPStatusCode": 403
-        }
-      },
-      "restore_object": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
+          "HTTPStatusCode": 200
         }
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_list_objects_empty_marker": {
-    "recorded-date": "02-09-2022, 13:13:55",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_uppercase_bucket_name": {
+    "recorded-date": "21-09-2022, 13:38:06",
     "recorded-content": {
-      "list-objects": {
+      "uppercase-bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "InvalidBucketName",
+          "Message": "The specified bucket is not valid."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_with_existing_name": {
+    "recorded-date": "21-09-2022, 13:38:08",
+    "recorded-content": {
+      "create-bucket-us-west-1": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "BucketAlreadyOwnedByYou",
+          "Message": "Your previous request to create the named bucket succeeded and you already own it."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "create-bucket-us-east-2": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "BucketAlreadyOwnedByYou",
+          "Message": "Your previous request to create the named bucket succeeded and you already own it."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_bucket_does_not_exist": {
+    "recorded-date": "21-09-2022, 13:38:20",
+    "recorded-content": {
+      "list_object": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "list_object_vhost": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
+    "recorded-date": "21-09-2022, 13:38:23",
+    "recorded-content": {
+      "create_bucket": {
+        "Location": "/<bucket-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_bucket_location_constraint": {
+        "Location": "http://<bucket-name:2>.host/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_bucket": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_bucket_filtered_header": {
+        "content-type": "application/xml",
+        "x-amz-access-point-alias": "false",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      },
+      "head_bucket_2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "head_bucket_2_filtered_header": {
+        "content-type": "application/xml",
+        "x-amz-access-point-alias": "false",
+        "x-amz-bucket-region": "us-west-1",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_bucket_name_with_dots": {
+    "recorded-date": "21-09-2022, 13:38:25",
+    "recorded-content": {
+      "list_objects": {
+        "Contents": [
+          {
+            "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+            "Key": "my-content",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 9,
+            "StorageClass": "STANDARD"
+          }
+        ],
         "EncodingType": "url",
         "IsTruncated": false,
         "Marker": "",
@@ -1305,11 +1633,40 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "list_objects_headers": {
+        "content-type": "application/xml",
+        "date": "date",
+        "server": "AmazonS3",
+        "transfer-encoding": "chunked",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      },
+      "request_vhost_url_content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name><bucket-name:1></Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>my-content</Key><LastModified>date</LastModified><ETag>&quot;437b930db84b8079c2dd804a71936b5f&quot;</ETag><Size>9</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>",
+      "request_vhost_headers": {
+        "Content-Type": "application/xml",
+        "Date": "date",
+        "Server": "AmazonS3",
+        "Transfer-Encoding": "chunked",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
+      },
+      "request_path_url_content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name><bucket-name:1></Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>my-content</Key><LastModified>date</LastModified><ETag>&quot;437b930db84b8079c2dd804a71936b5f&quot;</ETag><Size>9</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>",
+      "request_path_headers": {
+        "Content-Type": "application/xml",
+        "Date": "date",
+        "Server": "AmazonS3",
+        "Transfer-Encoding": "chunked",
+        "x-amz-bucket-region": "<region>",
+        "x-amz-id-2": "x-amz-id-2",
+        "x-amz-request-id": "x-amz-request-id"
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_more_than_1000_items": {
-    "recorded-date": "02-09-2022, 14:49:04",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_put_more_than_1000_items": {
+    "recorded-date": "21-09-2022, 13:43:01",
     "recorded-content": {
       "get_object-1009": {
         "AcceptRanges": "bytes",
@@ -1478,8 +1835,25 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_upload_big_file": {
-    "recorded-date": "02-09-2022, 15:06:55",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_list_objects_empty_marker": {
+    "recorded-date": "21-09-2022, 13:43:06",
+    "recorded-content": {
+      "list-objects": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "Marker": "",
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_upload_big_file": {
+    "recorded-date": "21-09-2022, 13:43:19",
     "recorded-content": {
       "put_object_key1": {
         "ETag": "\"a649c4228b2b9e8bfca3510ed9d9a764\"",
@@ -1521,8 +1895,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_get_bucket_versioning_order": {
-    "recorded-date": "02-09-2022, 15:21:13",
+  "tests/integration/s3/test_s3.py::TestS3::test_get_bucket_versioning_order": {
+    "recorded-date": "21-09-2022, 13:43:23",
     "recorded-content": {
       "list_object_versions_before": {
         "EncodingType": "url",
@@ -1606,8 +1980,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_etag_on_get_object_call": {
-    "recorded-date": "02-09-2022, 15:32:43",
+  "tests/integration/s3/test_s3.py::TestS3::test_etag_on_get_object_call": {
+    "recorded-date": "21-09-2022, 13:43:27",
     "recorded-content": {
       "get_object": {
         "AcceptRanges": "bytes",
@@ -1638,8 +2012,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_delete_object_with_version_id": {
-    "recorded-date": "02-09-2022, 15:49:00",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_delete_object_with_version_id": {
+    "recorded-date": "21-09-2022, 13:43:31",
     "recorded-content": {
       "get_bucket_versioning": {
         "Status": "Enabled",
@@ -1697,73 +2071,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_s3_lambda_integration": {
-    "recorded-date": "05-09-2022, 12:40:12",
-    "recorded-content": {
-      "head_object": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 0,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_get_object_no_such_bucket": {
-    "recorded-date": "13-09-2022, 15:36:32",
-    "recorded-content": {
-      "expected_error": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_delete_bucket_no_such_bucket": {
-    "recorded-date": "05-09-2022, 13:49:41",
-    "recorded-content": {
-      "expected_error": {
-        "Error": {
-          "BucketName": "does-not-exist-1581ad5c",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_get_bucket_notification_configuration_no_such_bucket": {
-    "recorded-date": "13-09-2022, 15:34:44",
-    "recorded-content": {
-      "expected_error": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_batch_delete_objects_using_requests": {
-    "recorded-date": "05-09-2022, 16:45:46",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_batch_delete_objects_using_requests_with_acl": {
+    "recorded-date": "21-09-2022, 13:43:35",
     "recorded-content": {
       "multi-delete-with-requests": {
         "DeleteResult": {
@@ -1804,8 +2113,8 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_batch_delete_public_objects_using_requests": {
-    "recorded-date": "05-09-2022, 16:53:55",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_batch_delete_public_objects_using_requests": {
+    "recorded-date": "21-09-2022, 13:43:39",
     "recorded-content": {
       "multi-delete-with-requests": {
         "DeleteResult": {
@@ -1833,239 +2142,25 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32]": {
-    "recorded-date": "12-09-2022, 19:48:18",
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_batch_delete_objects": {
+    "recorded-date": "21-09-2022, 13:43:42",
     "recorded-content": {
-      "put-wrong-checksum": {
-        "Error": {
-          "Code": "InvalidRequest",
-          "Message": "Value for x-amz-checksum-crc32 header is invalid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-generated": {
-        "ChecksumCRC32": "cZWHwQ==",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-autogenerated": {
-        "ChecksumCRC32": "cZWHwQ==",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[CRC32C]": {
-    "recorded-date": "12-09-2022, 19:48:20",
-    "recorded-content": {
-      "put-wrong-checksum": {
-        "Error": {
-          "Code": "InvalidRequest",
-          "Message": "Value for x-amz-checksum-crc32c header is invalid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-generated": {
-        "ChecksumCRC32C": "Pf4upw==",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-autogenerated": {
-        "ChecksumCRC32C": "Pf4upw==",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[SHA1]": {
-    "recorded-date": "12-09-2022, 19:48:23",
-    "recorded-content": {
-      "put-wrong-checksum": {
-        "Error": {
-          "Code": "InvalidRequest",
-          "Message": "Value for x-amz-checksum-sha1 header is invalid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-generated": {
-        "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-autogenerated": {
-        "ChecksumSHA1": "B++3uSfJMSHWToQMQ1g6lIJY5Eo=",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_object_checksum[SHA256]": {
-    "recorded-date": "12-09-2022, 19:48:27",
-    "recorded-content": {
-      "put-wrong-checksum": {
-        "Error": {
-          "Code": "InvalidRequest",
-          "Message": "Value for x-amz-checksum-sha256 header is invalid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put-object-generated": {
-        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put-object-autogenerated": {
-        "ChecksumSHA256": "2l26x0trnT0r2AvakoFk2MB7eKVKzYESLMxSAKAzoik=",
-        "ETag": "\"e6d9226c2a86b7232933663c13467527\"",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_s3_uppercase_bucket_name": {
-    "recorded-date": "09-09-2022, 13:18:19",
-    "recorded-content": {
-      "uppercase-bucket": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "InvalidBucketName",
-          "Message": "The specified bucket is not valid."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_with_existing_name": {
-    "recorded-date": "09-09-2022, 16:06:06",
-    "recorded-content": {
-      "create-bucket-us-west-1": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "BucketAlreadyOwnedByYou",
-          "Message": "Your previous request to create the named bucket succeeded and you already own it."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      },
-      "create-bucket-us-east-2": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "BucketAlreadyOwnedByYou",
-          "Message": "Your previous request to create the named bucket succeeded and you already own it."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_with_prefix[/]": {
-    "recorded-date": "09-09-2022, 19:35:53",
-    "recorded-content": {
-      "list-objects": {
-        "CommonPrefixes": [
+      "batch-delete": {
+        "Deleted": [
           {
-            "Prefix": "test/foo/"
-          }
-        ],
-        "Delimiter": "/",
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "Marker": "",
-        "MaxKeys": 1,
-        "Name": "<bucket-name:1>",
-        "Prefix": "test/",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_with_prefix[%2F]": {
-    "recorded-date": "09-09-2022, 19:35:56",
-    "recorded-content": {
-      "list-objects": {
-        "Contents": [
+            "Key": "<key:1>"
+          },
           {
-            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
-            "Key": "test/foo/bar/123",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 11,
-            "StorageClass": "STANDARD"
-          }
-        ],
-        "Delimiter": "%252F",
-        "EncodingType": "url",
-        "IsTruncated": false,
-        "Marker": "",
-        "MaxKeys": 1,
-        "Name": "<bucket-name:1>",
-        "Prefix": "test/",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_bucket_lifecycle_configuration_object_expiry": {
-    "recorded-date": "09-09-2022, 22:19:34",
-    "recorded-content": {
-      "get-bucket-lifecycle-conf": {
-        "Rules": [
+            "Key": "<key:2>"
+          },
           {
-            "Expiration": "<expiration>",
-            "Filter": {
-              "Prefix": ""
-            },
-            "ID": "wholebucket",
-            "Status": "Enabled"
+            "Key": "<key:3>"
+          },
+          {
+            "Key": "<key:4>"
+          },
+          {
+            "Key": "<key:5>"
           }
         ],
         "ResponseMetadata": {
@@ -2073,142 +2168,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "head-object-expiry": {
-        "AcceptRanges": "bytes",
-        "ContentLength": 4,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
-        "Expiration": "<expiration>",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get-object-expiry": {
-        "AcceptRanges": "bytes",
-        "Body": "test",
-        "ContentLength": 4,
-        "ContentType": "binary/octet-stream",
-        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
-        "Expiration": "<expiration>",
-        "LastModified": "datetime",
-        "Metadata": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_bucket_policy": {
-    "recorded-date": "09-09-2022, 22:39:34",
-    "recorded-content": {
-      "put-bucket-policy": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      },
-      "get-bucket-policy": {
-        "Policy": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "AWS": "*"
-              },
-              "Action": "s3:GetObject",
-              "Resource": "<resource:1>"
-            }
-          ]
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_invalid_range_error": {
-    "recorded-date": "13-09-2022, 16:01:02",
-    "recorded-content": {
-      "exc": {
-        "Error": {
-          "ActualObjectSize": "8",
-          "Code": "InvalidRange",
-          "Message": "The requested range is not satisfiable",
-          "RangeRequested": "bytes=1024-4096"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 416
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_range_key_not_exists": {
-    "recorded-date": "13-09-2022, 16:05:49",
-    "recorded-content": {
-      "exc": {
-        "Error": {
-          "Code": "NoSuchKey",
-          "Key": "my-key",
-          "Message": "The specified key does not exist."
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_bucket_does_not_exist": {
-    "recorded-date": "15-09-2022, 18:54:54",
-    "recorded-content": {
-      "list_object": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "list_object_vhost": {
-        "Error": {
-          "BucketName": "<bucket-name:1>",
-          "Code": "NoSuchBucket",
-          "Message": "The specified bucket does not exist"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      }
-    }
-  },
-  "tests/integration/s3/test_s3.py::TestS3::test_bucket_name_with_dots": {
-    "recorded-date": "16-09-2022, 11:57:35",
-    "recorded-content": {
-      "list_objects": {
-        "Contents": [
-          {
-            "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
-            "Key": "my-content",
-            "LastModified": "datetime",
-            "Owner": {
-              "DisplayName": "<display-name>",
-              "ID": "<owner-id>"
-            },
-            "Size": 9,
-            "StorageClass": "STANDARD"
-          }
-        ],
+      "list-remaining-objects": {
         "EncodingType": "url",
         "IsTruncated": false,
         "Marker": "",
@@ -2219,80 +2179,213 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "list_objects_headers": {
-        "content-type": "application/xml",
-        "date": "date",
-        "server": "AmazonS3",
-        "transfer-encoding": "chunked",
-        "x-amz-bucket-region": "<region>",
-        "x-amz-id-2": "x-amz-id-2",
-        "x-amz-request-id": "x-amz-request-id"
-      },
-      "request_vhost_url_content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name><bucket-name:1></Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>my-content</Key><LastModified>date</LastModified><ETag>&quot;437b930db84b8079c2dd804a71936b5f&quot;</ETag><Size>9</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>",
-      "request_vhost_headers": {
-        "Content-Type": "application/xml",
-        "Date": "date",
-        "Server": "AmazonS3",
-        "Transfer-Encoding": "chunked",
-        "x-amz-bucket-region": "<region>",
-        "x-amz-id-2": "x-amz-id-2",
-        "x-amz-request-id": "x-amz-request-id"
-      },
-      "request_path_url_content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Name><bucket-name:1></Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>my-content</Key><LastModified>date</LastModified><ETag>&quot;437b930db84b8079c2dd804a71936b5f&quot;</ETag><Size>9</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>",
-      "request_path_headers": {
-        "Content-Type": "application/xml",
-        "Date": "date",
-        "Server": "AmazonS3",
-        "Transfer-Encoding": "chunked",
-        "x-amz-bucket-region": "<region>",
-        "x-amz-id-2": "x-amz-id-2",
-        "x-amz-request-id": "x-amz-request-id"
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3::test_create_bucket_head_bucket": {
-    "recorded-date": "16-09-2022, 12:00:07",
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object": {
+    "recorded-date": "21-09-2022, 13:43:45",
     "recorded-content": {
-      "create_bucket": {
-        "Location": "/<bucket-name:1>",
+      "get_object": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ContentLength": 9,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "LastModified": "datetime",
+        "Metadata": {},
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "create_bucket_location_constraint": {
-        "Location": "http://<bucket-name:2>.host/",
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_url_metadata": {
+    "recorded-date": "21-09-2022, 13:44:01",
+    "recorded-content": {
+      "head_object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+        "LastModified": "datetime",
+        "Metadata": {
+          "foo": "bar"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "head_bucket": {
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_get_response_headers": {
+    "recorded-date": "21-09-2022, 13:44:26",
+    "recorded-content": {
+      "bucket-cors-response": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET",
+              "PUT",
+              "POST"
+            ],
+            "AllowedOrigins": [
+              "*"
+            ],
+            "ExposeHeaders": [
+              "ETag",
+              "x-amz-version-id"
+            ]
+          }
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "head_bucket_filtered_header": {
-        "content-type": "application/xml",
-        "x-amz-access-point-alias": "false",
-        "x-amz-bucket-region": "<region>",
-        "x-amz-id-2": "x-amz-id-2",
-        "x-amz-request-id": "x-amz-request-id"
-      },
-      "head_bucket_2": {
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_copy_md5": {
+    "recorded-date": "21-09-2022, 13:44:37",
+    "recorded-content": {
+      "copy-obj": {
+        "CopyObjectResult": {
+          "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+          "LastModified": "datetime"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3Cors::test_cors_with_allowed_origins": {
+    "recorded-date": "21-09-2022, 13:45:31",
+    "recorded-content": {
+      "raw-response-headers": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, PUT",
+        "Access-Control-Allow-Origin": "https://localhost:4200",
+        "Access-Control-Max-Age": "3000",
+        "Content-Length": "0",
+        "Date": "<date>",
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "Server": "<server>",
+        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+        "x-amz-id-2": "<id>",
+        "x-amz-request-id": "<request-id>"
       },
-      "head_bucket_2_filtered_header": {
-        "content-type": "application/xml",
-        "x-amz-access-point-alias": "false",
-        "x-amz-bucket-region": "us-west-1",
-        "x-amz-id-2": "x-amz-id-2",
-        "x-amz-request-id": "x-amz-request-id"
+      "raw-response-headers-2": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, PUT",
+        "Access-Control-Allow-Origin": "https://localhost:4200",
+        "Access-Control-Max-Age": "3000",
+        "Content-Length": "0",
+        "Date": "<date>",
+        "Server": "<server>",
+        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+        "x-amz-id-2": "<id>",
+        "x-amz-request-id": "<request-id>"
+      },
+      "raw-response-headers-3": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, PUT",
+        "Access-Control-Allow-Origin": "https://localhost:4200",
+        "Access-Control-Max-Age": "3000",
+        "Content-Length": "0",
+        "Date": "<date>",
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "Server": "<server>",
+        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+        "x-amz-id-2": "<id>",
+        "x-amz-request-id": "<request-id>"
+      },
+      "raw-response-headers-4": {
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, PUT",
+        "Access-Control-Allow-Origin": "https://localhost:4201",
+        "Access-Control-Max-Age": "3000",
+        "Content-Length": "0",
+        "Date": "<date>",
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "Server": "<server>",
+        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+        "x-amz-id-2": "<id>",
+        "x-amz-request-id": "<request-id>"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3Cors::test_cors_configurations": {
+    "recorded-date": "21-09-2022, 13:45:35",
+    "recorded-content": {
+      "raw-response-headers": {
+        "Accept-Ranges": "bytes",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Methods": "GET, PUT",
+        "Access-Control-Allow-Origin": "http://localhost:4566",
+        "Access-Control-Max-Age": "3000",
+        "Content-Length": "16",
+        "Content-Type": "binary/octet-stream",
+        "Date": "<date>",
+        "ETag": "\"aa4315fde513528bf6580028d3341f0b\"",
+        "Last-Modified": "<date>",
+        "Server": "<server>",
+        "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+        "x-amz-id-2": "<id>",
+        "x-amz-request-id": "<request-id>"
+      },
+      "raw-response-headers-2": {
+        "Accept-Ranges": "bytes",
+        "Content-Length": "16",
+        "Content-Type": "binary/octet-stream",
+        "Date": "<date>",
+        "ETag": "\"aa4315fde513528bf6580028d3341f0b\"",
+        "Last-Modified": "<date>",
+        "Server": "<server>",
+        "x-amz-id-2": "<id>",
+        "x-amz-request-id": "<request-id>"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3DeepArchive::test_s3_get_deep_archive_object_restore": {
+    "recorded-date": "21-09-2022, 13:45:42",
+    "recorded-content": {
+      "get_object_invalid_state": {
+        "Error": {
+          "Code": "InvalidObjectState",
+          "Message": "The operation is not valid for the object's storage class",
+          "StorageClass": "DEEP_ARCHIVE"
+        },
+        "StorageClass": "DEEP_ARCHIVE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 403
+        }
+      },
+      "restore_object": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_head_object_fields": {
+    "recorded-date": "21-09-2022, 13:54:45",
+    "recorded-content": {
+      "head-object": {
+        "AcceptRanges": "bytes",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e8dc4081b13434b45189a720b77b6818\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   }

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -297,6 +297,7 @@ def test_rest_xml_serializer_s3_2_with_botocore():
         "ObjectLockMode": "GOVERNANCE",
         "ObjectLockRetainUntilDate": datetime(2015, 1, 1, 23, 59, 59, tzinfo=tzutc()),
         "ObjectLockLegalHoldStatus": "ON",
+        "StatusCode": 200,
     }
     _botocore_serializer_integration_test("s3", "GetObject", parameters)
 
@@ -1258,6 +1259,7 @@ def test_restxml_header_location():
         "DeleteMarker": True,
         "ContentType": "string",
         "Metadata": {"string": "string"},
+        "StatusCode": 200,
     }
     _botocore_serializer_integration_test("s3", "GetObject", parameters)
 
@@ -1665,6 +1667,7 @@ def test_restxml_streaming_payload(payload):
         "Body": payload,
         "ContentType": "text/xml",
         "Metadata": {},
+        "StatusCode": 200,
     }
     _botocore_serializer_integration_test("s3", "GetObject", parameters)
 


### PR DESCRIPTION
This PR adds more operations to the S3 provider, and reorganised the tests by class, grouping them more coherently.
This will reduces the number of failing test and implement a lot of basic functionality, and fixes some current bugs at the same time. 
It is a bit hard to keep track of implemented operation and fixed exceptions, as a lot of fixes are done by moto patching. 

Implemented operations:
- `GetBucketRequestPayment`
- `PutBucketRequestPayment`
- `GetBucketLifecycleConfiguration` (had to reimplement it, moto is not validating correctly Transition actions, and will raise exceptions. Would need a bigger rewrite in moto. Needed for Terraform).
- `PutBucketLifecycleConfiguration`
- `DeleteBucketLifecycleConfiguration`

- fix object Expires parameter
- fix `GetObject` with range headers, and return proper status code
- fix restoring object from `DEEP_ARCHIVE`, raise error if trying to get an object in that state
- fix exceptions missing in the specs, or missing members
- implement proper DeleteResult for `DeleteObjects`

Also had to regenerate all s3 snapshots as the moving of tests made a lot of changes, it was simpler to regenerate everything from scratch. 

~~Currently having unit tests failing as they are testing patched behaviour against original specs. Will need to fix this before merging.~~ Done, seen with Alex. 

Sorry this PR is quite large, subsequent PR based on this one will be smaller and implement specific things. This one was quite general.