### PR TITLE
Fix the supervisord.conf file using a full path

### DIFF
--- a/bin/supervisord.conf
+++ b/bin/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/tmp/supervisord.log
 
 [program:infra]
 directory=/opt/code/localstack
-command=.venv/bin/python -m localstack.cli.main start --host --no-banner
+command=/opt/code/localstack/.venv/bin/python -m localstack.cli.main start --host --no-banner
 environment=
     LOCALSTACK_INFRA_PROCESS=1
 autostart=true


### PR DESCRIPTION
This is a fix for https://github.com/localstack/localstack/issues/6739. There is no breaking changes and the linting / format tests are passing.