### PR TITLE
Pin pyOpenSSL to 21.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ runtime =
     moto-ext[all]==4.0.1.post2
     opensearch-py==1.1.0
     pproxy>=2.7.0
-    pyopenssl>=21.0.0
+    pyopenssl==21.0.0
     Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9


### PR DESCRIPTION
pyOpenSSL 21.1.0 drops support for SSLv2 and SSLv3. This breaks pyftplib which is used in AWS Transfer tests. It is not possible to pin it in pyftplib as it uses pyOpenSSL as an indirect dependency (by not having an explicit dependency in setup).

Changelog: https://pypi.org/project/pyOpenSSL/

Failure: https://github.com/localstack/localstack-ext/actions/runs/3125572451/jobs/5071294179#step:17:1174