### PR TITLE
Add tags to GatewayRestApi resource creation

### DIFF
--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -130,9 +130,14 @@ class GatewayRestAPI(GenericBaseModel):
             resource = resources[resource_id]
             props = resource["Properties"]
 
+            tag_list = props.get("Tags", [])
+            tag_map = {tag["Key"]: tag["Value"] for tag in tag_list}
+
             # TODO: add missing attributes
             result = client.create_rest_api(
-                name=props["Name"], description=props.get("Description", "")
+                name=props["Name"],
+                description=props.get("Description", ""),
+                tags=tag_map,
             )
             body = props.get("Body")
             if body:

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -130,14 +130,13 @@ class GatewayRestAPI(GenericBaseModel):
             resource = resources[resource_id]
             props = resource["Properties"]
 
-            tag_list = props.get("Tags", [])
-            tag_map = {tag["Key"]: tag["Value"] for tag in tag_list}
+            tags = {tag["Key"]: tag["Value"] for tag in props.get("Tags", [])}
 
             # TODO: add missing attributes
             result = client.create_rest_api(
                 name=props["Name"],
                 description=props.get("Description", ""),
-                tags=tag_map,
+                tags=tags,
             )
             body = props.get("Body")
             if body:


### PR DESCRIPTION
The missing tags property in Rest API creation causes custom API IDs to not work in CDK deployments. This PR fixes that.