### PR TITLE
change batch size range values for sqs

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -59,7 +59,7 @@ class SQSEventSourceListener(EventSourceListener):
                     queue_arn = source["EventSourceArn"]
                     region_name = extract_region_from_arn(queue_arn)
                     sqs_client = aws_stack.connect_to_service("sqs", region_name=region_name)
-                    batch_size = max(min(source.get("BatchSize", 1), 10), 1)
+                    batch_size = min(max(source.get("BatchSize", 10), 1), 10_000)
 
                     try:
                         queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)


### PR DESCRIPTION
Not sure if these are the only files that need changing. Should I also add more tests?

Based on the `BatchSize` values documented in https://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html#SSS-CreateEventSourceMapping-request-BatchSize.

Appreciate any feedback 🙂 