### PR TITLE
pin terraform version to 1.2.9 for terraform-tests

### DIFF
--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -42,9 +42,9 @@ jobs:
 
     # FIXME: pinned because of https://github.com/hashicorp/terraform-provider-aws/issues/27049
     - name: Install terraform
-      uses: little-core-labs/install-terraform@v2.0.0
+      uses: hashicorp/setup-terraform@v2
       with:
-        version: 1.2.9
+        terraform_version: 1.2.9
 
     - name: Check Terraform version
       run: |

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -45,6 +45,7 @@ jobs:
       uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.2.9
+        terraform_wrapper: false
 
     - name: Check Terraform version
       run: |

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -40,6 +40,17 @@ jobs:
     - name: Checkout Localstack
       uses: actions/checkout@v3
 
+    # FIXME: pinned because of https://github.com/hashicorp/terraform-provider-aws/issues/27049
+    - name: Install terraform
+      uses: little-core-labs/install-terraform@v2.0.0
+      with:
+        version: 1.2.9
+
+    - name: Check Terraform version
+      run: |
+        which terraform
+        terraform --version
+
     - name: Checkout Terraform AWS Provider
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This PR downgrades terraform to 1.2.9 in the terraform tests. This is a wrokaround for an issue that started appearing with 1.3.0 https://github.com/hashicorp/terraform-provider-aws/issues/27049

@dominikschubert already did some initial detective work in https://github.com/localstack/localstack/pull/6954.

I remembered from working on https://github.com/localstack/localstack-terraform-test that the tests actually check the path for an existing terraform binary, and they will use that to deploy the test scripts. The github action seems to come with terraform 1.3.0, so I added an action to overwrite it with a pinned version, in this case 1.2.9, which seems to still work.