### PR TITLE
add patch to parse VariableExpression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ requirements.copy.txt
 
 .python-version
 
-.sourcery.yaml
 venv
 api_states
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ requirements.copy.txt
 
 .python-version
 
+.sourcery.yaml
 venv
 api_states
 

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from enum import Enum
-from typing import Any, Dict, Optional, Union, List
+from typing import Any, Dict, List, Optional, Union
 
 from responses import Response
 

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -154,7 +154,7 @@ class ApiInvocationContext:
     def cookies(self):
         if cookies := self.headers.get("cookie") or "":
             return list(cookies.split(";"))
-        return []
+        return None
 
     @property
     def is_data_base64_encoded(self):

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, List
 
 from responses import Response
 
@@ -151,7 +151,7 @@ class ApiInvocationContext:
         """Whether this is an API Gateway v1 request"""
         return self.apigw_version == ApiGatewayVersion.V1
 
-    def cookies(self):
+    def cookies(self) -> Optional[List[str]]:
         if cookies := self.headers.get("cookie") or "":
             return list(cookies.split(";"))
         return None

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -1,3 +1,4 @@
+import contextlib
 import copy
 import json
 import re
@@ -119,6 +120,17 @@ def calculate(fn, self, *args, **kwarg):
     result = fn(self, *args, **kwarg)
     result = "" if result is None else result
     return result
+
+
+class ExtNameOrCall(airspeed.NameOrCall):
+    NAME = re.compile(r"([a-zA-Z0-9_-]+)(.*)$", re.S)
+
+
+@patch(airspeed.VariableExpression.parse, pass_target=False)
+def parse_expr(self):
+    self.part = self.next_element(ExtNameOrCall)
+    with contextlib.suppress(airspeed.NoMatch):
+        self.subexpression = self.next_element(airspeed.SubExpression)
 
 
 class ReturnDirective(airspeed.EvaluateDirective):

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -226,3 +226,10 @@ class TestMessageTransformationApiGateway:
         template = "#set($start = 1)#set($end = 5)#foreach($i in [$start .. $end])$i -#end"
         result = ApiGatewayVtlTemplate().render_vtl(template, {})
         assert result == "1 -2 -3 -4 -5 -"
+
+        template = """
+         $method.request.header.X-My-Header
+        """
+        variables = {"method": {"request": {"header": {"X-My-Header": "my-header-value"}}}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables).strip()
+        assert result == "my-header-value"

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -221,3 +221,8 @@ class TestMessageTransformationApiGateway:
         variables = {"input": {"body": body}}
         result = ApiGatewayVtlTemplate().render_vtl(template, variables)
         assert result == " b"
+
+    def test_dash_in_variable_name(self):
+        template = "#set($start = 1)#set($end = 5)#foreach($i in [$start .. $end])$i -#end"
+        result = ApiGatewayVtlTemplate().render_vtl(template, {})
+        assert result == "1 -2 -3 -4 -5 -"


### PR DESCRIPTION
This PR patches the `VariableExpression` parse method from airspeed to support variables with dashes (`$request.header.X-User`)

This change was tested in airspeed test set and broke only one test because `-` need spacing to be correctly interpreted. The failing test is the same include in this change set.

https://velocity.apache.org/engine/devel/vtl-reference.html#variables