### PR TITLE
S3 ASF fix pre-signed ports permutation

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -549,7 +549,7 @@ class S3SigV4SignatureContext:
             self._original_host = netloc
             self.path = context.request.path
 
-        self._set_aws_request(self.request_url)
+        self.aws_request = self._to_aws_request(self.request_url)
 
     def update_host_port(self, new_host_port: str, original_host_port: str = None):
         """
@@ -564,7 +564,7 @@ class S3SigV4SignatureContext:
             updated_netloc = f"{self._original_host}{new_host_port}"
         self.host = updated_netloc
         self.signed_headers["host"] = updated_netloc
-        self._set_aws_request(request_url=self.request_url)
+        self.aws_request = self._to_aws_request(request_url=self.request_url)
 
     @property
     def request_url(self) -> str:
@@ -614,7 +614,7 @@ class S3SigV4SignatureContext:
         new_query_string = percent_encode_sequence(new_query_args)
         return signature_headers, new_query_string
 
-    def _set_aws_request(self, request_url: str) -> None:
+    def _to_aws_request(self, request_url: str) -> AWSRequest:
         """
         Creates and sets the AWSRequest needed for S3SigV4QueryAuth signer
         :param request_url: the request_url used for the calculation
@@ -631,7 +631,7 @@ class S3SigV4SignatureContext:
                 "signing": {"bucket": self._bucket},
             },
         }
-        self.aws_request: AWSRequest = create_request_object(request_dict)
+        return create_request_object(request_dict)
 
 
 def _validate_headers_for_moto(headers: Headers) -> None:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2780,7 +2780,7 @@ class TestS3PresignedUrl:
         # attempt to use the presigned request
         response = requests.get(presigned_request)
         # response should not be successful as it is expired -> signature will not match
-        "SignatureDoesNotMatch" in str(response.content)
+        # "SignatureDoesNotMatch" in str(response.content)
         assert response.status_code in [400, 403]
 
         # set skip signature validation to True -> the request should now work


### PR DESCRIPTION
Follow-up PR to #7070
While migrating the tests, it came to light that port permutation while checking for SigV4 signature was not working.
For context, while validating the signature, we check the host value. But with LocalStack, you can access S3 from different ports (edge port, 443, 80 or not port at all for example in the browser). So we permute ports to try for different `host` value if the first received one is incorrect.
This also comes with a significant refactor, as we would create a lot of resource for every permutation which needed to be created only once. 