### PR TITLE
S3 asf fixes detected by Terraform test suite

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -698,6 +698,13 @@ class NoSuchWebsiteConfiguration(ServiceException):
     BucketName: Optional[BucketName]
 
 
+class ReplicationConfigurationNotFoundError(ServiceException):
+    code: str = "ReplicationConfigurationNotFoundError"
+    sender_fault: bool = False
+    status_code: int = 404
+    BucketName: Optional[BucketName]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -198,6 +198,7 @@ class BucketCannedACL(str):
     public_read = "public-read"
     public_read_write = "public-read-write"
     authenticated_read = "authenticated-read"
+    log_delivery_write = "log-delivery-write"
 
 
 class BucketLocationConstraint(str):

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -622,6 +622,23 @@
       "value": {
         "shape": "MultipartUploadId"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ReplicationConfigurationNotFoundError",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>The replication configuration was not found.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -639,6 +639,12 @@
         "documentation": "<p>The replication configuration was not found.</p>",
         "exception": true
       }
+    },
+    {
+        "op": "add",
+        "path": "/shapes/BucketCannedACL/enum/4",
+        "value": "log-delivery-write",
+        "documentation": "<p>Not included in the specs, but valid value according to the docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl</p>"
     }
   ]
 }

--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -37,7 +37,7 @@ class SimpleRequestsClient(HttpClient):
         """
         response = requests.request(
             method=request.method,
-            url=request.url,
+            url=request.base_url,
             params=request.args,
             headers=request.headers,
             data=restore_payload(request),

--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -43,11 +43,16 @@ class SimpleRequestsClient(HttpClient):
             data=restore_payload(request),
         )
 
-        return Response(
+        final_response = Response(
             response=response.content,
             status=response.status_code,
             headers=Headers(dict(response.headers)),
         )
+        if request.method == "HEAD":
+            # for head we have to keep the original content-length, but it will be re-calcualated when creating
+            # the final_response object
+            final_response.content_length = response.headers.get("Content-Length", 0)
+        return final_response
 
 
 def make_request(request: Request) -> Response:

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -917,6 +917,7 @@ def apply_moto_patches():
             "content-encoding",
             "content-language",
             "content-disposition",
+            "cache-control",
         ]:
             if header_value := resp_headers.pop(low_case_header, None):
                 header_name = capitalize_header_name_from_snake_case(low_case_header)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -915,6 +915,8 @@ def apply_moto_patches():
             "content-length",
             "content-range",
             "content-encoding",
+            "content-language",
+            "content-disposition",
         ]:
             if header_value := resp_headers.pop(low_case_header, None):
                 header_name = capitalize_header_name_from_snake_case(low_case_header)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -849,11 +849,6 @@ def validate_website_configuration(website_config: WebsiteConfiguration) -> None
                     "You can only define ReplaceKeyPrefix or ReplaceKey but not both."
                 )
 
-            # validating values length, to be confident while using the rules in the router
-            for field_value in redirect.values():
-                if not field_value:
-                    raise MalformedXML()
-
             if "Condition" in routing_rule and not routing_rule.get("Condition", {}):
                 raise InvalidRequest(
                     "Condition cannot be empty. To redirect all requests without a condition, the condition element shouldn't be present."

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -100,7 +100,7 @@ from localstack.services.s3.utils import (
     get_header_name,
     get_key_from_moto_bucket,
     is_bucket_name_valid,
-    is_canned_acl_valid,
+    is_canned_acl_bucket_valid,
     is_key_expired,
     is_valid_canonical_id,
     verify_checksum,
@@ -604,9 +604,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: PutBucketAclRequest,
     ) -> None:
-        if (canned_acl := request.get("ACL")) and not is_canned_acl_valid(canned_acl):
-            ex = _create_invalid_argument_exc(None, name="x-amz-acl", value=canned_acl)
-            raise ex
+        validate_bucket_canned_acl(request.get("ACL"))
 
         grant_keys = [
             "GrantFullControl",
@@ -815,11 +813,11 @@ def validate_bucket_name(bucket: BucketName) -> None:
         raise ex
 
 
-def validate_canned_acl(canned_acl: str) -> None:
+def validate_bucket_canned_acl(canned_acl: str) -> None:
     """
     Validate the canned ACL value, or raise an Exception
     """
-    if not is_canned_acl_valid(canned_acl):
+    if canned_acl and not is_canned_acl_bucket_valid(canned_acl):
         ex = _create_invalid_argument_exc(None, "x-amz-acl", canned_acl)
         raise ex
 

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -8,6 +8,7 @@ from moto.s3.models import FakeDeleteMarker, FakeKey
 
 from localstack.aws.api import ServiceException
 from localstack.aws.api.s3 import (
+    BucketCannedACL,
     BucketName,
     ChecksumAlgorithm,
     InvalidArgument,
@@ -40,7 +41,9 @@ S3_VIRTUAL_HOSTNAME_REGEX = (  # path based refs have at least valid bucket expr
 
 S3_VIRTUAL_HOST_FORWARDED_HEADER = "x-s3-vhost-forwarded-for"
 
-VALID_CANNED_ACLS = {
+VALID_CANNED_ACLS_BUCKET = {
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+    # bucket-owner-read + bucket-owner-full-control are allowed, but ignored for buckets
     ObjectCannedACL.private,
     ObjectCannedACL.authenticated_read,
     ObjectCannedACL.aws_exec_read,
@@ -48,6 +51,7 @@ VALID_CANNED_ACLS = {
     ObjectCannedACL.bucket_owner_read,
     ObjectCannedACL.public_read,
     ObjectCannedACL.public_read_write,
+    BucketCannedACL.log_delivery_write,
 }
 
 VALID_ACL_PREDEFINED_GROUPS = {
@@ -124,8 +128,8 @@ def is_bucket_name_valid(bucket_name: str) -> bool:
     return True if re.match(BUCKET_NAME_REGEX, bucket_name) else False
 
 
-def is_canned_acl_valid(canned_acl: str) -> bool:
-    return canned_acl in VALID_CANNED_ACLS
+def is_canned_acl_bucket_valid(canned_acl: str) -> bool:
+    return canned_acl in VALID_CANNED_ACLS_BUCKET
 
 
 def get_header_name(capitalized_field: str) -> str:

--- a/localstack/services/s3/website_hosting.py
+++ b/localstack/services/s3/website_hosting.py
@@ -260,10 +260,9 @@ def _get_redirect_from_routing_rule(request: Request, routing_rule: RoutingRule)
         redirect_to = redirect_to.replace(parsed_url.scheme, protocol)
     if redirect_to_key := redirect.get("ReplaceKeyWith"):
         redirect_to = redirect_to.replace(parsed_url.path, f"/{redirect_to_key}")
-    elif new_key_prefix := redirect.get("ReplaceKeyPrefixWith"):
-        # TODO test if KeyPrefixEquals is not supplied???
-        matched_prefix = routing_rule["Condition"].get("KeyPrefixEquals")
-        redirect_to = redirect_to.replace(matched_prefix, new_key_prefix)
+    elif "ReplaceKeyPrefixWith" in redirect:  # the value might be empty and it's a valid config
+        matched_prefix = routing_rule["Condition"].get("KeyPrefixEquals", "")
+        redirect_to = redirect_to.replace(matched_prefix, redirect.get("ReplaceKeyPrefixWith"), 1)
 
     return Response(
         "", headers={"Location": redirect_to}, status=redirect.get("HttpRedirectCode", 301)

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -239,6 +239,7 @@ class TestS3:
     def test_resource_object_with_slashes_in_key(self, s3_resource, s3_bucket):
         s3_resource.Object(s3_bucket, "/foo").put(Body="foobar")
         s3_resource.Object(s3_bucket, "bar").put(Body="barfoo")
+        s3_resource.Object(s3_bucket, "/bar/foo/").put(Body="test")
 
         with pytest.raises(ClientError) as e:
             s3_resource.Object(s3_bucket, "foo").get()
@@ -252,6 +253,8 @@ class TestS3:
         assert response["Body"].read() == b"foobar"
         response = s3_resource.Object(s3_bucket, "bar").get()
         assert response["Body"].read() == b"barfoo"
+        response = s3_resource.Object(s3_bucket, "/bar/foo/").get()
+        assert response["Body"].read() == b"test"
 
     @pytest.mark.aws_validated
     def test_metadata_header_character_decoding(self, s3_client, s3_bucket, snapshot):

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -324,6 +324,7 @@ class TestS3:
             Body=b"abc123",
             ContentLanguage="de",
             ContentDisposition='attachment; filename="foo.jpg"',
+            CacheControl="no-cache",
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
         snapshot.match("put-object", response)

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3901,5 +3901,72 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_replication_config_without_filter": {
+    "recorded-date": "19-10-2022, 15:32:31",
+    "recorded-content": {
+      "expected_error_dest_does_not_exist": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Destination bucket must have versioning enabled."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "expected_error_dest_versioning_disabled": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Destination bucket must have versioning enabled."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-replication": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-replication": {
+        "ReplicationConfiguration": {
+          "Role": "role",
+          "Rules": [
+            {
+              "DeleteMarkerReplication": {
+                "Status": "Disabled"
+              },
+              "Destination": {
+                "Bucket": "dest-bucket",
+                "Metrics": {
+                  "EventThreshold": {
+                    "Minutes": 15
+                  },
+                  "Status": "Enabled"
+                },
+                "ReplicationTime": {
+                  "Status": "Enabled",
+                  "Time": {
+                    "Minutes": 15
+                  }
+                },
+                "StorageClass": "STANDARD"
+              },
+              "Filter": {},
+              "ID": "rtc",
+              "Priority": 0,
+              "Status": "Disabled"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3833,5 +3833,62 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_replication_config": {
+    "recorded-date": "18-10-2022, 14:49:15",
+    "recorded-content": {
+      "expected_error_no_replication_set": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "ReplicationConfigurationNotFoundError",
+          "Message": "The replication configuration was not found"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "expected_error_versioning_not_enabled": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Versioning must be 'Enabled' on the bucket to apply a replication configuration"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-bucket-replication": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-replication": {
+        "ReplicationConfiguration": {
+          "Role": "role",
+          "Rules": [
+            {
+              "DeleteMarkerReplication": {
+                "Status": "Disabled"
+              },
+              "Destination": {
+                "Bucket": "dest-bucket"
+              },
+              "Filter": {
+                "Prefix": "Tax"
+              },
+              "ID": "id",
+              "Priority": 1,
+              "Status": "Enabled"
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3724,5 +3724,65 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_content_language_disposition": {
+    "recorded-date": "14-10-2022, 17:59:39",
+    "recorded-content": {
+      "put-object": {
+        "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-object-headers": {
+        "HTTPHeaders": {
+          "content-length": "0",
+          "date": "date",
+          "etag": "\"e99a18c428cb38d5f260853678922e03\"",
+          "server": "server",
+          "x-amz-id-2": "id-2",
+          "x-amz-request-id": "request-id"
+        },
+        "HTTPStatusCode": 200,
+        "HostId": "host-id",
+        "RequestId": "request-id",
+        "RetryAttempts": 0
+      },
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "",
+        "ContentDisposition": "attachment; filename=\"foo.jpg\"",
+        "ContentLanguage": "de",
+        "ContentLength": 6,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-object-headers": {
+        "HTTPHeaders": {
+          "accept-ranges": "bytes",
+          "content-disposition": "attachment; filename=\"foo.jpg\"",
+          "content-language": "de",
+          "content-length": "6",
+          "content-type": "binary/octet-stream",
+          "date": "date",
+          "etag": "\"e99a18c428cb38d5f260853678922e03\"",
+          "last-modified": "last-modified",
+          "server": "server",
+          "x-amz-id-2": "id-2",
+          "x-amz-request-id": "request-id"
+        },
+        "HTTPStatusCode": 200,
+        "HostId": "host-id",
+        "RequestId": "request-id",
+        "RetryAttempts": 0
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3784,5 +3784,52 @@
         "RetryAttempts": 0
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_copy_object_kms": {
+    "recorded-date": "17-10-2022, 14:27:01",
+    "recorded-content": {
+      "get-object": {
+        "AcceptRanges": "bytes",
+        "Body": "hello world",
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"5eb63bbbe01eeed093cb22bb8f5acdc3\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "copy-object": {
+        "BucketKeyEnabled": true,
+        "CopyObjectResult": {
+          "ETag": "copy-etag",
+          "LastModified": "datetime"
+        },
+        "SSEKMSKeyId": "<key-id:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-copied-object": {
+        "AcceptRanges": "bytes",
+        "Body": "hello world",
+        "BucketKeyEnabled": true,
+        "ContentLength": 11,
+        "ContentType": "binary/octet-stream",
+        "ETag": "etag",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "<key-id:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3890,5 +3890,16 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_delete_non_existing_keys_quiet": {
+    "recorded-date": "19-10-2022, 10:11:26",
+    "recorded-content": {
+      "deleted-resp": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -3726,7 +3726,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_and_get_object_with_content_language_disposition": {
-    "recorded-date": "14-10-2022, 17:59:39",
+    "recorded-date": "18-10-2022, 10:25:38",
     "recorded-content": {
       "put-object": {
         "ETag": "\"e99a18c428cb38d5f260853678922e03\"",
@@ -3752,6 +3752,7 @@
       "get-object": {
         "AcceptRanges": "bytes",
         "Body": "",
+        "CacheControl": "no-cache",
         "ContentDisposition": "attachment; filename=\"foo.jpg\"",
         "ContentLanguage": "de",
         "ContentLength": 6,
@@ -3767,6 +3768,7 @@
       "get-object-headers": {
         "HTTPHeaders": {
           "accept-ranges": "bytes",
+          "cache-control": "no-cache",
           "content-disposition": "attachment; filename=\"foo.jpg\"",
           "content-language": "de",
           "content-length": "6",

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -738,5 +738,110 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_delete_objects": {
+    "recorded-date": "19-10-2022, 10:39:20",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectRemoved:Delete",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "key": "<object-key:1>",
+                "sequencer": "sequencer"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          },
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectRemoved:Delete",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "key": "<object-key:2>",
+                "sequencer": "sequencer"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          },
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectRemoved:Delete",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.1",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "key": "<object-key:3>",
+                "sequencer": "sequencer"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          }
+        ]
+      }
+    }
   }
 }

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -557,10 +557,11 @@ class TestS3UtilsAsf:
             ("bucket-owner-full-control", True),
             ("not-a-canned-one", False),
             ("aws--exec-read", False),
+            ("log-delivery-write", True),
         ]
 
         for canned_acl, expected_result in canned_acls:
-            assert s3_utils_asf.is_canned_acl_valid(canned_acl) == expected_result
+            assert s3_utils_asf.is_canned_acl_bucket_valid(canned_acl) == expected_result
 
     def test_s3_bucket_name(self):
         bucket_names = [


### PR DESCRIPTION
This PR contains several fixes for S3 ASF that were detected by the terraform test suite:

- Website Hosting: fix handling for empty `ReplaceKeyPrefixWith` for redirect-routing rule (in that case it should remove the the `KeyPrefixEquals` from the original url and then do the redirect)
- Bucket name with slashes: fix parsing issue; preserve name for keys that end with slash
- Patch to change casing of `content-lanugage` , `content-disposition` and `cache-control` to be picked up by parser
- Patch for bucket-key-enbled header `x-amz-server-side-encryption-bucket-key-enabled` which is returned as camel-case by moto, but should be lowercase to be picked up by the parser
- fix resetting of `content-length` for HEAD requests that are forwarded using the `Proxy` for vhost-style requests.
- fix issues with `delete-objects`:
   - query parameter was added twice to the url for vhost-style forwarding
   - add moto-patch to include old fix from legacy s3 provider
   - remove trailing `=` from the path (`/<bucket>/?delete=` but expects `/<bucket>/?delete`)
   - add notifications for `delete-objects`
   - implement `quiet` mode for `delete-objects`
- fix bucket replication and added tests
- add spec-patch for `log-delivery-write`, which was missing from the `BucketCannedACL`


## TODO before merge:

- [x]  remove last commit, which excludes some cors-related tests, that were timing out (CORS not yet implemented)
- [x] rebase with master (remove ASF enabled by default)