### PR TITLE
fix internal botocore API usage

### DIFF
--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -166,7 +166,7 @@ def create_aws_request_context(
     }
     # The endpoint URL is mandatory here, set a dummy if not given
     if not endpoint_url:
-        endpoint_url = "http://example.com"
+        endpoint_url = "http://dummy-endpoint.com/"
     request_dict = client._convert_to_request_dict(
         parameters, operation, endpoint_url, context=request_context
     )

--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -164,7 +164,12 @@ def create_aws_request_context(
         "has_streaming_input": operation.has_streaming_input,
         "auth_type": operation.auth_type,
     }
-    request_dict = client._convert_to_request_dict(parameters, operation, context=request_context)
+    # The endpoint URL is mandatory here, set a dummy if not given
+    if not endpoint_url:
+        endpoint_url = "http://example.com"
+    request_dict = client._convert_to_request_dict(
+        parameters, operation, endpoint_url, context=request_context
+    )
     aws_request = client._endpoint.create_request(request_dict, operation)
 
     context = RequestContext()

--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from collections import defaultdict
 from typing import Any, AnyStr, Dict, List, Mapping, Match, NamedTuple, Optional, Tuple
@@ -11,8 +10,6 @@ from werkzeug.routing import Map, MapAdapter, PathConverter, Rule
 
 from localstack.http import Request
 from localstack.http.request import get_raw_path
-
-LOG = logging.getLogger(__name__)
 
 
 class GreedyPathConverter(PathConverter):
@@ -31,8 +28,11 @@ class _HttpOperation(NamedTuple):
 
     @staticmethod
     def from_operation(op: OperationModel) -> "_HttpOperation":
-        if "authPath" in op.http:
-            uri = op.http["authPath"].rstrip("/")
+        # following botocore update above 1.25, botocore will strip the bucket from the requestUri in the spec.
+        # it will then set the original requestUri to authPath. We need to use the original request if set, otherwise
+        # use the regular requestUri
+        if auth_path := op.http.get("authPath"):
+            uri = auth_path.rstrip("/")
         else:
             uri = op.http.get("requestUri")
 
@@ -233,15 +233,11 @@ def _create_service_map(service: ServiceModel) -> Map:
 
     rules = []
 
-    is_s3 = service.service_name == "s3"
-
     # group all operations by their path and method
     path_index: Dict[(str, str), List[_HttpOperation]] = defaultdict(list)
     for op in ops:
         http_op = _HttpOperation.from_operation(op)
         path_index[(http_op.path, http_op.method)].append(http_op)
-        if is_s3:
-            LOG.info("Operation %s -> HTTP op %s", op, http_op)
 
     # create a matching rule for each (path, method) combination
     for (path, method), ops in path_index.items():
@@ -254,14 +250,6 @@ def _create_service_map(service: ServiceModel) -> Map:
             op = ops[0]
             rules.append(_StrictMethodRule(string=rule_string, method=method, endpoint=op.operation))  # type: ignore
         else:
-            if is_s3:
-                LOG.info(
-                    "ambiguity: path: '%s', rule_string '%s', method '%s', ops: '%s'",
-                    path,
-                    rule_string,
-                    method,
-                    ops,
-                )
             # if there is an ambiguity with only the (path, method) combination,
             # a custom rule - which can use additional request metadata - needs to be used
             rules.append(_RequestMatchingRule(string=rule_string, method=method, operations=ops))

--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -31,11 +31,11 @@ class _HttpOperation(NamedTuple):
 
     @staticmethod
     def from_operation(op: OperationModel) -> "_HttpOperation":
-        uri = (
-            op.http.get("requestUri")
-            if op.service_model.service_name != "s3"
-            else op.http.get("authPath")
-        )
+        if "authPath" in op.http:
+            uri = op.http["authPath"].rstrip("/")
+        else:
+            uri = op.http.get("requestUri")
+
         method = op.http.get("method")
         deprecated = op.deprecated
 

--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -28,9 +28,9 @@ class _HttpOperation(NamedTuple):
 
     @staticmethod
     def from_operation(op: OperationModel) -> "_HttpOperation":
-        # following botocore update above 1.25, botocore will strip the bucket from the requestUri in the spec.
-        # it will then set the original requestUri to authPath. We need to use the original request if set, otherwise
-        # use the regular requestUri
+        # botocore >= 1.28 might modify the internal model (specifically for S3).
+        # It will modify the request URI and set the original value at "authPath".
+        # Use authPath if set, otherwise use the regular requestUri.
         if auth_path := op.http.get("authPath"):
             uri = auth_path.rstrip("/")
         else:

--- a/localstack/aws/protocol/op_router.py
+++ b/localstack/aws/protocol/op_router.py
@@ -31,7 +31,11 @@ class _HttpOperation(NamedTuple):
 
     @staticmethod
     def from_operation(op: OperationModel) -> "_HttpOperation":
-        uri = op.http.get("requestUri")
+        uri = (
+            op.http.get("requestUri")
+            if op.service_model.service_name != "s3"
+            else op.http.get("authPath")
+        )
         method = op.http.get("method")
         deprecated = op.deprecated
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages=find:
 
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
-    boto3>=1.20,<1.25.0
+    boto3>=1.25.0
     click>=7.0
     cachetools~=5.0.0
     #dnspython==1.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ runtime =
     awscli>=1.22.90
     awscrt>=0.13.14
     boto>=2.49.0
-    botocore>=1.12.13,<1.28.0
+    botocore>=1.28.0
     cbor2>=5.2.0
     crontab>=0.22.6
     cryptography

--- a/tests/integration/test_moto.py
+++ b/tests/integration/test_moto.py
@@ -81,34 +81,34 @@ def test_call_s3_with_streaming_trait(payload, monkeypatch):
     # In the absence of below patch, Moto and LocalStack uses difference AWS Account IDs causing the test to fail
     monkeypatch.setattr(localstack.aws.accounts, "DEFAULT_AWS_ACCOUNT_ID", DEFAULT_MOTO_ACCOUNT_ID)
 
+    def _call_moto_s3(action, params):
+        # we need to set the endpoint because moto will match the host to know if it's a path addressed or
+        # virtual host addressed bucket
+        # see moto.s3.responses.S3Response.subdomain_based_buckets
+        context = moto.create_aws_request_context(
+            "s3", action, params, endpoint_url="http://localstack.com"
+        )
+        return moto.call_moto(context)
+
     bucket_name = f"bucket-{short_uid()}"
     key_name = f"key-{short_uid()}"
 
     # create the bucket
-    moto.call_moto(moto.create_aws_request_context("s3", "CreateBucket", {"Bucket": bucket_name}))
+    _call_moto_s3("CreateBucket", {"Bucket": bucket_name})
 
-    moto.call_moto(
-        moto.create_aws_request_context(
-            "s3", "PutObject", {"Bucket": bucket_name, "Key": key_name, "Body": payload}
-        )
-    )
+    _call_moto_s3("PutObject", {"Bucket": bucket_name, "Key": key_name, "Body": payload})
 
     # check whether it was created/received correctly
-    response = moto.call_moto(
-        moto.create_aws_request_context("s3", "GetObject", {"Bucket": bucket_name, "Key": key_name})
-    )
+    response = _call_moto_s3("GetObject", {"Bucket": bucket_name, "Key": key_name})
+
     assert hasattr(
         response["Body"], "read"
     ), f"expected Body to be readable, was {type(response['Body'])}"
     assert response["Body"].read() == b"foobar"
 
     # cleanup
-    moto.call_moto(
-        moto.create_aws_request_context(
-            "s3", "DeleteObject", {"Bucket": bucket_name, "Key": key_name}
-        )
-    )
-    moto.call_moto(moto.create_aws_request_context("s3", "DeleteBucket", {"Bucket": bucket_name}))
+    _call_moto_s3("DeleteObject", {"Bucket": bucket_name, "Key": key_name})
+    _call_moto_s3("DeleteBucket", {"Bucket": bucket_name})
 
 
 def test_call_include_response_metadata():
@@ -299,7 +299,12 @@ def test_moto_fallback_dispatcher_error_handling(monkeypatch):
     dispatcher = MotoFallbackDispatcher(provider)
 
     def _dispatch(action, params):
-        context = moto.create_aws_request_context("s3", action, params)
+        # we need to set the endpoint because moto will match the host to know if it's a path addressed or
+        # virtual host addressed bucket
+        # see moto.s3.responses.S3Response.subdomain_based_buckets
+        context = moto.create_aws_request_context(
+            "s3", action, params, endpoint_url="http://localstack.com"
+        )
         return dispatcher[action](context, params)
 
     bucket_name = f"bucket-{short_uid()}"

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -302,8 +302,12 @@ def _botocore_parser_integration_test(
 
     operation_model = service.operation_model(action)
     serialized_request = serializer.serialize_to_request(kwargs, operation_model)
-    if "auth_path" in serialized_request:
-        serialized_request["url_path"] = serialized_request["auth_path"]
+    # following botocore update above 1.25, botocore will strip the bucket from the requestUri in the spec.
+    # it will then set the original requestUri to authPath, that we can retrieve in the serialized_request
+    # we need to check if the original path is there, otherwise use the provided one
+    if auth_path := serialized_request.get("auth_path"):
+        serialized_request["url_path"] = auth_path
+
     prepare_request_dict(serialized_request, "")
     split_url = urlsplit(serialized_request.get("url"))
     path = split_url.path

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -302,9 +302,9 @@ def _botocore_parser_integration_test(
 
     operation_model = service.operation_model(action)
     serialized_request = serializer.serialize_to_request(kwargs, operation_model)
-    # following botocore update above 1.25, botocore will strip the bucket from the requestUri in the spec.
-    # it will then set the original requestUri to authPath, that we can retrieve in the serialized_request
-    # we need to check if the original path is there, otherwise use the provided one
+
+    # botocore >= 1.28 might modify the url path of the request dict (specifically for S3).
+    # It will then set the original url path as "auth_path". If the auth_path is set, we reset the url_path.
     if auth_path := serialized_request.get("auth_path"):
         serialized_request["url_path"] = auth_path
 

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -302,6 +302,8 @@ def _botocore_parser_integration_test(
 
     operation_model = service.operation_model(action)
     serialized_request = serializer.serialize_to_request(kwargs, operation_model)
+    if "auth_path" in serialized_request:
+        serialized_request["url_path"] = serialized_request["auth_path"]
     prepare_request_dict(serialized_request, "")
     split_url = urlsplit(serialized_request.get("url"))
     path = split_url.path

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -165,7 +165,7 @@ def test_service_router_works_for_every_service(
     }
     request_args = _create_dummy_request_args(operation)
     request_dict = client._convert_to_request_dict(
-        request_args, operation, "http://dummy-endpoint", request_context
+        request_args, operation, "http://dummy-endpoint.com/", request_context
     )
     request_object = create_request_object(request_dict)
     client._request_signer.sign(operation.name, request_object)

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -164,7 +164,9 @@ def test_service_router_works_for_every_service(
         "auth_type": operation.auth_type,
     }
     request_args = _create_dummy_request_args(operation)
-    request_dict = client._convert_to_request_dict(request_args, operation, request_context)
+    request_dict = client._convert_to_request_dict(
+        request_args, operation, "http://dummy-endpoint", request_context
+    )
     request_object = create_request_object(request_dict)
     client._request_signer.sign(operation.name, request_object)
     request: Request = _botocore_request_to_localstack_request(request_object)

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -169,8 +169,10 @@ def test_service_router_works_for_every_service(
         "auth_type": operation.auth_type,
     }
     request_args = _create_dummy_request_args(operation)
+
+    # The endpoint URL is mandatory here, just set a dummy (doesn't _need_ to be localstack specific)
     request_dict = client._convert_to_request_dict(
-        request_args, operation, "http://dummy-endpoint.com/", request_context
+        request_args, operation, "http://localhost.localstack.cloud", request_context
     )
     request_object = create_request_object(request_dict)
     client._request_signer.sign(operation.name, request_object)

--- a/tests/unit/aws/test_service_router.py
+++ b/tests/unit/aws/test_service_router.py
@@ -30,6 +30,8 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
                 "chime-sdk-media-pipelines",
                 "chime-sdk-meetings",
                 "chime-sdk-messaging",
+                "chime-sdk-voice",
+                "codecatalyst",
                 "connect",
                 "connect-contact-lens",
                 "greengrassv2",
@@ -40,6 +42,7 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
                 "kinesis-video-archived-media",
                 "kinesis-video-media",
                 "kinesis-video-signaling",
+                "kinesis-video-webrtc-storage",
                 "kinesisvideo",
                 "lex-models",
                 "lex-runtime",
@@ -51,9 +54,11 @@ def _collect_operations() -> Tuple[ServiceModel, OperationModel]:
                 "pinpoint-sms-voice",
                 "sagemaker-edge",
                 "sagemaker-featurestore-runtime",
+                "sagemaker-metrics",
                 "sms-voice",
                 "sso",
                 "sso-oidc",
+                "workdocs",
             ]:
                 yield pytest.param(
                     service,


### PR DESCRIPTION
[boto/botocore](https://github.com/boto/botocore) recently changed the endpoint detection: https://github.com/boto/botocore/commit/357d5a81311b9c63286423b64d54ff3d6b99534b
These changes (which are contained in [`botocore==1.28.0`](https://github.com/boto/botocore/releases/tag/1.28.0)) break some of the internal APIs we are using for testing and for our forwarding API (because the endpoint parameter became mandatory).

This PR aims at adjusting to these changes.