### PR TITLE
implement S3 ASF website hosting support

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -689,6 +689,13 @@ class AuthorizationQueryParametersError(ServiceException):
     HostId: Optional[HostId]
 
 
+class NoSuchWebsiteConfiguration(ServiceException):
+    code: str = "NoSuchWebsiteConfiguration"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
 AbortDate = datetime
 
 
@@ -1042,6 +1049,7 @@ class CopyObjectOutput(TypedDict, total=False):
 
 ObjectLockRetainUntilDate = datetime
 Metadata = Dict[MetadataKey, MetadataValue]
+Expires = datetime
 CopySourceIfUnmodifiedSince = datetime
 CopySourceIfModifiedSince = datetime
 

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -1049,7 +1049,6 @@ class CopyObjectOutput(TypedDict, total=False):
 
 ObjectLockRetainUntilDate = datetime
 Metadata = Dict[MetadataKey, MetadataValue]
-Expires = datetime
 CopySourceIfUnmodifiedSince = datetime
 CopySourceIfModifiedSince = datetime
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -438,6 +438,23 @@
         "documentation": "<p>Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchWebsiteConfiguration",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>The specified bucket does not have a website configuration</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -41,7 +41,6 @@ class S3Store(BaseStore):
 
     bucket_versioning_status: Dict[BucketName, bool] = LocalAttribute(default=dict)
 
-    # TODO: validation
     bucket_website_configuration: Dict[BucketName, WebsiteConfiguration] = LocalAttribute(
         default=dict
     )

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
-import moto.s3.models as moto_s3_models
 from moto.s3 import s3_backends as moto_s3_backends
+from moto.s3.models import S3Backend as MotoS3Backend
 
 from localstack.aws.api import RequestContext
 from localstack.aws.api.s3 import (
@@ -10,12 +10,15 @@ from localstack.aws.api.s3 import (
     CORSConfiguration,
     NotificationConfiguration,
     ReplicationConfiguration,
+    WebsiteConfiguration,
 )
+from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 
 
-def get_moto_s3_backend(context: RequestContext) -> moto_s3_models.S3Backend:
-    return moto_s3_backends[context.account_id]["global"]
+def get_moto_s3_backend(context: RequestContext = None) -> MotoS3Backend:
+    account_id = context.account_id if context else DEFAULT_AWS_ACCOUNT_ID
+    return moto_s3_backends[account_id]["global"]
 
 
 class S3Store(BaseStore):
@@ -37,6 +40,11 @@ class S3Store(BaseStore):
     )
 
     bucket_versioning_status: Dict[BucketName, bool] = LocalAttribute(default=dict)
+
+    # TODO: validation
+    bucket_website_configuration: Dict[BucketName, WebsiteConfiguration] = LocalAttribute(
+        default=dict
+    )
 
 
 s3_stores = AccountRegionBundle("s3", S3Store)

--- a/localstack/services/s3/website_hosting.py
+++ b/localstack/services/s3/website_hosting.py
@@ -1,0 +1,377 @@
+import logging
+from typing import Dict, Optional, Union
+from urllib.parse import urlparse
+
+from moto.core.utils import gen_amzn_requestid_long
+from moto.s3.exceptions import MissingBucket
+from moto.s3.models import FakeBucket, FakeKey
+from werkzeug.datastructures import Headers
+
+from localstack.aws.accounts import get_aws_account_id
+from localstack.aws.api.s3 import (
+    BucketName,
+    NoSuchBucket,
+    NoSuchKey,
+    NoSuchWebsiteConfiguration,
+    ObjectKey,
+    RoutingRule,
+    RoutingRules,
+    WebsiteConfiguration,
+)
+from localstack.constants import S3_STATIC_WEBSITE_HOSTNAME
+from localstack.http import Request, Response, Router
+from localstack.http.dispatcher import Handler
+from localstack.services.s3.models import S3Store, get_moto_s3_backend, s3_stores
+from localstack.utils.aws import aws_stack
+
+LOG = logging.getLogger(__name__)
+
+STATIC_WEBSITE_HOST_REGEX = (
+    '<regex(".*"):bucket_name>.%s<regex("(:[0-9]{2,5})?"):port>' % S3_STATIC_WEBSITE_HOSTNAME
+)
+
+
+class NoSuchKeyFromErrorDocument(NoSuchKey):
+    code: str = "NoSuchKey"
+    sender_fault: bool = False
+    status_code: int = 404
+    Key: Optional[ObjectKey]
+    ErrorDocumentKey: Optional[ObjectKey]
+
+
+def get_bucket_from_moto(bucket: BucketName) -> FakeBucket:
+    # TODO: check authorization for buckets as well? would need to be public-read at least
+    # not enforced in the current provider
+    try:
+        return get_moto_s3_backend().get_bucket(bucket_name=bucket)
+    except MissingBucket:
+        ex = NoSuchBucket("The specified bucket does not exist")
+        ex.BucketName = bucket
+        raise ex
+
+
+def get_key_from_moto_bucket(moto_bucket: FakeBucket, key: ObjectKey) -> FakeKey:
+    return moto_bucket.keys.get(key)
+
+
+def get_store() -> S3Store:
+    return s3_stores[get_aws_account_id()][aws_stack.get_region()]
+
+
+def get_bucket_website_configuration(bucket: BucketName) -> WebsiteConfiguration:
+    """
+    Retrieve the website configuration for the given bucket
+    :param bucket: the bucket name
+    :raises NoSuchWebsiteConfiguration if the bucket does not have a website config
+    :return: the WebsiteConfiguration of the bucket
+    """
+    website_configuration = get_store().bucket_website_configuration.get(bucket)
+    if not website_configuration:
+        ex = NoSuchWebsiteConfiguration(
+            "The specified bucket does not have a website configuration"
+        )
+        ex.BucketName = bucket
+        raise ex
+    return website_configuration
+
+
+def website_handler(
+    request: Request, bucket_name: str, path: str = None, port: str = None
+) -> Response:
+    """
+    Tries to serve the key, and if an Exception is encountered, returns a generic response
+    This will allow to easily extend it to 403 exceptions
+    :param request: router Request object
+    :param bucket_name: str, bucket name
+    :param path: the path of the request
+    :param port: /
+    :return: Response object
+    """
+    try:
+        return _serve_key(request, bucket_name, path)
+
+    except (NoSuchBucket, NoSuchWebsiteConfiguration, NoSuchKeyFromErrorDocument, NoSuchKey) as e:
+        resource_name = e.Key if hasattr(e, "Key") else e.BucketName
+        response_body = create_404_error_string(
+            code=e.code,
+            message=e.message,
+            resource_name=resource_name,
+            from_error_document=getattr(e, "ErrorDocumentKey", None),
+        )
+        return Response(response_body, status=e.status_code)
+
+    except Exception:
+        LOG.exception("Exception encountered while trying to serve s3-website at %s", request.url)
+        return Response(SERVICE_ERROR_STRING, status=500)
+
+
+def _serve_key(request: Request, bucket_name: BucketName, path: str = None) -> Response:
+    """
+    Serves the S3 key as a website handler. It will match routing rules set in the configuration first, and redirect
+    the request if necessary. They are specific case for handling configured index, see the docs:
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/IndexDocumentSupport.html
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/CustomErrorDocSupport.html
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-page-redirect.html
+    :param request: Request object received by the router
+    :param bucket_name: bucket name contained in the host name
+    :param path: path of the request, corresponds to the S3 key
+    :return: Response object, either the key, a redirection or an error
+    """
+    bucket = get_bucket_from_moto(bucket=bucket_name)
+    headers = {}
+
+    website_config = get_bucket_website_configuration(bucket_name)
+
+    redirection = website_config.get("RedirectAllRequestsTo")
+    if redirection:
+        parsed_url = urlparse(request.url)
+        redirect_to = request.url.replace(parsed_url.netloc, redirection["HostName"])
+        if protocol := redirection.get("Protocol"):
+            redirect_to = redirect_to.replace(parsed_url.scheme, protocol)
+
+        headers["Location"] = redirect_to
+        return Response("", status=301, headers=headers)
+
+    key_name = path
+    routing_rules = website_config.get("RoutingRules")
+    # checks for prefix rules, before trying to get the key
+    if (
+        key_name
+        and routing_rules
+        and (rule := find_matching_rule(routing_rules, key_name=key_name))
+    ):
+        redirect_response = get_redirect_from_routing_rule(request, rule)
+        return redirect_response
+
+    # if the URL ends with a trailing slash, try getting the index first
+    is_folder = request.url[-1] == "/"
+    if (
+        not key_name or is_folder
+    ):  # the path automatically remove the trailing slash, even with strict_slashes=False
+        index_key = website_config["IndexDocument"]["Suffix"]
+        key_name = f"{key_name}/{index_key}" if key_name else index_key
+
+    key = get_key_from_moto_bucket(bucket, key_name)
+    if not key:
+        if not is_folder:
+            # try appending the index suffix in case we're accessing a "folder" without a trailing slash
+            index_key = website_config["IndexDocument"]["Suffix"]
+            key = get_key_from_moto_bucket(bucket, f"{key_name}/{index_key}")
+            if key:
+                return Response("", status=302, headers={"Location": f"/{key_name}/"})
+
+        # checks for error code (and prefix) rules, after trying to get the key
+        if routing_rules and (
+            rule := find_matching_rule(routing_rules, key_name=key_name, error_code=404)
+        ):
+            redirect_response = get_redirect_from_routing_rule(request, rule)
+            return redirect_response
+
+        # tries to get the error document, otherwise raises NoSuchKey
+        response = get_error_document(
+            website_config=website_config,
+            bucket=bucket,
+            missing_key=key_name,
+        )
+        return response
+
+    # TODO CHECK IF WEBSITE_REDIRECT_LOCATION is copied (should not by default)
+    if key.website_redirect_location:
+        headers["Location"] = key.website_redirect_location
+        return Response("", status=301, headers=headers)
+
+    if check_if_headers(request.headers, key=key):
+        return Response("", status=304)
+
+    headers = get_response_headers_from_key(key)
+    return Response(key.value, headers=headers)
+
+
+def get_response_headers_from_key(key: FakeKey) -> Dict[str, str]:
+    """
+    Get some header values from the key
+    :param key: the key name
+    :return: headers from the key to be part of the response
+    """
+    response_headers = {}
+    if content_type := key.metadata.get("Content-Type"):
+        response_headers["Content-Type"] = content_type
+    if key.etag:
+        response_headers["etag"] = key.etag
+
+    return response_headers
+
+
+def find_matching_rule(
+    routing_rules: RoutingRules, key_name: ObjectKey, error_code: int = None
+) -> Union[RoutingRule, None]:
+    """
+    Iterate over the routing rules set in the configuration, and return the first that match the key name and/or the
+    error code (in the 4XX range).
+    :param routing_rules: RoutingRules part of WebsiteConfiguration
+    :param key_name:
+    :param error_code: error code of the Response in the 4XX range
+    :return: a RoutingRule if matched, or None
+    """
+    # TODO: we could separate rules depending in they have the HttpErrorCodeReturnedEquals field
+    #  we would not try to match on them early, no need to iterate on them
+    #  and iterate them over only if an exception is encountered
+    for rule in routing_rules:
+        if condition := rule.get("Condition"):
+            prefix = condition.get("KeyPrefixEquals")
+            return_http_code = condition.get("HttpErrorCodeReturnedEquals")
+            # if both prefix matching and http error matching conditions are set
+            if prefix and return_http_code:
+                if key_name.startswith(prefix) and error_code == int(return_http_code):
+                    return rule
+                else:
+                    # it must either match both or it does not apply
+                    continue
+            # only prefix is set, but this should have been matched before the error
+            elif prefix and key_name.startswith(prefix):
+                return rule
+            elif return_http_code and error_code == int(return_http_code):
+                return rule
+
+        else:
+            # if no Condition is set, the redirect is applied to all requests
+            return rule
+
+
+def get_redirect_from_routing_rule(request: Request, routing_rule: RoutingRule) -> Response:
+    """
+    Return a redirect Response object created with the different parameters set in the RoutingRule
+    :param request: the original Request object received from the router
+    :param routing_rule: a RoutingRule from the WebsiteConfiguration
+    :return: a redirect Response
+    """
+    parsed_url = urlparse(request.url)
+    redirect_to = request.url
+    redirect = routing_rule["Redirect"]
+    if host_name := redirect.get("HostName"):
+        redirect_to = redirect_to.replace(parsed_url.netloc, host_name)
+    if protocol := redirect.get("Protocol"):
+        redirect_to = redirect_to.replace(parsed_url.scheme, protocol)
+    if redirect_to_key := redirect.get("ReplaceKeyWith"):
+        redirect_to = redirect_to.replace(parsed_url.path, f"/{redirect_to_key}")
+    elif new_key_prefix := redirect.get("ReplaceKeyPrefixWith"):
+        # TODO test if KeyPrefixEquals is not supplied???
+        matched_prefix = routing_rule["Condition"].get("KeyPrefixEquals")
+        redirect_to = redirect_to.replace(matched_prefix, new_key_prefix)
+
+    return Response(
+        "", headers={"Location": redirect_to}, status=redirect.get("HttpRedirectCode", 301)
+    )
+
+
+def get_error_document(
+    website_config: WebsiteConfiguration, bucket: FakeBucket, missing_key: ObjectKey
+) -> Response:
+    """
+    Either tries to get the
+    https://docs.aws.amazon.com/AmazonS3/latest/userguide/CustomErrorDocSupport.html
+    :param website_config: the bucket WebsiteConfiguration
+    :param bucket: the bucket object from moto
+    :param missing_key: the missing key not found in the bucket
+    :return:
+    """
+    headers = {}
+    if error_document := website_config.get("ErrorDocument"):
+        # if an error document is configured, try to fetch the key
+        error_key = error_document["Key"]
+        key = get_key_from_moto_bucket(bucket, error_key)
+        if key:
+            # if the key is found, return the key, or if that key has a redirect, return a redirect
+            error_body = key.value
+            if key.website_redirect_location:
+                headers["Location"] = key.website_redirect_location
+                return Response("", status=301, headers=headers)
+
+            headers = get_response_headers_from_key(key)
+            return Response(error_body, status=404, headers=headers)
+        else:
+            ex = NoSuchKeyFromErrorDocument("The specified key does not exist.")
+            ex.Key = missing_key
+            ex.ErrorDocumentKey = error_key
+            raise ex
+
+    else:
+        ex = NoSuchKey("The specified key does not exist.")
+        ex.Key = missing_key
+        raise ex
+
+
+def check_if_headers(headers: Headers, key: FakeKey) -> bool:
+    # TODO: add other conditions here If-Modified-Since, etc etc
+    if "if-none-match" in headers and key.etag and key.etag in headers["if-none-match"]:
+        return True
+
+
+def register_website_hosting_routes(router: Router[Handler]):
+    """
+    Registers the S3 website hosting handlers into the given router.
+
+    :param router: the router to add the handlers into.
+    """
+    router.add(
+        path="/",
+        host=STATIC_WEBSITE_HOST_REGEX,
+        endpoint=website_handler,
+        methods=["GET"],
+    )
+    router.add(
+        path="/<path:path>",
+        host=STATIC_WEBSITE_HOST_REGEX,
+        endpoint=website_handler,
+        methods=["GET"],
+    )
+
+
+def create_404_error_string(
+    code: str, message: str, resource_name: str, from_error_document: str = None
+) -> str:
+    # TODO: the nested error could be permission related
+    #  permission are not enforced currently
+    resource_key = "Key" if "Key" in code else "BucketName"
+    return f"""<html>
+    <head>
+        <title>404 Not Found</title>
+    </head>
+    <body>
+        <h1>404 Not Found</h1>
+        <ul>
+            <li>Code: {code}</li>
+            <li>Message: {message}</li>
+            <li>{resource_key}: {resource_name}</li>
+            <li>RequestId: {gen_amzn_requestid_long()}</li>
+            <li>HostId: h6t23Wl2Ndijztq+COn9kvx32omFVRLLtwk36D6+2/CIYSey+Uox6kBxRgcnAASsgnGwctU6zzU=</li>
+        </ul>
+        {create_nested_404_error_string(from_error_document)}
+        <hr/>
+    </body>
+</html>
+"""
+
+
+def create_nested_404_error_string(error_document_key: str) -> str:
+    if not error_document_key:
+        return ""
+    return f"""<h3>An Error Occurred While Attempting to Retrieve a Custom Error Document</h3>
+        <ul>
+            <li>Code: NoSuchKey</li>
+            <li>Message: Message: The specified key does not exist.</li>
+            <li>Key: {error_document_key}</li>
+        </ul>
+    """
+
+
+SERVICE_ERROR_STRING = """<html>
+    <head>
+        <title>500 Service Error</title>
+    </head>
+    <body>
+        <h1>500 Service Error</h1>
+        <hr/>
+    </body>
+</html>
+"""

--- a/localstack/services/s3/website_hosting.py
+++ b/localstack/services/s3/website_hosting.py
@@ -175,7 +175,6 @@ def _serve_key(request: Request, bucket_name: BucketName, path: str = None) -> R
         )
         return response
 
-    # TODO CHECK IF WEBSITE_REDIRECT_LOCATION is copied (should not by default)
     if key.website_redirect_location:
         headers["Location"] = key.website_redirect_location
         return Response("", status=301, headers=headers)

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3519,12 +3519,11 @@ class TestS3StaticWebsiteHosting:
         url = _website_bucket_url(bucket_name)
 
         response = requests.get(url, verify=False)
-        assert 200 == response.status_code
-        assert "index" == response.text
+        assert response.status_code == 200
+        assert response.text == "index"
 
     @pytest.mark.aws_validated
     def test_s3_static_website_hosting(self, s3_client, s3_create_bucket):
-
         bucket_name = f"bucket-{short_uid()}"
 
         s3_create_bucket(Bucket=bucket_name, ACL="public-read")
@@ -3618,6 +3617,7 @@ class TestS3StaticWebsiteHosting:
 
         # error document
         url = f"{website_url}/something"
+        response = requests.get(url, verify=False)
         assert 404 == response.status_code
         assert "error" == response.text
         assert "content-type" in response.headers
@@ -3633,8 +3633,553 @@ class TestS3StaticWebsiteHosting:
         assert "actual/key.html" in response.headers["location"]
 
         response = requests.get(url, verify=False)
-        assert 200 == response.status_code
-        assert actual_key_obj["ETag"] == response.headers["etag"]
+        assert response.status_code == 200
+        assert response.headers["etag"] == actual_key_obj["ETag"]
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide proper website support",
+    )
+    def test_website_hosting_no_such_website(self, s3_client, s3_create_bucket):
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+
+        random_url = _website_bucket_url(f"non-existent-bucket-{short_uid()}")
+        response = requests.get(random_url, verify=False)
+        assert response.status_code == 404
+        assert "<li>Code: NoSuchBucket</li>" in response.text
+
+        website_url = _website_bucket_url(bucket_name)
+        # actual key
+        response = requests.get(website_url, verify=False)
+        assert response.status_code == 404
+        assert "<li>Code: NoSuchWebsiteConfiguration</li>" in response.text
+
+        url = f"{website_url}/actual/key.html"
+        response = requests.get(url)
+        assert response.status_code == 404
+        assert "<li>Code: NoSuchWebsiteConfiguration</li>" in response.text
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide proper website redirection",
+    )
+    def test_website_hosting_index_lookup(self, s3_client, s3_create_bucket):
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+            },
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="index.html",
+            Body="index",
+            ContentType="text/html",
+            ACL="public-read",
+        )
+
+        website_url = _website_bucket_url(bucket_name)
+        # actual key
+        response = requests.get(website_url)
+        assert response.status_code == 200
+        assert response.text == "index"
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="directory/index.html",
+            Body="index",
+            ContentType="text/html",
+            ACL="public-read",
+        )
+
+        response = requests.get(f"{website_url}/directory", allow_redirects=False)
+        assert response.status_code == 302
+        assert response.headers["Location"] == "/directory/"
+
+        response = requests.get(f"{website_url}/directory/", verify=False)
+        assert response.status_code == 200
+        assert response.text == "index"
+
+        response = requests.get(f"{website_url}/directory-wrong", verify=False)
+        assert response.status_code == 404
+        assert "<li>Key: directory-wrong</li>" in response.text
+
+        response = requests.get(f"{website_url}/directory-wrong/", verify=False)
+        assert response.status_code == 404
+        assert "<li>Key: directory-wrong/index.html</li>" in response.text
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide proper website support",
+    )
+    def test_website_hosting_404(self, s3_client, s3_create_bucket):
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+            },
+        )
+
+        website_url = _website_bucket_url(bucket_name)
+
+        response = requests.get(website_url)
+        assert response.status_code == 404
+        assert "<li>Code: NoSuchKey</li>" in response.text
+        assert "<li>Key: index.html</li>" in response.text
+
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+                "ErrorDocument": {"Key": "error.html"},
+            },
+        )
+        response = requests.get(website_url)
+        assert response.status_code == 404
+        assert "<li>Code: NoSuchKey</li>" in response.text
+        assert "<li>Key: index.html</li>" in response.text
+        assert "Custom Error Document</h3>" in response.text
+        assert "<li>Key: error.html</li>" in response.text
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="error.html",
+            Body="error",
+            ContentType="text/html",
+            ACL="public-read",
+        )
+
+        response = requests.get(website_url)
+        assert response.status_code == 404
+        assert response.text == "error"
+
+    @pytest.mark.aws_validated
+    def test_object_website_redirect_location(self, s3_client, s3_create_bucket):
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+                "ErrorDocument": {"Key": "error.html"},
+            },
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="index.html",
+            WebsiteRedirectLocation="/another/index.html",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="error.html",
+            Body="error_redirected",
+            WebsiteRedirectLocation="/another/error.html",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="another/error.html",
+            Body="error",
+            ACL="public-read",
+        )
+
+        website_url = _website_bucket_url(bucket_name)
+
+        response = requests.get(website_url)
+        # losing the status code because of the redirection in the error document
+        assert response.status_code == 200
+        assert response.text == "error"
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide website routing rules",
+    )
+    def test_routing_rules_conditions(self, s3_client, s3_create_bucket):
+        # https://github.com/localstack/localstack/issues/6308
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+                "ErrorDocument": {"Key": "error.html"},
+                "RoutingRules": [
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "both-prefixed/",
+                            "HttpErrorCodeReturnedEquals": "404",
+                        },
+                        "Redirect": {"ReplaceKeyWith": "redirected-both.html"},
+                    },
+                    {
+                        "Condition": {"KeyPrefixEquals": "prefixed"},
+                        "Redirect": {"ReplaceKeyWith": "redirected.html"},
+                    },
+                    {
+                        "Condition": {"HttpErrorCodeReturnedEquals": "404"},
+                        "Redirect": {"ReplaceKeyWith": "redirected.html"},
+                    },
+                ],
+            },
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="redirected.html",
+            Body="redirected",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="prefixed-key-test",
+            Body="prefixed",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="redirected-both.html",
+            Body="redirected-both",
+            ACL="public-read",
+        )
+
+        website_url = _website_bucket_url(bucket_name)
+
+        response = requests.get(f"{website_url}/non-existent-key", allow_redirects=False)
+        assert response.status_code == 301
+        assert response.headers["Location"] == f"{website_url}/redirected.html"
+
+        # redirects when the custom ErrorDocument is not found
+        response = requests.get(f"{website_url}/non-existent-key")
+        assert response.status_code == 200
+        assert response.text == "redirected"
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="error.html",
+            Body="error",
+            ACL="public-read",
+        )
+
+        response = requests.get(f"{website_url}/non-existent-key")
+        assert response.status_code == 200
+        assert response.text == "redirected"
+
+        response = requests.get(f"{website_url}/prefixed-key-test")
+        assert response.status_code == 200
+        assert response.text == "redirected"
+
+        response = requests.get(f"{website_url}/both-prefixed/")
+        assert response.status_code == 200
+        assert response.text == "redirected-both"
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide website routing rules",
+    )
+    def test_routing_rules_redirects(self, s3_client, s3_create_bucket):
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+                "ErrorDocument": {"Key": "error.html"},
+                "RoutingRules": [
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "host/",
+                        },
+                        "Redirect": {"HostName": "random-hostname"},
+                    },
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "replace-prefix/",
+                        },
+                        "Redirect": {"ReplaceKeyPrefixWith": "replaced-prefix/"},
+                    },
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "protocol/",
+                        },
+                        "Redirect": {"Protocol": "https"},
+                    },
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "code/",
+                        },
+                        "Redirect": {"HttpRedirectCode": "307"},
+                    },
+                ],
+            },
+        )
+
+        website_url = _website_bucket_url(bucket_name)
+
+        response = requests.get(f"{website_url}/host/key", allow_redirects=False)
+        assert response.status_code == 301
+        assert response.headers["Location"] == "http://random-hostname/host/key"
+
+        response = requests.get(f"{website_url}/replace-prefix/key", allow_redirects=False)
+        assert response.status_code == 301
+        assert response.headers["Location"] == f"{website_url}/replaced-prefix/key"
+
+        response = requests.get(f"{website_url}/protocol/key", allow_redirects=False)
+        assert response.status_code == 301
+        assert not website_url.startswith("https")
+        assert response.headers["Location"].startswith("https")
+
+        response = requests.get(f"{website_url}/code/key", allow_redirects=False)
+        assert response.status_code == 307
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER,
+        reason="Legacy S3 provider does not provide website routing rules",
+    )
+    def test_routing_rules_order(self, s3_client, s3_create_bucket):
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+                "ErrorDocument": {"Key": "error.html"},
+                "RoutingRules": [
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "prefix",
+                        },
+                        "Redirect": {"ReplaceKeyWith": "redirected.html"},
+                    },
+                    {
+                        "Condition": {
+                            "KeyPrefixEquals": "index",
+                        },
+                        "Redirect": {"ReplaceKeyWith": "redirected.html"},
+                    },
+                ],
+            },
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="index.html",
+            Body="index",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="redirected.html",
+            Body="redirected",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="website-redirected.html",
+            Body="website-redirected",
+            ACL="public-read",
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="prefixed-key-test",
+            Body="prefixed",
+            ACL="public-read",
+            WebsiteRedirectLocation="/website-redirected.html",
+        )
+
+        website_url = _website_bucket_url(bucket_name)
+        # testing that routing rules have precedence over individual object redirection
+        response = requests.get(f"{website_url}/prefixed-key-test")
+        assert response.status_code == 200
+        assert response.text == "redirected"
+
+        # assert that prefix rules don't apply for root path (internally redirected to index.html)
+        response = requests.get(website_url)
+        assert response.status_code == 200
+        assert response.text == "index"
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide website configuration validation",
+    )
+    @pytest.mark.skip_snapshot_verify(
+        # todo: serializer issue with empty node, very tricky one...
+        paths=["$.invalid-website-conf-1.Error.ArgumentValue"]
+    )
+    def test_validate_website_configuration(self, s3_client, s3_bucket, snapshot):
+
+        website_configurations = [
+            # can't have slash in the suffix
+            {
+                "IndexDocument": {"Suffix": "/index.html"},
+            },
+            # empty suffix value
+            {
+                "IndexDocument": {"Suffix": ""},
+            },
+            # if RedirectAllRequestsTo is set, cannot have other fields
+            {
+                "RedirectAllRequestsTo": {"HostName": "test"},
+                "IndexDocument": {"Suffix": "/index.html"},
+            },
+            # does not have an IndexDocument field
+            {
+                "ErrorDocument": {"Key": "/index.html"},
+            },
+            # wrong protocol, must be http|https
+            {
+                "IndexDocument": {"Suffix": "index.html"},
+                "RoutingRules": [{"Redirect": {"Protocol": "protocol"}}],
+            },
+            # has both ReplaceKeyPrefixWith and ReplaceKeyWith
+            {
+                "IndexDocument": {"Suffix": "index.html"},
+                "RoutingRules": [
+                    {
+                        "Redirect": {
+                            "ReplaceKeyPrefixWith": "prefix",
+                            "ReplaceKeyWith": "key-name",
+                        }
+                    }
+                ],
+            },
+            # empty Condition field in Routing Rule
+            {
+                "IndexDocument": {"Suffix": "index.html"},
+                "RoutingRules": [
+                    {
+                        "Redirect": {
+                            "ReplaceKeyPrefixWith": "prefix",
+                        },
+                        "Condition": {},
+                    }
+                ],
+            },
+            # empty routing rules
+            {
+                "IndexDocument": {"Suffix": "index.html"},
+                "RoutingRules": [],
+            },
+        ]
+
+        for index, invalid_configuration in enumerate(website_configurations):
+            # not using pytest.raises, to have better debugging value in case of not raising exception
+            # because of the loop, we don't know which configuration has not raised the exception
+            try:
+                s3_client.put_bucket_website(
+                    Bucket=s3_bucket,
+                    WebsiteConfiguration=invalid_configuration,
+                )
+                assert False, f"{invalid_configuration} should have raised an exception"
+            except ClientError as e:
+                snapshot.match(f"invalid-website-conf-{index}", e.response)
+
+    @pytest.mark.aws_validated
+    def test_crud_website_configuration(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+
+        with pytest.raises(ClientError) as e:
+            s3_client.get_bucket_website(Bucket=s3_bucket)
+        snapshot.match("get-no-such-website-config", e.value.response)
+
+        resp = s3_client.delete_bucket_website(Bucket=s3_bucket)
+        snapshot.match("del-no-such-website-config", resp)
+
+        response = s3_client.put_bucket_website(
+            Bucket=s3_bucket,
+            WebsiteConfiguration={"IndexDocument": {"Suffix": "index.html"}},
+        )
+        snapshot.match("put-website-config", response)
+
+        response = s3_client.get_bucket_website(Bucket=s3_bucket)
+        snapshot.match("get-website-config", response)
+
+        s3_client.delete_bucket_website(Bucket=s3_bucket)
+        with pytest.raises(ClientError):
+            s3_client.get_bucket_website(Bucket=s3_bucket)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(
+        condition=LEGACY_S3_PROVIDER and not is_aws_cloud(),
+        reason="Legacy S3 provider does not provide website redirection",
+    )
+    def test_website_hosting_redirect_all(self, s3_client, s3_create_bucket):
+        bucket_name_redirected = f"bucket-{short_uid()}"
+        bucket_name = f"bucket-{short_uid()}"
+
+        s3_create_bucket(Bucket=bucket_name_redirected, ACL="public-read")
+        bucket_website_url = _website_bucket_url(bucket_name)
+        bucket_website_host = urlparse(bucket_website_url).netloc
+
+        s3_client.put_bucket_website(
+            Bucket=bucket_name_redirected,
+            WebsiteConfiguration={
+                "RedirectAllRequestsTo": {"HostName": bucket_website_host},
+            },
+        )
+
+        s3_create_bucket(Bucket=bucket_name, ACL="public-read")
+        s3_client.put_bucket_website(
+            Bucket=bucket_name,
+            WebsiteConfiguration={
+                "IndexDocument": {"Suffix": "index.html"},
+            },
+        )
+
+        s3_client.put_object(
+            Bucket=bucket_name,
+            Key="index.html",
+            Body="index",
+            ContentType="text/html",
+            ACL="public-read",
+        )
+
+        redirected_bucket_website = _website_bucket_url(bucket_name_redirected)
+
+        response_no_redirect = requests.get(redirected_bucket_website, allow_redirects=False)
+        assert response_no_redirect.status_code == 301
+        assert response_no_redirect.content == b""
+
+        response_redirected = requests.get(redirected_bucket_website)
+        assert response_redirected.status_code == 200
+        assert response_redirected.content == b"index"
+
+        response = requests.get(bucket_website_url)
+        assert response.status_code == 200
+        assert response.content == b"index"
+
+        assert response.content == response_redirected.content
+
+        response_redirected = requests.get(f"{redirected_bucket_website}/random-key")
+        assert response_redirected.status_code == 404
 
 
 def _anon_client(service: str):

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3291,5 +3291,135 @@
         "StatusCode": 403
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_validate_website_configuration": {
+    "recorded-date": "28-09-2022, 22:44:53",
+    "recorded-content": {
+      "invalid-website-conf-0": {
+        "Error": {
+          "ArgumentName": "IndexDocument",
+          "ArgumentValue": "/index.html",
+          "Code": "InvalidArgument",
+          "Message": "The IndexDocument Suffix is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-1": {
+        "Error": {
+          "ArgumentName": "IndexDocument",
+          "ArgumentValue": null,
+          "Code": "InvalidArgument",
+          "Message": "The IndexDocument Suffix is not well formed"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-2": {
+        "Error": {
+          "ArgumentName": "RedirectAllRequestsTo",
+          "ArgumentValue": "not null",
+          "Code": "InvalidArgument",
+          "Message": "RedirectAllRequestsTo cannot be provided in conjunction with other Routing Rules."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-3": {
+        "Error": {
+          "ArgumentName": "IndexDocument",
+          "ArgumentValue": "null",
+          "Code": "InvalidArgument",
+          "Message": "A value for IndexDocument Suffix must be provided if RedirectAllRequestsTo is empty"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-4": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-5": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "You can only define ReplaceKeyPrefix or ReplaceKey but not both."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-6": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Condition cannot be empty. To redirect all requests without a condition, the condition element shouldn't be present."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-website-conf-7": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_crud_website_configuration": {
+    "recorded-date": "28-09-2022, 23:23:11",
+    "recorded-content": {
+      "get-no-such-website-config": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchWebsiteConfiguration",
+          "Message": "The specified bucket does not have a website configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "del-no-such-website-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-website-config": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-website-config": {
+        "IndexDocument": {
+          "Suffix": "index.html"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3421,5 +3421,38 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_website_hosting_http_methods": {
+    "recorded-date": "04-10-2022, 16:11:12",
+    "recorded-content": {
+      "not-allowed-post": {
+        "content": "<html>\n<head><title>405 Method Not Allowed</title></head>\n<body>\n<h1>405 Method Not Allowed</h1>\n<ul>\n<li>Code: MethodNotAllowed</li>\n<li>Message: The specified method is not allowed against this resource.</li>\n<li>Method: POST</li>\n<li>ResourceType: OBJECT</li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n"
+      },
+      "not-allowed-delete": {
+        "content": "<html>\n<head><title>405 Method Not Allowed</title></head>\n<body>\n<h1>405 Method Not Allowed</h1>\n<ul>\n<li>Code: MethodNotAllowed</li>\n<li>Message: The specified method is not allowed against this resource.</li>\n<li>Method: DELETE</li>\n<li>ResourceType: OBJECT</li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_website_hosting_index_lookup": {
+    "recorded-date": "04-10-2022, 16:45:08",
+    "recorded-content": {
+      "404-no-trailing-slash": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchKey</li>\n<li>Message: The specified key does not exist.</li>\n<li>Key: directory-wrong</li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n",
+      "404-with-trailing-slash": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchKey</li>\n<li>Message: The specified key does not exist.</li>\n<li>Key: directory-wrong/index.html</li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n"
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_website_hosting_404": {
+    "recorded-date": "04-10-2022, 16:51:12",
+    "recorded-content": {
+      "404-no-such-key": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchKey</li>\n<li>Message: The specified key does not exist.</li>\n<li>Key: index.html</li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n",
+      "404-no-such-key-nor-custom": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchKey</li>\n<li>Message: The specified key does not exist.</li>\n<li>Key: index.html</li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<h3>An Error Occurred While Attempting to Retrieve a Custom Error Document</h3>\n<ul>\n<li>Code: NoSuchKey</li>\n<li>Message: The specified key does not exist.</li>\n<li>Key: error.html</li>\n</ul>\n<hr/>\n</body>\n</html>\n"
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_website_hosting_no_such_website": {
+    "recorded-date": "04-10-2022, 16:56:34",
+    "recorded-content": {
+      "no-such-bucket": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchBucket</li>\n<li>Message: The specified bucket does not exist</li>\n<li>BucketName: <bucket-name></li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n",
+      "no-such-website-config": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchWebsiteConfiguration</li>\n<li>Message: The specified bucket does not have a website configuration</li>\n<li>BucketName: <bucket-name></li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n",
+      "no-such-website-config-key": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchWebsiteConfiguration</li>\n<li>Message: The specified bucket does not have a website configuration</li>\n<li>BucketName: <bucket-name></li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n"
+    }
   }
 }


### PR DESCRIPTION
This PR implement support for S3 website hosting with additional features than the current provider.

Most S3 website features are now implemented, including `RoutingRules`, configuration validation...

https://docs.aws.amazon.com/AmazonS3/latest/userguide/WebsiteHosting.html

Note: permission/ACLs are not enforced currently, and it can be added in another PR with a feature flag in the same vein as IAM. 