### PR TITLE
add apigateway eventbridge support

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -904,7 +904,7 @@ class EventBridgeIntegration(BackendIntegration):
         try:
             payload = self.request_templates.render(invocation_context)
         except Exception as e:
-            LOG.warning("Failed to apply template for EventBridge integration", e)
+            LOG.warning("Failed to apply template for EventBridge integration: %s", e)
             raise
         uri = (
             invocation_context.integration.get("uri")

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -912,7 +912,12 @@ class EventBridgeIntegration(BackendIntegration):
             or ""
         )
         region_name = uri.split(":")[3]
-        headers = aws_stack.mock_aws_request_headers(service="events", region_name=region_name)
+        headers = get_internal_mocked_headers(
+            service_name="events",
+            region_name=region_name,
+            role_arn=invocation_context.integration.get("credentials"),
+            source_arn=get_source_arn(invocation_context),
+        )
         headers.update({"X-Amz-Target": invocation_context.headers.get("X-Amz-Target")})
         response = make_http_request(
             config.service_url("events"), method="POST", headers=headers, data=payload

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -913,6 +913,7 @@ class EventBridgeIntegration(BackendIntegration):
         )
         region_name = uri.split(":")[3]
         headers = aws_stack.mock_aws_request_headers(service="events", region_name=region_name)
+        headers.update({"X-Amz-Target": invocation_context.headers.get("X-Amz-Target")})
         response = make_http_request(
             config.service_url("events"), method="POST", headers=headers, data=payload
         )

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -23,6 +23,7 @@ from localstack.services.apigateway.helpers import (
 from localstack.services.apigateway.integration import (
     ApiGatewayIntegrationError,
     DynamoDBIntegration,
+    EventBridgeIntegration,
     HTTPIntegration,
     KinesisIntegration,
     LambdaIntegration,
@@ -365,6 +366,13 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
 
         if method == "POST" and ":sns:path" in uri:
             return SNSIntegration().invoke(invocation_context)
+
+        if (
+            method == "POST"
+            and uri.startswith("arn:aws:apigateway:")
+            and "events:action/PutEvents" in uri
+        ):
+            return EventBridgeIntegration().invoke(invocation_context)
 
     elif integration_type in ["HTTP_PROXY", "HTTP"]:
         return HTTPIntegration().invoke(invocation_context)

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -138,11 +138,12 @@ class ApigatewayRouter:
         )
 
     def invoke_rest_api(self, request: Request, **url_params: Dict[str, str]) -> Response:
-        _, region_name = get_api_account_id_and_region(url_params["api_id"])
+        account_id, region_name = get_api_account_id_and_region(url_params["api_id"])
         if not region_name:
             return Response(status=404)
         invocation_context = to_invocation_context(request, url_params)
         invocation_context.region_name = region_name
+        invocation_context.account_id = account_id
         result = invoke_rest_api_from_request(invocation_context)
         if result is not None:
             return convert_response(result)

--- a/tests/integration/apigateway/test_apigateway_eventbridge.py
+++ b/tests/integration/apigateway/test_apigateway_eventbridge.py
@@ -1,0 +1,128 @@
+import json
+
+import pytest
+import requests
+
+from localstack.utils.strings import short_uid
+from localstack.utils.sync import retry
+from tests.integration.apigateway.apigateway_fixtures import (
+    api_invoke_url,
+    create_rest_api_deployment,
+    create_rest_api_integration,
+    create_rest_api_integration_response,
+    create_rest_api_method_response,
+    create_rest_resource,
+    create_rest_resource_method,
+)
+from tests.integration.apigateway.conftest import APIGATEWAY_ASSUME_ROLE_POLICY
+
+
+@pytest.mark.aws_validated
+def test_apigateway_to_eventbridge(
+    aws_client, create_rest_apigw, create_role_with_policy, region, account_id, snapshot
+):
+    api_id, _, root = create_rest_apigw(name=f"{short_uid()}-eventbridge")
+
+    resource_id, _ = create_rest_resource(
+        aws_client.apigateway, restApiId=api_id, parentId=root, pathPart="event"
+    )
+
+    create_rest_resource_method(
+        aws_client.apigateway,
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        authorizationType="NONE",
+        requestParameters={
+            "method.request.header.X-Amz-Target": False,
+            "method.request.header.Content-Type": False,
+        },
+    )
+
+    _, role_arn = create_role_with_policy(
+        "Allow", "events:PutEvents", json.dumps(APIGATEWAY_ASSUME_ROLE_POLICY), "*"
+    )
+
+    create_rest_api_integration(
+        aws_client.apigateway,
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        integrationHttpMethod="POST",
+        type="AWS",
+        uri=f"arn:aws:apigateway:{region}:events:action/PutEvents",
+        passthroughBehavior="WHEN_NO_TEMPLATES",
+        credentials=role_arn,
+        requestParameters={},
+        requestTemplates={
+            "application/json": """
+              #set($context.requestOverride.header.X-Amz-Target = "AWSEvents.PutEvents")
+              #set($context.requestOverride.header.Content-Type = "application/x-amz-json-1.1")
+              #set($inputRoot = $input.path('$'))
+              {
+                "Entries": [
+                  #foreach($elem in $inputRoot.items)
+                  {
+                    "Detail": "$util.escapeJavaScript($elem.Detail).replaceAll("\\'","'")",
+                    "DetailType": "$elem.DetailType",
+                    "Source":"$elem.Source"
+                  }#if($foreach.hasNext),#end
+                  #end
+                ]
+              }
+            """
+        },
+    )
+
+    create_rest_api_method_response(
+        aws_client.apigateway,
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        statusCode="200",
+        responseModels={"application/json": "Empty"},
+        responseParameters={},
+    )
+
+    create_rest_api_integration_response(
+        aws_client.apigateway,
+        restApiId=api_id,
+        resourceId=resource_id,
+        httpMethod="POST",
+        statusCode="200",
+        responseTemplates={"application/json": "#set($inputRoot = $input.json('$'))\n$inputRoot"},
+    )
+
+    create_rest_api_deployment(aws_client.apigateway, restApiId=api_id, stageName="dev")
+
+    # invoke rest api
+    invocation_url = api_invoke_url(
+        api_id=api_id,
+        stage="dev",
+        path="/event",
+    )
+
+    def invoke_api(url):
+        response = requests.post(
+            url,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            data=json.dumps(
+                {
+                    "items": [
+                        {
+                            "Detail": '{"data":"Order is created"}',
+                            "DetailType": "Test",
+                            "Source": "order",
+                        }
+                    ]
+                }
+            ),
+            verify=False,
+        )
+        assert 200 == response.status_code
+        return response
+
+    # retry is necessary against AWS, probably IAM permission delay
+    response = retry(invoke_api, sleep=1, retries=10, url=invocation_url)
+    assert response.ok
+    snapshot.match("eventbridge-put-events-response", response.json())

--- a/tests/integration/apigateway/test_apigateway_eventbridge.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_eventbridge.snapshot.json
@@ -1,0 +1,15 @@
+{
+  "tests/integration/apigateway/test_apigateway_eventbridge.py::test_apigateway_to_eventbridge": {
+    "recorded-date": "05-07-2023, 18:09:01",
+    "recorded-content": {
+      "eventbridge-put-events-response": {
+        "Entries": [
+          {
+            "EventId": "<uuid:1>"
+          }
+        ],
+        "FailedEntryCount": 0
+      }
+    }
+  }
+}

--- a/tests/integration/apigateway/test_apigateway_eventbridge.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_eventbridge.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/apigateway/test_apigateway_eventbridge.py::test_apigateway_to_eventbridge": {
-    "recorded-date": "05-07-2023, 18:09:01",
+    "recorded-date": "05-07-2023, 22:31:40",
     "recorded-content": {
       "eventbridge-put-events-response": {
         "Entries": [

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1818,3 +1818,46 @@ class TestEvents:
         with pytest.raises(ClientError) as e:
             aws_client.events.describe_event_bus(Name=nonexistent_event_bus)
         snapshot.match("non-existent-bus", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_test_event_pattern(self, aws_client, snapshot, account_id, region):
+        response = aws_client.events.test_event_pattern(
+            Event=json.dumps(
+                {
+                    "id": "1",
+                    "source": "order",
+                    "detail-type": "Test",
+                    "account": account_id,
+                    "region": region,
+                    "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }
+            ),
+            EventPattern=json.dumps(
+                {
+                    "source": ["order"],
+                    "detail-type": ["Test"],
+                }
+            ),
+        )
+        snapshot.match("eventbridge-test-event-pattern-response", response)
+
+        # negative test, source is not matched
+        response = aws_client.events.test_event_pattern(
+            Event=json.dumps(
+                {
+                    "id": "1",
+                    "source": "order",
+                    "detail-type": "Test",
+                    "account": account_id,
+                    "region": region,
+                    "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }
+            ),
+            EventPattern=json.dumps(
+                {
+                    "source": ["shipment"],
+                    "detail-type": ["Test"],
+                }
+            ),
+        )
+        snapshot.match("eventbridge-test-event-pattern-response-no-match", response)

--- a/tests/integration/test_events.snapshot.json
+++ b/tests/integration/test_events.snapshot.json
@@ -152,5 +152,24 @@
         }
       }
     }
+  },
+  "tests/integration/test_events.py::TestEvents::test_test_event_pattern": {
+    "recorded-date": "05-07-2023, 19:41:16",
+    "recorded-content": {
+      "eventbridge-test-event-pattern-response": {
+        "Result": true,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "eventbridge-test-event-pattern-response-no-match": {
+        "Result": false,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds support for API Gateway EventBridge integration
API Reference - https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_PutEvents.html


# What changes:

- Adds support to eventbridge integration
- Adds support to eventbridge **test_event_pattern**
- Adds snapshot test
- Implements a first version of `requestOverride` just to support the use case, that will be augment on a follow up issue (https://github.com/localstack/localstack/issues/7727)
- Add support to hiphens in assignments (airspeed, https://github.com/localstack/airspeed/issues/4).

## Related issues:
Implements - https://github.com/localstack/localstack/issues/6925
Fixes - https://github.com/localstack/localstack/issues/6806

## Partial fixes:
https://github.com/localstack/localstack/issues/7727
https://github.com/localstack/airspeed/issues/4

## TF Sample
terraform sample - https://github.com/localstack/localstack-terraform-samples/tree/master/apigateway-eventbridge-integration