### PR TITLE
[wip] Add installation of OpenSearch cluster if version not available

### DIFF
--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -86,8 +86,13 @@ def resolve_directories(version: str, cluster_path: str, data_root: str = None) 
     :returns: a Directories data structure
     """
     # where to find cluster binary and the modules
-    engine_type, install_version = versions.get_install_type_and_version(version)
+    engine_type, _ = versions.get_install_type_and_version(version)
     install_dir = opensearch_package.get_installed_dir(version)
+
+    if not install_dir:
+        # install package, if it doesn't exist yet
+        opensearch_package.install(version)
+        install_dir = opensearch_package.get_installed_dir(version)
 
     modules_dir = os.path.join(install_dir, "modules")
 


### PR DESCRIPTION
🚧 **Work in progress - please do not merge yet**

Add installation of OpenSearch cluster if version not yet available (i.e., not installed locally).

Should fix this issue that we're currently seeing upstream for persistence tests:
```
    result = orig_func(version=version, cluster_path=cluster_path, data_root=data_root)
  File "/opt/code/localstack/localstack/services/opensearch/cluster.py", line 95, in resolve_directories
    install_dir = opensearch_package.get_installed_dir(version)
  File "/usr/local/lib/python3.10/posixpath.py", line 76, in join
    a = os.fspath(a)
```

Update: This is not yet ready to merge - briefly discussed different solution approaches with @baermat today, he'll be helping out with this issue. Feel free to push any changes directly to this branch @baermat 👍 