### PR TITLE
S3 ASF test fixes

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -600,6 +600,7 @@ class NoSuchUpload(ServiceException):
     code: str = "NoSuchUpload"
     sender_fault: bool = False
     status_code: int = 400
+    UploadId: Optional[MultipartUploadId]
 
 
 class ObjectAlreadyInActiveTierError(ServiceException):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -615,6 +615,13 @@
         "documentation": "<p>The specified bucket does not have a website configuration</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchUpload/members/UploadId",
+      "value": {
+        "shape": "MultipartUploadId"
+      }
     }
   ]
 }

--- a/localstack/services/s3/models.py
+++ b/localstack/services/s3/models.py
@@ -13,7 +13,7 @@ from localstack.aws.api.s3 import (
     WebsiteConfiguration,
 )
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
-from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
+from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
 
 
 def get_moto_s3_backend(context: RequestContext = None) -> MotoS3Backend:
@@ -23,25 +23,27 @@ def get_moto_s3_backend(context: RequestContext = None) -> MotoS3Backend:
 
 class S3Store(BaseStore):
     # maps bucket name to bucket's list of notification configurations
-    bucket_notification_configs: Dict[BucketName, NotificationConfiguration] = LocalAttribute(
+    bucket_notification_configs: Dict[BucketName, NotificationConfiguration] = CrossRegionAttribute(
         default=dict
     )
 
     # maps bucket name to bucket's CORS settings
-    bucket_cors: Dict[BucketName, CORSConfiguration] = LocalAttribute(default=dict)
+    bucket_cors: Dict[BucketName, CORSConfiguration] = CrossRegionAttribute(default=dict)
 
     # maps bucket name to bucket's replication settings
-    bucket_replication: Dict[BucketName, ReplicationConfiguration] = LocalAttribute(default=dict)
-
-    # maps bucket name to bucket's lifecycle configuration
-    # TODO: need to check "globality" of parameters / redirect
-    bucket_lifecycle_configuration: Dict[BucketName, BucketLifecycleConfiguration] = LocalAttribute(
+    bucket_replication: Dict[BucketName, ReplicationConfiguration] = CrossRegionAttribute(
         default=dict
     )
 
-    bucket_versioning_status: Dict[BucketName, bool] = LocalAttribute(default=dict)
+    # maps bucket name to bucket's lifecycle configuration
+    # TODO: need to check "globality" of parameters / redirect
+    bucket_lifecycle_configuration: Dict[
+        BucketName, BucketLifecycleConfiguration
+    ] = CrossRegionAttribute(default=dict)
 
-    bucket_website_configuration: Dict[BucketName, WebsiteConfiguration] = LocalAttribute(
+    bucket_versioning_status: Dict[BucketName, bool] = CrossRegionAttribute(default=dict)
+
+    bucket_website_configuration: Dict[BucketName, WebsiteConfiguration] = CrossRegionAttribute(
         default=dict
     )
 

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -287,6 +287,7 @@ class SqsNotifier(BaseNotifier):
                 QueueName=arn_data["resource"], QueueOwnerAWSAccountId=arn_data["account"]
             )
         except ClientError:
+            LOG.exception("Could not validate the notification destination %s", arn)
             raise _create_invalid_argument_exc(
                 "Unable to validate the following destination configurations",
                 name=arn,

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -45,6 +45,7 @@ EVENT_OPERATION_MAP = {
     "PutObject": Event.s3_ObjectCreated_Put,
     "CopyObject": Event.s3_ObjectCreated_Copy,
     "CompleteMultipartUpload": Event.s3_ObjectCreated_CompleteMultipartUpload,
+    "PostObject": Event.s3_ObjectCreated_Post,
     "PutObjectTagging": Event.s3_ObjectTagging_Put,
     "DeleteObjectTagging": Event.s3_ObjectTagging_Delete,
     "DeleteObject": Event.s3_ObjectRemoved_Delete,
@@ -89,12 +90,22 @@ class S3EventNotificationContext:
     key_version_id: str
 
     @classmethod
-    def from_request_context(cls, request_context: RequestContext) -> "S3EventNotificationContext":
+    def from_request_context(
+        cls, request_context: RequestContext, key_name: str = None
+    ) -> "S3EventNotificationContext":
+        """
+        Create an S3EventNotificationContext from a RequestContext.
+        The key is not always present in the request context depending on the event type. In that case, we can use
+        a provided one.
+        :param request_context: RequestContext
+        :param key_name: Optional, in case it's not provided in the RequestContext
+        :return: S3EventNotificationContext
+        """
         bucket_name = request_context.service_request["Bucket"]
         moto_backend = get_moto_s3_backend(request_context)
         bucket: FakeBucket = get_bucket_from_moto(moto_backend, bucket=bucket_name)
         key: FakeKey = get_key_from_moto_bucket(
-            moto_bucket=bucket, key=request_context.service_request["Key"]
+            moto_bucket=bucket, key=key_name or request_context.service_request["Key"]
         )
         return cls(
             event_type=EVENT_OPERATION_MAP.get(request_context.operation.wire_name, ""),

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -385,7 +385,7 @@ def _reverse_inject_signature_hmac_v1_query(context: RequestContext) -> Request:
     for header, value in context.request.headers.items():
         header_low = header.lower()
         if header_low.startswith("x-amz-") or header_low in ["content-type", "date", "content-md5"]:
-            new_headers[header] = value
+            new_headers[header_low] = value
 
     # rebuild the query string
     new_query_string = percent_encode_sequence(new_query_string_dict)

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -707,7 +707,12 @@ def _is_match_with_signature_fields(
         for p in signature_fields:
             if p not in request_form:
                 LOG.info("POST pre-sign missing fields")
-                argument_name = capitalize_header_name_from_snake_case(p) if "-" in p else p
+                # .capitalize() does not work here, because of AWSAccessKeyId casing
+                argument_name = (
+                    capitalize_header_name_from_snake_case(p)
+                    if "-" in p
+                    else f"{p[0].upper()}{p[1:]}"
+                )
                 ex: InvalidArgument = _create_invalid_argument_exc(
                     message=f"Bucket POST must contain a field named '{argument_name}'.  If it is specified, please check the order of the fields.",
                     name=argument_name,

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -4,7 +4,7 @@ from typing import Dict, Union
 
 import moto.s3.models as moto_s3_models
 from moto.s3.exceptions import MissingBucket
-from moto.s3.models import FakeKey
+from moto.s3.models import FakeDeleteMarker, FakeKey
 
 from localstack.aws.api import ServiceException
 from localstack.aws.api.s3 import (
@@ -111,8 +111,8 @@ def verify_checksum(checksum_algorithm: str, data: bytes, request: Dict):
         )
 
 
-def is_key_expired(key_object: FakeKey) -> bool:
-    if not key_object or not key_object._expiry:
+def is_key_expired(key_object: Union[FakeKey, FakeDeleteMarker]) -> bool:
+    if not key_object or isinstance(key_object, FakeDeleteMarker) or not key_object._expiry:
         return False
     return key_object._expiry <= datetime.datetime.now(key_object._expiry.tzinfo)
 

--- a/tests/integration/cloudformation/test_cloudformation_legacy.py
+++ b/tests/integration/cloudformation/test_cloudformation_legacy.py
@@ -365,7 +365,8 @@ class TestCloudFormation:
         s3_client = create_boto_client("s3", region_name=region)
         bucket_name = f"target-{short_uid()}"
         queue_name = f"queue-{short_uid()}"
-        queue_arn = aws_stack.sqs_queue_arn(queue_name, region_name=s3_client.meta.region_name)
+        # the queue is always created in us-east-1
+        queue_arn = aws_stack.sqs_queue_arn(queue_name)
         if create_bucket_first:
             s3_client.create_bucket(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -108,29 +108,42 @@ def s3_create_bucket_with_client(s3_resource):
 
 @pytest.fixture
 def s3_multipart_upload(s3_client):
-    def perform_multipart_upload(bucket, key, data=None, zipped=False, acl=None):
+    def perform_multipart_upload(bucket, key, data=None, zipped=False, acl=None, parts: int = 1):
+        # beware, the last part can be under 5 MiB, but previous parts needs to be between 5MiB and 5GiB
         kwargs = {"ACL": acl} if acl else {}
         multipart_upload_dict = s3_client.create_multipart_upload(Bucket=bucket, Key=key, **kwargs)
         upload_id = multipart_upload_dict["UploadId"]
-
-        # Write contents to memory rather than a file.
         data = data or (5 * short_uid())
-        data = to_bytes(data)
-        upload_file_object = BytesIO(data)
-        if zipped:
-            upload_file_object = BytesIO()
-            with gzip.GzipFile(fileobj=upload_file_object, mode="w") as filestream:
-                filestream.write(data)
+        multipart_upload_parts = []
+        for part in range(parts):
+            # Write contents to memory rather than a file.
+            part_number = part + 1
 
-        response = s3_client.upload_part(
-            Bucket=bucket,
-            Key=key,
-            Body=upload_file_object,
-            PartNumber=1,
-            UploadId=upload_id,
-        )
+            part_data = data or (5 * short_uid())
+            if part_number < parts and ((len_data := len(part_data)) < 5_242_880):
+                # data must be at least 5MiB
+                multiple = 5_242_880 // len_data
+                part_data = part_data * (multiple + 1)
 
-        multipart_upload_parts = [{"ETag": response["ETag"], "PartNumber": 1}]
+            part_data = to_bytes(part_data)
+            upload_file_object = BytesIO(part_data)
+            if zipped:
+                upload_file_object = BytesIO()
+                with gzip.GzipFile(fileobj=upload_file_object, mode="w") as filestream:
+                    filestream.write(part_data)
+
+            response = s3_client.upload_part(
+                Bucket=bucket,
+                Key=key,
+                Body=upload_file_object,
+                PartNumber=part_number,
+                UploadId=upload_id,
+            )
+
+            multipart_upload_parts.append({"ETag": response["ETag"], "PartNumber": part_number})
+            # multiple parts won't work with zip, stop at one
+            if zipped:
+                break
 
         return s3_client.complete_multipart_upload(
             Bucket=bucket,
@@ -337,17 +350,89 @@ class TestS3:
 
     @pytest.mark.aws_validated
     @pytest.mark.xfail(
-        reason="currently not implemented in moto, see https://github.com/localstack/localstack/issues/6217"
+        condition=LEGACY_S3_PROVIDER,
+        reason="currently not implemented in moto, see https://github.com/localstack/localstack/issues/6217",
     )
-    # TODO: see also XML issue in https://github.com/localstack/localstack/issues/6422
-    def test_get_object_attributes(self, s3_client, s3_bucket, snapshot):
+    # parser issue in https://github.com/localstack/localstack/issues/6422 because moto returns wrong response
+    # TODO test versioned KEY
+    def test_get_object_attributes(self, s3_client, s3_bucket, snapshot, s3_multipart_upload):
         s3_client.put_object(Bucket=s3_bucket, Key="data.txt", Body=b"69\n420\n")
         response = s3_client.get_object_attributes(
             Bucket=s3_bucket,
             Key="data.txt",
-            ObjectAttributes=["StorageClass", "ETag", "ObjectSize"],
+            ObjectAttributes=["StorageClass", "ETag", "ObjectSize", "ObjectParts"],
         )
         snapshot.match("object-attrs", response)
+
+        multipart_key = "test-get-obj-attrs-multipart"
+        s3_multipart_upload(bucket=s3_bucket, key=multipart_key, data="upload-part-1" * 5)
+        response = s3_client.get_object_attributes(
+            Bucket=s3_bucket,
+            Key=multipart_key,
+            ObjectAttributes=["StorageClass", "ETag", "ObjectSize", "ObjectParts"],
+        )
+        snapshot.match("object-attrs-multiparts-1-part", response)
+
+        multipart_key = "test-get-obj-attrs-multipart-2"
+        s3_multipart_upload(bucket=s3_bucket, key=multipart_key, data="upload-part-1" * 5, parts=2)
+        response = s3_client.get_object_attributes(
+            Bucket=s3_bucket,
+            Key=multipart_key,
+            ObjectAttributes=["StorageClass", "ETag", "ObjectSize", "ObjectParts"],
+            MaxParts=3,
+        )
+        snapshot.match("object-attrs-multiparts-2-parts", response)
+
+    @pytest.mark.aws_validated
+    def test_multipart_and_list_parts(self, s3_client, s3_bucket, s3_multipart_upload, snapshot):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Bucket", reference_replacement=False),
+                snapshot.transform.key_value("DisplayName", reference_replacement=False),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("Location"),
+                snapshot.transform.key_value(
+                    "ID", value_replacement="owner-id", reference_replacement=False
+                ),
+            ]
+        )
+
+        key_name = "test-list-parts"
+        response = s3_client.create_multipart_upload(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("create-multipart", response)
+        upload_id = response["UploadId"]
+
+        list_part = s3_client.list_parts(Bucket=s3_bucket, Key=key_name, UploadId=upload_id)
+        snapshot.match("list-part-after-created", list_part)
+
+        # Write contents to memory rather than a file.
+        data = "upload-part-1" * 5
+        data = to_bytes(data)
+        upload_file_object = BytesIO(data)
+
+        response = s3_client.upload_part(
+            Bucket=s3_bucket,
+            Key=key_name,
+            Body=upload_file_object,
+            PartNumber=1,
+            UploadId=upload_id,
+        )
+        snapshot.match("upload-part", response)
+        list_part = s3_client.list_parts(Bucket=s3_bucket, Key=key_name, UploadId=upload_id)
+        snapshot.match("list-part-after-upload", list_part)
+
+        multipart_upload_parts = [{"ETag": response["ETag"], "PartNumber": 1}]
+
+        response = s3_client.complete_multipart_upload(
+            Bucket=s3_bucket,
+            Key=key_name,
+            MultipartUpload={"Parts": multipart_upload_parts},
+            UploadId=upload_id,
+        )
+        snapshot.match("complete-multipart", response)
+        with pytest.raises(ClientError) as e:
+            s3_client.list_parts(Bucket=s3_bucket, Key=key_name, UploadId=upload_id)
+        snapshot.match("list-part-after-complete-exc", e.value.response)
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
@@ -2429,8 +2514,8 @@ class TestS3PresignedUrl:
             if encoding:
                 headers["Accept-Encoding"] = encoding
             response = requests.delete(url, headers=headers, verify=False)
+            assert not response.content
             assert response.status_code == 204
-            assert not response.text
             # AWS does not send a content-length header at all, legacy localstack sends a 0 length header
             assert response.headers.get("content-length") in [
                 "0",
@@ -2680,6 +2765,7 @@ class TestS3PresignedUrl:
             data="test_data",
             headers={"Content-Type": "text/plain"},
         )
+        assert not response.content
         assert response.status_code == 200
 
         response = requests.put(
@@ -2708,6 +2794,7 @@ class TestS3PresignedUrl:
             data="test_data",
             headers={"Content-Encoding": "identity"},
         )
+        assert not response.content
         assert response.status_code == 200
 
         response = requests.put(
@@ -3218,6 +3305,8 @@ class TestS3PresignedUrl:
             _generate_presigned_url(client, simple_params, expires, client_method="put_object"),
             data=object_data,
         )
+        # body should be empty, and it will show us the exception if it's not
+        assert not response.content
         assert response.status_code == 200
 
         params = {
@@ -3233,6 +3322,7 @@ class TestS3PresignedUrl:
             data=object_data,
             headers={"Content-Type": "text/plain"},
         )
+        assert not response.content
         assert response.status_code == 200
 
         # Invalid request

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -465,10 +465,14 @@ class TestS3:
         snapshot.match("head-object", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/6553")
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER,
+        reason="see https://github.com/localstack/localstack/issues/6553",
+    )
     def test_get_object_after_deleted_in_versioned_bucket(
         self, s3_client, s3_bucket, s3_resource, snapshot
     ):
+        snapshot.add_transformer(snapshot.transform.key_value("VersionId"))
         bucket = s3_resource.Bucket(s3_bucket)
         bucket.Versioning().enable()
 
@@ -858,7 +862,9 @@ class TestS3:
         snapshot.match("get_object", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(reason="Get 404 Not Found instead of NoSuchBucket")
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER, reason="Get 404 Not Found instead of NoSuchBucket"
+    )
     @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..Error.BucketName"])
     def test_bucket_availability(self, s3_client, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
@@ -1386,6 +1392,7 @@ class TestS3:
     @pytest.mark.xfail(reason="Error format is wrong and missing keys")
     def test_s3_invalid_content_md5(self, s3_client, s3_bucket, snapshot):
         # put object with invalid content MD5
+        # TODO: implement ContentMD5 in ASF
         hashes = ["__invalid__", "000", "not base64 encoded checksum", "MTIz"]
         for index, md5hash in enumerate(hashes):
             with pytest.raises(ClientError) as e:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -384,6 +384,9 @@ class TestS3:
         snapshot.match("object-attrs-multiparts-2-parts", response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider, paths=["$..VersionId", "$..Error.RequestID"]
+    )
     def test_multipart_and_list_parts(self, s3_client, s3_bucket, s3_multipart_upload, snapshot):
         snapshot.add_transformer(
             [

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -518,7 +518,10 @@ class TestS3:
         assert policy == json.loads(response["Policy"])
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(reason="see https://github.com/localstack/localstack/issues/5769")
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER,
+        reason="see https://github.com/localstack/localstack/issues/5769",
+    )
     def test_put_object_tagging_empty_list(self, s3_client, s3_bucket, snapshot):
         key = "my-key"
         s3_client.put_object(Bucket=s3_bucket, Key=key, Body=b"abcdefgh")

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -456,7 +456,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_after_deleted_in_versioned_bucket": {
-    "recorded-date": "21-09-2022, 13:35:18",
+    "recorded-date": "06-10-2022, 22:35:23",
     "recorded-content": {
       "get-object": {
         "AcceptRanges": "bytes",
@@ -466,7 +466,7 @@
         "ETag": "\"e8dc4081b13434b45189a720b77b6818\"",
         "LastModified": "datetime",
         "Metadata": {},
-        "VersionId": "tJEw7LZJ5OQQyUBbur6az2mmK7NnO1sy",
+        "VersionId": "<version-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -322,12 +322,38 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_get_object_attributes": {
-    "recorded-date": "21-09-2022, 13:35:02",
+    "recorded-date": "06-10-2022, 19:45:18",
     "recorded-content": {
       "object-attrs": {
         "ETag": "e92499db864217242396e8ef766079a9",
         "LastModified": "datetime",
         "ObjectSize": 7,
+        "StorageClass": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-multiparts-1-part": {
+        "ETag": "e747540af6911dbc890f8d3e0b48549b-1",
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 1
+        },
+        "ObjectSize": 65,
+        "StorageClass": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs-multiparts-2-parts": {
+        "ETag": "5389a7fb9c7e4b97c90255e2ee5e57f7-2",
+        "LastModified": "datetime",
+        "ObjectParts": {
+          "TotalPartsCount": 2
+        },
+        "ObjectSize": 5242965,
         "StorageClass": "STANDARD",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3603,6 +3629,100 @@
       "no-such-bucket": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchBucket</li>\n<li>Message: The specified bucket does not exist</li>\n<li>BucketName: <bucket-name></li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n",
       "no-such-website-config": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchWebsiteConfiguration</li>\n<li>Message: The specified bucket does not have a website configuration</li>\n<li>BucketName: <bucket-name></li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n",
       "no-such-website-config-key": "<html>\n<head><title>404 Not Found</title></head>\n<body>\n<h1>404 Not Found</h1>\n<ul>\n<li>Code: NoSuchWebsiteConfiguration</li>\n<li>Message: The specified bucket does not have a website configuration</li>\n<li>BucketName: <bucket-name></li>\n<li>RequestId: <request-id></li>\n<li>HostId: <host-id></li>\n</ul>\n<hr/>\n</body>\n</html>\n"
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_multipart_and_list_parts": {
+    "recorded-date": "06-10-2022, 18:49:24",
+    "recorded-content": {
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "test-list-parts",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-part-after-created": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "owner-id"
+        },
+        "IsTruncated": false,
+        "Key": "test-list-parts",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 0,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "owner-id"
+        },
+        "PartNumberMarker": 0,
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part": {
+        "ETag": "\"3237c18681adb6a9d843c733ce249480\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-part-after-upload": {
+        "Bucket": "bucket",
+        "Initiator": {
+          "DisplayName": "display-name",
+          "ID": "owner-id"
+        },
+        "IsTruncated": false,
+        "Key": "test-list-parts",
+        "MaxParts": 1000,
+        "NextPartNumberMarker": 1,
+        "Owner": {
+          "DisplayName": "display-name",
+          "ID": "owner-id"
+        },
+        "PartNumberMarker": 0,
+        "Parts": [
+          {
+            "ETag": "\"3237c18681adb6a9d843c733ce249480\"",
+            "LastModified": "datetime",
+            "PartNumber": 1,
+            "Size": 65
+          }
+        ],
+        "StorageClass": "STANDARD",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart": {
+        "Bucket": "bucket",
+        "ETag": "\"e747540af6911dbc890f8d3e0b48549b-1\"",
+        "Key": "test-list-parts",
+        "Location": "<location:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-part-after-complete-exc": {
+        "Error": {
+          "Code": "NoSuchUpload",
+          "Message": "The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
     }
   }
 }

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -46,6 +46,9 @@ class TestEdgeAPI:
         edge_url = config.get_edge_url()
         self._invoke_stepfunctions_via_edge(edge_url)
 
+    @pytest.mark.skipif(
+        condition=not config.LEGACY_S3_PROVIDER, reason="S3 ASF provider does not have POST yet"
+    )
     def test_invoke_s3(self):
         edge_url = config.get_edge_url()
         self._invoke_s3_via_edge(edge_url)
@@ -238,6 +241,9 @@ class TestEdgeAPI:
         if region_original is not None:
             os.environ["DEFAULT_REGION"] = region_original
 
+    @pytest.mark.skipif(
+        condition=not config.LEGACY_S3_PROVIDER, reason="S3 ASF provider does not use ProxyListener"
+    )
     def test_message_modifying_handler(self, s3_client, monkeypatch):
         class MessageModifier(MessageModifyingProxyListener):
             def forward_request(self, method, path: str, data, headers):
@@ -270,6 +276,9 @@ class TestEdgeAPI:
         content = to_str(result["Body"].read())
         assert " patched" in content
 
+    @pytest.mark.skipif(
+        condition=not config.LEGACY_S3_PROVIDER, reason="S3 ASF provider does not use ProxyListener"
+    )
     def test_handler_returning_none_method(self, s3_client, monkeypatch):
         class MessageModifier(ProxyListener):
             def forward_request(self, method, path: str, data, headers):


### PR DESCRIPTION
This PR implements the last small fixes to get the tests green in community.

- Set the attributes stored in the `S3Store` to be `CrossRegionAttribute`, as a bucket can only be created in one region, and its configuration can be accessed from anywhere.
- Fix notifications in case of a S3 pre-signed POST request (a bit of an ugly fix)
- fix headers capitalization for S3 pre-signed URLs
- return `Location` header in `CompleteMultipartUpload` response
- fix tagging an object with an empty list
- implement `GetObjectAttributes` operation, which is not implemented at all in moto (a mix of `HeadObject` and `ListParts`
- fix non-caught exception when trying to get a deleted key in a versioned bucket
- disable tests for the ASF S3 provider in `test_edge.py` that were related to S3 and the old proxy listener behaviour. 
- @dominikschubert fix a test in `test_cloudformation_legacy.py`: for s3 notifications configuration, when you set a target for notifications, S3 will check that the target exists by default. The provided ARN was computed using the region of the S3 bucket, but the actual queue was created in `us-east-1` by CFn. Not sure what the expected behaviour was, but computing the ARN to match the actual created queue's ARN fixed the test. 