### PR TITLE
Fix prerelease smoke tests for RDS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ ci-pro-smoke-tests:
 	awslocal mediastore list-containers
 	awslocal mwaa list-environments
 	awslocal qldb list-ledgers
-	awslocal rds create-db-cluster --db-cluster-identifier test-cluster --engine aurora-postgresql --database-name test --master-username master --master-user-password secret99 --db-subnet-group-name mysubnetgroup --db-cluster-parameter-group-name mydbclusterparametergroup
+	awslocal rds create-db-cluster --db-cluster-identifier test-cluster --engine aurora-postgresql --database-name test --master-username master --master-user-password secret99 --db-subnet-group-name mysubnetgroup
 	awslocal rds describe-db-instances
 	awslocal s3 mb s3://test-bucket
 	awslocal timestream-write create-database --database-name db1


### PR DESCRIPTION
## Problem
With a recent PRO PR, we have introduced a better parameter validation for rds create-db-cluster. Mainly, we have to specify an existing db cluster parameter group name (if specified).
Since the current pre release pro tests do not do this, the tests fail.

## Fix
Remove the non-existent parameter group name, and let RDS create one for us.