### PR TITLE
pin pyOpenSSL to 22.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ runtime =
     moto-ext[all]==4.0.1.post2
     opensearch-py==1.1.0
     pproxy>=2.7.0
-    pyopenssl==21.0.0
+    pyopenssl==22.0.0
     Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth==0.9


### PR DESCRIPTION
PyOpenSSL was pinned to 21.0.0 in #6936. However this introduced other unrelated regressions.

This PR now pins PyOpenSSL to 22.0.0, which is compatible with OpenSSL 1.1.1 and without the issue in #6936 

Previously failing ext test: https://github.com/localstack/localstack-ext/actions/runs/3133713131/jobs/5087396457#step:17:1157