### PR TITLE
Prevent inconsistent persistence states for DynamoDB

### DIFF
--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -106,8 +106,13 @@ def create_dynamodb_server(
     server = DynamodbServer(port)
     db_path = f"{config.dirs.data}/dynamodb" if not db_path and config.dirs.data else db_path
 
-    if is_env_true("DYNAMODB_IN_MEMORY"):
+    if is_env_true("DYNAMODB_IN_MEMORY") or not (
+        config.PERSISTENCE and os.environ.get("LOCALSTACK_API_KEY", "").strip()
+    ):
+
         # the DYNAMODB_IN_MEMORY variable takes precedence and will set the DB path to None which forces inMemory=true
+        # Furthermore, avoid cases where DBLocal data is persisted but not the Store data leading to an inconsistent state (#7118)
+        # The naive way to do this is to check whether persistence is enabled and API key is set.
         db_path = None
 
     if db_path:

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -6,8 +6,10 @@ from localstack import config
 from localstack.config import is_env_true
 from localstack.services.dynamodb.packages import dynamodblocal_package
 from localstack.utils.aws import aws_stack
+from localstack.utils.bootstrap import is_api_key_configured
 from localstack.utils.common import TMP_THREADS, ShellCommandThread, get_free_tcp_port, mkdir
 from localstack.utils.files import rm_rf
+from localstack.utils.persistence import is_persistence_enabled
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 from localstack.utils.sync import retry
@@ -107,7 +109,7 @@ def create_dynamodb_server(
     db_path = f"{config.dirs.data}/dynamodb" if not db_path and config.dirs.data else db_path
 
     if is_env_true("DYNAMODB_IN_MEMORY") or not (
-        config.PERSISTENCE and os.environ.get("LOCALSTACK_API_KEY", "").strip()
+        is_persistence_enabled() and is_api_key_configured()
     ):
 
         # the DYNAMODB_IN_MEMORY variable takes precedence and will set the DB path to None which forces inMemory=true

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -738,3 +738,12 @@ def in_ci():
         if os.environ.get(key, "") not in [False, "", "0", "false"]:
             return True
     return False
+
+
+def is_api_key_configured() -> bool:
+    """Whether an API key is set in the environment."""
+    return (
+        True
+        if os.environ.get("LOCALSTACK_API_KEY") and os.environ.get("LOCALSTACK_API_KEY").strip()
+        else False
+    )


### PR DESCRIPTION
DynamoDB provider went into an inconsistent state when `PERSISTENCE=1` and API key was not set. 

Only the DBLocal data was being persisted and Store data was not.

See #7118