### PR TITLE
fix performance issue with ResponseStream wrapper

### DIFF
--- a/localstack/aws/client.py
+++ b/localstack/aws/client.py
@@ -17,7 +17,8 @@ LOG = logging.getLogger(__name__)
 
 class _ResponseStream(io.RawIOBase):
     """
-    Wraps a Response and makes it available as a readable IO stream.
+    Wraps a Response and makes it available as a readable IO stream. If the response stream is used as an iterable, it
+    will use the underlying response object directly.
 
     Adapted from https://stackoverflow.com/a/20260030/804840
     """
@@ -30,15 +31,25 @@ class _ResponseStream(io.RawIOBase):
     def readable(self):
         return True
 
-    def readinto(self, b):
+    def readinto(self, buffer):
         try:
-            upto = len(b)  # We're supposed to return at most this much
+            upto = len(buffer)  # We're supposed to return at most this much
             chunk = self._buf or next(self.iterator)
+            # FIXME: this is very slow as it copies the entire chunk
             output, self._buf = chunk[:upto], chunk[upto:]
-            b[: len(output)] = output
+            buffer[: len(output)] = output
             return len(output)
         except StopIteration:
             return 0  # indicate EOF
+
+    def close(self) -> None:
+        return self.response.close()
+
+    def __iter__(self):
+        return self.iterator
+
+    def __next__(self):
+        return next(self.iterator)
 
     def __str__(self):
         length = self.response.content_length

--- a/tests/unit/aws/test_client.py
+++ b/tests/unit/aws/test_client.py
@@ -1,5 +1,7 @@
+import pytest
+
 from localstack.aws.api import ServiceException
-from localstack.aws.client import parse_service_exception
+from localstack.aws.client import _ResponseStream, parse_service_exception
 from localstack.http import Response
 
 
@@ -21,3 +23,38 @@ def test_parse_service_exception():
     # Ensure that the parsed exception does not have the "Error" field from the botocore response dict
     assert not hasattr(exception, "Error")
     assert not hasattr(exception, "error")
+
+
+class TestResponseStream:
+    def test_read(self):
+        response = Response(b"foobar")
+
+        with _ResponseStream(response) as stream:
+            assert stream.read(3) == b"foo"
+            assert stream.read(3) == b"bar"
+
+    def test_read_with_generator_response(self):
+        def _gen():
+            yield b"foo"
+            yield b"bar"
+
+        response = Response(_gen())
+
+        with _ResponseStream(response) as stream:
+            assert stream.read(2) == b"fo"
+            # currently the response stream will not buffer across the next line
+            assert stream.read(4) == b"o"
+            assert stream.read(4) == b"bar"
+
+    def test_as_iterator(self):
+        def _gen():
+            yield b"foo"
+            yield b"bar"
+
+        response = Response(_gen())
+
+        with _ResponseStream(response) as stream:
+            assert next(stream) == b"foo"
+            assert next(stream) == b"bar"
+            with pytest.raises(StopIteration):
+                next(stream)


### PR DESCRIPTION
This PR fixes a performance issue that occurred with AWS responses that have streaming bodies. The change exposes the underlying iterator of `Response` directly through the `_ResponseStream` wrapper, so invocations of the form `for item in stream` no longer go through the pointless `read_into` abstraction.

## Detailed explanation

This issues surfaced with the new S3 provider, where `get_object` download would take exponentially longer the larger the body. When bodies are streamed, we wrap the response in a `_ResponseStream` object that exposes the response as a readable IO object
https://github.com/localstack/localstack/blob/68c507ed073da8d5c5bd626e4106e4a40b4daee0/localstack/aws/client.py#L150

The issue is that the `_ResponseStream` is invoked in the form `for item in stream`. Through the RawIOBase abstraction, this creates an iterator by looping over calls to `read_into` with a byte buffer of size 1.
The culprit is this line in particular:
https://github.com/localstack/localstack/blob/68c507ed073da8d5c5bd626e4106e4a40b4daee0/localstack/aws/client.py#L37
Since the underlying response is one big blob in memory, `chunk` will actually contain the entire s3 object. Consequently, we're always popping a _single_ byte off the entire chunk to populate the response, and copying the remaining buffer. This will take longer depending on how big chunk is, which is the exponential runtime behavior we were seeing.

After the fix, read_into might actually be dead code now, since the underlying webserver always consumes the response stream using the `for data in stream` pattern. However, `read_into` is still necessary for the `RawIOBase` implementation, so I added tests to cover it.

## Reproduce

Here's a simple benchmark. On my machine this takes
* 1.3 seconds without the fix
* 0.00016 seconds with the fix

```python
import timeit

from werkzeug.wrappers.response import _iter_encoded, Response

from localstack.aws.client import _ResponseStream

n_bytes = 200000


def process_stream():
    b = b'0' * n_bytes
    stream = _ResponseStream(Response(b))

    for line in _iter_encoded(stream, 'utf-8'):
        assert line


def main():
    print(timeit.timeit(stmt=process_stream, number=1))


if __name__ == '__main__':
    main()
```