### PR TITLE
fix not-implemented evaluation for s3

### DIFF
--- a/scripts/capture_notimplemented_responses.py
+++ b/scripts/capture_notimplemented_responses.py
@@ -132,7 +132,7 @@ def map_to_notimplemented(row: RowEntry) -> bool:
         row["service"]
         in [
             "route53",
-            "s3",
+            # "s3", -> for s3 404 not found is returned in some case when the bucket does not exist
             "s3control",
         ]
         and row["status_code"] == 404


### PR DESCRIPTION
Recent automated docs update revealed that some s3 API calls are sometimes classified as not being implemented, even though those are available. 
* the API sometime returns `404 Not Found` if the bucket does not exist, e.g. for:
  - DeleteBucketCors
  - GetBucketLifecycle
  - GetBucketLifecycleConfiguration
  - GetBucketRequestPayment
  - HeadBucket
  - PutBucketLifecycle
  - PutBucketLifecycleConfiguration
* previously some of those have been assumed as "implemented" but only if the API returned a `Bad Request` (which might be caused by an invalid bucket name)

As a fix, we exclude `s3` for the specific paths that assumed responses `404 Not Found` relates to not implemented API calls.



