### PR TITLE
WIP: update CORS logic (CORS should not be enforced server-side)

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -25,7 +25,7 @@ class LocalstackAwsGateway(Gateway):
                 handlers.push_request_context,
                 metric_collector.create_metric_handler_item,
                 handlers.parse_service_name,  # enforce_cors and content_decoder depend on the service name
-                handlers.enforce_cors,
+                handlers.preflight_cors,
                 handlers.content_decoder,
                 handlers.serve_localstack_resources,  # try to serve internal resources in /_localstack first
                 handlers.serve_default_listeners,  # legacy proxy default listeners

--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -26,6 +26,7 @@ class LocalstackAwsGateway(Gateway):
                 metric_collector.create_metric_handler_item,
                 handlers.parse_service_name,  # enforce_cors and content_decoder depend on the service name
                 handlers.preflight_cors,
+                handlers.enforce_origin_csrf,
                 handlers.content_decoder,
                 handlers.serve_localstack_resources,  # try to serve internal resources in /_localstack first
                 handlers.serve_default_listeners,  # legacy proxy default listeners

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -3,7 +3,7 @@
 from .. import chain
 from . import analytics, auth, codec, cors, fallback, internal, legacy, logging, region, service
 
-enforce_cors = cors.CorsEnforcer()
+preflight_cors = cors.CorsPreflightHandler()
 add_cors_response_headers = cors.CorsResponseEnricher()
 content_decoder = codec.ContentDecoder()
 parse_service_name = service.ServiceNameParser()

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -4,6 +4,7 @@ from .. import chain
 from . import analytics, auth, codec, cors, fallback, internal, legacy, logging, region, service
 
 preflight_cors = cors.CorsPreflightHandler()
+enforce_origin_csrf = cors.CsrfEnforcerHandler()
 add_cors_response_headers = cors.CorsResponseEnricher()
 content_decoder = codec.ContentDecoder()
 parse_service_name = service.ServiceNameParser()

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -127,7 +127,12 @@ class CsrfEnforcerHandler(Handler):
         # docs: Whether to disable all CSRF (server-side) mitigations.
         # OPTIONS requests should go through for better debugging, no security issue
         if context.request.method != "OPTIONS" and not config.DISABLE_CORS_CHECKS:
-            if not is_origin_allowed(context.request.headers):
+            headers = context.request.headers
+            if not is_origin_allowed(headers):
+                LOG.info(
+                    "Blocked request from forbidden origin %s (CSRF mitigation)",
+                    headers.get("origin") or headers.get("referer"),
+                )
                 response.status_code = 403
                 chain.terminate()
 

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -171,7 +171,7 @@ class CorsResponseEnricher(Handler):
         if (
             config.DISABLE_CORS_HEADERS
             or not should_enforce_self_managed_service(context)
-            or not self.is_cors_origin_allowed(headers)
+            or not is_origin_allowed(headers)
         ):
             return
 

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -141,7 +141,8 @@ class CorsPreflightHandler(Handler):
             return
 
         if context.request.method == "OPTIONS" and not config.DISABLE_PREFLIGHT_PROCESSING:
-            response.status_code = 204
+            # preflight should use 200, no chance for breaking in the future
+            response.status_code = 200
             chain.stop()
 
 
@@ -178,6 +179,7 @@ class CorsResponseEnricher(Handler):
             )
         if ACL_METHODS not in headers:
             headers[ACL_METHODS] = ",".join(CORS_ALLOWED_METHODS)
+        # TODO: we should actually check if there's more headers than we want here to reject the request
         if ACL_ALLOW_HEADERS not in headers:
             requested_headers = headers.get(ACL_REQUEST_HEADERS, "")
             requested_headers = re.split(r"[,\s]+", requested_headers) + CORS_ALLOWED_HEADERS


### PR DESCRIPTION
WIP, more explanation will be written soon!
Maybe some tests will fail, I haven't checked that. 
There another handler to check Origin/Referrer for CSRF protection, but we should separate CORS and CSRF protection to allow us to debug more easily CORS and not create issues between the two. 

I think we should CSRF reject requests that are not `GET` and not from allowed origins even for self managed services. (S3 does not enforce any origin check by default, and it only concerns CORS, not CSRF)

Also, we let `OPTIONS` requests pass through first, there's no security issue with them. 

@thrau to continue on the subject. I think this is what the logic should look like

note: we should also validate CORS rules with `CORS_ALLOWED_HEADERS` instead of joining the request one and allowed ones, otherwise we don't validate the rule and accept any headers.

edit: currently failing APIGW tests because of the change of logic with `OPTIONS` requests. Would be easily fixable