### PR TITLE
implement S3 ASF pre-signed POST support

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -652,6 +652,7 @@ class InvalidArgument(ServiceException):
     status_code: int = 400
     ArgumentName: Optional[ArgumentName]
     ArgumentValue: Optional[ArgumentValue]
+    HostId: Optional[HostId]
 
 
 class SignatureDoesNotMatch(ServiceException):
@@ -3011,6 +3012,34 @@ class DeleteResult(TypedDict, total=False):
     Errors: Optional[Errors]
 
 
+class PostObjectRequest(ServiceRequest):
+    Body: Optional[IO[Body]]
+    Bucket: BucketName
+
+
+class PostResponse(TypedDict, total=False):
+    StatusCode: Optional[GetObjectResponseStatusCode]
+    Location: Optional[Location]
+    LocationHeader: Optional[Location]
+    Bucket: Optional[BucketName]
+    Key: Optional[ObjectKey]
+    Expiration: Optional[Expiration]
+    ETag: Optional[ETag]
+    ETagHeader: Optional[ETag]
+    ChecksumCRC32: Optional[ChecksumCRC32]
+    ChecksumCRC32C: Optional[ChecksumCRC32C]
+    ChecksumSHA1: Optional[ChecksumSHA1]
+    ChecksumSHA256: Optional[ChecksumSHA256]
+    ServerSideEncryption: Optional[ServerSideEncryption]
+    VersionId: Optional[ObjectVersionId]
+    SSECustomerAlgorithm: Optional[SSECustomerAlgorithm]
+    SSECustomerKeyMD5: Optional[SSECustomerKeyMD5]
+    SSEKMSKeyId: Optional[SSEKMSKeyId]
+    SSEKMSEncryptionContext: Optional[SSEKMSEncryptionContext]
+    BucketKeyEnabled: Optional[BucketKeyEnabled]
+    RequestCharged: Optional[RequestCharged]
+
+
 class S3Api:
 
     service = "s3"
@@ -4201,4 +4230,10 @@ class S3Api:
         version_id: ObjectVersionId = None,
         bucket_key_enabled: BucketKeyEnabled = None,
     ) -> None:
+        raise NotImplementedError
+
+    @handler("PostObject")
+    def post_object(
+        self, context: RequestContext, bucket: BucketName, body: IO[Body] = None
+    ) -> PostResponse:
         raise NotImplementedError

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -267,6 +267,9 @@
           },
           "ArgumentValue": {
             "shape": "ArgumentValue"
+          },
+          "HostId": {
+            "shape": "HostId"
           }
         },
         "error": {
@@ -437,6 +440,163 @@
         },
         "documentation": "<p>Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.</p>",
         "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/operations/PostObject",
+      "value": {
+        "name":"PostObject",
+        "http":{
+          "method":"POST",
+          "requestUri":"/{Bucket}"
+        },
+        "input":{"shape":"PostObjectRequest"},
+        "output":{"shape":"PostResponse"},
+        "documentationUrl":"http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html",
+        "documentation":"<p>The POST operation adds an object to a specified bucket by using HTML forms. POST is an alternate form of PUT that enables browser-based uploads as a way of putting objects in buckets. Parameters that are passed to PUT through HTTP Headers are instead passed as form fields to POST in the multipart/form-data encoded message body. To add an object to a bucket, you must have WRITE access on the bucket. Amazon S3 never stores partial objects. If you receive a successful response, you can be confident that the entire object was stored.<p>"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/PostObjectRequest",
+      "value": {
+        "type":"structure",
+        "required":[
+          "Bucket"
+        ],
+        "members":{
+          "Body":{
+            "shape":"Body",
+            "documentation":"<p>Object data.</p>",
+            "streaming":true
+          },
+          "Bucket":{
+            "shape":"BucketName",
+            "documentation":"<p>The bucket name to which the PUT action was initiated. </p> <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html\">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p> <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <code> <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>. When using this action with S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html\">Using Amazon S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>",
+            "location":"uri",
+            "locationName":"Bucket"
+          }
+        },
+        "payload":"Body"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/PostResponse",
+      "value": {
+        "type":"structure",
+        "members":{
+          "StatusCode": {
+            "shape": "GetObjectResponseStatusCode",
+            "location": "statusCode"
+          },
+          "Location":{
+            "shape":"Location",
+            "documentation":"<p>The URI that identifies the newly created object.</p>"
+          },
+          "LocationHeader":{
+            "shape":"Location",
+            "documentation":"<p>The URI that identifies the newly created object.</p>",
+            "location": "header",
+            "locationName": "Location"
+          },
+          "Bucket":{
+            "shape":"BucketName",
+            "documentation":"<p>The name of the bucket that contains the newly created object. Does not return the access point ARN or access point alias if used.</p> <p>When using this action with an access point, you must direct requests to the access point hostname. The access point hostname takes the form <i>AccessPointName</i>-<i>AccountId</i>.s3-accesspoint.<i>Region</i>.amazonaws.com. When using this action with an access point through the Amazon Web Services SDKs, you provide the access point ARN in place of the bucket name. For more information about access point ARNs, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html\">Using access points</a> in the <i>Amazon S3 User Guide</i>.</p> <p>When using this action with Amazon S3 on Outposts, you must direct requests to the S3 on Outposts hostname. The S3 on Outposts hostname takes the form <code> <i>AccessPointName</i>-<i>AccountId</i>.<i>outpostID</i>.s3-outposts.<i>Region</i>.amazonaws.com</code>. When using this action with S3 on Outposts through the Amazon Web Services SDKs, you provide the Outposts bucket ARN in place of the bucket name. For more information about S3 on Outposts ARNs, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html\">Using Amazon S3 on Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>"
+          },
+          "Key":{
+            "shape":"ObjectKey",
+            "documentation":"<p>The object key of the newly created object.</p>"
+          },
+          "Expiration": {
+            "shape": "Expiration",
+            "documentation": "<p>If the expiration is configured for the object (see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html\">PutBucketLifecycleConfiguration</a>), the response includes this header. It includes the <code>expiry-date</code> and <code>rule-id</code> key-value pairs that provide information about object expiration. The value of the <code>rule-id</code> is URL-encoded.</p>",
+            "location": "header",
+            "locationName": "x-amz-expiration"
+          },
+          "ETag":{
+            "shape":"ETag",
+            "documentation":"<p>Entity tag that identifies the newly created object's data. Objects with different object data will have different entity tags. The entity tag is an opaque string. The entity tag may or may not be an MD5 digest of the object data. If the entity tag is not an MD5 digest of the object data, it will contain one or more nonhexadecimal characters and/or will consist of less than 32 or more than 32 hexadecimal digits. For more information about how the entity tag is calculated, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>"
+          },
+          "ETagHeader":{
+            "shape":"ETag",
+            "documentation":"<p>Entity tag that identifies the newly created object's data. Objects with different object data will have different entity tags. The entity tag is an opaque string. The entity tag may or may not be an MD5 digest of the object data. If the entity tag is not an MD5 digest of the object data, it will contain one or more nonhexadecimal characters and/or will consist of less than 32 or more than 32 hexadecimal digits. For more information about how the entity tag is calculated, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html\">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>",
+            "location": "header",
+            "locationName": "ETag"
+          },
+          "ChecksumCRC32": {
+            "shape": "ChecksumCRC32",
+            "documentation": "<p>The base64-encoded, 32-bit CRC32 checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>",
+            "location": "header",
+            "locationName": "x-amz-checksum-crc32"
+          },
+          "ChecksumCRC32C": {
+            "shape": "ChecksumCRC32C",
+            "documentation": "<p>The base64-encoded, 32-bit CRC32C checksum of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>",
+            "location": "header",
+            "locationName": "x-amz-checksum-crc32c"
+          },
+          "ChecksumSHA1": {
+            "shape": "ChecksumSHA1",
+            "documentation": "<p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>",
+            "location": "header",
+            "locationName": "x-amz-checksum-sha1"
+          },
+          "ChecksumSHA256": {
+            "shape": "ChecksumSHA256",
+            "documentation": "<p>The base64-encoded, 256-bit SHA-256 digest of the object. This will only be present if it was uploaded with the object. With multipart uploads, this may not be a checksum value of the object. For more information about how checksums are calculated with multipart uploads, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>",
+            "location": "header",
+            "locationName": "x-amz-checksum-sha256"
+          },
+          "ServerSideEncryption": {
+            "shape": "ServerSideEncryption",
+            "documentation": "<p>If you specified server-side encryption either with an Amazon Web Services KMS key or Amazon S3-managed encryption key in your PUT request, the response includes this header. It confirms the encryption algorithm that Amazon S3 used to encrypt the object.</p>",
+            "location": "header",
+            "locationName": "x-amz-server-side-encryption"
+          },
+          "VersionId": {
+            "shape": "ObjectVersionId",
+            "documentation": "<p>Version of the object.</p>",
+            "location": "header",
+            "locationName": "x-amz-version-id"
+          },
+          "SSECustomerAlgorithm": {
+            "shape": "SSECustomerAlgorithm",
+            "documentation": "<p>If server-side encryption with a customer-provided encryption key was requested, the response will include this header confirming the encryption algorithm used.</p>",
+            "location": "header",
+            "locationName": "x-amz-server-side-encryption-customer-algorithm"
+          },
+          "SSECustomerKeyMD5": {
+            "shape": "SSECustomerKeyMD5",
+            "documentation": "<p>If server-side encryption with a customer-provided encryption key was requested, the response will include this header to provide round-trip message integrity verification of the customer-provided encryption key.</p>",
+            "location": "header",
+            "locationName": "x-amz-server-side-encryption-customer-key-MD5"
+          },
+          "SSEKMSKeyId": {
+            "shape": "SSEKMSKeyId",
+            "documentation": "<p>If <code>x-amz-server-side-encryption</code> is present and has the value of <code>aws:kms</code>, this header specifies the ID of the Amazon Web Services Key Management Service (Amazon Web Services KMS) symmetric customer managed key that was used for the object. </p>",
+            "location": "header",
+            "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
+          },
+          "SSEKMSEncryptionContext": {
+            "shape": "SSEKMSEncryptionContext",
+            "documentation": "<p>If present, specifies the Amazon Web Services KMS Encryption Context to use for object encryption. The value of this header is a base64-encoded UTF-8 string holding JSON with the encryption context key-value pairs.</p>",
+            "location": "header",
+            "locationName": "x-amz-server-side-encryption-context"
+          },
+          "BucketKeyEnabled": {
+            "shape": "BucketKeyEnabled",
+            "documentation": "<p>Indicates whether the uploaded object uses an S3 Bucket Key for server-side encryption with Amazon Web Services KMS (SSE-KMS).</p>",
+            "location": "header",
+            "locationName": "x-amz-server-side-encryption-bucket-key-enabled"
+          },
+          "RequestCharged": {
+            "shape": "RequestCharged",
+            "location": "header",
+            "locationName": "x-amz-request-charged"
+          }
+        }
       }
     },
     {

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1,15 +1,26 @@
 import copy
 import logging
 import os
-from urllib.parse import SplitResult, quote, urlsplit, urlunsplit
+from typing import IO
+from urllib.parse import (
+    SplitResult,
+    parse_qs,
+    quote,
+    urlencode,
+    urlparse,
+    urlsplit,
+    urlunparse,
+    urlunsplit,
+)
 
 import moto.s3.responses as moto_s3_responses
 
 from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.api import CommonServiceException, RequestContext, handler
+from localstack.aws.api import CommonServiceException, RequestContext, ServiceException, handler
 from localstack.aws.api.s3 import (
     AccessControlPolicy,
     AccountId,
+    Body,
     BucketName,
     ChecksumAlgorithm,
     CompleteMultipartUploadOutput,
@@ -23,6 +34,7 @@ from localstack.aws.api.s3 import (
     DeleteObjectRequest,
     DeleteObjectTaggingOutput,
     DeleteObjectTaggingRequest,
+    ETag,
     GetBucketAclOutput,
     GetBucketLifecycleConfigurationOutput,
     GetBucketLifecycleOutput,
@@ -44,6 +56,7 @@ from localstack.aws.api.s3 import (
     NoSuchWebsiteConfiguration,
     NotificationConfiguration,
     ObjectKey,
+    PostResponse,
     PutBucketAclRequest,
     PutBucketLifecycleConfigurationRequest,
     PutBucketLifecycleRequest,
@@ -71,6 +84,7 @@ from localstack.services.s3.notifications import NotificationDispatcher, S3Event
 from localstack.services.s3.presigned_url import (
     s3_presigned_url_request_handler,
     s3_presigned_url_response_handler,
+    validate_post_policy,
 )
 from localstack.services.s3.utils import (
     ALLOWED_HEADER_OVERRIDES,
@@ -78,6 +92,7 @@ from localstack.services.s3.utils import (
     VALID_ACL_PREDEFINED_GROUPS,
     VALID_GRANTEE_PERMISSIONS,
     _create_invalid_argument_exc,
+    capitalize_header_name_from_snake_case,
     get_bucket_from_moto,
     get_header_name,
     get_key_from_moto_bucket,
@@ -572,6 +587,67 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # does not raise error if the bucket did not have a config, will simply return
         self.get_store().bucket_website_configuration.pop(bucket, None)
 
+    def post_object(
+        self, context: RequestContext, bucket: BucketName, body: IO[Body] = None
+    ) -> PostResponse:
+        # see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
+        # TODO: signature validation is not implemented for pre-signed POST
+        # policy validation is not implemented either, except expiration and mandatory fields
+        validate_post_policy(context.request.form)
+
+        # Botocore has trouble parsing responses with status code in the 3XX range, it interprets them as exception
+        # it then raises a nonsense one with a wrong code
+        # We have to create and populate the response manually if that happens
+        try:
+            response: PostResponse = call_moto(context=context)
+        except ServiceException as e:
+            if e.code == "303":
+                response = PostResponse(StatusCode=303)
+            else:
+                raise e
+
+        key_name = context.request.form.get("key")
+        if "${filename}" in key_name:
+            key_name = key_name.replace("${filename}", context.request.files["file"].filename)
+
+        moto_backend = get_moto_s3_backend(context)
+        key = get_key_from_moto_bucket(
+            get_bucket_from_moto(moto_backend, bucket=bucket), key=key_name
+        )
+        # hacky way to set the etag in the headers as well: two locations for one value
+        response["ETagHeader"] = key.etag
+
+        if response["StatusCode"] == 303:
+            # we need to create the redirect, as the parser could not return the moto-calculated one
+            try:
+                redirect = _create_redirect_for_post_request(
+                    base_redirect=context.request.form["success_action_redirect"],
+                    bucket=bucket,
+                    key=key_name,
+                    etag=key.etag,
+                )
+                response["LocationHeader"] = redirect
+            except ValueError:
+                # If S3 cannot interpret the URL, it acts as if the field is not present.
+                response["StatusCode"] = 204
+
+        response["LocationHeader"] = response.get(
+            "LocationHeader", f"{get_full_default_bucket_location(bucket)}{key_name}"
+        )
+
+        if bucket in self.get_store().bucket_versioning_status:
+            response["VersionId"] = key.version_id
+
+        if context.request.form.get("success_action_status") != "201":
+            return response
+
+        response["ETag"] = key.etag
+        response["Bucket"] = bucket
+        response["Key"] = key_name
+        response["Location"] = response["LocationHeader"]
+
+        return response
+
     def add_custom_routes(self):
         # virtual-host style: https://bucket-name.s3.region-code.amazonaws.com/key-name
         # host_pattern_vhost_style = f"{bucket}.s3.<regex('({AWS_REGION_REGEX}\.)?'):region>{LOCALHOST_HOSTNAME}:{get_edge_port_http()}"
@@ -820,15 +896,43 @@ def is_object_expired(context: RequestContext, bucket: BucketName, key: ObjectKe
     return is_key_expired(key_object=key_object)
 
 
+def _create_redirect_for_post_request(
+    base_redirect: str, bucket: BucketName, key: ObjectKey, etag: ETag
+):
+    """
+    POST requests can redirect if successful. It will take the URL provided and append query string parameters
+    (key, bucket and ETag). It needs to be a full URL.
+    :param base_redirect: the URL provided for redirection
+    :param bucket: bucket name
+    :param key: key name
+    :param etag: key ETag
+    :return: the URL provided with the new appended query string parameters
+    """
+    parts = urlparse(base_redirect)
+    if not parts.netloc:
+        raise ValueError("The provided URL is not valid")
+    queryargs = parse_qs(parts.query)
+    queryargs["key"] = [key]
+    queryargs["bucket"] = [bucket]
+    queryargs["etag"] = [etag]
+    redirect_queryargs = urlencode(queryargs, doseq=True)
+    newparts = (
+        parts.scheme,
+        parts.netloc,
+        parts.path,
+        parts.params,
+        redirect_queryargs,
+        parts.fragment,
+    )
+    return urlunparse(newparts)
+
+
 def apply_moto_patches():
     # importing here in case we need InvalidObjectState from `localstack.aws.api.s3`
     from moto.s3.exceptions import InvalidObjectState
 
     if not os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"):
         os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = str(S3_MAX_FILE_SIZE_BYTES)
-
-    def _capitalize_header_name_from_snake_case(header_name: str) -> str:
-        return "-".join([part.capitalize() for part in header_name.split("-")])
 
     @patch(moto_s3_responses.S3Response.key_response)
     def _fix_key_response(fn, self, *args, **kwargs):
@@ -842,7 +946,7 @@ def apply_moto_patches():
             "content-encoding",
         ]:
             if header_value := resp_headers.pop(low_case_header, None):
-                header_name = _capitalize_header_name_from_snake_case(low_case_header)
+                header_name = capitalize_header_name_from_snake_case(low_case_header)
                 resp_headers[header_name] = header_value
 
         return status_code, resp_headers, key_value

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -601,8 +601,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         try:
             response: PostResponse = call_moto(context=context)
         except ServiceException as e:
-            if e.code == "303":
-                response = PostResponse(StatusCode=303)
+            if e.status_code == 303:
+                # the parser did not succeed in parsing the moto respond, we start constructing the response ourselves
+                response = PostResponse(StatusCode=e.status_code)
             else:
                 raise e
 

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -180,9 +180,15 @@ def get_key_from_moto_bucket(
 
 
 def _create_invalid_argument_exc(
-    message: Union[str, None], name: str, value: str
+    message: Union[str, None], name: str, value: str, host_id: str = None
 ) -> InvalidArgument:
     ex = InvalidArgument(message)
     ex.ArgumentName = name
     ex.ArgumentValue = value
+    if host_id:
+        ex.HostId = host_id
     return ex
+
+
+def capitalize_header_name_from_snake_case(header_name: str) -> str:
+    return "-".join([part.capitalize() for part in header_name.split("-")])

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2211,9 +2211,10 @@ class TestS3PresignedUrl:
         snapshot.match("get_object", response)
 
     @pytest.mark.aws_validated
-    # @pytest.mark.xfail(
-    #     condition=LEGACY_S3_PROVIDER, reason="status code in hardcoded in legacy provider"
-    # )
+    @pytest.mark.xfail(
+        condition=not config.LEGACY_EDGE_PROXY and LEGACY_S3_PROVIDER,
+        reason="failing with new HTTP gateway (only in CI)",
+    )
     def test_post_object_with_files(self, s3_client, s3_bucket):
         object_key = "test-presigned-post-key"
 

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2211,16 +2211,19 @@ class TestS3PresignedUrl:
         snapshot.match("get_object", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(
-        condition=not config.LEGACY_EDGE_PROXY, reason="failing with new HTTP gateway (only in CI)"
-    )
+    # @pytest.mark.xfail(
+    #     condition=LEGACY_S3_PROVIDER, reason="status code in hardcoded in legacy provider"
+    # )
     def test_post_object_with_files(self, s3_client, s3_bucket):
         object_key = "test-presigned-post-key"
 
         body = b"something body"
 
         presigned_request = s3_client.generate_presigned_post(
-            Bucket=s3_bucket, Key=object_key, ExpiresIn=60
+            Bucket=s3_bucket,
+            Key=object_key,
+            ExpiresIn=60,
+            Conditions=[{"bucket": s3_bucket}],
         )
         # put object
         response = requests.post(
@@ -2229,15 +2232,17 @@ class TestS3PresignedUrl:
             files={"file": body},
             verify=False,
         )
-
         assert response.status_code == 204
+
         # get object and compare results
         downloaded_object = s3_client.get_object(Bucket=s3_bucket, Key=object_key)
         assert downloaded_object["Body"].read() == body
 
     @pytest.mark.aws_validated
-    def test_post_request_expires(self, s3_client, s3_bucket):
-        # TODO: failed against AWS
+    # old provider does not raise the right exception
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider)
+    def test_post_request_expires(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(self._get_presigned_snapshot_transformers(snapshot))
         # presign a post with a short expiry time
         object_key = "test-presigned-post-key"
 
@@ -2256,12 +2261,145 @@ class TestS3PresignedUrl:
             verify=False,
         )
 
-        # should be AccessDenied instead of expired?
-        # expired Token must be about the identity token??
-
-        # FIXME: localstack returns 400 but aws returns 403
+        exception = xmltodict.parse(response.content)
+        exception["StatusCode"] = response.status_code
+        snapshot.match("exception", exception)
         assert response.status_code in [400, 403]
-        assert "ExpiredToken" in response.text
+
+    @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER, reason="Policy is not validated in legacy provider"
+    )
+    @pytest.mark.parametrize(
+        "signature_version",
+        ["s3", "s3v4"],
+    )
+    def test_post_request_malformed_policy(self, s3_client, s3_bucket, snapshot, signature_version):
+        snapshot.add_transformer(self._get_presigned_snapshot_transformers(snapshot))
+        object_key = "test-presigned-malformed-policy"
+
+        presigned_client = _s3_client_custom_config(
+            Config(signature_version=signature_version),
+            endpoint_url=_endpoint_url(),
+        )
+
+        presigned_request = presigned_client.generate_presigned_post(
+            Bucket=s3_bucket, Key=object_key, ExpiresIn=60
+        )
+
+        # modify the base64 string to be wrong
+        original_policy = presigned_request["fields"]["policy"]
+        presigned_request["fields"]["policy"] = original_policy[:-2]
+
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files={"file": "file content"},
+            verify=False,
+        )
+        # the policy has been modified, so the signature does not correspond
+        exception = xmltodict.parse(response.content)
+        exception["StatusCode"] = response.status_code
+        snapshot.match("exception-policy", exception)
+        # assert fields that snapshot cannot match
+        signature_field = "signature" if signature_version == "s3" else "x-amz-signature"
+        assert (
+            exception["Error"]["SignatureProvided"] == presigned_request["fields"][signature_field]
+        )
+        assert exception["Error"]["StringToSign"] == presigned_request["fields"]["policy"]
+
+    @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER, reason="Signature is not validated in legacy provider"
+    )
+    @pytest.mark.parametrize(
+        "signature_version",
+        ["s3", "s3v4"],
+    )
+    def test_post_request_missing_signature(
+        self, s3_client, s3_bucket, snapshot, signature_version
+    ):
+        snapshot.add_transformer(self._get_presigned_snapshot_transformers(snapshot))
+        object_key = "test-presigned-missing-signature"
+
+        presigned_client = _s3_client_custom_config(
+            Config(signature_version=signature_version),
+            endpoint_url=_endpoint_url(),
+        )
+
+        presigned_request = presigned_client.generate_presigned_post(
+            Bucket=s3_bucket, Key=object_key, ExpiresIn=60
+        )
+
+        # remove the signature field
+        signature_field = "signature" if signature_version == "s3" else "x-amz-signature"
+        presigned_request["fields"].pop(signature_field)
+
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files={"file": "file content"},
+            verify=False,
+        )
+
+        # AWS seems to detected what kind of signature is missing from the policy fields
+        exception = xmltodict.parse(response.content)
+        exception["StatusCode"] = response.status_code
+        snapshot.match("exception-missing-signature", exception)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER, reason="Policy is not validated in legacy provider"
+    )
+    @pytest.mark.parametrize(
+        "signature_version",
+        ["s3", "s3v4"],
+    )
+    def test_post_request_missing_fields(self, s3_client, s3_bucket, snapshot, signature_version):
+        snapshot.add_transformer(self._get_presigned_snapshot_transformers(snapshot))
+        object_key = "test-presigned-missing-fields"
+
+        presigned_client = _s3_client_custom_config(
+            Config(signature_version=signature_version),
+            endpoint_url=_endpoint_url(),
+        )
+
+        presigned_request = presigned_client.generate_presigned_post(
+            Bucket=s3_bucket, Key=object_key, ExpiresIn=60
+        )
+
+        # remove some signature related fields
+        if signature_version == "s3":
+            presigned_request["fields"].pop("AWSAccessKeyId")
+        else:
+            presigned_request["fields"].pop("x-amz-algorithm")
+            presigned_request["fields"].pop("x-amz-credential")
+
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files={"file": "file content"},
+            verify=False,
+        )
+
+        exception = xmltodict.parse(response.content)
+        exception["StatusCode"] = response.status_code
+        snapshot.match("exception-missing-fields", exception)
+
+        # pop everything else to see what exception comes back
+        presigned_request["fields"] = {
+            k: v for k, v in presigned_request["fields"].items() if k in ("key", "policy")
+        }
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files={"file": "file content"},
+            verify=False,
+        )
+
+        exception = xmltodict.parse(response.content)
+        exception["StatusCode"] = response.status_code
+        snapshot.match("exception-no-sig-related-fields", exception)
 
     @pytest.mark.aws_validated
     def test_delete_has_empty_content_length_header(self, s3_client, s3_bucket):
@@ -2413,7 +2551,7 @@ class TestS3PresignedUrl:
             snapshot.match("with-decoded-content-length", exception)
 
         # old provider does not raise the right error message
-        if LEGACY_S3_PROVIDER or (signature_version == "s3" and is_aws_cloud()):
+        if LEGACY_S3_PROVIDER or signature_version == "s3":
             assert b"SignatureDoesNotMatch" in result.content
         # we are either using s3v4 with new provider or whichever signature against AWS
         else:
@@ -2426,7 +2564,7 @@ class TestS3PresignedUrl:
         if snapshotted:
             exception = xmltodict.parse(result.content)
             snapshot.match("without-decoded-content-length", exception)
-        if LEGACY_S3_PROVIDER or (signature_version == "s3" and is_aws_cloud()):
+        if LEGACY_S3_PROVIDER or signature_version == "s3":
             assert b"SignatureDoesNotMatch" in result.content
         else:
             assert b"AccessDenied" in result.content
@@ -2728,7 +2866,6 @@ class TestS3PresignedUrl:
     def test_s3_presigned_post_success_action_status_201_response(self, s3_client, s3_bucket):
         # a security policy is required if the bucket is not publicly writable
         # see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html#RESTObjectPOST-requests-form-fields
-        # TODO need to create new operation in the specs to handle presigned POST
         body = "something body"
         # get presigned URL
         object_key = "key-${filename}"
@@ -2746,28 +2883,87 @@ class TestS3PresignedUrl:
             files=files,
             verify=False,
         )
-        # test
+
         assert response.status_code == 201
         json_response = xmltodict.parse(response.content)
         assert "PostResponse" in json_response
         json_response = json_response["PostResponse"]
-        # fixme 201 response is hardcoded
-        # see localstack.services.s3.s3_listener.ProxyListenerS3.get_201_response
-        if is_aws_cloud():
-            location = f"{_bucket_url_vhost(s3_bucket, aws_stack.get_region())}/key-my-file"
-            etag = '"43281e21fce675ac3bcb3524b38ca4ed"'  # TODO check quoting of etag
-        else:
-            # TODO: this location is very wrong
+
+        if LEGACY_S3_PROVIDER and not is_aws_cloud():
+            # legacy provider is does not manage PostResponse adequately
             location = "http://localhost/key-my-file"
             etag = "d41d8cd98f00b204e9800998ecf8427f"
+        else:
+            location = f"{_bucket_url_vhost(s3_bucket, aws_stack.get_region())}/key-my-file"
+            etag = '"43281e21fce675ac3bcb3524b38ca4ed"'
+            assert response.headers["ETag"] == etag
+            assert response.headers["Location"] == location
+
         assert json_response["Location"] == location
         assert json_response["Bucket"] == s3_bucket
         assert json_response["Key"] == "key-my-file"
         assert json_response["ETag"] == etag
 
     @pytest.mark.aws_validated
+    @pytest.mark.xfail(condition=LEGACY_S3_PROVIDER, reason="not supported in legacy provider")
+    def test_s3_presigned_post_success_action_redirect(self, s3_client, s3_bucket):
+        # a security policy is required if the bucket is not publicly writable
+        # see https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html#RESTObjectPOST-requests-form-fields
+        body = "something body"
+        # get presigned URL
+        object_key = "key-test"
+        redirect_location = "http://localhost.test/random"
+        presigned_request = s3_client.generate_presigned_post(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Fields={"success_action_redirect": redirect_location},
+            Conditions=[
+                {"bucket": s3_bucket},
+                ["eq", "$success_action_redirect", redirect_location],
+            ],
+            ExpiresIn=60,
+        )
+        files = {"file": ("my-file", body)}
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files=files,
+            verify=False,
+            allow_redirects=False,
+        )
+
+        assert response.status_code == 303
+        assert not response.text
+        location = urlparse(response.headers["Location"])
+        location_qs = parse_qs(location.query)
+        assert location_qs["key"][0] == object_key
+        assert location_qs["bucket"][0] == s3_bucket
+        assert location_qs["etag"][0] == '"43281e21fce675ac3bcb3524b38ca4ed"'
+
+        # If S3 cannot interpret the URL, it acts as if the field is not present.
+        wrong_redirect = "/wrong/redirect/relative"
+        presigned_request = s3_client.generate_presigned_post(
+            Bucket=s3_bucket,
+            Key=object_key,
+            Fields={"success_action_redirect": wrong_redirect},
+            Conditions=[
+                {"bucket": s3_bucket},
+                ["eq", "$success_action_redirect", wrong_redirect],
+            ],
+            ExpiresIn=60,
+        )
+        response = requests.post(
+            presigned_request["url"],
+            data=presigned_request["fields"],
+            files=files,
+            verify=False,
+            allow_redirects=False,
+        )
+        assert response.status_code == 204
+
+    @pytest.mark.aws_validated
     def test_presigned_url_with_session_token(self, s3_create_bucket_with_client, sts_client):
-        # TODO we might be skipping signature validation here......
+        # TODO we might be skipping signature validation here...
         bucket_name = f"bucket-{short_uid()}"
         key_name = "key"
         response = sts_client.get_session_token()

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3292,6 +3292,156 @@
       }
     }
   },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_expires": {
+    "recorded-date": "04-10-2022, 17:59:26",
+    "recorded-content": {
+      "exception": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "host-id",
+          "Message": "Invalid according to Policy: Policy expired.",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy": {
+    "recorded-date": "04-10-2022, 20:42:19",
+    "recorded-content": {
+      "exception": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy[s3]": {
+    "recorded-date": "05-10-2022, 18:11:44",
+    "recorded-content": {
+      "exception-policy": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_malformed_policy[s3v4]": {
+    "recorded-date": "05-10-2022, 18:11:46",
+    "recorded-content": {
+      "exception-policy": {
+        "Error": {
+          "AWSAccessKeyId": "<a-w-s-access-key-id:1>",
+          "Code": "SignatureDoesNotMatch",
+          "HostId": "host-id",
+          "Message": "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
+          "RequestId": "<request-id:1>",
+          "SignatureProvided": "<signature-provided:1>",
+          "StringToSign": "<string-to-sign>",
+          "StringToSignBytes": "<string-to-sign-bytes:1>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_signature[s3]": {
+    "recorded-date": "05-10-2022, 18:14:22",
+    "recorded-content": {
+      "exception-missing-signature": {
+        "Error": {
+          "ArgumentName": "Signature",
+          "ArgumentValue": null,
+          "Code": "InvalidArgument",
+          "HostId": "host-id",
+          "Message": "Bucket POST must contain a field named 'Signature'.  If it is specified, please check the order of the fields.",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 400
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_signature[s3v4]": {
+    "recorded-date": "05-10-2022, 18:14:24",
+    "recorded-content": {
+      "exception-missing-signature": {
+        "Error": {
+          "ArgumentName": "X-Amz-Signature",
+          "ArgumentValue": null,
+          "Code": "InvalidArgument",
+          "HostId": "host-id",
+          "Message": "Bucket POST must contain a field named 'X-Amz-Signature'.  If it is specified, please check the order of the fields.",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 400
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_fields[s3]": {
+    "recorded-date": "05-10-2022, 18:29:23",
+    "recorded-content": {
+      "exception-missing-fields": {
+        "Error": {
+          "ArgumentName": "AWSAccessKeyId",
+          "ArgumentValue": null,
+          "Code": "InvalidArgument",
+          "HostId": "host-id",
+          "Message": "Bucket POST must contain a field named 'AWSAccessKeyId'.  If it is specified, please check the order of the fields.",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 400
+      },
+      "exception-no-sig-related-fields": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "host-id",
+          "Message": "Access Denied",
+          "RequestId": "<request-id:2>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_post_request_missing_fields[s3v4]": {
+    "recorded-date": "05-10-2022, 18:29:26",
+    "recorded-content": {
+      "exception-missing-fields": {
+        "Error": {
+          "ArgumentName": "X-Amz-Algorithm",
+          "ArgumentValue": null,
+          "Code": "InvalidArgument",
+          "HostId": "host-id",
+          "Message": "Bucket POST must contain a field named 'X-Amz-Algorithm'.  If it is specified, please check the order of the fields.",
+          "RequestId": "<request-id:1>"
+        },
+        "StatusCode": 400
+      },
+      "exception-no-sig-related-fields": {
+        "Error": {
+          "Code": "AccessDenied",
+          "HostId": "host-id",
+          "Message": "Access Denied",
+          "RequestId": "<request-id:2>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
   "tests/integration/s3/test_s3.py::TestS3StaticWebsiteHosting::test_validate_website_configuration": {
     "recorded-date": "28-09-2022, 22:44:53",
     "recorded-content": {


### PR DESCRIPTION
This PR implements S3 pre-signed POST support
Currently, the provider does not implement signature validation, but it is not a lot of work to implement, as only the policy is signed (a JSON string encoded in base64). It can be done in a follow up PR. 

To implement support for this operation, we needed to create an operation not defined in the specs, as the clients (like `Boto`) would never call directly to this URL. But it is implement server side, and documented. See https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html

Also, I had to make a small change to the serializer, but I'm not sure it should be generalised. I think 3XX status code are not supposed to return a body. So I skipped serializing the body in case the status code was >= 300 and < 400. 

It also came to light that the botocore parser does not like 3XX responses from moto, as it tries to parse them as exception. I need to add a special `try...except` clause to catch the exception and act in consequence. 

It also implements small tests fixes for pre-signed URL in general, and wrong logic in skipping them/checking conditions based on Legacy/ASF. 