### PR TITLE
check provider is asf_pro for S3 legacy config

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -397,7 +397,7 @@ LEGACY_EDGE_PROXY = is_env_true("LEGACY_EDGE_PROXY")
 
 # whether legacy s3 is enabled
 # TODO change when asf becomes default: os.environ.get("PROVIDER_OVERRIDE_S3", "") == 'legacy'
-LEGACY_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") != "asf"
+LEGACY_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") not in ("asf", "asf_pro")
 
 # whether to use the legacy installers in LPM or enable the new package-based installers (with versions and targets)
 LEGACY_LPM_INSTALLERS = is_env_not_false("LEGACY_LPM_INSTALLERS")


### PR DESCRIPTION
This PR modifies the internally used config for `LEGACY_S3_PROVIDER` and checks if the provider is not "asf" neither "asf_pro".