### PR TITLE
DDB - clean DB path when persistence is not set

### DIFF
--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -108,14 +108,14 @@ def create_dynamodb_server(
     server = DynamodbServer(port)
     db_path = f"{config.dirs.data}/dynamodb" if not db_path and config.dirs.data else db_path
 
-    if is_env_true("DYNAMODB_IN_MEMORY") or not (
-        is_persistence_enabled() and is_api_key_configured()
-    ):
-
+    if is_env_true("DYNAMODB_IN_MEMORY"):
         # the DYNAMODB_IN_MEMORY variable takes precedence and will set the DB path to None which forces inMemory=true
-        # Furthermore, avoid cases where DBLocal data is persisted but not the Store data leading to an inconsistent state (#7118)
-        # The naive way to do this is to check whether persistence is enabled and API key is set.
         db_path = None
+
+    # In some cases (e.g., DDB starting not in memory and persistence not set), the DBLocal assets are persisted
+    # but the Store data is not. This might lead to an inconsistent state (#7118). Therefore, we clean the db path
+    # before starting the DynamoDB server.
+    clean_db_path = clean_db_path or not (is_persistence_enabled() and is_api_key_configured())
 
     if db_path:
         if clean_db_path:


### PR DESCRIPTION
Following up on the discussion in https://github.com/localstack/localstack/pull/7123. Went on with option 1 since pods always fetch from a well-known directory (we do not have to implement the logic for random assets dir).


