### PR TITLE
S3 ASF Presigned URL 

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -168,6 +168,15 @@ IfCondition = str
 RestoreObjectOutputStatusCode = int
 ArgumentName = str
 ArgumentValue = str
+AWSAccessKeyId = str
+HostId = str
+HeadersNotSigned = str
+SignatureProvided = str
+StringToSign = str
+StringToSignBytes = str
+CanonicalRequest = str
+CanonicalRequestBytes = str
+X_Amz_Expires = int
 
 
 class AnalyticsS3ExportFileFormat(str):
@@ -645,6 +654,41 @@ class InvalidArgument(ServiceException):
     ArgumentValue: Optional[ArgumentValue]
 
 
+class SignatureDoesNotMatch(ServiceException):
+    code: str = "SignatureDoesNotMatch"
+    sender_fault: bool = False
+    status_code: int = 403
+    AWSAccessKeyId: Optional[AWSAccessKeyId]
+    CanonicalRequest: Optional[CanonicalRequest]
+    CanonicalRequestBytes: Optional[CanonicalRequestBytes]
+    HostId: Optional[HostId]
+    SignatureProvided: Optional[SignatureProvided]
+    StringToSign: Optional[StringToSign]
+    StringToSignBytes: Optional[StringToSignBytes]
+
+
+ServerTime = datetime
+Expires = datetime
+
+
+class AccessDenied(ServiceException):
+    code: str = "AccessDenied"
+    sender_fault: bool = False
+    status_code: int = 403
+    Expires: Optional[Expires]
+    ServerTime: Optional[ServerTime]
+    X_Amz_Expires: Optional[X_Amz_Expires]
+    HostId: Optional[HostId]
+    HeadersNotSigned: Optional[HeadersNotSigned]
+
+
+class AuthorizationQueryParametersError(ServiceException):
+    code: str = "AuthorizationQueryParametersError"
+    sender_fault: bool = False
+    status_code: int = 400
+    HostId: Optional[HostId]
+
+
 AbortDate = datetime
 
 
@@ -998,7 +1042,6 @@ class CopyObjectOutput(TypedDict, total=False):
 
 ObjectLockRetainUntilDate = datetime
 Metadata = Dict[MetadataKey, MetadataValue]
-Expires = datetime
 CopySourceIfUnmodifiedSince = datetime
 CopySourceIfModifiedSince = datetime
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -289,6 +289,155 @@
       "value": {
         "type": "string"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/SignatureDoesNotMatch",
+      "value": {
+        "type": "structure",
+        "members": {
+          "AWSAccessKeyId": {
+            "shape": "AWSAccessKeyId"
+          },
+          "CanonicalRequest": {
+            "shape": "CanonicalRequest"
+          },
+          "CanonicalRequestBytes": {
+            "shape": "CanonicalRequestBytes"
+          },
+          "HostId": {
+            "shape": "HostId"
+          },
+          "SignatureProvided": {
+            "shape": "SignatureProvided"
+          },
+          "StringToSign": {
+            "shape": "StringToSign"
+          },
+          "StringToSignBytes": {
+            "shape": "StringToSignBytes"
+          }
+        },
+        "error": {
+          "httpStatusCode": 403
+        },
+        "documentation": "<p>The request signature we calculated does not match the signature you provided. Check your key and signing method.</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/AccessDenied",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Expires": {
+            "shape": "Expires"
+          },
+          "ServerTime": {
+            "shape": "ServerTime"
+          },
+          "X_Amz_Expires": {
+            "shape": "X-Amz-Expires",
+            "locationName":"X-Amz-Expires"
+          },
+          "HostId": {
+            "shape": "HostId"
+          },
+          "HeadersNotSigned": {
+            "shape": "HeadersNotSigned"
+          }
+        },
+        "error": {
+          "httpStatusCode": 403
+        },
+        "documentation": "<p>Request has expired</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/AWSAccessKeyId",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/HostId",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/HeadersNotSigned",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/SignatureProvided",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/StringToSign",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/StringToSignBytes",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/CanonicalRequest",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/CanonicalRequestBytes",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ServerTime",
+      "value": {
+        "type": "timestamp"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/X-Amz-Expires",
+      "value": {
+        "type": "integer"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/AuthorizationQueryParametersError",
+      "value": {
+        "type": "structure",
+        "members": {
+          "HostId": {
+            "shape": "HostId"
+          }
+        },
+        "documentation": "<p>Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -1,0 +1,597 @@
+import copy
+import datetime
+import logging
+import re
+import time
+from typing import Dict, Tuple, TypedDict, Union
+from urllib import parse as urlparse
+
+from botocore.auth import HmacV1QueryAuth, S3SigV4QueryAuth
+from botocore.awsrequest import AWSRequest, create_request_object
+from botocore.compat import HTTPHeaders, urlsplit
+from botocore.credentials import Credentials, ReadOnlyCredentials
+from botocore.exceptions import NoCredentialsError
+from botocore.utils import percent_encode_sequence
+from werkzeug.datastructures import Headers
+
+from localstack import config
+from localstack.aws.api import RequestContext
+from localstack.aws.api.s3 import (
+    AccessDenied,
+    AuthorizationQueryParametersError,
+    SignatureDoesNotMatch,
+)
+from localstack.aws.chain import HandlerChain
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
+from localstack.http import Request, Response
+from localstack.services.s3.utils import S3_VIRTUAL_HOST_FORWARDED_HEADER, uses_host_addressing
+from localstack.utils.strings import to_bytes
+
+LOG = logging.getLogger(__name__)
+
+# params are required in presigned url
+SIGNATURE_V2_PARAMS = ["Signature", "Expires", "AWSAccessKeyId"]
+
+SIGNATURE_V4_PARAMS = [
+    "X-Amz-Algorithm",
+    "X-Amz-Credential",
+    "X-Amz-Date",
+    "X-Amz-Expires",
+    "X-Amz-SignedHeaders",
+    "X-Amz-Signature",
+]
+
+# headers to blacklist from request_dict.signed_headers
+BLACKLISTED_HEADERS = ["X-Amz-Security-Token"]
+
+# query params overrides for multipart upload and node sdk
+# TODO: this will depends on query/post v2/v4. Manage independently
+ALLOWED_QUERY_PARAMS = [
+    "x-id",
+    "x-amz-user-agent",
+    "x-amz-content-sha256",
+    "versionid",
+    "uploadid",
+    "partnumber",
+]
+
+IGNORED_SIGV4_HEADERS = [
+    "x-id",
+    "x-amz-user-agent",
+    "x-amz-content-sha256",
+]
+
+FAKE_HOST_ID = "9Gjjt1m+cjU4OPvX9O9/8RuvnG41MRb/18Oux2o5H5MY7ISNTlXN+Dz9IG62/ILVxhAGI0qyPfg="
+
+HOST_COMBINATION_REGEX = r"^(.*)(:[\d]{0,6})"
+PORT_REPLACEMENT = [":80", ":443", ":%s" % config.EDGE_PORT, ""]
+
+
+class NotValidSigV4Signature(TypedDict):
+    signature_provided: str
+    string_to_sign: str
+    canonical_request: str
+
+
+FindSigV4Result = Tuple[Union[str, None], Union[NotValidSigV4Signature, None]]
+
+
+class HmacV1QueryAuthValidation(HmacV1QueryAuth):
+    """
+    Override _get_date for signature calculation, to use received date instead of adding a fixed Expired time
+    """
+
+    post_signature_headers = [
+        header.lower()
+        for header in SIGNATURE_V2_PARAMS + BLACKLISTED_HEADERS + HmacV1QueryAuth.QSAOfInterest
+    ]
+    QSAOfInterest_low = [qs.lower() for qs in HmacV1QueryAuth.QSAOfInterest]
+
+    def _get_date(self):
+        return str(int(self._expires))  # noqa
+
+    def get_signature(self, method, split, headers: HTTPHeaders, expires=None, auth_path=None):
+        if self.credentials.token:
+            del headers["x-amz-security-token"]
+            headers["x-amz-security-token"] = self.credentials.token
+        string_to_sign = self.canonical_string(method, split, headers, auth_path=auth_path)
+        return self.sign_string(string_to_sign), string_to_sign
+
+
+class S3SigV4QueryAuthValidation(S3SigV4QueryAuth):
+    """
+    Override the timestamp for signature calculation, to use received timestamp instead of adding a fixed Expired time
+    """
+
+    def add_auth(self, request, timestamp):  # noqa
+        if self.credentials is None:  # noqa
+            raise NoCredentialsError()
+        request.context["timestamp"] = timestamp
+        canonical_request = self.canonical_request(request)
+        string_to_sign = self.string_to_sign(request, canonical_request)
+        signature = self.signature(string_to_sign, request)
+
+        return signature, canonical_request, signature
+
+
+# we are taking advantages of the fact that non-attached members are not returned
+# those exceptions are polymorphic, they can have multiple shapes under the same name
+
+
+def create_access_denied_headers_not_signed(headers_not_signed: str) -> AccessDenied:
+    ex = AccessDenied("There were headers present in the request which were not signed")
+    ex.HostId = FAKE_HOST_ID
+    ex.HeadersNotSigned = headers_not_signed
+    return ex
+
+
+def create_access_denied_missing_parameters_sig_v2() -> AccessDenied:
+    ex = AccessDenied(
+        "Query-string authentication requires the Signature, Expires and AWSAccessKeyId parameters"
+    )
+    ex.HostId = FAKE_HOST_ID
+    return ex
+
+
+def create_authorization_query_parameters_error() -> AuthorizationQueryParametersError:
+    ex = AuthorizationQueryParametersError(
+        "Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters."
+    )
+    ex.HostId = FAKE_HOST_ID
+    return ex
+
+
+def create_access_denied_expired_sig_v2(expires: float) -> AccessDenied:
+    ex = AccessDenied("Request has expired")
+    ex.HostId = FAKE_HOST_ID
+    ex.Expires = expires
+    ex.ServerTime = time.time()
+    return ex
+
+
+def create_access_denied_expired_sig_v4(expires: float, amz_expires: int) -> AccessDenied:
+    ex = create_access_denied_expired_sig_v2(expires)
+    ex.X_Amz_Expires = amz_expires
+    return ex
+
+
+def create_signature_does_not_match_sig_v2(
+    request_signature: str, string_to_sign: str
+) -> SignatureDoesNotMatch:
+    ex = SignatureDoesNotMatch(
+        "The request signature we calculated does not match the signature you provided. Check your key and signing method."
+    )
+    ex.AWSAccessKeyId = TEST_AWS_ACCESS_KEY_ID
+    ex.HostId = FAKE_HOST_ID
+    ex.SignatureProvided = request_signature
+    ex.StringToSign = string_to_sign
+    ex.StringToSignBytes = to_bytes(string_to_sign).hex(sep=" ", bytes_per_sep=2).upper()
+    return ex
+
+
+def create_signature_does_not_match_sig_v4(
+    not_valid_sig_v4: NotValidSigV4Signature,
+) -> SignatureDoesNotMatch:
+    ex = create_signature_does_not_match_sig_v2(
+        request_signature=not_valid_sig_v4["signature_provided"],
+        string_to_sign=not_valid_sig_v4["string_to_sign"],
+    )
+    ex.CanonicalRequest = not_valid_sig_v4["canonical_request"]
+    ex.CanonicalRequestBytes = to_bytes(ex.CanonicalRequest).hex(sep=" ", bytes_per_sep=2).upper()
+    return ex
+
+
+def s3_presigned_url_response_handler(_: HandlerChain, context: RequestContext, response: Response):
+    """
+    Pre-signed URL with PUT method (typically object upload) should return an empty body
+    """
+    if (
+        not context.request.method == "PUT"
+        or not is_presigned_url_request(context)
+        or response.status_code >= 400
+    ):
+        return
+    else:
+        response.data = b""
+
+
+def s3_presigned_url_request_handler(_: HandlerChain, context: RequestContext, __: Response):
+    """
+    Handler to validate S3 presigned URL. Checks the validity of the request signature, and raises an error if
+    `S3_SKIP_SIGNATURE_VALIDATION` is set to False
+    """
+    if context.service.service_name != "s3":
+        return
+
+    if not is_presigned_url_request(context):
+        # validate headers, as some can raise ValueError in Moto
+        _validate_headers_for_moto(context.request.headers)
+        return
+    # will raise exceptions if the url is not valid, except if S3_SKIP_SIGNATURE_VALIDATION is True
+    # will still try to validate it and log if there's an error
+
+    # We save the query args as a set to save time for lookup in validation
+    query_arg_set = set(context.request.args)
+
+    if is_valid_sig_v2(query_arg_set):
+        validate_presigned_url_s3(context)
+
+    elif is_valid_sig_v4(query_arg_set):
+        validate_presigned_url_s3v4(context)
+
+    _validate_headers_for_moto(context.request.headers)
+    LOG.debug("Valid presign url.")
+
+
+def is_expired(expiry_datetime: datetime.datetime):
+    now_datetime = datetime.datetime.now(tz=expiry_datetime.tzinfo)
+    return now_datetime > expiry_datetime
+
+
+def is_presigned_url_request(context: RequestContext) -> bool:
+    """
+    Detects pre-signed URL from query string parameters
+    Return True if any kind of presigned URL query string parameter is encountered
+    :param context: the request context from the handler chain
+    """
+    # Detecting pre-sign url and checking signature
+    query_parameters = context.request.args
+    return any(p in query_parameters for p in SIGNATURE_V2_PARAMS) or any(
+        p in query_parameters for p in SIGNATURE_V4_PARAMS
+    )
+
+
+def is_valid_sig_v2(query_args: set) -> bool:
+    """
+    :param query_args: a Set representing the query parameters from the presign URL request
+    :raises AccessDenied: if the query contains parts of the required parameters but not all
+    :return: True if the request is a valid SigV2 request, or False if no parameters are found to be related to SigV2
+    """
+    if any(p in query_args for p in SIGNATURE_V2_PARAMS):
+        if not all(p in query_args for p in SIGNATURE_V2_PARAMS):
+            LOG.info("Presign signature calculation failed")
+            ex: AccessDenied = create_access_denied_missing_parameters_sig_v2()
+            raise ex
+
+        return True
+    return False
+
+
+def is_valid_sig_v4(query_args: set) -> bool:
+    """
+    :param query_args: a Set representing the query parameters from the presign URL request
+    :raises AuthorizationQueryParametersError: if the query contains parts of the required parameters but not all
+    :return: True if the request is a valid SigV4 request, or False if no parameters are found to be related to SigV4
+    """
+    if any(p in query_args for p in SIGNATURE_V4_PARAMS):
+        if not all(p in query_args for p in SIGNATURE_V4_PARAMS):
+            LOG.info("Presign signature calculation failed")
+            ex: AuthorizationQueryParametersError = create_authorization_query_parameters_error()
+            raise ex
+
+        return True
+    return False
+
+
+def _get_aws_request_headers(werkzeug_headers: Headers) -> HTTPHeaders:
+    """
+    Converts Werkzeug headers into HTTPHeaders() needed to form an AWSRequest
+    :param werkzeug_headers: Werkzeug request headers
+    :return: headers in HTTPHeaders format
+    """
+    # Werkzeug Headers can have multiple values for the same key
+    # HTTPHeaders will append automatically the values when we set it to the same key multiple times
+    # see https://docs.python.org/3/library/http.client.html#httpmessage-objects
+    # see https://docs.python.org/3/library/email.compat32-message.html#email.message.Message.__setitem__
+    headers = HTTPHeaders()
+    for key, value in werkzeug_headers.items():
+        headers[key] = value
+
+    return headers
+
+
+def _create_new_request(request: Request, headers: Dict[str, str], query_string: str) -> Request:
+    """
+    Create a new request from an existent one, with new headers and query string
+    It is easier to create a new one as the existing request has a lot of cached properties based on query_string
+    :param request: the incoming pre-signed request
+    :param headers: new headers used for signature calculation
+    :param query_string: new query string for signature calculation
+    :return: a new Request with passed headers and query_string
+    """
+    return Request(
+        method=request.method,
+        headers=headers,
+        path=request.path,
+        query_string=query_string,
+        body=request.data,
+        scheme=request.scheme,
+        root_path=request.root_path,
+        server=request.server,
+        remote_addr=request.remote_addr,
+    )
+
+
+def _create_aws_request(
+    context: RequestContext, request_url: str, headers: Dict[str, str]
+) -> AWSRequest:
+    """
+    Create a new AWSRequest based on the request_url and new headers
+    :param context: RequestContext
+    :param request_url: the request_url used for the calculation
+    :param headers: headers used for calculation
+    :return: AWSRequest needed for S3SigV4QueryAuth signer
+    """
+    request_dict = {
+        "method": context.request.method,
+        "url": request_url,
+        "body": b"",
+        "headers": headers,
+        "context": {
+            "is_presign_request": True,
+            "use_global_endpoint": True,
+            "signing": {"bucket": context.service_request.get("Bucket")},
+        },
+    }
+    return create_request_object(request_dict)
+
+
+def _reverse_inject_signature_hmac_v1_query(context: RequestContext) -> Request:
+    """
+    Reverses what does HmacV1QueryAuth._inject_signature while injecting the signature in the request.
+    Transforms the query string parameters in headers to recalculate the signature
+    see botocore.auth.HmacV1QueryAuth._inject_signature
+    :param context:
+    :return:
+    """
+
+    new_headers = {}
+    new_query_string_dict = {}
+
+    for header, value in context.request.args.items():
+        header_low = header.lower()
+        if header_low not in HmacV1QueryAuthValidation.post_signature_headers:
+            new_headers[header] = value
+        elif header_low in HmacV1QueryAuthValidation.QSAOfInterest_low:
+            new_query_string_dict[header] = value
+
+    # there should not be any headers here. If there are, it means they have been added by the client
+    # We should verify them, they will fail the signature except if they were part of the original request
+    for header, value in context.request.headers.items():
+        header_low = header.lower()
+        if header_low.startswith("x-amz-") or header_low in ["content-type", "date", "content-md5"]:
+            new_headers[header] = value
+
+    # rebuild the query string
+    new_query_string = percent_encode_sequence(new_query_string_dict)
+
+    # easier to recreate the request, we would have to delete every cached property otherwise
+    reversed_request = _create_new_request(
+        request=context.request,
+        headers=new_headers,
+        query_string=new_query_string,
+    )
+
+    return reversed_request
+
+
+def _prepare_request_for_sig_v4_signature(
+    context: RequestContext, request_netloc: str
+) -> AWSRequest:
+    """
+    Prepare the request and reverse what S3SigV4QueryAuth does to allow signature calculation of the request
+    see botocore.auth.SigV4QueryAuth
+    :param context: RequestContext
+    :return: Request
+    """
+    request_headers = copy.copy(context.request.headers)
+    # set automatically by the handler chain, we don't want that
+    request_headers.pop("Authorization", None)
+    signed_headers = context.request.args.get("X-Amz-SignedHeaders")
+
+    signature_headers = {}
+    if uses_host_addressing(request_headers):
+        request_headers["Host"] = request_headers.pop(S3_VIRTUAL_HOST_FORWARDED_HEADER, "")
+        splitted_path = context.request.path.split("/", maxsplit=2)
+        path = f"/{splitted_path[-1]}"
+    else:
+        path = context.request.path
+
+    not_signed_headers = []
+    for header, value in request_headers.items():
+        header_low = header.lower()
+        if header_low.startswith("x-amz-"):
+            if header_low in IGNORED_SIGV4_HEADERS:
+                continue
+            if header_low not in signed_headers.lower():
+                not_signed_headers.append(header)
+        if header_low in signed_headers:
+            signature_headers[header] = value
+
+    if not_signed_headers:
+        ex: AccessDenied = create_access_denied_headers_not_signed(", ".join(not_signed_headers))
+        raise ex
+
+    new_query_string_dict = {
+        arg: value for arg, value in context.request.args.items() if arg != "X-Amz-Signature"
+    }
+    new_query_string = percent_encode_sequence(new_query_string_dict)
+    # need to set path + query string as url for aws_request
+    request_url = f"{context.request.scheme}://{request_netloc}{path}?{new_query_string}"
+
+    aws_request = _create_aws_request(context, request_url=request_url, headers=signature_headers)
+
+    return aws_request
+
+
+def validate_presigned_url_s3(context: RequestContext) -> None:
+    """
+    Validate the presigned URL signed with SigV2.
+    :param context: RequestContext
+    """
+    query_parameters = context.request.args
+    # todo: use the current User credentials instead? so it would not be set in stone??
+    credentials = Credentials(
+        access_key=TEST_AWS_ACCESS_KEY_ID,
+        secret_key=TEST_AWS_SECRET_ACCESS_KEY,
+        token=query_parameters.get("X-Amz-Security-Token", None),
+    )
+    try:
+        expires = int(query_parameters["Expires"])
+    except (ValueError, TypeError):
+        # TODO: test this in AWS??
+        raise SignatureDoesNotMatch("Expires error?")
+
+    auth_signer = HmacV1QueryAuthValidation(credentials=credentials, expires=expires)
+
+    pre_signature_request = _reverse_inject_signature_hmac_v1_query(context)
+
+    split = urlsplit(pre_signature_request.url)
+    headers = _get_aws_request_headers(pre_signature_request.headers)
+
+    signature, string_to_sign = auth_signer.get_signature(
+        pre_signature_request.method, split, headers, auth_path=None
+    )
+    # after passing through the virtual host to path proxy, the signature is parsed and `+` are replaced by space
+    req_signature = context.request.args.get("Signature").replace(" ", "+")
+
+    if not signature == req_signature:
+        if config.S3_SKIP_SIGNATURE_VALIDATION:
+            LOG.warning(
+                "Signatures do not match, but not raising an error, as S3_SKIP_SIGNATURE_VALIDATION=1"
+            )
+        else:
+            ex: SignatureDoesNotMatch = create_signature_does_not_match_sig_v2(
+                request_signature=req_signature, string_to_sign=string_to_sign
+            )
+            raise ex
+
+    # Checking whether the url is expired or not (maybe do it first?)
+    if expires < time.time():
+        if config.S3_SKIP_SIGNATURE_VALIDATION:
+            LOG.warning(
+                "Signature is expired, but not raising an error, as S3_SKIP_SIGNATURE_VALIDATION=1"
+            )
+        else:
+            ex: AccessDenied = create_access_denied_expired_sig_v2(expires=expires)
+            raise ex
+
+
+def _validate_headers_for_moto(headers: Headers) -> None:
+    """
+    The headers can contain values that do not have the right type, and it will throw Exception when passed to Moto
+    Validate them before it get passed
+    :param headers: request headers
+    """
+    if headers.get("x-amz-content-sha256", None) == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD":
+        # this is sign that this is a SigV4 request, with payload encoded
+        # we do not support payload encoding yet
+        # moto parses it to an int, it would raise a 500
+        content_length = headers.get("x-amz-decoded-content-length")
+        if not content_length:
+            raise SignatureDoesNotMatch('"X-Amz-Decoded-Content-Length" header is missing')
+        try:
+            int(content_length)
+        except ValueError:
+            raise SignatureDoesNotMatch('Wrong "X-Amz-Decoded-Content-Length" header')
+
+
+def _get_signature_of_presigned_request_s3v4(
+    context: RequestContext, request_netloc: str
+) -> FindSigV4Result:
+    """
+    Returns the signature of the request
+    :param context: RequestContext
+    :param request_netloc: the host of the original request
+    :return:
+    """
+    # if both x-amz* header and query param, InvalidRequest, conflicting -> test it
+    query_parameters = context.request.args
+
+    credentials = ReadOnlyCredentials(
+        TEST_AWS_ACCESS_KEY_ID,
+        TEST_AWS_SECRET_ACCESS_KEY,
+        query_parameters.get("X-Amz-Security-Token", None),
+    )
+    region = query_parameters["X-Amz-Credential"].split("/")[2]
+    expires = int(query_parameters["X-Amz-Expires"])
+    signer = S3SigV4QueryAuthValidation(credentials, "s3", region, expires=expires)
+
+    aws_request = _prepare_request_for_sig_v4_signature(context, request_netloc=request_netloc)
+
+    signature, string_to_sign, canonical_request = signer.add_auth(  # noqa
+        aws_request, query_parameters["X-Amz-Date"]
+    )
+    request_sig = query_parameters["X-Amz-Signature"]
+    if signature == request_sig:
+        return signature, None
+    else:
+        return None, NotValidSigV4Signature(
+            signature_provided=request_sig,
+            string_to_sign=string_to_sign,
+            canonical_request=canonical_request,
+        )
+
+
+def validate_presigned_url_s3v4(context: RequestContext) -> None:
+    """
+    Validate the presigned URL signed with SigV2.
+    :param context: RequestContext
+    :return:
+    """
+    signature, exception = _find_valid_signature_through_ports(context)
+    if not signature:
+        if config.S3_SKIP_SIGNATURE_VALIDATION:
+            LOG.warning(
+                "Signatures do not match, but not raising an error, as S3_SKIP_SIGNATURE_VALIDATION=1"
+            )
+        else:
+            ex: SignatureDoesNotMatch = create_signature_does_not_match_sig_v4(exception)
+            raise ex
+
+    # Checking whether the url is expired or not
+    query_parameters = context.request.args
+    # TODO: should maybe try/except here -> create auth params validation before checking signature, above!!
+    x_amz_date = datetime.datetime.strptime(query_parameters["X-Amz-Date"], "%Y%m%dT%H%M%SZ")
+    x_amz_expires = int(query_parameters["X-Amz-Expires"])
+    x_amz_expires_dt = datetime.timedelta(seconds=int(query_parameters["X-Amz-Expires"]))
+    expiration_time = x_amz_date + x_amz_expires_dt
+    expiration_time = expiration_time.replace(tzinfo=datetime.timezone.utc)
+
+    if is_expired(expiration_time):
+        if config.S3_SKIP_SIGNATURE_VALIDATION:
+            LOG.warning(
+                "Signature is expired, but not raising an error, as S3_SKIP_SIGNATURE_VALIDATION=1"
+            )
+        else:
+            ex: AccessDenied = create_access_denied_expired_sig_v4(
+                expires=expiration_time.timestamp(), amz_expires=x_amz_expires
+            )
+            raise ex
+
+
+def _find_valid_signature_through_ports(context: RequestContext) -> FindSigV4Result:
+    """
+    Iterate through ports to find a valid signature
+    :param context:
+    :return: signature of the request if valid
+    """
+    exception = None
+    for port in PORT_REPLACEMENT:
+        url = context.request.url
+        if uses_host_addressing(context.request.headers):
+            netloc = context.request.headers.get(S3_VIRTUAL_HOST_FORWARDED_HEADER)
+        else:
+            netloc = urlparse.urlparse(url).netloc
+        match = re.match(HOST_COMBINATION_REGEX, netloc)
+        if match and match.group(2):
+            request_netloc = netloc.replace(f"{match.group(2)}", str(port))
+        else:
+            request_netloc = f"{netloc}:{port}"
+
+        signature, exception = _get_signature_of_presigned_request_s3v4(context, request_netloc)
+        if signature:
+            return signature, None
+
+    # Return the last values returned by the loop, not sure which one we should select
+    return None, exception

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Union
+from typing import Dict, Union
 
 import moto.s3.models as moto_s3_models
 from moto.s3.exceptions import MissingBucket
@@ -16,7 +16,6 @@ from localstack.aws.api.s3 import (
     ObjectCannedACL,
     ObjectKey,
     Permission,
-    PutObjectRequest,
 )
 from localstack.utils.strings import checksum_crc32, checksum_crc32c, hash_sha1, hash_sha256
 
@@ -26,6 +25,20 @@ BUCKET_NAME_REGEX = (
     r"(?=^.{3,63}$)(?!^(\d+\.)+\d+$)"
     + r"(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)"
 )
+
+REGION_REGEX = r"[a-z]{2}-[a-z]+-[0-9]{1,}"
+PORT_REGEX = r"(:[\d]{0,6})?"
+
+S3_VIRTUAL_HOSTNAME_REGEX = (  # path based refs have at least valid bucket expression (separated by .) followed by .s3
+    r"^(http(s)?://)?((?!s3\.)[^\./]+)\."  # the negative lookahead part is for considering buckets
+    r"(((s3(-website)?\.({}\.)?)localhost(\.localstack\.cloud)?)|(localhost\.localstack\.cloud)|"
+    r"(s3((-website)|(-external-1))?[\.-](dualstack\.)?"
+    r"({}\.)?amazonaws\.com(.cn)?)){}(/[\w\-. ]*)*$"
+).format(
+    REGION_REGEX, REGION_REGEX, PORT_REGEX
+)
+
+S3_VIRTUAL_HOST_FORWARDED_HEADER = "x-s3-vhost-forwarded-for"
 
 VALID_CANNED_ACLS = {
     ObjectCannedACL.private,
@@ -63,16 +76,17 @@ ALLOWED_HEADER_OVERRIDES = {
 
 
 class InvalidRequest(ServiceException):
-    """The lifecycle configuration does not exist."""
-
     code: str = "InvalidRequest"
     sender_fault: bool = False
     status_code: int = 400
 
 
-def verify_checksum(checksum_algorithm: str, data: bytes, request: PutObjectRequest):
+def verify_checksum(checksum_algorithm: str, data: bytes, request: Dict):
+    # TODO: you don't have to specify the checksum algorithm
+    # you can use only the checksum-{algorithm-type} header
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
     key = f"Checksum{checksum_algorithm.upper()}"
-    checksum = request.get(key)  # noqa
+    checksum = request.get(key)
     # TODO: is there a message if the header is missing?
     match checksum_algorithm:
         case ChecksumAlgorithm.CRC32:
@@ -107,7 +121,7 @@ def is_bucket_name_valid(bucket_name: str) -> bool:
     """
     ref. https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
     """
-    return bucket_name.islower() and re.match(BUCKET_NAME_REGEX, bucket_name)
+    return True if re.match(BUCKET_NAME_REGEX, bucket_name) else False
 
 
 def is_canned_acl_valid(canned_acl: str) -> bool:
@@ -115,8 +129,8 @@ def is_canned_acl_valid(canned_acl: str) -> bool:
 
 
 def get_header_name(capitalized_field: str) -> str:
-    headers_parts = re.findall("[A-Z][^A-Z]*", capitalized_field)
-    return f"x-amz-{'-'.join([part.lower() for part in headers_parts])}"
+    headers_parts = re.split(r"([A-Z][a-z]+)", capitalized_field)
+    return f"x-amz-{'-'.join([part.lower() for part in headers_parts if part])}"
 
 
 def is_valid_canonical_id(canonical_id: str) -> bool:
@@ -124,9 +138,21 @@ def is_valid_canonical_id(canonical_id: str) -> bool:
     Validate that the string is a hex string with 64 char
     """
     try:
-        return len(canonical_id) == 64 and int(canonical_id, 16)
+        return int(canonical_id, 16) and len(canonical_id) == 64
     except ValueError:
         return False
+
+
+def uses_host_addressing(headers: Dict[str, str]) -> bool:
+    """
+    Determines if the request was forwarded from a v-host addressing style into a path one
+    """
+    # we can assume that the host header we are receiving here is actually the header we originally received
+    # from the client (because the edge service is forwarding the request in memory)
+    match = re.match(S3_VIRTUAL_HOSTNAME_REGEX, headers.get(S3_VIRTUAL_HOST_FORWARDED_HEADER, ""))
+
+    # checks whether there is a bucket name. This is sort of hacky
+    return True if match and match.group(3) else False
 
 
 def get_bucket_from_moto(

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -2390,7 +2390,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_bucket_acl": {
-    "recorded-date": "14-09-2022, 16:07:13",
+    "recorded-date": "20-09-2022, 15:12:21",
     "recorded-content": {
       "get-bucket-acl": {
         "Grants": [
@@ -2880,6 +2880,415 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3-True]": {
+    "recorded-date": "22-09-2022, 00:02:59",
+    "recorded-content": {
+      "with-decoded-content-length": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        }
+      },
+      "without-decoded-content-length": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:2>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3-False]": {
+    "recorded-date": "22-09-2022, 00:03:00",
+    "recorded-content": {}
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3v4-True]": {
+    "recorded-date": "22-09-2022, 00:03:01",
+    "recorded-content": {
+      "with-decoded-content-length": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HeadersNotSigned": "x-amz-date, x-amz-decoded-content-length",
+          "HostId": "host-id",
+          "Message": "There were headers present in the request which were not signed",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "without-decoded-content-length": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HeadersNotSigned": "x-amz-date",
+          "HostId": "host-id",
+          "Message": "There were headers present in the request which were not signed",
+          "RequestId": "<request-id:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_put_object_with_md5_and_chunk_signature_bad_headers[s3v4-False]": {
+    "recorded-date": "22-09-2022, 00:03:02",
+    "recorded-content": {}
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_presigned_url_expired[s3]": {
+    "recorded-date": "21-09-2022, 20:18:10",
+    "recorded-content": {
+      "expired-exception": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Expires": "date",
+          "HostId": "host-id",
+          "Message": "Request has expired",
+          "RequestId": "<request-id:1>",
+          "ServerTime": "date"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_presigned_url_expired[s3v4]": {
+    "recorded-date": "21-09-2022, 20:18:17",
+    "recorded-content": {
+      "expired-exception": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Expires": "date",
+          "HostId": "host-id",
+          "Message": "Request has expired",
+          "RequestId": "<request-id:1>",
+          "ServerTime": "date",
+          "X-Amz-Expires": "2"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3-False]": {
+    "recorded-date": "21-09-2022, 20:37:44",
+    "recorded-content": {
+      "expired": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Expires": "date",
+          "HostId": "host-id",
+          "Message": "Request has expired",
+          "RequestId": "<request-id:1>",
+          "ServerTime": "date"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3-True]": {
+    "recorded-date": "21-09-2022, 20:37:53",
+    "recorded-content": {
+      "expired": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Expires": "date",
+          "HostId": "host-id",
+          "Message": "Request has expired",
+          "RequestId": "<request-id:1>",
+          "ServerTime": "date"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3v4-False]": {
+    "recorded-date": "21-09-2022, 20:37:57",
+    "recorded-content": {
+      "expired": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Expires": "date",
+          "HostId": "host-id",
+          "Message": "Request has expired",
+          "RequestId": "<request-id:1>",
+          "ServerTime": "date",
+          "X-Amz-Expires": "1"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication_expired[s3v4-True]": {
+    "recorded-date": "21-09-2022, 20:38:01",
+    "recorded-content": {
+      "expired": {
+        "Error": {
+          "Code": "AccessDenied",
+          "Expires": "date",
+          "HostId": "host-id",
+          "Message": "Request has expired",
+          "RequestId": "<request-id:1>",
+          "ServerTime": "date",
+          "X-Amz-Expires": "1"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-False]": {
+    "recorded-date": "21-09-2022, 23:43:59",
+    "recorded-content": {
+      "invalid-get-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        }
+      },
+      "invalid-put-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:2>",
+          "SignatureProvided": "<signature-provided:2>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3-True]": {
+    "recorded-date": "21-09-2022, 23:44:05",
+    "recorded-content": {
+      "invalid-get-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        }
+      },
+      "invalid-put-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:2>",
+          "SignatureProvided": "<signature-provided:2>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3v4-False]": {
+    "recorded-date": "21-09-2022, 23:44:10",
+    "recorded-content": {
+      "invalid-get-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        }
+      },
+      "invalid-put-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:2>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:2>",
+          "SignatureProvided": "<signature-provided:2>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_presigned_url_signature_authentication[s3v4-True]": {
+    "recorded-date": "21-09-2022, 23:44:15",
+    "recorded-content": {
+      "invalid-get-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        }
+      },
+      "invalid-put-1": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:2>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:2>",
+          "SignatureProvided": "<signature-provided:2>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_missing_sig_param[s3]": {
+    "recorded-date": "22-09-2022, 13:32:19",
+    "recorded-content": {
+      "missing-param-exception": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "host-id",
+          "Message": "Query-string authentication requires the Signature, Expires and AWSAccessKeyId parameters",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_missing_sig_param[s3v4]": {
+    "recorded-date": "22-09-2022, 13:32:22",
+    "recorded-content": {
+      "missing-param-exception": {
+        "Error": {
+          "Code": "AuthorizationQueryParametersError",
+          "HostId": "host-id",
+          "Message": "Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 400
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_with_different_headers[s3]": {
+    "recorded-date": "22-09-2022, 14:02:07",
+    "recorded-content": {
+      "content-type-exception": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        },
+        "StatusCode": 403
+      },
+      "content-encoding-response": {
+        "StatusCode": 200
+      },
+      "missing-content-encoding-response": {
+        "StatusCode": 200
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_with_different_headers[s3v4]": {
+    "recorded-date": "22-09-2022, 14:02:12",
+    "recorded-content": {
+      "content-type-exception": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        },
+        "StatusCode": 403
+      },
+      "content-encoding-response": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:2>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:2>",
+          "SignatureProvided": "<signature-provided:2>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        },
+        "StatusCode": 403
+      },
+      "missing-content-encoding-response": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:2>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:3>",
+          "SignatureProvided": "<signature-provided:2>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:2>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_put_presigned_url_same_header_and_qs_parameter": {
+    "recorded-date": "22-09-2022, 14:28:14",
+    "recorded-content": {
+      "double-header-query-string": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "CanonicalRequest": "<canonical-request>",
+          "CanonicalRequestBytes": "<canonical-request-bytes:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        },
+        "StatusCode": 403
+      },
+      "override-signed-qs": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HeadersNotSigned": "x-amz-expires",
+          "HostId": "host-id",
+          "Message": "There were headers present in the request which were not signed",
+          "RequestId": "<request-id:2>"
+        },
+        "StatusCode": 403
       }
     }
   }


### PR DESCRIPTION
Pre-signed URLs are a feature of S3, allowing to use the client or the CLI to pre-sign a request with the credentials used by the client. The docs are quite extensive about it, and you see more about it here:
https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3_Authentication2.html

You can sign the request with 2 types: `SigV2`, which is supposed to be deprecated by still used, and `SigV4`.
You effectively sign the request like you would in the headers normally, but pass it in the query parameters instead.

The LocalStack pre-signed URLs feature is checking if the signature of the request is valid (and does not authenticate the request).

We verify the signature by checking the request we received, reconstructing the Canonical Request as required by AWS, and signing the request with the utilities from `botocore` to check if the signatures are identical. We keep the usage of the feature flag `S3_SKIP_SIGNATURE_VALIDATION` to allow requests with wrong signatures to go through.

We are making use of the handler chain, to catch the requests before they go through the skeleton to reject them if necessary.
We also modify the responses of operations using `PUT` method, because AWS "erases" the body content when the request is coming from a pre-signed URL. 

This PR still miss the pre-signed POST requests, added in a follow-up PR.

The validation should work better than the old provider, and be more precise and in-line with AWS.
