### PR TITLE
add default converters to Router

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -24,7 +24,6 @@ from localstack.constants import (
 from localstack.http import Router
 from localstack.http.adapters import create_request_from_parts
 from localstack.http.dispatcher import Handler, handler_dispatcher
-from localstack.http.router import RegexConverter
 from localstack.runtime import events
 from localstack.services.generic_proxy import ProxyListener, modify_and_forward, start_proxy_server
 from localstack.services.infra import PROXY_LISTENERS
@@ -322,9 +321,7 @@ def get_service_port_for_account(service, headers):
 
 PROXY_LISTENER_EDGE = ProxyListenerEdge()
 
-ROUTER: Router[Handler] = Router(
-    dispatcher=handler_dispatcher(), converters={"regex": RegexConverter}
-)
+ROUTER: Router[Handler] = Router(dispatcher=handler_dispatcher())
 """This special Router is part of the edge proxy. Use the router to inject custom handlers that are handled before
 the actual AWS service call is made."""
 


### PR DESCRIPTION
This PR adds the RegexConverter, and a new PortConverter as default converters to the `Router`. I've changed my mind a bit since this PR https://github.com/localstack/localstack/pull/5574, and I think adding some default converters to the `Router` can add value on top of werkzeug's `Map`. (/cc @giograno)

The port converter can hopefully simplify some of our URL patterns.