### PR TITLE
implement ASF S3 CORS

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -177,6 +177,8 @@ StringToSignBytes = str
 CanonicalRequest = str
 CanonicalRequestBytes = str
 X_Amz_Expires = int
+HttpMethod = str
+ResourceType = str
 
 
 class AnalyticsS3ExportFileFormat(str):
@@ -705,6 +707,22 @@ class ReplicationConfigurationNotFoundError(ServiceException):
     sender_fault: bool = False
     status_code: int = 404
     BucketName: Optional[BucketName]
+
+
+class BadRequest(ServiceException):
+    code: str = "BadRequest"
+    sender_fault: bool = False
+    status_code: int = 400
+    HostId: Optional[HostId]
+
+
+class AccessForbidden(ServiceException):
+    code: str = "AccessForbidden"
+    sender_fault: bool = False
+    status_code: int = 403
+    HostId: Optional[HostId]
+    Method: Optional[HttpMethod]
+    ResourceType: Optional[ResourceType]
 
 
 AbortDate = datetime

--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -24,6 +24,7 @@ class LocalstackAwsGateway(Gateway):
             [
                 handlers.push_request_context,
                 metric_collector.create_metric_handler_item,
+                handlers.preprocess_request,
                 handlers.parse_service_name,  # enforce_cors and content_decoder depend on the service name
                 handlers.enforce_cors,
                 handlers.content_decoder,

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -4,6 +4,7 @@ from .. import chain
 from . import analytics, auth, codec, cors, fallback, internal, legacy, logging, region, service
 
 enforce_cors = cors.CorsEnforcer()
+preprocess_request = chain.CompositeHandler()
 add_cors_response_headers = cors.CorsResponseEnricher()
 content_decoder = codec.ContentDecoder()
 parse_service_name = service.ServiceNameParser()

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -181,22 +181,26 @@ class CorsResponseEnricher(Handler):
             return
 
         request_headers = context.request.headers
-        if ACL_ORIGIN not in headers:
-            headers[ACL_ORIGIN] = (
+        self.add_cors_headers(request_headers, response_headers=headers)
+
+    @staticmethod
+    def add_cors_headers(request_headers: Headers, response_headers: Headers):
+        if ACL_ORIGIN not in response_headers:
+            response_headers[ACL_ORIGIN] = (
                 request_headers["origin"]
                 if request_headers.get("origin") and not config.DISABLE_CORS_CHECKS
                 else "*"
             )
-        if ACL_METHODS not in headers:
-            headers[ACL_METHODS] = ",".join(CORS_ALLOWED_METHODS)
-        if ACL_ALLOW_HEADERS not in headers:
-            requested_headers = headers.get(ACL_REQUEST_HEADERS, "")
+        if ACL_METHODS not in response_headers:
+            response_headers[ACL_METHODS] = ",".join(CORS_ALLOWED_METHODS)
+        if ACL_ALLOW_HEADERS not in response_headers:
+            requested_headers = response_headers.get(ACL_REQUEST_HEADERS, "")
             requested_headers = re.split(r"[,\s]+", requested_headers) + CORS_ALLOWED_HEADERS
-            headers[ACL_ALLOW_HEADERS] = ",".join([h for h in requested_headers if h])
-        if ACL_EXPOSE_HEADERS not in headers:
-            headers[ACL_EXPOSE_HEADERS] = ",".join(CORS_EXPOSE_HEADERS)
+            response_headers[ACL_ALLOW_HEADERS] = ",".join([h for h in requested_headers if h])
+        if ACL_EXPOSE_HEADERS not in response_headers:
+            response_headers[ACL_EXPOSE_HEADERS] = ",".join(CORS_EXPOSE_HEADERS)
         if (
             request_headers.get(ACL_REQUEST_PRIVATE_NETWORK) == "true"
-            and ACL_ALLOW_PRIVATE_NETWORK not in headers
+            and ACL_ALLOW_PRIVATE_NETWORK not in response_headers
         ):
-            headers[ACL_ALLOW_PRIVATE_NETWORK] = "true"
+            response_headers[ACL_ALLOW_PRIVATE_NETWORK] = "true"

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1353,7 +1353,7 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
     serialization.
     """
 
-    SUPPORTED_MIME_TYPES = [TEXT_XML, APPLICATION_XML]
+    SUPPORTED_MIME_TYPES = [APPLICATION_XML, TEXT_XML]
 
     def _serialize_response(
         self,

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -645,6 +645,74 @@
         "path": "/shapes/BucketCannedACL/enum/4",
         "value": "log-delivery-write",
         "documentation": "<p>Not included in the specs, but valid value according to the docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl</p>"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/BadRequest",
+      "value": {
+        "type": "structure",
+        "members": {
+          "HostId": {
+            "shape": "HostId"
+          }
+        },
+        "documentation": "<p>Insufficient information. Origin request header needed.</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/AccessForbidden",
+      "value": {
+        "type": "structure",
+        "members": {
+          "HostId": {
+            "shape": "HostId"
+          },
+          "Method": {
+            "shape": "HttpMethod"
+          },
+          "ResourceType": {
+            "shape": "ResourceType"
+          }
+        },
+        "error": {
+          "httpStatusCode": 403
+        },
+        "documentation": "<p>CORSResponse</p>",
+        "exception": true
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/HttpMethod",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ResourceType",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/NoSuchCORSConfiguration",
+      "value": {
+        "type": "structure",
+        "members": {
+          "BucketName": {
+            "shape": "BucketName"
+          }
+        },
+        "error": {
+          "httpStatusCode": 404
+        },
+        "documentation": "<p>The CORS configuration does not exist</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -100,6 +100,7 @@ class S3CorsHandler(Handler):
             ] = f"MzRISOwyjmnup{request_id}7/JypPGXLh0OVFGcJaaO3KW/hRAqKOpIEEp"
 
             response.set_response(b"")
+            response.headers.pop("Content-Type", None)
             chain.stop()
 
         # check the presence of the Origin header. If not there, it means the request is not concerned about CORS

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -1,0 +1,251 @@
+import re
+from typing import Optional, Tuple
+
+from werkzeug.datastructures import Headers
+
+from localstack import config
+from localstack.aws.api import RequestContext
+from localstack.aws.api.s3 import AccessForbidden, BadRequest, CORSRule, CORSRules
+from localstack.aws.chain import Handler, HandlerChain
+
+# TODO: refactor those to expose the needed methods
+from localstack.aws.handlers.cors import CorsEnforcer, CorsResponseEnricher
+from localstack.aws.protocol.op_router import RestServiceOperationRouter
+from localstack.aws.protocol.serializer import gen_amzn_requestid_long
+from localstack.aws.protocol.service_router import get_service_catalog
+from localstack.constants import S3_VIRTUAL_HOSTNAME
+from localstack.http import Request, Response
+from localstack.services.s3.models import BucketCorsIndex
+from localstack.services.s3.utils import S3_VIRTUAL_HOSTNAME_REGEX
+from localstack.utils.bootstrap import log_duration
+
+_s3_virtual_host_regex = re.compile(S3_VIRTUAL_HOSTNAME_REGEX)
+FAKE_HOST_ID = "9Gjjt1m+cjU4OPvX9O9/8RuvnG41MRb/18Oux2o5H5MY7ISNTlXN+Dz9IG62/ILVxhAGI0qyPfg="
+
+# TODO: refactor those to expose the needed methods maybe in another way that both can import
+add_default_headers = CorsResponseEnricher.add_cors_headers
+is_origin_allowed_default = CorsEnforcer.is_cors_origin_allowed
+
+
+class S3CorsHandler(Handler):
+
+    bucket_cors_index: BucketCorsIndex
+
+    def __init__(self):
+        self.bucket_cors_index = BucketCorsIndex()
+        self._service = get_service_catalog().get("s3")
+        self._s3_op_router = RestServiceOperationRouter(self._service)
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        self.handle_cors(chain, context, response)
+
+    def pre_parse_s3_request(self, context: RequestContext) -> Tuple[bool, Optional[str]]:
+        is_s3: bool
+        bucket_name: str
+
+        path = context.request.path
+        host = context.request.host
+
+        # first, try to figure out best-effort whether the request is an s3 request
+        if host.startswith(S3_VIRTUAL_HOSTNAME):
+            is_s3 = True
+            bucket_name = path.split("/")[1]
+        # try to extract the bucket from the hostname (the "in" check is a minor optimization
+        elif ".s3" in host and (match := _s3_virtual_host_regex.match(host)):
+            is_s3 = True
+            bucket_name = match.group(3)
+        # otherwise we're not sure, and whether it's s3 depends on whether the bucket exists. check later
+        else:
+            is_s3 = False
+            bucket_name = path.split("/")[1]
+
+        existing_buckets = self.bucket_cors_index.buckets
+        if bucket_name not in existing_buckets:
+            return is_s3, None
+
+        return True, bucket_name
+
+    @log_duration(min_ms=0)
+    def handle_cors(self, chain: HandlerChain, context: RequestContext, response: Response):
+        """
+        Handle CORS for S3 requests. S3 CORS rules can be configured.
+        https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html
+        https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html
+        """
+
+        # this is used with the new ASF S3 provider
+        # although, we could use it to pre-parse the request and set the context to move the service name parser
+        if config.LEGACY_S3_PROVIDER or config.DISABLE_CUSTOM_CORS_S3:
+            return
+
+        is_s3, bucket_name = self.pre_parse_s3_request(context)
+
+        if not is_s3 and not bucket_name:
+            # continue the chain, let the default CORS handler take care of the request
+            return
+
+        # set the service so that the regular CORS enforcer knows it needs to ignore this request
+        context.service = self._service
+
+        request = context.request
+        is_options_request = request.method == "OPTIONS"
+
+        def stop_options_chain():
+            # FIXME: need to add it there as not handled by the serializer, we stop the chain to avoid the request
+            #  being parsed
+            request_id = gen_amzn_requestid_long()
+            response.headers["x-amz-request-id"] = request_id
+            response.headers[
+                "x-amz-id-2"
+            ] = f"MzRISOwyjmnup{request_id}7/JypPGXLh0OVFGcJaaO3KW/hRAqKOpIEEp"
+
+            response.set_response(b"")
+            chain.stop()
+
+        # check the presence of the Origin header. If not there, it means the request is not concerned about CORS
+        if not (origin := request.headers.get("Origin")):
+            if is_options_request:
+                context.operation = self._get_op_from_request(request)
+                raise BadRequest(
+                    "Insufficient information. Origin request header needed.", HostId=FAKE_HOST_ID
+                )
+            else:
+                # If the header is missing, Amazon S3 doesn't treat the request as a cross-origin request,
+                # and doesn't send CORS response headers in the response.
+                return
+
+        is_origin_allowed_by_default = is_origin_allowed_default(request.headers)
+
+        # The bucket does not exist or does have CORS configured
+        # might apply default LS CORS or raise AWS specific errors
+        if not bucket_name or bucket_name not in self.bucket_cors_index.cors:
+            # if the origin is allowed by localstack per default, adds default LS CORS headers
+            if is_origin_allowed_by_default:
+                add_default_headers(
+                    response_headers=response.headers, request_headers=request.headers
+                )
+                if is_options_request:
+                    stop_options_chain()
+                return
+            # if the origin is not allowed, raise a specific S3 options in case of OPTIONS
+            # if it's a regular request, simply return without adding CORS
+            else:
+                if is_options_request:
+                    if not bucket_name:
+                        message = "CORSResponse: Bucket not found"
+                    else:
+                        message = "CORSResponse: CORS is not enabled for this bucket."
+                    try:
+                        context.operation = self._get_op_from_request(request)
+                    except Exception:
+                        context.operation = context.service.operation_model("GetObject")
+
+                    raise AccessForbidden(
+                        message, HostId=FAKE_HOST_ID, Method="OPTIONS", ResourceType="BUCKET"
+                    )
+
+                # we return without adding any CORS headers, we could even block the request with 403 here
+                return
+
+        rules = self.bucket_cors_index.cors[bucket_name]["CORSRules"]
+        # check this but should not happen? maybe?
+        if not rules:
+            if is_options_request:
+                stop_options_chain()
+            return
+
+        if not (rule := self.match_rules(request, rules)):
+            if is_options_request:
+                ex = AccessForbidden(
+                    "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec."
+                )
+                ex.HostId = FAKE_HOST_ID
+                ex.Method = request.headers.get("Access-Control-Request-Method")
+                ex.ResourceType = "OBJECT"
+                context.operation = self._get_op_from_request(request)
+                raise ex
+
+            if is_options_request:
+                stop_options_chain()
+            return
+
+        is_wildcard = "*" in rule["AllowedOrigins"]
+        # this is contrary to CORS specs. The Access-Control-Allow-Origin should always return the request Origin
+        response.headers["Access-Control-Allow-Origin"] = origin if not is_wildcard else "*"
+        if not is_wildcard:
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+
+        response.headers[
+            "Vary"
+        ] = "Origin, Access-Control-Request-Headers, Access-Control-Request-Method"
+
+        response.headers["Access-Control-Allow-Methods"] = ", ".join(rule["AllowedMethods"])
+
+        if requested_headers := request.headers.get("Access-Control-Request-Headers"):
+            # if the rule matched, it means all Requested Headers are allowed
+            response.headers["Access-Control-Allow-Headers"] = requested_headers
+
+        if expose_headers := rule.get("ExposeHeaders"):
+            response.headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
+
+        if max_age := rule.get("MaxAgeSeconds"):
+            response.headers["Access-Control-Max-Age"] = str(max_age)
+
+        if is_options_request:
+            stop_options_chain()
+
+    def invalidate_cache(self):
+        self.bucket_cors_index.invalidate()
+
+    def match_rules(self, request: Request, rules: CORSRules) -> Optional[CORSRule]:
+        """
+        Try to match the request to the bucket rules. How to match rules:
+          - The request's Origin header must match AllowedOrigin elements.
+          - The request method (for example, GET, PUT, HEAD, and so on) or the Access-Control-Request-Method
+            header in case of a pre-flight OPTIONS request must be one of the AllowedMethod elements.
+          - Every header specified in the Access-Control-Request-Headers request header of a pre-flight request
+            must match an AllowedHeader element.
+        :param request: RequestContext:
+        :param rules: CORSRules: the bucket CORS rules
+        :return: return a CORSRule if it finds a match, or None
+        """
+        headers = request.headers
+        method = request.method
+        for rule in rules:
+            if matched_rule := self._match_rule(rule, method, headers):
+                return matched_rule
+
+    @staticmethod
+    def _match_rule(rule: CORSRule, method: str, headers: Headers) -> Optional[CORSRule]:
+        """
+        Check if the request method and headers matches the given CORS rule.
+        :param rule: CORSRule: a CORS Rule from the bucket
+        :param method: HTTP method of the request
+        :param headers: Headers of the request
+        :return: CORSRule if the rule match, or None
+        """
+        # AWS treats any method as an OPTIONS if it has the specific OPTIONS CORS headers
+        request_method = headers.get("Access-Control-Request-Method") or method
+        origin = headers.get("Origin")
+        if request_method not in rule["AllowedMethods"]:
+            return
+
+        if "*" not in rule["AllowedOrigins"] and origin not in rule["AllowedOrigins"]:
+            return
+
+        if request_headers := headers.get("Access-Control-Request-Headers"):
+            if not (allowed_headers := rule.get("AllowedHeaders")) or (
+                "*" not in allowed_headers
+                and not all(header in allowed_headers for header in request_headers.split(", "))
+            ):
+                return
+
+        return rule
+
+    def _get_op_from_request(self, request: Request):
+        try:
+            op, _ = self._s3_op_router.match(request)
+            return op
+        except Exception:
+            # if we can't parse the request, just set GetObject
+            return self._service.operation_model("GetObject")

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -17,7 +17,6 @@ from localstack.constants import S3_VIRTUAL_HOSTNAME
 from localstack.http import Request, Response
 from localstack.services.s3.models import BucketCorsIndex
 from localstack.services.s3.utils import S3_VIRTUAL_HOSTNAME_REGEX
-from localstack.utils.bootstrap import log_duration
 
 _s3_virtual_host_regex = re.compile(S3_VIRTUAL_HOSTNAME_REGEX)
 FAKE_HOST_ID = "9Gjjt1m+cjU4OPvX9O9/8RuvnG41MRb/18Oux2o5H5MY7ISNTlXN+Dz9IG62/ILVxhAGI0qyPfg="
@@ -65,7 +64,6 @@ class S3CorsHandler(Handler):
 
         return True, bucket_name
 
-    @log_duration(min_ms=0)
     def handle_cors(self, chain: HandlerChain, context: RequestContext, response: Response):
         """
         Handle CORS for S3 requests. S3 CORS rules can be configured.

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1129,6 +1129,17 @@ def apply_moto_patches():
             tags = {}
         return tags
 
+    @patch(moto_s3_responses.S3Response._cors_from_body)
+    def _fix_parsing_cors_rules(fn, *args, **kwargs) -> List[Dict]:
+        """
+        Fix parsing of CORS Rules from moto, you can set empty origin in AWS. Replace None by an empty string
+        """
+        cors_rules = fn(*args, **kwargs)
+        for rule in cors_rules:
+            if rule["AllowedOrigin"] is None:
+                rule["AllowedOrigin"] = ""
+        return cors_rules
+
     @patch(moto_s3_responses.S3Response.is_delete_keys)
     def s3_response_is_delete_keys(fn, self, request, path, bucket_name):
         """

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -609,8 +609,6 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
     ) -> None:
         response = call_moto(context)
-        # max 100 rules
-        # validate CORS? see moto
         self.get_store().bucket_cors[bucket] = cors_configuration
         self._cors_handler.invalidate_cache()
         return response

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -21,6 +21,7 @@ from localstack.aws.api.s3 import (
     ContentMD5,
     CopyObjectOutput,
     CopyObjectRequest,
+    CORSConfiguration,
     CreateBucketOutput,
     CreateBucketRequest,
     Delete,
@@ -31,6 +32,7 @@ from localstack.aws.api.s3 import (
     DeleteResult,
     ETag,
     GetBucketAclOutput,
+    GetBucketCorsOutput,
     GetBucketLifecycleConfigurationOutput,
     GetBucketLifecycleOutput,
     GetBucketLocationOutput,
@@ -78,11 +80,16 @@ from localstack.aws.api.s3 import (
 )
 from localstack.aws.api.s3 import Type as GranteeType
 from localstack.aws.api.s3 import WebsiteConfiguration
-from localstack.aws.handlers import modify_service_response, serve_custom_service_request_handlers
+from localstack.aws.handlers import (
+    modify_service_response,
+    preprocess_request,
+    serve_custom_service_request_handlers,
+)
 from localstack.constants import LOCALHOST_HOSTNAME
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
+from localstack.services.s3.cors import S3CorsHandler
 from localstack.services.s3.models import S3Store, get_moto_s3_backend, s3_stores
 from localstack.services.s3.notifications import NotificationDispatcher, S3EventNotificationContext
 from localstack.services.s3.presigned_url import (
@@ -162,6 +169,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
     def on_after_init(self):
         apply_moto_patches()
+        preprocess_request.append(self._cors_handler)
         register_website_hosting_routes(router=ROUTER)
         register_custom_handlers()
         # registering of virtual host routes happens with the hook on_infra_ready in virtual_host.py
@@ -169,6 +177,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def __init__(self) -> None:
         super().__init__()
         self._notification_dispatcher = NotificationDispatcher()
+        self._cors_handler = S3CorsHandler()
 
     def on_before_stop(self):
         self._notification_dispatcher.shutdown()
@@ -215,6 +224,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 response["Location"] = get_full_default_bucket_location(bucket_name)
         if "Location" not in response:
             response["Location"] = f"/{bucket_name}"
+        self._cors_handler.invalidate_cache()
         return response
 
     def delete_bucket(
@@ -222,6 +232,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     ) -> None:
         call_moto(context)
         self._clear_bucket_from_store(bucket)
+        self._cors_handler.invalidate_cache()
 
     def get_bucket_location(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
@@ -587,6 +598,38 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         store = self.get_store()
         store.bucket_lifecycle_configuration.pop(bucket, None)
+
+    def put_bucket_cors(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        cors_configuration: CORSConfiguration,
+        content_md5: ContentMD5 = None,
+        checksum_algorithm: ChecksumAlgorithm = None,
+        expected_bucket_owner: AccountId = None,
+    ) -> None:
+        response = call_moto(context)
+        # max 100 rules
+        # validate CORS? see moto
+        self.get_store().bucket_cors[bucket] = cors_configuration
+        self._cors_handler.invalidate_cache()
+        return response
+
+    def get_bucket_cors(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> GetBucketCorsOutput:
+        response = call_moto(context)
+        self.get_store().bucket_cors.get(bucket)
+        # TODO: see here what to do
+        return response
+
+    def delete_bucket_cors(
+        self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
+    ) -> None:
+        response = call_moto(context)
+        if self.get_store().bucket_cors.pop(bucket, None):
+            self._cors_handler.invalidate_cache()
+        return response
 
     def get_bucket_acl(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -618,10 +618,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_cors(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketCorsOutput:
-        response = call_moto(context)
-        self.get_store().bucket_cors.get(bucket)
-        # TODO: see here what to do
-        return response
+        call_moto(context)
+        cors_rules = self.get_store().bucket_cors.get(bucket)
+        return GetBucketCorsOutput(CORSRules=cors_rules["CORSRules"])
 
     def delete_bucket_cors(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -638,7 +638,9 @@ def append_cors_headers(
 
             for allowed in allowed_origins:
                 allowed = allowed or ""
-                if origin in allowed or re.match(allowed.replace("*", ".*"), origin):
+                if origin in allowed or re.match(
+                    allowed.replace("*", ".*"), origin
+                ):  # no wildcard in origin?
 
                     response.headers["Access-Control-Allow-Origin"] = origin
                     if "AllowedMethod" in rule:

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -638,9 +638,7 @@ def append_cors_headers(
 
             for allowed in allowed_origins:
                 allowed = allowed or ""
-                if origin in allowed or re.match(
-                    allowed.replace("*", ".*"), origin
-                ):  # no wildcard in origin?
+                if origin in allowed or re.match(allowed.replace("*", ".*"), origin):
 
                     response.headers["Access-Control-Allow-Origin"] = origin
                     if "AllowedMethod" in rule:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -4089,7 +4089,10 @@ class TestS3Cors:
         snapshot.match("raw-response-headers-2", dict(response.headers))
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(reason="Access-Control-Allow-Origin returns Origin value in LS")
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER,
+        reason="Access-Control-Allow-Origin returns Origin value in LS",
+    )
     def test_s3_get_response_headers(self, s3_client, s3_bucket, snapshot):
         # put object and CORS configuration
         object_key = "key-by-hostname"
@@ -4123,7 +4126,10 @@ class TestS3Cors:
         )  # returns http://localhost in LS
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(reason="Behaviour diverges from AWS, Access-Control-* headers always added")
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER,
+        reason="Behaviour diverges from AWS, Access-Control-* headers always added",
+    )
     def test_s3_get_response_headers_without_origin(self, s3_client, s3_bucket):
         # put object and CORS configuration
         object_key = "key-by-hostname"

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3895,6 +3895,10 @@ class TestS3PresignedUrl:
         ]
 
 
+@pytest.mark.skipif(
+    condition=is_asf_provider(),
+    reason="ASF provider is tested in test_s3_cors.py, this will be deprecated",
+)
 class TestS3Cors:
     @pytest.mark.aws_validated
     # TODO x-amzn-requestid should be 'x-amz-request-id'
@@ -4090,7 +4094,6 @@ class TestS3Cors:
 
     @pytest.mark.aws_validated
     @pytest.mark.xfail(
-        condition=LEGACY_S3_PROVIDER,
         reason="Access-Control-Allow-Origin returns Origin value in LS",
     )
     def test_s3_get_response_headers(self, s3_client, s3_bucket, snapshot):
@@ -4127,7 +4130,6 @@ class TestS3Cors:
 
     @pytest.mark.aws_validated
     @pytest.mark.xfail(
-        condition=LEGACY_S3_PROVIDER,
         reason="Behaviour diverges from AWS, Access-Control-* headers always added",
     )
     def test_s3_get_response_headers_without_origin(self, s3_client, s3_bucket):

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -2245,33 +2245,6 @@
       }
     }
   },
-  "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_get_response_headers": {
-    "recorded-date": "21-09-2022, 13:44:26",
-    "recorded-content": {
-      "bucket-cors-response": {
-        "CORSRules": [
-          {
-            "AllowedMethods": [
-              "GET",
-              "PUT",
-              "POST"
-            ],
-            "AllowedOrigins": [
-              "*"
-            ],
-            "ExposeHeaders": [
-              "ETag",
-              "x-amz-version-id"
-            ]
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/s3/test_s3.py::TestS3PresignedUrl::test_s3_copy_md5": {
     "recorded-date": "21-09-2022, 13:44:37",
     "recorded-content": {
@@ -3721,6 +3694,33 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3Cors::test_s3_get_response_headers": {
+    "recorded-date": "24-10-2022, 15:57:19",
+    "recorded-content": {
+      "bucket-cors-response": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET",
+              "PUT",
+              "POST"
+            ],
+            "AllowedOrigins": [
+              "*"
+            ],
+            "ExposeHeaders": [
+              "ETag",
+              "x-amz-version-id"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/s3/test_s3_cors.py
+++ b/tests/integration/s3/test_s3_cors.py
@@ -1,0 +1,616 @@
+import os
+
+import pytest
+import requests
+import xmltodict
+from botocore.exceptions import ClientError
+
+from localstack import config
+from localstack.aws.handlers.cors import ALLOWED_CORS_ORIGINS
+from localstack.constants import LOCALHOST_HOSTNAME, S3_VIRTUAL_HOSTNAME
+from localstack.utils.strings import short_uid
+
+
+def _bucket_url_vhost(bucket_name: str, region: str = "", localstack_host: str = None) -> str:
+    if not region:
+        region = config.DEFAULT_REGION
+    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
+        if region == "us-east-1":
+            return f"https://{bucket_name}.s3.amazonaws.com"
+        else:
+            return f"https://{bucket_name}.s3.{region}.amazonaws.com"
+    host = localstack_host or (
+        f"s3.{region}.{LOCALHOST_HOSTNAME}" if region != "us-east-1" else S3_VIRTUAL_HOSTNAME
+    )
+    s3_edge_url = config.get_edge_url(localstack_hostname=host)
+    # TODO might add the region here
+    return s3_edge_url.replace(f"://{host}", f"://{bucket_name}.{host}")
+
+
+@pytest.fixture
+def snapshot_headers(snapshot):
+    # should remove localstack specific headers as well
+    snapshot.add_transformer(
+        [
+            snapshot.transform.key_value("x-amz-id-2"),
+            snapshot.transform.key_value("x-amz-request-id"),
+            snapshot.transform.key_value("date", reference_replacement=False),
+            snapshot.transform.key_value("Last-Modified", reference_replacement=False),
+            snapshot.transform.key_value("server"),
+        ]
+    )
+
+
+@pytest.fixture
+def match_headers(snapshot, snapshot_headers):
+    def _match(key: str, response: requests.Response):
+        # lower case some server specific headers
+        lower_case_headers = {"Date", "Server", "Accept-Ranges"}
+        headers = {
+            k if k not in lower_case_headers else k.lower(): v
+            for k, v in dict(response.headers).items()
+        }
+        match_object = {
+            "StatusCode": response.status_code,
+            "Headers": headers,
+        }
+        if response.headers.get("Content-Type") in ("application/xml", "text/xml"):
+            match_object["Body"] = xmltodict.parse(response.content)
+        else:
+            match_object["Body"] = response.text
+        snapshot.match(key, match_object)
+
+    return _match
+
+
+class TestS3Cors:
+    @pytest.mark.aws_validated
+    def test_cors_http_options_no_config(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("HostId", reference_replacement=False),
+                snapshot.transform.key_value("RequestId"),
+            ]
+        )
+        key = "test-cors-options-no-config"
+        body = "cors-test"
+        response = s3_client.put_object(Bucket=s3_bucket, Key=key, Body=body, ACL="public-read")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
+
+        response = requests.options(key_url)
+        assert response.status_code == 400
+        # TODO: match_headers
+        # yes, a body in an `options` request
+        parsed_response = xmltodict.parse(response.content)
+        snapshot.match("options-no-origin", parsed_response)
+
+        response = requests.options(
+            key_url, headers={"Origin": "whatever", "Access-Control-Request-Method": "PUT"}
+        )
+        assert response.status_code == 403
+        parsed_response = xmltodict.parse(response.content)
+        snapshot.match("options-with-origin", parsed_response)
+
+    @pytest.mark.aws_validated
+    def test_cors_http_get_no_config(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("HostId", reference_replacement=False),
+                snapshot.transform.key_value("RequestId"),
+            ]
+        )
+        key = "test-cors-get-no-config"
+        body = "cors-test"
+        response = s3_client.put_object(Bucket=s3_bucket, Key=key, Body=body, ACL="public-read")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
+
+        response = requests.get(key_url)
+        assert response.status_code == 200
+        assert response.text == body
+        assert not any("access-control" in header.lower() for header in response.headers)
+
+        response = requests.get(key_url, headers={"Origin": "whatever"})
+        assert response.status_code == 200
+        assert response.text == body
+        assert not any("access-control" in header.lower() for header in response.headers)
+
+    @pytest.mark.only_localstack
+    def test_cors_no_config_localstack_allowed(self, s3_client, s3_bucket):
+        key = "test-cors-get-no-config"
+        body = "cors-test"
+        response = s3_client.put_object(Bucket=s3_bucket, Key=key, Body=body, ACL="public-read")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
+        origin = ALLOWED_CORS_ORIGINS[0]
+
+        response = requests.options(
+            key_url, headers={"Origin": origin, "Access-Control-Request-Method": "PUT"}
+        )
+        assert response.ok
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+
+        response = requests.get(key_url, headers={"Origin": origin})
+        assert response.status_code == 200
+        assert response.text == body
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+
+    @pytest.mark.aws_validated
+    def test_cors_http_options_non_existent_bucket(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("HostId", reference_replacement=False),
+                snapshot.transform.key_value("RequestId"),
+            ]
+        )
+        key = "test-cors-options-no-bucket"
+        key_url = (
+            f'{_bucket_url_vhost(bucket_name=f"fake-bucket-{short_uid()}-{short_uid()}")}/{key}'
+        )
+
+        response = requests.options(key_url)
+        assert response.status_code == 400
+        parsed_response = xmltodict.parse(response.content)
+        snapshot.match("options-no-origin", parsed_response)
+
+        response = requests.options(key_url, headers={"Origin": "whatever"})
+        assert response.status_code == 403
+        parsed_response = xmltodict.parse(response.content)
+        snapshot.match("options-with-origin", parsed_response)
+
+    @pytest.mark.only_localstack
+    def test_cors_http_options_non_existent_bucket_ls_allowed(self, s3_client, s3_bucket):
+        key = "test-cors-options-no-bucket"
+        key_url = f'{_bucket_url_vhost(bucket_name=f"fake-bucket-{short_uid()}")}/{key}'
+        origin = ALLOWED_CORS_ORIGINS[0]
+        response = requests.options(key_url, headers={"Origin": origin})
+        assert response.ok
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Headers.Connection",  # TODO: fix me? OPTIONS with body is missing it
+            "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
+            "$..Headers.Transfer-Encoding",  # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
+        ]
+    )
+    def test_cors_match_origins(self, s3_client, s3_bucket, match_headers, monkeypatch):
+        # monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["https://localhost:4200"],
+                    "AllowedMethods": ["GET", "PUT"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": ["*"],
+                }
+            ]
+        }
+
+        object_key = "test-cors-123"
+        response = s3_client.put_object(
+            Bucket=s3_bucket, Key=object_key, Body="test-cors", ACL="public-read"
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        s3_client.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
+
+        key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{object_key}"
+
+        # no origin, akin to no CORS
+        opt_req = requests.options(key_url)
+        match_headers("opt-no-origin", opt_req)
+        get_req = requests.get(key_url)
+        match_headers("get-no-origin", get_req)
+
+        # origin from the rule
+        opt_req = requests.options(
+            key_url,
+            headers={"Origin": "https://localhost:4200", "Access-Control-Request-Method": "PUT"},
+        )
+        match_headers("opt-right-origin", opt_req)
+        get_req = requests.get(key_url, headers={"Origin": "https://localhost:4200"})
+        match_headers("get-right-origin", get_req)
+
+        # wrong origin
+        opt_req = requests.options(
+            key_url,
+            headers={"Origin": "http://localhost:4200", "Access-Control-Request-Method": "PUT"},
+        )
+        match_headers("opt-wrong-origin", opt_req)
+        get_req = requests.get(key_url, headers={"Origin": "http://localhost:4200"})
+        match_headers("get-wrong-origin", get_req)
+
+        # test * origin
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*"],
+                    "AllowedMethods": ["GET", "PUT"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": ["*"],
+                }
+            ]
+        }
+        s3_client.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
+        # random origin
+        opt_req = requests.options(
+            key_url,
+            headers={"Origin": "http://random:1234", "Access-Control-Request-Method": "PUT"},
+        )
+        match_headers("opt-random-wildcard-origin", opt_req)
+        get_req = requests.get(key_url, headers={"Origin": "http://random:1234"})
+        match_headers("get-random-wildcard-origin", get_req)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Headers.Connection",  # TODO: fix me? OPTIONS with body is missing it
+            "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
+            "$..Headers.Transfer-Encoding",  # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
+            "$.put-op.Body",  # TODO: We should not return a body for almost all PUT requests
+            "$.put-op.Headers.Content-Type",  # issue with default Response values
+        ]
+    )
+    def test_cors_match_methods(self, s3_client, s3_create_bucket, match_headers, monkeypatch):
+        # monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
+        origin = "https://localhost:4200"
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": [origin],
+                    "AllowedMethods": ["GET"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": ["*"],
+                }
+            ]
+        }
+
+        object_key = "test-cors-method"
+        bucket_name = s3_create_bucket(ACL="public-read-write")
+        response = s3_client.put_object(
+            Bucket=bucket_name, Key=object_key, Body="test-cors", ACL="public-read"
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+        key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}"
+
+        # test with allowed method: GET
+        opt_req = requests.options(
+            key_url, headers={"Origin": origin, "Access-Control-Request-Method": "GET"}
+        )
+        match_headers("opt-get", opt_req)
+        # try a get with a supposed OPTIONS headers, to check behaviour (AWS is weird about it)
+        get_req = requests.get(
+            key_url, headers={"Origin": origin, "Access-Control-Request-Method": "PUT"}
+        )
+        match_headers("get-wrong-op", get_req)
+
+        get_req = requests.get(key_url, headers={"Origin": origin})
+        match_headers("get-op", get_req)
+
+        # test with method: PUT
+        new_key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}new"
+        opt_req = requests.options(
+            new_key_url, headers={"Origin": origin, "Access-Control-Request-Method": "PUT"}
+        )
+        match_headers("opt-put", opt_req)
+        get_req = requests.put(new_key_url, headers={"Origin": origin})
+        match_headers("put-op", get_req)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Headers.Connection",  # TODO: fix me? OPTIONS with body is missing it
+            "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
+            "$..Headers.Transfer-Encoding",
+            # TODO: fix me? supposed to be chunked, fully missing for OPTIONS with body (to be expected, honestly)
+            "$.put-op.Body",  # TODO: We should not return a body for almost all PUT requests
+            "$.put-op.Headers.Content-Type",  # issue with default Response values
+        ]
+    )
+    def test_cors_match_headers(self, s3_client, s3_create_bucket, match_headers, monkeypatch):
+        # monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_S3", False)
+        origin = "https://localhost:4200"
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": [origin],
+                    "AllowedMethods": ["GET"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": ["*"],
+                }
+            ]
+        }
+
+        object_key = "test-cors-method"
+        bucket_name = s3_create_bucket(ACL="public-read-write")
+        response = s3_client.put_object(
+            Bucket=bucket_name, Key=object_key, Body="test-cors", ACL="public-read"
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+        key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}"
+
+        # test with a specific header: x-amz-request-payer
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-amz-request-payer",
+            },
+        )
+        match_headers("opt-get", opt_req)
+        # test with two specific headers: x-amz-request-payer & x-amz-expected-bucket-owner
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-amz-request-payer, x-amz-expected-bucket-owner",
+            },
+        )
+        match_headers("opt-get-two", opt_req)
+        get_req = requests.get(
+            key_url, headers={"Origin": origin, "x-amz-request-payer": "requester"}
+        )
+        match_headers("get-op", get_req)
+
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": [origin],
+                    "AllowedMethods": ["GET"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": [
+                        "x-amz-expected-bucket-owner",
+                        "x-amz-server-side-encryption-customer-algorithm",
+                    ],
+                }
+            ]
+        }
+        s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+        # test with a specific header: x-amz-request-payer, but not allowed in the config
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-amz-request-payer",
+            },
+        )
+        match_headers("opt-get-non-allowed", opt_req)
+        assert opt_req.status_code == 403
+
+        # test with a specific header: x-amz-expected-bucket-owner, allowed in the config
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-amz-expected-bucket-owner",
+            },
+        )
+        match_headers("opt-get-allowed", opt_req)
+        assert opt_req.ok
+
+        # test GET with Access-Control-Request-Headers: should not happen in reality, AWS is considering it like an
+        # OPTIONS request
+        get_req = requests.get(
+            key_url,
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Headers": "x-amz-request-payer",
+            },
+        )
+        # no CORS in the headers
+        match_headers("get-non-allowed-with-acl", get_req)
+
+        # test GET with x-amz-request-payer in non-allowed headers, should work when Access-Control-Request-Headers
+        # is not present
+        get_req = requests.get(
+            key_url,
+            headers={
+                "Origin": origin,
+                "x-amz-request-payer": "requester",
+            },
+        )
+        match_headers("get-non-allowed", get_req)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$.opt-get.Headers.Content-Type",  # issue with default Response values
+        ]
+    )
+    def test_cors_expose_headers(self, s3_client, s3_create_bucket, match_headers):
+        object_key = "test-cors-expose"
+        bucket_name = s3_create_bucket(ACL="public-read-write")
+        response = s3_client.put_object(
+            Bucket=bucket_name, Key=object_key, Body="test-cors", ACL="public-read"
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        # ExposeHeaders allows the browser to access those headers from the response
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*"],
+                    "AllowedMethods": ["GET"],
+                    "ExposeHeaders": ["x-amz-id-2", "x-amz-request-id", "x-amz-request-payer"],
+                }
+            ]
+        }
+        s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+        key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}"
+
+        # get CORS headers from the response matching the rule
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": "localhost:4566",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        match_headers("opt-get", opt_req)
+
+    @pytest.mark.aws_validated
+    def test_get_cors(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        with pytest.raises(ClientError) as e:
+            s3_client.get_bucket_cors(Bucket=s3_bucket)
+
+        snapshot.match("get-cors-no-set", e.value.response)
+
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*"],
+                    "AllowedMethods": ["GET"],
+                }
+            ]
+        }
+        s3_client.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
+
+        response = s3_client.get_bucket_cors(Bucket=s3_bucket)
+        snapshot.match("get-cors-after-set", response)
+
+    @pytest.mark.aws_validated
+    def test_put_cors(self, s3_client, s3_bucket, snapshot):
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": [
+                        "https://test.com",
+                        "https://app.test.com",
+                        "http://test.com:80",
+                    ],
+                    "AllowedMethods": ["GET", "PUT", "HEAD"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": [
+                        "x-amz-expected-bucket-owner",
+                        "x-amz-server-side-encryption-customer-algorithm",
+                    ],
+                }
+            ]
+        }
+        put_response = s3_client.put_bucket_cors(
+            Bucket=s3_bucket, CORSConfiguration=bucket_cors_config
+        )
+        snapshot.match("put-cors", put_response)
+
+        response = s3_client.get_bucket_cors(Bucket=s3_bucket)
+        snapshot.match("get-cors", response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..Body.Error.HostId",  # it's because HostId is supposed to match x-amz-id-2 but is handled in serializer
+            "$..Body.Error.RequestId",  # it's because RequestId is supposed to match x-amz-request-id ^
+            "$..Headers.Content-Length",  # TODO: fix me? not supposed to be here, OPTIONS with body
+            "$..Headers.Transfer-Encoding",
+        ]
+    )
+    def test_put_cors_default_values(self, s3_client, s3_create_bucket, match_headers):
+        object_key = "test-cors-default"
+        bucket_name = s3_create_bucket(ACL="public-read-write")
+        response = s3_client.put_object(
+            Bucket=bucket_name, Key=object_key, Body="test-cors", ACL="public-read"
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+        # don't set MaxAge, AllowHeaders and ExposeHeaders
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*"],
+                    "AllowedMethods": ["GET"],
+                }
+            ]
+        }
+        s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=bucket_cors_config)
+
+        key_url = f"{_bucket_url_vhost(bucket_name=bucket_name)}/{object_key}"
+
+        # get CORS headers from the response matching the rule
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": "localhost:4566",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        match_headers("opt-get", opt_req)
+
+        # get CORS headers from the response not matching the rule because AllowedHeaders is missing from the rule
+        opt_req = requests.options(
+            key_url,
+            headers={
+                "Origin": "localhost:4566",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-amz-request-payer",
+            },
+        )
+        match_headers("opt-get-headers", opt_req)
+
+    @pytest.mark.aws_validated
+    def test_put_cors_invalid_rules(self, s3_client, s3_bucket, snapshot):
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*", "https://test.com"],
+                    "AllowedMethods": ["GET", "PUT", "HEAD", "MYMETHOD"],
+                }
+            ]
+        }
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
+
+        snapshot.match("put-cors-exc", e.value.response)
+
+    def test_delete_cors(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
+        response = s3_client.delete_bucket_cors(Bucket=s3_bucket)
+        snapshot.match("delete-cors-before-set", response)
+
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*"],
+                    "AllowedMethods": ["GET"],
+                }
+            ]
+        }
+        put_response = s3_client.put_bucket_cors(
+            Bucket=s3_bucket, CORSConfiguration=bucket_cors_config
+        )
+        snapshot.match("put-cors", put_response)
+
+        response = s3_client.get_bucket_cors(Bucket=s3_bucket)
+        snapshot.match("get-cors", response)
+
+        response = s3_client.delete_bucket_cors(Bucket=s3_bucket)
+        snapshot.match("delete-cors", response)
+
+        with pytest.raises(ClientError) as e:
+            s3_client.get_bucket_cors(Bucket=s3_bucket)
+
+        snapshot.match("get-cors-deleted", e.value.response)

--- a/tests/integration/s3/test_s3_cors.py
+++ b/tests/integration/s3/test_s3_cors.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 
 from localstack import config
 from localstack.aws.handlers.cors import ALLOWED_CORS_ORIGINS
+from localstack.config import LEGACY_S3_PROVIDER
 from localstack.constants import LOCALHOST_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.utils.strings import short_uid
 
@@ -63,6 +64,7 @@ def match_headers(snapshot, snapshot_headers):
     return _match
 
 
+@pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="Tests are for new ASF provider")
 class TestS3Cors:
     @pytest.mark.aws_validated
     def test_cors_http_options_no_config(self, s3_client, s3_bucket, snapshot):

--- a/tests/integration/s3/test_s3_cors.py
+++ b/tests/integration/s3/test_s3_cors.py
@@ -588,6 +588,24 @@ class TestS3Cors:
 
         snapshot.match("put-cors-exc", e.value.response)
 
+    @pytest.mark.aws_validated
+    def test_put_cors_empty_origin(self, s3_client, s3_bucket, snapshot):
+        # derived from TestAccS3Bucket_Security_corsEmptyOrigin TF test
+        bucket_cors_config = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": [""],
+                    "AllowedMethods": ["GET", "PUT", "HEAD"],
+                }
+            ]
+        }
+        s3_client.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration=bucket_cors_config)
+
+        response = s3_client.get_bucket_cors(Bucket=s3_bucket)
+
+        snapshot.match("get-cors-empty", response)
+
+    @pytest.mark.aws_validated
     def test_delete_cors(self, s3_client, s3_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.key_value("BucketName"))
         response = s3_client.delete_bucket_cors(Bucket=s3_bucket)

--- a/tests/integration/s3/test_s3_cors.py
+++ b/tests/integration/s3/test_s3_cors.py
@@ -588,6 +588,11 @@ class TestS3Cors:
 
         snapshot.match("put-cors-exc", e.value.response)
 
+        with pytest.raises(ClientError) as e:
+            s3_client.put_bucket_cors(Bucket=s3_bucket, CORSConfiguration={"CORSRules": []})
+
+        snapshot.match("put-cors-exc-empty", e.value.response)
+
     @pytest.mark.aws_validated
     def test_put_cors_empty_origin(self, s3_client, s3_bucket, snapshot):
         # derived from TestAccS3Bucket_Security_corsEmptyOrigin TF test

--- a/tests/integration/s3/test_s3_cors.snapshot.json
+++ b/tests/integration/s3/test_s3_cors.snapshot.json
@@ -449,7 +449,7 @@
     }
   },
   "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_put_cors": {
-    "recorded-date": "24-10-2022, 14:24:23",
+    "recorded-date": "25-10-2022, 11:17:15",
     "recorded-content": {
       "put-cors": {
         "ResponseMetadata": {
@@ -470,9 +470,9 @@
               "HEAD"
             ],
             "AllowedOrigins": [
-              "test.com",
-              "app.test.com",
-              "test.com:80"
+              "https://test.com",
+              "https://app.test.com",
+              "http://test.com:80"
             ],
             "MaxAgeSeconds": 3000
           }

--- a/tests/integration/s3/test_s3_cors.snapshot.json
+++ b/tests/integration/s3/test_s3_cors.snapshot.json
@@ -525,12 +525,22 @@
     }
   },
   "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_put_cors_invalid_rules": {
-    "recorded-date": "24-10-2022, 14:39:40",
+    "recorded-date": "28-10-2022, 15:57:45",
     "recorded-content": {
       "put-cors-exc": {
         "Error": {
           "Code": "InvalidRequest",
           "Message": "Found unsupported HTTP method in CORS config. Unsupported method is MYMETHOD"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-cors-exc-empty": {
+        "Error": {
+          "Code": "MalformedXML",
+          "Message": "The XML you provided was not well-formed or did not validate against our published schema"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/s3/test_s3_cors.snapshot.json
+++ b/tests/integration/s3/test_s3_cors.snapshot.json
@@ -608,5 +608,28 @@
         "StatusCode": 200
       }
     }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_put_cors_empty_origin": {
+    "recorded-date": "25-10-2022, 11:57:55",
+    "recorded-content": {
+      "get-cors-empty": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET",
+              "PUT",
+              "HEAD"
+            ],
+            "AllowedOrigins": [
+              ""
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3_cors.snapshot.json
+++ b/tests/integration/s3/test_s3_cors.snapshot.json
@@ -1,0 +1,612 @@
+{
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_http_options_no_config": {
+    "recorded-date": "10-10-2022, 16:03:27",
+    "recorded-content": {
+      "options-no-origin": {
+        "Error": {
+          "Code": "BadRequest",
+          "HostId": "host-id",
+          "Message": "Insufficient information. Origin request header needed.",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "options-with-origin": {
+        "Error": {
+          "Code": "AccessForbidden",
+          "HostId": "host-id",
+          "Message": "CORSResponse: CORS is not enabled for this bucket.",
+          "Method": "OPTIONS",
+          "RequestId": "<request-id:2>",
+          "ResourceType": "BUCKET"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_http_get_no_config": {
+    "recorded-date": "10-10-2022, 16:03:31",
+    "recorded-content": {}
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_http_options_non_existent_bucket": {
+    "recorded-date": "10-10-2022, 16:03:34",
+    "recorded-content": {
+      "options-no-origin": {
+        "Error": {
+          "Code": "BadRequest",
+          "HostId": "host-id",
+          "Message": "Insufficient information. Origin request header needed.",
+          "RequestId": "<request-id:1>"
+        }
+      },
+      "options-with-origin": {
+        "Error": {
+          "Code": "AccessForbidden",
+          "HostId": "host-id",
+          "Message": "CORSResponse: Bucket not found",
+          "Method": "OPTIONS",
+          "RequestId": "<request-id:2>",
+          "ResourceType": "BUCKET"
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_match_origins": {
+    "recorded-date": "11-10-2022, 23:43:24",
+    "recorded-content": {
+      "opt-no-origin": {
+        "Body": {
+          "Error": {
+            "Code": "BadRequest",
+            "HostId": "<x-amz-id-2:1>",
+            "Message": "Insufficient information. Origin request header needed.",
+            "RequestId": "<x-amz-request-id:1>"
+          }
+        },
+        "Headers": {
+          "Connection": "close",
+          "Content-Type": "application/xml",
+          "Transfer-Encoding": "chunked",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:1>",
+          "x-amz-request-id": "<x-amz-request-id:1>"
+        },
+        "StatusCode": 400
+      },
+      "get-no-origin": {
+        "Body": "test-cors",
+        "Headers": {
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:2>",
+          "x-amz-request-id": "<x-amz-request-id:2>"
+        },
+        "StatusCode": 200
+      },
+      "opt-right-origin": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, PUT",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:3>",
+          "x-amz-request-id": "<x-amz-request-id:3>"
+        },
+        "StatusCode": 200
+      },
+      "get-right-origin": {
+        "Body": "test-cors",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET, PUT",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:4>",
+          "x-amz-request-id": "<x-amz-request-id:4>"
+        },
+        "StatusCode": 200
+      },
+      "opt-wrong-origin": {
+        "Body": {
+          "Error": {
+            "Code": "AccessForbidden",
+            "HostId": "<x-amz-id-2:5>",
+            "Message": "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
+            "Method": "PUT",
+            "RequestId": "<x-amz-request-id:5>",
+            "ResourceType": "OBJECT"
+          }
+        },
+        "Headers": {
+          "Content-Type": "application/xml",
+          "Transfer-Encoding": "chunked",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:5>",
+          "x-amz-request-id": "<x-amz-request-id:5>"
+        },
+        "StatusCode": 403
+      },
+      "get-wrong-origin": {
+        "Body": "test-cors",
+        "Headers": {
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:6>",
+          "x-amz-request-id": "<x-amz-request-id:6>"
+        },
+        "StatusCode": 200
+      },
+      "opt-random-wildcard-origin": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Methods": "GET, PUT",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:7>",
+          "x-amz-request-id": "<x-amz-request-id:7>"
+        },
+        "StatusCode": 200
+      },
+      "get-random-wildcard-origin": {
+        "Body": "test-cors",
+        "Headers": {
+          "Access-Control-Allow-Methods": "GET, PUT",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:8>",
+          "x-amz-request-id": "<x-amz-request-id:8>"
+        },
+        "StatusCode": 200
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_match_methods": {
+    "recorded-date": "20-10-2022, 23:02:45",
+    "recorded-content": {
+      "opt-get": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:1>",
+          "x-amz-request-id": "<x-amz-request-id:1>"
+        },
+        "StatusCode": 200
+      },
+      "get-wrong-op": {
+        "Body": "test-cors",
+        "Headers": {
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:2>",
+          "x-amz-request-id": "<x-amz-request-id:2>"
+        },
+        "StatusCode": 200
+      },
+      "get-op": {
+        "Body": "test-cors",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:3>",
+          "x-amz-request-id": "<x-amz-request-id:3>"
+        },
+        "StatusCode": 200
+      },
+      "opt-put": {
+        "Body": {
+          "Error": {
+            "Code": "AccessForbidden",
+            "HostId": "<x-amz-id-2:4>",
+            "Message": "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
+            "Method": "PUT",
+            "RequestId": "<x-amz-request-id:4>",
+            "ResourceType": "OBJECT"
+          }
+        },
+        "Headers": {
+          "Content-Type": "application/xml",
+          "Transfer-Encoding": "chunked",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:4>",
+          "x-amz-request-id": "<x-amz-request-id:4>"
+        },
+        "StatusCode": 403
+      },
+      "put-op": {
+        "Body": "",
+        "Headers": {
+          "Content-Length": "0",
+          "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:5>",
+          "x-amz-request-id": "<x-amz-request-id:5>"
+        },
+        "StatusCode": 200
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_match_headers": {
+    "recorded-date": "20-10-2022, 22:58:38",
+    "recorded-content": {
+      "opt-get": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Headers": "x-amz-request-payer",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:1>",
+          "x-amz-request-id": "<x-amz-request-id:1>"
+        },
+        "StatusCode": 200
+      },
+      "opt-get-two": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Headers": "x-amz-request-payer, x-amz-expected-bucket-owner",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:2>",
+          "x-amz-request-id": "<x-amz-request-id:2>"
+        },
+        "StatusCode": 200
+      },
+      "get-op": {
+        "Body": "test-cors",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:3>",
+          "x-amz-request-id": "<x-amz-request-id:3>"
+        },
+        "StatusCode": 200
+      },
+      "opt-get-non-allowed": {
+        "Body": {
+          "Error": {
+            "Code": "AccessForbidden",
+            "HostId": "<x-amz-id-2:4>",
+            "Message": "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
+            "Method": "GET",
+            "RequestId": "<x-amz-request-id:4>",
+            "ResourceType": "OBJECT"
+          }
+        },
+        "Headers": {
+          "Content-Type": "application/xml",
+          "Transfer-Encoding": "chunked",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:4>",
+          "x-amz-request-id": "<x-amz-request-id:4>"
+        },
+        "StatusCode": 403
+      },
+      "opt-get-allowed": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Headers": "x-amz-expected-bucket-owner",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:5>",
+          "x-amz-request-id": "<x-amz-request-id:5>"
+        },
+        "StatusCode": 200
+      },
+      "get-non-allowed-with-acl": {
+        "Body": "test-cors",
+        "Headers": {
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:6>",
+          "x-amz-request-id": "<x-amz-request-id:6>"
+        },
+        "StatusCode": 200
+      },
+      "get-non-allowed": {
+        "Body": "test-cors",
+        "Headers": {
+          "Access-Control-Allow-Credentials": "true",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "https://localhost:4200",
+          "Access-Control-Max-Age": "3000",
+          "Content-Length": "9",
+          "Content-Type": "binary/octet-stream",
+          "ETag": "\"e94e402d42b2ca551212dbac49d5a38b\"",
+          "Last-Modified": "last--modified",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "accept-ranges": "bytes",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:7>",
+          "x-amz-request-id": "<x-amz-request-id:7>"
+        },
+        "StatusCode": 200
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_get_cors": {
+    "recorded-date": "24-10-2022, 14:11:39",
+    "recorded-content": {
+      "get-cors-no-set": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchCORSConfiguration",
+          "Message": "The CORS configuration does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-cors-after-set": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET"
+            ],
+            "AllowedOrigins": [
+              "*"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_put_cors": {
+    "recorded-date": "24-10-2022, 14:24:23",
+    "recorded-content": {
+      "put-cors": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-cors": {
+        "CORSRules": [
+          {
+            "AllowedHeaders": [
+              "x-amz-expected-bucket-owner",
+              "x-amz-server-side-encryption-customer-algorithm"
+            ],
+            "AllowedMethods": [
+              "GET",
+              "PUT",
+              "HEAD"
+            ],
+            "AllowedOrigins": [
+              "test.com",
+              "app.test.com",
+              "test.com:80"
+            ],
+            "MaxAgeSeconds": 3000
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_put_cors_default_values": {
+    "recorded-date": "24-10-2022, 14:31:24",
+    "recorded-content": {
+      "opt-get": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "*",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:1>",
+          "x-amz-request-id": "<x-amz-request-id:1>"
+        },
+        "StatusCode": 200
+      },
+      "opt-get-headers": {
+        "Body": {
+          "Error": {
+            "Code": "AccessForbidden",
+            "HostId": "<x-amz-id-2:2>",
+            "Message": "CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method or Access-Control-Request-Headers are not whitelisted by the resource's CORS spec.",
+            "Method": "GET",
+            "RequestId": "<x-amz-request-id:2>",
+            "ResourceType": "OBJECT"
+          }
+        },
+        "Headers": {
+          "Content-Type": "application/xml",
+          "Transfer-Encoding": "chunked",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:2>",
+          "x-amz-request-id": "<x-amz-request-id:2>"
+        },
+        "StatusCode": 403
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_put_cors_invalid_rules": {
+    "recorded-date": "24-10-2022, 14:39:40",
+    "recorded-content": {
+      "put-cors-exc": {
+        "Error": {
+          "Code": "InvalidRequest",
+          "Message": "Found unsupported HTTP method in CORS config. Unsupported method is MYMETHOD"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_delete_cors": {
+    "recorded-date": "24-10-2022, 14:44:10",
+    "recorded-content": {
+      "delete-cors-before-set": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "put-cors": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-cors": {
+        "CORSRules": [
+          {
+            "AllowedMethods": [
+              "GET"
+            ],
+            "AllowedOrigins": [
+              "*"
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-cors": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get-cors-deleted": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchCORSConfiguration",
+          "Message": "The CORS configuration does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_cors.py::TestS3Cors::test_cors_expose_headers": {
+    "recorded-date": "24-10-2022, 15:11:01",
+    "recorded-content": {
+      "opt-get": {
+        "Body": "",
+        "Headers": {
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Expose-Headers": "x-amz-id-2, x-amz-request-id, x-amz-request-payer",
+          "Content-Length": "0",
+          "Vary": "Origin, Access-Control-Request-Headers, Access-Control-Request-Method",
+          "date": "date",
+          "server": "<server:1>",
+          "x-amz-id-2": "<x-amz-id-2:1>",
+          "x-amz-request-id": "<x-amz-request-id:1>"
+        },
+        "StatusCode": 200
+      }
+    }
+  }
+}

--- a/tests/unit/aws/protocol/test_serializer.py
+++ b/tests/unit/aws/protocol/test_serializer.py
@@ -1698,7 +1698,7 @@ def test_restjson_streaming_payload(payload):
     "service,accept_header,content_type_header,expected_mime_type",
     [
         # Test default S3
-        ("s3", None, None, "text/xml"),
+        ("s3", None, None, "application/xml"),
         # Test default STS
         ("sts", None, None, "text/xml"),
         # Test STS for "any" Accept header


### PR DESCRIPTION
This implements S3 CORS for the new provider.
Current issues with CORS is that we depend on the service name parser to correctly handle CORS depending on the service (S3 and API GW can both manage their own CORS rules). 

We make use of the handler chain, with a very early handler which "pre-parse" the request with a simplified way to determine if the request would be directed towards S3. If it does, we then handle CORS based on the configured rules if there are, otherwise default to the LocalStack behaviour for CORS.

Here's a simplified flow chart for how we handle CORS.
(The top right box will actually differ depending on the previous path, but to simplify the chart, it is drawn as one path only).

![s3 cors2](https://user-images.githubusercontent.com/42031100/197566884-94d2fe7c-fb9f-4642-92ee-cb580348e7d9.png)
