### PR TITLE
disable verify_ssl for downloading vosk language models

### DIFF
--- a/localstack/services/transcribe/provider.py
+++ b/localstack/services/transcribe/provider.py
@@ -175,7 +175,9 @@ class TranscribeProvider(TranscribeApi):
             model_zip_path = str(model_path) + ".zip"
 
             LOG.debug("Downloading language model: %s", model_path.name)
-            download(MODEL_PRE_URL + str(model_path.name) + ".zip", model_zip_path)
+            download(
+                MODEL_PRE_URL + str(model_path.name) + ".zip", model_zip_path, verify_ssl=False
+            )
 
             LOG.debug("Extracting language model: %s", model_path.name)
             with ZipFile(model_zip_path, "r") as model_ref:


### PR DESCRIPTION
Transcribe tests have been causing issues because the SSL cert of  https://alphacephei.com has expired. This is blocking the CI pipeline, so i've disabled SSL verification for now. But we should keep an eye on this, and also check whether we should maybe host these assets ourselves somewhere.

/cc @viren-nadkarni 