### PR TITLE
allow package installers to define custom locks

### DIFF
--- a/localstack/cli/lpm.py
+++ b/localstack/cli/lpm.py
@@ -1,6 +1,6 @@
 import itertools
 import logging
-from multiprocessing import Pool
+from multiprocessing.pool import ThreadPool
 from typing import List, Optional
 
 import click
@@ -13,7 +13,6 @@ from localstack.packages.api import NoSuchPackageException, PackagesPluginManage
 from localstack.utils.bootstrap import setup_logging
 
 LOG = logging.getLogger(__name__)
-
 
 console = Console()
 
@@ -99,7 +98,7 @@ def install(
 
         config.dirs.mkdirs()
 
-        with Pool(processes=parallel) as pool:
+        with ThreadPool(processes=parallel) as pool:
             pool.starmap(
                 _do_install_package,
                 zip(package_instances, itertools.repeat(version), itertools.repeat(target)),

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -2,7 +2,7 @@ import abc
 import functools
 import logging
 import os
-import threading
+from threading import RLock
 from collections import defaultdict
 from enum import Enum
 from inspect import getmodule
@@ -52,14 +52,18 @@ class PackageInstaller(abc.ABC):
     multiple versions).
     """
 
-    def __init__(self, name: str, version: str):
+    def __init__(self, name: str, version: str, install_lock: Optional[RLock] = None):
         """
         :param name: technical package name, f.e. "opensearch"
         :param version: version of the package to install
+        :param install_lock: custom lock which should be used for this package installer instance for the
+                             complete #install call. Defaults to a per-instance reentrant lock (RLock).
+                             Package instances create one installer per version. Therefore, by default, the lock
+                             ensures that package installations of the same package and version are mutually exclusive.
         """
         self.name = name
         self.version = version
-        self.lock = threading.RLock()
+        self.install_lock = install_lock or RLock()
 
     def install(self, target: Optional[InstallTarget] = None) -> None:
         """
@@ -72,15 +76,18 @@ class PackageInstaller(abc.ABC):
         try:
             if not target:
                 target = InstallTarget.VAR_LIBS
-            with self.lock:
-                if not self.is_installed():
-                    LOG.debug("Starting installation of %s...", self.name)
-                    self._prepare_installation(target)
-                    self._install(target)
-                    self._post_process(target)
-                    LOG.debug("Installation of %s finished.", self.name)
-                else:
-                    LOG.debug("Installation of %s skipped (already installed).", self.name)
+            # Skip the installation if it's already installed
+            if not self.is_installed():
+                with self.install_lock:
+                    # Package might have been installed in the meantime, check again
+                    if not self.is_installed():
+                        LOG.debug("Starting installation of %s...", self.name)
+                        self._prepare_installation(target)
+                        self._install(target)
+                        self._post_process(target)
+                        LOG.debug("Installation of %s finished.", self.name)
+            else:
+                LOG.debug("Installation of %s skipped (already installed).", self.name)
         except PackageException as e:
             raise e
         except Exception as e:

--- a/localstack/packages/api.py
+++ b/localstack/packages/api.py
@@ -2,10 +2,10 @@ import abc
 import functools
 import logging
 import os
-from threading import RLock
 from collections import defaultdict
 from enum import Enum
 from inspect import getmodule
+from threading import RLock
 from typing import Callable, List, Optional, Tuple
 
 from plugin import Plugin, PluginManager, PluginSpec

--- a/tests/unit/packages/test_api.py
+++ b/tests/unit/packages/test_api.py
@@ -1,11 +1,14 @@
 import os
 from pathlib import Path
-from typing import List
+from queue import Queue
+from threading import Event, RLock
+from typing import List, Optional
 
 import pytest
 
 from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.utils.files import rm_rf
+from localstack.utils.threads import FuncThread
 
 
 class TestPackage(Package):
@@ -20,8 +23,8 @@ class TestPackage(Package):
 
 
 class TestPackageInstaller(PackageInstaller):
-    def __init__(self, version: str):
-        super().__init__("test-installer", version)
+    def __init__(self, version: str, install_lock: Optional[RLock] = None):
+        super().__init__("test-installer", version, install_lock)
 
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "test-installer-marker")
@@ -55,3 +58,84 @@ def test_package_get_installed_dir_returns_none(test_package):
 def test_package_get_installed_dir_returns_install_dir(test_package):
     test_package.install()
     assert test_package.get_installed_dir() is not None
+
+
+class LockingTestPackageInstaller(PackageInstaller):
+    """
+    Package installer class used for testing the locking behavior.
+    """
+    def __init__(self, queue: Queue = Queue(), install_lock: Optional[RLock] = None):
+        super().__init__("lock-test-installer", "test", install_lock)
+        self.queue = queue
+        self.about_to_wait = Event()
+
+    def _get_install_marker_path(self, target: InstallTarget) -> str:
+        return "/non-existing-path"
+
+    def set_event(self, event: Event, name: str):
+        self.event = event
+        self.name = name
+
+    def _install(self, target: InstallTarget) -> None:
+        # Store the object references before waiting for the event (it might be changed in the meantime)
+        event_at_the_time = self.event
+        name_at_the_time = self.name
+        self.about_to_wait.set()
+        event_at_the_time.wait()
+        self.queue.put(name_at_the_time)
+
+
+def test_package_installer_default_lock():
+    # Create a single instance of the installer (by default single instance installer's install methods are mutex)
+    installer = LockingTestPackageInstaller()
+
+    # Set that the installer should wait for event 1 and start
+    event_installer_1 = Event()
+    installer.set_event(event_installer_1, "installer1")
+    # Run the installer in a new thread
+    FuncThread(func=installer.install).start()
+    # Wait for installer 1 to wait for the event
+    installer.about_to_wait.wait()
+    # Create a new event and set it as the new event to wait for
+    event_installer_2 = Event()
+    installer.set_event(event_installer_2, "installer2")
+    # Again, run the installer in a new thread
+    FuncThread(func=installer.install).start()
+    # Release the second installer (by setting the event)
+    event_installer_2.set()
+    # Afterwards release the first installer
+    event_installer_1.set()
+    # Since the first installer should have the lock when being first run, ensure it finishes first
+    assert installer.queue.get() == "installer1"
+
+
+def test_package_installer_custom_lock():
+    shared_lock = RLock()
+    shared_queue = Queue()
+
+    # Create the two installers with the same shared lock
+    installer_1 = LockingTestPackageInstaller(queue=shared_queue, install_lock=shared_lock)
+    installer_2 = LockingTestPackageInstaller(queue=shared_queue, install_lock=shared_lock)
+
+    # Set that the installer 1 should wait for event 1 and start
+    event_installer_1 = Event()
+    installer_1.set_event(event_installer_1, "installer1")
+    FuncThread(func=installer_1.install).start()
+
+    # Create a new event and set it as the new event for installer 2 to wait for
+    event_installer_2 = Event()
+    installer_2.set_event(event_installer_2, "installer2")
+    # Again, run the installer in a new thread
+    FuncThread(func=installer_2.install).start()
+
+    # Wait for installer 1 to wait for the event (it acquired the shared lock)
+    installer_1.about_to_wait.wait()
+
+    # Release the second installer (by setting the event)
+    event_installer_2.set()
+    # Afterwards release the first installer
+    event_installer_1.set()
+
+    first_finished_installer = shared_queue.get(block=True)
+    # Since the first installer should have the lock when being first run, ensure it finishes first
+    assert first_finished_installer == "installer1"

--- a/tests/unit/packages/test_api.py
+++ b/tests/unit/packages/test_api.py
@@ -64,6 +64,7 @@ class LockingTestPackageInstaller(PackageInstaller):
     """
     Package installer class used for testing the locking behavior.
     """
+
     def __init__(self, queue: Queue = Queue(), install_lock: Optional[RLock] = None):
         super().__init__("lock-test-installer", "test", install_lock)
         self.queue = queue


### PR DESCRIPTION
This PR enhances the lock handling for the new package installers such that `PackageInstallers` can define custom locks used for the installers. This can be useful when multiple installers need to be synchronized with each other.
It also changes the parallelization approach in LPM from process-based to thread-based parallelization (in order to ensure that the thread-based locks are respected).

See also:
- Package abstraction introduced in https://github.com/localstack/localstack/pull/6783
- Initial lock handling introduced in https://github.com/localstack/localstack/pull/7053