### PR TITLE
disable generic local_api_checker for new gateway

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -708,16 +708,21 @@ def local_api_checker(service: str) -> Callable:
         return lambda *args, **kwargs: None
 
     def _check(expect_shutdown=False, print_error=False):
+        port = None
         try:
             if service not in PROXY_LISTENERS:
                 LOG.debug("cannot find backend port for service %s", service)
                 return
             port = PROXY_LISTENERS[service][1]
 
+            if port is None:
+                # for modern ASF services, the port can be none since the service is just served by localstack
+                return
+
             LOG.debug("checking service health %s:%d", service, port)
             wait_for_port_status(port, expect_success=not expect_shutdown)
         except Exception:
             if print_error:
-                LOG.exception("service health check %s:%d failed", service, port)
+                LOG.exception("service health check %s:%s failed", service, port)
 
     return _check


### PR DESCRIPTION
In the old edge proxy, we assumed each proxy listener was assigned a port which pointed to the running backend (this was often just moto). A generic health check would check whether the port of the backend was available. For ASF services, this doesn't really make sense, so the port may be None in these cases. This PR adds a guard to avoid errors that would emerge sometimes when adding new services.

This is candidate code to be removed/reworked once we have the remaining proxy listeners (S3, Lambda) refactored.

Example:

```
--- Logging error ---
Traceback (most recent call last):
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: %d format: a real number is required, not NoneType
Call stack:
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/threading.py", line 966, in _bootstrap
    self._bootstrap_inner()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/concurrent/futures/thread.py", line 83, in _worker
    work_item.run()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/serving/wsgi.py", line 50, in __call__
    self.gateway.process(request, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/gateway.py", line 36, in process
    chain.handle(context, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/chain.py", line 57, in handle
    handler(self, self.context, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/handlers/service_plugin.py", line 34, in __call__
    return self.require_service(chain, context, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/handlers/service_plugin.py", line 56, in require_service
    service_plugin: Service = self.service_manager.require(service_name)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/bootstrap.py", line 77, in wrapped
    return f(*args, **kwargs)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 356, in require
    if container.start():
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 259, in start
    return self.check()
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 263, in check
    self.service.check(print_error=True)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 211, in check
    return self.check_function(expect_shutdown=expect_shutdown, print_error=print_error)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 717, in _check
    LOG.debug("checking service health %s:%d", service, port)
Message: 'checking service health %s:%d'
Arguments: ('mq', None)
--- Logging error ---
Traceback (most recent call last):
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 718, in _check
    wait_for_port_status(port, expect_success=not expect_shutdown)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/net.py", line 133, in wait_for_port_status
    return retry(check, sleep=sleep_time, retries=retries)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/sync.py", line 63, in retry
    raise raise_error
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/sync.py", line 59, in retry
    return function(**kwargs)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/net.py", line 126, in check
    status = is_port_open(port, http_path=http_path, expect_success=expect_success)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/net.py", line 70, in is_port_open
    result = sock.connect_ex((host, port))
TypeError: 'NoneType' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: %d format: a real number is required, not NoneType
Call stack:
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/threading.py", line 966, in _bootstrap
    self._bootstrap_inner()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/concurrent/futures/thread.py", line 83, in _worker
    work_item.run()
  File "/home/thomas/.pyenv/versions/3.10.4/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/serving/wsgi.py", line 50, in __call__
    self.gateway.process(request, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/gateway.py", line 36, in process
    chain.handle(context, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/chain.py", line 57, in handle
    handler(self, self.context, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/handlers/service_plugin.py", line 34, in __call__
    return self.require_service(chain, context, response)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/aws/handlers/service_plugin.py", line 56, in require_service
    service_plugin: Service = self.service_manager.require(service_name)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/utils/bootstrap.py", line 77, in wrapped
    return f(*args, **kwargs)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 356, in require
    if container.start():
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 259, in start
    return self.check()
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 263, in check
    self.service.check(print_error=True)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 211, in check
    return self.check_function(expect_shutdown=expect_shutdown, print_error=print_error)
  File "/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/localstack/services/plugins.py", line 721, in _check
    LOG.exception("service health check %s:%d failed", service, port)
Message: 'service health check %s:%d failed'
Arguments: ('mq', None)
```