### PR TITLE
Visitor pattern to collect service backends

### DIFF
--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -29,7 +29,7 @@ class StateVisitable(Protocol):
         """
 
 
-class ServiceBackend(TypedDict):
+class ServiceBackend(TypedDict, total=False):
     """Wrapper of the possible type of backends that a service can use."""
 
     localstack: AccountRegionBundle | None
@@ -56,7 +56,12 @@ class ServiceBackendCollectorVisitor:
         self.backend_dict = state_container
 
     def collect(self) -> ServiceBackend:
-        return ServiceBackend(localstack=self.store, moto=self.backend_dict)
+        service_backend = ServiceBackend()
+        if self.store:
+            service_backend.update({"localstack": self.store})
+        if self.backend_dict:
+            service_backend.update({"moto": self.backend_dict})
+        return service_backend
 
 
 def _load_attribute_from_module(module_name: str, attribute_name: str) -> Any | None:

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -39,9 +39,12 @@ class ServiceBackend(TypedDict, total=False):
 class ServiceBackendCollectorVisitor:
     """Implementation of StateVisitor meant to collect the backends that a given service use to hold its state."""
 
+    store: AccountRegionBundle | None
+    backend_dict: BackendDict | Dict | None
+
     def __init__(self) -> None:
-        self.store: AccountRegionBundle | None = None
-        self.backend_dict: BackendDict | Dict | None = None
+        self.store = None
+        self.backend_dict = None
 
     @singledispatchmethod
     def visit(self, state_container: Any):

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -10,7 +10,7 @@ from localstack.services.stores import AccountRegionBundle
 LOG = logging.getLogger(__name__)
 
 
-class StateVisitor:
+class StateVisitor(Protocol):
     def visit(self, state_container: Any):
         """
         Visit (=do something with) a given state container. A state container can be anything that holds service state.
@@ -127,9 +127,8 @@ class ReflectionStateLocator:
                 # it first looks for a module in ext; eventually, it falls back to community
                 attribute = _load_attribute_from_module(module_name, attribute_name)
                 if attribute is None:
-                    attribute = _load_attribute_from_module(
-                        f"localstack.services.{service_name}.models", attribute_name
-                    )
+                    module_name = f"localstack.services.{service_name}.models"
+                    attribute = _load_attribute_from_module(module_name, attribute_name)
 
                 if attribute is not None:
                     LOG.debug("Visiting attribute %s in module %s", attribute_name, module_name)

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -1,0 +1,140 @@
+import importlib
+import logging
+from functools import singledispatchmethod
+from typing import Any, Dict, List, Protocol, TypedDict, runtime_checkable
+
+from moto.core.utils import BackendDict
+
+from localstack.services.stores import AccountRegionBundle
+
+LOG = logging.getLogger(__name__)
+
+
+class StateVisitor:
+    def visit(self, state_container: Any):
+        """
+        Visit (=do something with) a given state container. A state container can be anything that holds service state.
+        An AccountRegionBundle, a moto BackendDict, or a directory containing assets.
+        """
+        raise NotImplementedError
+
+
+@runtime_checkable
+class StateVisitable(Protocol):
+    def accept(self, visitor: StateVisitor):
+        """
+        Accept a StateVisitor. The implementing method should call visit not necessarily on itself, but can also call
+        the visit method on the state container it holds. The common case is calling visit on the stores of a provider.
+        :param visitor: the StateVisitor
+        """
+
+
+class ServiceBackend(TypedDict):
+    """Wrapper of the possible type of backends that a service can use."""
+
+    localstack: AccountRegionBundle | None
+    moto: BackendDict | Dict | None
+
+
+class ServiceBackendCollectorVisitor:
+    """Implementation of StateVisitor meant to collect the backends that a given service use to hold its state."""
+
+    def __init__(self) -> None:
+        self.store: AccountRegionBundle | None = None
+        self.backend_dict: BackendDict | Dict | None = None
+
+    @singledispatchmethod
+    def visit(self, state_container: Any):
+        raise NotImplementedError("Can't restore state container o type %s", type(state_container))
+
+    @visit.register(AccountRegionBundle)
+    def _(self, state_container: AccountRegionBundle):
+        self.store = state_container
+
+    @visit.register(BackendDict)
+    def _(self, state_container: BackendDict):
+        self.backend_dict = state_container
+
+    def collect(self) -> ServiceBackend:
+        return ServiceBackend(localstack=self.store, moto=self.backend_dict)
+
+
+def _load_attribute_from_module(module_name: str, attribute_name: str) -> Any | None:
+    """
+    Attempts at getting an attribute from a given module.
+    :return the attribute or None, if the attribute can't be found
+    """
+    try:
+        module = importlib.import_module(module_name)
+        return getattr(module, attribute_name)
+    except (ModuleNotFoundError, AttributeError) as e:
+        LOG.debug(
+            'Unable to get attribute "%s" for module "%s": "%s"', attribute_name, module_name, e
+        )
+        return None
+
+
+def _load_attributes(module_names: List[str], attribute_names: List[str]) -> List:
+    attributes = []
+    for _module, _attribute in zip(module_names, attribute_names):
+        attribute = _load_attribute_from_module(_module, _attribute)
+        if attribute:
+            attributes.append(attribute)
+    return attributes
+
+
+class ReflectionStateLocator:
+    """
+    Implementation of the StateVisitable protocol that uses reflection to visit and collect anything that hold state
+    for a service, based on the assumption that AccountRegionBundle and BackendDict are stored in a predictable
+    location with a predictable naming.
+    """
+
+    provider: Any
+
+    def __init__(self, provider: Any):
+        self.provider = provider
+
+    def accept(self, visitor: StateVisitor):
+        service: str = self.provider.snake_service_name.replace(
+            "-", "_"
+        )  # needed for services like cognito-idp
+
+        match service:
+            # lambda is a special case in package and module naming
+            # the store attribute is `awslambda_stores` in `localstack.services.awslambda.lambda_models`
+            case "lambda":
+                modules = [
+                    ("localstack.services.awslambda.lambda_models", "awslambda_stores"),
+                    ("moto.awslambda.models", "lambda_backends"),
+                ]
+                for _module, _attribute in modules:
+                    attribute = _load_attribute_from_module(_module, _attribute)
+                    if attribute is not None:
+                        LOG.debug("Visiting attribute %s in module %s", _attribute, _module)
+                        visitor.visit(attribute)
+
+            case _:
+                # try to load AccountRegionBundle from predictable location
+                attribute_name = f"{service}_stores"
+                module_name = f"localstack_ext.services.{service}.models"
+
+                # it first looks for a module in ext; eventually, it falls back to community
+                attribute = _load_attribute_from_module(module_name, attribute_name)
+                if attribute is None:
+                    attribute = _load_attribute_from_module(
+                        f"localstack.services.{service}.models", attribute_name
+                    )
+
+                if attribute is not None:
+                    LOG.debug("Visiting attribute %s in module %s", attribute_name, module_name)
+                    visitor.visit(attribute)
+
+                # try to load BackendDict from predictable location
+                module_name = f"moto.{service}.models"
+                attribute_name = f"{service}_backends"
+                attribute = _load_attribute_from_module(module_name, attribute_name)
+
+                if attribute is not None:
+                    LOG.debug("Visiting attribute %s in module %s", attribute_name, module_name)
+                    visitor.visit(attribute)

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -45,7 +45,7 @@ class ServiceBackendCollectorVisitor:
 
     @singledispatchmethod
     def visit(self, state_container: Any):
-        raise NotImplementedError("Can't restore state container o type %s", type(state_container))
+        raise NotImplementedError("Can't restore state container of type %s", type(state_container))
 
     @visit.register(AccountRegionBundle)
     def _(self, state_container: AccountRegionBundle):

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -1,7 +1,7 @@
 import importlib
 import logging
 from functools import singledispatchmethod
-from typing import Any, Dict, List, Protocol, TypedDict, runtime_checkable, Optional
+from typing import Any, Dict, List, Optional, Protocol, TypedDict, runtime_checkable
 
 from moto.core.utils import BackendDict
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -16,11 +16,19 @@ from _pytest.config import Config
 from _pytest.nodes import Item
 from botocore.exceptions import ClientError
 from botocore.regions import EndpointResolver
+from moto.core import BaseBackend
+from moto.core.utils import BackendDict
 from pytest_httpserver import HTTPServer
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
+from localstack.services.stores import (
+    AccountRegionBundle,
+    BaseStore,
+    CrossRegionAttribute,
+    LocalAttribute,
+)
 from localstack.testing.aws.cloudformation_utils import load_template_file, render_template
 from localstack.testing.aws.util import get_lambda_logs
 from localstack.utils import testutil
@@ -1745,3 +1753,22 @@ def pytest_collection_modifyitems(config: Config, items: list[Item]):
     for item in items:
         if "only_localstack" in item.keywords:
             item.add_marker(only_localstack)
+
+
+@pytest.fixture
+def sample_stores() -> AccountRegionBundle:
+    class SampleStore(BaseStore):
+        CROSS_REGION_ATTR = CrossRegionAttribute(default=list)
+        region_specific_attr = LocalAttribute(default=list)
+
+    return AccountRegionBundle("zzz", SampleStore, validate=False)
+
+
+@pytest.fixture()
+def sample_backend_dict() -> BackendDict:
+    class SampleBackend(BaseBackend):
+        def __init__(self, region_name, account_id):
+            super().__init__(region_name, account_id)
+            self.attributes = {}
+
+    return BackendDict(SampleBackend, "sns")

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -1,21 +1,6 @@
 import pytest
-from pytest import fixture
 
-from localstack.services.stores import (
-    AccountRegionBundle,
-    BaseStore,
-    CrossRegionAttribute,
-    LocalAttribute,
-)
-
-
-@fixture
-def sample_stores() -> AccountRegionBundle:
-    class SampleStore(BaseStore):
-        CROSS_REGION_ATTR = CrossRegionAttribute(default=list)
-        region_specific_attr = LocalAttribute(default=list)
-
-    return AccountRegionBundle("zzz", SampleStore, validate=False)
+from localstack.services.stores import AccountRegionBundle, BaseStore
 
 
 class TestStores:

--- a/tests/unit/test_visitors.py
+++ b/tests/unit/test_visitors.py
@@ -5,7 +5,7 @@ from localstack.services.visitors import ReflectionStateLocator, ServiceBackendC
 
 
 class TestVisitors:
-    def test_store_load(self, sample_stores, monkeypatch):
+    def test_collect_store(self, sample_stores, monkeypatch):
         """Ensures that the visitor can effectively collect store backend"""
         account = "696969696969"
         eu_region = "eu-central-1"
@@ -24,7 +24,7 @@ class TestVisitors:
         oracle = {account: {eu_region: store}}
         assert store_backend == oracle
 
-    def test_load_backend_dicts(self, sample_backend_dict, monkeypatch):
+    def test_collect_backend_dict(self, sample_backend_dict, monkeypatch):
         """Ensures that the visitor can effectively collect backend dict backends"""
 
         account = "696969696969"

--- a/tests/unit/test_visitors.py
+++ b/tests/unit/test_visitors.py
@@ -1,0 +1,45 @@
+from moto.sns import models as sns_models
+
+from localstack.services.sqs import models as sqs_models
+from localstack.services.visitors import ReflectionStateLocator, ServiceBackendCollectorVisitor
+
+
+class TestVisitors:
+    def test_store_load(self, sample_stores, monkeypatch):
+        """Ensures that the visitor can effectively collect store backend"""
+        account = "696969696969"
+        eu_region = "eu-central-1"
+
+        store = sample_stores[account][eu_region]
+        monkeypatch.setattr(sqs_models, "sqs_stores", sample_stores)
+
+        visitor = ServiceBackendCollectorVisitor()
+        state_manager = ReflectionStateLocator(service="sqs")
+        state_manager.accept(visitor=visitor)
+        backends = visitor.collect()
+
+        store_backend = backends.get("localstack")
+        assert store_backend
+
+        oracle = {account: {eu_region: store}}
+        assert store_backend == oracle
+
+    def test_load_backend_dicts(self, sample_backend_dict, monkeypatch):
+        """Ensures that the visitor can effectively collect backend dict backends"""
+
+        account = "696969696969"
+        eu_region = "eu-central-1"
+
+        store = sample_backend_dict[account][eu_region]
+        store.attributes = {"key": "value"}
+
+        monkeypatch.setattr(sns_models, "sns_backends", sample_backend_dict)
+
+        visitor = ServiceBackendCollectorVisitor()
+        state_manager = ReflectionStateLocator(service="sns")
+        state_manager.accept(visitor=visitor)
+        backends = visitor.collect()
+
+        store_backend = backends.get("moto")
+        assert store_backend
+        assert store_backend[account][eu_region] == store


### PR DESCRIPTION
First POC of a visitor pattern we can use to retrieve the backends (meaning, an `AccountRegionBundle` and/or a `BackendDict`) of a service.

This is going to be used in the Cloud Pods code to replace `lookup_utils` and `get_backends` (see companion [PR](https://github.com/localstack/localstack-ext/pull/1124)).