### PR TITLE
deactivate VirtualHostRewriter for s3 ASF

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -87,6 +87,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 
 from localstack.aws.api import HttpRequest
 from localstack.aws.protocol.op_router import RestServiceOperationRouter
+from localstack.config import LEGACY_S3_PROVIDER
 
 
 def _text_content(func):
@@ -1048,8 +1049,11 @@ class S3RequestParser(RestXMLRequestParser):
 
     @_handle_exceptions
     def parse(self, request: HttpRequest) -> Tuple[OperationModel, Any]:
-        """Handle virtual-host-addressing for S3."""
-        with self.VirtualHostRewriter(request):
+        if LEGACY_S3_PROVIDER:
+            """Handle virtual-host-addressing for S3."""
+            with self.VirtualHostRewriter(request):
+                return super().parse(request)
+        else:
             return super().parse(request)
 
     def _parse_shape(

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -156,6 +156,10 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         store = self.get_store()
         store.bucket_lifecycle_configuration.pop(bucket, None)
         store.bucket_versioning_status.pop(bucket, None)
+        store.bucket_cors.pop(bucket, None)
+        store.bucket_notification_configs.pop(bucket, None)
+        store.bucket_replication.pop(bucket, None)
+        store.bucket_website_configuration.pop(bucket, None)
 
     def on_after_init(self):
         apply_moto_patches()

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -105,7 +105,6 @@ from localstack.services.s3.utils import (
     is_valid_canonical_id,
     verify_checksum,
 )
-from localstack.services.s3.virtual_host import register_virtual_host_routes
 from localstack.services.s3.website_hosting import register_website_hosting_routes
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_stack import s3_bucket_name
@@ -163,7 +162,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
     def on_after_init(self):
         apply_moto_patches()
-        register_virtual_host_routes(router=ROUTER)
+        # registering of virtual host routes happens with the hook on_infra_ready
         register_website_hosting_routes(router=ROUTER)
         register_custom_handlers()
 

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -162,9 +162,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
     def on_after_init(self):
         apply_moto_patches()
-        # registering of virtual host routes happens with the hook on_infra_ready
         register_website_hosting_routes(router=ROUTER)
         register_custom_handlers()
+        # registering of virtual host routes happens with the hook on_infra_ready in virtual_host.py
 
     def __init__(self) -> None:
         super().__init__()

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1281,7 +1281,7 @@ class TestS3:
         assert re.match(r"^<\?xml [^>]+>\n<.*", content, flags=re.MULTILINE)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..Error.RequestID"])
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..Error.RequestID"])
     def test_different_location_constraint(
         self,
         s3_client,
@@ -2442,7 +2442,6 @@ class TestS3:
             ACL="public-read-write",
         )
 
-        # TODO delete does currently not work with S3_VIRTUAL_HOSTNAME
         url = f"{_bucket_url(bucket_name, localstack_host=config.LOCALSTACK_HOSTNAME)}?delete"
 
         data = f"""
@@ -2463,7 +2462,7 @@ class TestS3:
 
         assert 200 == r.status_code
         response = xmltodict.parse(r.content)
-        response["DeleteResult"].pop("@xmlns")
+        response["DeleteResult"].pop("@xmlns", None)
         assert response["DeleteResult"]["Error"]["Key"] == object_key_1
         assert response["DeleteResult"]["Error"]["Code"] == "AccessDenied"
         assert response["DeleteResult"]["Deleted"]["Key"] == object_key_2

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -6,6 +6,7 @@ import pytest
 from botocore.awsrequest import prepare_request_dict
 from botocore.serialize import create_serializer
 
+from localstack import config
 from localstack.aws.protocol.parser import (
     OperationNotFoundParserError,
     ProtocolParserError,
@@ -1098,6 +1099,9 @@ def test_restxml_header_date_parsing():
     )
 
 
+@pytest.mark.skipif(
+    not config.LEGACY_S3_PROVIDER, reason="ASF provider does not rely on virtual host parser"
+)
 def test_s3_virtual_host_addressing():
     """Test the parsing of an S3 bucket request using the bucket encoded in the domain."""
     request = HttpRequest(


### PR DESCRIPTION
This PR deactivates the `VirtualHostRewriter` if the ASF provider for S3 is activated.

S3 virtual host routes are registered `on_infra_ready` to ensure the hosts are resolved correctly, even if s3 is not yet loaded (this requirement was revealed by the terraform test suite).



