### PR TITLE
Disable resolve_refs_recursively in GenericResourceModel by default

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -712,11 +712,16 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER") or is_en
 # TODO remove fallback to LAMBDA_DOCKER_NETWORK with next minor version
 MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER_NETWORK
 
+# EXPERIMENTAL/LEGACY. Use this flag to return to the legacy behavior of resolving references in the specific models
+CFN_ENABLE_RESOLVE_REFS_IN_MODELS = is_env_true("CFN_ENABLE_RESOLVE_REFS_IN_MODELS")
+
+
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = [
     "BUCKET_MARKER_LOCAL",
+    "CFN_ENABLE_RESOLVE_REFS_IN_MODELS",
     "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
     "DEFAULT_REGION",

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -3,6 +3,7 @@ import logging
 # TODO: remove
 from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 
+from localstack import config
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import camel_to_snake_case
 
@@ -187,10 +188,12 @@ class GenericBaseModel:
 
     @classmethod
     def resolve_refs_recursively(cls, stack_name, value, resources):
+        if config.CFN_ENABLE_RESOLVE_REFS_IN_MODELS:
+            # TODO: restructure code to avoid circular import here
+            from localstack.services.cloudformation.provider import find_stack
+            from localstack.utils.cloudformation.template_deployer import resolve_refs_recursively
+
+            stack = find_stack(stack_name)
+            return resolve_refs_recursively(stack, value)
+
         return value
-        # TODO: restructure code to avoid circular import here
-        # from localstack.services.cloudformation.provider import find_stack
-        # from localstack.utils.cloudformation.template_deployer import resolve_refs_recursively
-        #
-        # stack = find_stack(stack_name)
-        # return resolve_refs_recursively(stack, value)

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -187,9 +187,10 @@ class GenericBaseModel:
 
     @classmethod
     def resolve_refs_recursively(cls, stack_name, value, resources):
+        return value
         # TODO: restructure code to avoid circular import here
-        from localstack.services.cloudformation.provider import find_stack
-        from localstack.utils.cloudformation.template_deployer import resolve_refs_recursively
-
-        stack = find_stack(stack_name)
-        return resolve_refs_recursively(stack, value)
+        # from localstack.services.cloudformation.provider import find_stack
+        # from localstack.utils.cloudformation.template_deployer import resolve_refs_recursively
+        #
+        # stack = find_stack(stack_name)
+        # return resolve_refs_recursively(stack, value)


### PR DESCRIPTION
Changed the scope of the PR to only disabling the calls to resolve_refs_recursively in `GenericResourceModel`. It can be re-enabled via a feature flag if someone experiences any issues.