### PR TITLE
Revert "Extract account id from access key id for each request (#7045)"

### DIFF
--- a/localstack/aws/accounts.py
+++ b/localstack/aws/accounts.py
@@ -1,7 +1,4 @@
 """Functionality related to AWS Accounts"""
-import base64
-import binascii
-import logging
 import re
 import threading
 from typing import Optional
@@ -13,13 +10,6 @@ from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 # Thread local storage for keeping current request & account related info
 REQUEST_CTX_TLS = threading.local()
 
-# Account id offset for id extraction
-# generated from int.from_bytes(base64.b32decode(b"QAAAAAAA"), byteorder="big") (user id 000000000000)
-ACCOUNT_OFFSET = 549755813888
-# Basically the base32 alphabet, for better access as constant here
-AWS_ACCESS_KEY_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
-
-LOG = logging.getLogger(__name__)
 #
 # Access Key IDs
 #
@@ -59,55 +49,12 @@ account_id_resolver = get_default_account_id
 #
 
 
-def extract_account_id_from_access_key_id(access_key_id: str) -> str:
-    """
-    Extract account id from access key id
-
-    Example:
-        "ASIAQAAAAAAAGMKEM7X5" => "000000000000"
-        "AKIARZPUZDIKGB2VALC4" => "123456789012"
-    :param access_key_id: Access key id. Must start with either ASIA or AKIA and has at least 20 characters
-    :return: Account ID (as string), 12 digits
-    """
-    account_id_part = access_key_id[4:12]
-    # decode account id part
-    try:
-        account_id_part_int = int.from_bytes(base64.b32decode(account_id_part), byteorder="big")
-    except binascii.Error:
-        LOG.warning(
-            "Invalid Access Key Id format. Falling back to default id: %s", get_default_account_id()
-        )
-        return get_default_account_id()
-
-    account_id = 2 * (account_id_part_int - ACCOUNT_OFFSET)
-    try:
-        if AWS_ACCESS_KEY_ALPHABET.index(access_key_id[12]) >= 16:
-            account_id += 1
-    except ValueError:
-        LOG.warning(
-            "Char at index 12 not from base32 alphabet. Falling back to default id: %s",
-            get_default_account_id(),
-        )
-        return get_default_account_id()
-    if account_id < 0 or account_id > 999999999999:
-        LOG.warning(
-            "Extracted account id not between 000000000000 and 999999999999. Falling back to default id: %s",
-            get_default_account_id(),
-        )
-        return get_default_account_id()
-    return f"{account_id:012}"
-
-
 def get_account_id_from_access_key_id(access_key_id: str) -> str:
     """Return the Account ID associated the Access Key ID."""
-    # For now, we assume the client sends Account ID or an IAM Access Key ID in Access Key ID field.
+    # This utility ignores IAM mappings.
+    # For now, we assume the client sends Account ID in Access Key ID field.
 
     if re.match(r"\d{12}", access_key_id):
         return access_key_id
     else:
-        if len(access_key_id) >= 20 and (
-            access_key_id.startswith("ASIA") or access_key_id.startswith("AKIA")
-        ):
-            return extract_account_id_from_access_key_id(access_key_id)
-        else:
-            return get_default_account_id()
+        return get_default_account_id()


### PR DESCRIPTION
Reverting for now since users are experiencing issues with their setups. 

We should probably re-introduce this (or in a modified way) in a proper release.