### PR TITLE
allow SNS message attributes data type with dot suffixes

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -133,6 +133,7 @@ LOG = logging.getLogger(__name__)
 GCM_URL = "https://fcm.googleapis.com/fcm/send"
 
 MSG_ATTR_NAME_REGEX = r"^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_\-.]+$"
+ATTR_TYPE_REGEX = "^(String|Number|Binary).*$"
 VALID_MSG_ATTR_NAME_CHARS = set(ascii_letters + digits + "." + "-" + "_")
 
 
@@ -1376,7 +1377,7 @@ def validate_message_attributes(message_attributes: MessageAttributeMap) -> None
         validate_message_attribute_name(attr_name)
         # `DataType` is a required field for MessageAttributeValue
         data_type = attr["DataType"]
-        if data_type not in ("String", "Number", "Binary", "String.Array"):
+        if not re.match(ATTR_TYPE_REGEX, data_type):
             raise InvalidParameterValueException(
                 f"The message attribute '{attr_name}' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String."
             )

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -133,7 +133,7 @@ LOG = logging.getLogger(__name__)
 GCM_URL = "https://fcm.googleapis.com/fcm/send"
 
 MSG_ATTR_NAME_REGEX = re.compile(r"^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_\-.]+$")
-ATTR_TYPE_REGEX = re.compile(r"^(String|Number|Binary)\..*$")
+ATTR_TYPE_REGEX = re.compile(r"^(String|Number|Binary)\..+$")
 VALID_MSG_ATTR_NAME_CHARS = set(ascii_letters + digits + "." + "-" + "_")
 
 
@@ -1377,9 +1377,7 @@ def validate_message_attributes(message_attributes: MessageAttributeMap) -> None
         validate_message_attribute_name(attr_name)
         # `DataType` is a required field for MessageAttributeValue
         data_type = attr["DataType"]
-        if data_type not in ("String", "Number", "Binary") and not re.match(
-            ATTR_TYPE_REGEX, data_type
-        ):
+        if data_type not in ("String", "Number", "Binary") and not ATTR_TYPE_REGEX.match(data_type):
             raise InvalidParameterValueException(
                 f"The message attribute '{attr_name}' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String."
             )
@@ -1402,7 +1400,7 @@ def validate_message_attribute_name(name: str) -> None:
     :param name: message attribute name
     :raises InvalidParameterValueException: if the name does not conform to the spec
     """
-    if not re.match(MSG_ATTR_NAME_REGEX, name):
+    if not MSG_ATTR_NAME_REGEX.match(name):
         # find the proper exception
         if name[0] == ".":
             raise InvalidParameterValueException(

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -132,8 +132,8 @@ LOG = logging.getLogger(__name__)
 
 GCM_URL = "https://fcm.googleapis.com/fcm/send"
 
-MSG_ATTR_NAME_REGEX = r"^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_\-.]+$"
-ATTR_TYPE_REGEX = "^(String|Number|Binary).*$"
+MSG_ATTR_NAME_REGEX = re.compile(r"^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_\-.]+$")
+ATTR_TYPE_REGEX = re.compile(r"^(String|Number|Binary)\..*$")
 VALID_MSG_ATTR_NAME_CHARS = set(ascii_letters + digits + "." + "-" + "_")
 
 
@@ -1377,7 +1377,9 @@ def validate_message_attributes(message_attributes: MessageAttributeMap) -> None
         validate_message_attribute_name(attr_name)
         # `DataType` is a required field for MessageAttributeValue
         data_type = attr["DataType"]
-        if not re.match(ATTR_TYPE_REGEX, data_type):
+        if data_type not in ("String", "Number", "Binary") and not re.match(
+            ATTR_TYPE_REGEX, data_type
+        ):
             raise InvalidParameterValueException(
                 f"The message attribute '{attr_name}' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String."
             )

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2612,6 +2612,16 @@ class TestSNSProvider:
             )
         snapshot.match("publish-error", e.value.response)
 
+        with pytest.raises(ClientError) as e:
+            sns_client.publish(
+                TopicArn=topic_arn,
+                Message="test message",
+                MessageAttributes={
+                    "attr1": {"DataType": "Stringprefixed", "StringValue": "prefixed-1"}
+                },
+            )
+        snapshot.match("publish-error-2", e.value.response)
+
         response = sns_client.publish(
             TopicArn=topic_arn,
             Message="test message",

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2589,3 +2589,26 @@ class TestSNSProvider:
         # each endpoint should only receive the message that was directed to them
         assert platform_endpoint_msgs[endpoints_arn["GCM"]][0]["Message"][0] == message["GCM"]
         assert platform_endpoint_msgs[endpoints_arn["APNS"]][0]["Message"][0] == message["APNS"]
+
+    @pytest.mark.aws_validated
+    def test_message_attributes_prefixes(
+        self,
+        sns_client,
+        sns_create_sqs_subscription,
+        sns_create_topic,
+        sqs_create_queue,
+        snapshot,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+
+        response = sns_client.publish(
+            TopicArn=topic_arn,
+            Message="test message",
+            MessageAttributes={
+                "attr1": {"DataType": "String.prefixed", "StringValue": "prefixed-1"}
+            },
+        )
+        snapshot.match("publish-ok", response)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2604,6 +2604,14 @@ class TestSNSProvider:
 
         sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
 
+        with pytest.raises(ClientError) as e:
+            sns_client.publish(
+                TopicArn=topic_arn,
+                Message="test message",
+                MessageAttributes={"attr1": {"DataType": "String.", "StringValue": "prefixed-1"}},
+            )
+        snapshot.match("publish-error", e.value.response)
+
         response = sns_client.publish(
             TopicArn=topic_arn,
             Message="test message",
@@ -2611,14 +2619,13 @@ class TestSNSProvider:
                 "attr1": {"DataType": "String.prefixed", "StringValue": "prefixed-1"}
             },
         )
-        snapshot.match("publish-ok", response)
+        snapshot.match("publish-ok-1", response)
 
-        with pytest.raises(ClientError) as e:
-            sns_client.publish(
-                TopicArn=topic_arn,
-                Message="test message",
-                MessageAttributes={
-                    "attr1": {"DataType": "Stringprefixed", "StringValue": "prefixed-1"}
-                },
-            )
-        snapshot.match("publish-error", e.value.response)
+        response = sns_client.publish(
+            TopicArn=topic_arn,
+            Message="test message",
+            MessageAttributes={
+                "attr1": {"DataType": "String.  prefixed.", "StringValue": "prefixed-1"}
+            },
+        )
+        snapshot.match("publish-ok-2", response)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2612,3 +2612,13 @@ class TestSNSProvider:
             },
         )
         snapshot.match("publish-ok", response)
+
+        with pytest.raises(ClientError) as e:
+            sns_client.publish(
+                TopicArn=topic_arn,
+                Message="test message",
+                MessageAttributes={
+                    "attr1": {"DataType": "Stringprefixed", "StringValue": "prefixed-1"}
+                },
+            )
+        snapshot.match("publish-error", e.value.response)

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2170,9 +2170,20 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_message_attributes_prefixes": {
-    "recorded-date": "16-11-2022, 15:26:57",
+    "recorded-date": "16-11-2022, 15:34:40",
     "recorded-content": {
       "publish-error": {
+        "Error": {
+          "Code": "ParameterValueInvalid",
+          "Message": "The message attribute 'attr1' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "publish-error-2": {
         "Error": {
           "Code": "ParameterValueInvalid",
           "Message": "The message attribute 'attr1' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String.",

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2168,5 +2168,17 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_message_attributes_prefixes": {
+    "recorded-date": "15-11-2022, 15:59:45",
+    "recorded-content": {
+      "publish-ok": {
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2170,15 +2170,8 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_message_attributes_prefixes": {
-    "recorded-date": "15-11-2022, 16:35:07",
+    "recorded-date": "16-11-2022, 15:26:57",
     "recorded-content": {
-      "publish-ok": {
-        "MessageId": "<uuid:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "publish-error": {
         "Error": {
           "Code": "ParameterValueInvalid",
@@ -2188,6 +2181,20 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      },
+      "publish-ok-1": {
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "publish-ok-2": {
+        "MessageId": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2170,13 +2170,24 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_message_attributes_prefixes": {
-    "recorded-date": "15-11-2022, 15:59:45",
+    "recorded-date": "15-11-2022, 16:35:07",
     "recorded-content": {
       "publish-ok": {
         "MessageId": "<uuid:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "publish-error": {
+        "Error": {
+          "Code": "ParameterValueInvalid",
+          "Message": "The message attribute 'attr1' has an invalid message attribute type, the set of supported type prefixes is Binary, Number, and String.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }


### PR DESCRIPTION
This PR fixes a regression introduced in #6938 and reported by many users in #7109, the validation of SNS message attributes data types was a bit too strict. A user (@rafaelpontezup, thanks again for the pointer!) in the reported issue made a very good summary of the issue:

> The interesting thing is that SQS supports optional custom data type labels with the format .custom-data-type. [Its documentation says](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes):
> Custom – To create a custom data type, append a custom-type label to any data type. For example:
> Number.byte, Number.short, Number.int, and Number.float can help distinguish between number types.
Binary.gif and Binary.png can help distinguish between file types.
But [SNS documentation says nothing about that](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html). Although AWS SNS does not shows this issue, I guess it simply ignores those custom data type labels, I think the Localstack is following the spec correctly.
> Looking at the code of Spring Cloud Message 2.4.2 it seems like the it is adding those custom data type labels for both SQS and SNS, but the later does not support them by spec.

I've introduced a test to support the case of correctly prefixed data types, and reused the same logic as SQS to validate the correctly prefixed data types. 

_fix #7109_