### PR TITLE
Fix get output attribute of Stack Resource

### DIFF
--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -32,7 +32,7 @@ class CloudFormationStack(GenericBaseModel):
                 )
             output_key = parts[1]
             candidates = [
-                o["OutputValue"] for o in self.props["Outputs"] if o["OutputKey"] == output_key
+                o.get("OutputValue") for o in self.props["Outputs"] if o["OutputKey"] == output_key
             ]
             if len(candidates) == 1:
                 return candidates[0]

--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -28,7 +28,7 @@ from localstack.utils.collections import merge_recursive
 from localstack.utils.functions import prevent_stack_overflow, run_safe
 from localstack.utils.json import clone_safe, json_safe
 from localstack.utils.objects import get_all_subclasses, recurse_object
-from localstack.utils.strings import first_char_to_lower, is_string, to_bytes, to_str
+from localstack.utils.strings import is_string, to_bytes, to_str
 from localstack.utils.threads import start_worker_thread
 
 from localstack.services.cloudformation.models import *  # noqa: F401, isort:skip
@@ -304,7 +304,6 @@ def extract_resource_attribute(
         )
 
     return attribute_value
-
 
 
 def canonical_resource_type(resource_type):

--- a/tests/integration/cloudformation/api/test_nested_stacks.py
+++ b/tests/integration/cloudformation/api/test_nested_stacks.py
@@ -69,3 +69,32 @@ def test_nested_stack_output_refs(cfn_client, deploy_cfn_template, s3_client, s3
         ][0]
     )
     assert f"{nested_bucket_name}-suffix" == result.outputs["CustomOutput"]
+
+
+def test_nested_with_nested_stack(cfn_client, deploy_cfn_template, s3_client, s3_create_bucket):
+    bucket_name = s3_create_bucket()
+    bucket_to_create_name = f"test-bucket-{short_uid()}"
+
+    nested_stacks = ["nested_child.yml", "nested_parent.yml"]
+    urls = []
+
+    for nested_stack in nested_stacks:
+        s3_client.upload_file(
+            os.path.join(os.path.dirname(__file__), "../../templates/", nested_stack),
+            Bucket=bucket_name,
+            Key=nested_stack,
+        )
+        urls.append(f"https://{bucket_name}.s3.localhost.localstack.cloud:4566/{nested_stack}")
+
+    outputs = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/nested_grand_parent.yml"
+        ),
+        parameters={
+            "ChildStackURL": urls[0],
+            "ParentStackURL": urls[1],
+            "BucketToCreate": bucket_to_create_name,
+        },
+    ).outputs
+
+    assert f"arn:aws:s3:::{bucket_to_create_name}" == outputs["parameterValue"]

--- a/tests/integration/templates/nested_child.yml
+++ b/tests/integration/templates/nested_child.yml
@@ -1,0 +1,15 @@
+Parameters:
+  BucketName:
+    Type: String
+
+Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketName
+  
+Outputs:
+  BucketArn:
+    Value: !GetAtt [Bucket, Arn]
+    Export:
+      Name: NestedBucketArn

--- a/tests/integration/templates/nested_grand_parent.yml
+++ b/tests/integration/templates/nested_grand_parent.yml
@@ -1,0 +1,35 @@
+Parameters:
+  ChildStackURL:
+    Type: String
+
+  BucketToCreate:
+    Type: String
+
+  ParentStackURL:
+    Type: String
+ 
+Resources:
+  myImportingStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Ref ParentStackURL
+      Parameters:
+        ChildStackURL: !Ref ChildStackURL
+        BucketName: !Ref BucketToCreate
+
+  parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !GetAtt [myImportingStack, Outputs.arnOfImportedBucket]
+
+
+    DependsOn:
+      - myImportingStack
+
+Outputs:
+  parameterValue:
+    Value:
+      Fn::GetAtt:
+        - parameter
+        - Value

--- a/tests/integration/templates/nested_parent.yml
+++ b/tests/integration/templates/nested_parent.yml
@@ -1,0 +1,29 @@
+Parameters:
+  ChildStackURL:
+    Type: String
+  BucketName:
+    Type: String
+
+Resources:
+  myStackWithParams:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Ref ChildStackURL
+      Parameters:
+        BucketName: !Ref BucketName
+
+  
+  parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: !GetAtt [myStackWithParams, Outputs.BucketArn]
+    DependsOn:
+      - myStackWithParams
+
+Outputs:
+  arnOfImportedBucket:
+    Value:
+      Fn::GetAtt:
+        - parameter
+        - Value


### PR DESCRIPTION
The template deployer fails to obtaining the value of an Stack model output as an attribute due to sometimes the resource is handle as dictionary. The changes forces to obtain all attributes from the Resource Model.

Change related to ticket. 