### PR TITLE
Fix override for cleaning DynamoDB state file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ jobs:
       - run:
           name: Install prerequisites
           command: |
+            # fix for: https://discuss.circleci.com/t/heroku-gpg-issues-in-ubuntu-images/43834/3
+            sudo rm -rf /etc/apt/sources.list.d/heroku.list
             sudo apt-get update
             sudo apt-get install -y libsasl2-dev
       - run:

--- a/localstack/services/dynamodb/server.py
+++ b/localstack/services/dynamodb/server.py
@@ -99,10 +99,15 @@ class DynamodbServer(Server):
 
 
 def create_dynamodb_server(
-    port=None, db_path: Optional[str] = None, clean_db_path: bool = False
+    port: Optional[int] = None, db_path: Optional[str] = None, clean_db_path: Optional[bool] = None
 ) -> DynamodbServer:
     """
-    Creates a dynamodb server from the LocalStack configuration.
+    Creates a DynamoDB server from the local configuration.
+    :param port:          optional, the port to start the server on (defaults to a random port)
+    :param db_path:       path to the persistent state files used by the DynamoDB Local process
+    :param clean_db_path: optional, whether to clean the state files before starting the process; if None is passed,
+                          the state files are cleaned by default, unless persistence is enabled with API key configured
+    :return: the server instance
     """
     port = port or get_free_tcp_port()
     server = DynamodbServer(port)
@@ -114,8 +119,9 @@ def create_dynamodb_server(
 
     # In some cases (e.g., DDB starting not in memory and persistence not set), the DBLocal assets are persisted
     # but the Store data is not. This might lead to an inconsistent state (#7118). Therefore, we clean the db path
-    # before starting the DynamoDB server.
-    clean_db_path = clean_db_path or not (is_persistence_enabled() and is_api_key_configured())
+    # before starting the DynamoDB server. Note: only cleaning if clean_db_path is None (i.e., not specified)
+    if clean_db_path is None:
+        clean_db_path = not (is_persistence_enabled() and is_api_key_configured())
 
     if db_path:
         if clean_db_path:


### PR DESCRIPTION
This is a follow-up from #7174 and #7123 . Unfortunately, one control path (if `clean_db_path=False` is passed explicitly) was still not being considered properly, leading to cloud pods testing issues upstream. This should be fixed in this PR now - also added a docstring to clarify the parameters for the `create_dynamodb_server(..)` function.