### PR TITLE
migrate installer routines to new architecture

### DIFF
--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -27,6 +27,18 @@ class NoSuchVersionException(PackageException):
     pass
 
 
+class UnsupportedOSException(PackageException):
+    """Exception indicating that the requested package does not exist for the used operating system"""
+
+    pass
+
+
+class UnsupportedArchException(PackageException):
+    """Exception indicating that the requested package does not exist for the used architecture"""
+
+    pass
+
+
 class InstallTarget(Enum):
     """
     Different installation targets.

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -27,18 +27,6 @@ class NoSuchVersionException(PackageException):
     pass
 
 
-class UnsupportedOSException(PackageException):
-    """Exception indicating that the requested package does not exist for the used operating system"""
-
-    pass
-
-
-class UnsupportedArchException(PackageException):
-    """Exception indicating that the requested package does not exist for the used architecture"""
-
-    pass
-
-
 class InstallTarget(Enum):
     """
     Different installation targets.

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -187,10 +187,19 @@ class DownloadInstaller(PackageInstaller):
         download_url = self._get_download_url()
         target_path = self._get_install_marker_path(target_directory)
         download(download_url, target_path)
-        chmod_r(target_path, 0o777)
 
 
-class GitHubReleaseInstaller(DownloadInstaller):
+# TODO: name!
+class PermissionDownloadInstaller(DownloadInstaller):
+    def _get_download_url(self) -> str:
+        raise NotImplementedError()
+
+    def _install(self, target: InstallTarget) -> None:
+        super()._install(target)
+        chmod_r(self.get_executable_path(), 0o777)
+
+
+class GitHubReleaseInstaller(PermissionDownloadInstaller):
     """
     Installer which downloads an asset from a GitHub project's tag.
     """

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -241,10 +241,7 @@ class ArchiveDownloadAndExtractInstaller(ExecutableInstaller):
         )
 
 
-class PermissionDownloadInstaller(DownloadInstaller):
-    def _get_download_url(self) -> str:
-        raise NotImplementedError()
-
+class PermissionDownloadInstaller(DownloadInstaller, ABC):
     def _install(self, target: InstallTarget) -> None:
         super()._install(target)
         chmod_r(self.get_executable_path(), 0o777)

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -11,6 +11,7 @@ from localstack import config
 from localstack.utils.platform import in_docker, is_debian, is_redhat
 from localstack.utils.run import run
 
+from ..services.install import extract
 from ..utils.files import chmod_r, mkdir
 from ..utils.http import download
 from .api import InstallTarget, PackageException, PackageInstaller
@@ -189,7 +190,19 @@ class DownloadInstaller(PackageInstaller):
         download(download_url, target_path)
 
 
-# TODO: name!
+# TODO: names!
+class ExtractDownloadInstaller(DownloadInstaller):
+    def _get_download_url(self) -> str:
+        raise NotImplementedError()
+
+    def _install(self, target: InstallTarget) -> None:
+        super()._install(target)
+        target_directory = self._get_install_dir(target)
+        target_path = self._get_install_marker_path(target_directory)
+        extract(target_path, target_directory)
+        chmod_r(self.get_executable_path(), 0o777)
+
+
 class PermissionDownloadInstaller(DownloadInstaller):
     def _get_download_url(self) -> str:
         raise NotImplementedError()

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -221,6 +221,16 @@ class ArchiveDownloadAndExtractInstaller(ExecutableInstaller):
         """
         return None
 
+    def get_executable_path(self) -> str | None:
+        subdir = self._get_archive_subdir()
+        if subdir is None:
+            return super().get_executable_path()
+        else:
+            install_dir = self.get_installed_dir()
+            if install_dir:
+                install_dir = install_dir[: -len(subdir)]
+                return self._get_install_marker_path(install_dir)
+
     def _install(self, target: InstallTarget) -> None:
         target_directory = self._get_install_dir(target)
         mkdir(target_directory)

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -204,7 +204,6 @@ class ExtractDownloadInstaller(PackageInstaller, ABC):
         download_and_extract(
             download_url, target_directory, tmp_archive=os.path.join("/tmp", archive_name)
         )
-        chmod_r(self.get_executable_path(), 0o777)
 
     # TODO: potentially restructure this with in regards to DownloadInstaller to introduce a common base
     def get_executable_path(self) -> str | None:

--- a/localstack/packages/terraform.py
+++ b/localstack/packages/terraform.py
@@ -1,0 +1,34 @@
+import platform
+from typing import List
+
+from localstack.packages import Package, PackageInstaller
+from localstack.packages.core import ExtractDownloadInstaller
+from localstack.utils.platform import get_arch
+
+TERRAFORM_VERSION = "1.1.3"
+TERRAFORM_URL_TEMPLATE = (
+    "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_{os}_{arch}.zip"
+)
+
+
+class TerraformPackage(Package):
+    def __init__(self):
+        super().__init__("Terraform", "1.1.3")
+
+    def get_versions(self) -> List[str]:
+        return ["1.1.3"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return TerraformPackageInstaller("terraform", version)
+
+
+class TerraformPackageInstaller(ExtractDownloadInstaller):
+    def _get_download_url(self) -> str:
+        system = platform.system().lower()
+        arch = get_arch()
+        return TERRAFORM_URL_TEMPLATE.format(version=TERRAFORM_VERSION, os=system, arch=arch)
+
+
+terraform_package = TerraformPackage()
+# TODO: solve this cleanly, violates inheritance rules right now (accessing member not part of the top level interface)
+TERRAFORM_BIN = terraform_package.get_installer().get_executable_path()

--- a/localstack/packages/terraform.py
+++ b/localstack/packages/terraform.py
@@ -2,8 +2,9 @@ import os
 import platform
 from typing import List
 
-from localstack.packages import Package, PackageInstaller
+from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.packages.core import ExtractDownloadInstaller
+from localstack.utils.files import chmod_r
 from localstack.utils.platform import get_arch
 
 TERRAFORM_VERSION = "1.1.3"
@@ -31,6 +32,11 @@ class TerraformPackageInstaller(ExtractDownloadInstaller):
         system = platform.system().lower()
         arch = get_arch()
         return TERRAFORM_URL_TEMPLATE.format(version=TERRAFORM_VERSION, os=system, arch=arch)
+
+    def _install(self, target: InstallTarget) -> None:
+        super()._install(target)
+        # TODO: separate class? decorator pattern?
+        chmod_r(self.get_executable_path(), 0o777)
 
 
 terraform_package = TerraformPackage()

--- a/localstack/packages/terraform.py
+++ b/localstack/packages/terraform.py
@@ -39,4 +39,3 @@ class TerraformPackageInstaller(ArchiveDownloadAndExtractInstaller):
 
 
 terraform_package = TerraformPackage()
-TERRAFORM_BIN = terraform_package.get_installer().get_executable_path()

--- a/localstack/packages/terraform.py
+++ b/localstack/packages/terraform.py
@@ -1,3 +1,4 @@
+import os
 import platform
 from typing import List
 
@@ -23,6 +24,9 @@ class TerraformPackage(Package):
 
 
 class TerraformPackageInstaller(ExtractDownloadInstaller):
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "terraform")
+
     def _get_download_url(self) -> str:
         system = platform.system().lower()
         arch = get_arch()

--- a/localstack/packages/terraform.py
+++ b/localstack/packages/terraform.py
@@ -3,7 +3,7 @@ import platform
 from typing import List
 
 from localstack.packages import InstallTarget, Package, PackageInstaller
-from localstack.packages.core import ExtractDownloadInstaller
+from localstack.packages.core import ArchiveDownloadAndExtractInstaller
 from localstack.utils.files import chmod_r
 from localstack.utils.platform import get_arch
 
@@ -24,7 +24,7 @@ class TerraformPackage(Package):
         return TerraformPackageInstaller("terraform", version)
 
 
-class TerraformPackageInstaller(ExtractDownloadInstaller):
+class TerraformPackageInstaller(ArchiveDownloadAndExtractInstaller):
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "terraform")
 

--- a/localstack/packages/terraform.py
+++ b/localstack/packages/terraform.py
@@ -35,10 +35,8 @@ class TerraformPackageInstaller(ArchiveDownloadAndExtractInstaller):
 
     def _install(self, target: InstallTarget) -> None:
         super()._install(target)
-        # TODO: separate class? decorator pattern?
         chmod_r(self.get_executable_path(), 0o777)
 
 
 terraform_package = TerraformPackage()
-# TODO: solve this cleanly, violates inheritance rules right now (accessing member not part of the top level interface)
 TERRAFORM_BIN = terraform_package.get_installer().get_executable_path()

--- a/localstack/services/awslambda/invocation/runtime_executor.py
+++ b/localstack/services/awslambda/invocation/runtime_executor.py
@@ -64,8 +64,7 @@ def get_image_for_runtime(runtime: str) -> str:
 
 def get_runtime_client_path() -> Path:
     installer = awslambda_runtime_package.get_installer()
-    return Path(installer._get_install_marker_path(installer.get_installed_dir()))
-    # return Path(awslambda_runtime_package.get_installed_dir())
+    return Path(installer.get_executable_path())
 
 
 def prepare_image(target_path: Path, function_version: FunctionVersion) -> None:

--- a/localstack/services/awslambda/invocation/runtime_executor.py
+++ b/localstack/services/awslambda/invocation/runtime_executor.py
@@ -64,7 +64,7 @@ def get_image_for_runtime(runtime: str) -> str:
 
 def get_runtime_client_path() -> Path:
     # TODO: discuss: Lambda seems to have a lot of code related to copying runtimes. Should this all be moved
-    #   to the installer, or remain here because it is "business logic"?
+    #   to the installer, or remain here because it is "business logic"? Same for GO_runtime code
     installer = awslambda_runtime_package.get_installer()
     return Path(installer._get_install_marker_path(installer.get_installed_dir()))
     # return Path(awslambda_runtime_package.get_installed_dir())

--- a/localstack/services/awslambda/invocation/runtime_executor.py
+++ b/localstack/services/awslambda/invocation/runtime_executor.py
@@ -63,8 +63,6 @@ def get_image_for_runtime(runtime: str) -> str:
 
 
 def get_runtime_client_path() -> Path:
-    # TODO: discuss: Lambda seems to have a lot of code related to copying runtimes. Should this all be moved
-    #   to the installer, or remain here because it is "business logic"? Same for GO_runtime code
     installer = awslambda_runtime_package.get_installer()
     return Path(installer._get_install_marker_path(installer.get_installed_dir()))
     # return Path(awslambda_runtime_package.get_installed_dir())

--- a/localstack/services/awslambda/invocation/runtime_executor.py
+++ b/localstack/services/awslambda/invocation/runtime_executor.py
@@ -17,7 +17,7 @@ from localstack.services.awslambda.lambda_utils import (
     get_container_network_for_lambda,
     get_main_endpoint_from_container,
 )
-from localstack.services.install import LAMBDA_RUNTIME_INIT_PATH
+from localstack.services.awslambda.packages import awslambda_runtime_package
 from localstack.utils.archives import unzip
 from localstack.utils.container_utils.container_client import ContainerConfiguration
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
@@ -63,7 +63,11 @@ def get_image_for_runtime(runtime: str) -> str:
 
 
 def get_runtime_client_path() -> Path:
-    return Path(LAMBDA_RUNTIME_INIT_PATH)
+    # TODO: discuss: Lambda seems to have a lot of code related to copying runtimes. Should this all be moved
+    #   to the installer, or remain here because it is "business logic"?
+    installer = awslambda_runtime_package.get_installer()
+    return Path(installer._get_install_marker_path(installer.get_installed_dir()))
+    # return Path(awslambda_runtime_package.get_installed_dir())
 
 
 def prepare_image(target_path: Path, function_version: FunctionVersion) -> None:

--- a/localstack/services/awslambda/invocation/runtime_executor.py
+++ b/localstack/services/awslambda/invocation/runtime_executor.py
@@ -72,7 +72,7 @@ def prepare_image(target_path: Path, function_version: FunctionVersion) -> None:
         raise NotImplementedError("Custom images are currently not supported")
     src_init = get_runtime_client_path()
     # copy init file
-    target_init = target_path / "aws-lambda-rie"
+    target_init = awslambda_runtime_package.get_installer().get_executable_path()
     shutil.copy(src_init, target_init)
     target_init.chmod(0o755)
     # copy code

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -52,7 +52,6 @@ from localstack.services.awslambda.lambda_utils import (
 )
 from localstack.services.awslambda.packages import awslambda_go_runtime_package
 from localstack.services.generic_proxy import RegionBackend
-from localstack.services.install import INSTALL_DIR_STEPFUNCTIONS
 from localstack.utils.archives import unzip
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import CodeSigningConfig, InvalidEnvVars, LambdaFunction
@@ -1838,8 +1837,14 @@ def invoke_function(function):
     # remove this block when AWS updates the stepfunctions image to support aws-sdk invocations
     if not_found and "localstack-internal-awssdk" in arn:
         # init aws-sdk stepfunctions handler
+        from localstack.services.stepfunctions.packages import stepfunctions_local_package
+
         code = load_file(
-            os.path.join(INSTALL_DIR_STEPFUNCTIONS, "localstack-internal-awssdk", "awssdk.zip"),
+            os.path.join(
+                stepfunctions_local_package.get_installed_dir(),
+                "localstack-internal-awssdk",
+                "awssdk.zip",
+            ),
             mode="rb",
         )
         lambda_client = aws_stack.connect_to_service("lambda")

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -819,9 +819,7 @@ def do_set_function_code(lambda_function: LambdaFunction):
             lambda_handler = execute
 
         if runtime.startswith("go1") and not use_docker():
-            go_installer = awslambda_go_runtime_package.get_installer()
-            if not go_installer.is_installed():
-                go_installer.install()
+            awslambda_go_runtime_package.install()
 
             ensure_readable(main_file)
 

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -819,7 +819,6 @@ def do_set_function_code(lambda_function: LambdaFunction):
             lambda_handler = execute
 
         if runtime.startswith("go1") and not use_docker():
-            # TODO: subject to removal, migrated from old code
             go_installer = awslambda_go_runtime_package.get_installer()
             if not go_installer.is_installed():
                 go_installer.install()

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -50,8 +50,9 @@ from localstack.services.awslambda.lambda_utils import (
     get_zip_bytes,
     validate_filters,
 )
+from localstack.services.awslambda.packages import awslambda_go_runtime_package
 from localstack.services.generic_proxy import RegionBackend
-from localstack.services.install import INSTALL_DIR_STEPFUNCTIONS, install_go_lambda_runtime
+from localstack.services.install import INSTALL_DIR_STEPFUNCTIONS
 from localstack.utils.archives import unzip
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import CodeSigningConfig, InvalidEnvVars, LambdaFunction
@@ -819,7 +820,11 @@ def do_set_function_code(lambda_function: LambdaFunction):
             lambda_handler = execute
 
         if runtime.startswith("go1") and not use_docker():
-            install_go_lambda_runtime()
+            # TODO: subject to removal, migrated from old code
+            go_installer = awslambda_go_runtime_package.get_installer()
+            if not go_installer.is_installed():
+                go_installer.install()
+
             ensure_readable(main_file)
 
             def execute_go(event, context):

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -73,7 +73,11 @@ from localstack.utils.run import CaptureOutputProcess, FuncThread
 from localstack.utils.time import timestamp_millis
 
 # constants
-LAMBDA_EXECUTOR_JAR = lambda_java_libs.get_installer()._get_installed_marker_path()
+# TODO: direct reference to installed binary, should be handled by the installer, or called here?
+LAMBDA_JAVA_INSTALLER = lambda_java_libs.get_installer()
+LAMBDA_EXECUTOR_JAR = LAMBDA_JAVA_INSTALLER._get_install_marker_path(
+    LAMBDA_JAVA_INSTALLER.get_installed_dir()
+)
 LAMBDA_EXECUTOR_CLASS = "cloud.localstack.LambdaExecutor"
 LAMBDA_HANDLER_ENV_VAR_NAME = "_HANDLER"
 EVENT_FILE_PATTERN = "%s/lambda.event.*.json" % config.dirs.tmp

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -31,7 +31,10 @@ from localstack.services.awslambda.lambda_utils import (
     rm_docker_container,
     store_lambda_logs,
 )
-from localstack.services.awslambda.packages import awslambda_go_runtime_package, lambda_java_libs
+from localstack.services.awslambda.packages import (
+    awslambda_go_runtime_package,
+    lambda_java_libs_package,
+)
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.aws.dead_letter_queue import lambda_error_to_dead_letter_queue
@@ -74,7 +77,7 @@ from localstack.utils.time import timestamp_millis
 
 # constants
 # TODO: direct reference to installed binary, should be handled by the installer, or called here?
-LAMBDA_JAVA_INSTALLER = lambda_java_libs.get_installer()
+LAMBDA_JAVA_INSTALLER = lambda_java_libs_package.get_installer()
 LAMBDA_EXECUTOR_JAR = LAMBDA_JAVA_INSTALLER._get_install_marker_path(
     LAMBDA_JAVA_INSTALLER.get_installed_dir()
 )

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -31,8 +31,7 @@ from localstack.services.awslambda.lambda_utils import (
     rm_docker_container,
     store_lambda_logs,
 )
-from localstack.services.awslambda.packages import awslambda_go_runtime_package
-from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR
+from localstack.services.awslambda.packages import awslambda_go_runtime_package, lambda_java_libs
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.aws.dead_letter_queue import lambda_error_to_dead_letter_queue
@@ -74,7 +73,7 @@ from localstack.utils.run import CaptureOutputProcess, FuncThread
 from localstack.utils.time import timestamp_millis
 
 # constants
-LAMBDA_EXECUTOR_JAR = INSTALL_PATH_LOCALSTACK_FAT_JAR
+LAMBDA_EXECUTOR_JAR = lambda_java_libs.get_installer()._get_installed_marker_path()
 LAMBDA_EXECUTOR_CLASS = "cloud.localstack.LambdaExecutor"
 LAMBDA_HANDLER_ENV_VAR_NAME = "_HANDLER"
 EVENT_FILE_PATTERN = "%s/lambda.event.*.json" % config.dirs.tmp

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1595,9 +1595,8 @@ class LambdaExecutorLocal(LambdaExecutor):
             lambda_function.envvars["AWS_LAMBDA_EVENT_BODY"] = json.dumps(json_safe(event))
         else:
             LOG.warning("Unable to get function details for local execution of Golang Lambda")
-        # TODO: should this remain here or get moved to the installer? Same in runetime_executor.py
         go_installer = awslambda_go_runtime_package.get_installer()
-        cmd = go_installer._get_install_marker_path(go_installer.get_installed_dir())
+        cmd = go_installer.get_executable_path()
         LOG.debug("Running Golang Lambda with runtime: %s", cmd)
         result = self._execute_in_custom_runtime(cmd, lambda_function=lambda_function)
         return result

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -31,7 +31,8 @@ from localstack.services.awslambda.lambda_utils import (
     rm_docker_container,
     store_lambda_logs,
 )
-from localstack.services.install import GO_LAMBDA_RUNTIME, INSTALL_PATH_LOCALSTACK_FAT_JAR
+from localstack.services.awslambda.packages import awslambda_go_runtime_package
+from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.aws.dead_letter_queue import lambda_error_to_dead_letter_queue
@@ -1591,8 +1592,9 @@ class LambdaExecutorLocal(LambdaExecutor):
             lambda_function.envvars["AWS_LAMBDA_EVENT_BODY"] = json.dumps(json_safe(event))
         else:
             LOG.warning("Unable to get function details for local execution of Golang Lambda")
-
-        cmd = GO_LAMBDA_RUNTIME
+        # TODO: should this remain here or get moved to the installer? Same in runetime_executor.py
+        go_installer = awslambda_go_runtime_package.get_installer()
+        cmd = go_installer._get_install_marker_path(go_installer.get_installed_dir())
         LOG.debug("Running Golang Lambda with runtime: %s", cmd)
         result = self._execute_in_custom_runtime(cmd, lambda_function=lambda_function)
         return result

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1541,10 +1541,7 @@ class LambdaExecutorLocal(LambdaExecutor):
         save_file(event_file, json.dumps(json_safe(event)))
         TMP_FILES.append(event_file)
 
-        # TODO: direct reference to installed binary, should be handled by the installer, or called here?
-        lambda_executor_jar = LAMBDA_JAVA_INSTALLER._get_install_marker_path(
-            LAMBDA_JAVA_INSTALLER.get_installed_dir()
-        )
+        lambda_executor_jar = LAMBDA_JAVA_INSTALLER.get_executable_path()
         classpath = "%s:%s:%s" % (
             main_file,
             Util.get_java_classpath(lambda_function.cwd),

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -76,11 +76,7 @@ from localstack.utils.run import CaptureOutputProcess, FuncThread
 from localstack.utils.time import timestamp_millis
 
 # constants
-# TODO: direct reference to installed binary, should be handled by the installer, or called here?
 LAMBDA_JAVA_INSTALLER = lambda_java_libs_package.get_installer()
-LAMBDA_EXECUTOR_JAR = LAMBDA_JAVA_INSTALLER._get_install_marker_path(
-    LAMBDA_JAVA_INSTALLER.get_installed_dir()
-)
 LAMBDA_EXECUTOR_CLASS = "cloud.localstack.LambdaExecutor"
 LAMBDA_HANDLER_ENV_VAR_NAME = "_HANDLER"
 EVENT_FILE_PATTERN = "%s/lambda.event.*.json" % config.dirs.tmp
@@ -1545,10 +1541,14 @@ class LambdaExecutorLocal(LambdaExecutor):
         save_file(event_file, json.dumps(json_safe(event)))
         TMP_FILES.append(event_file)
 
+        # TODO: direct reference to installed binary, should be handled by the installer, or called here?
+        lambda_executor_jar = LAMBDA_JAVA_INSTALLER._get_install_marker_path(
+            LAMBDA_JAVA_INSTALLER.get_installed_dir()
+        )
         classpath = "%s:%s:%s" % (
             main_file,
             Util.get_java_classpath(lambda_function.cwd),
-            LAMBDA_EXECUTOR_JAR,
+            lambda_executor_jar,
         )
         cmd = "java %s -cp %s %s %s" % (
             java_opts,

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -1,9 +1,11 @@
 import os
+import platform
 import stat
 from typing import List
 
 from localstack.packages import InstallTarget, Package, PackageInstaller
-from localstack.services.install import log_install_msg
+from localstack.packages.api import UnsupportedArchException, UnsupportedOSException
+from localstack.services.install import download_and_extract, log_install_msg
 from localstack.utils.http import download
 from localstack.utils.platform import get_arch
 
@@ -12,8 +14,12 @@ LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/rel
 # TODO: talk with Alex, move this really to constants?
 LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.4-pre"
 
+# GO Lambda runtime
+GO_RUNTIME_VERSION = "0.4.0"
+GO_RUNTIME_DOWNLOAD_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-runtime/releases/download/v{version}/awslamba-go-runtime-{version}-{os}-{arch}.tar.gz"
 
-class AwsLambdaRuntimePackage(Package):
+
+class AWSLambdaRuntimePackage(Package):
     def __init__(self, default_version: str = LAMBDA_RUNTIME_DEFAULT_VERSION):
         super().__init__(name="AwsLambda", default_version=default_version)
 
@@ -21,10 +27,10 @@ class AwsLambdaRuntimePackage(Package):
         return ["v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
-        return AwsLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)
+        return AWSLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)
 
 
-class AwsLambdaRuntimePackageInstaller(PackageInstaller):
+class AWSLambdaRuntimePackageInstaller(PackageInstaller):
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "aws-lambda-rie")
 
@@ -41,4 +47,50 @@ class AwsLambdaRuntimePackageInstaller(PackageInstaller):
         os.chmod(install_location, mode=st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
-awslambda_runtime_package = AwsLambdaRuntimePackage()
+class AWSLambdaGoRuntimePackage(Package):
+    def __init__(self, default_version: str = GO_RUNTIME_VERSION):
+        super().__init__(name="AwsLambdaGo", default_version=default_version)
+
+    def get_versions(self) -> List[str]:
+        return [GO_RUNTIME_VERSION]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return AWSLambdaGoRuntimePackageInstaller(name="awslamba-go-runtime", version=version)
+
+
+class AWSLambdaGoRuntimePackageInstaller(PackageInstaller):
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "aws-lambda-mock")
+
+    def _install(self, target: InstallTarget) -> None:
+
+        log_install_msg("Installing golang runtime")
+
+        system = platform.system().lower()
+        arch = get_arch()
+
+        if system not in ["linux"]:
+            raise UnsupportedOSException(f"Unsupported os {system} for awslambda-go-runtime")
+        if arch not in ["amd64", "arm64"]:
+            raise UnsupportedArchException(f"Unsupported arch {arch} for awslambda-go-runtime")
+
+        url = GO_RUNTIME_DOWNLOAD_URL_TEMPLATE.format(
+            version=GO_RUNTIME_VERSION,
+            os=system,
+            arch=arch,
+        )
+
+        install_dir = self._get_install_dir(target)
+        install_location = self._get_install_marker_path(install_dir)
+        download_and_extract(url, install_dir)
+
+        st = os.stat(install_location)
+        os.chmod(install_location, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+        go_lambda_mockserver = os.path.join(install_dir, "mockserver")
+        st = os.stat(go_lambda_mockserver)
+        os.chmod(go_lambda_mockserver, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+awslambda_runtime_package = AWSLambdaRuntimePackage()
+awslambda_go_runtime_package = AWSLambdaGoRuntimePackage()

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -134,4 +134,4 @@ class AWSLambdaJavaPackageInstaller(PackageInstaller):
 
 awslambda_runtime_package = AWSLambdaRuntimePackage()
 awslambda_go_runtime_package = AWSLambdaGoRuntimePackage()
-lambda_java_libs = AWSLambdaJavaPackage()
+lambda_java_libs_package = AWSLambdaJavaPackage()

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -4,8 +4,7 @@ import stat
 from typing import List
 
 from localstack.packages import DownloadInstaller, InstallTarget, Package, PackageInstaller
-from localstack.packages.api import UnsupportedArchException, UnsupportedOSException
-from localstack.packages.core import ArchiveDownloadAndExtractInstaller
+from localstack.packages.core import ArchiveDownloadAndExtractInstaller, SystemNotSupportedException
 from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
@@ -58,9 +57,9 @@ class AWSLambdaGoRuntimePackageInstaller(ArchiveDownloadAndExtractInstaller):
         arch = get_arch()
 
         if system not in ["linux"]:
-            raise UnsupportedOSException(f"Unsupported os {system} for awslambda-go-runtime")
+            raise SystemNotSupportedException(f"Unsupported os {system} for awslambda-go-runtime")
         if arch not in ["amd64", "arm64"]:
-            raise UnsupportedArchException(f"Unsupported arch {arch} for awslambda-go-runtime")
+            raise SystemNotSupportedException(f"Unsupported arch {arch} for awslambda-go-runtime")
 
         return GO_RUNTIME_DOWNLOAD_URL_TEMPLATE.format(
             version=GO_RUNTIME_VERSION,

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -12,7 +12,6 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-# TODO: talk with Alex, move this really to constants?
 LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.4-pre"
 
 # GO Lambda runtime

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -1,0 +1,44 @@
+import os
+import stat
+from typing import List
+
+from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.services.install import log_install_msg
+from localstack.utils.http import download
+from localstack.utils.platform import get_arch
+
+LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
+
+# TODO: talk with Alex, move this really to constants?
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.4-pre"
+
+
+class AwsLambdaRuntimePackage(Package):
+    def __init__(self, default_version: str = LAMBDA_RUNTIME_DEFAULT_VERSION):
+        super().__init__(name="AwsLambda", default_version=default_version)
+
+    def get_versions(self) -> List[str]:
+        return ["v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return AwsLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)
+
+
+class AwsLambdaRuntimePackageInstaller(PackageInstaller):
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "aws-lambda-rie")
+
+    def _install(self, target: InstallTarget) -> None:
+        install_location = self._get_install_marker_path(self._get_install_dir(target))
+        if os.path.isfile(install_location):
+            return
+        log_install_msg("Installing lambda runtime")
+        arch = get_arch()
+        arch = "x86_64" if arch == "amd64" else arch
+        download_url = LAMBDA_RUNTIME_INIT_URL.format(version=self.version, arch=arch)
+        download(download_url, install_location)
+        st = os.stat(install_location)
+        os.chmod(install_location, mode=st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+awslambda_runtime_package = AwsLambdaRuntimePackage()

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -108,7 +108,7 @@ class AWSLambdaJavaPackage(Package):
         return ["0.2.21"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
-        return AWSLambdaGoRuntimePackageInstaller("lambda-java-libs", version)
+        return AWSLambdaJavaPackageInstaller("lambda-java-libs", version)
 
 
 class AWSLambdaJavaPackageInstaller(PackageInstaller):

--- a/localstack/services/awslambda/plugins.py
+++ b/localstack/services/awslambda/plugins.py
@@ -13,3 +13,10 @@ def awslambda_go_runtime_package() -> Package:
     from localstack.services.awslambda.packages import awslambda_go_runtime_package
 
     return awslambda_go_runtime_package
+
+
+@packages(name="lambda_java_libs")
+def lambda_javalibs_package() -> Package:
+    from localstack.services.awslambda.packages import lambda_java_libs
+
+    return lambda_java_libs

--- a/localstack/services/awslambda/plugins.py
+++ b/localstack/services/awslambda/plugins.py
@@ -6,3 +6,10 @@ def awslambda_runtime_package() -> Package:
     from localstack.services.awslambda.packages import awslambda_runtime_package
 
     return awslambda_runtime_package
+
+
+@packages(name="awslambda_go_runtime")
+def awslambda_go_runtime_package() -> Package:
+    from localstack.services.awslambda.packages import awslambda_go_runtime_package
+
+    return awslambda_go_runtime_package

--- a/localstack/services/awslambda/plugins.py
+++ b/localstack/services/awslambda/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import Package, packages
+
+
+@packages()
+def awslambda_runtime_package() -> Package:
+    from localstack.services.awslambda.packages import awslambda_runtime_package
+
+    return awslambda_runtime_package

--- a/localstack/services/awslambda/plugins.py
+++ b/localstack/services/awslambda/plugins.py
@@ -17,6 +17,6 @@ def awslambda_go_runtime_package() -> Package:
 
 @packages(name="lambda_java_libs")
 def lambda_javalibs_package() -> Package:
-    from localstack.services.awslambda.packages import lambda_java_libs
+    from localstack.services.awslambda.packages import lambda_java_libs_package
 
-    return lambda_java_libs
+    return lambda_java_libs_package

--- a/localstack/services/cloudformation/packages.py
+++ b/localstack/services/cloudformation/packages.py
@@ -1,0 +1,22 @@
+from typing import List
+
+from localstack.packages import DownloadInstaller, Package, PackageInstaller
+
+
+class CloudformationPackage(Package):
+    def __init__(self):
+        super().__init__("Clouformation", "latest")
+
+    def get_versions(self) -> List[str]:
+        return ["latest"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return CloudformationPackageInstaller("cloudformation", version)
+
+
+class CloudformationPackageInstaller(DownloadInstaller):
+    def _get_download_url(self) -> str:
+        return "https://raw.githubusercontent.com/LukeMizuhashi/cfn-response/master/index.js"
+
+
+cloudformation_package = CloudformationPackage()

--- a/localstack/services/cloudformation/plugins.py
+++ b/localstack/services/cloudformation/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import packages
+
+
+@packages()
+def cloudformation_package():
+    from localstack.services.cloudformation.packages import cloudformation_package
+
+    return cloudformation_package

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -207,6 +207,8 @@ def extract(source_archive, target):
 
 def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archive=None):
     mkdir(target_dir)
+
+    _, ext = os.path.splitext(tmp_archive or archive_url)
     tmp_archive = tmp_archive or new_tmp_file()
     if not os.path.exists(tmp_archive) or os.path.getsize(tmp_archive) <= 0:
         # create temporary placeholder file, to avoid duplicate parallel downloads
@@ -217,7 +219,12 @@ def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archiv
                 break
             except Exception:
                 time.sleep(sleep)
-    extract(tmp_archive, target_dir)
+    if ext == ".zip":
+        unzip(tmp_archive, target_dir)
+    elif ext in [".bz2", ".gz", ".tgz"]:
+        untar(tmp_archive, target_dir)
+    else:
+        raise Exception(f"Unsupported archive format: {ext}")
 
 
 def download_and_extract_with_retry(archive_url, tmp_archive, target_dir):

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -164,6 +164,7 @@ def get_terraform_binary() -> str:
 
 def install_component(name):
     from localstack.services.awslambda.packages import awslambda_runtime_package
+    from localstack.services.cloudformation.packages import cloudformation_package
     from localstack.services.dynamodb.packages import dynamodblocal_package
     from localstack.services.kinesis.packages import kinesismock_package
     from localstack.services.kms.packages import kms_local_package
@@ -171,7 +172,7 @@ def install_component(name):
     from localstack.services.stepfunctions.packages import stepfunctions_local_package
 
     installers = {
-        "cloudformation": install_cloudformation_libs,
+        "cloudformation": cloudformation_package.install,
         "dynamodb": dynamodblocal_package.install,
         "kinesis": kinesismock_package.install,
         "kms": kms_local_package.install,
@@ -281,6 +282,7 @@ class CommunityInstallerRepository(InstallerRepository):
             awslambda_runtime_package,
             lambda_java_libs_package,
         )
+        from localstack.services.cloudformation.packages import cloudformation_package
         from localstack.services.dynamodb.packages import dynamodblocal_package
         from localstack.services.kinesis.packages import kinesalite_package, kinesismock_package
         from localstack.services.kms.packages import kms_local_package
@@ -294,7 +296,7 @@ class CommunityInstallerRepository(InstallerRepository):
         return [
             ("awslambda-go-runtime", awslambda_go_runtime_package),
             ("awslambda-runtime", awslambda_runtime_package),
-            ("cloudformation-libs", install_cloudformation_libs),
+            ("cloudformation-libs", cloudformation_package),
             ("dynamodb-local", dynamodblocal_package),
             ("elasticmq", elasticmq_package),
             ("elasticsearch", elasticsearch_package),

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -331,9 +331,9 @@ def install_components(names):
     parallelize(install_component, names)
 
     # TODO: subject to removal, migrated from old code
-    from localstack.services.awslambda.packages import lambda_java_libs
+    from localstack.services.awslambda.packages import lambda_java_libs_package
 
-    lambda_java_libs.install()
+    lambda_java_libs_package.install()
 
 
 def install_all_components():
@@ -421,7 +421,7 @@ class CommunityInstallerRepository(InstallerRepository):
         from localstack.services.awslambda.packages import (
             awslambda_go_runtime_package,
             awslambda_runtime_package,
-            lambda_java_libs,
+            lambda_java_libs_package,
         )
         from localstack.services.dynamodb.packages import dynamodblocal_package
         from localstack.services.kinesis.packages import kinesalite_package, kinesismock_package
@@ -441,7 +441,7 @@ class CommunityInstallerRepository(InstallerRepository):
             ("opensearch", opensearch_package),
             ("kinesalite", kinesalite_package),
             ("kinesis-mock", kinesismock_package),
-            ("lambda-java-libs", lambda_java_libs),
+            ("lambda-java-libs", lambda_java_libs_package),
             ("local-kms", install_local_kms),
             ("postgresql", PostgresqlPackage()),
             ("stepfunctions-local", install_stepfunctions_local),

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -225,16 +225,6 @@ def log_install_msg(component, verbatim=False):
     LOG.info("Downloading and installing %s. This may take some time.", component)
 
 
-def extract(source_archive, target):
-    _, ext = os.path.splitext(source_archive)
-    if ext == ".zip":
-        unzip(source_archive, target)
-    elif ext in [".bz2", ".gz", ".tgz"]:
-        untar(source_archive, target)
-    else:
-        raise Exception(f"Unsupported archive format: {ext}")
-
-
 def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archive=None):
     mkdir(target_dir)
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -57,6 +57,36 @@ TEST_LAMBDA_JAR_URL = "{url}/cloud/localstack/{name}/{version}/{name}-{version}-
     version=LOCALSTACK_MAVEN_VERSION, url=MAVEN_REPO_URL, name="localstack-utils"
 )
 
+# BEGIN OF SECTION
+
+# remove this whole section once its absence doesn't cause any problems anymore
+INSTALL_DIR_STEPFUNCTIONS = "%s/stepfunctions" % dirs.static_libs
+INSTALL_PATH_STEPFUNCTIONS_JAR = os.path.join(INSTALL_DIR_STEPFUNCTIONS, "StepFunctionsLocal.jar")
+IMAGE_NAME_SFN_LOCAL = "amazon/aws-stepfunctions-local:1.7.9"
+SFN_PATCH_URL_PREFIX = (
+    f"{ARTIFACTS_REPO}/raw/ac84739adc87ff4b5553478f6849134bcd259672/stepfunctions-local-patch"
+)
+SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
+SFN_PATCH_CLASS2 = (
+    "com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class"
+)
+SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
+SFN_PATCH_CLASS_REGION = "cloud/localstack/RegionAspect.class"
+SFN_PATCH_CLASS_ASYNC2SERVICEAPI = "cloud/localstack/Async2ServiceApi.class"
+SFN_PATCH_CLASS_DESCRIBEEXECUTIONPARSED = "cloud/localstack/DescribeExecutionParsed.class"
+SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
+
+SFN_IMAGE = "amazon/aws-stepfunctions-local"
+SFN_IMAGE_LAYER_DIGEST = "sha256:e7b256bdbc9d58c20436970e8a56bd03581b891a784b00fea7385faff897b777"
+
+SFN_AWS_SDK_URL_PREFIX = (
+    f"{ARTIFACTS_REPO}/raw/a4adc8f4da9c7ec0d93b50ca5b73dd14df791c0e/stepfunctions-internal-awssdk"
+)
+SFN_AWS_SDK_LAMBDA_ZIP_FILE = f"{SFN_AWS_SDK_URL_PREFIX}/awssdk.zip"
+
+
+# END OF SECTION
+
 
 def add_file_to_jar(class_file, class_url, target_jar, base_dir=None):
     base_dir = base_dir or os.path.dirname(target_jar)

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -430,6 +430,7 @@ class CommunityInstallerRepository(InstallerRepository):
             opensearch_package,
         )
         from localstack.services.sqs.legacy.packages import elasticmq_package
+        from localstack.services.stepfunctions.packages import stepfunctions_local_package
 
         return [
             ("awslambda-go-runtime", awslambda_go_runtime_package),
@@ -444,7 +445,7 @@ class CommunityInstallerRepository(InstallerRepository):
             ("lambda-java-libs", lambda_java_libs_package),
             ("local-kms", install_local_kms),
             ("postgresql", PostgresqlPackage()),
-            ("stepfunctions-local", install_stepfunctions_local),
+            ("stepfunctions-local", stepfunctions_local_package),
             ("terraform", install_terraform),
         ]
 

--- a/localstack/services/kms/kms_starter.py
+++ b/localstack/services/kms/kms_starter.py
@@ -1,21 +1,19 @@
 import logging
-import platform
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.infra import do_run, log_startup_message, start_proxy_for_service
-from localstack.services.install import INSTALL_PATH_KMS_BINARY_PATTERN
-from localstack.utils.common import get_arch, get_free_tcp_port, wait_for_port_open
+from localstack.utils.common import get_free_tcp_port, wait_for_port_open
 
 LOG = logging.getLogger(__name__)
 
 
 def start_kms_local(port=None, backend_port=None, asynchronous=None, update_listener=None):
+    from localstack.services.kms.packages import kms_local_package
+
     port = port or config.service_port("kms")
     backend_port = get_free_tcp_port()
-    kms_binary = INSTALL_PATH_KMS_BINARY_PATTERN.replace(
-        "<arch>", f"{platform.system().lower()}-{get_arch()}"
-    )
+    kms_binary = kms_local_package.get_installer().get_executable_path()
     log_startup_message("KMS")
     start_proxy_for_service("kms", port, backend_port, update_listener)
     account_id = get_aws_account_id()

--- a/localstack/services/kms/packages.py
+++ b/localstack/services/kms/packages.py
@@ -1,0 +1,37 @@
+import os
+import platform
+from typing import List
+
+from localstack.constants import KMS_URL_PATTERN
+from localstack.packages import Package, PackageInstaller
+from localstack.packages.core import PermissionDownloadInstaller
+from localstack.utils.platform import get_arch
+
+
+class KMSLocalPackage(Package):
+    def __init__(self):
+        super().__init__("LocalKMS", "latest")
+
+    def get_versions(self) -> List[str]:
+        return ["latest"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return KMSLocalPackageInstaller("local-kms", version)
+
+
+class KMSLocalPackageInstaller(PermissionDownloadInstaller):
+    # TODO: this used to be in static libs, fix or remove this
+    @staticmethod
+    def _get_local_arch():
+        return f"{platform.system().lower()}-{get_arch()}"
+
+    def _get_download_url(self) -> str:
+        return KMS_URL_PATTERN.replace("<arch>", KMSLocalPackageInstaller._get_local_arch())
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(
+            install_dir, f"{self.name}.{KMSLocalPackageInstaller._get_local_arch()}.bin"
+        )
+
+
+kms_local_package = KMSLocalPackage()

--- a/localstack/services/kms/packages.py
+++ b/localstack/services/kms/packages.py
@@ -1,4 +1,3 @@
-import os
 import platform
 from typing import List
 
@@ -20,17 +19,8 @@ class KMSLocalPackage(Package):
 
 
 class KMSLocalPackageInstaller(PermissionDownloadInstaller):
-    @staticmethod
-    def _get_local_arch():
-        return f"{platform.system().lower()}-{get_arch()}"
-
     def _get_download_url(self) -> str:
-        return KMS_URL_PATTERN.replace("<arch>", KMSLocalPackageInstaller._get_local_arch())
-
-    def _get_install_marker_path(self, install_dir: str) -> str:
-        return os.path.join(
-            install_dir, f"{self.name}.{KMSLocalPackageInstaller._get_local_arch()}.bin"
-        )
+        return KMS_URL_PATTERN.replace("<arch>", f"{platform.system().lower()}-{get_arch()}")
 
 
 kms_local_package = KMSLocalPackage()

--- a/localstack/services/kms/packages.py
+++ b/localstack/services/kms/packages.py
@@ -20,7 +20,6 @@ class KMSLocalPackage(Package):
 
 
 class KMSLocalPackageInstaller(PermissionDownloadInstaller):
-    # TODO: this used to be in static libs, fix or remove this
     @staticmethod
     def _get_local_arch():
         return f"{platform.system().lower()}-{get_arch()}"

--- a/localstack/services/kms/plugins.py
+++ b/localstack/services/kms/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import Package, packages
+
+
+@packages()
+def kms_local_package() -> Package:
+    from localstack.services.kms.packages import kms_local_package
+
+    return kms_local_package

--- a/localstack/services/sqs/legacy/packages.py
+++ b/localstack/services/sqs/legacy/packages.py
@@ -1,0 +1,36 @@
+import os
+from typing import List
+
+from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.services.install import log_install_msg
+from localstack.utils.files import mkdir
+from localstack.utils.http import download
+
+ELASTICMQ_JAR_URL = (
+    "https://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-1.1.0.jar"
+)
+
+
+class ElasticMQPackage(Package):
+    def __init__(self):
+        super().__init__("ElasticMQ", "1.1.0")
+
+    def get_versions(self) -> List[str]:
+        return ["1.1.0"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return ElasticMQPackageInstaller("elasticmq", version)
+
+
+class ElasticMQPackageInstaller(PackageInstaller):
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "elasticmq-server.jar")
+
+    def _install(self, target: InstallTarget) -> None:
+        log_install_msg("ElasticMQ")
+        install_dir = self._get_install_dir(target)
+        mkdir(install_dir)
+        download(ELASTICMQ_JAR_URL, self._get_install_marker_path(self._get_install_dir(target)))
+
+
+elasticmq_package = ElasticMQPackage()

--- a/localstack/services/sqs/legacy/plugins.py
+++ b/localstack/services/sqs/legacy/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import packages
+
+
+@packages(service="sqs", name="elasticmq")
+def elasticmq_package():
+    from localstack.services.sqs.legacy.packages import elasticmq_package
+
+    return elasticmq_package

--- a/localstack/services/stepfunctions/packages.py
+++ b/localstack/services/stepfunctions/packages.py
@@ -7,6 +7,7 @@ from typing import List
 import requests
 
 from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.packages.core import ExecutableInstaller
 from localstack.services.install import (
     ARTIFACTS_REPO,
     JAR_URLS,
@@ -52,7 +53,7 @@ Since the JAR files are platform-independent, you can use the layer digest of an
 """
 
 
-class StepFunctionsLocalePackage(Package):
+class StepFunctionsLocalPackage(Package):
     def __init__(self):
         super().__init__("StepFunctionsLocal", "1.7.9")
 
@@ -60,20 +61,14 @@ class StepFunctionsLocalePackage(Package):
         return ["1.7.9"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
-        return StepFunctionsLocalePackageInstaller("stepfunctions-local", version)
+        return StepFunctionsLocalPackageInstaller("stepfunctions-local", version)
 
 
-class StepFunctionsLocalePackageInstaller(PackageInstaller):
-    def get_executable_path(self) -> str | None:
-        install_dir = self.get_installed_dir()
-        if install_dir:
-            return self._get_install_marker_path(install_dir)
-
+class StepFunctionsLocalPackageInstaller(ExecutableInstaller):
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "StepFunctionsLocal.jar")
 
     def _install(self, target: InstallTarget) -> None:
-
         """
         The StepFunctionsLocal JAR files are downloaded using the artifacts in DockerHub (because AWS only provides an
         HTTP link to the most recent version). Installers are executed when building Docker, this means they _cannot_ use
@@ -83,8 +78,6 @@ class StepFunctionsLocalePackageInstaller(PackageInstaller):
         install_dir = self._get_install_dir(target)
         install_destination = self._get_install_marker_path(install_dir)
         if not os.path.exists(install_destination):
-
-            # target_path = dirs.static_libs
 
             # Download layer that contains the necessary jars
             def download_stepfunctions_jar(image, image_digest, target_path):
@@ -152,4 +145,4 @@ class StepFunctionsLocalePackageInstaller(PackageInstaller):
             download(SFN_AWS_SDK_LAMBDA_ZIP_FILE, target)
 
 
-stepfunctions_local_package = StepFunctionsLocalePackage()
+stepfunctions_local_package = StepFunctionsLocalPackage()

--- a/localstack/services/stepfunctions/packages.py
+++ b/localstack/services/stepfunctions/packages.py
@@ -64,7 +64,6 @@ class StepFunctionsLocalePackage(Package):
 
 
 class StepFunctionsLocalePackageInstaller(PackageInstaller):
-    # TODO: check if it makes sense to inherit from DownloadInstaller
     def get_executable_path(self) -> str | None:
         install_dir = self.get_installed_dir()
         if install_dir:

--- a/localstack/services/stepfunctions/packages.py
+++ b/localstack/services/stepfunctions/packages.py
@@ -64,6 +64,12 @@ class StepFunctionsLocalePackage(Package):
 
 
 class StepFunctionsLocalePackageInstaller(PackageInstaller):
+    # TODO: check if it makes sense to inherit from DownloadInstaller
+    def get_executable_path(self) -> str | None:
+        install_dir = self.get_installed_dir()
+        if install_dir:
+            return self._get_install_marker_path(install_dir)
+
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "StepFunctionsLocal.jar")
 

--- a/localstack/services/stepfunctions/packages.py
+++ b/localstack/services/stepfunctions/packages.py
@@ -1,0 +1,150 @@
+import json
+import os
+import re
+from pathlib import Path
+from typing import List
+
+import requests
+
+from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.services.install import (
+    ARTIFACTS_REPO,
+    JAR_URLS,
+    add_file_to_jar,
+    update_jar_manifest,
+)
+from localstack.utils.archives import untar
+from localstack.utils.files import file_exists_not_empty, mkdir, new_tmp_file, rm_rf
+from localstack.utils.http import download
+
+SFN_PATCH_URL_PREFIX = (
+    f"{ARTIFACTS_REPO}/raw/ac84739adc87ff4b5553478f6849134bcd259672/stepfunctions-local-patch"
+)
+SFN_PATCH_CLASS1 = "com/amazonaws/stepfunctions/local/runtime/Config.class"
+SFN_PATCH_CLASS2 = (
+    "com/amazonaws/stepfunctions/local/runtime/executors/task/LambdaTaskStateExecutor.class"
+)
+SFN_PATCH_CLASS_STARTER = "cloud/localstack/StepFunctionsStarter.class"
+SFN_PATCH_CLASS_REGION = "cloud/localstack/RegionAspect.class"
+SFN_PATCH_CLASS_ASYNC2SERVICEAPI = "cloud/localstack/Async2ServiceApi.class"
+SFN_PATCH_CLASS_DESCRIBEEXECUTIONPARSED = "cloud/localstack/DescribeExecutionParsed.class"
+SFN_PATCH_FILE_METAINF = "META-INF/aop.xml"
+
+SFN_AWS_SDK_URL_PREFIX = (
+    f"{ARTIFACTS_REPO}/raw/a4adc8f4da9c7ec0d93b50ca5b73dd14df791c0e/stepfunctions-internal-awssdk"
+)
+SFN_AWS_SDK_LAMBDA_ZIP_FILE = f"{SFN_AWS_SDK_URL_PREFIX}/awssdk.zip"
+
+SFN_IMAGE = "amazon/aws-stepfunctions-local"
+SFN_IMAGE_LAYER_DIGEST = "sha256:e7b256bdbc9d58c20436970e8a56bd03581b891a784b00fea7385faff897b777"
+"""
+Digest of the Docker layer which adds the StepFunctionsLocal JAR files to the Docker image.
+This digest pin defines the version of StepFunctionsLocal used in LocalStack.
+
+The Docker image layer digest can be determined by:
+- Use regclient: regctl image manifest amazon/aws-stepfunctions-local:1.7.9 --platform local
+- Inspect the manifest in the Docker registry manually:
+  - Get the auth bearer token (see download code).
+  - Download the manifest (/v2/<image/name>/manifests/<tag>) with the bearer token
+  - Follow any platform link
+  - Extract the layer digest
+Since the JAR files are platform-independent, you can use the layer digest of any platform's image.
+"""
+
+
+class StepFunctionsLocalePackage(Package):
+    def __init__(self):
+        super().__init__("StepFunctionsLocal", "1.7.9")
+
+    def get_versions(self) -> List[str]:
+        return ["1.7.9"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return StepFunctionsLocalePackageInstaller("stepfunctions-local", version)
+
+
+class StepFunctionsLocalePackageInstaller(PackageInstaller):
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "StepFunctionsLocal.jar")
+
+    def _install(self, target: InstallTarget) -> None:
+
+        """
+        The StepFunctionsLocal JAR files are downloaded using the artifacts in DockerHub (because AWS only provides an
+        HTTP link to the most recent version). Installers are executed when building Docker, this means they _cannot_ use
+        the Docker socket. Therefore, this installer downloads a pinned Docker Layer Digest (i.e. only the data for a single
+        Docker build step which adds the JAR files of the desired version to a Docker image) using plain HTTP requests.
+        """
+        install_dir = self._get_install_dir(target)
+        install_destination = self._get_install_marker_path(install_dir)
+        if not os.path.exists(install_destination):
+
+            # target_path = dirs.static_libs
+
+            # Download layer that contains the necessary jars
+            def download_stepfunctions_jar(image, image_digest, target_path):
+                registry_base = "https://registry-1.docker.io"
+                auth_base = "https://auth.docker.io"
+                auth_service = "registry.docker.io"
+                token_request = requests.get(
+                    f"{auth_base}/token?service={auth_service}&scope=repository:{image}:pull"
+                )
+                token = json.loads(token_request.content.decode("utf-8"))["token"]
+                headers = {"Authorization": f"Bearer {token}"}
+                response = requests.get(
+                    headers=headers,
+                    url=f"{registry_base}/v2/{image}/blobs/{image_digest}",
+                )
+                temp_path = new_tmp_file()
+                with open(temp_path, "wb") as f:
+                    f.write(response.content)
+                untar(temp_path, target_path)
+
+            download_stepfunctions_jar(SFN_IMAGE, SFN_IMAGE_LAYER_DIGEST, target.value)
+            mkdir(install_dir)
+            path = Path(f"{target.value}/home/stepfunctionslocal")
+            for file in path.glob("*.jar"):
+                file.rename(Path(install_dir) / file.name)
+            rm_rf(f"{target.value}/home")
+
+        classes = [
+            SFN_PATCH_CLASS1,
+            SFN_PATCH_CLASS2,
+            SFN_PATCH_CLASS_REGION,
+            SFN_PATCH_CLASS_STARTER,
+            SFN_PATCH_CLASS_ASYNC2SERVICEAPI,
+            SFN_PATCH_CLASS_DESCRIBEEXECUTIONPARSED,
+            SFN_PATCH_FILE_METAINF,
+        ]
+        for patch_class in classes:
+            patch_url = f"{SFN_PATCH_URL_PREFIX}/{patch_class}"
+            add_file_to_jar(patch_class, patch_url, target_jar=install_destination)
+
+        # add additional classpath entries to JAR manifest file
+        classpath = " ".join([os.path.basename(jar) for jar in JAR_URLS])
+        update_jar_manifest(
+            "StepFunctionsLocal.jar",
+            install_dir,
+            "Class-Path: . ",
+            f"Class-Path: {classpath} . ",
+        )
+        update_jar_manifest(
+            "StepFunctionsLocal.jar",
+            install_dir,
+            re.compile(r"Main-Class: com\.amazonaws.+"),
+            "Main-Class: cloud.localstack.StepFunctionsStarter",
+        )
+
+        # download additional jar libs
+        for jar_url in JAR_URLS:
+            jar_target = os.path.join(install_dir, os.path.basename(jar_url))
+            if not file_exists_not_empty(jar_target):
+                download(jar_url, jar_target)
+
+        # download aws-sdk lambda handler
+        target = os.path.join(install_dir, "localstack-internal-awssdk", "awssdk.zip")
+        if not file_exists_not_empty(target):
+            download(SFN_AWS_SDK_LAMBDA_ZIP_FILE, target)
+
+
+stepfunctions_local_package = StepFunctionsLocalePackage()

--- a/localstack/services/stepfunctions/plugins.py
+++ b/localstack/services/stepfunctions/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages import Package, packages
+
+
+@packages()
+def stepfunctions_local_package() -> Package:
+    from localstack.services.stepfunctions.packages import stepfunctions_local_package
+
+    return stepfunctions_local_package

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -70,7 +70,6 @@ def start_stepfunctions(asynchronous=True, persistence_path: Optional[str] = Non
     # TODO: introduce Server abstraction for StepFunctions process
     global PROCESS_THREAD
     backend_port = config.LOCAL_PORT_STEPFUNCTIONS
-    # TODO: this should be solved via Plugin discovery, remove once confirmed
     stepfunctions_local_package.install()
     cmd = get_command(backend_port)
     log_startup_message("StepFunctions")

--- a/localstack/services/stepfunctions/stepfunctions_starter.py
+++ b/localstack/services/stepfunctions/stepfunctions_starter.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
-from localstack.services import install
 from localstack.services.infra import do_run, log_startup_message
+from localstack.services.stepfunctions.packages import stepfunctions_local_package
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import wait_for_port_open
 from localstack.utils.sync import retry
@@ -20,6 +20,7 @@ PROCESS_THREAD = None
 
 # TODO: pass env more explicitly
 def get_command(backend_port):
+    install_dir_stepfunctions = stepfunctions_local_package.get_installed_dir()
     cmd = (
         "cd %s; PORT=%s java "
         "-javaagent:aspectjweaver-1.9.7.jar "
@@ -27,7 +28,7 @@ def get_command(backend_port):
         "-Dcom.amazonaws.sdk.disableCertChecking -Xmx%s "
         "-jar StepFunctionsLocal.jar --aws-account %s"
     ) % (
-        install.INSTALL_DIR_STEPFUNCTIONS,
+        install_dir_stepfunctions,
         backend_port,
         MAX_HEAP_SIZE,
         get_aws_account_id(),
@@ -69,7 +70,8 @@ def start_stepfunctions(asynchronous=True, persistence_path: Optional[str] = Non
     # TODO: introduce Server abstraction for StepFunctions process
     global PROCESS_THREAD
     backend_port = config.LOCAL_PORT_STEPFUNCTIONS
-    install.install_stepfunctions_local()
+    # TODO: this should be solved via Plugin discovery, remove once confirmed
+    stepfunctions_local_package.install()
     cmd = get_command(backend_port)
     log_startup_message("StepFunctions")
     # TODO: change ports in stepfunctions.jar, then update here

--- a/tests/integration/awslambda/test_lambda_legacy.py
+++ b/tests/integration/awslambda/test_lambda_legacy.py
@@ -13,7 +13,8 @@ from localstack.services.awslambda.lambda_api import (
     use_docker,
 )
 from localstack.services.awslambda.lambda_utils import LAMBDA_DEFAULT_HANDLER
-from localstack.services.install import GO_RUNTIME_VERSION, download_and_extract
+from localstack.services.awslambda.packages import awslambda_go_runtime_package
+from localstack.services.install import download_and_extract
 from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.testing.pytest.fixtures import skip_if_pro_enabled
 from localstack.utils import testutil
@@ -272,7 +273,7 @@ class TestGolangRuntimes:
 
         # fetch platform-specific example handler
         url = TEST_GOLANG_LAMBDA_URL_TEMPLATE.format(
-            version=GO_RUNTIME_VERSION,
+            version=awslambda_go_runtime_package.default_version,
             os=get_os(),
             arch=get_arch(),
         )

--- a/tests/integration/awslambda/test_lambda_runtimes.py
+++ b/tests/integration/awslambda/test_lambda_runtimes.py
@@ -122,7 +122,7 @@ class TestJavaRuntimes:
         zip_jar_path = os.path.join(zip_lib_dir, "test.lambda.jar")
         mkdir(zip_lib_dir)
         installer = lambda_java_libs_package.get_installer()
-        java_lib_dir = installer._get_install_marker_path(installer.get_installed_dir())
+        java_lib_dir = installer.get_executable_path()
         cp_r(
             java_lib_dir,
             os.path.join(zip_lib_dir, "executor.lambda.jar"),

--- a/tests/integration/awslambda/test_lambda_runtimes.py
+++ b/tests/integration/awslambda/test_lambda_runtimes.py
@@ -6,7 +6,8 @@ import pytest
 
 from localstack.aws.api.lambda_ import Runtime
 from localstack.services.awslambda.lambda_api import use_docker
-from localstack.services.install import INSTALL_PATH_LOCALSTACK_FAT_JAR, TEST_LAMBDA_JAVA
+from localstack.services.awslambda.packages import lambda_java_libs_package
+from localstack.services.install import TEST_LAMBDA_JAVA
 from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.utils import testutil
 from localstack.utils.archives import unzip
@@ -121,7 +122,7 @@ class TestJavaRuntimes:
         zip_jar_path = os.path.join(zip_lib_dir, "test.lambda.jar")
         mkdir(zip_lib_dir)
         cp_r(
-            INSTALL_PATH_LOCALSTACK_FAT_JAR,
+            lambda_java_libs_package.get_installed_dir(),
             os.path.join(zip_lib_dir, "executor.lambda.jar"),
         )
         save_file(zip_jar_path, test_java_jar)

--- a/tests/integration/awslambda/test_lambda_runtimes.py
+++ b/tests/integration/awslambda/test_lambda_runtimes.py
@@ -121,8 +121,10 @@ class TestJavaRuntimes:
         zip_lib_dir = os.path.join(tmpdir, "lib")
         zip_jar_path = os.path.join(zip_lib_dir, "test.lambda.jar")
         mkdir(zip_lib_dir)
+        installer = lambda_java_libs_package.get_installer()
+        java_lib_dir = installer._get_install_marker_path(installer.get_installed_dir())
         cp_r(
-            lambda_java_libs_package.get_installed_dir(),
+            java_lib_dir,
             os.path.join(zip_lib_dir, "executor.lambda.jar"),
         )
         save_file(zip_jar_path, test_java_jar)

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -6,7 +6,7 @@ import pytest
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
-from localstack.services.install import TERRAFORM_BIN, install_terraform
+from localstack.packages.terraform import terraform_package
 from localstack.utils.common import is_command_available, rm_rf, run, start_worker_thread
 
 #  TODO: remove all of these
@@ -23,6 +23,9 @@ LAMBDA_RUNTIME = "dotnetcore2.0"
 LAMBDA_ROLE = "arn:aws:iam::{account_id}:role/iam_for_lambda"
 
 INIT_LOCK = threading.RLock()
+
+# set after calling install()
+TERRAFORM_BIN = None
 
 
 def check_terraform_version():
@@ -72,8 +75,9 @@ class TestTerraform:
     def init_async(cls):
         def _run(*args):
             with INIT_LOCK:
-                install_terraform()
-
+                terraform_package.install()
+                global TERRAFORM_BIN
+                TERRAFORM_BIN = terraform_package.get_installer().get_executable_path()
                 base_dir = get_base_dir()
                 if not os.path.exists(os.path.join(base_dir, ".terraform", "plugins")):
                     run(f"cd {base_dir}; {TERRAFORM_BIN} init -input=false")

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -52,8 +52,8 @@ def test_install_failure_returns_non_zero_exit_code(runner, monkeypatch):
 
 @pytest.mark.skip_offline
 def test_install_with_package(runner):
-    from localstack.services.install import INSTALL_PATH_ELASTICMQ_JAR
+    from localstack.services.sqs.legacy.packages import elasticmq_package
 
     result = runner.invoke(cli, ["install", "elasticmq"])
     assert result.exit_code == 0
-    assert os.path.exists(INSTALL_PATH_ELASTICMQ_JAR)
+    assert os.path.exists(elasticmq_package.get_installed_dir())


### PR DESCRIPTION
This pr migrates the install routines of the following dependencies to the new architecture as introduced in #6783:

- awslambda-runtime
- awslambda-go-runtime
- cloudformation-libs
- elasticmq (legacy)
- kms-local
- lambda-java-libs
- stepfunctions-local
- terraform

This completes all the install routines currently installable via lpm.