### PR TITLE
fix pipeline by disabling CircleCI Docker Layer Cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,8 @@ jobs:
         type: string
     machine:
       image: << parameters.machine_image >>
-      docker_layer_caching: true
+      # TODO re-enable docker layer caching after file system problems are fixed
+      # docker_layer_caching: true
     resource_class: << parameters.resource_class >>
     working_directory: /tmp/workspace/repo
     steps:


### PR DESCRIPTION
This PR is a workaround for current problems with the build pipeline in CircleCI, for example here: https://app.circleci.com/pipelines/github/localstack/localstack/10408/workflows/b393d654-3e68-4fd3-9b30-0bceed6828ac/jobs/69777
The (CircleCI internal) Docker Layer Cache Teardown fails with the following error:
```
running command: fstrim [-v /var/lib/docker]
fstrim: /var/lib/docker: FITRIM ioctl failed: Structure needs cleaning
  failed with error exit status 1: 16.997204ms
Error saving DLC after 18.144823504s: exit status 1
```
Since [DLC caches cannot be destroyed manually](https://support.circleci.com/hc/en-us/articles/4407580027675-Docker-Layer-Caching-FAQ), we need to disable the feature for at least 3 days (or until CircleCI fixes issues on their end if it's not only related to our cache).