### PR TITLE
Display helpful message if --host fails

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -144,7 +144,13 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
         console.rule("LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)")
 
     if host:
-        bootstrap.start_infra_locally()
+        try:
+            bootstrap.start_infra_locally()
+        except ImportError:
+            raise click.ClickException(
+                "It appears you have a light install of localstack which only supports running in docker\n"
+                "If you would like to use --host, please reinstall localstack using `pip install localstack[runtime]`"
+            )
     else:
         if detached:
             bootstrap.start_infra_in_docker_detached(console)

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -147,6 +147,8 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
         try:
             bootstrap.start_infra_locally()
         except ImportError:
+            if config.DEBUG:
+                console.print_exception()
             raise click.ClickException(
                 "It appears you have a light install of localstack which only supports running in docker\n"
                 "If you would like to use --host, please reinstall localstack using `pip install localstack[runtime]`"


### PR DESCRIPTION
I went to use localstack for the first time yesterday, installed it via homebrew, and ran `localstack start --host` as I didn't have docker running at the moment. Because homebrew is effectively the same as the "light" docker image, I got greeted with an unhelpful stacktrace and no indication of what went wrong:

```
$ localstack start --host

     __                     _______ __             __
    / /   ____  _________ _/ / ___// /_____ ______/ /__
   / /   / __ \/ ___/ __ `/ /\__ \/ __/ __ `/ ___/ //_/
  / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
 /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|

 💻 LocalStack CLI 1.1.0

[16:59:23] starting LocalStack in host mode 💻                                                                                                                                                                                    localstack.py:137
────────────────────────────────────────────────────────────────────────────────────────────────── LocalStack Runtime Log (press CTRL-C to quit) ──────────────────────────────────────────────────────────────────────────────────────────────────
Traceback (most recent call last):
  File "/opt/homebrew/bin/localstack", line 23, in <module>
    main()
  File "/opt/homebrew/bin/localstack", line 19, in main
    main.main()
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/localstack/cli/main.py", line 6, in main
    cli()
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/localstack/cli/plugin.py", line 15, in __call__
    self.group(*args, **kwargs)
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/localstack/utils/analytics/cli.py", line 66, in publisher_wrapper
    return fn(*args, **kwargs)
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/localstack/cli/localstack.py", line 147, in cmd_start
    bootstrap.start_infra_locally()
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/localstack/utils/bootstrap.py", line 258, in start_infra_locally
    from localstack.services import infra
  File "/opt/homebrew/Cellar/localstack/1.1.0/libexec/lib/python3.10/site-packages/localstack/services/infra.py", line 13, in <module>
    from moto.core import BaseModel
ModuleNotFoundError: No module named 'moto'
```

At first I was afraid that I had actually done something to break localstack without even trying, but eventually realized I simply didn't have a "full" install of localstack. I've added an ImportError check around running in `--host` mode that prints out a nicer message with a potential resolution:

```
$ localstack start --host --no-banner
Error: It appears you have a light install of localstack which only supports running in docker
If you would like to use --host, please reinstall localstack using `pip install localstack[runtime]`
```