### PR TITLE
Removed duplicate `setup_logging` from bootstrap

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -614,7 +614,6 @@ def prepare_host():
     if os.environ.get(constants.LOCALSTACK_INFRA_PROCESS) in constants.TRUE_STRINGS:
         return
 
-    setup_logging()
     hooks.prepare_host.run()
 
 


### PR DESCRIPTION
[`setup_logging`](https://github.com/localstack/localstack/blob/75f70e667fa164d442413372154b3e28269fea58/localstack/services/infra.py#L414
) is also being done on `infra.start_infra()`

**Please refer to the contribution guidelines in the README when submitting PRs.**
