### PR TITLE
Fix logging in local python lambdas

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -492,14 +492,17 @@ def exec_lambda_code(script, handler_function="handler", lambda_cwd=None, lambda
     #  (e.g., mutating environment variables, and globally loaded modules). Should be redesigned.
 
     def _do_exec_lambda_code():
+        import os as exec_os
+        import sys as exec_sys
+
         if lambda_cwd or lambda_env:
             if lambda_cwd:
-                previous_cwd = os.getcwd()
-                os.chdir(lambda_cwd)
-                sys.path = [lambda_cwd] + sys.path
+                previous_cwd = exec_os.getcwd()
+                exec_os.chdir(lambda_cwd)
+                exec_sys.path = [lambda_cwd] + exec_sys.path
             if lambda_env:
-                previous_env = dict(os.environ)
-                os.environ.update(lambda_env)
+                previous_env = dict(exec_os.environ)
+                exec_os.environ.update(lambda_env)
         # generate lambda file name
         lambda_id = "l_%s" % short_uid()
         lambda_file = LAMBDA_SCRIPT_PATTERN.replace("*", lambda_id)
@@ -508,7 +511,7 @@ def exec_lambda_code(script, handler_function="handler", lambda_cwd=None, lambda
         TMP_FILES.append(lambda_file)
         TMP_FILES.append("%sc" % lambda_file)
         try:
-            pre_sys_modules_keys = set(sys.modules.keys())
+            pre_sys_modules_keys = set(exec_sys.modules.keys())
             # set default env variables required for most Lambda handlers
             env_vars_before = lambda_executors.LambdaExecutorLocal.set_default_env_variables()
             try:
@@ -520,20 +523,20 @@ def exec_lambda_code(script, handler_function="handler", lambda_cwd=None, lambda
                 # (eg settings.py) into the global namespace. subsequent
                 # calls can pick up file from another function, causing
                 # general issues.
-                post_sys_modules_keys = set(sys.modules.keys())
+                post_sys_modules_keys = set(exec_sys.modules.keys())
                 for key in post_sys_modules_keys:
                     if key not in pre_sys_modules_keys:
-                        sys.modules.pop(key)
+                        exec_sys.modules.pop(key)
         except Exception as e:
             LOG.error("Unable to exec: %s %s", script, traceback.format_exc())
             raise e
         finally:
             if lambda_cwd or lambda_env:
                 if lambda_cwd:
-                    os.chdir(previous_cwd)
-                    sys.path.pop(0)
+                    exec_os.chdir(previous_cwd)
+                    exec_sys.path.pop(0)
                 if lambda_env:
-                    os.environ = previous_env
+                    exec_os.environ = previous_env
         return module_vars[handler_function]
 
     lock = EXEC_MUTEX if lambda_cwd or lambda_env else empty_context_manager()
@@ -775,12 +778,18 @@ def do_set_function_code(lambda_function: LambdaFunction):
                 zip_file_content = load_file(main_file, mode="rb")
                 # extract handler
                 handler_function = get_handler_function_from_name(handler_name, runtime=runtime)
-                lambda_handler = exec_lambda_code(
-                    zip_file_content,
-                    handler_function=handler_function,
-                    lambda_cwd=lambda_cwd,
-                    lambda_env=lambda_environment,
-                )
+
+                def exec_local_python():
+                    inner_handler = exec_lambda_code(
+                        zip_file_content,
+                        handler_function=handler_function,
+                        lambda_cwd=lambda_cwd,
+                        lambda_env=lambda_environment,
+                    )
+                    return inner_handler
+
+                lambda_handler = exec_local_python
+
             except Exception as e:
                 raise ClientError("Unable to get handler function from lambda code: %s" % e)
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -779,14 +779,14 @@ def do_set_function_code(lambda_function: LambdaFunction):
                 # extract handler
                 handler_function = get_handler_function_from_name(handler_name, runtime=runtime)
 
-                def exec_local_python():
+                def exec_local_python(event, context):
                     inner_handler = exec_lambda_code(
                         zip_file_content,
                         handler_function=handler_function,
                         lambda_cwd=lambda_cwd,
                         lambda_env=lambda_environment,
                     )
-                    return inner_handler
+                    return inner_handler(event, context)
 
                 lambda_handler = exec_local_python
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -422,6 +422,7 @@ def run_lambda(
 
     # Ensure that the service provider has been initialized. This is required to ensure all lifecycle hooks
     # (e.g., persistence) have been executed when the run_lambda(..) function gets called (e.g., from API GW).
+    LOG.debug("Running lambda %s", func_arn)
     if not hasattr(run_lambda, "_provider_initialized"):
         aws_stack.connect_to_service("lambda").list_functions()
         run_lambda._provider_initialized = True

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1412,13 +1412,15 @@ class LambdaExecutorLocal(LambdaExecutor):
                     # set default env variables required for most Lambda handlers
                     self.set_default_env_variables()
 
+                    # patch to make local python handlers properly log. otherwise it'll use the existing logging setup
+                    # ideally this wouldn't be necessary and the handler would be more isolated but for now it's fine
+                    # until the new provider takes over
                     import importlib
 
                     importlib.reload(logging)
 
-                    handler_fn = lambda_function_callable()
+                    execute_result = lambda_function_callable(inv_context.event, context)
 
-                    execute_result = handler_fn(inv_context.event, context)
                 except Exception as e:
                     execute_result = str(e)
                     sys.stderr.write("%s %s" % (e, traceback.format_exc()))

--- a/tests/integration/awslambda/functions/lambda_logging.py
+++ b/tests/integration/awslambda/functions/lambda_logging.py
@@ -1,0 +1,10 @@
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+def handler(event, ctx):
+    verification_token = event["verification_token"]
+    logging.info(f"{verification_token=}")
+    return {"verification_token": verification_token}

--- a/tests/integration/awslambda/functions/lambda_print.py
+++ b/tests/integration/awslambda/functions/lambda_print.py
@@ -1,0 +1,4 @@
+def handler(event, ctx):
+    verification_token = event["verification_token"]
+    print(f"{verification_token=}")
+    return {"verification_token": verification_token}


### PR DESCRIPTION
Some minor fixes for the local execution of python lambdas (and local executor in general)

* Actually spawns a new process now instead of calling `Process.run` which just executed the handler in the same process.
* Usage of the `logging` module now works in lambdas as expected
* Usage of print now should also work as expected