### PR TITLE
Fix replicate secret to region (#6221)

### DIFF
--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -173,6 +173,11 @@ class TestSecretsManager:
             sm_client.list_secret_version_ids(SecretId=f"s-{short_uid()}")
         sm_snapshot.match("list_secret_version_ids_not_found_ex", not_found.value.response)
 
+        with pytest.raises(Exception) as not_found:
+            sm_client.replicate_secret_to_regions(SecretId=f"s-{short_uid()}",
+                                                  AddReplicaRegions=[{'Region':'us-east-2'}])
+        sm_snapshot.match("resource_not_found_ex", not_found.value.response)
+
     def test_call_lists_secrets_multiple_times(self, sm_client, secret_name):
         sm_client.create_secret(
             Name=secret_name,

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -285,6 +285,18 @@ class TestSecretsManager:
         assert len(random_password["RandomPassword"]) == 120
         assert all(c not in "xyzDje@?!." for c in random_password["RandomPassword"])
 
+    def test_replicate_secret_to_region_first_time(self, sm_client, secret_id, region):
+        [arn, replication_status] = sm_client.replicate_secret_to_regions(
+            SecretId=secret_id,
+            AddReplicaRegions=['us-east-1', 'us-west-1'])
+
+        assert arn != ""
+        for rep_st in replication_status:
+            assert rep_st.Status != "Failed"
+
+    def test_replicate_secret_to_region_updating_secret(self):
+        pass
+
     def test_resource_policy(self, sm_client, secret_name):
         sm_client.create_secret(
             Name=secret_name,

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -320,9 +320,46 @@ class TestSecretsManager:
         sm_snapshot.match("delete_secret_res", delete_secret_res)
 
 
-        assert arn != ""
-        for rep_st in replication_status:
-            assert rep_st.Status != "Failed"
+    def test_create_secret_secret_name_already_exists(self, sm_client, sm_snapshot):
+        """
+        Should raise an exception the secret already exists
+        """
+        secret_name = f"{short_uid()}"
+        create_secret_replicated = sm_client.create_secret(
+            Name=secret_name,
+            SecretString=secret_name,
+            AddReplicaRegions=[{"Region":"us-east-1"}]
+        )
+        sm_snapshot.add_transformers_list(
+            sm_snapshot.transform.secretsmanager_secret_id_arn(create_secret_replicated, 0)
+        )
+        sm_snapshot.match("create_secret_replicated", create_secret_replicated)
+        # wait for the replication to complete
+        self._wait_created_is_listed(sm_client, secret_id=secret_name)
+        describe_secret_res = sm_snapshot.describe_secret(SecretId=secret_name)
+
+        assert isinstance(describe_secret_res.Replication_Status, list)
+        assert describe_secret_res.Replication_Status[0].Status == "InSync"
+
+        for replication_status in describe_secret_res.Replication_Status:
+            assert replication_status.Status != "Failed"
+
+        # Repeat the creation request to trigger the exception
+        with pytest.raises(Exception) as already_exists:
+            create_secret_replicated = sm_client.create_secret(
+                Name=secret_name,
+                SecretString=secret_name,
+                AddReplicaRegions=[{"Region":"us-east-1"}]
+            )
+        sm_snapshot.match("resource_exists_ex", already_exists.value.response)
+
+        # cleanup
+        delete_secret_res = sm_client.delete_secret(
+            SecretId=secret_name, ForceDeleteWithoutRecovery=True
+        )
+        sm_snapshot.match("delete_secret_res", delete_secret_res)
+
+
 
     def test_replicate_secret_to_region_updating_secret(self):
         pass

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -292,7 +292,7 @@ class TestSecretsManager:
 
     def test_create_secret_new_name_in_region(self, sm_client, sm_snapshot):
         """
-        The new secret should be created and replicated without problems
+        1.1 The new secret should be created and replicated without problems
         """
         secret_name = f"{short_uid()}"
         create_secret_replicated = sm_client.create_secret(
@@ -319,7 +319,7 @@ class TestSecretsManager:
 
     def test_create_secret_secret_name_already_exists(self, sm_client, sm_snapshot):
         """
-        Should raise an exception the secret already exists
+        1.2 Should raise an exception the secret already exists
         """
         secret_name = f"{short_uid()}"
         create_secret_replicated = sm_client.create_secret(
@@ -354,12 +354,13 @@ class TestSecretsManager:
         sm_snapshot.match("delete_secret_res", delete_secret_res)
 
 
-    def test_create_secret_secret_name_already_exists_as_replica_to_regions_force_overwrite(self, sm_client, sm_snapshot):
+    def test_create_secret_secret_name_already_exists_in_replica(self, sm_client, sm_snapshot):
         """
-        Create secret in region1 replicated to region2.
+        1.3 Create secret in region1 replicated to region2.
         Then, create secret in region 3 replicated to region2.
-        Then, fetch secret details from region3, replication status in region2 must be `Failed`
-        and StatusMessage: "Replication failed: Can't overwrite secret myts0 that is currently replicated to other region(s)."
+        Then, fetch secret details from region3, ReplicationStatus.Status for
+        region2 must be `Failed` and
+        "StatusMessage": "Replication failed: Secret name myts0 already exists in region us-east-2."
         """
         secret_name = f"{short_uid()}"
         create_secret_replicated1 = sm_client.create_secret(
@@ -431,6 +432,9 @@ class TestSecretsManager:
         pass
 
     def test_add_replication_secret_name_exists_only_in_region(self):
+        """
+        2.2 The secret exists only in region, replication must succeed
+        """
         pass
 
     def test_add_replication_secret_name_exists_in_replica_regions(self):

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -308,9 +308,6 @@ class TestSecretsManager:
         self._wait_created_is_listed(sm_client, secret_id=secret_name)
         describe_secret_res = sm_snapshot.describe_secret(SecretId=secret_name)
 
-        assert isinstance(describe_secret_res.Replication_Status, list)
-        assert describe_secret_res.Replication_Status[0].Status == "InSync"
-
         for replication_status in describe_secret_res.Replication_Status:
             assert replication_status.Status != "Failed"
         # cleanup
@@ -337,9 +334,6 @@ class TestSecretsManager:
         # wait for the replication to complete
         self._wait_created_is_listed(sm_client, secret_id=secret_name)
         describe_secret_res = sm_snapshot.describe_secret(SecretId=secret_name)
-
-        assert isinstance(describe_secret_res.Replication_Status, list)
-        assert describe_secret_res.Replication_Status[0].Status == "InSync"
 
         for replication_status in describe_secret_res.Replication_Status:
             assert replication_status.Status != "Failed"

--- a/tests/integration/secretsmanager/test_secretsmanager.py
+++ b/tests/integration/secretsmanager/test_secretsmanager.py
@@ -354,11 +354,12 @@ class TestSecretsManager:
         sm_snapshot.match("delete_secret_res", delete_secret_res)
 
 
-    def test_create_secret_secret_name_already_exists_in_replica_regions(self, sm_client, sm_snapshot):
+    def test_create_secret_secret_name_already_exists_as_replica_to_regions_force_overwrite(self, sm_client, sm_snapshot):
         """
-        Creates secret in region1 replicated to region2, then creates the same secret
-        in region 3 replicated to region2. Then, fetch details from region3, replication
-        status in region2 must show `Failure`
+        Create secret in region1 replicated to region2.
+        Then, create secret in region 3 replicated to region2.
+        Then, fetch secret details from region3, replication status in region2 must be `Failed`
+        and StatusMessage: "Replication failed: Can't overwrite secret myts0 that is currently replicated to other region(s)."
         """
         secret_name = f"{short_uid()}"
         create_secret_replicated1 = sm_client.create_secret(
@@ -420,10 +421,27 @@ class TestSecretsManager:
         )
         sm_snapshot.match("delete_secret_res2", delete_secret_res2)
 
-
-
-    def test_replicate_secret_to_region_updating_secret(self):
+    def test_create_secret_secret_name_already_exists_as_replica_from_region_force_overwrite(self):
+        """
+        Create secret in region1 replicated to region2.
+        Then, create secret in region 3 replicated to region2.
+        Then, fetch secret details from region3, replication status in region2 must be `Failed`
+        and StatusMessage: "Replication failed: Can't overwrite secret myts0 that is currently replicated from us-east-1."
+        """
         pass
+
+    def test_add_replication_secret_name_exists_only_in_region(self):
+        pass
+
+    def test_add_replication_secret_name_exists_in_replica_regions(self):
+        pass
+
+    def test_add_replication_secret_name_exists_as_replica_to_regions_force_overwrite(self):
+        pass
+
+    def test_add_replication_secret_name_exists_as_replica_from_region_force_overwrite(self):
+        pass
+
 
     def test_resource_policy(self, sm_client, secret_name):
         sm_client.create_secret(

--- a/tests/integration/secretsmanager/test_secretsmanager.snapshot.json
+++ b/tests/integration/secretsmanager/test_secretsmanager.snapshot.json
@@ -3099,7 +3099,188 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
         }
+      },
+      "replicate_secret_to_regions_not_found_ex": {
+        "Error": {
+          "Code": "InternalFailure",
+          "Message": "API action 'ReplicateSecretToRegions' for service 'secretsmanager' not yet implemented or pro feature - check https://docs.localstack.cloud/aws/feature-coverage for further information"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 501
+        }
       }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_new_name_in_region[us-east-1-us-east-2]": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+      "create_secret_replicated_rs0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rs0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "LastChangedDate": "datetime",
+        "VersionIdsToStages": {
+            "<version_uuid:1>": [
+                "AWSCURRENT"
+            ]
+        },
+        "CreatedDate": "datetime",
+        "PrimaryRegion": "us-east-1",
+        "ReplicationStatus": [
+            {
+                "Region": "us-east-2",
+                "KmsKeyId": "alias/aws/secretsmanager",
+                "Status": "InSync",
+                "StatusMessage": "Replication succeeded"
+            }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_secret_res0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_secret_name_already_exists[us-east-1-us-east-2]": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+      "create_secret_replicated_rs0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_secret_res0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_secret_name_already_exists_in_replica[us-east-1-us-east-2-us-west-1]": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+      "create_secret_replicated_rs0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rs0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "Name": "<SecretId-0idx>",
+        "LastChangedDate": "datetime",
+        "VersionIdsToStages": {
+            "<version_uuid:1>": [
+                "AWSCURRENT"
+            ]
+        },
+        "CreatedDate": "datetime",
+        "PrimaryRegion": "us-east-1",
+        "ReplicationStatus": [
+            {
+                "Region": "us-east-2",
+                "KmsKeyId": "alias/aws/secretsmanager",
+                "Status": "InSync",
+                "StatusMessage": "Replication succeeded"
+            }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_secret_replicated_rs1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-1idx><ArnPart-1idx>",
+        "Name": "<SecretId-1idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe_secret_rs1": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-1idx><ArnPart-1idx>",
+        "Name": "<SecretId-1idx>",
+        "LastChangedDate": "datetime",
+        "VersionIdsToStages": {
+            "<version_uuid:1>": [
+                "AWSCURRENT"
+            ]
+        },
+        "CreatedDate": "datetime",
+        "PrimaryRegion": "us-west-1",
+        "ReplicationStatus": [
+            {
+                "Region": "us-east-2",
+                "KmsKeyId": "alias/aws/secretsmanager",
+                "Status": "Failed",
+                "StatusMessage": "Replication failed: Secret name <SecretId-1idx> already exists in region us-east-2."
+            }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_secret_res0": {
+        "ARN": "arn:aws:secretsmanager:<region>:111111111111:secret:<SecretId-0idx><ArnPart-0idx>",
+        "DeletionDate": "datetime",
+        "Name": "<SecretId-0idx>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_create_secret_secret_name_already_exists_in_replica_regions_force_overwrite": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_replicate_secret_name_exists_only_in_region": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_replicate_secret_name_exists_in_replica_regions": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_replicate_secret_name_exists_as_replica_to_regions_force_overwrite": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
+    }
+  },
+  "tests/integration/secretsmanager/test_secretsmanager.py::TestSecretsManager::test_replicate_secret_name_exists_as_replica_from_region_force_overwrite": {
+    "recorded-date": "25-10-2022, 8:07:07",
+    "recorded-content": {
     }
   }
 }


### PR DESCRIPTION
To prepare for this issue, I tried to identify all the scenarios replicating secrets to region in `AWS SecretsManager`, I identified the following,

1. Create secret
  - [x] New name in region
  - [x] SECRET_NAME already exists
  - [x] SECRET_NAME already exists in replica
  - [x] SECRET_NAME already exists as replica to regions, --force-overwrite-replica-secret
  - [x] SECRET_NAME already exists as replica from region, --force-overwrite-replica-secret
2. Replicate secret to regions
  - [x] New name in region. Implemented in `test_secret_not_found`
  - [ ] The secret exists only in region
  - [ ] SECRET_NAME already exists in replica
  - [ ] SECRET_NAME already exists as replica to regions, --force-overwrite-replica-secret
  - [ ] SECRET_NAME already exists as replica from region, --force-overwrite-replica-secret

Each item checked indicates the testing coverage I've already implemented. I am still working on the non-checked tests.

Full detail of the testing I did against `AWS SecretsManager` is available in this [gist](https://gist.github.com/cmoralesmx/d7ed1455f463003390432046d950bfcd)