### PR TITLE
Fix DynamodbStreams binary data consistency

### DIFF
--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -1,4 +1,4 @@
-import json
+import bson
 import logging
 import threading
 import time
@@ -73,7 +73,7 @@ def forward_events(records: Dict) -> None:
             stream_name = get_kinesis_stream_name(table_name)
             kinesis.put_record(
                 StreamName=stream_name,
-                Data=json.dumps(record, cls=BytesEncoder),
+                Data=bson.BSON.encode(record),
                 PartitionKey="TODO",
             )
 

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -1,15 +1,15 @@
-import bson
 import logging
 import threading
 import time
 from typing import Dict
+
+import bson
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodbstreams import StreamStatus, StreamViewType
 from localstack.services.dynamodbstreams.models import DynamoDbStreamsStore, dynamodbstreams_stores
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import now_utc
-from localstack.utils.json import BytesEncoder
 
 DDB_KINESIS_STREAM_NAME_PREFIX = "__ddb_stream_"
 

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -73,7 +73,7 @@ def forward_events(records: Dict) -> None:
             stream_name = get_kinesis_stream_name(table_name)
             kinesis.put_record(
                 StreamName=stream_name,
-                Data=bson.BSON.encode(record),
+                Data=bson.dumps(record),
                 PartitionKey="TODO",
             )
 

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -103,7 +103,7 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
             "NextShardIterator": kinesis_records.get("NextShardIterator"),
         }
         for record in kinesis_records["Records"]:
-            record_data = bson.BSON.decode(record["Data"])
+            record_data = bson.loads(record["Data"])
             record_data["dynamodb"]["SequenceNumber"] = record["SequenceNumber"]
             result["Records"].append(record_data)
         return GetRecordsOutput(**result)

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -1,6 +1,7 @@
 import copy
-import bson
 import logging
+
+import bson
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.dynamodbstreams import (
@@ -33,7 +34,6 @@ from localstack.services.dynamodbstreams.dynamodbstreams_api import (
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import aws_stack
 from localstack.utils.collections import select_from_typed_dict
-from localstack.utils.common import to_str
 
 LOG = logging.getLogger(__name__)
 

--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -1,5 +1,5 @@
 import copy
-import json
+import bson
 import logging
 
 from localstack.aws.api import RequestContext, handler
@@ -103,7 +103,7 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
             "NextShardIterator": kinesis_records.get("NextShardIterator"),
         }
         for record in kinesis_records["Records"]:
-            record_data = json.loads(to_str(record["Data"]))
+            record_data = bson.BSON.decode(record["Data"])
             record_data["dynamodb"]["SequenceNumber"] = record["SequenceNumber"]
             result["Records"].append(record_data)
         return GetRecordsOutput(**result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,7 @@ runtime =
     xmltodict>=0.11.0
     awscrt>=0.13.14
     vosk==0.3.43
+    bson==0.5.10
 
 # @deprecated - use extra 'runtime' instead.
 full =

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1544,8 +1544,15 @@ class TestDynamoDB:
         table = client.describe_table(TableName=table_name)
         assert table.get("Table")
 
-    @pytest.mark.skip_snapshot_verify(paths=["$..eventID", "$..SequenceNumber"])
-    def test_data_encoding_consistency(self, dynamodbstreams_client, dynamodb_create_table_with_parameters, wait_for_stream_ready, dynamodb_client, snapshot):
+    @pytest.mark.skip_snapshot_verify(paths=["$..eventID", "$..SequenceNumber", "$..SizeBytes"])
+    def test_data_encoding_consistency(
+        self,
+        dynamodbstreams_client,
+        dynamodb_create_table_with_parameters,
+        wait_for_stream_ready,
+        dynamodb_client,
+        snapshot,
+    ):
         table_name = f"table-{short_uid()}"
         table = dynamodb_create_table_with_parameters(
             TableName=table_name,
@@ -1564,7 +1571,9 @@ class TestDynamoDB:
         )
 
         # get item
-        item = dynamodb_client.get_item(TableName=table_name, Key={PARTITION_KEY: {"S": "id1"}})["Item"]
+        item = dynamodb_client.get_item(TableName=table_name, Key={PARTITION_KEY: {"S": "id1"}})[
+            "Item"
+        ]
         snapshot.match("GetItem", item)
 
         # get stream records
@@ -1580,9 +1589,12 @@ class TestDynamoDB:
             .get("SequenceNumberRange")
             .get("StartingSequenceNumber"),
         )
-        records = dynamodbstreams_client.get_records(ShardIterator=response["ShardIterator"])["Records"]
+        records = dynamodbstreams_client.get_records(ShardIterator=response["ShardIterator"])[
+            "Records"
+        ]
 
         snapshot.match("GetRecords", records[0]["dynamodb"])
+
 
 def delete_table(name):
     dynamodb_client = aws_stack.create_external_boto_client("dynamodb")

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1544,6 +1544,7 @@ class TestDynamoDB:
         table = client.describe_table(TableName=table_name)
         assert table.get("Table")
 
+    @pytest.mark.only_localstack(reason="wait_for_stream_ready of kinesis stream")
     @pytest.mark.skip_snapshot_verify(paths=["$..eventID", "$..SequenceNumber", "$..SizeBytes"])
     def test_data_encoding_consistency(
         self,
@@ -1564,6 +1565,8 @@ class TestDynamoDB:
                 "StreamViewType": "NEW_AND_OLD_IMAGES",
             },
         )
+        stream_name = get_kinesis_stream_name(table_name)
+        wait_for_stream_ready(stream_name)
 
         # put item
         dynamodb_client.put_item(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1544,6 +1544,7 @@ class TestDynamoDB:
         table = client.describe_table(TableName=table_name)
         assert table.get("Table")
 
+    @pytest.mark.skip_snapshot_verify(paths=["$..eventID", "$..SequenceNumber"])
     def test_data_encoding_consistency(self, dynamodbstreams_client, dynamodb_create_table_with_parameters, wait_for_stream_ready, dynamodb_client, snapshot):
         table_name = f"table-{short_uid()}"
         table = dynamodb_create_table_with_parameters(

--- a/tests/integration/test_dynamodb.snapshot.json
+++ b/tests/integration/test_dynamodb.snapshot.json
@@ -327,5 +327,37 @@
     "recorded-content": {
       "ValidationException": "An error occurred (ValidationException) when calling the BatchWriteItem operation: The provided key element does not match the schema"
     }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_data_encoding_consistency": {
+    "recorded-date": "23-09-2022, 13:03:42",
+    "recorded-content": {
+      "GetItem": {
+        "data": {
+          "B": "b'\\x90'"
+        },
+        "id": {
+          "S": "id1"
+        }
+      },
+      "GetRecords": {
+        "ApproximateCreationDateTime": "datetime",
+        "Keys": {
+          "id": {
+            "S": "id1"
+          }
+        },
+        "NewImage": {
+          "data": {
+            "B": "b'\\x90'"
+          },
+          "id": {
+            "S": "id1"
+          }
+        },
+        "SequenceNumber": "100000000023871950156",
+        "SizeBytes": 15,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      }
+    }
   }
 }


### PR DESCRIPTION
### Summary
This PR solves an issue where `GetItem` of DynamoDB returns a differently encoded value than `GetRecords` of DynamoDBStreams. This is especially obvious when using binary data (a test case of `b"\x90"` already reveals the issue).

Adds test case `test_data_encoding_consistency`

### Related
Fixes: #6786, Fixes: #6700 

### Note
The test case is currently flaky, therefore I draft the PR for now. 
However, since a similary structured test case [here](https://github.com/localstack/localstack/blob/master/tests/integration/test_dynamodb.py#L1188) is also flaky, I highly suspect that the flakiness is not because of my solution, but because of the client. 