### PR TITLE
refactor test_integration.py to be more resilient towards reruns

### DIFF
--- a/tests/integration/awslambda/functions/lambda_integration.py
+++ b/tests/integration/awslambda/functions/lambda_integration.py
@@ -11,7 +11,7 @@ from typing import Union
 import boto3.dynamodb.types
 
 TEST_BUCKET_NAME = "test-bucket"
-KINESIS_STREAM_NAME = "test_stream_1"
+KINESIS_STREAM_NAME = os.getenv("KINESIS_STREAM_NAME") or "test_stream_1"
 MSG_BODY_RAISE_ERROR_FLAG = "raise_error"
 MSG_BODY_MESSAGE_TARGET = "message_target"
 MSG_BODY_DELETE_BATCH = "delete_batch_test"

--- a/tests/integration/awslambda/test_lambda_integration_sqs.py
+++ b/tests/integration/awslambda/test_lambda_integration_sqs.py
@@ -1084,3 +1084,6 @@ class TestSQSEventSourceMapping:
             )
         snapshot.match("create_event_source_mapping_exception", expected.value.response)
         expected.match(INVALID_PARAMETER_VALUE_EXCEPTION)
+
+
+# TODO: test integration with lambda logs


### PR DESCRIPTION
test_integration.py has been notoriously flaky, which i think is in part because it is not resilient towards reruns. reruns almost never work, because tests don't clean up resources properly. [Here is an example](https://circleci.com/api/v1.1/project/github/localstack/localstack/64160/output/105/0?file=true&allocation-id=633a1249265c77718d64f868-0-build%2FW9WZCTDV) (search for `tests/integration/test_integration.py::TestIntegration::test_firehose_kinesis_to_s3 `).

This PR refactors the test to use our factory fixtures, and generated resource names where possible.

I also removed a flaky sqs test that has been skipped for a while, which is now in covered by `test_lambda_integration_sqs.py` (apart from the assert whether the lambda logs return the correct events, for which i created a TODO)

This will hopefully greenify https://github.com/localstack/localstack/pull/6964