### PR TITLE
Update docker-maven ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 ENV MAVEN_HOME /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
-ADD https://raw.githubusercontent.com/carlossg/docker-maven/master/openjdk-11/settings-docker.xml /usr/share/maven/ref/
+ADD https://raw.githubusercontent.com/carlossg/docker-maven/9d82eaf48ee8b14ac15a36c431ba28b735e99c92/openjdk-11/settings-docker.xml /usr/share/maven/ref/
 
 # set workdir
 RUN mkdir -p /opt/code/localstack


### PR DESCRIPTION
This PR fixes refs to an upstream dependency: https://github.com/carlossg/docker-maven

The files were removed from `master` and are causing build failures:

https://github.com/carlossg/docker-maven/commit/b0539da7612b617ecc19de057872e1469e2ac825

```
#6 [java-builder 1/3] FROM docker.io/library/python:3.10.7-slim-buster@sha256:7bb70ac0176d6a8bdabba60cd8ededd6494605f225365510f7ee5691a4004463
#6 DONE 0.0s

#7 https://raw.githubusercontent.com/carlossg/docker-maven/master/openjdk-11/settings-docker.xml
#7 ERROR: invalid response status 404

#8 importing cache manifest from localstack/localstack-light
#8 ...

#9 [auth] localstack/localstack-light:pull token for registry-1.docker.io
#9 DONE 0.0s

#8 importing cache manifest from localstack/localstack-light
#8 DONE 1.2s

#3 [internal] load metadata for docker.io/library/python:3.10.7-slim-buster@sha256:7bb70ac0176d6a8bdabba60cd8ededd6494605f225365510f7ee5691a4004463
------
 > https://raw.githubusercontent.com/carlossg/docker-maven/master/openjdk-11/settings-docker.xml:
------
ERROR: failed to solve: failed to load cache key: invalid response status 404
make[1]: *** [Makefile:99: docker-build] Error 1
make[1]: Leaving directory '/home/runner/work/localstack-ext/localstack-ext/localstack'
make: *** [Makefile:109: docker-build-light] Error 2
Error: Process completed with exit code 2.
```

https://github.com/localstack/localstack-ext/actions/runs/3150725974/jobs/5125007279#step:16:882