### PR TITLE
Update patch for IAM backend

### DIFF
--- a/localstack/services/iam/provider.py
+++ b/localstack/services/iam/provider.py
@@ -459,8 +459,8 @@ def apply_patches():
 
     # Add missing managed polices
     @patch(IAMBackend.__init__)
-    def add_attributes(__init__, self, region_name, account_id):
-        __init__(self, region_name, account_id)
+    def add_attributes(__init__, self, region_name, account_id, aws_policies=None):
+        __init__(self, region_name, account_id, aws_policies=aws_policies)
         self.aws_managed_policies.extend(
             [
                 AWSManagedPolicy.from_data(name, self.account_id, d)


### PR DESCRIPTION
Adapting the patch to match the signature of the `IAMBackend`. We experienced a `TypeError: apply_patches.<locals>.add_attributes() takes 4 positional arguments but 5 were given` when trying to reset the IAM status. Thanks to @whummer for noticing the problem.