### PR TITLE
fixes bug: service-linked role creation does not match to aws role

### DIFF
--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -304,8 +304,8 @@ class IamProvider(IamApi):
                 ],
             }
         )
-        path = f"{SERVICE_LINKED_ROLE_PATH_PREFIX}/{aws_service_name}"
-        role_name = f"r-{short_uid()}"
+        path = f"{SERVICE_LINKED_ROLE_PATH_PREFIX}/{aws_service_name}/"
+        role_name = f"AWSServiceRoleFor%s" % aws_service_name.split(".")[0].upper()
         backend = get_iam_backend(context)
         role = backend.create_role(
             role_name=role_name,


### PR DESCRIPTION
Fixes issues raised by #5249
1. unique RoleName is created, so throws an error if the same role is created twice.
2. fixes a `/` suffix issue in PATH as given in [cli docs](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/create-service-linked-role.html)

However, mapping is still not complete i.e. works for `ecs/ecr` as it's simply uppercase of the service name, but not so for `Lex` etc. The reason is, I'm not able to find a complete source of all potential RoleNames. 

Can anyone can point me to the right document? Else I will try to search and see if I can improve on this.