### PR TITLE
Avoid triggering healthcheck failure which times out after 5s

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -268,7 +268,7 @@ def is_linux():
 def ping(host):
     """Returns True if host responds to a ping request"""
     is_windows = platform.system().lower() == "windows"
-    ping_opts = "-n 1" if is_windows else "-c 1"
+    ping_opts = "-n 1 -w 2000" if is_windows else "-c 1 -W 2"
     args = "ping %s %s" % (ping_opts, host)
     return (
         subprocess.call(args, shell=not is_windows, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
This healthcheck inside the image times out after 5 seconds (https://github.com/localstack/localstack/blob/434b9eb2daaf27a5dda6e1c6f75e56d7958fe3f8/Dockerfile#L268)

The ping command used to determine bridge IP has a timeout of 10 secs on each IP (2 of them) that it attempts.

Net result is that if localstack is running in a docker daemon that doesn't respond to the first IP that gets pinged then the service is going to be marked as unhealthy.

This PR sets a timeout of 2 secs on each ping so that it will still allow the healthcheck command to finish even when the bridge IP determination logic couldn't find docker daemon. Because if and when the IP is valid... it doesn't take that long so if it hasn't worked by 2 secs then it's unlikely going to work by 10 secs.