### PR TITLE
add apigateway stage variables support

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -27,7 +27,6 @@ from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_responses import LambdaResponse, requests_response
-from localstack.utils.aws.aws_stack import extract_region_from_arn
 from localstack.utils.aws.templating import VtlTemplate
 from localstack.utils.collections import remove_attributes
 from localstack.utils.common import make_http_request, to_str

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -332,9 +332,7 @@ class LambdaIntegration(BackendIntegration):
             or invocation_context.integration.get("integrationUri")
             or ""
         )
-        variables = {
-            "stageVariables": invocation_context.stage_variables
-        }
+        variables = {"stageVariables": invocation_context.stage_variables}
         uri = VtlTemplate().render_vtl(uri, variables)
         if ":lambda:path" in uri:
             uri = uri.split(":lambda:path")[1].split("functions/")[1].split("/invocations")[0]

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -2136,6 +2136,104 @@ class TestAPIGateway:
         assert "/pets" in paths
         assert "/pets/{petId}" in paths
 
+    @pytest.mark.aws_validated
+    @pytest.mark.parametrize("stage_name", ["local", "dev"])
+    def test_apigw_stage_variables(
+        self,
+        apigateway_client,
+        create_lambda_function,
+        create_rest_apigw,
+        lambda_client,
+        sts_client,
+        stage_name,
+    ):
+        aws_account_id = sts_client.get_caller_identity()["Account"]
+        region_name = apigateway_client._client_config.region_name
+        api_id, _, root = create_rest_apigw(name="aws lambda api")
+        resource_id, _ = create_rest_resource(
+            apigateway_client, restApiId=api_id, parentId=root, pathPart="test"
+        )
+        create_rest_resource_method(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+        )
+
+        fn_name = f"test-{short_uid()}"
+        create_lambda_function(
+            func_name=fn_name,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            runtime=LAMBDA_RUNTIME_PYTHON39,
+        )
+        lambda_arn = lambda_client.get_function(FunctionName=fn_name)["Configuration"][
+            "FunctionArn"
+        ]
+
+        if stage_name == "dev":
+            uri = f"arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/arn:aws:lambda:{region_name}:{aws_account_id}:function:${{stageVariables.lambdaFunction}}/invocations"
+        else:
+            uri = f"arn:aws:apigateway:{region_name}:lambda:path/2015-03-31/functions/arn:aws:lambda:{region_name}:{aws_account_id}:function:{fn_name}/invocations"
+
+        create_rest_api_integration(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            integrationHttpMethod="POST",
+            type="AWS",
+            uri=uri,
+            requestTemplates={"application/json": '{ "version": "$stageVariables.version" }'},
+        )
+        create_rest_api_method_response(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+            responseParameters={
+                "method.response.header.Content-Type": False,
+                "method.response.header.Access-Control-Allow-Origin": False,
+            },
+        )
+        create_rest_api_integration_response(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
+        deployment_id, _ = create_rest_api_deployment(apigateway_client, restApiId=api_id)
+
+        stage_variables = (
+            {"lambdaFunction": fn_name, "version": "1.0"} if stage_name == "dev" else {}
+        )
+        create_rest_api_stage(
+            apigateway_client,
+            restApiId=api_id,
+            stageName=stage_name,
+            deploymentId=deployment_id,
+            variables=stage_variables,
+        )
+
+        source_arn = f"arn:aws:execute-api:{region_name}:{aws_account_id}:{api_id}/*/*/test"
+        lambda_client.add_permission(
+            FunctionName=lambda_arn,
+            StatementId=str(short_uid()),
+            Action="lambda:InvokeFunction",
+            Principal="apigateway.amazonaws.com",
+            SourceArn=source_arn,
+        )
+
+        url = api_invoke_url(api_id, stage=stage_name, path="/test")
+        response = requests.post(url, json={"test": "test"})
+
+        if stage_name == "local":
+            assert response.json() == {"version": ""}
+        else:
+            assert response.json() == {"version": "1.0"}
+
 
 def test_import_swagger_api(apigateway_client):
     api_spec = load_test_resource("openapi.swagger.json")

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -37,6 +37,7 @@ from localstack.services.apigateway.helpers import (
     path_based_url,
 )
 from localstack.services.awslambda.lambda_api import add_event_source, use_docker
+from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.utils import testutil
 from localstack.utils.aws import arns, aws_stack, queries
 from localstack.utils.aws import resources as resource_util


### PR DESCRIPTION
Adds support for stage variables. Stage variables can be used to render request mapping and request parameters.

Reference API - https://docs.aws.amazon.com/apigateway/latest/developerguide/aws-api-gateway-stage-variables-reference.html

Verified with https://github.com/localstack/localstack-terraform-samples/tree/master/apigateway-stage-variables
Implements https://github.com/localstack/localstack/issues/6928

TODO

- [ ] stage variables doesn't warrant a snapshot test by itself but we can add to a templating request test with AWS_PROXY