### PR TITLE
[KMS] Add support for generate random

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -477,9 +477,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         number_of_bytes = request.get("NumberOfBytes")
 
         byte_string = os.urandom(number_of_bytes)
-        response_entropy = base64.b64encode(byte_string)
+        plaintext = base64.b64encode(byte_string)
 
-        return GenerateRandomResponse(Plaintext=response_entropy)
+        return GenerateRandomResponse(Plaintext=plaintext)
 
     @handler("GenerateDataKeyPairWithoutPlaintext", expand=False)
     def generate_data_key_pair_without_plaintext(

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -38,6 +38,8 @@ from localstack.aws.api.kms import (
     GenerateDataKeyResponse,
     GenerateDataKeyWithoutPlaintextRequest,
     GenerateDataKeyWithoutPlaintextResponse,
+    GenerateRandomRequest,
+    GenerateRandomResponse,
     GetKeyPolicyRequest,
     GetKeyPolicyResponse,
     GetKeyRotationStatusRequest,
@@ -465,6 +467,12 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
             request.get("KeyId"), request.get("KeyPairSpec"), context
         )
         return GenerateDataKeyPairResponse(**result)
+
+    @handler("GenerateRandom", expand=False)
+    def generate_random(
+        self, context: RequestContext, request: GenerateRandomRequest
+    ) -> GenerateRandomResponse:
+        return GenerateRandomResponse(Plaintext=b"+Q2hxK6OBuU6K6ZIIBucFMCW2NJkhiSWDySSQyWp9zA=")
 
     @handler("GenerateDataKeyPairWithoutPlaintext", expand=False)
     def generate_data_key_pair_without_plaintext(

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -474,12 +474,15 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self, context: RequestContext, request: GenerateRandomRequest
     ) -> GenerateRandomResponse:
         number_of_bytes = request.get("NumberOfBytes")
-        if number_of_bytes and not 1 <= number_of_bytes <= 1024:
+        if not number_of_bytes:
+            raise ValidationException("NumberOfBytes is required.")
+        if number_of_bytes > 1024:
             raise ValidationException(
                 f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
                 "to satisfy constraint: Member must have value less than or "
                 "equal to 1024"
             )
+
         byte_string = os.urandom(number_of_bytes)
 
         return GenerateRandomResponse(Plaintext=byte_string)

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -476,11 +476,16 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         number_of_bytes = request.get("NumberOfBytes")
         if number_of_bytes is None:
             raise ValidationException("NumberOfBytes is required.")
-        if number_of_bytes < 1 or number_of_bytes > 1024:
+        if number_of_bytes > 1024:
             raise ValidationException(
                 f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
-                "to satisfy constraint: Member must have value less than or "
-                "equal to 1024"
+                "to satisfy constraint: Member must have value less than or equal to 1024"
+            )
+
+        if number_of_bytes < 1:
+            raise ValidationException(
+                f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
+                "to satisfy constraint: Member must have value greater than or equal to 1"
             )
 
         byte_string = os.urandom(number_of_bytes)

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -481,7 +481,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
                 f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
                 "to satisfy constraint: Member must have value less than or equal to 1024"
             )
-
         if number_of_bytes < 1:
             raise ValidationException(
                 f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -474,9 +474,9 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self, context: RequestContext, request: GenerateRandomRequest
     ) -> GenerateRandomResponse:
         number_of_bytes = request.get("NumberOfBytes")
-        if not number_of_bytes:
+        if number_of_bytes is None:
             raise ValidationException("NumberOfBytes is required.")
-        if number_of_bytes > 1024:
+        if number_of_bytes < 1 or number_of_bytes > 1024:
             raise ValidationException(
                 f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
                 "to satisfy constraint: Member must have value less than or "

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1,4 +1,3 @@
-import base64
 import copy
 import datetime
 import logging
@@ -475,18 +474,15 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         self, context: RequestContext, request: GenerateRandomRequest
     ) -> GenerateRandomResponse:
         number_of_bytes = request.get("NumberOfBytes")
-
         if number_of_bytes and not 1 <= number_of_bytes <= 1024:
             raise ValidationException(
                 f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
                 "to satisfy constraint: Member must have value less than or "
                 "equal to 1024"
             )
-
         byte_string = os.urandom(number_of_bytes)
-        plaintext = base64.b64encode(byte_string)
 
-        return GenerateRandomResponse(Plaintext=plaintext)
+        return GenerateRandomResponse(Plaintext=byte_string)
 
     @handler("GenerateDataKeyPairWithoutPlaintext", expand=False)
     def generate_data_key_pair_without_plaintext(

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -476,6 +476,13 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     ) -> GenerateRandomResponse:
         number_of_bytes = request.get("NumberOfBytes")
 
+        if number_of_bytes and not 1 <= number_of_bytes <= 1024:
+            raise ValidationException(
+                f"1 validation error detected: Value '{number_of_bytes}' at 'numberOfBytes' failed "
+                "to satisfy constraint: Member must have value less than or "
+                "equal to 1024"
+            )
+
         byte_string = os.urandom(number_of_bytes)
         plaintext = base64.b64encode(byte_string)
 

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -1,6 +1,8 @@
+import base64
 import copy
 import datetime
 import logging
+import os
 from typing import Dict
 
 from cryptography.hazmat.primitives import hashes
@@ -472,7 +474,12 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     def generate_random(
         self, context: RequestContext, request: GenerateRandomRequest
     ) -> GenerateRandomResponse:
-        return GenerateRandomResponse(Plaintext=b"+Q2hxK6OBuU6K6ZIIBucFMCW2NJkhiSWDySSQyWp9zA=")
+        number_of_bytes = request.get("NumberOfBytes")
+
+        byte_string = os.urandom(number_of_bytes)
+        response_entropy = base64.b64encode(byte_string)
+
+        return GenerateRandomResponse(Plaintext=response_entropy)
 
     @handler("GenerateDataKeyPairWithoutPlaintext", expand=False)
     def generate_data_key_pair_without_plaintext(

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -252,24 +252,17 @@ class TestKMS:
         assert len(plain_text) == number_of_bytes
         snapshot.match("result_length", len(plain_text))
 
-    @pytest.mark.parametrize(
-        "number_of_bytes,error_type",
-        [
-            (None, botocore.exceptions.ClientError),
-            (0, botocore.exceptions.ClientError),
-            (1025, botocore.exceptions.ClientError),
-        ],
-    )
+    @pytest.mark.parametrize("number_of_bytes", [None, 0, 1025])
     @pytest.mark.aws_validated
     def test_generate_random_invalid_number_of_bytes(
-        self, create_boto_client, snapshot, number_of_bytes, error_type
+        self, create_boto_client, snapshot, number_of_bytes
     ):
         kms_client = create_boto_client("kms", additional_config=Config(parameter_validation=False))
 
-        with pytest.raises(error_type) as exinfo:
+        with pytest.raises(botocore.exceptions.ClientError) as e:
             kms_client.generate_random(NumberOfBytes=number_of_bytes)
 
-        snapshot.match("generate-random-exc", exinfo.value.response)
+        snapshot.match("generate-random-exc", e.value.response)
 
     @pytest.mark.aws_validated
     def test_generate_data_key(self, kms_client, kms_key):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -240,6 +240,11 @@ class TestKMS:
         assert decrypted["Plaintext"] == result["PrivateKeyPlaintext"]
 
     @pytest.mark.aws_validated
+    def test_generate_random(self, kms_client):
+        result = kms_client.generate_random()
+        assert result.get("Plaintext")
+
+    @pytest.mark.aws_validated
     def test_generate_data_key(self, kms_client, kms_key):
         key_id = kms_key["KeyId"]
         # LocalStack currently doesn't act on KeySpec or on NumberOfBytes params, but one of them has to be set.

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -240,10 +240,9 @@ class TestKMS:
         )
         assert decrypted["Plaintext"] == result["PrivateKeyPlaintext"]
 
+    @pytest.mark.parametrize("number_of_bytes", [12, 44, 91, 1, 1024])
     @pytest.mark.aws_validated
-    def test_generate_random(self, kms_client):
-        number_of_bytes = 32
-
+    def test_generate_random(self, kms_client, number_of_bytes):
         result = kms_client.generate_random(NumberOfBytes=number_of_bytes)
 
         plain_text = result.get("Plaintext")

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -250,6 +250,14 @@ class TestKMS:
         assert isinstance(plain_text, bytes)
         assert len(base64.b64decode(plain_text)) == number_of_bytes
 
+    @pytest.mark.parametrize(
+        "number_of_bytes,error_type",
+        [(0, botocore.exceptions.ParamValidationError), (1025, botocore.exceptions.ClientError)],
+    )
+    def test_generate_random_invalid_number_of_bytes(self, kms_client, number_of_bytes, error_type):
+        with pytest.raises(error_type):
+            kms_client.generate_random(NumberOfBytes=number_of_bytes)
+
     @pytest.mark.aws_validated
     def test_generate_data_key(self, kms_client, kms_key):
         key_id = kms_key["KeyId"]

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -254,9 +254,21 @@ class TestKMS:
     @pytest.mark.parametrize(
         "number_of_bytes,error_type,error_message",
         [
-            (None, botocore.exceptions.ClientError, "NumberOfBytes is required."),
-            (0, botocore.exceptions.ClientError, "1 validation error detected"),
-            (1025, botocore.exceptions.ClientError, "1 validation error detected"),
+            (
+                None,
+                botocore.exceptions.ClientError,
+                "NumberOfBytes is required.",
+            ),
+            (
+                0,
+                botocore.exceptions.ClientError,
+                "Member must have value greater than or equal to 1",
+            ),
+            (
+                1025,
+                botocore.exceptions.ClientError,
+                "Member must have value less than or equal to 1024",
+            ),
         ],
     )
     @pytest.mark.aws_validated

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from datetime import datetime
 from random import getrandbits
@@ -241,8 +242,14 @@ class TestKMS:
 
     @pytest.mark.aws_validated
     def test_generate_random(self, kms_client):
-        result = kms_client.generate_random()
-        assert result.get("Plaintext")
+        number_of_bytes = 32
+
+        result = kms_client.generate_random(NumberOfBytes=number_of_bytes)
+
+        plain_text = result.get("Plaintext")
+        assert plain_text
+        assert isinstance(plain_text, bytes)
+        assert len(base64.b64decode(plain_text)) == number_of_bytes
 
     @pytest.mark.aws_validated
     def test_generate_data_key(self, kms_client, kms_key):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -242,13 +242,14 @@ class TestKMS:
 
     @pytest.mark.parametrize("number_of_bytes", [12, 44, 91, 1, 1024])
     @pytest.mark.aws_validated
-    def test_generate_random(self, kms_client, number_of_bytes):
+    def test_generate_random(self, kms_client, snapshot, number_of_bytes):
         result = kms_client.generate_random(NumberOfBytes=number_of_bytes)
 
         plain_text = result.get("Plaintext")
         assert plain_text
         assert isinstance(plain_text, bytes)
         assert len(plain_text) == number_of_bytes
+        snapshot.match("result_length", len(plain_text))
 
     @pytest.mark.parametrize(
         "number_of_bytes,error_type,error_message",
@@ -260,13 +261,14 @@ class TestKMS:
     )
     @pytest.mark.aws_validated
     def test_generate_random_invalid_number_of_bytes(
-        self, create_boto_client, number_of_bytes, error_type, error_message
+        self, create_boto_client, snapshot, number_of_bytes, error_type, error_message
     ):
         kms_client = create_boto_client("kms", additional_config=Config(parameter_validation=False))
         with pytest.raises(error_type) as exinfo:
             kms_client.generate_random(NumberOfBytes=number_of_bytes)
 
         assert error_message in str(exinfo.value)
+        snapshot.match("error_message", str(exinfo.value))
 
     @pytest.mark.aws_validated
     def test_generate_data_key(self, kms_client, kms_key):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -253,6 +253,7 @@ class TestKMS:
         "number_of_bytes,error_type",
         [(0, botocore.exceptions.ParamValidationError), (1025, botocore.exceptions.ClientError)],
     )
+    @pytest.mark.aws_validated
     def test_generate_random_invalid_number_of_bytes(self, kms_client, number_of_bytes, error_type):
         with pytest.raises(error_type):
             kms_client.generate_random(NumberOfBytes=number_of_bytes)

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1,4 +1,3 @@
-import base64
 import json
 from datetime import datetime
 from random import getrandbits
@@ -248,7 +247,7 @@ class TestKMS:
         plain_text = result.get("Plaintext")
         assert plain_text
         assert isinstance(plain_text, bytes)
-        assert len(base64.b64decode(plain_text)) == number_of_bytes
+        assert len(plain_text) == number_of_bytes
 
     @pytest.mark.parametrize(
         "number_of_bytes,error_type",

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1,60 +1,48 @@
 {
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError-NumberOfBytes is required.]": {
-    "recorded-date": "25-10-2022, 12:08:51",
-    "recorded-content": {
-      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: NumberOfBytes is required."
-    }
-  },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError-1 validation error detected]": {
-    "recorded-date": "25-10-2022, 10:24:07",
-    "recorded-content": {
-      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '0' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"
-    }
-  },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError-1 validation error detected]": {
-    "recorded-date": "25-10-2022, 12:08:09",
-    "recorded-content": {
-      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
-    }
-  },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[12]": {
-    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-date": "25-10-2022, 14:59:41",
     "recorded-content": {
       "result_length": 12
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[44]": {
-    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-date": "25-10-2022, 14:59:42",
     "recorded-content": {
       "result_length": 44
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[91]": {
-    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-date": "25-10-2022, 14:59:42",
     "recorded-content": {
       "result_length": 91
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[1]": {
-    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-date": "25-10-2022, 14:59:42",
     "recorded-content": {
       "result_length": 1
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[1024]": {
-    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-date": "25-10-2022, 14:59:42",
     "recorded-content": {
       "result_length": 1024
     }
   },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError-NumberOfBytes is required.]": {
+    "recorded-date": "25-10-2022, 14:59:53",
+    "recorded-content": {
+      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: NumberOfBytes is required."
+    }
+  },
   "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError-Member must have value greater than or equal to 1]": {
-    "recorded-date": "25-10-2022, 12:08:52",
+    "recorded-date": "25-10-2022, 14:59:54",
     "recorded-content": {
       "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '0' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError-Member must have value less than or equal to 1024]": {
-    "recorded-date": "25-10-2022, 12:08:52",
+    "recorded-date": "25-10-2022, 14:59:54",
     "recorded-content": {
       "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
     }

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1,0 +1,50 @@
+{
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError-NumberOfBytes is required.]": {
+    "recorded-date": "25-10-2022, 10:24:07",
+    "recorded-content": {
+      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: NumberOfBytes is required."
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError-1 validation error detected]": {
+    "recorded-date": "25-10-2022, 10:24:07",
+    "recorded-content": {
+      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '0' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError-1 validation error detected]": {
+    "recorded-date": "25-10-2022, 10:24:08",
+    "recorded-content": {
+      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random[12]": {
+    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-content": {
+      "result_length": 12
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random[44]": {
+    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-content": {
+      "result_length": 44
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random[91]": {
+    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-content": {
+      "result_length": 91
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random[1]": {
+    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-content": {
+      "result_length": 1
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random[1024]": {
+    "recorded-date": "25-10-2022, 10:31:15",
+    "recorded-content": {
+      "result_length": 1024
+    }
+  }
+}

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1,50 +1,77 @@
 {
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError]": {
+    "recorded-date": "25-10-2022, 18:50:50",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "NumberOfBytes is required."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError]": {
+    "recorded-date": "25-10-2022, 18:50:50",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '0' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError]": {
+    "recorded-date": "25-10-2022, 18:50:51",
+    "recorded-content": {
+      "generate-random-exc": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[12]": {
-    "recorded-date": "25-10-2022, 14:59:41",
+    "recorded-date": "25-10-2022, 18:52:48",
     "recorded-content": {
       "result_length": 12
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[44]": {
-    "recorded-date": "25-10-2022, 14:59:42",
+    "recorded-date": "25-10-2022, 18:52:48",
     "recorded-content": {
       "result_length": 44
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[91]": {
-    "recorded-date": "25-10-2022, 14:59:42",
+    "recorded-date": "25-10-2022, 18:52:48",
     "recorded-content": {
       "result_length": 91
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[1]": {
-    "recorded-date": "25-10-2022, 14:59:42",
+    "recorded-date": "25-10-2022, 18:52:48",
     "recorded-content": {
       "result_length": 1
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[1024]": {
-    "recorded-date": "25-10-2022, 14:59:42",
+    "recorded-date": "25-10-2022, 18:52:48",
     "recorded-content": {
       "result_length": 1024
-    }
-  },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError-NumberOfBytes is required.]": {
-    "recorded-date": "25-10-2022, 14:59:53",
-    "recorded-content": {
-      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: NumberOfBytes is required."
-    }
-  },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError-Member must have value greater than or equal to 1]": {
-    "recorded-date": "25-10-2022, 14:59:54",
-    "recorded-content": {
-      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '0' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"
-    }
-  },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError-Member must have value less than or equal to 1024]": {
-    "recorded-date": "25-10-2022, 14:59:54",
-    "recorded-content": {
-      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
     }
   }
 }

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError-NumberOfBytes is required.]": {
-    "recorded-date": "25-10-2022, 10:24:07",
+    "recorded-date": "25-10-2022, 12:08:51",
     "recorded-content": {
       "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: NumberOfBytes is required."
     }
@@ -12,7 +12,7 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError-1 validation error detected]": {
-    "recorded-date": "25-10-2022, 10:24:08",
+    "recorded-date": "25-10-2022, 12:08:09",
     "recorded-content": {
       "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
     }
@@ -45,6 +45,18 @@
     "recorded-date": "25-10-2022, 10:31:15",
     "recorded-content": {
       "result_length": 1024
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError-Member must have value greater than or equal to 1]": {
+    "recorded-date": "25-10-2022, 12:08:52",
+    "recorded-content": {
+      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '0' at 'numberOfBytes' failed to satisfy constraint: Member must have value greater than or equal to 1"
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError-Member must have value less than or equal to 1024]": {
+    "recorded-date": "25-10-2022, 12:08:52",
+    "recorded-content": {
+      "error_message": "An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024"
     }
   }
 }

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None-ClientError]": {
-    "recorded-date": "25-10-2022, 18:50:50",
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[None]": {
+    "recorded-date": "25-10-2022, 19:27:14",
     "recorded-content": {
       "generate-random-exc": {
         "Error": {
@@ -14,8 +14,8 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0-ClientError]": {
-    "recorded-date": "25-10-2022, 18:50:50",
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[0]": {
+    "recorded-date": "25-10-2022, 19:27:14",
     "recorded-content": {
       "generate-random-exc": {
         "Error": {
@@ -29,8 +29,8 @@
       }
     }
   },
-  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025-ClientError]": {
-    "recorded-date": "25-10-2022, 18:50:51",
+  "tests/integration/test_kms.py::TestKMS::test_generate_random_invalid_number_of_bytes[1025]": {
+    "recorded-date": "25-10-2022, 19:27:14",
     "recorded-content": {
       "generate-random-exc": {
         "Error": {
@@ -45,31 +45,31 @@
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[12]": {
-    "recorded-date": "25-10-2022, 18:52:48",
+    "recorded-date": "25-10-2022, 19:27:20",
     "recorded-content": {
       "result_length": 12
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[44]": {
-    "recorded-date": "25-10-2022, 18:52:48",
+    "recorded-date": "25-10-2022, 19:27:20",
     "recorded-content": {
       "result_length": 44
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[91]": {
-    "recorded-date": "25-10-2022, 18:52:48",
+    "recorded-date": "25-10-2022, 19:27:21",
     "recorded-content": {
       "result_length": 91
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[1]": {
-    "recorded-date": "25-10-2022, 18:52:48",
+    "recorded-date": "25-10-2022, 19:27:21",
     "recorded-content": {
       "result_length": 1
     }
   },
   "tests/integration/test_kms.py::TestKMS::test_generate_random[1024]": {
-    "recorded-date": "25-10-2022, 18:52:48",
+    "recorded-date": "25-10-2022, 19:27:21",
     "recorded-content": {
       "result_length": 1024
     }


### PR DESCRIPTION
## Summary 
To increase Localstack coverage for [KMS](https://docs.localstack.cloud/localstack/coverage/#kms), this is a request to add `GenerateRandom` implementation. 

AWS Docs : [AWS APIReference/API_GenerateRandom](https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateRandom.html)
Moto example: [localstack/moto/kms/responses.py#L588-L605](https://github.com/localstack/moto/blob/localstack/moto/kms/responses.py#L588-L605)

## awslocal test

Success case

```bash
$ awslocal kms generate-random --number-of-bytes 32
{
    "Plaintext": "gIOXDaGrFBmWRKIlqalIaAJDVX9CBWWi0JRLxzJLLGE="
}

$ echo gIOXDaGrFBmWRKIlqalIaAJDVX9CBWWi0JRLxzJLLGE= | base64 --decode | wc -c
    
      32
```

Validations 
```bash
$ awslocal kms generate-random --number-of-bytes 0

Parameter validation failed:
Invalid value for parameter NumberOfBytes, value: 0, valid min value: 1
```

```bash
$ awslocal kms generate-random --number-of-bytes 1025

An error occurred (ValidationException) when calling the GenerateRandom operation: 1 validation error detected: Value '1025' at 'numberOfBytes' failed to satisfy constraint: Member must have value less than or equal to 1024
```

```bash
$ awslocal kms generate-random                    

An error occurred (ValidationException) when calling the GenerateRandom operation: NumberOfBytes is required.
```