### PR TITLE
migrate S3 notifications to ASF

### DIFF
--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -1,5 +1,9 @@
 from typing import Dict
 
+import moto.s3.models as moto_s3_models
+from moto.s3 import s3_backends as moto_s3_backends
+
+from localstack.aws.api import RequestContext
 from localstack.aws.api.s3 import (
     BucketLifecycleConfiguration,
     BucketName,
@@ -8,6 +12,10 @@ from localstack.aws.api.s3 import (
     ReplicationConfiguration,
 )
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+
+
+def get_moto_s3_backend(context: RequestContext) -> moto_s3_models.S3Backend:
+    return moto_s3_backends[context.account_id]["global"]
 
 
 class S3Store(BaseStore):

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -1,0 +1,513 @@
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
+from urllib.parse import quote
+
+from botocore.exceptions import ClientError
+from moto.s3.models import FakeBucket, FakeKey
+
+from localstack.aws.api import RequestContext
+from localstack.aws.api.events import PutEventsRequestEntry
+from localstack.aws.api.s3 import (
+    Event,
+    EventBridgeConfiguration,
+    EventList,
+    LambdaFunctionArn,
+    LambdaFunctionConfiguration,
+    NotificationConfiguration,
+    NotificationConfigurationFilter,
+    NotificationId,
+    QueueArn,
+    QueueConfiguration,
+    TopicArn,
+    TopicConfiguration,
+)
+from localstack.config import DEFAULT_REGION
+from localstack.services.s3.models import get_moto_s3_backend
+from localstack.services.s3.utils import (
+    _create_invalid_argument_exc,
+    get_bucket_from_moto,
+    get_key_from_moto_bucket,
+)
+from localstack.utils.aws import aws_stack
+from localstack.utils.aws.aws_stack import ArnData, parse_arn
+from localstack.utils.strings import short_uid
+from localstack.utils.time import timestamp_millis
+
+LOG = logging.getLogger(__name__)
+
+EVENT_OPERATION_MAP = {
+    "PutObject": Event.s3_ObjectCreated_Put,
+    "CopyObject": Event.s3_ObjectCreated_Copy,
+    "CompleteMultipartUpload": Event.s3_ObjectCreated_CompleteMultipartUpload,
+    "PutObjectTagging": Event.s3_ObjectTagging_Put,
+    "DeleteObjectTagging": Event.s3_ObjectTagging_Delete,
+    "DeleteObject": Event.s3_ObjectRemoved_Delete,
+}
+
+HEADER_AMZN_XRAY = "X-Amzn-Trace-Id"
+
+
+class S3NotificationContent(TypedDict):
+    s3SchemaVersion: str
+    configurationId: NotificationId
+    bucket: Dict[str, str]  # todo
+    object: Dict[str, Union[str, int]]  # todo
+
+
+class EventRecord(TypedDict):
+    eventVersion: str
+    eventSource: str
+    awsRegion: str
+    eventTime: str
+    eventName: str
+    userIdentity: Dict[str, str]
+    requestParameters: Dict[str, str]
+    responseElements: Dict[str, str]
+    s3: S3NotificationContent
+
+
+class Notification(TypedDict):
+    Records: List[EventRecord]
+
+
+class S3EventNotificationContext:
+    def __init__(self, context: RequestContext):
+        self.event_type = EVENT_OPERATION_MAP.get(context.operation.wire_name, "")
+        self.region = context.region
+        self.bucket_name = context.service_request["Bucket"]
+        self.key_name = context.service_request["Key"]
+        self.xray = context.request.headers.get(HEADER_AMZN_XRAY)
+
+        moto_backend = get_moto_s3_backend(context)
+        bucket: FakeBucket = get_bucket_from_moto(moto_backend, bucket=self.bucket_name)
+        key: FakeKey = get_key_from_moto_bucket(moto_bucket=bucket, key=self.key_name)
+        self.bucket_location = bucket.location
+        self.key_size = key.contentsize
+        self.key_etag = key.etag.strip('"')
+        self.key_name = quote(key.name)
+        self.key_version_id = key.version_id if bucket.is_versioned else None  # todo: check this?
+
+
+def _matching_event(events: EventList, event_name: str) -> bool:
+    """
+    See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html
+    Checks if the event is part of the NotificationConfiguration, and returns if the event should be notified for
+    this configuration
+    :param events: the list of events of the NotificationConfiguration
+    :param event_name: the event type, like s3:ObjectCreated:* or s3:ObjectRemoved:Delete
+    :return: boolean indicating if the event should be sent to the notifiers
+    """
+    if event_name in events:
+        return True
+    wildcard_pattern = f"{event_name[0:event_name.rindex(':')]}:*"
+    return wildcard_pattern in events
+
+
+def _matching_filter(
+    notification_filter: Optional[NotificationConfigurationFilter], key_name: str
+) -> bool:
+    """
+    See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-filtering.html
+    S3 allows filtering notification events with rules about the key name.
+    If the key does not have a filter rule, or if it matches the rule, then returns that the event should be sent
+    :param notification_filter: the Filter structure from NotificationConfiguration
+    :param key_name: the key name of the key concerned by the event
+    :return: boolean indicating if the key name matches the rules and the event should be sent
+    """
+    # TODO: implement wildcard filtering
+    if not notification_filter or not notification_filter.get("Key", {}).get("FilterRules"):
+        return True
+    filter_rules = notification_filter.get("Key").get("FilterRules")
+    for rule in filter_rules:
+        name = rule.get("Name", "").lower()
+        value = rule.get("Value", "")
+        if name == "prefix" and not key_name.startswith(value):
+            return False
+        elif name == "suffix" and not key_name.endswith(value):
+            return False
+
+    return True
+
+
+class BaseNotifier:
+    service_name = None
+
+    def notify(self, ctx: S3EventNotificationContext, config: Dict):
+        raise NotImplementedError
+
+    @staticmethod
+    def should_notify(ctx: S3EventNotificationContext, config: Dict) -> bool:
+        """
+        Helper method checking if the event should be notified to the configured notifiers from the configuration
+        :param ctx: S3EventNotificationContext
+        :param config: the notification config
+        :return: if the notifier should send the event or not
+        """
+        return _matching_event(config["Events"], ctx.event_type) and _matching_filter(
+            config.get("Filter"), ctx.key_name
+        )
+
+    @staticmethod
+    def _get_arn_value_and_name(notifier_configuration: Dict) -> Tuple[str, str]:
+        raise NotImplementedError
+
+    def validate_configuration_for_notifier(
+        self, configurations: List[Dict], skip_destination_validation=False
+    ):
+        for configuration in configurations:
+            self._validate_notification(configuration, skip_destination_validation)
+
+    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+        raise NotImplementedError
+
+    def _validate_notification(self, configuration: Dict, skip_destination_validation=False):
+        """
+        Validates the notification configuration
+        - setting default ID if not provided
+        - validate the arn pattern
+        - validating the Rule names (and normalizing to capitalized)
+        - check if the filter value is not empty
+        :param configuration: a configuration for a notifier, like QueueConfiguration for SQS or
+        TopicConfiguration for SNS
+        :param skip_destination_validation: allow skipping the validation of the target
+        :raises InvalidArgument if the rule is not valid, infos in ArgumentName and ArgumentValue members
+        :return:
+        """
+
+        # id's can be set the request, but need to be auto-generated if they are not provided
+        if not configuration.get("Id"):
+            configuration["Id"] = short_uid()
+
+        arn, argument_name = self._get_arn_value_and_name(configuration)
+
+        if not arn.startswith(f"arn:aws:{self.service_name}:"):
+            raise _create_invalid_argument_exc(
+                "The ARN is not well formed", name=argument_name, value=arn
+            )
+        if not skip_destination_validation:
+            arn_data = parse_arn(arn)
+            self._verify_target_exists(arn, arn_data)
+
+        if filter_rules := configuration.get("Filter", {}).get("Key", {}).get("FilterRules"):
+            for rule in filter_rules:
+                rule["Name"] = rule["Name"].capitalize()
+                if not rule["Name"] in ["Suffix", "Prefix"]:
+                    raise _create_invalid_argument_exc(
+                        "filter rule name must be either prefix or suffix",
+                        rule["Name"],
+                        rule["Value"],
+                    )
+                if not rule["Value"]:
+                    raise _create_invalid_argument_exc(
+                        "filter value cannot be empty", rule["Name"], rule["Value"]
+                    )
+
+    @staticmethod
+    def _get_event_payload(
+        ctx: S3EventNotificationContext, config_id: NotificationId
+    ) -> Notification:
+        # Based on: http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
+        # TODO: think about caching or generating the payload only once, because only the config_id changes
+        #  except if it is EventBridge. Check that.
+        record = EventRecord(
+            eventVersion="2.1",
+            eventSource="aws:s3",
+            awsRegion=ctx.region,
+            eventTime=timestamp_millis(),
+            eventName=ctx.event_type.removeprefix("s3:"),
+            userIdentity={"principalId": "AIDAJDPLRKLG7UEXAMPLE"},
+            requestParameters={
+                "sourceIPAddress": "127.0.0.1"
+            },  # TODO sourceIPAddress was previously extracted from headers ("X-Forwarded-For")
+            responseElements={
+                "x-amz-request-id": short_uid(),
+                # todo this one is tricky, as it's generated by the response serializer...
+                "x-amz-id-2": "eftixk72aD6Ap51TnqcoF8eFidJG9Z/2",  # Amazon S3 host that processed the request
+            },
+            s3=S3NotificationContent(
+                s3SchemaVersion="1.0",
+                configurationId=config_id,
+                bucket={
+                    "name": ctx.bucket_name,
+                    "ownerIdentity": {"principalId": "A3NL1KOZZKExample"},
+                    "arn": f"arn:aws:s3:::{ctx.bucket_name}",
+                },
+                object={
+                    "key": ctx.key_name,
+                    "sequencer": "0055AED6DCD90281E5",
+                },
+            ),
+        )
+
+        if ctx.key_version_id:
+            # object version if bucket is versioning-enabled, otherwise null
+            record["s3"]["object"]["versionId"] = ctx.key_version_id
+        if "created" in ctx.event_type.lower():
+            record["s3"]["object"]["size"] = ctx.key_size
+            record["s3"]["object"]["eTag"] = ctx.key_etag
+        if "ObjectTagging" in ctx.event_type:
+            record["eventVersion"] = "2.3"
+            record["s3"]["object"]["eTag"] = ctx.key_etag
+            record["s3"]["object"].pop("sequencer")
+        return {"Records": [record]}
+
+
+class SqsNotifier(BaseNotifier):
+    service_name = "sqs"
+
+    @staticmethod
+    def _get_arn_value_and_name(queue_configuration: QueueConfiguration) -> Tuple[QueueArn, str]:
+        return queue_configuration.get("QueueArn", ""), "QueueArn"
+
+    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+        client = aws_stack.connect_to_service(self.service_name, region_name=arn_data["region"])
+        try:
+            client.get_queue_url(
+                QueueName=arn_data["resource"], QueueOwnerAWSAccountId=arn_data["account"]
+            )
+        except ClientError:
+            raise _create_invalid_argument_exc(
+                "Unable to validate the following destination configurations",
+                name=arn,
+                value="The destination queue does not exist",
+            )
+
+    def notify(self, ctx: S3EventNotificationContext, config: QueueConfiguration):
+        event_payload = self._get_event_payload(ctx, config.get("Id"))
+        message = json.dumps(event_payload)
+        queue_arn = config["QueueArn"]
+
+        parsed_arn = parse_arn(queue_arn)
+        sqs_client = aws_stack.connect_to_service("sqs", region_name=parsed_arn["region"])
+        try:
+            queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
+            system_attributes = {}
+            if ctx.xray:
+                system_attributes["AWSTraceHeader"] = {
+                    "DataType": "String",
+                    "StringValue": ctx.xray,
+                }
+            sqs_client.send_message(
+                QueueUrl=queue_url,
+                MessageBody=message,
+                MessageSystemAttributes=system_attributes,
+            )
+        except Exception:
+            LOG.exception(
+                'Unable to send notification for S3 bucket "%s" to SQS queue "%s"',
+                ctx.bucket_name,
+                parsed_arn["resource"],
+            )
+
+
+class SnsNotifier(BaseNotifier):
+    service_name = "sns"
+
+    @staticmethod
+    def _get_arn_value_and_name(topic_configuration: TopicConfiguration) -> [TopicArn, str]:
+        return topic_configuration.get("TopicArn", ""), "TopicArn"
+
+    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+        client = aws_stack.connect_to_service(self.service_name, region_name=arn_data["region"])
+        try:
+            client.get_topic_attributes(TopicArn=arn)
+        except ClientError:
+            raise _create_invalid_argument_exc(
+                "Unable to validate the following destination configurations",
+                name=arn,
+                value="The destination topic does not exist",
+            )
+
+    def notify(self, ctx: S3EventNotificationContext, config: TopicConfiguration):
+        LOG.debug(
+            "Task received by a worker for notification to %s for bucket %s, key %s, action %s",
+            self.service_name,
+            ctx.bucket_name,
+            ctx.key_name,
+            ctx.event_type,
+        )
+        event_payload = self._get_event_payload(ctx, config.get("Id"))
+        message = json.dumps(event_payload)
+        topic_arn = config["TopicArn"]
+
+        region_name = aws_stack.extract_region_from_arn(topic_arn)
+        sns_client = aws_stack.connect_to_service("sns", region_name=region_name)
+        try:
+            sns_client.publish(
+                TopicArn=topic_arn,
+                Message=message,
+                Subject="Amazon S3 Notification",
+            )
+        except Exception:
+            LOG.exception(
+                'Unable to send notification for S3 bucket "%s" to SNS topic "%s"',
+                ctx.bucket_name,
+                topic_arn,
+            )
+
+
+class LambdaNotifier(BaseNotifier):
+    service_name = "lambda"
+
+    @staticmethod
+    def _get_arn_value_and_name(
+        lambda_configuration: LambdaFunctionConfiguration,
+    ) -> Tuple[LambdaFunctionArn, str]:
+        return lambda_configuration.get("LambdaFunctionArn", ""), "LambdaFunctionArn"
+
+    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+        client = aws_stack.connect_to_service(self.service_name, region_name=arn_data["region"])
+        try:
+            client.get_function(FunctionName=arn_data["resource"])
+        except ClientError:
+            raise _create_invalid_argument_exc(
+                "Unable to validate the following destination configurations",
+                name=arn,
+                value="The destination Lambda does not exist",
+            )
+
+    def notify(self, ctx: S3EventNotificationContext, config: LambdaFunctionConfiguration):
+        event_payload = self._get_event_payload(ctx, config.get("Id"))
+        payload = json.dumps(event_payload)
+        lambda_arn = config["LambdaFunctionArn"]
+
+        region_name = aws_stack.extract_region_from_arn(lambda_arn)
+        lambda_client = aws_stack.connect_to_service("lambda", region_name=region_name)
+        lambda_function_config = aws_stack.lambda_function_name(lambda_arn)
+        try:
+            lambda_client.invoke(
+                FunctionName=lambda_function_config,
+                InvocationType="Event",
+                Payload=payload,
+            )
+        except Exception:
+            LOG.exception(
+                'Unable to send notification for S3 bucket "%s" to Lambda function "%s".',
+                ctx.bucket_name,
+                lambda_function_config,
+            )
+
+
+class EventBridgeNotifier(BaseNotifier):
+    @staticmethod
+    def _get_event_payload(
+        ctx: S3EventNotificationContext, config_id: NotificationId = None
+    ) -> PutEventsRequestEntry:
+        # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html
+        # see also https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
+        entry: PutEventsRequestEntry = {
+            "Source": "aws.s3",
+            "Resources": [f"arn:aws:s3:::{ctx.bucket_name}"],
+        }
+
+        if ctx.xray:
+            entry["TraceHeader"] = ctx.xray
+
+        event_details = {
+            "version": "0",
+            "bucket": {"name": ctx.bucket_name},
+            "object": {
+                "key": ctx.key_name,
+                "size": ctx.key_size,
+                "etag": ctx.key_etag,
+                "sequencer": "0062E99A88DC407460",
+            },
+            "request-id": "RKREYG1RN2X92YX6",
+            "requester": "074255357339",
+            "source-ip-address": "127.0.0.1",
+            # TODO previously headers.get("X-Forwarded-For", "127.0.0.1").split(",")[0]
+        }
+
+        if "ObjectCreated" in ctx.event_type:
+            entry["DetailType"] = "Object Created"
+            event_type = ctx.event_type
+            event_action = event_type[event_type.rindex(":") + 1 :]
+            if event_action in ["Put", "Post", "Copy"]:
+                event_type = f"{event_action}Object"
+            # TODO: what about CompleteMultiformUpload??
+            event_details["reason"] = event_type
+
+        elif "ObjectRemoved" in ctx.event_type:
+            entry["DetailType"] = "Object Deleted"
+            event_details["reason"] = "DeleteObject"
+            event_details[
+                "deletion-type"
+            ] = "Permanently Deleted"  # TODO: check with versioned bucket?
+            event_details["object"].pop("etag")
+            event_details["object"].pop("size")
+
+        elif "ObjectTagging" in ctx.event_type:
+            entry["DetailType"] = (
+                "Object Tags Added" if "Put" in ctx.event_type else "Object Tags Deleted"
+            )
+
+        entry["Detail"] = json.dumps(event_details)
+        return entry
+
+    @staticmethod
+    def should_notify(ctx: S3EventNotificationContext, config: Dict) -> bool:
+        # Events are always passed to EventBridge, you can route the event in EventBridge
+        # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html
+        return True
+
+    def validate_configuration_for_notifier(
+        self, configurations: List[Dict], skip_destination_validation=False
+    ):
+        # There are no configuration for EventBridge, simply passing an empty dict will enable notifications
+        return
+
+    def _verify_target_exists(self, arn: str, arn_data: ArnData) -> None:
+        # There are no target for EventBridge
+        return
+
+    def notify(self, ctx: S3EventNotificationContext, config: EventBridgeConfiguration):
+        region = ctx.bucket_location or DEFAULT_REGION
+        events_client = aws_stack.connect_to_service("events", region_name=region)
+        entry = self._get_event_payload(ctx)
+        try:
+            events_client.put_events(Entries=[entry])
+        except Exception:
+            LOG.exception(
+                'Unable to send notification for S3 bucket "%s" to EventBridge', ctx.bucket_name
+            )
+
+
+class NotificationDispatcher:
+    notifiers = {
+        "QueueConfigurations": SqsNotifier(),
+        "TopicConfigurations": SnsNotifier(),
+        "LambdaFunctionConfigurations": LambdaNotifier(),
+        "EventBridgeConfiguration": EventBridgeNotifier(),
+    }
+
+    def __init__(self, num_thread: int = 3):
+        self.executor = ThreadPoolExecutor(num_thread, thread_name_prefix="s3_ev")
+
+    def shutdown(self):
+        self.executor.shutdown(wait=False)
+
+    def send_notifications(
+        self, ctx: S3EventNotificationContext, notification_config: NotificationConfiguration
+    ):
+        for configuration_key, configurations in notification_config.items():
+            notifier = self.notifiers[configuration_key]
+            # there is not really a configuration for EventBridge, it is an empty dict
+            configurations = (
+                configurations if isinstance(configurations, list) else [configurations]
+            )
+            for config in configurations:
+                if notifier.should_notify(ctx, config):  # we check before sending it to the thread
+                    LOG.debug("Submitting task to the executor for notifier %s", notifier)
+                    self.executor.submit(notifier.notify, ctx, config)
+
+    def verify_configuration(
+        self,
+        notification_configurations: NotificationConfiguration,
+        skip_destination_validation=False,
+    ):
+        for notifier_type, notification_configuration in notification_configurations.items():
+            self.notifiers[notifier_type].validate_configuration_for_notifier(
+                notification_configuration, skip_destination_validation
+            )

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -129,7 +129,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # we can provide the s3_event_notification_context, so in case of deletion of keys, we can create it before
         # it happens
         if not s3_notif_ctx:
-            s3_notif_ctx = S3EventNotificationContext(context)
+            s3_notif_ctx = S3EventNotificationContext.from_request_context(context)
         if notification_config := self.get_store().bucket_notification_configs.get(
             s3_notif_ctx.bucket_name
         ):
@@ -308,7 +308,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             return call_moto(context)
 
         # create the notification context before deleting the object, to be able to retrieve its properties
-        s3_notification_ctx = S3EventNotificationContext(context)
+        s3_notification_ctx = S3EventNotificationContext.from_request_context(context)
 
         response: DeleteObjectOutput = call_moto(context)
         self._notify(context, s3_notification_ctx)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1,17 +1,10 @@
 import copy
-import json
 import logging
 import os
-from typing import List, Optional, Union
 from urllib.parse import SplitResult, quote, urlsplit, urlunsplit
 
-import moto.s3.models as moto_s3_models
 import moto.s3.responses as moto_s3_responses
-from botocore.config import Config as BotoConfig
-from moto.s3 import s3_backends as moto_s3_backends
-from moto.s3.exceptions import MissingBucket
 
-from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.s3 import (
@@ -28,8 +21,6 @@ from localstack.aws.api.s3 import (
     DeleteObjectRequest,
     DeleteObjectTaggingOutput,
     DeleteObjectTaggingRequest,
-    Event,
-    EventList,
     GetBucketAclOutput,
     GetBucketLifecycleConfigurationOutput,
     GetBucketLifecycleOutput,
@@ -40,18 +31,14 @@ from localstack.aws.api.s3 import (
     GetObjectRequest,
     HeadObjectOutput,
     HeadObjectRequest,
-    InvalidArgument,
     InvalidBucketName,
-    LambdaFunctionConfiguration,
     ListObjectsOutput,
     ListObjectsRequest,
     ListObjectsV2Output,
     ListObjectsV2Request,
-    NoSuchBucket,
     NoSuchKey,
     NoSuchLifecycleConfiguration,
     NotificationConfiguration,
-    NotificationConfigurationFilter,
     ObjectKey,
     PutBucketAclRequest,
     PutBucketLifecycleConfigurationRequest,
@@ -62,10 +49,8 @@ from localstack.aws.api.s3 import (
     PutObjectRequest,
     PutObjectTaggingOutput,
     PutObjectTaggingRequest,
-    QueueConfiguration,
     S3Api,
     SkipValidation,
-    TopicConfiguration,
 )
 from localstack.aws.api.s3 import Type as GranteeType
 from localstack.config import get_edge_port_http, get_protocol
@@ -75,12 +60,16 @@ from localstack.http.proxy import forward
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.services.s3.models import S3Store, s3_stores
+from localstack.services.s3.models import S3Store, get_moto_s3_backend, s3_stores
+from localstack.services.s3.notifications import NotificationDispatcher, S3EventNotificationContext
 from localstack.services.s3.utils import (
     ALLOWED_HEADER_OVERRIDES,
     VALID_ACL_PREDEFINED_GROUPS,
     VALID_GRANTEE_PERMISSIONS,
+    _create_invalid_argument_exc,
+    get_bucket_from_moto,
     get_header_name,
+    get_key_from_moto_bucket,
     is_bucket_name_valid,
     is_canned_acl_valid,
     is_key_expired,
@@ -91,8 +80,6 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.aws.request_context import AWS_REGION_REGEX
 from localstack.utils.objects import singleton_factory
 from localstack.utils.patch import patch
-from localstack.utils.strings import short_uid
-from localstack.utils.time import timestamp_millis
 
 LOG = logging.getLogger(__name__)
 
@@ -101,10 +88,6 @@ os.environ[
 ] = "s3.localhost.localstack.cloud:4566,s3.localhost.localstack.cloud"
 
 MOTO_CANONICAL_USER_ID = "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a"
-
-HEADER_AMZN_XRAY = "X-Amzn-Trace-Id"
-
-NOTIFICATION_FIELDS = {"TopicArn": "sns", "QueueArn": "sqs", "LambdaFunctionArn": "lambda"}
 
 
 class MalformedXML(CommonServiceException):
@@ -117,18 +100,8 @@ class MalformedACLError(CommonServiceException):
         super().__init__("MalformedACLError", status_code=400, message=message)
 
 
-def get_moto_s3_backend(context: RequestContext) -> moto_s3_models.S3Backend:
-    return moto_s3_backends[context.account_id]["global"]
-
-
 def get_full_default_bucket_location(bucket_name):
     return f"{get_protocol()}://{bucket_name}.s3.{LOCALHOST_HOSTNAME}:{get_edge_port_http()}/"
-
-
-class InvalidArgumentError(CommonServiceException):
-    def __init__(self, message: str, name: str, value: str):
-        super().__init__("InvalidArgument", message, 400, False)
-        # TODO how to set values?
 
 
 class S3Provider(S3Api, ServiceLifecycleHook):
@@ -144,6 +117,32 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def on_after_init(self):
         apply_moto_patches()
         self.add_custom_routes()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._notification_dispatcher = NotificationDispatcher()
+
+    def on_before_stop(self):
+        self._notification_dispatcher.shutdown()
+
+    def _notify(self, context: RequestContext, s3_notif_ctx: S3EventNotificationContext = None):
+        # we can provide the s3_event_notification_context, so in case of deletion of keys, we can create it before
+        # it happens
+        if not s3_notif_ctx:
+            s3_notif_ctx = S3EventNotificationContext(context)
+        if notification_config := self.get_store().bucket_notification_configs.get(
+            s3_notif_ctx.bucket_name
+        ):
+            self._notification_dispatcher.send_notifications(s3_notif_ctx, notification_config)
+
+    def _verify_notification_configuration(
+        self,
+        notification_configuration: NotificationConfiguration,
+        skip_destination_validation: SkipValidation,
+    ):
+        self._notification_dispatcher.verify_configuration(
+            notification_configuration, skip_destination_validation
+        )
 
     @handler("CreateBucket", expand=False)
     def create_bucket(
@@ -284,12 +283,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             metadata = {k: v for k, v in key_object.metadata.items() if k != "expires"}
             key_object.set_metadata(metadata, replace=True)
 
-        self.send_bucket_notifications(
-            context,
-            request.get("Bucket"),
-            request.get("Key"),
-            event=Event.s3_ObjectCreated_Put,
-        )
+        self._notify(context)
+
         return response
 
     @handler("CopyObject", expand=False)
@@ -299,12 +294,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         request: CopyObjectRequest,
     ) -> CopyObjectOutput:
         response: CopyObjectOutput = call_moto(context)
-        self.send_bucket_notifications(
-            context,
-            request.get("Bucket"),
-            request.get("Key"),
-            event=Event.s3_ObjectCreated_Copy,
-        )
+        self._notify(context)
         return response
 
     @handler("DeleteObject", expand=False)
@@ -313,35 +303,24 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: DeleteObjectRequest,
     ) -> DeleteObjectOutput:
-        # we need to make copies as the bucket and key will get deleted if the request was successful
-        bucket = copy.deepcopy(
-            get_bucket_from_moto(get_moto_s3_backend(context), bucket=request.get("Bucket"))
-        )
-        key = copy.deepcopy(bucket.keys.get(request.get("Key")))
+
+        if request["Bucket"] not in self.get_store().bucket_notification_configs:
+            return call_moto(context)
+
+        # create the notification context before deleting the object, to be able to retrieve its properties
+        s3_notification_ctx = S3EventNotificationContext(context)
 
         response: DeleteObjectOutput = call_moto(context)
-        bucket_notifications = self.get_store().bucket_notification_configs.get(bucket.name)
-        if bucket_notifications:
-            _send_event_message(
-                event_name=Event.s3_ObjectRemoved_Delete,
-                bucket=bucket,
-                key=key,
-                notifications=bucket_notifications,
-                xray=context.request.headers.get(HEADER_AMZN_XRAY),
-            )
+        self._notify(context, s3_notification_ctx)
+
         return response
 
     @handler("CompleteMultipartUpload", expand=False)
     def complete_multipart_upload(
         self, context: RequestContext, request: CompleteMultipartUploadRequest
     ) -> CompleteMultipartUploadOutput:
-        response: CopyObjectOutput = call_moto(context)
-        self.send_bucket_notifications(
-            context,
-            request.get("Bucket"),
-            request.get("Key"),
-            event=Event.s3_ObjectCreated_CompleteMultipartUpload,
-        )
+        response: CompleteMultipartUploadOutput = call_moto(context)
+        self._notify(context)
         return response
 
     @handler("PutObjectTagging", expand=False)
@@ -349,12 +328,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, request: PutObjectTaggingRequest
     ) -> PutObjectTaggingOutput:
         response: PutObjectTaggingOutput = call_moto(context)
-        self.send_bucket_notifications(
-            context,
-            request.get("Bucket"),
-            request.get("Key"),
-            event=Event.s3_ObjectTagging_Put,
-        )
+        self._notify(context)
         return response
 
     @handler("DeleteObjectTagging", expand=False)
@@ -362,12 +336,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, request: DeleteObjectTaggingRequest
     ) -> DeleteObjectTaggingOutput:
         response: DeleteObjectTaggingOutput = call_moto(context)
-        self.send_bucket_notifications(
-            context,
-            request.get("Bucket"),
-            request.get("Key"),
-            event=Event.s3_ObjectTagging_Delete,
-        )
+        self._notify(context)
         return response
 
     @handler("PutBucketRequestPayment", expand=False)
@@ -525,16 +494,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         # check if the bucket exists
         get_bucket_from_moto(get_moto_s3_backend(context), bucket=bucket)
-
-        for topic in notification_configuration.get("TopicConfigurations", {}):
-            self._verify_notification(topic, skip_destination_validation)
-
-        for queue in notification_configuration.get("QueueConfigurations", {}):
-            self._verify_notification(queue, skip_destination_validation)
-
-        for cloudfun in notification_configuration.get("LambdaFunctionConfigurations", {}):
-            self._verify_notification(cloudfun, skip_destination_validation)
-
+        self._verify_notification_configuration(
+            notification_configuration, skip_destination_validation
+        )
         self.get_store().bucket_notification_configs[bucket] = notification_configuration
 
     def get_bucket_notification_configuration(
@@ -544,105 +506,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # check if the bucket exists
         get_bucket_from_moto(get_moto_s3_backend(context), bucket=bucket)
         return self.get_store().bucket_notification_configs.get(bucket, NotificationConfiguration())
-
-    def send_bucket_notifications(
-        self,
-        context: RequestContext,
-        bucket_name: str,
-        key_name: str,
-        event: str,
-    ):
-        if self.get_store().bucket_notification_configs.get(bucket_name):
-            bucket = get_moto_s3_backend(context).get_bucket(bucket_name)
-            key = bucket.keys.get(key_name)
-
-            _send_event_message(
-                event_name=event,
-                bucket=bucket,
-                key=key,
-                notifications=self.get_store().bucket_notification_configs.get(bucket_name),
-                xray=context.request.headers.get(HEADER_AMZN_XRAY),
-            )
-
-    def _verify_notification(self, notification, skip_destination_validation=False):
-        """Does some verification of notification settings:
-        - validating the Rule names (and normalizing to capitalized),
-        - setting default ID if not provided,
-        - check if the filter value is not empty
-        - validate the arn pattern
-        """
-
-        # id's can be set the request, but need to be auto-generated if they are not provided
-        if not notification.get("Id"):
-            notification["Id"] = short_uid()
-
-        # arn pattern is always verified
-        # will contain the notification-key (e.g. TopicArn) and the actual arn
-        tmp = {k: v for k, v in notification.items() if "arn" in k.lower()}
-        (type,) = tmp
-        (arn,) = tmp.values()
-
-        if not arn.startswith(f"arn:aws:{NOTIFICATION_FIELDS.get(type)}:"):
-            # TODO raise InvalidArgument (patch service)
-            raise InvalidArgumentError(
-                "The ARN is not well formed", name=type.capitalize(), value=arn
-            )
-        if not skip_destination_validation:
-            self._verify_target_exists(NOTIFICATION_FIELDS.get(type), arn)
-
-        if filter_rules := notification.get("Filter", {}).get("Key", {}).get("FilterRules"):
-            for rule in filter_rules:
-                rule["Name"] = rule["Name"].capitalize()
-                if not rule["Name"] in ["Suffix", "Prefix"]:
-                    # TODO replace with patched InvalidArgument exception (patch service)
-                    raise InvalidArgumentError(
-                        "filter rule name must be either prefix or suffix",
-                        rule["Name"],
-                        rule["Value"],
-                    )
-                if not rule["Value"]:
-                    raise InvalidArgumentError(
-                        "filter value cannot be empty", rule["Name"], rule["Value"]
-                    )
-
-    def _verify_target_exists(self, type: str, arn: str):
-        """verifies if the notification target exists, by trying to access the resource"""
-        region_name = aws_stack.extract_region_from_arn(arn)
-        client = aws_stack.connect_to_service(type, region_name=region_name)
-        account_id = aws_stack.extract_account_id_from_arn(arn)
-
-        # TODO raise InvalidArgument error here (patch service)
-        #      it somehow adds numbers here, e.g. ArgumentValue1, ArgumentName1
-
-        if type == "sqs":
-            try:
-                queue_name = arn.split(":")[-1]
-                client.get_queue_url(QueueName=queue_name, QueueOwnerAWSAccountId=account_id)
-            except Exception:  # noqa
-                raise InvalidArgumentError(
-                    "Unable to validate the following destination configurations",
-                    name=arn,
-                    value="The destination queue does not exist",
-                )
-        elif type == "lambda":
-            try:
-                function_name = aws_stack.lambda_function_name(arn)
-                client.get_function(FunctionName=function_name)
-            except Exception:  # noqua
-                raise InvalidArgumentError(
-                    "Unable to validate the following destination configurations",
-                    name=arn,
-                    value="The destination Lambda does not exist",
-                )
-        elif type == "sns":
-            try:
-                client.get_topic_attributes(TopicArn=arn)
-            except Exception:  # noqua
-                raise InvalidArgumentError(
-                    "Unable to validate the following destination configurations",
-                    name=arn,
-                    value="The destination topic does not exist",
-                )
 
     def add_custom_routes(self):
         # virtual-host style: https://bucket-name.s3.region-code.amazonaws.com/key-name
@@ -731,15 +594,6 @@ def validate_bucket_name(bucket: BucketName) -> None:
         raise ex
 
 
-def _create_invalid_argument_exc(
-    message: Union[str, None], name: str, value: str
-) -> InvalidArgument:
-    ex = InvalidArgument(message)
-    ex.ArgumentName = name
-    ex.ArgumentValue = value
-    return ex
-
-
 def validate_canned_acl(canned_acl: str) -> None:
     """
     Validate the canned ACL value, or raise an Exception
@@ -814,314 +668,11 @@ def validate_acl_acp(acp: AccessControlPolicy) -> None:
             raise ex
 
 
-def get_bucket_from_moto(
-    moto_backend: moto_s3_models.S3Backend, bucket: BucketName
-) -> moto_s3_models.FakeBucket:
-    # TODO: check authorization for buckets as well?
-    try:
-        return moto_backend.get_bucket(bucket_name=bucket)
-    except MissingBucket:
-        ex = NoSuchBucket("The specified bucket does not exist")
-        ex.BucketName = bucket
-        raise ex
-
-
-def get_key_from_moto_bucket(
-    moto_bucket: moto_s3_models.FakeBucket, key: ObjectKey
-) -> moto_s3_models.FakeKey:
-    fake_key = moto_bucket.keys.get(key)
-    if not fake_key:
-        ex = NoSuchKey("The specified key does not exist.")
-        ex.Key = key
-        raise ex
-
-    return fake_key
-
-
 def is_object_expired(context: RequestContext, bucket: BucketName, key: ObjectKey) -> bool:
     moto_backend = get_moto_s3_backend(context)
     moto_bucket = get_bucket_from_moto(moto_backend, bucket)
     key_object = get_key_from_moto_bucket(moto_bucket, key)
     return is_key_expired(key_object=key_object)
-
-
-def normalize_bucket_name(bucket_name):
-    bucket_name = bucket_name or ""
-    bucket_name = bucket_name.lower()
-    return bucket_name
-
-
-def _send_event_message_to_topic(
-    notification: TopicConfiguration,
-    event_name: str,
-    bucket: moto_s3_models.FakeBucket,
-    key: moto_s3_models.FakeKey,
-    xray: str = None,
-):
-    event_body = _get_event_message(
-        event_name=event_name[3:],
-        bucket_name=bucket.name,
-        config_id=notification.get("Id"),
-        key_name=key.name,
-        key_etag=key.etag,
-        key_size=key.contentsize,
-        version_id=key.version_id if bucket.is_versioned else None,
-    )
-    message = json.dumps(event_body)
-    topic_arn = notification["TopicArn"]
-
-    region_name = aws_stack.extract_region_from_arn(topic_arn)
-    sns_client = aws_stack.connect_to_service("sns", region_name=region_name)
-    try:
-        sns_client.publish(
-            TopicArn=topic_arn,
-            Message=message,
-            Subject="Amazon S3 Notification",
-        )
-    except Exception as e:
-        LOG.warning(
-            f'Unable to send notification for S3 bucket "{bucket.name}" to SNS topic "{topic_arn}": {e}'
-        )
-
-
-def _send_event_message_to_lambda(
-    notification: LambdaFunctionConfiguration,
-    event_name: str,
-    bucket: moto_s3_models.FakeBucket,
-    key: moto_s3_models.FakeKey,
-    xray: str = None,
-):
-    event_body = _get_event_message(
-        event_name=event_name[3:],
-        bucket_name=bucket.name,
-        config_id=notification.get("Id"),
-        key_name=key.name,
-        key_etag=key.etag,
-        key_size=key.contentsize,
-        version_id=key.version_id if bucket.is_versioned else None,
-    )
-    message = json.dumps(event_body)
-    lambda_arn = notification["LambdaFunctionArn"]
-
-    region_name = aws_stack.extract_region_from_arn(lambda_arn)
-    # make sure we don't run into a socket timeout
-    connection_config = BotoConfig(read_timeout=300)
-    lambda_client = aws_stack.connect_to_service(
-        "lambda", config=connection_config, region_name=region_name
-    )
-    lambda_function_config = aws_stack.lambda_function_name(lambda_arn)
-    try:
-        lambda_client.invoke(
-            FunctionName=lambda_function_config,
-            InvocationType="Event",
-            Payload=message,
-        )
-    except Exception:
-        LOG.warning(
-            f'Unable to send notification for S3 bucket "{bucket.name}" to Lambda function "{lambda_function_config}".'
-        )
-
-
-def _send_event_message_to_queue(
-    notification: QueueConfiguration,
-    event_name: str,
-    bucket: moto_s3_models.FakeBucket,
-    key: moto_s3_models.FakeKey,
-    xray: str = None,
-):
-    event_body = _get_event_message(
-        event_name=event_name[3:],
-        bucket_name=bucket.name,
-        config_id=notification.get("Id"),
-        key_name=key.name,
-        key_etag=key.etag,
-        key_size=key.contentsize,
-        version_id=key.version_id if bucket.is_versioned else None,
-    )
-    message = json.dumps(event_body)
-    queue_arn = notification["QueueArn"]
-
-    region_name = aws_stack.extract_region_from_arn(queue_arn)
-    queue_name = queue_arn.split(":")[-1]
-    sqs_client = aws_stack.connect_to_service("sqs", region_name=region_name)
-    try:
-        queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
-        system_attributes = {}
-        if xray:
-            system_attributes["AWSTraceHeader"] = {
-                "DataType": "String",
-                "StringValue": xray,
-            }
-        sqs_client.send_message(
-            QueueUrl=queue_url,
-            MessageBody=message,
-            MessageSystemAttributes=system_attributes,
-        )
-    except Exception as e:
-        LOG.warning(
-            f'Unable to send notification for S3 bucket "{bucket.name}" to SQS queue "{queue_name}": {e}',
-        )
-
-
-def _matching_event(events: EventList, event_name: str) -> bool:
-    if event_name in events:
-        return True
-    wildcard_pattern = f"{event_name[0:event_name.rindex(':')]}:*"
-    if wildcard_pattern in events:
-        return True
-    return False
-
-
-def _matching_filter(filter: Optional[NotificationConfigurationFilter], key_name: str) -> bool:
-    if not filter or not filter.get("Key", {}).get("FilterRules"):
-        return True
-    filter_rules = filter.get("Key").get("FilterRules")
-    for rule in filter_rules:
-        name = rule.get("Name", "").lower()
-        value = rule.get("Value", "")
-        if name == "prefix" and not key_name.startswith(value):
-            return False
-        if name == "suffix" and not key_name.endswith(value):
-            return False
-
-    return True
-
-
-def _send_event_to_event_bridge(
-    event_name: str,
-    bucket: moto_s3_models.FakeBucket,
-    key: moto_s3_models.FakeKey,
-    xray: str = None,
-):
-    s3api_client = aws_stack.connect_to_service("s3")
-    region = (
-        s3api_client.get_bucket_location(Bucket=bucket.name)["LocationConstraint"]
-        or config.DEFAULT_REGION
-    )
-    events_client = aws_stack.connect_to_service("events", region_name=region)
-    # structure defined here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
-    entry = {
-        "Source": "aws.s3",
-        "Resources": [f"arn:aws:s3:::{bucket.name}"],
-        "Detail": {
-            "version": "0",
-            "bucket": {"name": bucket.name},
-            "object": {
-                "key": key.name,
-                "size": key.size,
-                "etag": key.etag.strip('"'),
-                "sequencer": "0062E99A88DC407460",
-            },
-            "request-id": "RKREYG1RN2X92YX6",
-            "requester": "074255357339",
-            "source-ip-address": "127.0.0.1",  # TODO previously headers.get("X-Forwarded-For", "127.0.0.1").split(",")[0]
-        },
-    }
-    # messages are bit different for EventBridge, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html
-    if "ObjectCreated" in event_name:
-        entry["DetailType"] = "Object Created"
-        event_type = event_name[event_name.rindex(":") + 1 :]
-        if event_type in ["Put", "Post", "Copy"]:
-            event_type = f"{event_type}Object"
-        entry["Detail"]["reason"] = event_type
-
-    if "ObjectRemoved" in event_name:
-        entry["DetailType"] = "Object Deleted"
-        entry["Detail"]["reason"] = "DeleteObject"
-        entry["Detail"]["deletion-type"] = "Permanently Deleted"
-        entry["Detail"]["object"].pop("etag")
-        entry["Detail"]["object"].pop("size")
-
-    if "ObjectTagging" in event_name:
-        entry["DetailType"] = "Object Tags Added" if "Put" in event_name else "Object Tags Deleted"
-
-    entry["Detail"] = json.dumps(entry["Detail"])
-
-    try:
-        events_client.put_events(Entries=[entry])
-    except Exception as e:
-        LOG.exception(f'Unable to send notification for S3 bucket "{bucket}" to EventBridge', e)
-
-
-def _send_event_message(
-    event_name: str,
-    bucket: moto_s3_models.FakeBucket,
-    key: moto_s3_models.FakeKey,
-    notifications: NotificationConfiguration,
-    xray: str = None,
-):
-    for notification in notifications.get("QueueConfigurations", {}):
-        if _matching_event(notification["Events"], event_name) and _matching_filter(
-            notification.get("Filter"), key.name
-        ):
-            _send_event_message_to_queue(notification, event_name, bucket, key, xray)
-
-    for notification in notifications.get("TopicConfigurations", {}):
-        if _matching_event(notification["Events"], event_name) and _matching_filter(
-            notification.get("Filter"), key.name
-        ):
-            _send_event_message_to_topic(notification, event_name, bucket, key, xray)
-
-    for notification in notifications.get("LambdaFunctionConfigurations", {}):
-        if _matching_event(notification["Events"], event_name) and _matching_filter(
-            notification.get("Filter"), key.name
-        ):
-            _send_event_message_to_lambda(notification, event_name, bucket, key, xray)
-
-    if "EventBridgeConfiguration" in notifications:
-        _send_event_to_event_bridge(event_name, bucket, key)
-
-
-def _get_event_message(
-    event_name: str,
-    bucket_name: str,
-    config_id: str,
-    key_name: str,
-    key_size: int,
-    key_etag: str,
-    version_id: str = None,
-) -> List[dict]:
-    # Based on: http://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
-    bucket_name = normalize_bucket_name(bucket_name)
-    content = {
-        "eventVersion": "2.1",
-        "eventSource": "aws:s3",
-        "awsRegion": aws_stack.get_region(),
-        "eventTime": timestamp_millis(),
-        "eventName": event_name,
-        "userIdentity": {"principalId": "AIDAJDPLRKLG7UEXAMPLE"},
-        "requestParameters": {
-            "sourceIPAddress": "127.0.0.1"
-        },  # TODO sourceIPAddress was previously extracted from headers ("X-Forwarded-For")
-        "responseElements": {
-            "x-amz-request-id": short_uid(),
-            "x-amz-id-2": "eftixk72aD6Ap51TnqcoF8eFidJG9Z/2",  # Amazon S3 host that processed the request
-        },
-        "s3": {
-            "s3SchemaVersion": "1.0",
-            "configurationId": config_id,
-            "bucket": {
-                "name": bucket_name,
-                "ownerIdentity": {"principalId": "A3NL1KOZZKExample"},
-                "arn": "arn:aws:s3:::%s" % bucket_name,
-            },
-            "object": {
-                "key": quote(key_name),
-                "sequencer": "0055AED6DCD90281E5",
-            },
-        },
-    }
-    if version_id:
-        # object version if bucket is versioning-enabled, otherwise null
-        content["s3"]["object"]["versionId"] = version_id
-    if "created" in event_name.lower():
-        content["s3"]["object"]["size"] = key_size
-        content["s3"]["object"]["eTag"] = key_etag.strip('"')
-    if "ObjectTagging" in event_name:
-        content["eventVersion"] = "2.3"
-        content["s3"]["object"]["eTag"] = key_etag.strip('"')
-        content["s3"]["object"].pop("sequencer")
-    return {"Records": [content]}
 
 
 @singleton_factory

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -205,7 +205,8 @@ class TransformerUtility:
         """
         :return: array with Transformers, for s3 api.
         """
-        return [
+
+        s3 = [
             TransformerUtility.key_value("Name", value_replacement="bucket-name"),
             TransformerUtility.key_value("BucketName"),
             TransformerUtility.key_value("VersionId"),
@@ -217,7 +218,14 @@ class TransformerUtility:
             TransformerUtility.jsonpath(
                 jsonpath="$..Owner.ID", value_replacement="<owner-id>", reference_replacement=False
             ),
-            # for s3 notifications:
+        ]
+        # for s3 notifications:
+        s3.extend(TransformerUtility.s3_notifications_transformer())
+        return s3
+
+    @staticmethod
+    def s3_notifications_transformer():
+        return [
             TransformerUtility.jsonpath(
                 "$..responseElements.x-amz-id-2", "amz-id", reference_replacement=False
             ),

--- a/tests/integration/s3/test_s3_notifications_eventbridge.py
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 
+from localstack.config import LEGACY_S3_PROVIDER
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
@@ -9,6 +10,9 @@ from localstack.utils.sync import retry
 
 class TestS3NotificationsToEventBridge:
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..detail.object.etag"]
+    )
     def test_object_created_put(
         self,
         s3_client,
@@ -79,19 +83,17 @@ class TestS3NotificationsToEventBridge:
         snapshot.add_transformer(snapshot.transform.s3_api())
         snapshot.add_transformers_list(
             [
-                snapshot.transform.jsonpath(
-                    "$..account", "111111111111", reference_replacement=False
-                ),
                 snapshot.transform.jsonpath("$..detail.bucket.name", "bucket-name"),
                 snapshot.transform.jsonpath("$..detail.object.key", "key-name"),
-                snapshot.transform.jsonpath("$..detail.object.etag", "object-etag"),
                 snapshot.transform.jsonpath(
                     "$..detail.object.sequencer", "object-sequencer", reference_replacement=False
                 ),
                 snapshot.transform.jsonpath(
                     "$..detail.request-id", "request-id", reference_replacement=False
                 ),
-                snapshot.transform.jsonpath("$..detail.requester", "111111111111"),
+                snapshot.transform.jsonpath(
+                    "$..detail.requester", "<requester>", reference_replacement=False
+                ),
                 snapshot.transform.jsonpath("$..detail.source-ip-address", "ip-address"),
             ]
         )

--- a/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put": {
-    "recorded-date": "16-08-2022, 11:38:49",
+    "recorded-date": "20-09-2022, 13:06:06",
     "recorded-content": {
       "object_deleted": {
         "account": "111111111111",
@@ -15,7 +15,7 @@
           },
           "reason": "DeleteObject",
           "request-id": "request-id",
-          "requester": "<111111111111:1>",
+          "requester": "<requester>",
           "source-ip-address": "<ip-address:1>",
           "version": "0"
         },
@@ -36,14 +36,14 @@
             "name": "<bucket-name:1>"
           },
           "object": {
-            "etag": "<object-etag:1>",
+            "etag": "8d777f385d3dfec8815d20f7496026dc",
             "key": "<key-name:1>",
             "sequencer": "object-sequencer",
             "size": 4
           },
           "reason": "PutObject",
           "request-id": "request-id",
-          "requester": "<111111111111:1>",
+          "requester": "<requester>",
           "source-ip-address": "<ip-address:1>",
           "version": "0"
         },

--- a/tests/integration/s3/test_s3_notifications_lambda.py
+++ b/tests/integration/s3/test_s3_notifications_lambda.py
@@ -2,7 +2,10 @@ import json
 import os
 
 import pytest
+from botocore.exceptions import ClientError
 
+from localstack.config import LEGACY_S3_PROVIDER
+from localstack.utils.aws import aws_stack
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
@@ -15,6 +18,9 @@ TEST_LAMBDA_PYTHON_TRIGGERED_S3 = os.path.join(
 
 class TestS3NotificationsToLambda:
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag", "$..s3.object.versionId"]
+    )
     def test_create_object_put_via_dynamodb(
         self,
         s3_client,
@@ -26,10 +32,19 @@ class TestS3NotificationsToLambda:
         create_role,
         dynamodb_create_table,
         dynamodb_resource,
+        snapshot,
     ):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        snapshot.add_transformer(
+            [
+                snapshot.transform.jsonpath("$..s3.bucket.name", "bucket-name"),
+                snapshot.transform.jsonpath("$..s3.object.key", "object-key"),
+            ]
+        )
+
         bucket_name = s3_create_bucket()
-        function_name = "func-%s" % short_uid()
-        table_name = "table-%s" % short_uid()
+        function_name = f"func-{short_uid()}"
+        table_name = f"table-{short_uid()}"
         role_name = f"test-role-{short_uid()}"
         trust_policy = {
             "Version": "2012-10-17",
@@ -78,8 +93,7 @@ class TestS3NotificationsToLambda:
         )
 
         # put an object
-        obj = s3_client.put_object(Bucket=bucket_name, Key=table_name, Body="something..")
-        etag = obj["ETag"]
+        s3_client.put_object(Bucket=bucket_name, Key=table_name, Body="something..")
 
         table = dynamodb_resource.Table(table_name)
 
@@ -87,15 +101,15 @@ class TestS3NotificationsToLambda:
             rs = table.scan()
             assert len(rs["Items"]) == 1
             event = rs["Items"][0]["data"]
-
-            assert event["eventSource"] == "aws:s3"
-            assert event["eventName"] == "ObjectCreated:Put"
-            assert event["s3"]["bucket"]["name"] == bucket_name
-            assert event["s3"]["object"]["eTag"].strip('"') == etag.strip('"')
+            snapshot.match("table_content", event)
 
         retry(check_table, retries=5, sleep=1)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER,
+        paths=["$..data.s3.object.eTag", "$..data.s3.object.versionId", "$..data.s3.object.size"],
+    )
     def test_create_object_by_presigned_request_via_dynamodb(
         self,
         s3_client,
@@ -107,8 +121,16 @@ class TestS3NotificationsToLambda:
         dynamodb_resource,
         iam_client,
         create_role,
+        snapshot,
     ):
-
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        snapshot.add_transformer(
+            [
+                snapshot.transform.jsonpath("$..s3.bucket.name", "bucket-name"),
+                snapshot.transform.jsonpath("$..s3.object.key", "object-key"),
+                snapshot.transform.key_value("uuid", "<uuid>", reference_replacement=False),
+            ]
+        )
         bucket_name = s3_create_bucket()
         function_name = "func-%s" % short_uid()
         table_name = "table-%s" % short_uid()
@@ -175,5 +197,63 @@ class TestS3NotificationsToLambda:
         def check_table():
             rs = table.scan()
             assert len(rs["Items"]) == 2
+            rs["Items"] = sorted(rs["Items"], key=lambda x: x["data"]["eventName"])
+            snapshot.match("items", rs["Items"])
 
         retry(check_table, retries=10, sleep=1)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="no validation implemented")
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: not LEGACY_S3_PROVIDER,
+        paths=[
+            "$..Error.ArgumentName1",
+            "$..Error.ArgumentValue1",
+            "$..Error.ArgumentName",
+            "$..Error.ArgumentValue",
+        ],
+    )
+    def test_invalid_lambda_arn(self, s3_client, s3_create_bucket, account_id, snapshot):
+        bucket_name = s3_create_bucket()
+        config = {
+            "LambdaFunctionConfigurations": [
+                {
+                    "Id": "id123",
+                    "Events": ["s3:ObjectCreated:*"],
+                }
+            ]
+        }
+
+        config["LambdaFunctionConfigurations"][0]["LambdaFunctionArn"] = "invalid-queue"
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+                SkipDestinationValidation=False,
+            )
+        snapshot.match("invalid_not_skip", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+                SkipDestinationValidation=True,
+            )
+        snapshot.match("invalid_skip", e.value.response)
+
+        # set valid but not-existing lambda
+        config["LambdaFunctionConfigurations"][0][
+            "LambdaFunctionArn"
+        ] = f"{aws_stack.lambda_function_arn('my-lambda', account_id=account_id)}"
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+            )
+        snapshot.match("lambda-does-not-exist", e.value.response)
+
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name, NotificationConfiguration=config, SkipDestinationValidation=True
+        )
+        config = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        snapshot.match("skip_destination_validation", config)

--- a/tests/integration/s3/test_s3_notifications_lambda.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_lambda.snapshot.json
@@ -1,0 +1,178 @@
+{
+  "tests/integration/s3/test_s3_notifications_lambda.py::TestS3NotificationsToLambda::test_create_object_put_via_dynamodb": {
+    "recorded-date": "20-09-2022, 14:23:56",
+    "recorded-content": {
+      "table_content": {
+        "awsRegion": "<region>",
+        "eventName": "ObjectCreated:Put",
+        "eventSource": "aws:s3",
+        "eventTime": "date",
+        "eventVersion": "2.1",
+        "requestParameters": {
+          "sourceIPAddress": "<ip-address:1>"
+        },
+        "responseElements": {
+          "x-amz-id-2": "amz-id",
+          "x-amz-request-id": "amz-request-id"
+        },
+        "s3": {
+          "bucket": {
+            "arn": "arn:aws:s3:::<bucket-name:1>",
+            "name": "<bucket-name:1>",
+            "ownerIdentity": {
+              "principalId": "<principal-id:1>"
+            }
+          },
+          "configurationId": "<config-id:1>",
+          "object": {
+            "eTag": "e9fb1ed1d5eaa36781088aae37acffbd",
+            "key": "<object-key:1>",
+            "sequencer": "sequencer",
+            "size": "11"
+          },
+          "s3SchemaVersion": "1.0"
+        },
+        "userIdentity": {
+          "principalId": "<principal-id:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_lambda.py::TestS3NotificationsToLambda::test_create_object_by_presigned_request_via_dynamodb": {
+    "recorded-date": "20-09-2022, 15:08:43",
+    "recorded-content": {
+      "items": [
+        {
+          "uuid": "<uuid>",
+          "data": {
+            "s3": {
+              "bucket": {
+                "name": "<bucket-name:1>",
+                "arn": "arn:aws:s3:::<bucket-name:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "s3SchemaVersion": "1.0",
+              "object": {
+                "eTag": "232d7472010db416df31c55fdc0490a5",
+                "size": "16",
+                "key": "<object-key:1>",
+                "sequencer": "sequencer"
+              }
+            },
+            "awsRegion": "<region>",
+            "eventVersion": "2.1",
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "eventName": "ObjectCreated:Post",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          }
+        },
+        {
+          "uuid": "<uuid>",
+          "data": {
+            "s3": {
+              "bucket": {
+                "name": "<bucket-name:1>",
+                "arn": "arn:aws:s3:::<bucket-name:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "s3SchemaVersion": "1.0",
+              "object": {
+                "eTag": "b0d833b208acd18be70a25c9323f210d",
+                "size": "16",
+                "key": "<object-key:1>",
+                "sequencer": "sequencer"
+              }
+            },
+            "awsRegion": "<region>",
+            "eventVersion": "2.1",
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "eventName": "ObjectCreated:Put",
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_lambda.py::TestS3NotificationsToLambda::test_invalid_lambda_arn": {
+    "recorded-date": "22-09-2022, 19:47:46",
+    "recorded-content": {
+      "invalid_not_skip": {
+        "Error": {
+          "ArgumentName": "CloudFunction",
+          "ArgumentValue": "invalid-queue",
+          "Code": "InvalidArgument",
+          "Message": "The ARN is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_skip": {
+        "Error": {
+          "ArgumentName": "CloudFunction",
+          "ArgumentValue": "invalid-queue",
+          "Code": "InvalidArgument",
+          "Message": "The ARN is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "lambda-does-not-exist": {
+        "Error": {
+          "ArgumentName1": "arn:aws:lambda:<region>:111111111111:function:my-lambda, null",
+          "ArgumentValue1": "Not authorized to invoke function [arn:aws:lambda:<region>:111111111111:function:my-lambda]",
+          "Code": "InvalidArgument",
+          "Message": "Unable to validate the following destination configurations"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "skip_destination_validation": {
+        "LambdaFunctionConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*"
+            ],
+            "Id": "id123",
+            "LambdaFunctionArn": "arn:aws:lambda:<region>:111111111111:function:my-lambda"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/s3/test_s3_notifications_sns.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sns.snapshot.json
@@ -105,5 +105,119 @@
         ]
       }
     }
+  },
+  "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_bucket_notifications_with_filter": {
+    "recorded-date": "22-09-2022, 13:28:52",
+    "recorded-content": {
+      "message": {
+        "Message": {
+          "Records": [
+            {
+              "eventVersion": "2.1",
+              "eventSource": "aws:s3",
+              "awsRegion": "<region>",
+              "eventTime": "date",
+              "eventName": "ObjectCreated:Put",
+              "userIdentity": {
+                "principalId": "<principal-id:2>"
+              },
+              "requestParameters": {
+                "sourceIPAddress": "<ip-address:1>"
+              },
+              "responseElements": {
+                "x-amz-request-id": "amz-request-id",
+                "x-amz-id-2": "amz-id"
+              },
+              "s3": {
+                "s3SchemaVersion": "1.0",
+                "configurationId": "<config-id:1>",
+                "bucket": {
+                  "name": "<resource:1>",
+                  "ownerIdentity": {
+                    "principalId": "<principal-id:1>"
+                  },
+                  "arn": "arn:aws:s3:::<resource:1>"
+                },
+                "object": {
+                  "key": "testupload/dir1/testfile.txt",
+                  "size": 35,
+                  "eTag": "f5260f0f41af2722d9fe17a57dfa9da5",
+                  "sequencer": "sequencer"
+                }
+              }
+            }
+          ]
+        },
+        "MessageId": "<uuid:1>",
+        "Signature": "<signature>",
+        "SignatureVersion": "1",
+        "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+        "Subject": "Amazon S3 Notification",
+        "Timestamp": "date",
+        "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>",
+        "Type": "Notification",
+        "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:2>:<resource:3>"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_invalid_topic_arn": {
+    "recorded-date": "22-09-2022, 19:29:33",
+    "recorded-content": {
+      "invalid_not_skip": {
+        "Error": {
+          "ArgumentName": "Topic",
+          "ArgumentValue": "invalid-topic",
+          "Code": "InvalidArgument",
+          "Message": "The ARN is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_skip": {
+        "Error": {
+          "ArgumentName": "Topic",
+          "ArgumentValue": "invalid-topic",
+          "Code": "InvalidArgument",
+          "Message": "The ARN is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "skip_destination_validation": {
+        "TopicConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*"
+            ],
+            "Id": "id123",
+            "TopicArn": "arn:aws:sns:<region>:111111111111:my-topic"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sns.py::TestS3NotificationsToSns::test_bucket_not_exist": {
+    "recorded-date": "23-09-2022, 12:38:09",
+    "recorded-content": {
+      "bucket_not_exists": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -1,11 +1,14 @@
 import json
 import logging
+from io import BytesIO
 from typing import TYPE_CHECKING, Dict, List, Protocol
 
 import pytest
 import requests
 from boto3.s3.transfer import KB, TransferConfig
+from botocore.exceptions import ClientError
 
+from localstack.config import LEGACY_S3_PROVIDER
 from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
@@ -47,14 +50,7 @@ def get_queue_arn(sqs_client, queue_url: str) -> str:
     return response["Attributes"]["QueueArn"]
 
 
-def create_sqs_bucket_notification(
-    s3_client: "S3Client",
-    sqs_client: "SQSClient",
-    bucket_name: str,
-    queue_url: str,
-    events: List["EventType"],
-):
-    """A NotificationFactory."""
+def set_policy_for_queue(sqs_client, queue_url, bucket_name):
     queue_arn = get_queue_arn(sqs_client, queue_url)
     assert queue_arn
     bucket_arn = aws_stack.s3_bucket_arn(bucket_name)
@@ -72,16 +68,22 @@ def create_sqs_bucket_notification(
         ],
     }
     sqs_client.set_queue_attributes(QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)})
+    return queue_arn
 
+
+def create_sqs_bucket_notification(
+    s3_client: "S3Client",
+    sqs_client: "SQSClient",
+    bucket_name: str,
+    queue_url: str,
+    events: List["EventType"],
+):
+    """A NotificationFactory."""
+    queue_arn = set_policy_for_queue(sqs_client, queue_url, bucket_name)
     s3_client.put_bucket_notification_configuration(
         Bucket=bucket_name,
         NotificationConfiguration=dict(
-            QueueConfigurations=[
-                dict(
-                    QueueArn=queue_arn,
-                    Events=events,
-                )
-            ]
+            QueueConfigurations=[dict(QueueArn=queue_arn, Events=events)]
         ),
     )
 
@@ -146,7 +148,9 @@ def sqs_collect_s3_events(
 
 class TestS3NotificationsToSQS:
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..s3.object.eTag"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag"]
+    )
     def test_object_created_put(
         self,
         s3_client,
@@ -196,7 +200,9 @@ class TestS3NotificationsToSQS:
         assert obj1["VersionId"] == events[1]["s3"]["object"]["versionId"]
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..s3.object.eTag", "$..s3.object.versionId"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag", "$..s3.object.versionId"]
+    )
     def test_object_created_copy(
         self,
         s3_client,
@@ -240,7 +246,8 @@ class TestS3NotificationsToSQS:
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
-        paths=["$..s3.object.eTag", "$..s3.object.versionId", "$..s3.object.size"]
+        condition=lambda: LEGACY_S3_PROVIDER,
+        paths=["$..s3.object.eTag", "$..s3.object.versionId", "$..s3.object.size"],
     )
     def test_object_created_and_object_removed(
         self,
@@ -298,7 +305,9 @@ class TestS3NotificationsToSQS:
         assert events[2]["s3"]["object"]["key"] == src_key
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..s3.object.eTag", "$..s3.object.versionId"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag", "$..s3.object.versionId"]
+    )
     def test_object_created_complete_multipart_upload(
         self,
         s3_client,
@@ -338,7 +347,9 @@ class TestS3NotificationsToSQS:
         assert events[0]["s3"]["object"]["size"] == file.size()
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..s3.object.eTag", "$..s3.object.versionId"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag", "$..s3.object.versionId"]
+    )
     def test_key_encoding(
         self,
         s3_client,
@@ -368,7 +379,9 @@ class TestS3NotificationsToSQS:
         assert events[0]["s3"]["object"]["key"] == key_encoded
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..s3.object.eTag", "$..s3.object.versionId"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag", "$..s3.object.versionId"]
+    )
     def test_object_created_put_with_presigned_url_upload(
         self,
         s3_client,
@@ -399,13 +412,14 @@ class TestS3NotificationsToSQS:
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER,
         paths=[
             "$..s3.object.eTag",
             "$..s3.object.versionId",
             "$..s3.object.size",
             "$..s3.object.sequencer",
             "$..eventVersion",
-        ]
+        ],
     )
     def test_object_tagging_put_event(
         self,
@@ -454,13 +468,14 @@ class TestS3NotificationsToSQS:
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER,
         paths=[
             "$..s3.object.eTag",
             "$..s3.object.versionId",
             "$..s3.object.size",
             "$..s3.object.sequencer",
             "$..eventVersion",
-        ]
+        ],
     )
     def test_object_tagging_delete_event(
         self,
@@ -513,7 +528,9 @@ class TestS3NotificationsToSQS:
         assert events[0]["s3"]["object"]["key"] == dest_key
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..s3.object.eTag", "$..s3.object.versionId"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER, paths=["$..s3.object.eTag", "$..s3.object.versionId"]
+    )
     def test_xray_header(
         self,
         s3_client,
@@ -577,3 +594,267 @@ class TestS3NotificationsToSQS:
             == "Root=1-3152b799-8954dae64eda91bc9a23a7e8;Parent=7fa8c0f79203be72;Sampled=1"
         )
         snapshot.match("receive_messages", {"messages": messages})
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER,
+        paths=[
+            "$..QueueConfigurations..Filter",
+            "$..s3.object.eTag",
+            "$..s3.object.versionId",
+        ],
+    )
+    def test_notifications_with_filter(
+        self,
+        s3_client,
+        s3_create_bucket,
+        sqs_client,
+        s3_create_sqs_bucket_notification,
+        sqs_create_queue,
+        snapshot,
+    ):
+        # create test bucket and queue
+        bucket_name = f"notification-bucket-{short_uid()}"
+        s3_create_bucket(Bucket=bucket_name)
+        queue_name = f"queue-{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+
+        snapshot.add_transformer(snapshot.transform.regex(queue_name, "<queue>"))
+        snapshot.add_transformer(snapshot.transform.regex(bucket_name, "<bucket>"))
+        snapshot.add_transformer(snapshot.transform.s3_notifications_transformer())
+        queue_arn = set_policy_for_queue(sqs_client, queue_url, bucket_name)
+
+        events = ["s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"]
+        filter_rules = {
+            "FilterRules": [
+                {"Name": "Prefix", "Value": "testupload/"},
+                {"Name": "Suffix", "Value": "testfile.txt"},
+            ]
+        }
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={
+                "QueueConfigurations": [
+                    {
+                        "Id": "id0001",
+                        "QueueArn": queue_arn,
+                        "Events": events,
+                        "Filter": {"Key": filter_rules},
+                    },
+                    {
+                        # Add second config to test fix https://github.com/localstack/localstack/issues/450
+                        "Id": "id0002",
+                        "QueueArn": queue_arn,
+                        "Events": ["s3:ObjectTagging:*"],
+                        "Filter": {"Key": filter_rules},
+                    },
+                ]
+            },
+        )
+
+        # retrieve and check notification config
+        config = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        snapshot.match("config", config)
+        assert 2 == len(config["QueueConfigurations"])
+        config = [c for c in config["QueueConfigurations"] if c.get("Events")][0]
+        assert events == config["Events"]
+        assert filter_rules == config["Filter"]["Key"]
+
+        # upload file to S3 (this should NOT trigger a notification)
+        test_key1 = "/testdata"
+        test_data1 = b'{"test": "bucket_notification1"}'
+        s3_client.upload_fileobj(BytesIO(test_data1), bucket_name, test_key1)
+
+        # upload file to S3 (this should trigger a notification)
+        test_key2 = "testupload/dir1/testfile.txt"
+        test_data2 = b'{"test": "bucket_notification2"}'
+        s3_client.upload_fileobj(BytesIO(test_data2), bucket_name, test_key2)
+
+        # receive, assert, and delete message from SQS
+        messages = sqs_collect_s3_events(sqs_client, queue_url, 1)
+        assert len(messages) == 1
+        snapshot.match("message", messages[0])
+        assert messages[0]["s3"]["object"]["key"] == test_key2
+        assert messages[0]["s3"]["bucket"]["name"] == bucket_name
+
+        # delete notification config
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name, NotificationConfiguration={}
+        )
+        config = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        snapshot.match("config_empty", config)
+        assert not config.get("QueueConfigurations")
+        assert not config.get("TopicConfiguration")
+        # put notification config with single event type
+        event = "s3:ObjectCreated:*"
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={
+                "QueueConfigurations": [
+                    {"Id": "id123456", "QueueArn": queue_arn, "Events": [event]}
+                ]
+            },
+        )
+        config = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        snapshot.match("config_updated", config)
+        config = config["QueueConfigurations"][0]
+        assert [event] == config["Events"]
+
+        # put notification config with single event type
+        event = "s3:ObjectCreated:*"
+        filter_rules = {"FilterRules": [{"Name": "Prefix", "Value": "testupload/"}]}
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={
+                "QueueConfigurations": [
+                    {
+                        "Id": "id123456",
+                        "QueueArn": queue_arn,
+                        "Events": [event],
+                        "Filter": {"Key": filter_rules},
+                    }
+                ]
+            },
+        )
+        config = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        snapshot.match("config_updated_filter", config)
+        config = config["QueueConfigurations"][0]
+        assert [event] == config["Events"]
+        assert filter_rules == config["Filter"]["Key"]
+
+    @pytest.mark.aws_validated
+    def test_filter_rules_case_insensitive(
+        self, s3_client, s3_create_bucket, sqs_create_queue, sqs_client, snapshot
+    ):
+        bucket_name = s3_create_bucket()
+        id = short_uid()
+        queue_url = sqs_create_queue(QueueName=f"my-queue-{id}")
+        queue_attributes = sqs_client.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["QueueArn"]
+        )
+        snapshot.add_transformer(snapshot.transform.key_value("Id", "id"))
+        snapshot.add_transformer(snapshot.transform.regex(id, "<queue_id>"))
+        cfg = {
+            "QueueConfigurations": [
+                {
+                    "QueueArn": queue_attributes["Attributes"]["QueueArn"],
+                    "Events": ["s3:ObjectCreated:*"],
+                    "Filter": {
+                        "Key": {
+                            "FilterRules": [
+                                {
+                                    "Name": "suffix",
+                                    "Value": ".txt",
+                                },  # different casing should be normalized to Suffix/Prefix
+                                {"Name": "PREFIX", "Value": "notif-"},
+                            ]
+                        }
+                    },
+                }
+            ]
+        }
+
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name, NotificationConfiguration=cfg, SkipDestinationValidation=True
+        )
+        response = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        # verify casing of filter rule names
+
+        rules = response["QueueConfigurations"][0]["Filter"]["Key"]["FilterRules"]
+        valid = ["Prefix", "Suffix"]
+        response["QueueConfigurations"][0]["Filter"]["Key"]["FilterRules"].sort(
+            key=lambda x: x["Name"]
+        )
+        assert rules[0]["Name"] in valid
+        assert rules[1]["Name"] in valid
+        snapshot.match("bucket_notification_configuration", response)
+
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: not LEGACY_S3_PROVIDER,
+        paths=["$..Error.ArgumentName", "$..Error.ArgumentValue"],
+    )  # TODO: add to exception for ASF
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: LEGACY_S3_PROVIDER,
+        paths=["$..Error.RequestID"],
+    )
+    @pytest.mark.aws_validated
+    def test_bucket_notification_with_invalid_filter_rules(
+        self, s3_create_bucket, sqs_create_queue, sqs_client, s3_client, snapshot
+    ):
+        bucket_name = s3_create_bucket()
+        queue_url = sqs_create_queue()
+        queue_attributes = sqs_client.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["QueueArn"]
+        )
+        cfg = {
+            "QueueConfigurations": [
+                {
+                    "QueueArn": queue_attributes["Attributes"]["QueueArn"],
+                    "Events": ["s3:ObjectCreated:*"],
+                    "Filter": {
+                        "Key": {"FilterRules": [{"Name": "INVALID", "Value": "does not matter"}]}
+                    },
+                }
+            ]
+        }
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name, NotificationConfiguration=cfg
+            )
+        snapshot.match("invalid_filter_name", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="no validation implemented")
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: not LEGACY_S3_PROVIDER,
+        paths=[
+            "$..Error.ArgumentName1",
+            "$..Error.ArgumentValue1",
+            "$..Error.ArgumentName",
+            "$..Error.ArgumentValue",
+        ],
+    )
+    def test_invalid_sqs_arn(self, s3_client, s3_create_bucket, account_id, snapshot):
+        bucket_name = s3_create_bucket()
+        config = {
+            "QueueConfigurations": [
+                {
+                    "Id": "id123",
+                    "Events": ["s3:ObjectCreated:*"],
+                }
+            ]
+        }
+
+        config["QueueConfigurations"][0]["QueueArn"] = "invalid-queue"
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+                SkipDestinationValidation=False,
+            )
+        snapshot.match("invalid_not_skip", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+                SkipDestinationValidation=True,
+            )
+        snapshot.match("invalid_skip", e.value.response)
+
+        # set valid but not-existing queue
+        config["QueueConfigurations"][0][
+            "QueueArn"
+        ] = f"{aws_stack.sqs_queue_arn('my-queue', account_id=account_id)}"
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_notification_configuration(
+                Bucket=bucket_name,
+                NotificationConfiguration=config,
+            )
+        snapshot.match("queue-does-not-exist", e.value.response)
+
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name, NotificationConfiguration=config, SkipDestinationValidation=True
+        )
+        config = s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
+        snapshot.match("skip_destination_validation", config)

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -495,5 +495,248 @@
         ]
       }
     }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_notifications_with_filter": {
+    "recorded-date": "22-09-2022, 13:52:49",
+    "recorded-content": {
+      "config": {
+        "QueueConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*",
+              "s3:ObjectRemoved:Delete"
+            ],
+            "Filter": {
+              "Key": {
+                "FilterRules": [
+                  {
+                    "Name": "Prefix",
+                    "Value": "testupload/"
+                  },
+                  {
+                    "Name": "Suffix",
+                    "Value": "testfile.txt"
+                  }
+                ]
+              }
+            },
+            "Id": "<config-id:1>",
+            "QueueArn": "arn:aws:sqs:<region>:111111111111:<queue>"
+          },
+          {
+            "Events": [
+              "s3:ObjectTagging:*"
+            ],
+            "Filter": {
+              "Key": {
+                "FilterRules": [
+                  {
+                    "Name": "Prefix",
+                    "Value": "testupload/"
+                  },
+                  {
+                    "Name": "Suffix",
+                    "Value": "testfile.txt"
+                  }
+                ]
+              }
+            },
+            "Id": "id0002",
+            "QueueArn": "arn:aws:sqs:<region>:111111111111:<queue>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "message": {
+        "awsRegion": "<region>",
+        "eventName": "ObjectCreated:Put",
+        "eventSource": "aws:s3",
+        "eventTime": "date",
+        "eventVersion": "2.1",
+        "requestParameters": {
+          "sourceIPAddress": "<ip-address:1>"
+        },
+        "responseElements": {
+          "x-amz-id-2": "amz-id",
+          "x-amz-request-id": "amz-request-id"
+        },
+        "s3": {
+          "bucket": {
+            "arn": "arn:aws:s3:::<bucket>",
+            "name": "<bucket>",
+            "ownerIdentity": {
+              "principalId": "<principal-id:1>"
+            }
+          },
+          "configurationId": "<config-id:1>",
+          "object": {
+            "eTag": "f527a5c9f427867aeaf091c134949aa0",
+            "key": "testupload/dir1/testfile.txt",
+            "sequencer": "sequencer",
+            "size": 32
+          },
+          "s3SchemaVersion": "1.0"
+        },
+        "userIdentity": {
+          "principalId": "<principal-id:2>"
+        }
+      },
+      "config_empty": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "config_updated": {
+        "QueueConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*"
+            ],
+            "Id": "id123456",
+            "QueueArn": "arn:aws:sqs:<region>:111111111111:<queue>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "config_updated_filter": {
+        "QueueConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*"
+            ],
+            "Filter": {
+              "Key": {
+                "FilterRules": [
+                  {
+                    "Name": "Prefix",
+                    "Value": "testupload/"
+                  }
+                ]
+              }
+            },
+            "Id": "id123456",
+            "QueueArn": "arn:aws:sqs:<region>:111111111111:<queue>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_filter_rules_case_insensitive": {
+    "recorded-date": "22-09-2022, 14:05:55",
+    "recorded-content": {
+      "bucket_notification_configuration": {
+        "QueueConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*"
+            ],
+            "Filter": {
+              "Key": {
+                "FilterRules": [
+                  {
+                    "Name": "Prefix",
+                    "Value": "notif-"
+                  },
+                  {
+                    "Name": "Suffix",
+                    "Value": ".txt"
+                  }
+                ]
+              }
+            },
+            "Id": "<id:1>",
+            "QueueArn": "arn:aws:sqs:<region>:111111111111:my-queue-<queue_id>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_bucket_notification_with_invalid_filter_rules": {
+    "recorded-date": "22-09-2022, 14:08:25",
+    "recorded-content": {
+      "invalid_filter_name": {
+        "Error": {
+          "ArgumentName": "FilterRule.Name",
+          "ArgumentValue": "INVALID",
+          "Code": "InvalidArgument",
+          "Message": "filter rule name must be either prefix or suffix"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_invalid_sqs_arn": {
+    "recorded-date": "22-09-2022, 19:40:45",
+    "recorded-content": {
+      "invalid_not_skip": {
+        "Error": {
+          "ArgumentName": "Queue",
+          "ArgumentValue": "invalid-queue",
+          "Code": "InvalidArgument",
+          "Message": "The ARN is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid_skip": {
+        "Error": {
+          "ArgumentName": "Queue",
+          "ArgumentValue": "invalid-queue",
+          "Code": "InvalidArgument",
+          "Message": "The ARN is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "queue-does-not-exist": {
+        "Error": {
+          "ArgumentName1": "arn:aws:sqs:<region>:111111111111:my-queue",
+          "ArgumentValue1": "The destination queue does not exist",
+          "Code": "InvalidArgument",
+          "Message": "Unable to validate the following destination configurations"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "skip_destination_validation": {
+        "QueueConfigurations": [
+          {
+            "Events": [
+              "s3:ObjectCreated:*"
+            ],
+            "Id": "id123",
+            "QueueArn": "arn:aws:sqs:<region>:111111111111:my-queue"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -1,330 +1,60 @@
 import json
-import unittest
-from io import BytesIO
 
-from botocore.exceptions import ClientError
+import pytest
 
-from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
 from localstack.utils.common import retry, short_uid, to_str
 
-TEST_BUCKET_NAME_WITH_NOTIFICATIONS = "test-bucket-notif-1"
-TEST_QUEUE_NAME_FOR_S3 = "test_queue"
-TEST_TOPIC_NAME = "test_topic_name_for_sqs"
-TEST_S3_TOPIC_NAME = "test_topic_name_for_s3_to_sns_to_sqs"
-TEST_QUEUE_NAME_FOR_SNS = "test_queue_for_sns"
-PUBLICATION_TIMEOUT = 0.500
-PUBLICATION_RETRIES = 4
+PUBLICATION_TIMEOUT = 1
+PUBLICATION_RETRIES = 20
 
 
-class TestNotifications(unittest.TestCase):
-    def setUp(self):
-        self.s3_client = aws_stack.create_external_boto_client("s3")
-        self.sqs_client = aws_stack.create_external_boto_client("sqs")
-        self.sns_client = aws_stack.create_external_boto_client("sns")
+class TestNotifications:
+    @pytest.mark.aws_validated
+    def test_sqs_queue_names(self, sqs_client):
+        queue_name = f"{short_uid()}.fifo"
 
-    def test_sqs_queue_names(self):
-        sqs_client = self.sqs_client
-        queue_name = "%s.fifo" % short_uid()
         # make sure we can create *.fifo queues
-        queue_url = sqs_client.create_queue(QueueName=queue_name, Attributes={"FifoQueue": "true"})[
-            "QueueUrl"
-        ]
-        sqs_client.delete_queue(QueueUrl=queue_url)
+        try:
+            queue = sqs_client.create_queue(QueueName=queue_name, Attributes={"FifoQueue": "true"})
+            assert queue_name in queue["QueueUrl"]
+        finally:
+            sqs_client.delete_queue(QueueUrl=queue["QueueUrl"])
 
-    def test_sns_to_sqs(self):
-        sqs_client = self.sqs_client
-        sns_client = self.sns_client
+    def test_sns_to_sqs(self, sqs_client, sns_client, sqs_create_queue, sns_create_topic):
 
         # create topic and queue
-        queue_info = sqs_client.create_queue(QueueName=TEST_QUEUE_NAME_FOR_SNS)
-        topic_info = sns_client.create_topic(Name=TEST_TOPIC_NAME)
-
+        queue_url = sqs_create_queue()
+        topic_info = sns_create_topic()
+        topic_arn = topic_info["TopicArn"]
         # subscribe SQS to SNS, publish message
-        subscription_arn = sns_client.subscribe(
-            TopicArn=topic_info["TopicArn"],
+        queue_arn = sqs_client.get_queue_attributes(
+            QueueUrl=queue_url, AttributeNames=["QueueArn"]
+        )["Attributes"]["QueueArn"]
+        subscription = sns_client.subscribe(
+            TopicArn=topic_arn,
             Protocol="sqs",
-            Endpoint=aws_stack.sqs_queue_arn(TEST_QUEUE_NAME_FOR_SNS),
-        )["SubscriptionArn"]
+            Endpoint=queue_arn,
+        )
         test_value = short_uid()
         sns_client.publish(
-            TopicArn=topic_info["TopicArn"],
+            TopicArn=topic_arn,
             Message="test message for SQS",
             MessageAttributes={"attr1": {"DataType": "String", "StringValue": test_value}},
         )
         # cleanup
-        sns_client.unsubscribe(SubscriptionArn=subscription_arn)
+        sns_client.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
 
         def assert_message():
-            # receive, assert, and delete message from SQS
-            queue_url = queue_info["QueueUrl"]
-            assertions = []
-            # make sure we receive the correct topic ARN in notifications
-            assertions.append({"TopicArn": topic_info["TopicArn"]})
-            # make sure the notification contains message attributes
-            assertions.append({"Value": test_value})
-            self._receive_assert_delete(queue_url, assertions, sqs_client)
+            # receive, and delete message from SQS
+            expected = {"attr1": {"Type": "String", "Value": test_value}}
+            messages = self._receive_messages_delete(queue_url, sqs_client)
+            assert len(messages) == 1
+            assert messages[0]["TopicArn"] == topic_arn
+            assert expected == messages[0]["MessageAttributes"]
 
         retry(assert_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
-    def test_put_bucket_notification_with_invalid_filter_rules(self):
-        bucket_name = self.create_test_bucket()
-        queue_url, queue_attributes = self.create_test_queue()
-
-        cfg = {
-            "QueueConfigurations": [
-                {
-                    "QueueArn": queue_attributes["Attributes"]["QueueArn"],
-                    "Events": ["s3:ObjectCreated:*"],
-                    "Filter": {
-                        "Key": {"FilterRules": [{"Name": "INVALID", "Value": "does not matter"}]}
-                    },
-                }
-            ]
-        }
-
-        try:
-            with self.assertRaises(ClientError) as error:
-                self.s3_client.put_bucket_notification_configuration(
-                    Bucket=bucket_name, NotificationConfiguration=cfg
-                )
-            self.assertIn("InvalidArgument", str(error.exception))
-        finally:
-            self.sqs_client.delete_queue(QueueUrl=queue_url)
-            self.s3_client.delete_bucket(Bucket=bucket_name)
-
-    def test_put_and_get_bucket_notification_with_filter_rules(self):
-        bucket_name = self.create_test_bucket()
-        queue_url, queue_attributes = self.create_test_queue()
-
-        cfg = {
-            "QueueConfigurations": [
-                {
-                    "QueueArn": queue_attributes["Attributes"]["QueueArn"],
-                    "Events": ["s3:ObjectCreated:*"],
-                    "Filter": {
-                        "Key": {
-                            "FilterRules": [
-                                {
-                                    "Name": "suffix",
-                                    "Value": ".txt",
-                                },  # different casing should be normalized to Suffix/Prefix
-                                {"Name": "PREFIX", "Value": "notif-"},
-                            ]
-                        }
-                    },
-                }
-            ]
-        }
-
-        try:
-            self.s3_client.put_bucket_notification_configuration(
-                Bucket=bucket_name, NotificationConfiguration=cfg
-            )
-            response = self.s3_client.get_bucket_notification_configuration(Bucket=bucket_name)
-            # verify casing of filter rule names
-            rules = response["QueueConfigurations"].pop()["Filter"]["Key"]["FilterRules"]
-            valid = ["Prefix", "Suffix"]
-
-            self.assertIn(rules[0]["Name"], valid)
-            self.assertIn(rules[1]["Name"], valid)
-
-        finally:
-            self.sqs_client.delete_queue(QueueUrl=queue_url)
-            self.s3_client.delete_bucket(Bucket=bucket_name)
-
-    def test_bucket_notifications(self):
-        s3_resource = aws_stack.connect_to_resource("s3")
-        s3_client = self.s3_client
-        sqs_client = self.sqs_client
-
-        # create test bucket and queue
-        s3_resource.create_bucket(Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS)
-        queue_info = sqs_client.create_queue(QueueName=TEST_QUEUE_NAME_FOR_S3)
-
-        # create notification on bucket
-        queue_url = queue_info["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(TEST_QUEUE_NAME_FOR_S3)
-        events = ["s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"]
-        filter_rules = {
-            "FilterRules": [
-                {"Name": "Prefix", "Value": "testupload/"},
-                {"Name": "Suffix", "Value": "testfile.txt"},
-            ]
-        }
-        s3_client.put_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS,
-            NotificationConfiguration={
-                "QueueConfigurations": [
-                    {
-                        "Id": "id0001",
-                        "QueueArn": queue_arn,
-                        "Events": events,
-                        "Filter": {"Key": filter_rules},
-                    },
-                    {
-                        # Add second dummy config to fix https://github.com/localstack/localstack/issues/450
-                        "Id": "id0002",
-                        "QueueArn": queue_arn,
-                        "Events": [],
-                        "Filter": {"Key": filter_rules},
-                    },
-                ]
-            },
-        )
-
-        # retrieve and check notification config
-        config = s3_client.get_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS
-        )
-        self.assertEqual(2, len(config["QueueConfigurations"]))
-        config = [c for c in config["QueueConfigurations"] if c["Events"]][0]
-        self.assertEqual(events, config["Events"])
-        self.assertEqual(filter_rules, config["Filter"]["Key"])
-
-        # upload file to S3 (this should NOT trigger a notification)
-        test_key1 = "/testdata"
-        test_data1 = b'{"test": "bucket_notification1"}'
-        s3_client.upload_fileobj(
-            BytesIO(test_data1), TEST_BUCKET_NAME_WITH_NOTIFICATIONS, test_key1
-        )
-
-        # upload file to S3 (this should trigger a notification)
-        test_key2 = "testupload/dir1/testfile.txt"
-        test_data2 = b'{"test": "bucket_notification2"}'
-        s3_client.upload_fileobj(
-            BytesIO(test_data2), TEST_BUCKET_NAME_WITH_NOTIFICATIONS, test_key2
-        )
-
-        # receive, assert, and delete message from SQS
-        self._receive_assert_delete(
-            queue_url,
-            [{"key": test_key2}, {"name": TEST_BUCKET_NAME_WITH_NOTIFICATIONS}],
-            sqs_client,
-        )
-
-        # delete notification config
-        self._delete_notification_config()
-
-        # put notification config with single event type
-        event = "s3:ObjectCreated:*"
-        s3_client.put_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS,
-            NotificationConfiguration={
-                "QueueConfigurations": [
-                    {"Id": "id123456", "QueueArn": queue_arn, "Events": [event]}
-                ]
-            },
-        )
-        config = s3_client.get_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS
-        )
-        config = config["QueueConfigurations"][0]
-        self.assertEqual([event], config["Events"])
-
-        # put notification config with single event type
-        event = "s3:ObjectCreated:*"
-        filter_rules = {"FilterRules": [{"Name": "Prefix", "Value": "testupload/"}]}
-        s3_client.put_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS,
-            NotificationConfiguration={
-                "QueueConfigurations": [
-                    {
-                        "Id": "id123456",
-                        "QueueArn": queue_arn,
-                        "Events": [event],
-                        "Filter": {"Key": filter_rules},
-                    }
-                ]
-            },
-        )
-        config = s3_client.get_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS
-        )
-        config = config["QueueConfigurations"][0]
-        self.assertEqual([event], config["Events"])
-        self.assertEqual(filter_rules, config["Filter"]["Key"])
-
-        # upload file to S3 (this should trigger a notification)
-        test_key2 = "testupload/dir1/testfile.txt"
-        test_data2 = b'{"test": "bucket_notification2"}'
-        s3_client.upload_fileobj(
-            BytesIO(test_data2), TEST_BUCKET_NAME_WITH_NOTIFICATIONS, test_key2
-        )
-        # receive, assert, and delete message from SQS
-        self._receive_assert_delete(
-            queue_url,
-            [{"key": test_key2}, {"name": TEST_BUCKET_NAME_WITH_NOTIFICATIONS}],
-            sqs_client,
-        )
-
-        # delete notification config
-        self._delete_notification_config()
-
-        #
-        # Tests s3->sns->sqs notifications
-        #
-        sns_client = aws_stack.create_external_boto_client("sns")
-        topic_info = sns_client.create_topic(Name=TEST_S3_TOPIC_NAME)
-
-        s3_client.put_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS,
-            NotificationConfiguration={
-                "TopicConfigurations": [
-                    {
-                        "Id": "id123",
-                        "Events": ["s3:ObjectCreated:*"],
-                        "TopicArn": topic_info["TopicArn"],
-                    }
-                ]
-            },
-        )
-
-        subscription_arn = sns_client.subscribe(
-            TopicArn=topic_info["TopicArn"], Protocol="sqs", Endpoint=queue_arn
-        )["SubscriptionArn"]
-
-        test_key2 = "testupload/dir1/testfile.txt"
-        test_data2 = b'{"test": "bucket_notification2"}'
-
-        s3_client.upload_fileobj(
-            BytesIO(test_data2), TEST_BUCKET_NAME_WITH_NOTIFICATIONS, test_key2
-        )
-
-        # verify subject and records
-        def verify():
-            response = sqs_client.receive_message(QueueUrl=queue_url)
-            for message in response["Messages"]:
-                sns_obj = json.loads(message["Body"])
-                testutil.assert_object({"Subject": "Amazon S3 Notification"}, sns_obj)
-                notification_obj = json.loads(sns_obj["Message"])
-                testutil.assert_objects(
-                    [{"key": test_key2}, {"name": TEST_BUCKET_NAME_WITH_NOTIFICATIONS}],
-                    notification_obj["Records"],
-                )
-
-                sqs_client.delete_message(
-                    QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"]
-                )
-
-        retry(verify, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-        self._delete_notification_config()
-        sns_client.unsubscribe(SubscriptionArn=subscription_arn)
-
-    def _delete_notification_config(self):
-        s3_client = aws_stack.create_external_boto_client("s3")
-        s3_client.put_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS, NotificationConfiguration={}
-        )
-        config = s3_client.get_bucket_notification_configuration(
-            Bucket=TEST_BUCKET_NAME_WITH_NOTIFICATIONS
-        )
-        self.assertFalse(config.get("QueueConfigurations"))
-        self.assertFalse(config.get("TopicConfiguration"))
-
-    def _receive_assert_delete(self, queue_url, assertions, sqs_client=None, required_subject=None):
-        if not sqs_client:
-            sqs_client = aws_stack.create_external_boto_client("sqs")
+    def _receive_messages_delete(self, queue_url, sqs_client, expected_messages=1):
 
         response = sqs_client.receive_message(
             QueueUrl=queue_url, MessageAttributeNames=["All"], VisibilityTimeout=0
@@ -332,20 +62,11 @@ class TestNotifications(unittest.TestCase):
         messages = []
         for m in response["Messages"]:
             message = json.loads(to_str(m["Body"]))
+            if message.get("Event") == "s3:TestEvent":
+                continue
             messages.append(message)
-        testutil.assert_objects(assertions, messages)
+        assert len(messages) == expected_messages
+
         for message in response["Messages"]:
             sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"])
-
-    def create_test_queue(self):
-        queue_name = "test-queue-%s" % short_uid()
-        queue_url = self.sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_attributes = self.sqs_client.get_queue_attributes(
-            QueueUrl=queue_url, AttributeNames=["QueueArn"]
-        )
-        return queue_url, queue_attributes
-
-    def create_test_bucket(self):
-        bucket_name = "test-bucket-%s" % short_uid()
-        self.s3_client.create_bucket(Bucket=bucket_name)
-        return bucket_name
+        return messages


### PR DESCRIPTION
This PR contains S3 bucket notifications for:
* SQS
* SNS
* Lambda (Cloudfunctions)
* Event Bridge

## Implemented:
Following events are covered (also by existing tests):
- s3_ObjectCreated_Put
- s3_ObjectCreated_Copy
- s3_ObjectCreated_CompleteMultipartUpload
- s3_ObjectRemoved_Delete
- s3_ObjectTagging_Put
- s3_ObjectTagging_Delete

Other implementation:
- Filters
- verification for filters, destination configuration
- added tests, refactored existing tests


## Known Issues + Future work:
- `InvalidArgument` Error: marked a few TODOs here, because in [another PR](https://github.com/localstack/localstack/commit/34a71b4cbf3ba7c472ea55abfc560eb9a9889db0#diff-4b0f4fffc414ff51da92d57d0afdbedd29bfd8cb5683c57867fa2bf31e8753efR640) we already have a batch for that missing Exception
- xray-feature: no tests yet for lambda + SQS and not sure how it should work here (need to AWS validate)
- s3_ObjectCreated_Post -> this is only triggered for pre-signed urls (related test `test_create_object_by_presigned_request_via_dynamodb` is failing)
- Only covered notifications that are actually covered by our test suite, but [there are more](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types) currently not covered, including:
  - s3:ObjectRemoved:DeleteMarkerCreated
  - s3:ObjectRestore:*
  - s3:ReducedRedundancyLostObject
  - s3:Replication:*
  - s3:LifecycleExpiration:*

