### PR TITLE
upgrade moto to 4.0.6.post1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.1.1.dev,<1.2
-    moto-ext[all]==4.0.5.post1
+    moto-ext[all]==4.0.6.post1
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl==22.0.0

--- a/tests/integration/cloudformation/test_cloudformation_ec2.py
+++ b/tests/integration/cloudformation/test_cloudformation_ec2.py
@@ -40,6 +40,7 @@ def test_cfn_with_multiple_route_tables(ec2_client, deploy_cfn_template):
 
 
 def test_cfn_with_multiple_route_table_associations(ec2_client, deploy_cfn_template):
+    # TODO: stack does not deploy to AWS
     stack = deploy_cfn_template(
         template_path=os.path.join(os.path.dirname(__file__), "../templates/template37.yaml")
     )
@@ -48,8 +49,7 @@ def test_cfn_with_multiple_route_table_associations(ec2_client, deploy_cfn_templ
         Filters=[{"Name": "route-table-id", "Values": [route_table_id]}]
     )["RouteTables"][0]
 
-    # CloudFormation will create more than one route table 2 in template + default
-    assert len(route_table["Associations"]) == 3
+    assert len(route_table["Associations"]) == 2
 
     # assert subnet attributes are present
     vpc_id = stack.outputs["VpcId"]


### PR DESCRIPTION
Upgrades moto to the latest version that was recently released.

* Had to fix one cfn ec2 test that started failing, apparently due to this change: https://github.com/spulec/moto/pull/5509 unfortunately I couldn't verify the behavior against AWS (stack would not deploy, did not figure out why)