### PR TITLE
set env DISABLE_EVENTS for the not-implemented-steps  in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
       - run:
           name: Run localstack
           command: |
-            <<#parameters.pro>>LOCALSTACK_API_KEY=$TEST_LOCALSTACK_API_KEY<</parameters.pro>> IMAGE_NAME="localstack/localstack-full:latest" bin/localstack start -d
+            <<#parameters.pro>>LOCALSTACK_API_KEY=$TEST_LOCALSTACK_API_KEY<</parameters.pro>> DISABLE_EVENTS="1" IMAGE_NAME="localstack/localstack-full:latest" bin/localstack start -d
             bin/localstack wait -t 120
       - run:
           name: Run capture-not-implemented


### PR DESCRIPTION
Disable the analytics collection for the CircleCI-steps where we collect information about not-implemented API endpoints.

