### PR TITLE
Add support for lambda timeouts

### DIFF
--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -9,7 +9,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.5-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.6-pre"
 
 # GO Lambda runtime
 GO_RUNTIME_VERSION = "0.4.0"
@@ -21,7 +21,7 @@ class AWSLambdaRuntimePackage(Package):
         super().__init__(name="AwsLambda", default_version=default_version)
 
     def get_versions(self) -> List[str]:
-        return ["v0.1.5-pre", "v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
+        return ["v0.1.6-pre", "v0.1.5-pre", "v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return AWSLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)

--- a/tests/integration/awslambda/functions/lambda_timeout_env.py
+++ b/tests/integration/awslambda/functions/lambda_timeout_env.py
@@ -1,0 +1,26 @@
+import logging
+import time
+
+INTERNAL_NUMBER = 0
+
+
+def handler(event, context):
+    if write_content := event.get("write-file"):
+        with open("/tmp/temp-store", mode="wt") as f:
+            f.write(write_content)
+    elif event.get("read-file"):
+        with open("/tmp/temp-store", mode="rt") as f:
+            return {"content": f.read(write_content)}
+    elif new_num := event.get("set-number"):
+        global INTERNAL_NUMBER
+        INTERNAL_NUMBER = new_num
+    elif event.get("read-number"):
+        return {"number": INTERNAL_NUMBER}
+    elif sleep_time := event.get("sleep"):
+        try:
+            print("starting wait")
+            time.sleep(sleep_time)
+            print("done waiting")
+        except Exception as e:
+            print("exception while waiting")
+            logging.error(e)

--- a/tests/integration/awslambda/functions/lambda_timeout_env.py
+++ b/tests/integration/awslambda/functions/lambda_timeout_env.py
@@ -10,12 +10,16 @@ def handler(event, context):
             f.write(write_content)
     elif event.get("read-file"):
         with open("/tmp/temp-store", mode="rt") as f:
-            return {"content": f.read(write_content)}
+            payload = {"content": f.read(write_content)}
+            print(payload)
+            return payload
     elif new_num := event.get("set-number"):
         global INTERNAL_NUMBER
         INTERNAL_NUMBER = new_num
     elif event.get("read-number"):
-        return {"number": INTERNAL_NUMBER}
+        payload = {"number": INTERNAL_NUMBER}
+        print(payload)
+        return payload
     elif sleep_time := event.get("sleep"):
         try:
             print("starting wait")

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -76,6 +76,7 @@ TEST_LAMBDA_URL = os.path.join(THIS_FOLDER, "functions/lambda_url.js")
 TEST_LAMBDA_CACHE_NODEJS = os.path.join(THIS_FOLDER, "functions/lambda_cache.js")
 TEST_LAMBDA_CACHE_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_cache.py")
 TEST_LAMBDA_TIMEOUT_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_timeout.py")
+TEST_LAMBDA_TIMEOUT_ENV_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_timeout_env.py")
 TEST_LAMBDA_SLEEP_ENVIRONMENT = os.path.join(THIS_FOLDER, "functions/lambda_sleep_environment.py")
 TEST_LAMBDA_INTROSPECT_PYTHON = os.path.join(THIS_FOLDER, "functions/lambda_introspect.py")
 TEST_LAMBDA_VERSION = os.path.join(THIS_FOLDER, "functions/lambda_version.py")
@@ -339,7 +340,7 @@ class TestLambdaBehavior:
 
     @pytest.mark.skipif(is_old_provider(), reason="old provider")
     @pytest.mark.aws_validated
-    @pytest.mark.skipif(not is_old_provider(), reason="Not yet implemented")
+    # @pytest.mark.skipif(not is_old_provider(), reason="Not yet implemented")
     def test_lambda_invoke_with_timeout(
         self,
         lambda_client,
@@ -427,6 +428,83 @@ class TestLambdaBehavior:
             )
 
         wait_until(_assert_log_output, strategy="linear")
+
+    @pytest.mark.skipif(is_old_provider(), reason="old provider")
+    @pytest.mark.aws_validated
+    # @pytest.mark.skipif(not is_old_provider(), reason="Not yet implemented")
+    def test_lambda_invoke_timed_out_environment_reuse(
+        self,
+        lambda_client,
+        create_lambda_function,
+        logs_client,
+        snapshot,
+    ):
+        """Test checking if a timeout leads to a new environment with a new filesystem (and lost /tmp) or not"""
+        regex = re.compile(r".*\s(?P<uuid>[-a-z0-9]+) Task timed out after \d.\d+ seconds")
+        snapshot.add_transformer(
+            KeyValueBasedTransformer(
+                lambda k, v: regex.search(v).group("uuid") if k == "errorMessage" else None,
+                "<timeout_error_msg>",
+                replace_reference=False,
+            )
+        )
+
+        func_name = f"test_lambda_{short_uid()}"
+        create_result = create_lambda_function(
+            func_name=func_name,
+            handler_file=TEST_LAMBDA_TIMEOUT_ENV_PYTHON,
+            runtime=Runtime.python3_9,
+            client=lambda_client,
+            timeout=1,
+        )
+        snapshot.match("create-result", create_result)
+        file_content = "some-content"
+        set_number = 42
+
+        result = lambda_client.invoke(
+            FunctionName=func_name, Payload=json.dumps({"write-file": file_content})
+        )
+        snapshot.match("invoke-result-file-write", result)
+        result = lambda_client.invoke(
+            FunctionName=func_name, Payload=json.dumps({"read-file": True})
+        )
+        snapshot.match("invoke-result-file-read", result)
+        result = lambda_client.invoke(
+            FunctionName=func_name, Payload=json.dumps({"set-number": set_number})
+        )
+        snapshot.match("invoke-result-set-number", result)
+        result = lambda_client.invoke(
+            FunctionName=func_name, Payload=json.dumps({"read-number": set_number})
+        )
+        snapshot.match("invoke-result-read-number", result)
+        # file is written, let's let the function timeout and check if it is still there
+
+        result = lambda_client.invoke(FunctionName=func_name, Payload=json.dumps({"sleep": 2}))
+        snapshot.match("invoke-result-timed-out", result)
+        log_group_name = f"/aws/lambda/{func_name}"
+        ls_result = logs_client.describe_log_streams(logGroupName=log_group_name)
+        log_stream_name = ls_result["logStreams"][0]["logStreamName"]
+
+        def assert_events():
+            log_events = logs_client.get_log_events(
+                logGroupName=log_group_name, logStreamName=log_stream_name
+            )["events"]
+
+            assert any(["starting wait" in e["message"] for e in log_events])
+            # TODO: this part is a bit flaky, at least locally with old provider
+            assert not any(["done waiting" in e["message"] for e in log_events])
+
+        retry(assert_events, retries=15)
+
+        # check if, for the next normal invocation, the file is still there:
+        result = lambda_client.invoke(
+            FunctionName=func_name, Payload=json.dumps({"read-file": True})
+        )
+        snapshot.match("invoke-result-file-read-after-timeout", result)
+        result = lambda_client.invoke(
+            FunctionName=func_name, Payload=json.dumps({"read-number": set_number})
+        )
+        snapshot.match("invoke-result-read-number-after-timeout", result)
 
 
 @pytest.mark.skipif(not is_old_provider(), reason="Not yet implemented")

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -474,7 +474,7 @@ class TestLambdaBehavior:
         )
         snapshot.match("invoke-result-set-number", result)
         result = lambda_client.invoke(
-            FunctionName=func_name, Payload=json.dumps({"read-number": set_number})
+            FunctionName=func_name, Payload=json.dumps({"read-number": True})
         )
         snapshot.match("invoke-result-read-number", result)
         # file is written, let's let the function timeout and check if it is still there
@@ -502,7 +502,7 @@ class TestLambdaBehavior:
         )
         snapshot.match("invoke-result-file-read-after-timeout", result)
         result = lambda_client.invoke(
-            FunctionName=func_name, Payload=json.dumps({"read-number": set_number})
+            FunctionName=func_name, Payload=json.dumps({"read-number": True})
         )
         snapshot.match("invoke-result-read-number-after-timeout", result)
 

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -340,7 +340,6 @@ class TestLambdaBehavior:
 
     @pytest.mark.skipif(is_old_provider(), reason="old provider")
     @pytest.mark.aws_validated
-    # @pytest.mark.skipif(not is_old_provider(), reason="Not yet implemented")
     def test_lambda_invoke_with_timeout(
         self,
         lambda_client,
@@ -431,7 +430,6 @@ class TestLambdaBehavior:
 
     @pytest.mark.skipif(is_old_provider(), reason="old provider")
     @pytest.mark.aws_validated
-    # @pytest.mark.skipif(not is_old_provider(), reason="Not yet implemented")
     def test_lambda_invoke_timed_out_environment_reuse(
         self,
         lambda_client,

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -370,6 +370,13 @@ class TestLambdaBehavior:
         snapshot.match("invoke-result", result)
 
         log_group_name = f"/aws/lambda/{func_name}"
+
+        def _log_stream_available():
+            result = logs_client.describe_log_streams(logGroupName=log_group_name)["logStreams"]
+            return len(result) > 0
+
+        wait_until(_log_stream_available, strategy="linear")
+
         ls_result = logs_client.describe_log_streams(logGroupName=log_group_name)
         log_stream_name = ls_result["logStreams"][0]["logStreamName"]
 
@@ -480,6 +487,13 @@ class TestLambdaBehavior:
         result = lambda_client.invoke(FunctionName=func_name, Payload=json.dumps({"sleep": 2}))
         snapshot.match("invoke-result-timed-out", result)
         log_group_name = f"/aws/lambda/{func_name}"
+
+        def _log_stream_available():
+            result = logs_client.describe_log_streams(logGroupName=log_group_name)["logStreams"]
+            return len(result) > 0
+
+        wait_until(_log_stream_available, strategy="linear")
+
         ls_result = logs_client.describe_log_streams(logGroupName=log_group_name)
         log_stream_name = ls_result["logStreams"][0]["logStreamName"]
 

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -293,7 +293,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_with_timeout": {
-    "recorded-date": "09-09-2022, 20:59:16",
+    "recorded-date": "14-11-2022, 16:13:13",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -1954,5 +1954,122 @@
         }
       ]
     }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_timed_out_environment_reuse": {
+    "recorded-date": "10-11-2022, 18:59:18",
+    "recorded-content": {
+      "create-result": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": 929,
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 1,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "invoke-result-file-write": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": "null",
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke-result-file-read": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "content": "some-content"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke-result-set-number": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": "null",
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke-result-read-number": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "number": 42
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke-result-timed-out": {
+        "ExecutedVersion": "$LATEST",
+        "FunctionError": "Unhandled",
+        "Payload": {
+          "errorMessage": "date <timeout_error_msg> Task timed out after 1.00 seconds"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke-result-file-read-after-timeout": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "content": "some-content"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invoke-result-read-number-after-timeout": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "number": 0
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
Implementing lambda timeouts, to achieve parity with AWS behavior.
This implementation only affects the new, ASF - based lambda provider.

## Changes
* Added test making assertions about the execution environment and infrastructure after a timeout
* Update aws lambda init binary to 0.1.6-pre.

Most actual changes for this functionality happened in https://github.com/localstack/lambda-runtime-init/pull/6 .