### PR TITLE
refactor lpm plugin mechanism

### DIFF
--- a/localstack/cli/lpm.py
+++ b/localstack/cli/lpm.py
@@ -110,10 +110,11 @@ def install(
     config.dirs.mkdirs()
 
     # collect installers and install in parallel:
+    package_instances = _load_packages(package)
     try:
         if target:
             target = InstallTarget[str.upper(target)]
-        for package_instance in _load_packages(package):
+        for package_instance in package_instances:
             _do_install_package(package_instance, version, target)
     except Exception:
         raise ClickException("one or more package installations failed.")

--- a/localstack/cli/lpm.py
+++ b/localstack/cli/lpm.py
@@ -1,16 +1,13 @@
-from collections import defaultdict
-from multiprocessing.pool import Pool
-from typing import Dict, List
+from typing import List, Optional
 
 import click
 from click import ClickException
+from plugin import PluginManager
 from rich.console import Console
 
 from localstack import config
 from localstack.packages import InstallTarget, Package
-from localstack.packages.api import PackagesPluginManager
-from localstack.services.install import InstallerManager
-from localstack.services.plugins import SERVICE_PLUGINS
+from localstack.packages.api import PLUGIN_NAMESPACE, PackagesPlugin
 from localstack.utils.bootstrap import setup_logging
 
 console = Console()
@@ -39,18 +36,7 @@ def cli():
     setup_logging()
 
 
-def _do_install(pkg, version=None, target=None):
-    console.print(f"installing... [bold]{pkg}[/bold]")
-    try:
-        package_installer = InstallerManager().get_installers()[pkg]
-        package_installer.install(version=version, target=target)
-        console.print(f"[green]installed[/green] [bold]{pkg}[/bold]")
-    except Exception as e:
-        console.print(f"[red]error[/red] installing {pkg}: {e}")
-        raise e
-
-
-def _do_install_package(package: Package, version=None, target=None):
+def _do_install_package(package: Package, version: str = None, target: InstallTarget = None):
     console.print(f"installing... [bold]{package}[/bold]")
     try:
         package.install(version=version, target=target)
@@ -69,78 +55,12 @@ def _do_install_package(package: Package, version=None, target=None):
     required=False,
     help="how many installers to run in parallel processes",
 )
-def install(package, parallel, version=None, target=None):
-    """
-    Install one or more packages.
-    """
-    console.print(f"resolving packages: {package}")
-    installers: Dict[str, Package] = InstallerManager().get_installers()
-    config.dirs.mkdirs()
-
-    for pkg in package:
-        if pkg not in installers:
-            raise ClickException(f"unable to locate installer for package {pkg}")
-
-    if parallel > 1:
-        console.print(f"install {parallel} packages in parallel:")
-
-    # collect installers and install in parallel:
-    try:
-        if version or target:
-            if target:
-                target = InstallTarget[str.upper(target)]
-            for pkg in package:
-                _do_install(pkg, version, target)
-        else:
-            with Pool(processes=parallel) as pool:
-                pool.map(_do_install, package)
-    except Exception:
-        raise ClickException("one or more package installations failed.")
-
-
-def _get_available_packages() -> Dict[str, Dict[str, List[Package]]]:
-    # get all AWS provider specs
-
-    aws_provider_specs = dict(sorted(SERVICE_PLUGINS.api_provider_specs.items()))
-
-    # get all package plugin specs
-    packages_plugin_manager = PackagesPluginManager()
-    package_plugin_specs = packages_plugin_manager.package_plugin_specs
-
-    package_plugins = packages_plugin_manager.get_packages()
-    available_packages = defaultdict(dict)
-    for api, names in aws_provider_specs.items():
-        for name in sorted(names):
-            # check if the plugin is available
-            if api not in package_plugin_specs or name not in package_plugin_specs[api]:
-                continue
-            if api in package_plugins and name in package_plugins[api]:
-                available_packages[api][name] = package_plugins[api][name]
-    return available_packages
-
-
-def list_service_packages():
-    available_packages = _get_available_packages()
-    for api, name_packages in available_packages.items():
-        console.print(f"[green]{api}[/green]:")
-        for name, packages in name_packages.items():
-            for package in packages:
-                scope = "community" if name == "default" else name
-                console.print(f"  - {package.name} ({scope})", highlight=False)
-                for version in package.get_versions():
-                    if version == package.default_version:
-                        console.print(f"    -  [bold]{version} (default)[/bold]", highlight=False)
-                    else:
-                        console.print(f"    -  {version}", highlight=False)
-
-
-@click.argument("services", nargs=-1, required=True)
 @click.option(
-    "--parallel",
-    type=int,
-    default=1,
+    "--version",
+    type=str,
+    default=None,
     required=False,
-    help="how many installers to run in parallel processes",
+    help="version to install of a package",
 )
 @click.option(
     "--target",
@@ -149,81 +69,62 @@ def list_service_packages():
     required=False,
     help="target of the installation",
 )
-def install_service_packages(services: List[str], parallel: int, target: str):
-    pass
+def install(
+    package: List[str],
+    parallel: Optional[int] = 1,
+    version: Optional[str] = None,
+    target: Optional[str] = None,
+):
     """
-    available_packages = _get_available_packages()
-    service_provider_config = ServiceProviderConfig("pro")
-    service_provider_config.load_from_environment()
-    aws_provider_specs = dict(sorted(SERVICE_PLUGINS.api_provider_specs.items()))
-    packages_plugin_manager = PackagesPluginManager()
-    package_plugin_specs = packages_plugin_manager.package_plugin_specs
-    package_plugins = packages_plugin_manager.get_packages()
-    for api, names in aws_provider_specs.items():
-        for name in sorted(names):
-            # check if the plugin is available
-            if api not in package_plugin_specs or name not in package_plugin_specs[api]:
-                continue
-            if api in package_plugins and name in package_plugins[api]:
-                service_provider_config.set_provider_if_not_exists()
-    service_provider_config = config.SERVICE_PROVIDER_CONFIG
-    service_provider_config.
-    packages = []
-    for service in services:
-        packages += available_packages.get(service, [])
+    Install one or more packages.
+    """
+    console.print(f"resolving packages: {package}")
 
-    if not packages:
-        console.print(f"[red]error[/red] installing packages for {services}: No packages found.")
-        return
-
-    if target:
-        target = InstallTarget[str.upper(target)]
+    plugin_manager: PluginManager[PackagesPlugin] = PluginManager(namespace=PLUGIN_NAMESPACE)
+    plugin_specs = {
+        plugin_spec.name: plugin_spec for plugin_spec in plugin_manager.list_plugin_specs()
+    }
+    config.dirs.mkdirs()
+    package_instances: List[Package] = []
+    for pkg in package:
+        if pkg not in plugin_specs:
+            raise ClickException(f"unable to locate installer for package {pkg}")
+        package_instances.append(plugin_manager.load(pkg).get_package())
 
     if parallel > 1:
         console.print(f"install {parallel} packages in parallel:")
 
-    with Pool(processes=parallel) as pool:
-        pool.starmap(
-            _do_install_package, zip(packages, itertools.repeat(None), itertools.repeat(target))
-        )
-    """
-
-
-if not config.LEGACY_LPM_INSTALLERS:
-    # TODO remove the feature flag and enable this by default with the next minor version
-    # Enables new features for LPM
-    cli.command(name="list-service-packages", help="Lists packages used by services.")(
-        list_service_packages
-    )
-    cli.command(name="install-service-packages", help="Installs all packages for a service.")(
-        install_service_packages
-    )
-
-    click.option(
-        "--version",
-        type=str,
-        default=None,
-        required=False,
-        help="version to install of a package",
-    )(install)
-    click.option(
-        "--target",
-        type=click.Choice([target.name.lower() for target in InstallTarget]),
-        default=None,
-        required=False,
-        help="target of the installation",
-    )(install)
+    # collect installers and install in parallel:
+    try:
+        if target:
+            target = InstallTarget[str.upper(target)]
+        for package_instance in package_instances:
+            _do_install_package(package_instance, version, target)
+    except Exception:
+        raise ClickException("one or more package installations failed.")
 
 
 @cli.command(name="list")
-def list_packages():
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    required=False,
+    help="Verbose output (show additional info on packages)",
+)
+def list_packages(verbose: bool):
     """List available packages of all repositories"""
-    # TODO migrate to new package based installers instead of using the repositories
-    installers = InstallerManager()
-
-    for repo in installers.repositories.load_all():
-        for package, _ in repo.get_installer():
-            console.print(f"[green]{package}[/green]/{repo.name}")
+    plugin_manager: PluginManager[PackagesPlugin] = PluginManager(namespace=PLUGIN_NAMESPACE)
+    plugins = plugin_manager.load_all()
+    packages = sorted([(plugin.name, plugin.scope, plugin.get_package()) for plugin in plugins])
+    for package_name, package_scope, package_instance in packages:
+        console.print(f"[green]{package_name}[/green]/{package_scope}")
+        if verbose:
+            for version in package_instance.get_versions():
+                if version == package_instance.default_version:
+                    console.print(f"    -  [bold]{version} (default)[/bold]", highlight=False)
+                else:
+                    console.print(f"    -  {version}", highlight=False)
 
 
 if __name__ == "__main__":

--- a/localstack/packages/__init__.py
+++ b/localstack/packages/__init__.py
@@ -5,7 +5,7 @@ from .api import (
     PackageException,
     PackageInstaller,
     PackagesPlugin,
-    packages,
+    package,
 )
 from .core import DownloadInstaller, GitHubReleaseInstaller, SystemNotSupportedException
 
@@ -19,5 +19,5 @@ __all__ = [
     "NoSuchVersionException",
     "SystemNotSupportedException",
     "PackagesPlugin",
-    "packages",
+    "package",
 ]

--- a/localstack/packages/__init__.py
+++ b/localstack/packages/__init__.py
@@ -4,7 +4,6 @@ from .api import (
     Package,
     PackageException,
     PackageInstaller,
-    PackageRepository,
     PackagesPlugin,
     packages,
 )
@@ -19,7 +18,6 @@ __all__ = [
     "PackageException",
     "NoSuchVersionException",
     "SystemNotSupportedException",
-    "PackageRepository",
     "PackagesPlugin",
     "packages",
 ]

--- a/localstack/packages/__init__.py
+++ b/localstack/packages/__init__.py
@@ -6,6 +6,7 @@ from .api import (
     PackageInstaller,
     PackagesPlugin,
     package,
+    packages,
 )
 from .core import DownloadInstaller, GitHubReleaseInstaller, SystemNotSupportedException
 
@@ -20,4 +21,5 @@ __all__ = [
     "SystemNotSupportedException",
     "PackagesPlugin",
     "package",
+    "packages",
 ]

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -246,7 +246,7 @@ class MultiPackageInstaller(PackageInstaller):
         :return: None
         """
         for package_installer in self.package_installer:
-            package_installer.install(target)
+            package_installer.install(target=target)
 
     def _install(self, target: InstallTarget) -> None:
         # This package installer actually only calls other installers, we pass here

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -248,6 +248,10 @@ class MultiPackageInstaller(PackageInstaller):
         for package_installer in self.package_installer:
             package_installer.install(target=target)
 
+    def get_installed_dir(self) -> str | None:
+        # By default, use the installed-dir of the first package
+        return self.package_installer[0].get_installed_dir()
+
     def _install(self, target: InstallTarget) -> None:
         # This package installer actually only calls other installers, we pass here
         pass

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -195,7 +195,7 @@ class Package(abc.ABC):
         :raises NoSuchVersionException: If the given version is not supported.
         """
         if not version:
-            version = self.default_version
+            return self.get_installer(self.default_version)
         if version not in self.get_versions():
             raise NoSuchVersionException()
         return self._get_installer(version)

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -220,6 +220,46 @@ class Package(abc.ABC):
         return self.name
 
 
+class MultiPackageInstaller(PackageInstaller):
+    """
+    PackageInstaller implementation which composes of multiple package installers.
+    """
+
+    def __init__(self, name: str, version: str, package_installer: List[PackageInstaller]):
+        """
+        :param name: of the (multi-)package installer
+        :param version: of this (multi-)package installer
+        :param package_installer: List of installers this multi-package installer consists of
+        """
+        super().__init__(name=name, version=version)
+
+        assert isinstance(package_installer, list)
+        assert len(package_installer) > 0
+        self.package_installer = package_installer
+
+    def install(self, target: Optional[InstallTarget] = None) -> None:
+        """
+        Installs the different packages this installer is composed of.
+
+        :param target: which defines where to install the packages.
+        :return: None
+        """
+        for package_installer in self.package_installer:
+            package_installer.install(target)
+
+    def _install(self, target: InstallTarget) -> None:
+        # This package installer actually only calls other installers, we pass here
+        pass
+
+    def _get_install_dir(self, target: InstallTarget) -> str:
+        # By default, use the install-dir of the first package
+        return self.package_installer[0]._get_install_dir(target)
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        # By default, use the install-marker-path of the first package
+        return self.package_installer[0]._get_install_marker_path(install_dir)
+
+
 PLUGIN_NAMESPACE = "localstack.packages"
 
 

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -317,3 +317,7 @@ def package(
         return PluginSpec(PLUGIN_NAMESPACE, f"{_name}/{scope}", factory=factory)
 
     return wrapper
+
+
+# TODO remove (only used for migrating to new #package decorator)
+packages = package

--- a/localstack/packages/debugpy.py
+++ b/localstack/packages/debugpy.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.utils.run import run
 
 
 class DebugPyPackage(Package):
@@ -34,12 +35,8 @@ class DebugPyPackageInstaller(PackageInstaller):
         return install_dir
 
     def _install(self, target: InstallTarget) -> None:
-        import pip
-
-        if hasattr(pip, "main"):
-            pip.main(["install", "debugpy"])
-        else:
-            pip._internal.main(["install", "debugpy"])
+        cmd = "pip install debugpy"
+        run(cmd)
 
 
 debugpy_package = DebugPyPackage()

--- a/localstack/packages/plugins.py
+++ b/localstack/packages/plugins.py
@@ -1,0 +1,8 @@
+from localstack.packages.api import Package, package
+
+
+@package(name="terraform")
+def terraform_package() -> Package:
+    from .terraform import terraform_package
+
+    return terraform_package

--- a/localstack/services/awslambda/plugins.py
+++ b/localstack/services/awslambda/plugins.py
@@ -1,14 +1,22 @@
-from typing import List
-
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-@packages(api="lambda")
-def awslambda_packages() -> List[Package]:
-    from localstack.services.awslambda.packages import (
-        awslambda_go_runtime_package,
-        awslambda_runtime_package,
-        lambda_java_libs_package,
-    )
+@package(name="awslambda-go-runtime")
+def awslambda_go_runtime_package() -> Package:
+    from localstack.services.awslambda.packages import awslambda_go_runtime_package
 
-    return [awslambda_runtime_package, awslambda_go_runtime_package, lambda_java_libs_package]
+    return awslambda_go_runtime_package
+
+
+@package(name="awslambda-runtime")
+def awslambda_runtime_package() -> Package:
+    from localstack.services.awslambda.packages import awslambda_runtime_package
+
+    return awslambda_runtime_package
+
+
+@package(name="lambda-java-libs")
+def lambda_java_libs() -> Package:
+    from localstack.services.awslambda.packages import lambda_java_libs_package
+
+    return lambda_java_libs_package

--- a/localstack/services/awslambda/plugins.py
+++ b/localstack/services/awslambda/plugins.py
@@ -1,22 +1,14 @@
+from typing import List
+
 from localstack.packages import Package, packages
 
 
-@packages()
-def awslambda_runtime_package() -> Package:
-    from localstack.services.awslambda.packages import awslambda_runtime_package
+@packages(api="lambda")
+def awslambda_packages() -> List[Package]:
+    from localstack.services.awslambda.packages import (
+        awslambda_go_runtime_package,
+        awslambda_runtime_package,
+        lambda_java_libs_package,
+    )
 
-    return awslambda_runtime_package
-
-
-@packages(name="awslambda_go_runtime")
-def awslambda_go_runtime_package() -> Package:
-    from localstack.services.awslambda.packages import awslambda_go_runtime_package
-
-    return awslambda_go_runtime_package
-
-
-@packages(name="lambda_java_libs")
-def lambda_javalibs_package() -> Package:
-    from localstack.services.awslambda.packages import lambda_java_libs_package
-
-    return lambda_java_libs_package
+    return [awslambda_runtime_package, awslambda_go_runtime_package, lambda_java_libs_package]

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -1,19 +1,11 @@
 import builtins
 import json
-import os
 import re
 from copy import deepcopy
 from typing import Callable
 
-from localstack.config import dirs
 from localstack.utils import common
 from localstack.utils.common import select_attributes, short_uid
-
-# URL to "cfn-response" module which is required in some CF Lambdas. The purpose of cfn-response is to make it easier
-# to write "inline" code for custom resources. TODO: consider copying code into our repo instead of downloading it
-CFN_RESPONSE_MODULE_URL = (
-    "https://raw.githubusercontent.com/LukeMizuhashi/cfn-response/master/index.js"
-)
 
 # placeholders
 PLACEHOLDER_RESOURCE_NAME = "__resource_name__"
@@ -119,13 +111,6 @@ def param_json_to_str(name):
         return result
 
     return _convert
-
-
-def get_cfn_response_mod_file():
-    cfn_response_tmp_file = os.path.join(dirs.static_libs, "lambda.cfn-response.js")
-    if not os.path.exists(cfn_response_tmp_file):
-        common.download(CFN_RESPONSE_MODULE_URL, cfn_response_tmp_file)
-    return cfn_response_tmp_file
 
 
 def lambda_select_params(*selected):

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -4,9 +4,9 @@ from localstack.services.awslambda.lambda_api import get_lambda_policy_name
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
-    get_cfn_response_mod_file,
     select_parameters,
 )
+from localstack.services.cloudformation.packages import cloudformation_package
 from localstack.services.cloudformation.service_models import LOG, REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import (
@@ -97,7 +97,10 @@ class LambdaFunction(GenericBaseModel):
 
             # add 'cfn-response' module to archive - see:
             # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html
-            cfn_response_tmp_file = get_cfn_response_mod_file()
+            cloudformation_installer = cloudformation_package.get_installer()
+            cloudformation_installer.install()
+            cfn_response_tmp_file = cloudformation_installer.get_executable_path()
+
             cfn_response_mod_dir = os.path.join(tmp_dir, "node_modules", "cfn-response")
             mkdir(cfn_response_mod_dir)
             cp_r(

--- a/localstack/services/cloudformation/plugins.py
+++ b/localstack/services/cloudformation/plugins.py
@@ -1,8 +1,8 @@
-from localstack.packages import packages
+from localstack.packages import Package, package
 
 
-@packages()
-def cloudformation_package():
+@package(name="cloudformation-libs")
+def cloudformation_package() -> Package:
     from localstack.services.cloudformation.packages import cloudformation_package
 
     return cloudformation_package

--- a/localstack/services/dynamodb/plugins.py
+++ b/localstack/services/dynamodb/plugins.py
@@ -1,8 +1,8 @@
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-@packages()
-def dynamodb_package() -> Package:
+@package(name="dynamodb-local")
+def dynamodb_local_package() -> Package:
     from localstack.services.dynamodb.packages import dynamodblocal_package
 
     return dynamodblocal_package

--- a/localstack/services/es/plugins.py
+++ b/localstack/services/es/plugins.py
@@ -1,7 +1,7 @@
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-@packages()
+@package(name="elasticsearch")
 def elasticsearch_package() -> Package:
     from localstack.services.opensearch.packages import elasticsearch_package
 

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -6,7 +6,9 @@ import re
 import sys
 import tempfile
 import time
-from typing import Union
+from typing import Callable, List, Tuple, Union
+
+from plugin import Plugin
 
 from localstack import config
 from localstack.config import dirs
@@ -214,6 +216,19 @@ def download_and_extract_with_retry(archive_url, tmp_archive, target_dir):
         LOG.info("Unable to extract file, re-downloading ZIP archive %s: %s", tmp_archive, e)
         rm_rf(tmp_archive)
         download_and_extract(archive_url, target_dir, tmp_archive=tmp_archive)
+
+
+# TODO remove (only used for migrating to new #package plugin system)
+
+Installer = Tuple[str, Callable]
+
+
+class InstallerRepository(Plugin):
+    # TODO the installer repositories should be migrated (downwards compatible) to use the packages / package installers
+    namespace = "localstack.installer"
+
+    def get_installer(self) -> List[Installer]:
+        raise NotImplementedError
 
 
 def main():

--- a/localstack/services/install.py
+++ b/localstack/services/install.py
@@ -132,13 +132,6 @@ def upgrade_jar_file(base_dir: str, file_glob: str, maven_asset: str):
     download(maven_asset_url, target_file)
 
 
-def install_cloudformation_libs():
-    from localstack.services.cloudformation import deployment_utils
-
-    # trigger download of CF module file
-    deployment_utils.get_cfn_response_mod_file()
-
-
 def install_component(name):
     from localstack.packages import InstallTarget
     from localstack.services.awslambda.packages import awslambda_runtime_package

--- a/localstack/services/kinesis/plugins.py
+++ b/localstack/services/kinesis/plugins.py
@@ -2,8 +2,7 @@ from localstack import config
 from localstack.packages import Package, packages
 
 
-@packages()
-def kinesis_package() -> Package:
+def _common_package() -> Package:
     if config.KINESIS_PROVIDER == "kinesalite":
         from localstack.services.kinesis.packages import kinesalite_package
 
@@ -12,3 +11,13 @@ def kinesis_package() -> Package:
         from localstack.services.kinesis.packages import kinesismock_package
 
         return kinesismock_package
+
+
+@packages()
+def kinesis_package() -> Package:
+    return _common_package()
+
+
+@packages(name="legacy")
+def kinesis_package_legacy() -> Package:
+    return _common_package()

--- a/localstack/services/kinesis/plugins.py
+++ b/localstack/services/kinesis/plugins.py
@@ -1,23 +1,15 @@
-from localstack import config
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-def _common_package() -> Package:
-    if config.KINESIS_PROVIDER == "kinesalite":
-        from localstack.services.kinesis.packages import kinesalite_package
+@package(name="kinesalite")
+def kinesalite_package() -> Package:
+    from localstack.services.kinesis.packages import kinesalite_package
 
-        return kinesalite_package
-    else:
-        from localstack.services.kinesis.packages import kinesismock_package
-
-        return kinesismock_package
+    return kinesalite_package
 
 
-@packages()
-def kinesis_package() -> Package:
-    return _common_package()
+@package(name="kinesis-mock")
+def kinesismock_package() -> Package:
+    from localstack.services.kinesis.packages import kinesismock_package
 
-
-@packages(name="legacy")
-def kinesis_package_legacy() -> Package:
-    return _common_package()
+    return kinesismock_package

--- a/localstack/services/kms/plugins.py
+++ b/localstack/services/kms/plugins.py
@@ -1,8 +1,8 @@
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-@packages()
-def kms_package() -> Package:
+@package(name="local-kms")
+def local_kms_package() -> Package:
     from localstack.services.kms.packages import kms_local_package
 
     return kms_local_package

--- a/localstack/services/kms/plugins.py
+++ b/localstack/services/kms/plugins.py
@@ -2,7 +2,7 @@ from localstack.packages import Package, packages
 
 
 @packages()
-def kms_local_package() -> Package:
+def kms_package() -> Package:
     from localstack.services.kms.packages import kms_local_package
 
     return kms_local_package

--- a/localstack/services/opensearch/plugins.py
+++ b/localstack/services/opensearch/plugins.py
@@ -1,7 +1,7 @@
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-@packages()
+@package(name="opensearch")
 def opensearch_package() -> Package:
     from localstack.services.opensearch.packages import opensearch_package
 

--- a/localstack/services/sqs/legacy/packages.py
+++ b/localstack/services/sqs/legacy/packages.py
@@ -19,10 +19,13 @@ class ElasticMQPackage(Package):
         return ["1.1.0"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
-        return ElasticMQPackageInstaller("elasticmq", version)
+        return ElasticMQPackageInstaller()
 
 
 class ElasticMQPackageInstaller(PackageInstaller):
+    def __init__(self):
+        super().__init__("elasticmq", "1.1.0")
+
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "elasticmq-server.jar")
 

--- a/localstack/services/sqs/legacy/plugins.py
+++ b/localstack/services/sqs/legacy/plugins.py
@@ -1,8 +1,8 @@
-from localstack.packages import packages
+from localstack.packages import package
 
 
-@packages(api="sqs", name="legacy")
-def sqs_package():
+@package(name="elasticmq")
+def elasticmq_package():
     from localstack.services.sqs.legacy.packages import elasticmq_package
 
     return elasticmq_package

--- a/localstack/services/sqs/legacy/plugins.py
+++ b/localstack/services/sqs/legacy/plugins.py
@@ -1,8 +1,8 @@
 from localstack.packages import packages
 
 
-@packages(service="sqs", name="elasticmq")
-def elasticmq_package():
+@packages(api="sqs", name="legacy")
+def sqs_package():
     from localstack.services.sqs.legacy.packages import elasticmq_package
 
     return elasticmq_package

--- a/localstack/services/stepfunctions/plugins.py
+++ b/localstack/services/stepfunctions/plugins.py
@@ -1,8 +1,8 @@
-from localstack.packages import Package, packages
+from localstack.packages import Package, package
 
 
-@packages()
-def stepfunctions_packages() -> Package:
+@package(name="stepfunctions-local")
+def stepfunctions_local_packages() -> Package:
     from localstack.services.stepfunctions.packages import stepfunctions_local_package
 
     return stepfunctions_local_package

--- a/localstack/services/stepfunctions/plugins.py
+++ b/localstack/services/stepfunctions/plugins.py
@@ -2,7 +2,7 @@ from localstack.packages import Package, packages
 
 
 @packages()
-def stepfunctions_local_package() -> Package:
+def stepfunctions_packages() -> Package:
     from localstack.services.stepfunctions.packages import stepfunctions_local_package
 
     return stepfunctions_local_package

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -1,11 +1,9 @@
 import os.path
-from typing import List
 
 import pytest
 from click.testing import CliRunner
 
 from localstack.cli.lpm import cli, console
-from localstack.services.install import CommunityInstallerRepository, Installer
 
 
 @pytest.fixture
@@ -31,29 +29,15 @@ def test_install_with_non_existing_package_fails(runner):
 
 @pytest.mark.skip_offline
 def test_install_failure_returns_non_zero_exit_code(runner, monkeypatch):
-    def failing_installer():
-        raise Exception("failing installer")
-
-    def successful_installer():
-        pass
-
-    def patched_get_installer(self) -> List[Installer]:
-        return [
-            ("failing-installer", failing_installer),
-            ("successful-installer", successful_installer),
-        ]
-
-    monkeypatch.setattr(CommunityInstallerRepository, "get_installer", patched_get_installer)
-
-    result = runner.invoke(cli, ["install", "successful-installer", "failing-installer"])
-    assert result.exit_code == 1
-    assert "one or more package installations failed." in result.output
+    # TODO Migrate to new structure
+    pass
 
 
 @pytest.mark.skip_offline
 def test_install_with_package(runner):
     from localstack.services.sqs.legacy.packages import elasticmq_package
 
+    # TODO The scope is now mandatory
     result = runner.invoke(cli, ["install", "elasticmq"])
     assert result.exit_code == 0
     assert os.path.exists(elasticmq_package.get_installed_dir())

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -4,8 +4,9 @@ from typing import List
 import pytest
 from click.testing import CliRunner
 
-from localstack.cli.lpm import _load_packages, cli, console
+from localstack.cli.lpm import cli, console
 from localstack.packages import InstallTarget, Package, PackageException, PackageInstaller
+from localstack.packages.api import PackagesPluginManager
 from localstack.utils.patch import Patch
 
 
@@ -84,10 +85,10 @@ def test_install_failure_returns_non_zero_exit_code(runner, monkeypatch):
         def _install(self, target: InstallTarget) -> None:
             pass
 
-    def patched_load_packages(_) -> List[Package]:
+    def patched_get_packages(*_) -> List[Package]:
         return [FailingPackage(), SuccessfulPackage()]
 
-    with Patch.function(target=_load_packages, fn=patched_load_packages):
+    with Patch.function(target=PackagesPluginManager.get_packages, fn=patched_get_packages):
         result = runner.invoke(cli, ["install", "successful-installer", "failing-installer"])
         assert result.exit_code == 1
         assert "one or more package installations failed." in result.output

--- a/tests/unit/cli/test_lpm.py
+++ b/tests/unit/cli/test_lpm.py
@@ -31,6 +31,16 @@ def test_install_with_non_existing_package_fails(runner):
 
 
 @pytest.mark.skip_offline
+def test_install_with_non_existing_version_fails(runner):
+    result = runner.invoke(cli, ["install", "elasticmq", "--version", "non-existing-version"])
+    assert result.exit_code == 1
+    assert (
+        "unable to locate installer for package elasticmq and version non-existing-version"
+        in result.output
+    )
+
+
+@pytest.mark.skip_offline
 def test_install_failure_returns_non_zero_exit_code(runner, monkeypatch):
     class FailingPackage(Package):
         def __init__(self):

--- a/tests/unit/packages/test_api.py
+++ b/tests/unit/packages/test_api.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.utils.files import rm_rf
+
+
+class TestPackage(Package):
+    def __init__(self):
+        super().__init__("Test Package", "test-version")
+
+    def get_versions(self) -> List[str]:
+        return ["test-version"]
+
+    def _get_installer(self, version: str) -> PackageInstaller:
+        return TestPackageInstaller(version=version)
+
+
+class TestPackageInstaller(PackageInstaller):
+    def __init__(self, version: str):
+        super().__init__("test-installer", version)
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "test-installer-marker")
+
+    def _install(self, target: InstallTarget) -> None:
+        path = Path(os.path.join(self._get_install_dir(target), "test-installer-marker"))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+
+@pytest.fixture(scope="module")
+def test_package():
+    package = TestPackage()
+    if package.get_installed_dir():
+        rm_rf(package.get_installed_dir())
+
+    yield package
+
+    if package.get_installed_dir():
+        rm_rf(package.get_installed_dir())
+
+
+def test_package_get_installer_caches_installers(test_package):
+    assert test_package.get_installer() is test_package.get_installer(test_package.default_version)
+
+
+def test_package_get_installed_dir_returns_none(test_package):
+    assert test_package.get_installed_dir() is None
+
+
+def test_package_get_installed_dir_returns_install_dir(test_package):
+    test_package.install()
+    assert test_package.get_installed_dir() is not None


### PR DESCRIPTION
This PR migrates LPM to use a new plugin mechanism based on the package abstraction introduced in https://github.com/localstack/localstack/pull/6783.

It basically replaces the (pluggable) `InstallerRepository` classes with **fine-grained package plugins** where each entrypoint delivers a single package. The package plugins can have a scope (f.e. `community` or `ext`), which directly relates to the former `InstallerRepository` namespace.

A package can easily be defined as follows:
```python
@package(name="dynamodb-local")
def dynamodb_local_package() -> Package:
    from localstack.services.dynamodb.packages import dynamodblocal_package

    return dynamodblocal_package
```
The local import is necessary to avoid loading all installers (and their code) when discovering / listing the packages.
The resulting `lpm list` looks the same as before:
```bash
dynamodb-local/community
```

It also adds the following features to `lpm`:
- **List package versions**: A "verbose" output to `lpm list` (with `--verbose` or `-v`) which shows the available versions for the different packages.
- **Specify the installation target**: Define if the package should be installed to `var_libs` or to `static_libs` (with `--target <var_libs|static_libs>`). Defaults to `static_libs` (since `lpm` is meant to be used at Docker build time).
- **Specify the version**: Define the version of a package to be installed (with `--version <version>`). This can be used across the installation of multiple packages, however there is no syntax for defining different versions for different packages yet.

Feedback on the plugin mechanism, usage, and the implementation in general is highly appreciated. :)