### PR TITLE
Implement Bucket ACL operations in S3 provider

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -166,6 +166,8 @@ BucketRegion = str
 BucketContentType = str
 IfCondition = str
 RestoreObjectOutputStatusCode = int
+ArgumentName = str
+ArgumentValue = str
 
 
 class AnalyticsS3ExportFileFormat(str):
@@ -633,6 +635,14 @@ class InvalidRange(ServiceException):
     status_code: int = 416
     ActualObjectSize: Optional[ObjectSize]
     RangeRequested: Optional[ContentRange]
+
+
+class InvalidArgument(ServiceException):
+    code: str = "InvalidArgument"
+    sender_fault: bool = False
+    status_code: int = 400
+    ArgumentName: Optional[ArgumentName]
+    ArgumentValue: Optional[ArgumentValue]
 
 
 AbortDate = datetime

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1385,6 +1385,25 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
         ] = f"MzRISOwyjmnup{request_id}7/JypPGXLh0OVFGcJaaO3KW/hRAqKOpIEEp"
         return response
 
+    def _add_error_tags(
+        self, error: ServiceException, error_tag: ETree.Element, mime_type: str
+    ) -> None:
+        code_tag = ETree.SubElement(error_tag, "Code")
+        code_tag.text = error.code
+        message = self._get_error_message(error)
+        if message:
+            self._default_serialize(error_tag, message, None, "Message", mime_type)
+        else:
+            # In S3, if there's no message, create an empty node
+            self._create_empty_node(error_tag, "Message")
+        if error.sender_fault:
+            # The sender fault is either not set or "Sender"
+            self._default_serialize(error_tag, "Sender", None, "Type", mime_type)
+
+    @staticmethod
+    def _create_empty_node(xmlnode: ETree.Element, name: str) -> None:
+        ETree.SubElement(xmlnode, name)
+
 
 class SqsResponseSerializer(QueryResponseSerializer):
     """

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -255,6 +255,40 @@
         "shape": "RestoreObjectOutputStatusCode",
         "location": "statusCode"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidArgument",
+      "value": {
+        "type": "structure",
+        "members": {
+          "ArgumentName": {
+            "shape": "ArgumentName"
+          },
+          "ArgumentValue": {
+            "shape": "ArgumentValue"
+          }
+        },
+        "error": {
+          "httpStatusCode": 400
+        },
+        "documentation": "<p>Invalid Argument</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ArgumentName",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ArgumentValue",
+      "value": {
+        "type": "string"
+      }
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+from typing import Union
 from urllib.parse import SplitResult, quote, urlsplit, urlunsplit
 
 import moto.s3.models as moto_s3_models
@@ -11,10 +12,12 @@ from moto.s3.exceptions import MissingBucket
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.s3 import (
+    AccessControlPolicy,
     AccountId,
     BucketName,
     CreateBucketOutput,
     CreateBucketRequest,
+    GetBucketAclOutput,
     GetBucketLifecycleConfigurationOutput,
     GetBucketLifecycleOutput,
     GetBucketLocationOutput,
@@ -24,6 +27,7 @@ from localstack.aws.api.s3 import (
     GetObjectRequest,
     HeadObjectOutput,
     HeadObjectRequest,
+    InvalidArgument,
     InvalidBucketName,
     ListObjectsOutput,
     ListObjectsRequest,
@@ -33,6 +37,7 @@ from localstack.aws.api.s3 import (
     NoSuchKey,
     NoSuchLifecycleConfiguration,
     ObjectKey,
+    PutBucketAclRequest,
     PutBucketLifecycleConfigurationRequest,
     PutBucketLifecycleRequest,
     PutBucketRequestPaymentRequest,
@@ -40,6 +45,7 @@ from localstack.aws.api.s3 import (
     PutObjectRequest,
     S3Api,
 )
+from localstack.aws.api.s3 import Type as GranteeType
 from localstack.config import get_edge_port_http, get_protocol
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.http import Request, Response
@@ -48,7 +54,16 @@ from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3.models import S3Store, s3_stores
-from localstack.services.s3.utils import is_bucket_name_valid, is_key_expired, verify_checksum
+from localstack.services.s3.utils import (
+    VALID_ACL_PREDEFINED_GROUPS,
+    VALID_GRANTEE_PERMISSIONS,
+    get_header_name,
+    is_bucket_name_valid,
+    is_canned_acl_valid,
+    is_key_expired,
+    is_valid_canonical_id,
+    verify_checksum,
+)
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.request_context import AWS_REGION_REGEX
 from localstack.utils.objects import singleton_factory
@@ -60,10 +75,17 @@ os.environ[
     "MOTO_S3_CUSTOM_ENDPOINTS"
 ] = "s3.localhost.localstack.cloud:4566,s3.localhost.localstack.cloud"
 
+MOTO_CANONICAL_USER_ID = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
+
 
 class MalformedXML(CommonServiceException):
     def __init__(self, message=None):
         super().__init__("MalformedXML", status_code=400, message=message)
+
+
+class MalformedACLError(CommonServiceException):
+    def __init__(self, message=None):
+        super().__init__("MalformedACLError", status_code=400, message=message)
 
 
 def get_moto_s3_backend(context: RequestContext) -> moto_s3_models.S3Backend:
@@ -301,6 +323,45 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store = self.get_store()
         store.bucket_lifecycle_configuration.pop(bucket, None)
 
+    def get_bucket_acl(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> GetBucketAclOutput:
+        response: GetBucketAclOutput = call_moto(context)
+
+        for grant in response["Grants"]:
+            grantee = grant.get("Grantee", {})
+            if grantee.get("ID") == MOTO_CANONICAL_USER_ID:
+                # adding the DisplayName used by moto for the owner
+                grantee["DisplayName"] = "webfile"
+
+        return response
+
+    @handler("PutBucketAcl", expand=False)
+    def put_bucket_acl(
+        self,
+        context: RequestContext,
+        request: PutBucketAclRequest,
+    ) -> None:
+        if (canned_acl := request.get("ACL")) and not is_canned_acl_valid(canned_acl):
+            ex = _create_invalid_argument_exc(None, name="x-amz-acl", value=canned_acl)
+            raise ex
+
+        grant_keys = [
+            "GrantFullControl",
+            "GrantRead",
+            "GrantReadACP",
+            "GrantWrite",
+            "GrantWriteACP",
+        ]
+        for key in grant_keys:
+            if grantees_values := request.get(key, ""):  # noqa
+                validate_grantee_in_headers(key, grantees_values)
+
+        if acp := request.get("AccessControlPolicy"):
+            validate_acl_acp(acp)
+
+        call_moto(context)
+
     def add_custom_routes(self):
         # virtual-host style: https://bucket-name.s3.region-code.amazonaws.com/key-name
         # host_pattern_vhost_style = f"{bucket}.s3.<regex('({AWS_REGION_REGEX}\.)?'):region>{LOCALHOST_HOSTNAME}:{get_edge_port_http()}"
@@ -377,7 +438,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         )
 
 
-def validate_bucket_name(bucket: BucketName):
+def validate_bucket_name(bucket: BucketName) -> None:
     """
     Validate s3 bucket name based on the documentation
     ref. https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
@@ -386,6 +447,89 @@ def validate_bucket_name(bucket: BucketName):
         ex = InvalidBucketName("The specified bucket is not valid.")
         ex.BucketName = bucket
         raise ex
+
+
+def _create_invalid_argument_exc(
+    message: Union[str, None], name: str, value: str
+) -> InvalidArgument:
+    ex = InvalidArgument(message)
+    ex.ArgumentName = name
+    ex.ArgumentValue = value
+    return ex
+
+
+def validate_canned_acl(canned_acl: str) -> None:
+    """
+    Validate the canned ACL value, or raise an Exception
+    """
+    if not is_canned_acl_valid(canned_acl):
+        ex = _create_invalid_argument_exc(None, "x-amz-acl", canned_acl)
+        raise ex
+
+
+def validate_grantee_in_headers(grant: str, grantees: str) -> None:
+    splitted_grantees = [grantee.strip() for grantee in grantees.split(",")]
+    for grantee in splitted_grantees:
+        grantee_type, grantee_id = grantee.split("=")
+        grantee_id = grantee_id.strip('"')
+        if grantee_type not in ("uri", "id", "emailAddress"):
+            ex = _create_invalid_argument_exc(
+                "Argument format not recognized", get_header_name(grant), grantee
+            )
+            raise ex
+        elif grantee_type == "uri" and grantee_id not in VALID_ACL_PREDEFINED_GROUPS:
+            ex = _create_invalid_argument_exc("Invalid group uri", "uri", grantee_id)
+            raise ex
+        elif grantee_type == "id" and not is_valid_canonical_id(grantee_id):
+            ex = _create_invalid_argument_exc("Invalid id", "id", grantee_id)
+            raise ex
+        elif grantee_type == "emailAddress":
+            # TODO: check validation here
+            continue
+
+
+def validate_acl_acp(acp: AccessControlPolicy) -> None:
+    if "Owner" not in acp or "Grants" not in acp:
+        raise MalformedACLError(
+            "The XML you provided was not well-formed or did not validate against our published schema"
+        )
+
+    if not is_valid_canonical_id(owner_id := acp["Owner"].get("ID", "")):
+        ex = _create_invalid_argument_exc("Invalid id", "CanonicalUser/ID", owner_id)
+        raise ex
+
+    for grant in acp["Grants"]:
+        if grant.get("Permission") not in VALID_GRANTEE_PERMISSIONS:
+            raise MalformedACLError(
+                "The XML you provided was not well-formed or did not validate against our published schema"
+            )
+
+        grantee = grant.get("Grantee", {})
+        grant_type = grantee.get("Type")
+        if grant_type not in (
+            GranteeType.Group,
+            GranteeType.CanonicalUser,
+            GranteeType.AmazonCustomerByEmail,
+        ):
+            raise MalformedACLError(
+                "The XML you provided was not well-formed or did not validate against our published schema"
+            )
+        elif (
+            grant_type == GranteeType.Group
+            and (grant_uri := grantee.get("URI", "")) not in VALID_ACL_PREDEFINED_GROUPS
+        ):
+            ex = _create_invalid_argument_exc("Invalid group uri", "Group/URI", grant_uri)
+            raise ex
+
+        elif grant_type == GranteeType.AmazonCustomerByEmail:
+            # TODO: add validation here
+            continue
+
+        elif grant_type == GranteeType.CanonicalUser and not is_valid_canonical_id(
+            (grantee_id := grantee.get("ID", ""))
+        ):
+            ex = _create_invalid_argument_exc("Invalid id", "CanonicalUser/ID", grantee_id)
+            raise ex
 
 
 def get_bucket_from_moto(
@@ -458,6 +602,18 @@ def apply_moto_patches():
             raise InvalidObjectState(storage_class=storage_class)
 
         return code, headers, body
+
+    @patch(moto_s3_responses.S3Response.all_buckets)
+    def _fix_owner_id_list_bucket(fn, *args, **kwargs) -> str:
+        """
+        Moto does not use the same CanonicalUser ID for the owner between ListBuckets and all ACLs related response
+        Patch ListBuckets to return the same ID as the ACL
+        """
+        res: str = fn(*args, **kwargs)
+        res = res.replace(
+            "<ID>bcaf1ffd86f41161ca5fb16fd081034f</ID>", f"<ID>{MOTO_CANONICAL_USER_ID}</ID>"
+        )
+        return res
 
 
 def _capitalize_header_name_from_snake_case(header_name: str) -> str:

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -2388,5 +2388,222 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_bucket_acl": {
+    "recorded-date": "14-09-2022, 16:07:13",
+    "recorded-content": {
+      "get-bucket-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          },
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
+            },
+            "Permission": "READ"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-canned-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-grant-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+            },
+            "Permission": "READ"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-acp-acl": {
+        "Grants": [
+          {
+            "Grantee": {
+              "DisplayName": "<display-name:1>",
+              "ID": "<owner-id:1>",
+              "Type": "CanonicalUser"
+            },
+            "Permission": "FULL_CONTROL"
+          },
+          {
+            "Grantee": {
+              "Type": "Group",
+              "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+            },
+            "Permission": "WRITE"
+          }
+        ],
+        "Owner": {
+          "DisplayName": "<display-name:1>",
+          "ID": "<owner-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_bucket_acl_exceptions": {
+    "recorded-date": "14-09-2022, 21:40:39",
+    "recorded-content": {
+      "put-bucket-canned-acl": {
+        "Error": {
+          "ArgumentName": "x-amz-acl",
+          "ArgumentValue": "fake-acl",
+          "Code": "InvalidArgument",
+          "Message": null
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-grant-acl-fake-uri": {
+        "Error": {
+          "ArgumentName": "uri",
+          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+          "Code": "InvalidArgument",
+          "Message": "Invalid group uri"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-grant-acl-fake-key": {
+        "Error": {
+          "ArgumentName": "x-amz-grant-write",
+          "ArgumentValue": "fakekey=\"1234\"",
+          "Code": "InvalidArgument",
+          "Message": "Argument format not recognized"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-grant-acl-wrong-id": {
+        "Error": {
+          "ArgumentName": "id",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-acp-acl-1": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-acp-acl-2": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-acp-acl-3": {
+        "Error": {
+          "ArgumentName": "CanonicalUser/ID",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-acp-acl-4": {
+        "Error": {
+          "ArgumentName": "Group/URI",
+          "ArgumentValue": "http://acs.amazonaws.com/groups/s3/FakeGroup",
+          "Code": "InvalidArgument",
+          "Message": "Invalid group uri"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-acp-acl-5": {
+        "Error": {
+          "ArgumentName": "CanonicalUser/ID",
+          "ArgumentValue": "wrong-id",
+          "Code": "InvalidArgument",
+          "Message": "Invalid id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-acp-acl-6": {
+        "Error": {
+          "Code": "MalformedACLError",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
No integration tests were really checking ACLs, so this one is not reducing tests failure as much.
- Implement Bucket ACL operations and validation in provider.
- ACL enforcement is not part of it, as it's not currently done in the current provider. 