### PR TITLE
Add infra shutdown handler / improve cleanup of processes and threads

### DIFF
--- a/localstack/runtime/shutdown.py
+++ b/localstack/runtime/shutdown.py
@@ -1,0 +1,49 @@
+from typing import Any, Callable
+
+from localstack.runtime import hooks
+from localstack.utils.functions import call_safe
+
+
+class ShutdownHandlers:
+    """
+    Register / unregister shutdown handlers. All registered shutdown handlers should execute as fast as possible.
+    Blocking shutdown handlers will block infra shutdown.
+    """
+
+    def __init__(self):
+        self._callbacks = []
+
+    def register(self, shutdown_handler: Callable[[], Any]) -> None:
+        """
+        Register shutdown handler. Handler should not block or take more than a couple seconds.
+
+        :param shutdown_handler: Callable without parameters
+        """
+        self._callbacks.append(shutdown_handler)
+
+    def unregister(self, shutdown_handler: Callable[[], Any]) -> None:
+        """
+        Unregister a handler. Idempotent operation.
+
+        :param shutdown_handler: Shutdown handler which was previously registered
+        """
+        try:
+            self._callbacks.remove(shutdown_handler)
+        except ValueError:
+            pass
+
+    def run(self) -> None:
+        """
+        Execute shutdown handlers in reverse order of registration.
+        Should only be called once, on shutdown.
+        """
+        for callback in reversed(list(self._callbacks)):
+            call_safe(callback)
+
+
+SHUTDOWN_HANDLERS = ShutdownHandlers()
+
+
+@hooks.on_infra_shutdown()
+def run_shutdown_handlers():
+    SHUTDOWN_HANDLERS.run()

--- a/localstack/services/awslambda/invocation/runtime_environment.py
+++ b/localstack/services/awslambda/invocation/runtime_environment.py
@@ -158,7 +158,7 @@ class RuntimeEnvironment:
             self.status = RuntimeStatus.READY
 
     def timed_out(self) -> None:
-        LOG.debug(
+        LOG.warning(
             "Executor %s for function %s timed out during startup",
             self.id,
             self.function_version.qualified_arn,

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1443,7 +1443,7 @@ class LambdaExecutorLocal(LambdaExecutor):
         start_time = now(millis=True)
         process.start()
         try:
-            process_result: LocalExecutorResult = process_queue.get(timeout=20)
+            process_result: LocalExecutorResult = process_queue.get(timeout=lambda_function.timeout or 20)
         except queue.Empty:
             process_result = LocalExecutorResult(
                 "",

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1443,7 +1443,9 @@ class LambdaExecutorLocal(LambdaExecutor):
         start_time = now(millis=True)
         process.start()
         try:
-            process_result: LocalExecutorResult = process_queue.get(timeout=lambda_function.timeout or 20)
+            process_result: LocalExecutorResult = process_queue.get(
+                timeout=lambda_function.timeout or 20
+            )
         except queue.Empty:
             process_result = LocalExecutorResult(
                 "",

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -5,6 +5,7 @@ import glob
 import json
 import logging
 import os
+import queue
 import re
 import shlex
 import subprocess
@@ -1441,8 +1442,37 @@ class LambdaExecutorLocal(LambdaExecutor):
         process = Process(target=do_execute, args=(process_queue,))
         start_time = now(millis=True)
         process.start()
-        process_result: LocalExecutorResult = process_queue.get()
-        process.join()
+        try:
+            process_result: LocalExecutorResult = process_queue.get(timeout=20)
+        except queue.Empty:
+            process_result = LocalExecutorResult(
+                "",
+                "",
+                "TimeoutError",
+                {
+                    "errorType": "TimeoutError",
+                    "errorMessage": "Function execution timed out",
+                    "stackTrace": [],
+                },
+            )
+        process.join(timeout=5)
+        if process.exitcode is None:
+            LOG.debug("Lambda process pid %s did not exit, trying SIGTERM", process.pid)
+            # process did not join after 5s
+            process.terminate()
+            process.join(timeout=2)
+            if process.exitcode is None:
+                # process not reacting to SIGTERM, let's kill it.
+                LOG.debug(
+                    "Lambda process pid %s did not exit on SIGTERM, trying SIGKILL", process.pid
+                )
+                process.kill()
+                process.join(timeout=1)
+                LOG.debug(
+                    "Lambda process %s exited after SIGKILL with exit code %s",
+                    process.pid,
+                    process.exitcode,
+                )
 
         result = process_result.result
 
@@ -1484,6 +1514,7 @@ class LambdaExecutorLocal(LambdaExecutor):
 
         # construct final invocation result
         invocation_result = InvocationResult(result, log_output=log_output)
+        LOG.info('Successfully executed lambda "%s"', lambda_function.arn())
         # run plugins post-processing logic
         invocation_result = self.process_result_via_plugins(inv_context, invocation_result)
         return invocation_result

--- a/localstack/services/events/scheduler.py
+++ b/localstack/services/events/scheduler.py
@@ -1,5 +1,5 @@
 import logging
-import time
+import threading
 
 from crontab import CronTab
 
@@ -40,6 +40,7 @@ class JobScheduler:
         # TODO: introduce RLock for mutating jobs list
         self.jobs = []
         self.thread = None
+        self._stop_event = threading.Event()
 
     def add_job(self, job_func, schedule, enabled=True):
         job = Job(job_func, schedule, enabled=enabled)
@@ -61,7 +62,7 @@ class JobScheduler:
                 i += 1
 
     def loop(self, *args):
-        while True:
+        while not self._stop_event.is_set():
             try:
                 for job in list(self.jobs):
                     job.run()
@@ -69,7 +70,7 @@ class JobScheduler:
                 pass
             # This is a simple heuristic to cause the loop to run apprx every minute
             # TODO: we should keep track of jobs execution times, to avoid duplicate executions
-            time.sleep(59.9)
+            self._stop_event.wait(timeout=59.9)
 
     def start_loop(self):
         self.thread = FuncThread(self.loop)
@@ -87,3 +88,10 @@ class JobScheduler:
         if not instance.thread:
             instance.start_loop()
         return instance
+
+    @classmethod
+    def shutdown(cls):
+        instance = cls.instance()
+        if not instance.thread:
+            return
+        instance._stop_event.set()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -281,13 +281,13 @@ def stop_infra():
     if events.infra_stopping.is_set():
         return
 
-    # run plugin hooks for infra shutdown
-    hooks.on_infra_shutdown.run()
+    analytics.log.event("infra_stop")
 
     # also used to signal shutdown for edge proxy so that any further requests will be rejected
     events.infra_stopping.set()
 
-    analytics.log.event("infra_stop")
+    # run plugin hooks for infra shutdown
+    hooks.on_infra_shutdown.run()
 
     try:
         generic_proxy.QUIET = True  # TODO: this doesn't seem to be doing anything

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -373,6 +373,7 @@ def events():
     return Service(
         "events",
         listener=AwsApiListener("events", MotoFallbackDispatcher(provider)),
+        lifecycle_hook=provider,
     )
 
 

--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -139,6 +139,8 @@ class PublisherBuffer(EventHandler):
         finally:
             self._stopped.set()
             flush_scheduler.stop()
+            if config.DEBUG_ANALYTICS:
+                LOG.debug("Exit analytics publisher")
 
     def _do_flush(self):
         queue = self._queue

--- a/localstack/utils/analytics/service_request_aggregator.py
+++ b/localstack/utils/analytics/service_request_aggregator.py
@@ -1,4 +1,3 @@
-import atexit
 import datetime
 import logging
 import threading
@@ -6,6 +5,7 @@ from collections import Counter
 from typing import Dict, List, NamedTuple, Optional
 
 from localstack import config
+from localstack.runtime.shutdown import SHUTDOWN_HANDLERS
 from localstack.utils import analytics
 from localstack.utils.scheduler import Scheduler
 
@@ -59,7 +59,7 @@ class ServiceRequestAggregator:
             )
             _flush_scheduler_thread.start()
 
-            atexit.register(self.shutdown)
+            SHUTDOWN_HANDLERS.register(self.shutdown)
 
     def shutdown(self):
         with self._mutex:
@@ -71,7 +71,7 @@ class ServiceRequestAggregator:
 
             self._flush()
             self._flush_scheduler.close()
-            atexit.unregister(self.shutdown)
+            SHUTDOWN_HANDLERS.unregister(self.shutdown)
 
     def add_request(self, request_info: ServiceRequestInfo):
         """


### PR DESCRIPTION
## Infra shutdown handler
This PR introduces a new option to hook into the infrastructure shutdown process.
The registered handlers will be called on infra shutdown, but before the python interpreter shutdown routine begins, giving a good alternative to `atexit` handlers, which can lead to problems with shutdown if they for example spawn non-daemonic threads.
The analytics still uses atexit, as it would need bigger refactoring to correctly differentiate between CLI and infra runs here.

## Other changes
* events job scheduler will now shutdown with the events service. If the interpreter hangs, at least most of the ASGI gateway error requests are related to this scheduler, and should be missing afterwards
* lambda local execution will no longer block if the process refuses to terminate / answer. This should solve a hanging thread I found in a failing CI run, after a test rerun (might or might not influence the interpreter hang, but definitely good to fix)