### PR TITLE
Minor fix for Lambda layer response parsing

### DIFF
--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -1400,6 +1400,7 @@ def update_function_configuration(function):
     if data.get("TracingConfig"):
         lambda_details.tracing_config = data["TracingConfig"]
     lambda_details.last_modified = datetime.utcnow()
+    data.pop("Layers", None)
     result = data
     lambda_function = region.lambdas.get(arn)
     result.update(format_func_details(lambda_function))

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -72,6 +72,22 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 
 
+def is_pro_enabled() -> bool:
+    """Return whether the Pro extensions are enabled, i.e., restricted modules can be imported"""
+    try:
+        import localstack_ext.utils.common
+
+        return True
+    except Exception:
+        return False
+
+
+# marker to indicate that a test should be skipped if the Pro extensions are enabled
+skip_if_pro_enabled = pytest.mark.skipif(
+    condition=is_pro_enabled(), reason="skipping, as Pro extensions are enabled"
+)
+
+
 def _client(service, region_name=None, *, additional_config=None):
     config = botocore.config.Config()
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -75,7 +75,7 @@ LOG = logging.getLogger(__name__)
 def is_pro_enabled() -> bool:
     """Return whether the Pro extensions are enabled, i.e., restricted modules can be imported"""
     try:
-        import localstack_ext.utils.common
+        import localstack_ext.utils.common  # noqa
 
         return True
     except Exception:

--- a/tests/integration/awslambda/test_lambda_legacy.py
+++ b/tests/integration/awslambda/test_lambda_legacy.py
@@ -217,6 +217,20 @@ class TestLambdaLegacyProvider:
             lambda_client.delete_function(FunctionName=func_name)
         assert "ResourceNotFoundException" in str(exc)
 
+    def test_update_lambda_with_layers(self, iam_client, lambda_client, create_lambda_function):
+        func_name = f"lambda-{short_uid()}"
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=func_name,
+            runtime=Runtime.python3_9,
+        )
+
+        # update function config with Layers - should be ignored (and not raise a serializer error)
+        result = lambda_client.update_function_configuration(
+            FunctionName=func_name, Layers=["foo:bar"]
+        )
+        assert "Layers" not in result
+
 
 # Ruby and Golang runtimes aren't heavily used and therefore not covered by the complete test suite
 # A legacy integration test can be found here

--- a/tests/integration/awslambda/test_lambda_legacy.py
+++ b/tests/integration/awslambda/test_lambda_legacy.py
@@ -15,6 +15,7 @@ from localstack.services.awslambda.lambda_api import (
 from localstack.services.awslambda.lambda_utils import LAMBDA_DEFAULT_HANDLER
 from localstack.services.install import GO_RUNTIME_VERSION, download_and_extract
 from localstack.testing.aws.lambda_utils import is_old_provider
+from localstack.testing.pytest.fixtures import skip_if_pro_enabled
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.files import load_file
@@ -217,6 +218,7 @@ class TestLambdaLegacyProvider:
             lambda_client.delete_function(FunctionName=func_name)
         assert "ResourceNotFoundException" in str(exc)
 
+    @skip_if_pro_enabled
     def test_update_lambda_with_layers(self, iam_client, lambda_client, create_lambda_function):
         func_name = f"lambda-{short_uid()}"
         create_lambda_function(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1089,7 +1089,7 @@ class TestDynamoDB:
     def test_transaction_write_canceled(
         self, dynamodb_create_table_with_parameters, dynamodb_client, snapshot
     ):
-        table_name = "table_%s" % short_uid()
+        table_name = f"table_{short_uid()}"
 
         # create table
         dynamodb_create_table_with_parameters(
@@ -1522,6 +1522,14 @@ class TestDynamoDB:
                 RequestItems={table_name: [{"PutRequest": faulty_item}]}
             )
         snapshot.match("ValidationException", ctx.value)
+
+    def test_batch_write_not_existing_table(self, dynamodb_client):
+        with pytest.raises(Exception) as ctx:
+            dynamodb_client.transact_write_items(
+                TransactItems=[{"Put": {"TableName": "non-existing-table", "Item": {}}}]
+            )
+        ctx.match("ResourceNotFoundException")
+        assert "retries" not in str(ctx)
 
     @pytest.mark.only_localstack
     def test_nosql_workbench_localhost_region(self, dynamodb_create_table, dynamodb_client):


### PR DESCRIPTION
Minor fix for Lambda layer response parsing. Addresses https://github.com/localstack/serverless-localstack/issues/175

Currently, we're taking the incoming `Layers` parameter (which is a list of strings) in the `UpdateFunctionConfiguration` API method, and simply pass it through to the response - however, the response `Layers` attribute should be a list of dicts with the details. 

For now, simply removing `Layers` from the response - it is already being added separately upstream, so this should not break -ext functionality.

---
PR also sneaks in a small fix for `transact_write_items` that surfaced during testing, to raise the correct exception (ASF exception, instead of boto3 error), in order to avoid 500 errors. (Happy to create that as a separate PR, but seemed reasonably simple/innocuous to add it here)