### PR TITLE
Fix SES email retrospective KeyError

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -109,7 +109,7 @@ class SesServiceApiResource:
         messages = []
 
         for msg in EMAILS.values():
-            if filter_source in (msg["Source"], None, ""):
+            if filter_source in (msg.get("Source"), None, ""):
                 messages.append(msg)
 
         return {


### PR DESCRIPTION
L112 in the SES Provider suggests that the Email source can have nil-values: 
```python
            if filter_source in (msg["Source"], None, ""):
```
The included dictionary access causes a KeyError in this case. This PR changes that to a `.get()` call to avoid that. 

