### PR TITLE
clean up and remove dead code

### DIFF
--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -3,8 +3,7 @@ import os
 from typing import Literal
 
 from localstack.utils.common import to_str
-from localstack.utils.generic.wait_utils import ShortCircuitWaitException
-from localstack.utils.sync import retry
+from localstack.utils.sync import ShortCircuitWaitException, retry
 from localstack.utils.testutil import get_lambda_log_events
 
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -27,12 +27,12 @@ from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import create_dynamodb_table
 from localstack.utils.aws.client import SigningHttpClient
-from localstack.utils.common import ensure_list, poll_condition, retry
-from localstack.utils.common import safe_requests as requests
-from localstack.utils.common import short_uid
+from localstack.utils.collections import ensure_list
 from localstack.utils.functions import run_safe
-from localstack.utils.generic.wait_utils import wait_until
+from localstack.utils.http import safe_requests as requests
 from localstack.utils.net import wait_for_port_open
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import poll_condition, retry, wait_until
 from localstack.utils.testutil import start_http_server
 
 if TYPE_CHECKING:

--- a/localstack/utils/generic/file_utils.py
+++ b/localstack/utils/generic/file_utils.py
@@ -1,2 +1,0 @@
-# DEPRECATED: use localstack.utils.files
-from ..files import cache_dir, parse_config_file  # noqa

--- a/localstack/utils/generic/number_utils.py
+++ b/localstack/utils/generic/number_utils.py
@@ -1,2 +1,0 @@
-# DEPRECATED: use localstack.utils.numbers
-from ..numbers import format_number, is_number, to_number  # noqa

--- a/localstack/utils/generic/wait_utils.py
+++ b/localstack/utils/generic/wait_utils.py
@@ -1,2 +1,0 @@
-# DEPRECATED: use localstack.utils.numbers
-from ..sync import ShortCircuitWaitException, poll_condition, retry, wait_until  # noqa

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -532,25 +532,6 @@ def send_dynamodb_request(path, action, request_body):
     return requests.put(url, data=request_body, headers=headers, verify=False)
 
 
-def create_sqs_queue(queue_name):
-    """Utility method to create a new queue via SQS API"""
-
-    client = aws_stack.connect_to_service("sqs")
-
-    # create queue
-    queue_url = client.create_queue(QueueName=queue_name)["QueueUrl"]
-
-    # get the queue arn
-    queue_arn = client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"],)[
-        "Attributes"
-    ]["QueueArn"]
-
-    return {
-        "QueueUrl": queue_url,
-        "QueueArn": queue_arn,
-    }
-
-
 def get_lambda_log_group_name(function_name):
     return "/aws/lambda/{}".format(function_name)
 
@@ -677,15 +658,6 @@ def proxy_server(proxy_listener, host="127.0.0.1", port=None) -> str:
     ), f"server on port {port} did not start"
     yield url
     thread.stop()
-
-
-def json_response(data, code=200, headers: Dict = None) -> requests.Response:
-    r = requests.Response()
-    r._content = json.dumps(data)
-    r.status_code = code
-    if headers:
-        r.headers.update(headers)
-    return r
 
 
 def list_all_resources(

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -15,8 +15,10 @@ from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.testing.snapshots.transformer_utility import PATTERN_UUID
 from localstack.utils import testutil
-from localstack.utils.common import load_file, retry, safe_requests, short_uid, to_bytes, to_str
-from localstack.utils.generic.wait_utils import wait_until
+from localstack.utils.files import load_file
+from localstack.utils.http import safe_requests
+from localstack.utils.strings import short_uid, to_bytes, to_str
+from localstack.utils.sync import retry, wait_until
 from localstack.utils.testutil import create_lambda_archive
 
 LOG = logging.getLogger(__name__)

--- a/tests/integration/cloudformation/test_cloudformation_changesets.py
+++ b/tests/integration/cloudformation/test_cloudformation_changesets.py
@@ -9,9 +9,8 @@ from localstack.testing.aws.cloudformation_utils import (
     render_template,
 )
 from localstack.testing.aws.util import is_aws_cloud
-from localstack.utils.common import short_uid
-from localstack.utils.generic.wait_utils import wait_until
-from localstack.utils.sync import ShortCircuitWaitException, poll_condition
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import ShortCircuitWaitException, poll_condition, wait_until
 
 
 def test_create_change_set_without_parameters(

--- a/tests/integration/cloudformation/test_cloudformation_events.py
+++ b/tests/integration/cloudformation/test_cloudformation_events.py
@@ -3,8 +3,8 @@ import logging
 import os
 
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import short_uid
-from localstack.utils.generic.wait_utils import wait_until
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import wait_until
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/integration/cloudformation/test_cloudformation_integration.py
+++ b/tests/integration/cloudformation/test_cloudformation_integration.py
@@ -1,8 +1,8 @@
 import json
 import os
 
-from localstack.utils.common import short_uid
-from localstack.utils.generic.wait_utils import wait_until
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import wait_until
 
 
 def test_events_sqs_sns_lambda(logs_client, events_client, sns_client, deploy_cfn_template):

--- a/tests/integration/cloudformation/test_cloudformation_stacks.py
+++ b/tests/integration/cloudformation/test_cloudformation_stacks.py
@@ -7,9 +7,8 @@ import yaml
 from localstack.testing.aws.cloudformation_utils import load_template_file, load_template_raw
 from localstack.utils.aws import aws_stack
 from localstack.utils.files import load_file
-from localstack.utils.generic.wait_utils import wait_until
 from localstack.utils.strings import short_uid
-from localstack.utils.sync import retry
+from localstack.utils.sync import retry, wait_until
 
 
 def test_create_stack_with_ssm_parameters(cfn_client, ssm_client, sns_client, deploy_cfn_template):

--- a/tests/integration/cloudformation/test_cloudformation_stepfunctions.py
+++ b/tests/integration/cloudformation/test_cloudformation_stepfunctions.py
@@ -5,7 +5,7 @@ import urllib.parse
 import pytest
 
 from localstack.constants import PATH_USER_REQUEST
-from localstack.utils.generic.wait_utils import wait_until
+from localstack.utils.sync import wait_until
 
 
 def test_statemachine_definitionsubstitution(stepfunctions_client, s3_client, deploy_cfn_template):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -549,17 +549,21 @@ class TestIntegration:
 
 
 @pytest.mark.skip(reason="This test is notoriously flaky in CI environments")  # FIXME
-def test_sqs_batch_lambda_forward(lambda_client, sqs_client, create_lambda_function):
+def test_sqs_batch_lambda_forward(
+    lambda_client, sqs_client, sqs_create_queue, create_lambda_function
+):
 
     lambda_name_queue_batch = "lambda_queue_batch-%s" % short_uid()
 
     # deploy test lambda connected to SQS queue
-    sqs_queue_info = testutil.create_sqs_queue(lambda_name_queue_batch)
-    queue_url = sqs_queue_info["QueueUrl"]
+    queue_url = sqs_create_queue(QueueName=lambda_name_queue_batch)
+    queue_arn = sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])[
+        "QueueArn"
+    ]
     resp = create_lambda_function(
         handler_file=TEST_LAMBDA_PYTHON_ECHO,
         func_name=lambda_name_queue_batch,
-        event_source_arn=sqs_queue_info["QueueArn"],
+        event_source_arn=queue_arn,
         libs=TEST_LAMBDA_LIBS,
     )
 

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -7,8 +7,10 @@ import pytest
 from localstack.services.events.provider import TEST_EVENTS_CACHE
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import clone, load_file, retry, short_uid
-from localstack.utils.generic.wait_utils import ShortCircuitWaitException, wait_until
+from localstack.utils.files import load_file
+from localstack.utils.json import clone
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import ShortCircuitWaitException, retry, wait_until
 
 from .awslambda.functions import lambda_environment
 from .awslambda.test_lambda import TEST_LAMBDA_ENV, TEST_LAMBDA_PYTHON_ECHO

--- a/tests/unit/aws/test_proxy.py
+++ b/tests/unit/aws/test_proxy.py
@@ -1,10 +1,8 @@
 import boto3
 
 from localstack.aws.api import handler
-from localstack.aws.proxy import AsfWithFallbackListener, AwsApiListener
-from localstack.services.generic_proxy import ProxyListener
+from localstack.aws.proxy import AwsApiListener
 from localstack.utils import testutil
-from localstack.utils.aws.aws_responses import requests_response
 
 
 class TestAwsApiListener:
@@ -37,55 +35,3 @@ class TestAwsApiListener:
             assert result["QueueUrls"] == [
                 "http://localhost:4566/000000000000/foo-queue",
             ]
-
-
-class TestAsfWithFallbackListener:
-    def test_request_response(self):
-        provider_calls = []
-        fallback_calls = []
-
-        class Provider:
-            @handler("ListQueues", expand=False)
-            def list_queues(self, context, request):
-                return {
-                    "QueueUrls": [
-                        "http://localhost:4566/000000000000/foo-queue",
-                    ],
-                }
-
-            @handler("DeleteQueue", expand=False)
-            def delete_queue(self, context, request):
-                provider_calls.append((context, request))
-                raise NotImplementedError
-
-        class Fallback(ProxyListener):
-            def forward_request(self, method: str, path: str, data, headers):
-                fallback_calls.append((method, path, data, headers))
-                return requests_response("<Response></Response>")
-
-        # create a proxy listener for the provider
-        listener = AsfWithFallbackListener("sqs", Provider(), Fallback())
-
-        # start temp proxy listener and connect to it
-        with testutil.proxy_server(listener) as url:
-            client = boto3.client(
-                "sqs",
-                aws_access_key_id="test",
-                aws_secret_access_key="test",
-                aws_session_token="test",
-                region_name="us-east-1",
-                endpoint_url=url,
-            )
-
-            # check that provider is called correctly
-            result = client.list_queues()
-            assert result["QueueUrls"] == [
-                "http://localhost:4566/000000000000/foo-queue",
-            ]
-            assert len(provider_calls) == 0
-            assert len(fallback_calls) == 0
-
-            # check that fallback is called correctly
-            client.delete_queue(QueueUrl="http://localhost:4566/000000000000/somequeue")
-            assert len(provider_calls) == 1
-            assert len(fallback_calls) == 1

--- a/tests/unit/utils/generic/test_file_utils.py
+++ b/tests/unit/utils/generic/test_file_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
 from localstack.utils.common import new_tmp_file, save_file
-from localstack.utils.generic.file_utils import parse_config_file
+from localstack.utils.files import parse_config_file
 
 CONFIG_FILE_SECTION = """
 [section{section}]


### PR DESCRIPTION
This PR cleans up some dead code, or simplifies existing code to remove util functions only used in few locations.

I also refactored some imports to get rid of the `utils.generic` package.