### PR TITLE
Add debug information to check CI failures

### DIFF
--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -371,11 +371,20 @@ class ASGIAdapter:
     ):
         env = self.to_wsgi_environment(scope, receive)
 
-        response = WsgiStartResponse(send, self.event_loop)
+        try:
+            response = WsgiStartResponse(send, self.event_loop)
 
-        iterable = await self.event_loop.run_in_executor(
-            self.executor, self.wsgi_app, env, response
-        )
+            iterable = await self.event_loop.run_in_executor(
+                self.executor, self.wsgi_app, env, response
+            )
+        except Exception as e:
+            LOG.error(
+                "Error while trying to schedule execution: %s with environment %s",
+                e,
+                env,
+                exc_info=LOG.isEnabledFor(logging.DEBUG),
+            )
+            raise
 
         try:
             if iterable:

--- a/localstack/testing/pytest/detect_thread_leakage.py
+++ b/localstack/testing/pytest/detect_thread_leakage.py
@@ -1,0 +1,39 @@
+import inspect
+import json
+import sys
+import threading
+import traceback
+
+import psutil
+import pytest
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config):
+    print(
+        f"Still running threads after pytest unconfigure: {threading.enumerate()}, Count: {threading.active_count()}"
+    )
+    thread_frames = [
+        (sys._current_frames().get(thread.ident), thread) for thread in threading.enumerate()
+    ]
+    info_tuples = [
+        {
+            "file_name": frame.f_code.co_filename,
+            "function_name": frame.f_code.co_name,
+            "line_no": frame.f_code.co_firstlineno,
+            "frame_traceback": traceback.format_stack(frame),
+            "thread_name": thread.name,
+            "thread_target": repr(thread._target),
+            "thread_target_file": inspect.getfile(thread._target) if thread._target else None,
+        }
+        for frame, thread in thread_frames
+        if frame
+    ]
+    print(f"Thread actions: {json.dumps(info_tuples, indent=None)}")
+    current_process = psutil.Process()
+    children = current_process.children(recursive=True)
+    process_information_list = [
+        {"cmdline": child.cmdline(), "pid": child.pid, "status": child.status()}
+        for child in children
+    ]
+    print(f"Subprocesses: {json.dumps(process_information_list, indent=None)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ pytest_plugins = [
     "localstack.testing.pytest.snapshot",
     "localstack.testing.pytest.filters",
     "localstack.testing.pytest.fixture_conflicts",
+    "localstack.testing.pytest.detect_thread_leakage",
 ]
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import multiprocessing as mp
 import os
 import sys
 import threading
+import traceback
 
 import pytest
 
@@ -97,6 +98,7 @@ def pytest_unconfigure(config):
             "file_name": frame.f_code.co_filename,
             "function_name": frame.f_code.co_name,
             "line_no": frame.f_code.co_firstlineno,
+            "frame_traceback": traceback.format_stack(frame),
             "thread_name": thread.name,
             "thread_target": thread._target,
             "thread_target_file": inspect.getfile(thread._target) if thread._target else None,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,10 +4,11 @@ See: https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-
 
 It is thread/process safe to run with pytest-parallel, however not for pytest-xdist.
 """
-
+import inspect
 import logging
 import multiprocessing as mp
 import os
+import sys
 import threading
 
 import pytest
@@ -85,6 +86,25 @@ def pytest_unconfigure(config):
     # wait for localstack to stop. We do not want to exit immediately, otherwise new threads during shutdown will fail
     if not localstack_stopped.wait(timeout=10):
         logger.warning("LocalStack did not exit in time!")
+    print(
+        f"Still running threads after pytest unconfigure: {threading.enumerate()}, Count: {threading.active_count()}"
+    )
+    thread_frames = [
+        (sys._current_frames().get(thread.ident), thread) for thread in threading.enumerate()
+    ]
+    info_tuples = [
+        {
+            "file_name": frame.f_code.co_filename,
+            "function_name": frame.f_code.co_name,
+            "line_no": frame.f_code.co_firstlineno,
+            "thread_name": thread.name,
+            "thread_target": thread._target,
+            "thread_target_file": inspect.getfile(thread._target) if thread._target else None,
+        }
+        for frame, thread in thread_frames
+        if frame
+    ]
+    print(f"Thread actions: {info_tuples}")
 
 
 def _start_monitor():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import traceback
 
+import psutil
 import pytest
 
 from localstack import config
@@ -107,6 +108,13 @@ def pytest_unconfigure(config):
         if frame
     ]
     print(f"Thread actions: {info_tuples}")
+    current_process = psutil.Process()
+    children = current_process.children(recursive=True)
+    process_information_list = [
+        {"cmdline": child.cmdline(), "pid": child.pid, "status": child.status()}
+        for child in children
+    ]
+    print(f"Subprocesses: {process_information_list}")
 
 
 def _start_monitor():


### PR DESCRIPTION
## Problem
We currently have the problem with the interpreter not shutting down on several test runs, both in CircleCI and GitHub Actions.
It seems some threads are actively still making requests, since requests keep coming in.

## Changes
* Add thread inspection output on the end of test executions, to check which threads are still running (and should not) after LocalStack is instructed to shutdown. Also, subprocesses spawned are enumerated and printed.
* Add informational log outputs to requests failing due to executor shutdown, to check what requests are actually coming in here, to potentially make assumptions about the caller.