### PR TITLE
Migrate debugpy installer

### DIFF
--- a/localstack/packages/debugpy.py
+++ b/localstack/packages/debugpy.py
@@ -1,0 +1,46 @@
+import os
+from typing import List
+
+from localstack.packages import InstallTarget, Package, PackageInstaller
+
+# debugpy module
+DEBUGPY_MODULE = "debugpy"
+
+
+class DebugPyPackage(Package):
+    def __init__(self):
+        super().__init__("DebugPy", "latest")
+
+    def get_versions(self) -> List[str]:
+        return ["latest"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return DebugPyPackageInstaller("debugpy", version)
+
+
+class DebugPyPackageInstaller(PackageInstaller):
+    def _get_install_dir(self, target: InstallTarget) -> str:
+        import inspect
+        from pathlib import Path
+
+        import localstack
+
+        # get the "root" LocalStack directory. We go two levels up from /localstack/localstack/__init__.py
+        ls_path = Path(inspect.getfile(localstack)).parent.parent
+        # TODO: make this python version independent
+        lib_path = os.path.join(ls_path, ".venv/lib/python3.10/site-packages/debugpy")
+        return lib_path
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return install_dir
+
+    def _install(self, target: InstallTarget) -> None:
+        import pip
+
+        if hasattr(pip, "main"):
+            pip.main(["install", DEBUGPY_MODULE])
+        else:
+            pip._internal.main(["install", DEBUGPY_MODULE])
+
+
+debugpy_package = DebugPyPackage()

--- a/localstack/packages/debugpy.py
+++ b/localstack/packages/debugpy.py
@@ -1,10 +1,6 @@
-import os
 from typing import List
 
 from localstack.packages import InstallTarget, Package, PackageInstaller
-
-# debugpy module
-DEBUGPY_MODULE = "debugpy"
 
 
 class DebugPyPackage(Package):
@@ -19,28 +15,31 @@ class DebugPyPackage(Package):
 
 
 class DebugPyPackageInstaller(PackageInstaller):
-    def _get_install_dir(self, target: InstallTarget) -> str:
-        import inspect
-        from pathlib import Path
+    # TODO: migrate this to the upcoming pip installer
 
-        import localstack
+    def is_installed(self) -> bool:
+        try:
+            import debugpy
 
-        # get the "root" LocalStack directory. We go two levels up from /localstack/localstack/__init__.py
-        ls_path = Path(inspect.getfile(localstack)).parent.parent
-        # TODO: make this python version independent
-        lib_path = os.path.join(ls_path, ".venv/lib/python3.10/site-packages/debugpy")
-        return lib_path
+            assert debugpy
+            return True
+        except ModuleNotFoundError:
+            return False
 
     def _get_install_marker_path(self, install_dir: str) -> str:
+        # TODO: This method currently does not provide the actual install_marker.
+        #  Since we overwrote is_installed(), this installer does not install anything under
+        #  var/static libs, and we also don't need an executable, we don't need it to operate the installer.
+        #  fix with migration to pip installer
         return install_dir
 
     def _install(self, target: InstallTarget) -> None:
         import pip
 
         if hasattr(pip, "main"):
-            pip.main(["install", DEBUGPY_MODULE])
+            pip.main(["install", "debugpy"])
         else:
-            pip._internal.main(["install", DEBUGPY_MODULE])
+            pip._internal.main(["install", "debugpy"])
 
 
 debugpy_package = DebugPyPackage()

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -440,7 +440,9 @@ def start_infra(asynchronous=False, apis=None):
 
 def do_start_infra(asynchronous, apis, is_in_docker):
     if config.DEVELOP:
-        install.install_debugpy_and_dependencies()
+        from localstack.packages.debugpy import debugpy_package
+
+        debugpy_package.install()
         import debugpy
 
         LOG.info("Starting debug server at: %s:%s", constants.BIND_HOST, config.DEVELOP_PORT)

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -39,11 +39,6 @@ URL_ASPECTJRT = f"{MAVEN_REPO_URL}/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.j
 URL_ASPECTJWEAVER = f"{MAVEN_REPO_URL}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7.jar"
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
 
-
-# debugpy module
-DEBUGPY_MODULE = "debugpy"
-DEBUGPY_DEPENDENCIES = ["gcc", "python3-dev", "musl-dev"]
-
 # Target version for javac, to ensure compatibility with earlier JREs
 JAVAC_TARGET_VERSION = "1.8"
 
@@ -200,22 +195,6 @@ def install_all_components():
     # install dependencies - make sure that install_components(..) is called before hooks.install below!
     install_components(DEFAULT_SERVICE_PORTS.keys())
     hooks.install.run()
-
-
-def install_debugpy_and_dependencies():
-    try:
-        import debugpy
-
-        assert debugpy
-        logging.debug("Debugpy module already Installed")
-    except ModuleNotFoundError:
-        logging.debug("Installing Debugpy module")
-        import pip
-
-        if hasattr(pip, "main"):
-            pip.main(["install", DEBUGPY_MODULE])
-        else:
-            pip._internal.main(["install", DEBUGPY_MODULE])
 
 
 # -----------------


### PR DESCRIPTION
This PR migrates the debugpy install routine to the new architecture introduced in https://github.com/localstack/localstack/pull/6783.
Note: the check if it is already installed seems kinda hacky (at least the part to determine the "root" localstack directory). Critique is very much appreciated
