### PR TITLE
upgrade moto-ext to 4.0.5.post1

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -75,6 +75,8 @@ import base64
 import functools
 import json
 import logging
+import random
+import string
 from abc import ABC
 from binascii import crc32
 from datetime import datetime
@@ -89,7 +91,6 @@ from boto.utils import ISO8601
 from botocore.model import ListShape, MapShape, OperationModel, ServiceModel, Shape, StructureShape
 from botocore.serialize import ISO8601_MICRO
 from botocore.utils import calculate_md5, is_json_value_header, parse_to_aware_datetime
-from moto.core.utils import gen_amzn_requestid_long
 from werkzeug.datastructures import Headers, MIMEAccept
 from werkzeug.http import parse_accept_header
 
@@ -107,6 +108,8 @@ from localstack.utils.common import to_bytes, to_str
 from localstack.utils.xml import strip_xmlns
 
 LOG = logging.getLogger(__name__)
+
+REQUEST_ID_CHARACTERS = string.digits + string.ascii_uppercase
 
 
 class ResponseSerializerError(Exception):
@@ -1441,6 +1444,10 @@ class SqsResponseSerializer(QueryResponseSerializer):
             if generated_string is not None
             else None
         )
+
+
+def gen_amzn_requestid_long():
+    return "".join([random.choice(REQUEST_ID_CHARACTERS) for _ in range(0, 52)])
 
 
 def create_serializer(service: ServiceModel) -> ResponseSerializer:

--- a/setup.cfg
+++ b/setup.cfg
@@ -78,7 +78,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.1.1.dev,<1.2
-    moto-ext[all]==4.0.1.post2
+    moto-ext[all]==4.0.5.post1
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl==22.0.0


### PR DESCRIPTION
Upgrades to the latest moto-ext which is based on https://github.com/spulec/moto/commit/76b127bba65771c1d3f279cd2c69309959b675d8 (already part of moto 4.0.6.dev)

I added a method to the serializer that was removed/renamed in moto to localstack.

/cc @ackdav: includes the fix for the organizations support case