### PR TITLE
pin boto(core) version 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages=find:
 
 # dependencies that are required for the cli (via pip install localstack)
 install_requires =
-    boto3>=1.20
+    boto3>=1.20,<1.25.0
     click>=7.0
     cachetools~=5.0.0
     #dnspython==1.16.0
@@ -66,7 +66,7 @@ runtime =
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
     boto>=2.49.0
-    botocore>=1.12.13
+    botocore>=1.12.13,<1.28.0
     cbor2>=5.2.0
     crontab>=0.22.6
     cryptography


### PR DESCRIPTION
[boto/botocore](https://github.com/boto/botocore) recently changed the endpoint detection: https://github.com/boto/botocore/commit/357d5a81311b9c63286423b64d54ff3d6b99534b
These changes (which are contained in [`boto3==1.25.0`](https://github.com/boto/boto3/releases/tag/1.25.0) / [`botocore==1.2.8`](https://github.com/boto/botocore/releases/tag/1.28.0)) break some of the internal APIs we are using for testing and for our forwarding API (because the endpoint parameter became mandatory), and have impact on the routing (due to changes with the endpoints).

This PR provides a quick-fix by pinning to the previous versions.
The root cause / adjustment to the new versions will be addressed https://github.com/localstack/localstack/pull/7086.
