### PR TITLE
add caching to package installers

### DIFF
--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -181,6 +181,7 @@ class Package(abc.ABC):
         """
         self.get_installer(version).install(target)
 
+    @functools.lru_cache()
     def get_installer(self, version: str | None = None) -> PackageInstaller:
         """
         Returns the installer instance for a specific version of the package.

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -165,7 +165,6 @@ class DownloadInstaller(PackageInstaller):
     def __init__(self, name: str, version: str):
         super().__init__(name, version)
 
-    @lru_cache()
     def _get_download_url(self) -> str:
         raise NotImplementedError()
 
@@ -202,6 +201,7 @@ class GitHubReleaseInstaller(DownloadInstaller):
             f"https://api.github.com/repos/{github_slug}/releases/tags/{self.version}"
         )
 
+    @lru_cache()
     def _get_download_url(self) -> str:
         response = requests.get(self.github_tag_url)
         if not response.ok:


### PR DESCRIPTION
this PR addresses several issues that caused builds to hit github rate limits and then causing kinesis tests to fail/time out.

* decorators are not inherited when methods are overwritten. therefore adding `@lru_cache()` on the abstract method will not cache anything. 
* `_get_installer` creates a fresh version of the installer every time, so even then, caches in the installer wouldn't be used, so i added an `lru_cache()` around the high-level `get_installer` function to memoize installer instances.

/cc @viren-nadkarni @alexrashed 