### PR TITLE
fix python init script execution

### DIFF
--- a/localstack/runtime/init.py
+++ b/localstack/runtime/init.py
@@ -78,7 +78,7 @@ class PythonScriptRunner(ScriptRunner):
 
     def run(self, path: str) -> None:
         with open(path, "rb") as fd:
-            exec(fd.read())
+            exec(fd.read(), {})
 
 
 class InitScriptManager:


### PR DESCRIPTION
Use `exec` passing in the globals from the interpreter rather than the globals from the function.

This fixes the issue with running a python init script that access a global variable. In essence, calling `exec` inside a class method evaluates that code from the context of that class, rather than the interpreter. "Global" variables in the users' script are stored in `locals()` when run from inside a function (as per in `PythonScriptRunner.run`) rather than in `globals()`. This means that when the variable is accessed inside the users' function, it is looked up from the `locals()` store rather than the `globals()` and is therefore not found.

See #7135