### PR TITLE
mark dynamodb tests and add snapshots

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -232,7 +232,9 @@ class SSEUtils:
         if existing_key:
             return existing_key
         kms_client = aws_stack.connect_to_service("kms")
-        key_data = kms_client.create_key(Description="Default key that protects DynamoDB data")
+        key_data = kms_client.create_key(
+            Description="Default key that protects my DynamoDB data when no other key is defined"
+        )
         key_id = key_data["KeyMetadata"]["KeyId"]
 
         provider.set_key_managed(key_id)
@@ -399,7 +401,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         # Check if table exists, to avoid error log output from DynamoDBLocal
         table_name = create_table_input["TableName"]
         if self.table_exists(table_name):
-            raise ResourceInUseException("Cannot create preexisting table")
+            raise ResourceInUseException(f"Table already exists: {table_name}")
         billing_mode = create_table_input.get("BillingMode")
         provisioned_throughput = create_table_input.get("ProvisionedThroughput")
         if billing_mode == BillingMode.PAY_PER_REQUEST and provisioned_throughput is not None:

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -101,9 +101,7 @@ class ItemFinder:
                     key_value = put_item["Item"].get(key_name)
                     if not key_value:
                         raise ValidationException(
-                            "An error occurred (ValidationException) when calling the "
-                            "BatchWriteItem operation: The provided key element does not match "
-                            "the schema"
+                            "The provided key element does not match the schema"
                         )
                     search_key[key_name] = key_value
             if not search_key:

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -160,6 +160,17 @@ class TransformerUtility:
         ]
 
     @staticmethod
+    def dynamodb_api():
+        """
+        :return: array with Transformers, for dynamodb api.
+        """
+        return [
+            RegexTransformer(
+                r"([a-zA-Z0-9-_.]*)?test_table_([a-zA-Z0-9-_.]*)?", replacement="<test-table>"
+            ),
+        ]
+
+    @staticmethod
     def iam_api():
         """
         :return: array with Transformers, for iam api.

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -11,6 +11,7 @@ from boto3.dynamodb.types import STRING
 
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
+from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import json_safe, long_uid, retry, short_uid
@@ -34,6 +35,11 @@ TEST_DDB_TAGS = [
 @pytest.fixture()
 def dynamodb(dynamodb_resource):
     return dynamodb_resource
+
+
+@pytest.fixture(autouse=True)
+def transcribe_snapshot_transformer(snapshot):
+    snapshot.add_transformer(snapshot.transform.dynamodb_api())
 
 
 class TestDynamoDB:
@@ -356,7 +362,7 @@ class TestDynamoDB:
 
     @pytest.mark.aws_validated
     def test_valid_local_secondary_index(
-        self, dynamodb_client, dynamodb_create_table_with_parameters
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
     ):
         table_name = f"test-table-{short_uid()}"
         dynamodb_create_table_with_parameters(
@@ -394,7 +400,10 @@ class TestDynamoDB:
             ExpressionAttributeValues={":v1": {"S": "test one"}},
             Select="ALL_ATTRIBUTES",
         )
-        assert result["Items"] == [item]
+        transformer = SortingTransformer("Items", lambda x: x)
+        transformed_dict = transformer.transform(result)
+
+        snapshot.match("Items", transformed_dict)
 
     @pytest.mark.only_localstack(reason="AWS has a 20 GSI limit")
     def test_more_than_20_global_secondary_indexes(
@@ -423,84 +432,71 @@ class TestDynamoDB:
         assert len(table["Table"]["GlobalSecondaryIndexes"]) == num_gsis
 
     @pytest.mark.aws_validated
-    def test_return_values_in_put_item(self, dynamodb, dynamodb_client):
+    def test_return_values_in_put_item(self, dynamodb, dynamodb_client, snapshot):
         aws_stack.create_dynamodb_table(
             TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY, client=dynamodb_client
         )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
-
-        def _validate_response(response, expected=None):
-            """
-            Validates the response against the optionally expected one.
-            It checks that the response doesn't contain `Attributes`,
-            `ConsumedCapacity` and `ItemCollectionMetrics` unless they are expected.
-            """
-            if expected is None:
-                expected = {}
-            should_not_contain = {
-                "Attributes",
-                "ConsumedCapacity",
-                "ItemCollectionMetrics",
-            } - expected.keys()
-            assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-            assert expected.items() <= response.items()
-            assert response.keys().isdisjoint(should_not_contain)
 
         # items which are being used to put in the table
         item1 = {PARTITION_KEY: "id1", "data": "foobar"}
         item1b = {PARTITION_KEY: "id1", "data": "barfoo"}
         item2 = {PARTITION_KEY: "id2", "data": "foobar"}
 
-        response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
         # there is no data present in the table already so even if return values
         # is set to 'ALL_OLD' as there is no data it will not return any data.
-        _validate_response(response)
+        response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
+        snapshot.match("PutFirstItem", response)
+
         # now the same data is present so when we pass return values as 'ALL_OLD'
         # it should give us attributes
         response = table.put_item(Item=item1, ReturnValues="ALL_OLD")
-        _validate_response(response, expected={"Attributes": item1})
+        snapshot.match("PutFirstItemOLD", response)
 
         # now a previous version of data is present, so when we pass return
         # values as 'ALL_OLD' it should give us the old attributes
         response = table.put_item(Item=item1b, ReturnValues="ALL_OLD")
-        _validate_response(response, expected={"Attributes": item1})
+        snapshot.match("PutFirstItemB", response)
 
-        response = table.put_item(Item=item2)
         # we do not have any same item as item2 already so when we add this by default
         # return values is set to None so no Attribute values should be returned
-        _validate_response(response)
-
         response = table.put_item(Item=item2)
+        snapshot.match("PutSecondItem", response)
+
         # in this case we already have item2 in the table so on this request
         # it should not return any data as return values is set to None so no
         # Attribute values should be returned
-        _validate_response(response)
+        response = table.put_item(Item=item2)
+        snapshot.match("PutSecondItemReturnNone", response)
 
         # cleanup
         table.delete()
 
     @pytest.mark.aws_validated
-    def test_empty_and_binary_values(self, dynamodb, dynamodb_client):
+    def test_empty_and_binary_values(self, dynamodb, dynamodb_client, snapshot):
+        table_name = f"table-{short_uid()}"
         aws_stack.create_dynamodb_table(
-            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY, client=dynamodb_client
+            table_name=table_name, partition_key=PARTITION_KEY, client=dynamodb_client
         )
-        table = dynamodb.Table(TEST_DDB_TABLE_NAME)
+        table = dynamodb.Table(table_name)
 
         # items which are being used to put in the table
         item1 = {PARTITION_KEY: "id1", "data": ""}
         item2 = {PARTITION_KEY: "id2", "data": b"\x90"}
 
         response = table.put_item(Item=item1)
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        snapshot.match("PutFirstItem", response)
 
         response = table.put_item(Item=item2)
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        snapshot.match("PutSecondItem", response)
 
         # clean up
         table.delete()
 
     @pytest.mark.aws_validated
-    def test_batch_write_binary(self, dynamodb_client, dynamodb_create_table_with_parameters):
+    def test_batch_write_binary(
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
+    ):
         table_name = f"table_batch_binary_{short_uid()}"
         dynamodb_create_table_with_parameters(
             TableName=table_name,
@@ -638,7 +634,7 @@ class TestDynamoDB:
 
     @pytest.mark.aws_validated
     def test_dynamodb_execute_transaction(
-        self, dynamodb_client, dynamodb_create_table_with_parameters
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
     ):
         table_name = f"table_{short_uid()}"
         dynamodb_create_table_with_parameters(
@@ -652,16 +648,16 @@ class TestDynamoDB:
             {"Statement": f"INSERT INTO {table_name} VALUE {{'Username': 'user02'}}"},
         ]
         result = dynamodb_client.execute_transaction(TransactStatements=statements)
-        assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+        snapshot.match("ExecutedTransaction", result)
 
         result = dynamodb_client.scan(TableName=table_name)
-        assert result["ScannedCount"] == 2
+        snapshot.match("TableScan", result)
 
     @pytest.mark.aws_validated
     def test_dynamodb_batch_execute_statement(
-        self, dynamodb_client, dynamodb_create_table_with_parameters
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
     ):
-        table_name = f"table_{short_uid()}"
+        table_name = f"test_table_{short_uid()}"
         dynamodb_create_table_with_parameters(
             TableName=table_name,
             KeySchema=[{"AttributeName": "Username", "KeyType": "HASH"}],
@@ -676,22 +672,24 @@ class TestDynamoDB:
         ]
         result = dynamodb_client.batch_execute_statement(Statements=statements)
         # actions always succeeds
-        assert not any("Error" in r for r in result["Responses"])
+        snapshot.match("ExecutedStatement", result)
 
         item = dynamodb_client.get_item(TableName=table_name, Key={"Username": {"S": "user02"}})[
             "Item"
         ]
-        assert item["Age"]["N"] == "20"
+        snapshot.match("ItemUser2", item)
 
         item = dynamodb_client.get_item(TableName=table_name, Key={"Username": {"S": "user01"}})[
             "Item"
         ]
-        assert item
+        snapshot.match("ItemUser1", item)
 
         dynamodb_client.delete_table(TableName=table_name)
 
     @pytest.mark.aws_validated
-    def test_dynamodb_partiql_missing(self, dynamodb_client, dynamodb_create_table_with_parameters):
+    def test_dynamodb_partiql_missing(
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
+    ):
         table_name = f"table_with_stream_{short_uid()}"
 
         # create table
@@ -708,7 +706,8 @@ class TestDynamoDB:
         items = dynamodb_client.execute_statement(
             Statement=f"SELECT * FROM {table_name} WHERE FirstName IS NOT MISSING"
         )["Items"]
-        assert len(items) == 1
+        snapshot.match("FirstNameNotMissing", items)
+
         items = dynamodb_client.execute_statement(
             Statement=f"SELECT * FROM {table_name} WHERE FirstName IS MISSING"
         )["Items"]
@@ -996,8 +995,8 @@ class TestDynamoDB:
         assert ctx.match("GlobalTableNotFoundException")
 
     @pytest.mark.aws_validated
-    def test_create_duplicate_table(self, dynamodb_create_table_with_parameters):
-        table_name = f"duplicateTable-{short_uid()}"
+    def test_create_duplicate_table(self, dynamodb_create_table_with_parameters, snapshot):
+        table_name = f"test_table_{short_uid()}"
 
         dynamodb_create_table_with_parameters(
             TableName=table_name,
@@ -1015,9 +1014,11 @@ class TestDynamoDB:
                 ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
                 Tags=TEST_DDB_TAGS,
             )
-        ctx.match("ResourceInUseException")
+        snapshot.match("Error", ctx.value)
 
-    @pytest.mark.only_localstack
+    @pytest.mark.only_localstack(
+        reason="timing issues - needs a check to see if table is successfully deleted"
+    )
     def test_delete_table(self, dynamodb_client, dynamodb_create_table):
         table_name = f"test-ddb-table-{short_uid()}"
 
@@ -1043,7 +1044,9 @@ class TestDynamoDB:
         assert ctx.match("ResourceNotFoundException")
 
     @pytest.mark.aws_validated
-    def test_transaction_write_items(self, dynamodb_client, dynamodb_create_table_with_parameters):
+    def test_transaction_write_items(
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
+    ):
         table_name = f"test-ddb-table-{short_uid()}"
 
         dynamodb_create_table_with_parameters(
@@ -1078,11 +1081,11 @@ class TestDynamoDB:
                 {"Delete": {"TableName": table_name, "Key": {"id": {"S": "test4"}}}},
             ]
         )
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        snapshot.match("Response", response)
 
     @pytest.mark.aws_validated
     def test_transaction_write_canceled(
-        self, dynamodb_create_table_with_parameters, dynamodb_client
+        self, dynamodb_create_table_with_parameters, dynamodb_client, snapshot
     ):
         table_name = "table_%s" % short_uid()
 
@@ -1111,31 +1114,11 @@ class TestDynamoDB:
                     {"Delete": {"TableName": table_name, "Key": {"Username": {"S": "Bert"}}}},
                 ]
             )
-        # Make sure the exception contains the cancellation reasons
-        assert ctx.match("TransactionCanceledException")
-        assert (
-            str(ctx.value)
-            == "An error occurred (TransactionCanceledException) when calling the TransactWriteItems operation: "
-            "Transaction cancelled, please refer cancellation reasons for specific reasons "
-            "[ConditionalCheckFailed, None]"
-        )
-        assert hasattr(ctx.value, "response")
-        assert "CancellationReasons" in ctx.value.response
-        conditional_check_failed = [
-            reason
-            for reason in ctx.value.response["CancellationReasons"]
-            if reason.get("Code") == "ConditionalCheckFailed"
-        ]
-        assert len(conditional_check_failed) == 1
-        assert "Message" in conditional_check_failed[0]
-        # dynamodb-local adds a trailing "." to the message, AWS does not
-        assert re.match(
-            r"^The conditional request failed\.?$", conditional_check_failed[0]["Message"]
-        )
+        snapshot.match("Error", ctx.value)
 
     @pytest.mark.aws_validated
     def test_transaction_write_binary_data(
-        self, dynamodb_client, dynamodb_create_table_with_parameters
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
     ):
         table_name = f"test-ddb-table-{short_uid()}"
         dynamodb_create_table_with_parameters(
@@ -1159,13 +1142,13 @@ class TestDynamoDB:
                 }
             ]
         )
+        snapshot.match("WriteResponse", response)
+
         item = dynamodb_client.get_item(TableName=table_name, Key={"id": {"S": "someUser"}})["Item"]
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        assert item["binaryData"]
-        assert item["binaryData"] == binary_item
+        snapshot.match("GetItem", item)
 
     @pytest.mark.aws_validated
-    def test_transact_get_items(self, dynamodb_client, dynamodb_create_table):
+    def test_transact_get_items(self, dynamodb_client, dynamodb_create_table, snapshot):
         table_name = f"test-ddb-table-{short_uid()}"
         dynamodb_create_table(
             table_name=table_name,
@@ -1175,10 +1158,12 @@ class TestDynamoDB:
         result = dynamodb_client.transact_get_items(
             TransactItems=[{"Get": {"Key": {"id": {"S": "John"}}, "TableName": table_name}}]
         )
-        assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+        snapshot.match("TransactGetItems", result)
 
     @pytest.mark.aws_validated
-    def test_batch_write_items(self, dynamodb_client, dynamodb_create_table_with_parameters):
+    def test_batch_write_items(
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
+    ):
         table_name = f"test-ddb-table-{short_uid()}"
         dynamodb_create_table_with_parameters(
             TableName=table_name,
@@ -1196,7 +1181,7 @@ class TestDynamoDB:
                 ]
             }
         )
-        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        snapshot.match("BatchWriteResponse", response)
 
     @pytest.mark.xfail(reason="this test flakes regularly in CI")
     def test_dynamodb_stream_records_with_update_item(
@@ -1362,7 +1347,7 @@ class TestDynamoDB:
 
     @pytest.mark.aws_validated
     def test_dynamodb_batch_write_item(
-        self, dynamodb_client, dynamodb_create_table_with_parameters
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
     ):
         table_name = f"ddb-table-{short_uid()}"
 
@@ -1383,11 +1368,10 @@ class TestDynamoDB:
                 ]
             }
         )
-
-        assert result.get("UnprocessedItems") == {}
+        snapshot.match("Result", result)
 
     @pytest.mark.aws_validated
-    def test_dynamodb_pay_per_request(self, dynamodb_create_table_with_parameters):
+    def test_dynamodb_pay_per_request(self, dynamodb_create_table_with_parameters, snapshot):
         table_name = f"ddb-table-{short_uid()}"
 
         with pytest.raises(Exception) as e:
@@ -1398,7 +1382,7 @@ class TestDynamoDB:
                 ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
                 BillingMode="PAY_PER_REQUEST",
             )
-        assert e.match("ValidationException")
+        snapshot.match("Error", e.value)
 
     @pytest.mark.only_localstack
     def test_dynamodb_create_table_with_sse_specification(
@@ -1424,11 +1408,19 @@ class TestDynamoDB:
         assert result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"] == kms_master_key_arn
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..TableDescription..ProvisionedThroughput..NumberOfDecreasesToday",
+            "$..TableDescription..TableStatus",
+            "$..KeyMetadata..KeyUsage",
+            "$..KeyMetadata..MultiRegion",
+            "$..KeyMetadata..SigningAlgorithms",
+        ]
+    )
     def test_dynamodb_create_table_with_partial_sse_specification(
-        self, dynamodb_create_table_with_parameters, kms_client
+        self, dynamodb_create_table_with_parameters, kms_client, snapshot
     ):
-        table_name = f"ddb-table-{short_uid()}"
-
+        table_name = f"test_table_{short_uid()}"
         sse_specification = {"Enabled": True}
 
         result = dynamodb_create_table_with_parameters(
@@ -1440,17 +1432,17 @@ class TestDynamoDB:
             Tags=TEST_DDB_TAGS,
         )
 
-        assert result["TableDescription"]["SSEDescription"]
-        assert result["TableDescription"]["SSEDescription"]["Status"] == "ENABLED"
-        assert result["TableDescription"]["SSEDescription"]["SSEType"] == "KMS"
-        assert "KMSMasterKeyArn" in result["TableDescription"]["SSEDescription"]
+        snapshot.match("Table", result)
+
         kms_master_key_arn = result["TableDescription"]["SSEDescription"]["KMSMasterKeyArn"]
         result = kms_client.describe_key(KeyId=kms_master_key_arn)
-        assert result["KeyMetadata"]["KeyManager"] == "AWS"
+        snapshot.match("KMSDescription", result)
 
     @pytest.mark.aws_validated
-    def test_dynamodb_get_batch_items(self, dynamodb_client, dynamodb_create_table_with_parameters):
-        table_name = f"ddb-table-{short_uid()}"
+    def test_dynamodb_get_batch_items(
+        self, dynamodb_client, dynamodb_create_table_with_parameters, snapshot
+    ):
+        table_name = f"test_table_{short_uid()}"
 
         dynamodb_create_table_with_parameters(
             TableName=table_name,
@@ -1462,7 +1454,7 @@ class TestDynamoDB:
         result = dynamodb_client.batch_get_item(
             RequestItems={table_name: {"Keys": [{"PK": {"S": "test-key"}}]}}
         )
-        assert list(result["Responses"])[0] == table_name
+        snapshot.match("Response", result)
 
     @pytest.mark.only_localstack
     def test_dynamodb_streams_describe_with_exclusive_start_shard_id(
@@ -1491,7 +1483,7 @@ class TestDynamoDB:
 
     @pytest.mark.aws_validated
     def test_dynamodb_idempotent_writing(
-        self, dynamodb_create_table_with_parameters, dynamodb_client
+        self, dynamodb_create_table_with_parameters, dynamodb_client, snapshot
     ):
         table_name = f"ddb-table-{short_uid()}"
         dynamodb_create_table_with_parameters(
@@ -1508,7 +1500,7 @@ class TestDynamoDB:
         )
 
         def _transact_write(_d: Dict):
-            response = dynamodb_client.transact_write_items(
+            return dynamodb_client.transact_write_items(
                 ClientRequestToken="dedupe_token",
                 TransactItems=[
                     {
@@ -1519,14 +1511,19 @@ class TestDynamoDB:
                     },
                 ],
             )
-            assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-        _transact_write({"id": {"S": "id1"}, "name": {"S": "name1"}})
-        _transact_write({"name": {"S": "name1"}, "id": {"S": "id1"}})
+        response = _transact_write({"id": {"S": "id1"}, "name": {"S": "name1"}})
+        snapshot.match("Response1", response)
+        response = _transact_write({"name": {"S": "name1"}, "id": {"S": "id1"}})
+        snapshot.match("Response2", response)
 
     @pytest.mark.aws_validated
     def test_batch_write_not_matching_schema(
-        self, dynamodb_client, dynamodb_create_table_with_parameters, dynamodb_wait_for_table_active
+        self,
+        dynamodb_client,
+        dynamodb_create_table_with_parameters,
+        dynamodb_wait_for_table_active,
+        snapshot,
     ):
         table_name = f"ddb-table-{short_uid()}"
 
@@ -1549,7 +1546,7 @@ class TestDynamoDB:
             dynamodb_client.batch_write_item(
                 RequestItems={table_name: [{"PutRequest": faulty_item}]}
             )
-        assert ctx.match("ValidationException")
+        snapshot.match("ValidationException", ctx.value)
 
     @pytest.mark.only_localstack
     def test_nosql_workbench_localhost_region(self, dynamodb_create_table, dynamodb_client):

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -37,6 +37,7 @@ def dynamodb(dynamodb_resource):
 
 
 class TestDynamoDB:
+    @pytest.mark.only_localstack
     def test_non_ascii_chars(self, dynamodb):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
@@ -61,6 +62,7 @@ class TestDynamoDB:
         # clean up
         delete_table(TEST_DDB_TABLE_NAME)
 
+    @pytest.mark.only_localstack
     def test_large_data_download(self, dynamodb):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME_2, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_2)
@@ -78,6 +80,7 @@ class TestDynamoDB:
         # clean up
         delete_table(TEST_DDB_TABLE_NAME_2)
 
+    @pytest.mark.only_localstack
     def test_time_to_live(self, dynamodb):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME_3, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_3)
@@ -137,6 +140,7 @@ class TestDynamoDB:
         # clean up
         delete_table(TEST_DDB_TABLE_NAME_3)
 
+    @pytest.mark.only_localstack
     def test_list_tags_of_resource(self, dynamodb):
         table_name = "ddb-table-%s" % short_uid()
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
@@ -173,6 +177,7 @@ class TestDynamoDB:
 
         delete_table(table_name)
 
+    @pytest.mark.only_localstack
     def test_stream_spec_and_region_replacement(self, dynamodb):
         ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
         kinesis = aws_stack.create_external_boto_client("kinesis")
@@ -213,6 +218,7 @@ class TestDynamoDB:
         # assert stream has been deleted
         retry(_assert_stream_deleted, sleep=0.4, retries=5)
 
+    @pytest.mark.only_localstack
     def test_multiple_update_expressions(self, dynamodb):
         dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
@@ -262,6 +268,7 @@ class TestDynamoDB:
             )
         assert ctx.match("ValidationException")
 
+    @pytest.mark.only_localstack
     def test_invalid_query_index(self, dynamodb):
         """Raises an exception when a query requests ALL_ATTRIBUTES,
         but the index does not have a ProjectionType of ALL"""
@@ -300,6 +307,7 @@ class TestDynamoDB:
         # clean up
         delete_table(table_name)
 
+    @pytest.mark.only_localstack
     def test_valid_query_index(self, dynamodb):
         """Query requests ALL_ATTRIBUTES and the named index has a ProjectionType of ALL,
         no exception should be raised."""
@@ -388,6 +396,7 @@ class TestDynamoDB:
         )
         assert result["Items"] == [item]
 
+    @pytest.mark.only_localstack(reason="AWS has a 20 GSI limit")
     def test_more_than_20_global_secondary_indexes(
         self, dynamodb_client, dynamodb_create_table_with_parameters
     ):
@@ -529,6 +538,7 @@ class TestDynamoDB:
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
+    @pytest.mark.only_localstack
     def test_binary_data_with_stream(
         self,
         wait_for_stream_ready,
@@ -560,6 +570,7 @@ class TestDynamoDB:
         assert 1 == len(json_records)
         assert "Data" in json_records[0]
 
+    @pytest.mark.only_localstack
     def test_dynamodb_stream_shard_iterator(
         self, wait_for_stream_ready, dynamodb_create_table_with_parameters
     ):
@@ -599,6 +610,7 @@ class TestDynamoDB:
         )
         assert "ShardIterator" in response
 
+    @pytest.mark.only_localstack
     def test_dynamodb_create_table_with_class(
         self, dynamodb_client, dynamodb_create_table_with_parameters
     ):
@@ -703,6 +715,7 @@ class TestDynamoDB:
         assert len(items) == 0
         dynamodb_client.delete_table(TableName=table_name)
 
+    @pytest.mark.only_localstack
     def test_dynamodb_stream_stream_view_type(self):
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
         ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
@@ -780,6 +793,7 @@ class TestDynamoDB:
         # clean up
         delete_table(table_name)
 
+    @pytest.mark.only_localstack
     def test_dynamodb_with_kinesis_stream(self):
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
         kinesis = aws_stack.create_external_boto_client("kinesis")
@@ -869,6 +883,7 @@ class TestDynamoDB:
         delete_table(table_name)
         kinesis.delete_stream(StreamName="kinesis_dest_stream")
 
+    @pytest.mark.only_localstack
     def test_global_tables_version_2019(
         self, create_boto_client, cleanups, dynamodb_wait_for_table_active
     ):
@@ -934,6 +949,7 @@ class TestDynamoDB:
             )
         ctx.match("ResourceNotFoundException")
 
+    @pytest.mark.only_localstack
     def test_global_tables(self):
         aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
@@ -1001,6 +1017,7 @@ class TestDynamoDB:
             )
         ctx.match("ResourceInUseException")
 
+    @pytest.mark.only_localstack
     def test_delete_table(self, dynamodb_client, dynamodb_create_table):
         table_name = f"test-ddb-table-{short_uid()}"
 
@@ -1264,6 +1281,7 @@ class TestDynamoDB:
 
         retry(check_expected_records, retries=5, sleep=1, sleep_before=2)
 
+    @pytest.mark.only_localstack
     def test_query_on_deleted_resource(self, dynamodb_client, dynamodb_create_table):
         table_name = f"ddb-table-{short_uid()}"
         partition_key = "username"
@@ -1287,6 +1305,7 @@ class TestDynamoDB:
             )
         assert ctx.match("ResourceNotFoundException")
 
+    @pytest.mark.only_localstack
     def test_dynamodb_stream_to_lambda(
         self, lambda_client, dynamodb_resource, dynamodb_create_table, wait_for_stream_ready
     ):
@@ -1381,6 +1400,7 @@ class TestDynamoDB:
             )
         assert e.match("ValidationException")
 
+    @pytest.mark.only_localstack
     def test_dynamodb_create_table_with_sse_specification(
         self, dynamodb_create_table_with_parameters
     ):
@@ -1444,6 +1464,7 @@ class TestDynamoDB:
         )
         assert list(result["Responses"])[0] == table_name
 
+    @pytest.mark.only_localstack
     def test_dynamodb_streams_describe_with_exclusive_start_shard_id(
         self, dynamodb_resource, dynamodb_create_table
     ):

--- a/tests/integration/test_dynamodb.snapshot.json
+++ b/tests/integration/test_dynamodb.snapshot.json
@@ -86,12 +86,16 @@
     }
   },
   "tests/integration/test_dynamodb.py::TestDynamoDB::test_batch_write_binary": {
-    "recorded-date": "15-09-2022, 09:00:49",
-    "recorded-content": {}
-  },
-  "tests/integration/test_dynamodb.py::TestDynamoDB::test_binary_data_with_stream": {
-    "recorded-date": "14-09-2022, 22:29:43",
-    "recorded-content": {}
+    "recorded-date": "15-09-2022, 10:19:38",
+    "recorded-content": {
+      "Response": {
+        "UnprocessedItems": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   },
   "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_transaction": {
     "recorded-date": "15-09-2022, 09:00:55",
@@ -246,18 +250,6 @@
       }
     }
   },
-  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_batch_write_item": {
-    "recorded-date": "15-09-2022, 09:01:57",
-    "recorded-content": {
-      "Result": {
-        "UnprocessedItems": {},
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_pay_per_request": {
     "recorded-date": "15-09-2022, 09:01:57",
     "recorded-content": {
@@ -265,49 +257,17 @@
     }
   },
   "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_create_table_with_partial_sse_specification": {
-    "recorded-date": "15-09-2022, 09:02:03",
+    "recorded-date": "15-09-2022, 10:35:34",
     "recorded-content": {
-      "Table": {
-        "TableDescription": {
-          "AttributeDefinitions": [
-            {
-              "AttributeName": "id",
-              "AttributeType": "S"
-            }
-          ],
-          "CreationDateTime": "datetime",
-          "ItemCount": 0,
-          "KeySchema": [
-            {
-              "AttributeName": "id",
-              "KeyType": "HASH"
-            }
-          ],
-          "ProvisionedThroughput": {
-            "NumberOfDecreasesToday": 0,
-            "ReadCapacityUnits": 5,
-            "WriteCapacityUnits": 5
-          },
-          "SSEDescription": {
-            "KMSMasterKeyArn": "arn:aws:kms:<region>:111111111111:key/<uuid:2>",
-            "SSEType": "KMS",
-            "Status": "ENABLED"
-          },
-          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<test-table>",
-          "TableId": "<uuid:1>",
-          "TableName": "<test-table>",
-          "TableSizeBytes": 0,
-          "TableStatus": "CREATING"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+      "SSEDescription": {
+        "KMSMasterKeyArn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "SSEType": "KMS",
+        "Status": "ENABLED"
       },
       "KMSDescription": {
         "KeyMetadata": {
           "AWSAccountId": "111111111111",
-          "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:2>",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
           "CreationDate": "datetime",
           "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
           "Description": "Default key that protects my DynamoDB data when no other key is defined",
@@ -315,7 +275,7 @@
           "EncryptionAlgorithms": [
             "SYMMETRIC_DEFAULT"
           ],
-          "KeyId": "<uuid:2>",
+          "KeyId": "<uuid:1>",
           "KeyManager": "AWS",
           "KeySpec": "SYMMETRIC_DEFAULT",
           "KeyState": "Enabled",
@@ -367,9 +327,5 @@
     "recorded-content": {
       "ValidationException": "An error occurred (ValidationException) when calling the BatchWriteItem operation: The provided key element does not match the schema"
     }
-  },
-  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
-    "recorded-date": "15-09-2022, 09:01:51",
-    "recorded-content": {}
   }
 }

--- a/tests/integration/test_dynamodb.snapshot.json
+++ b/tests/integration/test_dynamodb.snapshot.json
@@ -1,0 +1,375 @@
+{
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_valid_local_secondary_index": {
+    "recorded-date": "15-09-2022, 09:00:29",
+    "recorded-content": {
+      "Items": {
+        "Count": 1,
+        "Items": [
+          {
+            "LSI1SK": {
+              "N": "123"
+            },
+            "PK": {
+              "S": "test one"
+            },
+            "SK": {
+              "S": "hello"
+            }
+          }
+        ],
+        "ScannedCount": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_return_values_in_put_item": {
+    "recorded-date": "15-09-2022, 09:00:37",
+    "recorded-content": {
+      "PutFirstItem": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "PutFirstItemOLD": {
+        "Attributes": {
+          "data": "foobar",
+          "id": "id1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "PutFirstItemB": {
+        "Attributes": {
+          "data": "foobar",
+          "id": "id1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "PutSecondItem": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "PutSecondItemReturnNone": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_empty_and_binary_values": {
+    "recorded-date": "15-09-2022, 09:00:44",
+    "recorded-content": {
+      "PutFirstItem": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "PutSecondItem": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_batch_write_binary": {
+    "recorded-date": "15-09-2022, 09:00:49",
+    "recorded-content": {}
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_binary_data_with_stream": {
+    "recorded-date": "14-09-2022, 22:29:43",
+    "recorded-content": {}
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_execute_transaction": {
+    "recorded-date": "15-09-2022, 09:00:55",
+    "recorded-content": {
+      "ExecutedTransaction": {
+        "Responses": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "TableScan": {
+        "Count": 2,
+        "Items": [
+          {
+            "Username": {
+              "S": "user01"
+            }
+          },
+          {
+            "Username": {
+              "S": "user02"
+            }
+          }
+        ],
+        "ScannedCount": 2,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_batch_execute_statement": {
+    "recorded-date": "15-09-2022, 09:01:02",
+    "recorded-content": {
+      "ExecutedStatement": {
+        "Responses": [
+          {
+            "TableName": "<test-table>"
+          },
+          {
+            "TableName": "<test-table>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "ItemUser2": {
+        "Age": {
+          "N": "20"
+        },
+        "Username": {
+          "S": "user02"
+        }
+      },
+      "ItemUser1": {
+        "Username": {
+          "S": "user01"
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_partiql_missing": {
+    "recorded-date": "15-09-2022, 09:01:11",
+    "recorded-content": {
+      "FirstNameNotMissing": [
+        {
+          "FirstName": {
+            "S": "Alice"
+          },
+          "Username": {
+            "S": "Alice123"
+          }
+        }
+      ]
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_create_duplicate_table": {
+    "recorded-date": "15-09-2022, 09:01:17",
+    "recorded-content": {
+      "Error": "An error occurred (ResourceInUseException) when calling the CreateTable operation: Table already exists: <test-table>"
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_transaction_write_items": {
+    "recorded-date": "15-09-2022, 09:01:24",
+    "recorded-content": {
+      "Response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_transaction_write_canceled": {
+    "recorded-date": "15-09-2022, 09:01:29",
+    "recorded-content": {
+      "Error": "An error occurred (TransactionCanceledException) when calling the TransactWriteItems operation: Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed, None]"
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_transaction_write_binary_data": {
+    "recorded-date": "15-09-2022, 09:01:36",
+    "recorded-content": {
+      "WriteResponse": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "GetItem": {
+        "binaryData": {
+          "B": "b'foobar'"
+        },
+        "id": {
+          "S": "someUser"
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_transact_get_items": {
+    "recorded-date": "15-09-2022, 09:01:41",
+    "recorded-content": {
+      "TransactGetItems": {
+        "Responses": [
+          {
+            "Item": {
+              "id": {
+                "S": "John"
+              }
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_batch_write_items": {
+    "recorded-date": "15-09-2022, 09:01:46",
+    "recorded-content": {
+      "BatchWriteResponse": {
+        "UnprocessedItems": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_batch_write_item": {
+    "recorded-date": "15-09-2022, 09:01:57",
+    "recorded-content": {
+      "Result": {
+        "UnprocessedItems": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_pay_per_request": {
+    "recorded-date": "15-09-2022, 09:01:57",
+    "recorded-content": {
+      "Error": "An error occurred (ValidationException) when calling the CreateTable operation: One or more parameter values were invalid: Neither ReadCapacityUnits nor WriteCapacityUnits can be specified when BillingMode is PAY_PER_REQUEST"
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_create_table_with_partial_sse_specification": {
+    "recorded-date": "15-09-2022, 09:02:03",
+    "recorded-content": {
+      "Table": {
+        "TableDescription": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "id",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "SSEDescription": {
+            "KMSMasterKeyArn": "arn:aws:kms:<region>:111111111111:key/<uuid:2>",
+            "SSEType": "KMS",
+            "Status": "ENABLED"
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<test-table>",
+          "TableId": "<uuid:1>",
+          "TableName": "<test-table>",
+          "TableSizeBytes": 0,
+          "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "KMSDescription": {
+        "KeyMetadata": {
+          "AWSAccountId": "111111111111",
+          "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:2>",
+          "CreationDate": "datetime",
+          "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+          "Description": "Default key that protects my DynamoDB data when no other key is defined",
+          "Enabled": true,
+          "EncryptionAlgorithms": [
+            "SYMMETRIC_DEFAULT"
+          ],
+          "KeyId": "<uuid:2>",
+          "KeyManager": "AWS",
+          "KeySpec": "SYMMETRIC_DEFAULT",
+          "KeyState": "Enabled",
+          "KeyUsage": "ENCRYPT_DECRYPT",
+          "MultiRegion": false,
+          "Origin": "AWS_KMS"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_get_batch_items": {
+    "recorded-date": "15-09-2022, 09:02:09",
+    "recorded-content": {
+      "Response": {
+        "Responses": {
+          "<test-table>": []
+        },
+        "UnprocessedKeys": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_idempotent_writing": {
+    "recorded-date": "15-09-2022, 09:02:15",
+    "recorded-content": {
+      "Response1": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "Response2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_batch_write_not_matching_schema": {
+    "recorded-date": "15-09-2022, 09:02:20",
+    "recorded-content": {
+      "ValidationException": "An error occurred (ValidationException) when calling the BatchWriteItem operation: The provided key element does not match the schema"
+    }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_dynamodb_stream_records_with_update_item": {
+    "recorded-date": "15-09-2022, 09:01:51",
+    "recorded-content": {}
+  }
+}


### PR DESCRIPTION
### Summary
- Marked every dynamodb test with either only_localstack or aws_validated
- Added snapshots for each aws_validated test
- Corrected a few minor things to make snapshots validate (or added a skip_validate)
- Removed test_dynamodb_batch_write_item as it tests the same as test_batch_write_items 

In a second PR I will correct several only_localstack tests to make them aws validated... 