### PR TITLE
Extract account id from access key id for each request

### DIFF
--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -100,8 +100,7 @@ def extract_account_id_from_access_key_id(access_key_id: str) -> str:
 
 def get_account_id_from_access_key_id(access_key_id: str) -> str:
     """Return the Account ID associated the Access Key ID."""
-    # This utility ignores IAM mappings.
-    # For now, we assume the client sends Account ID in Access Key ID field.
+    # For now, we assume the client sends Account ID or an IAM Access Key ID in Access Key ID field.
 
     if re.match(r"\d{12}", access_key_id):
         return access_key_id

--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -1,4 +1,7 @@
 """Functionality related to AWS Accounts"""
+import base64
+import binascii
+import logging
 import re
 import threading
 from typing import Optional
@@ -10,6 +13,13 @@ from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 # Thread local storage for keeping current request & account related info
 REQUEST_CTX_TLS = threading.local()
 
+# Account id offset for id extraction
+# generated from int.from_bytes(base64.b32decode(b"QAAAAAAA"), byteorder="big") (user id 000000000000)
+ACCOUNT_OFFSET = 549755813888
+# Basically the base32 alphabet, for better access as constant here
+AWS_ACCESS_KEY_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+LOG = logging.getLogger(__name__)
 #
 # Access Key IDs
 #
@@ -49,6 +59,45 @@ account_id_resolver = get_default_account_id
 #
 
 
+def extract_account_id_from_access_key_id(access_key_id: str) -> str:
+    """
+    Extract account id from access key id
+
+    Example:
+        "ASIAQAAAAAAAGMKEM7X5" => "000000000000"
+        "AKIARZPUZDIKGB2VALC4" => "123456789012"
+    :param access_key_id: Access key id. Must start with either ASIA or AKIA and has at least 20 characters
+    :return: Account ID (as string), 12 digits
+    """
+    account_id_part = access_key_id[4:12]
+    # decode account id part
+    try:
+        account_id_part_int = int.from_bytes(base64.b32decode(account_id_part), byteorder="big")
+    except binascii.Error:
+        LOG.warning(
+            "Invalid Access Key Id format. Falling back to default id: %s", get_default_account_id()
+        )
+        return get_default_account_id()
+
+    account_id = 2 * (account_id_part_int - ACCOUNT_OFFSET)
+    try:
+        if AWS_ACCESS_KEY_ALPHABET.index(access_key_id[12]) >= 16:
+            account_id += 1
+    except ValueError:
+        LOG.warning(
+            "Char at index 12 not from base32 alphabet. Falling back to default id: %s",
+            get_default_account_id(),
+        )
+        return get_default_account_id()
+    if account_id < 0 or account_id > 999999999999:
+        LOG.warning(
+            "Extracted account id not between 000000000000 and 999999999999. Falling back to default id: %s",
+            get_default_account_id(),
+        )
+        return get_default_account_id()
+    return f"{account_id:012}"
+
+
 def get_account_id_from_access_key_id(access_key_id: str) -> str:
     """Return the Account ID associated the Access Key ID."""
     # This utility ignores IAM mappings.
@@ -57,4 +106,9 @@ def get_account_id_from_access_key_id(access_key_id: str) -> str:
     if re.match(r"\d{12}", access_key_id):
         return access_key_id
     else:
-        return get_default_account_id()
+        if len(access_key_id) >= 20 and (
+            access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA")
+        ):
+            return extract_account_id_from_access_key_id(access_key_id)
+        else:
+            return get_default_account_id()

--- a/tests/integration/test_sts.py
+++ b/tests/integration/test_sts.py
@@ -6,9 +6,10 @@ import requests
 
 from localstack import config
 from localstack.constants import APPLICATION_JSON
+from localstack.testing.aws.util import create_client_with_keys
 from localstack.utils.aws import aws_stack
 from localstack.utils.numbers import is_number
-from localstack.utils.strings import to_str
+from localstack.utils.strings import short_uid, to_str
 
 TEST_SAML_ASSERTION = """
 <?xml version="1.0"?>
@@ -162,7 +163,7 @@ class TestSTSIntegrations:
         assert federated_user_info[1] == token_name
 
     @pytest.mark.only_localstack
-    def test_get_caller_identity_root(self, sts_client, iam_client, monkeypatch):
+    def test_get_caller_identity_root(self, sts_client):
         response = sts_client.get_caller_identity()
         account_id = response["Account"]
         assert f"arn:aws:iam::{account_id}:root" == response["Arn"]
@@ -179,3 +180,63 @@ class TestSTSIntegrations:
         # Expiration field should be numeric (tested against AWS)
         result = content["GetSessionTokenResponse"]["GetSessionTokenResult"]
         assert is_number(result["Credentials"]["Expiration"])
+
+    @pytest.mark.only_localstack
+    def test_get_caller_identity_user_access_key(self, sts_client, cleanups):
+        """Check whether the correct account id is returned for requests by other users access keys"""
+        account_id = "123123123123"
+        account_creds = {"AccessKeyId": account_id, "SecretAccessKey": "test"}
+        iam_account_client = create_client_with_keys("iam", account_creds)
+        user_name = iam_account_client.create_user(UserName=f"test-user-{short_uid()}")["User"][
+            "UserName"
+        ]
+        cleanups.append(lambda: iam_account_client.delete_user(UserName=user_name))
+        access_key_response = iam_account_client.create_access_key(UserName=user_name)["AccessKey"]
+        cleanups.append(
+            lambda: iam_account_client.delete_access_key(
+                AccessKeyId=access_key_response["AccessKeyId"], UserName=user_name
+            )
+        )
+
+        sts_user_client = create_client_with_keys("sts", access_key_response)
+        response = sts_user_client.get_caller_identity()
+        assert account_id == response["Account"]
+
+    @pytest.mark.only_localstack
+    def test_get_caller_identity_role_access_key(self, sts_client, account_id, cleanups):
+        """Check whether the correct account id is returned for roles for other accounts"""
+        fake_account_id = "123123123123"
+        account_creds = {"AccessKeyId": fake_account_id, "SecretAccessKey": "test"}
+        iam_account_client = create_client_with_keys("iam", account_creds)
+        sts_account_client = create_client_with_keys("sts", account_creds)
+        assume_policy_doc = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {"AWS": [account_id, fake_account_id]},
+                    "Effect": "Allow",
+                }
+            ],
+        }
+        role_name = f"test-role-{short_uid()}"
+        role_arn = iam_account_client.create_role(
+            RoleName=role_name, AssumeRolePolicyDocument=json.dumps(assume_policy_doc)
+        )["Role"]["Arn"]
+        cleanups.append(lambda: iam_account_client.delete_role(RoleName=role_name))
+
+        # assume the role and check if account id is correct
+        assume_role_response = sts_account_client.assume_role(
+            RoleArn=role_arn, RoleSessionName=f"test-session-{short_uid()}"
+        )["Credentials"]
+        sts_role_client = create_client_with_keys("sts", assume_role_response)
+        response = sts_role_client.get_caller_identity()
+        assert fake_account_id == response["Account"]
+
+        # assume the role coming from another account, to check if the account id is handled properly
+        assume_role_response_other_account = sts_client.assume_role(
+            RoleArn=role_arn, RoleSessionName=f"test-session-{short_uid()}"
+        )["Credentials"]
+        sts_role_client_2 = create_client_with_keys("sts", assume_role_response_other_account)
+        response = sts_role_client_2.get_caller_identity()
+        assert fake_account_id == response["Account"]


### PR DESCRIPTION
## Motivation
Currently, we do not extract the account id from iam/sts access keys on requests, which leads to problems with the multi account feature when using iam access keys.
After the changes in https://github.com/spulec/moto/pull/5501 , we can now use this to extract the account id stateless from the access key id.
## Changes
* Extract account id for access key id if it matches the correct format. A lot of warnings/fallbacks if it gets an malformed one.
* Add two tests testing access keys generated by iam / sts and the sts get caller identity feature, which in the end depends on our account id extraction.