### PR TITLE
[KMS] Adding digests for KMS sign/verify.

### DIFF
--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -267,12 +267,41 @@ class TestKMS:
         key_spec = "RSA_2048" if key_type == "rsa" else "ECC_NIST_P256"
         result = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)
         key_id = result["KeyId"]
-
-        message = b"test message 123 !%$@"
+        # 32 bytes to also match the expected length of SHA 256 digest. Initially our code didn't react to
+        # MessageType at all, so both "RAW" and "DIGEST" values had the same result, i.e. digests were being treated
+        # like plaintext. So using this message both as a plaintext and a digest of some plaintext allows us to test
+        # that we have different implementations for different MessageTypes.
+        message = b"test message 123 !%$@ 1234567890"
         algo = "RSASSA_PSS_SHA_256" if key_type == "rsa" else "ECDSA_SHA_256"
         kwargs = {"KeyId": key_id, "Message": message, "SigningAlgorithm": algo}
-        signature = kms_client.sign(**kwargs)["Signature"]
-        assert kms_client.verify(Signature=signature, **kwargs)["SignatureValid"]
+
+        # These following locks basically test that MessageType="DIGEST" results in a different outcome
+        # from the default MessageType="RAW". As long as both Sign and Verify are called with the same MessageType,
+        # everything should work, while if this parameter mismatches between such two calls - the verifications is
+        # supposed to fail.
+        #
+        # There is a possibility that I do not understand how digests work, so can't write better tests. So if we
+        # have any issues with the digests - know that the current approach is not a calculated design, but rather a
+        # guess.
+        signature = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
+        assert kms_client.verify(MessageType="RAW", Signature=signature, **kwargs)["SignatureValid"]
+
+        signature = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
+        with pytest.raises(kms_client.exceptions.KMSInvalidSignatureException):
+            assert not kms_client.verify(MessageType="DIGEST", Signature=signature, **kwargs)[
+                "SignatureValid"
+            ]
+
+        signature = kms_client.sign(MessageType="DIGEST", **kwargs)["Signature"]
+        with pytest.raises(kms_client.exceptions.KMSInvalidSignatureException):
+            assert not kms_client.verify(MessageType="RAW", Signature=signature, **kwargs)[
+                "SignatureValid"
+            ]
+
+        signature = kms_client.sign(MessageType="DIGEST", **kwargs)["Signature"]
+        assert kms_client.verify(MessageType="DIGEST", Signature=signature, **kwargs)[
+            "SignatureValid"
+        ]
 
     @pytest.mark.aws_validated
     def test_get_public_key(self, kms_client, kms_create_key):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -267,22 +267,29 @@ class TestKMS:
         key_spec = "RSA_2048" if key_type == "rsa" else "ECC_NIST_P256"
         result = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)
         key_id = result["KeyId"]
-        # 32 bytes to also match the expected length of SHA 256 digest. Initially our code didn't react to
-        # MessageType at all, so both "RAW" and "DIGEST" values had the same result, i.e. digests were being treated
-        # like plaintext. So using this message both as a plaintext and a digest of some plaintext allows us to test
-        # that we have different implementations for different MessageTypes.
+        # The Message parameter for Sign contains either a message itself, or a signature of a message. It is
+        # MessageType parameter that specifies one of the two cases. Unfortunately, at some point our code was
+        # ignoring the MessageType setting, so both types of message were getting treated the same way. Want to have
+        # a test to make sure that is no longer the case.
+        #
+        # The following string is 32 bytes, the same length as SHA256 digests we use for message signatures. So KMS
+        # accepts the string both as a plaintext message and a signature. As a result - we can use the same string as
+        # Message with different settings for MessageType to see if the outcome is different.
         message = b"test message 123 !%$@ 1234567890"
         algo = "RSASSA_PSS_SHA_256" if key_type == "rsa" else "ECDSA_SHA_256"
         kwargs = {"KeyId": key_id, "Message": message, "SigningAlgorithm": algo}
 
-        # These following locks basically test that MessageType="DIGEST" results in a different outcome
+        signature_for_plaintext = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
+        signature_for_digest = kms_client.sign(MessageType="DIGEST", **kwargs)["Signature"]
+        assert signature_for_plaintext != signature_for_digest
+
+        # These following blocks basically test that MessageType="DIGEST" results in a different outcome
         # from the default MessageType="RAW". As long as both Sign and Verify are called with the same MessageType,
         # everything should work, while if this parameter mismatches between such two calls - the verifications is
         # supposed to fail.
         #
-        # There is a possibility that I do not understand how digests work, so can't write better tests. So if we
-        # have any issues with the digests - know that the current approach is not a calculated design, but rather a
-        # guess.
+        # There is a possibility that I do not understand how digests work, so can't write better tests. If we have
+        # any issues with the digests - know that the current approach is not a calculated design, but rather a guess.
         signature = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
         assert kms_client.verify(MessageType="RAW", Signature=signature, **kwargs)["SignatureValid"]
 


### PR DESCRIPTION
Addresses https://github.com/localstack/localstack/issues/6815

Sign/Verify operations in KMS have two modes. Users can supply
- either raw message - KMS then calculates a digest of that message internally and then signs/verifies that digest;
- or a digest prepared by a user - in this case the digest calculation inside of KMS is skipped, and the supplied digest is signed/verified directly.

Originally LocalStack was ignoring MessageType parameter. This PR adds logic to check the value of the MessageType parameter and to act accordingly.

AWS probably calculates different digests depending on the SigningAlgorithm parameter. While with this PR in LocalStack we are going to always use SHA256 digest. Not ideal, but currently there is little need to spend more effort into this.
