### PR TITLE
add config variable to define custom SSL cert path

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -468,6 +468,9 @@ SKIP_INFRA_DOWNLOADS = os.environ.get("SKIP_INFRA_DOWNLOADS", "").strip()
 # Whether to skip downloading our signed SSL cert.
 SKIP_SSL_CERT_DOWNLOAD = is_env_true("SKIP_SSL_CERT_DOWNLOAD")
 
+# Absolute path to a custom certificate (pem file)
+CUSTOM_SSL_CERT_PATH = os.environ.get("CUSTOM_SSL_CERT_PATH", "").strip()
+
 # name of the main Docker container
 MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack_main"
 
@@ -712,6 +715,7 @@ MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = [
     "BUCKET_MARKER_LOCAL",
+    "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
     "DEFAULT_REGION",
     "DEVELOP",

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -905,7 +905,7 @@ if hasattr(BaseSelectorEventLoop, "_accept_connection2") and not hasattr(
 
 
 def get_cert_pem_file_path():
-    return os.path.join(config.dirs.cache, SERVER_CERT_PEM_FILE)
+    return config.CUSTOM_SSL_CERT_PATH or os.path.join(config.dirs.cache, SERVER_CERT_PEM_FILE)
 
 
 def start_proxy_server(

--- a/tests/unit/services/test_generic_proxy.py
+++ b/tests/unit/services/test_generic_proxy.py
@@ -1,4 +1,7 @@
-from localstack.services.generic_proxy import UrlMatchingForwarder
+import pytest
+
+from localstack import config
+from localstack.services.generic_proxy import UrlMatchingForwarder, get_cert_pem_file_path
 
 
 class TestUrlMatchingForwarder:
@@ -264,3 +267,18 @@ class TestUrlMatchingForwarder:
         assert response.text == "baz/bar"
 
         httpserver.check()
+
+
+def test_custom_ssl_cert_path_is_used(monkeypatch):
+    monkeypatch.setattr(config, "CUSTOM_SSL_CERT_PATH", "/custom/path/server.cert.pem")
+    assert get_cert_pem_file_path() == "/custom/path/server.cert.pem"
+
+
+@pytest.mark.parametrize(
+    "custom_ssl_cert_path_config",
+    [None, ""],
+)
+def test_custom_ssl_cert_path_not_used_if_not_set(monkeypatch, custom_ssl_cert_path_config):
+    monkeypatch.setattr(config, "CUSTOM_SSL_CERT_PATH", custom_ssl_cert_path_config)
+    # the cache folder can differ for different environments, we only check the suffix
+    assert get_cert_pem_file_path().endswith("/cache/server.test.pem")


### PR DESCRIPTION
Adds a config environment variable which allows to define a path to a custom server certificate.
This setting is introduced as a simple "redirect". This means that if the cert cannot be found at the given path, the remote cert will be downloaded to the given path.