### PR TITLE
Small fix to handle empty init dir with legacy directories in non-Docker mode

### DIFF
--- a/localstack/runtime/init.py
+++ b/localstack/runtime/init.py
@@ -151,6 +151,10 @@ class InitScriptManager:
     def _find_scripts(self) -> Dict[Stage, List[Script]]:
         scripts = {}
 
+        if self.script_root is None:
+            LOG.debug("Unable to discover init scripts as script_root is None")
+            return {}
+
         for stage in Stage:
             scripts[stage] = []
 

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1355,7 +1355,7 @@ class TestS3:
         )
         temp_folder = create_tmp_folder_lambda(
             handler_file,
-            run_command="npm i @aws-sdk/client-s3; npm i @aws-sdk/s3-request-presigner",
+            run_command="npm i @aws-sdk/client-s3; npm i @aws-sdk/s3-request-presigner; npm i @aws-sdk/middleware-endpoint",
         )
 
         function_name = f"func-integration-{short_uid()}"

--- a/tests/unit/runtime/test_init.py
+++ b/tests/unit/runtime/test_init.py
@@ -179,3 +179,8 @@ class TestInitScriptManager:
         # check script output
         assert (tmp_path / "script_01.out").read_text().strip() == "hello 1"
         assert (tmp_path / "script_03.out").read_text().strip() == "hello 3"
+
+    def test_empty_init_path(self):
+        manager = InitScriptManager(script_root=None)
+        scripts = manager.scripts
+        assert scripts == {}


### PR DESCRIPTION
Small fix to handle empty (`None`) values for `init` dir with legacy directories in non-Docker mode.

Addresses https://github.com/localstack/helm-charts/issues/60 

The issue can be replicated when deploying the Helm chart in a local k3d Kubernetes cluster. More easily, can also be replicated when using legacy directories in host mode:
```
LEGACY_DIRECTORIES=1 bin/localstack start --host
```

@thrau If you feel that there is a better fix , please feel free to push changes directly to the PR. 👍  This is more of a bandaid/quickfix now - but seems to be good enough, just to fix the symptom for now (and as we're going to phase out the legacy filesystem hierarchy at some point soon).

---
Side note: Interestingly, this cannot be replicated in the built-in Kubernetes that ships with Docker Desktop (as commented on issue https://github.com/localstack/helm-charts/issues/60). The reason is that after deploying the Helm chart into the local kube cluster, and `exec`'ing into the pod, the `/.dockerenv` marker file is present in the pod (which we're using for our `in_docker()` detection):
```
$ helm install ...
...
$ kubectl exec -it test-localstack-776b769f8-k9rjw bash
# ls -la /.dockerenv
-rwxr-xr-x 1 root root 0 Sep 25 11:42 /.dockerenv
```