### PR TITLE
Fix test_s3_lambda_integration test

### DIFF
--- a/tests/integration/awslambda/functions/lambda_s3_integration.js
+++ b/tests/integration/awslambda/functions/lambda_s3_integration.js
@@ -15,15 +15,8 @@ exports.handler = async (event, context, callback) => {
             accessKeyId: 'test',
         };
 
-        const ENDPOINT = {
-            path: '',
-            hostname: 's3.localhost.localstack.cloud:4566',
-            protocol: 'http',
-        };
-
-
         s3 = new S3Client({
-            endpoint: ENDPOINT,
+            endpoint: "http://s3.localhost.localstack.cloud:4566",
             region: 'us-east-1',
             credentials: CREDENTIALS,
         });

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1602,11 +1602,11 @@ class TestS3:
     ):
         snapshot.add_transformer(snapshot.transform.s3_api())
         handler_file = os.path.join(
-            os.path.dirname(__file__), "../awslambda", "functions", "lambda_s3_integration.js"
+            os.path.dirname(__file__), "../awslambda/functions/lambda_s3_integration.js"
         )
         temp_folder = create_tmp_folder_lambda(
             handler_file,
-            run_command="npm i @aws-sdk/client-s3; npm i @aws-sdk/s3-request-presigner; npm i @aws-sdk/middleware-endpoint",
+            run_command="npm i @aws-sdk/util-endpoints @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @aws-sdk/middleware-endpoint",
         )
 
         function_name = f"func-integration-{short_uid()}"


### PR DESCRIPTION
Not super happy with the general install setup there but this should fix the immediate issue of the pipeline failing atm.

* Add missing `@aws-sdk/util-endpoints` dependency
* Merge the different npm installs
* Adjust endpoint since it seems to expect a string there now instead of an object.