### PR TITLE
DynamoDB Table CFn-model proper default table name

### DIFF
--- a/tests/integration/cloudformation/resources/test_dynamodb.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_dynamodb.snapshot.json
@@ -1,0 +1,39 @@
+{
+  "tests/integration/cloudformation/resources/test_dynamodb.py::test_default_name_for_table": {
+    "recorded-date": "21-10-2022, 11:11:09",
+    "recorded-content": {
+      "table_description": {
+        "Table": {
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "keyName",
+              "AttributeType": "S"
+            }
+          ],
+          "CreationDateTime": "datetime",
+          "ItemCount": 0,
+          "KeySchema": [
+            {
+              "AttributeName": "keyName",
+              "KeyType": "HASH"
+            }
+          ],
+          "ProvisionedThroughput": {
+            "NumberOfDecreasesToday": 0,
+            "ReadCapacityUnits": 5,
+            "WriteCapacityUnits": 5
+          },
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<table-name:1>",
+          "TableId": "<uuid:1>",
+          "TableName": "<table-name:1>",
+          "TableSizeBytes": 0,
+          "TableStatus": "ACTIVE"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/templates/dynamodb_table_defaults.yml
+++ b/tests/integration/templates/dynamodb_table_defaults.yml
@@ -1,0 +1,17 @@
+Resources:
+  Table:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        KeySchema:
+          - AttributeName: keyName
+            KeyType: HASH
+        AttributeDefinitions:
+          - AttributeName: keyName
+            AttributeType: S
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5
+
+Outputs:
+  TableName:
+    Value: !Ref Table


### PR DESCRIPTION
Related to #7050. The problem is that the resource model of the table generates the table name only when the resource is created, but the table name (also used as Ref) can be referenced before that.

The fix to the situation is to create the default name at the proper time so it can be used (referenced) before its creation.