### PR TITLE
Add rule for execute-api and extend test coverage for API GW custom CORS

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -23,6 +23,7 @@ from localstack.config import (
 )
 from localstack.http import Response
 
+from ...constants import PATH_USER_REQUEST
 from ..api import RequestContext
 from ..chain import Handler, HandlerChain
 
@@ -107,12 +108,12 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
         service_name = context.service.service_name
         if not config.DISABLE_CUSTOM_CORS_S3 and service_name == "s3":
             return False
-        if (
-            not config.DISABLE_CUSTOM_CORS_APIGATEWAY
-            and service_name == "apigateway"
-            and "_user_request_" in context.request.path
-        ):
-            return False
+        if not config.DISABLE_CUSTOM_CORS_APIGATEWAY and service_name == "apigateway":
+            is_user_request = (
+                PATH_USER_REQUEST in context.request.path or ".execute-api." in context.request.host
+            )
+            if is_user_request:
+                return False
     return True
 
 

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -90,6 +90,7 @@ class ApiInvocationContext:
         self.response_templates = {}
         self.stage_variables = {}
         self.path_params = {}
+        self.route = None
         self.ws_route = None
 
     @property

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -17,6 +17,7 @@ from requests.structures import CaseInsensitiveDict
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
+from localstack.aws.handlers import cors
 from localstack.config import get_edge_url
 from localstack.constants import (
     APPLICATION_JSON,
@@ -540,6 +541,48 @@ class TestAPIGateway:
 
         # clean up
         proxy.stop()
+
+    @pytest.mark.parametrize("use_hostname", [True, False])
+    @pytest.mark.parametrize("disable_custom_cors", [True, False])
+    @pytest.mark.parametrize("origin", ["http://allowed", "http://denied"])
+    def test_invoke_endpoint_cors_headers(
+        self, use_hostname, disable_custom_cors, origin, monkeypatch
+    ):
+        monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", disable_custom_cors)
+        monkeypatch.setattr(
+            cors, "ALLOWED_CORS_ORIGINS", cors.ALLOWED_CORS_ORIGINS + ["http://allowed"]
+        )
+
+        resps = [
+            {
+                "statusCode": "200",
+                "httpMethod": "OPTIONS",
+                "responseParameters": {
+                    "method.response.header.Access-Control-Allow-Origin": "'http://test.com'",
+                    "method.response.header.Vary": "'Origin'",
+                },
+            }
+        ]
+        api_id = self.create_api_gateway_and_deploy(
+            integration_type="MOCK", integration_responses=resps
+        )
+
+        # invoke endpoint with Origin header
+        endpoint = self._get_invoke_endpoint(
+            api_id, stage=self.TEST_STAGE_NAME, path="/", use_hostname=use_hostname
+        )
+        headers = {"Origin": origin}
+        response = requests.options(endpoint, headers=headers)
+
+        # assert response codes and CORS headers
+        if disable_custom_cors:
+            if origin == "http://allowed":
+                assert response.status_code == 204
+            else:
+                assert response.status_code == 403
+        else:
+            assert response.status_code == 200
+            assert "http://test.com" in response.headers["Access-Control-Allow-Origin"]
 
     def test_api_gateway_lambda_proxy_integration(self):
         self._test_api_gateway_lambda_proxy_integration(

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -553,7 +553,7 @@ class TestAPIGateway:
             cors, "ALLOWED_CORS_ORIGINS", cors.ALLOWED_CORS_ORIGINS + ["http://allowed"]
         )
 
-        resps = [
+        responses = [
             {
                 "statusCode": "200",
                 "httpMethod": "OPTIONS",
@@ -564,20 +564,20 @@ class TestAPIGateway:
             }
         ]
         api_id = self.create_api_gateway_and_deploy(
-            integration_type="MOCK", integration_responses=resps
+            integration_type="MOCK", integration_responses=responses
         )
 
         # invoke endpoint with Origin header
         endpoint = self._get_invoke_endpoint(
             api_id, stage=self.TEST_STAGE_NAME, path="/", use_hostname=use_hostname
         )
-        headers = {"Origin": origin}
-        response = requests.options(endpoint, headers=headers)
+        response = requests.options(endpoint, headers={"Origin": origin})
 
         # assert response codes and CORS headers
         if disable_custom_cors:
             if origin == "http://allowed":
                 assert response.status_code == 204
+                assert "http://allowed" in response.headers["Access-Control-Allow-Origin"]
             else:
                 assert response.status_code == 403
         else:


### PR DESCRIPTION
Add rule for execute-api and extend test coverage for API Gateway custom CORS. This is a follow-up from #6895 , where an additional switch for `../_user_request_/..` paths was introduced - we need to apply the same switch for `...execute-api...` domain names. (this should fix the tests upstream in ext)

Tried to cover the different cases with a parameterized integration test, which should cover the relevant combinations of settings (using a simple API GW MOCK integration).