### PR TITLE
add OpenSearch 1.2 and 1.3, change default to OpenSearch 1.3

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -128,7 +128,7 @@ ELASTICSEARCH_PLUGIN_LIST = [
 ELASTICSEARCH_DELETE_MODULES = ["ingest-geoip"]
 
 # the version of opensearch which is used by default
-OPENSEARCH_DEFAULT_VERSION = "OpenSearch_1.1"
+OPENSEARCH_DEFAULT_VERSION = "OpenSearch_1.3"
 
 # See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/supported-plugins.html
 OPENSEARCH_PLUGIN_LIST = [

--- a/localstack/services/opensearch/versions.py
+++ b/localstack/services/opensearch/versions.py
@@ -13,7 +13,7 @@ from localstack.aws.api.opensearch import CompatibleVersionsMap, EngineType
 from localstack.utils.common import get_arch
 
 # Internal representation of the OpenSearch versions (without the "OpenSearch_" prefix)
-_opensearch_install_versions = {"1.1": "1.1.0", "1.0": "1.0.0"}
+_opensearch_install_versions = {"1.0": "1.0.0", "1.1": "1.1.0", "1.2": "1.2.4", "1.3": "1.3.6"}
 # Internal representation of the Elasticsearch versions (without the "Elasticsearch_" prefix)
 _elasticsearch_install_versions = {
     "7.10": "7.10.0",
@@ -33,7 +33,6 @@ _elasticsearch_install_versions = {
     "5.5": "5.5.3",
     "5.3": "5.3.3",
     "5.1": "5.1.2",
-    "5.0": "5.0.2",
 }
 #  prefixed versions
 _prefixed_opensearch_install_versions = {
@@ -49,88 +48,20 @@ install_versions = {
 
 # List of compatible versions (using the external representations)
 compatible_versions = [
-    CompatibleVersionsMap(SourceVersion="OpenSearch_1.0", TargetVersions=["OpenSearch_1.1"]),
     CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_7.10", TargetVersions=["OpenSearch_1.0", "OpenSearch_1.1"]
+        SourceVersion="Elasticsearch_5.1",
+        TargetVersions=["Elasticsearch_5.6"],
     ),
     CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_7.9",
-        TargetVersions=["Elasticsearch_7.10", "OpenSearch_1.0", "OpenSearch_1.1"],
+        SourceVersion="Elasticsearch_5.3",
+        TargetVersions=["Elasticsearch_5.6"],
     ),
     CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_7.8",
-        TargetVersions=[
-            "Elasticsearch_7.9",
-            "Elasticsearch_7.10",
-            "OpenSearch_1.1",
-            "OpenSearch_1.0",
-        ],
+        SourceVersion="Elasticsearch_5.5",
+        TargetVersions=["Elasticsearch_5.6"],
     ),
     CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_7.7",
-        TargetVersions=[
-            "Elasticsearch_7.8",
-            "Elasticsearch_7.9",
-            "Elasticsearch_7.10",
-            "OpenSearch_1.0",
-            "OpenSearch_1.1",
-        ],
-    ),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_7.4",
-        TargetVersions=[
-            "Elasticsearch_7.7",
-            "Elasticsearch_7.8",
-            "Elasticsearch_7.9",
-            "Elasticsearch_7.10",
-            "OpenSearch_1.0",
-            "OpenSearch_1.1",
-        ],
-    ),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_7.1",
-        TargetVersions=[
-            "Elasticsearch_7.4",
-            "Elasticsearch_7.7",
-            "Elasticsearch_7.8",
-            "Elasticsearch_7.9",
-            "Elasticsearch_7.10",
-            "OpenSearch_1.0",
-            "OpenSearch_1.1",
-        ],
-    ),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_6.8",
-        TargetVersions=[
-            "Elasticsearch_7.1",
-            "Elasticsearch_7.4",
-            "Elasticsearch_7.7",
-            "Elasticsearch_7.8",
-            "Elasticsearch_7.9",
-            "Elasticsearch_7.10",
-            "OpenSearch_1.0",
-            "OpenSearch_1.1",
-        ],
-    ),
-    CompatibleVersionsMap(SourceVersion="Elasticsearch_6.7", TargetVersions=["Elasticsearch_6.8"]),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_6.5", TargetVersions=["Elasticsearch_6.7", "Elasticsearch_6.8"]
-    ),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_6.4",
-        TargetVersions=["Elasticsearch_6.5", "Elasticsearch_6.7", "Elasticsearch_6.8"],
-    ),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_6.3",
-        TargetVersions=[
-            "Elasticsearch_6.4",
-            "Elasticsearch_6.5",
-            "Elasticsearch_6.7",
-            "Elasticsearch_6.8",
-        ],
-    ),
-    CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_6.2",
+        SourceVersion="Elasticsearch_5.6",
         TargetVersions=[
             "Elasticsearch_6.3",
             "Elasticsearch_6.4",
@@ -150,7 +81,7 @@ compatible_versions = [
         ],
     ),
     CompatibleVersionsMap(
-        SourceVersion="Elasticsearch_5.6",
+        SourceVersion="Elasticsearch_6.2",
         TargetVersions=[
             "Elasticsearch_6.3",
             "Elasticsearch_6.4",
@@ -159,9 +90,118 @@ compatible_versions = [
             "Elasticsearch_6.8",
         ],
     ),
-    CompatibleVersionsMap(SourceVersion="Elasticsearch_5.5", TargetVersions=["Elasticsearch_5.6"]),
-    CompatibleVersionsMap(SourceVersion="Elasticsearch_5.3", TargetVersions=["Elasticsearch_5.6"]),
-    CompatibleVersionsMap(SourceVersion="Elasticsearch_5.1", TargetVersions=["Elasticsearch_5.6"]),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_6.3",
+        TargetVersions=[
+            "Elasticsearch_6.4",
+            "Elasticsearch_6.5",
+            "Elasticsearch_6.7",
+            "Elasticsearch_6.8",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_6.4",
+        TargetVersions=["Elasticsearch_6.5", "Elasticsearch_6.7", "Elasticsearch_6.8"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_6.5",
+        TargetVersions=["Elasticsearch_6.7", "Elasticsearch_6.8"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_6.7",
+        TargetVersions=["Elasticsearch_6.8"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_6.8",
+        TargetVersions=[
+            "Elasticsearch_7.1",
+            "Elasticsearch_7.4",
+            "Elasticsearch_7.7",
+            "Elasticsearch_7.8",
+            "Elasticsearch_7.9",
+            "Elasticsearch_7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_7.1",
+        TargetVersions=[
+            "Elasticsearch_7.4",
+            "Elasticsearch_7.7",
+            "Elasticsearch_7.8",
+            "Elasticsearch_7.9",
+            "Elasticsearch_7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_7.4",
+        TargetVersions=[
+            "Elasticsearch_7.7",
+            "Elasticsearch_7.8",
+            "Elasticsearch_7.9",
+            "Elasticsearch_7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_7.7",
+        TargetVersions=[
+            "Elasticsearch_7.8",
+            "Elasticsearch_7.9",
+            "Elasticsearch_7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_7.8",
+        TargetVersions=[
+            "Elasticsearch_7.9",
+            "Elasticsearch_7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_7.9",
+        TargetVersions=[
+            "Elasticsearch_7.10",
+            "OpenSearch_1.0",
+            "OpenSearch_1.1",
+            "OpenSearch_1.2",
+            "OpenSearch_1.3",
+        ],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="Elasticsearch_7.10",
+        TargetVersions=["OpenSearch_1.0", "OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_1.0",
+        TargetVersions=["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_1.1",
+        TargetVersions=["OpenSearch_1.2", "OpenSearch_1.3"],
+    ),
+    CompatibleVersionsMap(
+        SourceVersion="OpenSearch_1.2",
+        TargetVersions=["OpenSearch_1.3"],
+    ),
 ]
 
 

--- a/tests/integration/test_es.py
+++ b/tests/integration/test_es.py
@@ -83,16 +83,32 @@ class TestElasticsearchProvider:
 
         versions = response["CompatibleElasticsearchVersions"]
 
-        assert len(versions) == 18
+        assert len(versions) == 20
 
-        assert {"SourceVersion": "OpenSearch_1.0", "TargetVersions": ["OpenSearch_1.1"]} in versions
+        assert {
+            "SourceVersion": "OpenSearch_1.0",
+            "TargetVersions": ["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
+        } in versions
         assert {
             "SourceVersion": "7.10",
-            "TargetVersions": ["OpenSearch_1.0", "OpenSearch_1.1"],
+            "TargetVersions": [
+                "OpenSearch_1.0",
+                "OpenSearch_1.1",
+                "OpenSearch_1.2",
+                "OpenSearch_1.3",
+            ],
         } in versions
         assert {
             "SourceVersion": "7.7",
-            "TargetVersions": ["7.8", "7.9", "7.10", "OpenSearch_1.0", "OpenSearch_1.1"],
+            "TargetVersions": [
+                "7.8",
+                "7.9",
+                "7.10",
+                "OpenSearch_1.0",
+                "OpenSearch_1.1",
+                "OpenSearch_1.2",
+                "OpenSearch_1.3",
+            ],
         } in versions
 
     @pytest.mark.skip_offline

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -93,6 +93,8 @@ class TestOpensearchProvider:
         versions = response["Versions"]
 
         expected_versions = [
+            "OpenSearch_1.3",
+            "OpenSearch_1.2",
             "OpenSearch_1.1",
             "OpenSearch_1.0",
             "Elasticsearch_7.10",
@@ -112,7 +114,6 @@ class TestOpensearchProvider:
             "Elasticsearch_5.5",
             "Elasticsearch_5.3",
             "Elasticsearch_5.1",
-            "Elasticsearch_5.0",
         ]
         # We iterate over the expected versions to avoid breaking the test if new versions are supported
         for expected_version in expected_versions:
@@ -125,24 +126,40 @@ class TestOpensearchProvider:
 
         compatible_versions = response["CompatibleVersions"]
 
-        assert len(compatible_versions) >= 18
+        assert len(compatible_versions) >= 20
         expected_compatible_versions = [
-            {"SourceVersion": "OpenSearch_1.0", "TargetVersions": ["OpenSearch_1.1"]},
+            {
+                "SourceVersion": "OpenSearch_1.0",
+                "TargetVersions": ["OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3"],
+            },
             {
                 "SourceVersion": "Elasticsearch_7.10",
-                "TargetVersions": ["OpenSearch_1.0", "OpenSearch_1.1"],
+                "TargetVersions": [
+                    "OpenSearch_1.0",
+                    "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
+                ],
             },
             {
                 "SourceVersion": "Elasticsearch_7.9",
-                "TargetVersions": ["Elasticsearch_7.10", "OpenSearch_1.0", "OpenSearch_1.1"],
+                "TargetVersions": [
+                    "Elasticsearch_7.10",
+                    "OpenSearch_1.0",
+                    "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
+                ],
             },
             {
                 "SourceVersion": "Elasticsearch_7.8",
                 "TargetVersions": [
                     "Elasticsearch_7.9",
                     "Elasticsearch_7.10",
-                    "OpenSearch_1.1",
                     "OpenSearch_1.0",
+                    "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
                 ],
             },
             {
@@ -153,6 +170,8 @@ class TestOpensearchProvider:
                     "Elasticsearch_7.10",
                     "OpenSearch_1.0",
                     "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
                 ],
             },
             {
@@ -164,6 +183,8 @@ class TestOpensearchProvider:
                     "Elasticsearch_7.10",
                     "OpenSearch_1.0",
                     "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
                 ],
             },
             {
@@ -176,6 +197,8 @@ class TestOpensearchProvider:
                     "Elasticsearch_7.10",
                     "OpenSearch_1.0",
                     "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
                 ],
             },
             {
@@ -189,6 +212,8 @@ class TestOpensearchProvider:
                     "Elasticsearch_7.10",
                     "OpenSearch_1.0",
                     "OpenSearch_1.1",
+                    "OpenSearch_1.2",
+                    "OpenSearch_1.3",
                 ],
             },
             {"SourceVersion": "Elasticsearch_6.7", "TargetVersions": ["Elasticsearch_6.8"]},
@@ -448,7 +473,7 @@ class TestEdgeProxiedOpensearchCluster:
 
             response = requests.get(cluster_url)
             assert response.ok, f"cluster endpoint returned an error: {response.text}"
-            assert response.json()["version"]["number"] == "1.1.0"
+            assert response.json()["version"]["number"] == "1.3.6"
 
             response = requests.get(f"{cluster_url}/_cluster/health")
             assert response.ok, f"cluster health endpoint returned an error: {response.text}"


### PR DESCRIPTION
This PR adds two new versions to the OpenSearch and ElasticSearch service:
- `OpenSearch_1.2` (added in [April](https://aws.amazon.com/about-aws/whats-new/2022/04/amazon-opensearch-supports-version-1-2/))
- `OpenSearch_1.3` (added in [July](https://aws.amazon.com/about-aws/whats-new/2022/07/amazon-opensearch-service-supports-version-1-3/))

This PR also changes the default version of OpenSearch to 1.3 (since it is already the default version when creating a new domain in AWS without specifying any version).