### PR TITLE
Remove bson dependency and use pymongo

### DIFF
--- a/localstack/services/dynamodbstreams/provider.py
+++ b/localstack/services/dynamodbstreams/provider.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-import bson
+from bson.json_util import loads
 
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.dynamodbstreams import (
@@ -103,7 +103,7 @@ class DynamoDBStreamsProvider(DynamodbstreamsApi, ServiceLifecycleHook):
             "NextShardIterator": kinesis_records.get("NextShardIterator"),
         }
         for record in kinesis_records["Records"]:
-            record_data = bson.loads(record["Data"])
+            record_data = loads(record["Data"])
             record_data["dynamodb"]["SequenceNumber"] = record["SequenceNumber"]
             result["Records"].append(record_data)
         return GetRecordsOutput(**result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ runtime =
     xmltodict>=0.11.0
     awscrt>=0.13.14
     vosk==0.3.43
-    pymongo>=4.3.0
+    pymongo>=4.2.0
 
 # @deprecated - use extra 'runtime' instead.
 full =

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ runtime =
     xmltodict>=0.11.0
     awscrt>=0.13.14
     vosk==0.3.43
-    bson==0.5.10
+    pymongo>=4.3.0
 
 # @deprecated - use extra 'runtime' instead.
 full =


### PR DESCRIPTION
This PR removes `bson` direct dependency and adds `pymongo` as a dependency that in turn brings a compatible transitive `bson` dependency.