### PR TITLE
fix static infrastructure installer target

### DIFF
--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -161,6 +161,7 @@ def install_cloudformation_libs():
 
 
 def install_component(name):
+    from localstack.packages import InstallTarget
     from localstack.services.awslambda.packages import awslambda_runtime_package
     from localstack.services.cloudformation.packages import cloudformation_package
     from localstack.services.dynamodb.packages import dynamodblocal_package
@@ -181,16 +182,18 @@ def install_component(name):
 
     installer = installers.get(name)
     if installer:
-        installer()
+        # since these installers are called at build-time, they should be installed to STATIC_LIBS
+        installer(target=InstallTarget.STATIC_LIBS)
 
 
 def install_components(names):
     parallelize(install_component, names)
 
-    # TODO: subject to removal, migrated from old code
+    # TODO remove these installers here (the default services should be defined using an LPM call in the Dockerfile)
+    from localstack.packages import InstallTarget
     from localstack.services.awslambda.packages import lambda_java_libs_package
 
-    lambda_java_libs_package.install()
+    lambda_java_libs_package.install(target=InstallTarget.STATIC_LIBS)
 
 
 def install_all_components():


### PR DESCRIPTION
This PR fixes a small issue with those installers which have already been migrated to the new structure (introduced in https://github.com/localstack/localstack/pull/6783) and are installed at build time (via the `make init` command).
Unfortunately, these installers have been executed with the install target `VAR_LIBS` (the default - which is overwritten when a local filesystem is mounted) rather than with the `STATIC_LIBS` target (which is not overwritten when a var lib is mounted).

This can be verfied with the following commands:
```
$ docker pull localstack/localstack
$ docker run --entrypoint bash localstack/localstack 
# ls -al /var/lib/localstack/lib
total 172
drwxr-xr-x 11 root root   4096 Oct 17 15:23 .
drwxrwxrwx  6 root root   4096 Oct 17 15:23 ..
drwxr-xr-x  4 root root   4096 Oct 17 15:23 apt-libs
drwxr-xr-x  3 root root   4096 Oct 17 15:23 awslambda-runtime
drwxr-xr-x  3 root root   4096 Oct 17 15:23 cloudformation
drwxr-xr-x  3 root root   4096 Oct 17 15:23 dynamodb-local
drwxr-xr-x  3 root root   4096 Oct 17 15:23 elasticmq
drwxr-xr-x  3 root root   4096 Oct 17 15:23 kinesis-mock
drwxr-xr-x  3 root root   4096 Oct 17 15:23 lambda-java-libs
drwxr-xr-x  3 root root   4096 Oct 17 15:23 local-kms
-rw-r--r--  1 root root 127033 Oct 17 07:43 localstack-utils-tests.jar
drwxr-xr-x  3 root root   4096 Oct 17 15:23 stepfunctions-local

```

This PR simply fixes this by setting the default target for these installers to `STATIC_LIBS`. This should be enough for now because (1) these installers are only executed by `make init`, and (2) these installers will be superseded by explicit `lpm` calls in the Dockerfile / at Docker build-time soon.