### PR TITLE
fix http router to correctly add method constraints for route

### DIFF
--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -168,8 +168,9 @@ class Router(Generic[E]):
         :return: the rule that was added
         """
         attr: _RuleAttributes = fn.rule_attributes
-
-        return self.add(path=attr.path, endpoint=fn, host=attr.host, **attr.kwargs)
+        return self.add(
+            path=attr.path, endpoint=fn, host=attr.host, methods=attr.methods, **attr.kwargs
+        )
 
     def add_route_endpoints(self, obj: object) -> List[Rule]:
         """


### PR DESCRIPTION
This PR fixes a bug where we wouldn't correctly add the `methods=["GET", ...]` parameter from a route to the underlying rule, and would therefore not route correctly if there were multiple methods with different HTTP methods on the same URL.