### PR TITLE
upgrade moto-ext to 4.0.10.post1

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -605,7 +605,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                         or 300,
                     )
                     if authorizer:
-                        authorizers.update({security_scheme_name: authorizer})
+                        authorizers[security_scheme_name] = authorizer
                     return authorizer
 
     def get_or_create_path(abs_path: str, base_path: str):
@@ -700,9 +700,9 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
         return (
             child.add_method(
                 method,
-                authorization_type=authorizer.get("type"),
+                authorization_type=authorizer.type,
                 api_key_required=None,
-                authorizer_id=authorizer.get("id"),
+                authorizer_id=authorizer.id,
             )
             if (authorizer := create_authorizer(method_schema))
             else child.add_method(method, None, None)
@@ -710,7 +710,10 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
 
     if definitions := resolved_schema.get("definitions", {}):
         for name, model in definitions.items():
-            rest_api.add_model(name=name, schema=model, content_type=APPLICATION_JSON)
+            # TODO: validate if description is required
+            rest_api.add_model(
+                name=name, description="", schema=model, content_type=APPLICATION_JSON
+            )
 
     # determine base path
     basepath_mode = (query_params.get("basepath") or ["prepend"])[0]

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -655,7 +655,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
 
             method_integration = field_schema.get("x-amazon-apigateway-integration", {})
             method_resource = create_method_resource(resource, field, field_schema)
-            method_resource["requestParameters"] = method_integration.get("requestParameters")
+            method_resource.request_parameters = method_integration.get("requestParameters")
             responses = field_schema.get("responses", {})
             for status_code in responses:
                 response_model = None
@@ -691,7 +691,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                 .get("responseTemplates", None),
                 content_handling=None,
             )
-            resource.resource_methods[field]["methodIntegration"] = integration
+            resource.resource_methods[field].method_integration = integration
 
         rest_api.resources[child_id] = resource
         return resource

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -689,6 +689,7 @@ def import_api_from_openapi_spec(rest_api: RestAPI, body: Dict, query_params: Di
                 response_templates=method_integration.get("responses", {})
                 .get("default", {})
                 .get("responseTemplates", None),
+                response_parameters=None,
                 content_handling=None,
             )
             resource.resource_methods[field].method_integration = integration

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -158,16 +158,15 @@ def apply_patches():
         if len(result) != 3:
             return result
 
-        # if self.method == "PATCH":
-        #     patch_operations = self._get_param("patchOperations")
-        #     url_path_parts = self.path.split("/")
-        #     function_id = url_path_parts[2]
-        #     resource_id = url_path_parts[4]
-        #     method_type = url_path_parts[6]
-        #     method = self.backend.get_method(function_id, resource_id, method_type)
-        #     method = method.to_json() or {}
-        #     apply_json_patch_safe(method, patch_operations, in_place=True)
-        #     return 200, {}, json.dumps(method)
+        if self.method == "PATCH":
+            patch_operations = self._get_param("patchOperations")
+            url_path_parts = self.path.split("/")
+            function_id = url_path_parts[2]
+            resource_id = url_path_parts[4]
+            method_type = url_path_parts[6]
+            method = self.backend.get_method(function_id, resource_id, method_type)
+            method.apply_patch_operations(patch_operations)
+            return 200, {}, json.dumps(method)
 
         authorization_type = self._get_param("authorizationType")
         if authorization_type in ["CUSTOM", "COGNITO_USER_POOLS"]:

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -228,10 +228,13 @@ def apply_patches():
                 function_id, resource_id, method_type, status_code
             )
 
+            # to_json() returns a dict, not a json string
+            # we need to assemble integration_response with response_parameters
+            integration_response = integration_response.to_json()
             if response_parameters:
-                integration_response.response_parameters = response_parameters
+                integration_response["responseParameters"] = response_parameters
 
-            return 201, {}, integration_response.to_json()
+            return 201, {}, json.dumps(integration_response)
 
         return result
 

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -182,7 +182,7 @@ def apply_patches():
         resource_id = url_path_parts[4]
         method_type = url_path_parts[6]
 
-        integration = self.backend.get_integration(function_id, resource_id, method_type)
+        integration = self.backend.get_integration(function_id, resource_id, method_type).to_json()
         if not integration:
             return result
 
@@ -229,9 +229,9 @@ def apply_patches():
             )
 
             if response_parameters:
-                integration_response["responseParameters"] = response_parameters
+                integration_response.response_parameters = response_parameters
 
-            return 201, {}, json.dumps(integration_response)
+            return 201, {}, integration_response.to_json()
 
         return result
 
@@ -248,7 +248,7 @@ def apply_patches():
 
             method_response = self.backend.get_method_response(
                 function_id, resource_id, method_type, response_code
-            )
+            ).to_json()
 
             if response_parameters:
                 method_response["responseParameters"] = response_parameters
@@ -265,7 +265,7 @@ def apply_patches():
             url_path_parts = self.path.split("/")
             usage_plan_id = url_path_parts[2]
             patch_operations = self._get_param("patchOperations")
-            usage_plan = self.backend.usage_plans.get(usage_plan_id)
+            usage_plan = self.backend.usage_plans.get(usage_plan_id).to_json()
             if not usage_plan:
                 raise UsagePlanNotFoundException()
 
@@ -409,9 +409,9 @@ def apply_patches():
     # patch integration error responses
     def apigateway_models_resource_get_integration(self, method_type):
         resource_method = self.resource_methods.get(method_type, {})
-        if "methodIntegration" not in resource_method:
+        if not resource_method.method_integration:
             raise NoIntegrationDefined()
-        return resource_method["methodIntegration"]
+        return resource_method.method_integration
 
     # TODO: put_rest_api now available upstream - see if we can leverage some synergies
     apigateway_response_restapis_individual_orig = APIGatewayResponse.restapis_individual
@@ -453,7 +453,7 @@ def apply_patches():
             deployment = self.backend.update_deployment(
                 function_id, deployment_id, patch_operations
             )
-            return 201, {}, json.dumps(deployment)
+            return 201, {}, deployment.to_json()
         return result
 
     # patch create_rest_api to allow using static API IDs defined via tags

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -247,27 +247,27 @@ def apply_patches():
 
         return result
 
-    def apigateway_response_resource_method_responses(self, request, *args, **kwargs):
-        result = apigateway_response_resource_method_responses_orig(self, request, *args, **kwargs)
-        response_parameters = self._get_param("responseParameters")
-
-        if self.method == "PUT":
-            url_path_parts = self.path.split("/")
-            function_id = url_path_parts[2]
-            resource_id = url_path_parts[4]
-            method_type = url_path_parts[6]
-            response_code = url_path_parts[8]
-
-            method_response = self.backend.get_method_response(
-                function_id, resource_id, method_type, response_code
-            ).to_json()
-
-            if response_parameters:
-                method_response["responseParameters"] = response_parameters
-
-            return 201, {}, json.dumps(method_response)
-
-        return result
+    # def apigateway_response_resource_method_responses(self, request, *args, **kwargs):
+    #     result = apigateway_response_resource_method_responses_orig(self, request, *args, **kwargs)
+    #     response_parameters = self._get_param("responseParameters")
+    #
+    #     if self.method == "PUT":
+    #         url_path_parts = self.path.split("/")
+    #         function_id = url_path_parts[2]
+    #         resource_id = url_path_parts[4]
+    #         method_type = url_path_parts[6]
+    #         response_code = url_path_parts[8]
+    #
+    #         method_response = self.backend.get_method_response(
+    #             function_id, resource_id, method_type, response_code
+    #         ).to_json()
+    #
+    #         if response_parameters:
+    #             method_response["responseParameters"] = response_parameters
+    #
+    #         return 201, {}, json.dumps(method_response)
+    #
+    #     return result
 
     def apigateway_response_usage_plan_individual(
         self, request, full_url, headers, *args, **kwargs
@@ -479,18 +479,6 @@ def apply_patches():
             self.apis[custom_id] = result
         return result
 
-    def apigateway_response_deployments(self, request, full_url, headers):
-        result = apigateway_response_deployments_orig(self, request, full_url, headers)
-        if self.method == "POST":
-            return 201, {}, result[2]
-        return result
-
-    def apigateway_restapis_stages(self, request, full_url, headers):
-        result = apigateway_restapis_stages_orig(self, request, full_url, headers)
-        if self.method == "POST":
-            return 201, {}, result[2]
-        return result
-
     def get_rest_api(self, function_id):
         for key in self.apis.keys():
             if key.lower() == function_id.lower():
@@ -510,14 +498,6 @@ def apply_patches():
     APIGatewayResponse.integrations = apigateway_response_integrations
     apigateway_response_integration_responses_orig = APIGatewayResponse.integration_responses
     APIGatewayResponse.integration_responses = apigateway_response_integration_responses
-    apigateway_response_resource_method_responses_orig = (
-        APIGatewayResponse.resource_method_responses
-    )
-    APIGatewayResponse.resource_method_responses = apigateway_response_resource_method_responses
     apigateway_response_usage_plan_individual_orig = APIGatewayResponse.usage_plan_individual
     APIGatewayResponse.usage_plan_individual = apigateway_response_usage_plan_individual
     apigateway_models.RestAPI.to_dict = apigateway_models_RestAPI_to_dict
-    apigateway_response_deployments_orig = APIGatewayResponse.deployments
-    APIGatewayResponse.deployments = apigateway_response_deployments
-    apigateway_restapis_stages_orig = APIGatewayResponse.restapis_stages
-    APIGatewayResponse.restapis_stages = apigateway_restapis_stages

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -46,8 +46,8 @@ def apply_patches():
             **kwargs,
         )
 
-        if (cacheClusterSize or cacheClusterEnabled) and not self.get("cacheClusterStatus"):
-            self["cacheClusterStatus"] = "AVAILABLE"
+        if (cacheClusterSize or cacheClusterEnabled) and not self.cache_cluster_status:
+            self.cache_cluster_status = "AVAILABLE"
 
     apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -155,9 +155,9 @@ def apply_patches():
             resource_id = url_path_parts[4]
             method_type = url_path_parts[6]
             resource = self.backend.get_resource(function_id, resource_id)
-            resource.resource_methods[method_type]["requestParameters"] = request_parameters
+            resource.resource_methods[method_type].request_parameters = request_parameters
             method = resource.resource_methods[method_type]
-            result = 201, {}, json.dumps(method)
+            result = 201, {}, json.dumps(method.to_json())
         if len(result) != 3:
             return result
         authorization_type = self._get_param("authorizationType")
@@ -287,7 +287,7 @@ def apply_patches():
     def backend_update_deployment(self, function_id, deployment_id, patch_operations):
         rest_api = self.get_rest_api(function_id)
         deployment = rest_api.get_deployment(deployment_id)
-        deployment = deployment or {}
+        deployment = deployment.to_json() or {}
         apply_json_patch_safe(deployment, patch_operations, in_place=True)
         return deployment
 
@@ -453,7 +453,7 @@ def apply_patches():
             deployment = self.backend.update_deployment(
                 function_id, deployment_id, patch_operations
             )
-            return 201, {}, deployment.to_json()
+            return 201, {}, json.dumps(deployment)
         return result
 
     # patch create_rest_api to allow using static API IDs defined via tags

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -213,12 +213,8 @@ def apply_patches():
             # fix data types
             if integration.timeout_in_millis:
                 integration.timeout_in_millis = int(integration.timeout_in_millis)
-            if skip_verification := (integration.tls_config or {}).get(
-                "insecureSkipVerification"
-            ):
-                integration.tls_config["insecureSkipVerification"] = str_to_bool(
-                    skip_verification
-                )
+            if skip_verification := (integration.tls_config or {}).get("insecureSkipVerification"):
+                integration.tls_config["insecureSkipVerification"] = str_to_bool(skip_verification)
 
         return result
 

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -215,7 +215,7 @@ class ResponseTemplates(Templates):
     def render(self, api_context: ApiInvocationContext, **kwargs) -> Union[bytes, str]:
         # XXX: keep backwards compatibility until we migrate all integrations to this new classes
         # api_context contains a response object that we want slowly remove from it
-        data = kwargs["response"] if "response" in kwargs else ""
+        data = kwargs.get("response", "")
         response = data or api_context.response
         integration = api_context.integration
         # we set context data with the response content because later on we use context data as

--- a/localstack/services/moto.py
+++ b/localstack/services/moto.py
@@ -6,8 +6,8 @@ from functools import lru_cache
 from typing import Callable, Optional, Union
 
 import moto.backends as moto_backends
+from moto.core import BackendDict
 from moto.core.exceptions import RESTError
-from moto.core.utils import BackendDict
 from moto.moto_server.utilities import RegexConverter
 from werkzeug.exceptions import NotFound
 from werkzeug.routing import Map, Rule

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1142,7 +1142,7 @@ def apply_moto_patches():
     def s3_response_is_delete_keys(fn, self):
         """
         Old provider had a fix for a ticket, concerning 'x-id' - there is no documentation on AWS about this, but it is probably still valid
-        Additional fix for testing if this is a "delete_objects" request, by removing trailing "=" from the path
+        original comment: Temporary fix until moto supports x-id and DeleteObjects (#3931)
         """
         return get_safe(self.querystring, "$.x-id.0") == "DeleteObjects" or fn(self)
 

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -319,8 +319,7 @@ def apply_patches():
     @patch(s3_responses.S3Response.is_delete_keys)
     def s3_response_is_delete_keys(fn, self):
         """
-        Old provider had a fix for a ticket, concerning 'x-id' - there is no documentation on AWS about this, but it is probably still valid
-        Additional fix for testing if this is a "delete_objects" request, by removing trailing "=" from the path
+        Temporary fix until moto supports x-id and DeleteObjects (#3931)
         """
         return get_safe(self.querystring, "$.x-id.0") == "DeleteObjects" or fn(self)
 

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -6,9 +6,8 @@ from urllib.parse import urlparse
 from moto.s3 import models as s3_models
 from moto.s3 import responses as s3_responses
 from moto.s3.exceptions import MissingBucket, S3ClientError
-from moto.s3.responses import S3_ALL_MULTIPARTS, MalformedXML, is_delete_keys, minidom
+from moto.s3.responses import S3_ALL_MULTIPARTS, MalformedXML, minidom
 from moto.s3.utils import undo_clean_key_name
-from moto.s3bucket_path import utils as s3bucket_path_utils
 
 from localstack import config
 from localstack.services.infra import start_moto_server
@@ -317,29 +316,13 @@ def apply_patches():
 
         return rs_code, rs_headers, rs_content
 
-    # Patch utils_is_delete_keys
-    # https://github.com/localstack/localstack/issues/2866
-    # https://github.com/localstack/localstack/issues/2850
-    # https://github.com/localstack/localstack/issues/3931
-    # https://github.com/localstack/localstack/issues/4015
-    utils_is_delete_keys_orig = s3bucket_path_utils.is_delete_keys
-
-    def utils_is_delete_keys(request, path, bucket_name):
-        return "/" + bucket_name + "?delete=" in path or utils_is_delete_keys_orig(
-            request, path, bucket_name
-        )
-
-    @patch(s3_responses.S3ResponseInstance.is_delete_keys, pass_target=False)
-    def s3_response_is_delete_keys(self, request, path, bucket_name):
-        if self.subdomain_based_buckets(request):
-            # Temporary fix until moto supports x-id and DeleteObjects (#3931)
-            query = self._get_querystring(request.url)
-            is_delete_keys_v3 = (
-                query and ("delete" in query) and get_safe(query, "$.x-id.0") == "DeleteObjects"
-            )
-            return is_delete_keys_v3 or is_delete_keys(request, path)
-        else:
-            return utils_is_delete_keys(request, path, bucket_name)
+    @patch(s3_responses.S3Response.is_delete_keys)
+    def s3_response_is_delete_keys(fn, self):
+        """
+        Old provider had a fix for a ticket, concerning 'x-id' - there is no documentation on AWS about this, but it is probably still valid
+        Additional fix for testing if this is a "delete_objects" request, by removing trailing "=" from the path
+        """
+        return get_safe(self.querystring, "$.x-id.0") == "DeleteObjects" or fn(self)
 
     @patch(s3_responses.S3ResponseInstance.parse_bucket_name_from_url, pass_target=False)
     def parse_bucket_name_from_url(self, request, url):

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -3,7 +3,7 @@ import logging
 from functools import singledispatchmethod
 from typing import Any, Dict, List, Optional, Protocol, TypedDict, runtime_checkable
 
-from moto.core.utils import BackendDict
+from moto.core import BackendDict
 
 from localstack.services.stores import AccountRegionBundle
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -16,8 +16,7 @@ from _pytest.config import Config
 from _pytest.nodes import Item
 from botocore.exceptions import ClientError
 from botocore.regions import EndpointResolver
-from moto.core import BaseBackend
-from moto.core.utils import BackendDict
+from moto.core import BackendDict, BaseBackend
 from pytest_httpserver import HTTPServer
 
 from localstack import config

--- a/localstack/utils/patch.py
+++ b/localstack/utils/patch.py
@@ -148,6 +148,19 @@ def patch(target, pass_target=True):
         echo("foo")
         # will print "echo foo"
 
+    When you are patching classes, with ``pass_target=True``, the unbound function will be passed as the first
+    argument before ``self``.
+
+    For example::
+
+        @patch(target=MyEchoer.do_echo, pass_target=True)
+        def my_patch(fn, self, *args):
+            return fn(self, *args)
+
+        @patch(target=MyEchoer.do_echo, pass_target=False)
+        def my_patch(self, *args):
+            ...
+
     :param target: the function or method to patch
     :param pass_target: whether to pass the target to the patching function as first parameter
     :returns: the same function, but with a patch created

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.3.0.dev,<1.4
-    moto-ext[all]==4.0.9.post2
+    moto-ext[all]==4.0.10.post1
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl==22.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.3.0.dev,<1.4
-    moto-ext[all]==4.0.9.post1
+    moto-ext[all]==4.0.9.post2
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl==22.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,7 +80,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.3.0.dev,<1.4
-    moto-ext[all]==4.0.6.post1
+    moto-ext[all]==4.0.9.post1
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl==22.0.0

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -866,7 +866,6 @@ class TestAPIGateway:
             "uri",
             "cacheNamespace",
             "timeoutInMillis",
-            "contentHandling",
             "requestParameters",
         ]
         assert 201 == rs["ResponseMetadata"]["HTTPStatusCode"]

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1752,7 +1752,7 @@ class TestAPIGateway:
 
         url = path_based_url(api_id=api_id, stage_name=self.TEST_STAGE_NAME, path="/")
         result = requests.options(url)
-        assert result.status_code < 400
+        assert result.ok
         assert "Origin" == result.headers.get("vary")
         assert "POST,OPTIONS" == result.headers.get("Access-Control-Allow-Methods")
 
@@ -2144,32 +2144,30 @@ def test_import_swagger_api(apigateway_client):
     methods = {kk[0] for k, v in resource_methods.items() for kk in v.items()}
     assert methods == {"POST", "OPTIONS", "GET"}
 
-    assert resource_methods.get("/").get("GET")["methodResponses"] == {
-        "200": {
-            "statusCode": "200",
-            "responseModels": None,
-            "responseParameters": {"method.response.header.Content-Type": "'text/html'"},
-        }
+    response_resource = resource_methods.get("/").get("GET").method_responses.get("200")
+    assert response_resource.to_json() == {
+        "statusCode": "200",
+        "responseModels": None,
+        "responseParameters": {"method.response.header.Content-Type": "'text/html'"},
     }
 
-    assert resource_methods.get("pets").get("GET")["methodResponses"] == {
-        "200": {
-            "responseModels": {
-                "application/json": {
-                    "items": {
-                        "properties": {
-                            "id": {"type": "integer"},
-                            "price": {"type": "number"},
-                            "type": {"type": "string"},
-                        },
-                        "type": "object",
+    method_response_resource = resource_methods.get("pets").get("GET").method_responses.get("200")
+    assert method_response_resource.to_json() == {
+        "responseModels": {
+            "application/json": {
+                "items": {
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "price": {"type": "number"},
+                        "type": {"type": "string"},
                     },
-                    "type": "array",
-                }
-            },
-            "responseParameters": {"method.response.header.Access-Control-Allow-Origin": "'*'"},
-            "statusCode": "200",
-        }
+                    "type": "object",
+                },
+                "type": "array",
+            }
+        },
+        "responseParameters": {"method.response.header.Access-Control-Allow-Origin": "'*'"},
+        "statusCode": "200",
     }
 
 


### PR DESCRIPTION
Upgrades moto-ext to 4.0.10.post1, which builds on the recent 4.0.10 release

Adapted our patches/imports affected by
* https://github.com/spulec/moto/pull/5122
* https://github.com/spulec/moto/pull/5613
* https://github.com/spulec/moto/pull/5654
* https://github.com/spulec/moto/pull/5570