### PR TITLE
fix offline GitHub package presence check

### DIFF
--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -27,7 +27,7 @@ class KinesisMockPackageInstaller(GitHubReleaseInstaller):
     def __init__(self, version: str):
         super().__init__("kinesis-mock", version, "etspaceman/kinesis-mock")
 
-    def _get_github_asset_name(self, _):
+    def _get_github_asset_name(self):
         arch = get_arch()
         operating_system = get_os()
         if config.is_env_true("KINESIS_MOCK_FORCE_JAVA"):

--- a/tests/unit/packages/test_core.py
+++ b/tests/unit/packages/test_core.py
@@ -1,0 +1,30 @@
+import pytest
+
+from localstack.packages import PackageException
+from localstack.packages.core import GitHubReleaseInstaller
+
+
+class TestGitHubPackageInstaller(GitHubReleaseInstaller):
+    def __init__(self):
+        super().__init__(
+            "test-package", "test-default-version", "non-existing-user/non-existing-repo"
+        )
+
+    def _get_github_asset_name(self):
+        return "test-asset-name"
+
+
+def test_github_installer_does_not_fetch_versions_on_presence_check():
+    """
+    This test makes ensures that the check if a package installed via the GitHubReleaseInstaller does not require
+    requests to GitHub.
+    """
+    installer = TestGitHubPackageInstaller()
+    # Assert that the non-existing package is not installed (a request to a non-existing repo would raise an exception)
+    assert not installer.is_installed()
+
+
+def test_github_installer_raises_exception_on_install_with_non_existing_repo():
+    installer = TestGitHubPackageInstaller()
+    with pytest.raises(PackageException):
+        installer.install()


### PR DESCRIPTION
This PR fixes the GitHub package installer's (and in particular the KinesisMock installer's) presence check for offline startups of LocalStack.
Previously, the path which is checked to test if the package is already installed was created by using the filename in the download URL. However, for GitHub assets, the download URL needs to be fetched from the release / tag data.
In order to allow offline startups, the GitHub installer has been slightly refactored such that it now uses the GitHub asset name (which can not use the release data anymore, but this wasn't needed in the first place).

This might cause minor conflicts with https://github.com/localstack/localstack/pull/6916.
Fixes https://github.com/localstack/localstack/issues/7000.