### PR TITLE
Pin importlib-metadata dependency to maintain CLI compatibility for python 3.7

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - ".github/workflows/pro-integration.yml"
+      - ".github/workflows/cli-tests.yml"
       - "localstack/**"
       - "tests/**"
       - "setup.py"
@@ -17,7 +17,7 @@ on:
       - master
   push:
     paths:
-      - ".github/workflows/pro-integration.yml"
+      - ".github/workflows/cli-tests.yml"
       - "localstack/**"
       - "tests/**"
       - "setup.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ install_requires =
     requests>=2.20.0,<2.26
     semver>=2.10
     stevedore>=3.4.0
+    # needed for python3.7 compat of stevedore
+    importlib-metadata<5.0; python_version < '3.8'
     # needed for python3.7 compat (TypedDict, Literal, type hints)
     typing-extensions; python_version < '3.8'
     tailer>=0.4.1


### PR DESCRIPTION
## Problem
`importlib-metadata` recently had their 5.0 major version update, where they removed some "compatibility shims" (https://importlib-metadata.readthedocs.io/en/latest/history.html). I think it is, more concretely, https://github.com/python/importlib_metadata/issues/284 which lead to the incompatibility. 
This lead to stevedore returning an error, since it tries to access the entrypoints like a dict, and therefore in python 3.7 (3.8 and later use importlib.metadata directly) the CLI to start LS did not work anymore.
Since stevedore abandoned python3.7 with its latest version 4.0.0, the chances of a fix are slim (even though the dict-like access might be removed at some point), so for now a dependency pin has to suffice.

## Solution
Pin the dependency of importlib-metadata to <5.0 for now. Since this dependency is only used in python3.7 or lower, the pin is only applicable for those versions.