### PR TITLE
Fix proper AWS account ID from access key ID

### DIFF
--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -2,7 +2,6 @@
 import base64
 import binascii
 import logging
-import re
 import threading
 from typing import Optional
 
@@ -102,12 +101,9 @@ def get_account_id_from_access_key_id(access_key_id: str) -> str:
     """Return the Account ID associated the Access Key ID."""
     # For now, we assume the client sends Account ID or an IAM Access Key ID in Access Key ID field.
 
-    if re.match(r"\d{12}", access_key_id):
-        return access_key_id
-    else:
-        if len(access_key_id) >= 20 and (
-            access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA")
-        ):
-            return extract_account_id_from_access_key_id(access_key_id)
-        else:
-            return get_default_account_id()
+    if len(access_key_id) >= 20 and (
+        access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA")
+    ):
+        return extract_account_id_from_access_key_id(access_key_id)
+
+    return get_aws_account_id()

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -88,7 +88,9 @@ skip_if_pro_enabled = pytest.mark.skipif(
 )
 
 
-def _client(service, region_name=None, *, additional_config=None):
+def _client(
+    service: str, region_name: str = None, aws_access_key_id: str = None, *, additional_config=None
+):
     config = botocore.config.Config()
 
     # can't set the timeouts to 0 like in the AWS CLI because the underlying http client requires values > 0
@@ -105,7 +107,9 @@ def _client(service, region_name=None, *, additional_config=None):
     if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
         return boto3.client(service, region_name=region_name, config=config)
 
-    return aws_stack.create_external_boto_client(service, config=config, region_name=region_name)
+    return aws_stack.create_external_boto_client(
+        service, config=config, region_name=region_name, aws_access_key_id=aws_access_key_id
+    )
 
 
 def _resource(service):

--- a/tests/integration/test_multi_accounts.py
+++ b/tests/integration/test_multi_accounts.py
@@ -1,0 +1,26 @@
+import pytest
+
+from localstack.aws.accounts import get_default_account_id
+from localstack.testing.pytest.fixtures import _client
+
+
+@pytest.fixture
+def client_factory():
+    region_name = "eu-central-1"
+
+    def _client_factory(service: str, aws_access_key_id: str):
+        return _client(service, region_name=region_name, aws_access_key_id=aws_access_key_id)
+
+    yield _client_factory
+
+
+class TestMultiAccounts:
+    def test_arbitrary_account_id_is_ignored_on_community(self, client_factory):
+        sts_client = client_factory("sts", aws_access_key_id="112233445566")
+        response = sts_client.get_caller_identity()
+        assert response["Account"] == get_default_account_id()
+
+    def test_invalid_access_key_id_fallback_to_default_account_id(self, client_factory):
+        sts_client = client_factory("sts", aws_access_key_id="?=@#XYZ$%^&123")
+        response = sts_client.get_caller_identity()
+        assert response["Account"] == get_default_account_id()


### PR DESCRIPTION
Fix an issue where in certain scenarios, the default account ID is returned when in fact we want the patched account ID to be returned.