### PR TITLE
add snapshot test for cloudwatch put-metric-data with values list

### DIFF
--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -15,6 +15,8 @@ from localstack.aws.api.cloudwatch import (
     DescribeAlarmsOutput,
     GetMetricDataInput,
     GetMetricDataOutput,
+    GetMetricStatisticsInput,
+    GetMetricStatisticsOutput,
     ListTagsForResourceOutput,
     PutCompositeAlarmInput,
     PutMetricAlarmInput,
@@ -404,5 +406,18 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
             _cleanup_describe_output(c)
         for m in response["MetricAlarms"]:
             _cleanup_describe_output(m)
+
+        return response
+
+    @handler("GetMetricStatistics", expand=False)
+    def get_metric_statistics(
+        self, context: RequestContext, request: GetMetricStatisticsInput
+    ) -> GetMetricStatisticsOutput:
+        response = moto.call_moto(context)
+
+        # cleanup -> ExtendendStatics is not included in AWS response if it returned empty
+        for datapoint in response.get("Datapoints"):
+            if "ExtendedStatistics" in datapoint and not datapoint.get("ExtendedStatistics"):
+                datapoint.pop("ExtendedStatistics")
 
         return response

--- a/tests/integration/test_cloudwatch.snapshot.json
+++ b/tests/integration/test_cloudwatch.snapshot.json
@@ -666,5 +666,26 @@
         }
       }
     }
+  },
+  "tests/integration/test_cloudwatch.py::TestCloudwatch::test_put_metric_data_values_list": {
+    "recorded-date": "11-11-2022, 16:04:47",
+    "recorded-content": {
+      "get_metric_statistics": {
+        "Datapoints": [
+          {
+            "Maximum": 10.0,
+            "SampleCount": 6.0,
+            "Sum": 42.0,
+            "Timestamp": "timestamp",
+            "Unit": "Count"
+          }
+        ],
+        "Label": "test-metric",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR relates to an [upstream PR in moto](https://github.com/spulec/moto/pull/5658). The PR in moto fixes issue #7154, and adds support for using `values` lists for `put-metric-data`.
* adds snapshot test to verify parity with AWS
* fix small parity issue, by removing empty `ExtendedStatistics` from moto-result if it is empty
  
