### PR TITLE
send SQS metrics to cloudwatch

### DIFF
--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -13,20 +13,15 @@ from localstack.aws.api.cloudwatch import (
     CloudwatchApi,
     DescribeAlarmsInput,
     DescribeAlarmsOutput,
-    GetMetricDataMaxDatapoints,
+    GetMetricDataInput,
     GetMetricDataOutput,
-    LabelOptions,
     ListTagsForResourceOutput,
-    MetricDataQueries,
-    NextToken,
     PutCompositeAlarmInput,
     PutMetricAlarmInput,
-    ScanBy,
     StateValue,
     TagKeyList,
     TagList,
     TagResourceOutput,
-    Timestamp,
     UntagResourceOutput,
 )
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
@@ -292,20 +287,14 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         self.tags.tag_resource(resource_arn, tags)
         return TagResourceOutput()
 
+    @handler("GetMetricData", expand=False)
     def get_metric_data(
-        self,
-        context: RequestContext,
-        metric_data_queries: MetricDataQueries,
-        start_time: Timestamp,
-        end_time: Timestamp,
-        next_token: NextToken = None,
-        scan_by: ScanBy = None,
-        max_datapoints: GetMetricDataMaxDatapoints = None,
-        label_options: LabelOptions = None,
+        self, context: RequestContext, request: GetMetricDataInput
     ) -> GetMetricDataOutput:
         result = moto.call_moto(context)
         # moto currently uses hardcoded label metric_name + stat
         # parity tests shows that default is MetricStat, but there might also be a label explicitly set
+        metric_data_queries = request["MetricDataQueries"]
         for i in range(0, len(metric_data_queries)):
             metric_query = metric_data_queries[i]
             label = metric_query.get("Label") or metric_query.get("MetricStat", {}).get(

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -13,13 +13,20 @@ from localstack.aws.api.cloudwatch import (
     CloudwatchApi,
     DescribeAlarmsInput,
     DescribeAlarmsOutput,
+    GetMetricDataMaxDatapoints,
+    GetMetricDataOutput,
+    LabelOptions,
     ListTagsForResourceOutput,
+    MetricDataQueries,
+    NextToken,
     PutCompositeAlarmInput,
     PutMetricAlarmInput,
+    ScanBy,
     StateValue,
     TagKeyList,
     TagList,
     TagResourceOutput,
+    Timestamp,
     UntagResourceOutput,
 )
 from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
@@ -284,6 +291,32 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     ) -> TagResourceOutput:
         self.tags.tag_resource(resource_arn, tags)
         return TagResourceOutput()
+
+    def get_metric_data(
+        self,
+        context: RequestContext,
+        metric_data_queries: MetricDataQueries,
+        start_time: Timestamp,
+        end_time: Timestamp,
+        next_token: NextToken = None,
+        scan_by: ScanBy = None,
+        max_datapoints: GetMetricDataMaxDatapoints = None,
+        label_options: LabelOptions = None,
+    ) -> GetMetricDataOutput:
+        result = moto.call_moto(context)
+        # moto currently uses hardcoded label metric_name + stat
+        # parity tests shows that default is MetricStat, but there might also be a label explicitly set
+        for i in range(0, len(metric_data_queries)):
+            metric_query = metric_data_queries[i]
+            label = metric_query.get("Label") or metric_query.get("MetricStat", {}).get(
+                "Metric", {}
+            ).get("MetricName")
+            if label:
+                result["MetricDataResults"][i]["Label"] = label
+        if "Messages" not in result:
+            # parity tests reveals that an empty messages list is added
+            result["Messages"] = []
+        return result
 
     @handler("PutMetricAlarm", expand=False)
     def put_metric_alarm(

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -203,9 +203,9 @@ class SqsQueue:
 
     def default_attributes(self) -> QueueAttributeMap:
         return {
-            QueueAttributeName.ApproximateNumberOfMessages: lambda: self.visible._qsize(),
-            QueueAttributeName.ApproximateNumberOfMessagesNotVisible: lambda: len(self.inflight),
-            QueueAttributeName.ApproximateNumberOfMessagesDelayed: lambda: len(self.delayed),
+            QueueAttributeName.ApproximateNumberOfMessages: lambda: self.approx_number_of_messages,
+            QueueAttributeName.ApproximateNumberOfMessagesNotVisible: lambda: self.approx_number_of_messages_not_visible,
+            QueueAttributeName.ApproximateNumberOfMessagesDelayed: lambda: self.approx_number_of_messages_delayed,
             QueueAttributeName.CreatedTimestamp: str(now()),
             QueueAttributeName.DelaySeconds: "0",
             QueueAttributeName.LastModifiedTimestamp: str(now()),
@@ -278,6 +278,18 @@ class SqsQueue:
     @property
     def maximum_message_size(self):
         return int(self.attributes[QueueAttributeName.MaximumMessageSize])
+
+    @property
+    def approx_number_of_messages(self):
+        return self.visible._qsize()
+
+    @property
+    def approx_number_of_messages_not_visible(self):
+        return len(self.inflight)
+
+    @property
+    def approx_number_of_messages_delayed(self):
+        return len(self.delayed)
 
     def validate_receipt_handle(self, receipt_handle: str):
         if self.arn != decode_receipt_handle(receipt_handle):

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -146,6 +146,12 @@ def check_message_content(message_body: str):
 
 
 class CloudwatchPublishWorker:
+    """
+    Regularly publish metrics data about approximate messages to Cloudwatch.
+    Includes: ApproximateNumberOfMessagesVisible, ApproximateNumberOfMessagesNotVisible
+        and ApproximateNumberOfMessagesDelayed
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self.scheduler = Scheduler()
@@ -191,7 +197,7 @@ class CloudwatchPublishWorker:
         def _run(*_args):
             self.scheduler.run()
 
-        self.thread = start_thread(_run, name="sqs-queue-cloudwatch-publisher")
+        self.thread = start_thread(_run, name="sqs-metrics-cloudwatch-publisher")
 
     def stop(self):
         if self.scheduler:
@@ -740,7 +746,6 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
                 )
                 msg = standard_message.message
             except Empty:
-
                 break
 
             # setting block to false guarantees that, if we've already waited before, we don't wait the full time

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -112,7 +112,7 @@ class SnapshotSession:
                     }
                     full_state[self.scope_key] = recorded
                     state_to_dump = json.dumps(full_state, indent=2)
-                    fd.write(state_to_dump)
+                    fd.write(f"{state_to_dump}\n")
                 except Exception as e:
                     SNAPSHOT_LOGGER.exception(e)
 

--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -112,6 +112,7 @@ class SnapshotSession:
                     }
                     full_state[self.scope_key] = recorded
                     state_to_dump = json.dumps(full_state, indent=2)
+                    # add line ending to be compatible with pre-commit-hooks (end-of-file-fixer)
                     fd.write(f"{state_to_dump}\n")
                 except Exception as e:
                     SNAPSHOT_LOGGER.exception(e)

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -44,7 +44,9 @@ def publish_lambda_metric(metric, value, kwargs):
         LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %s', metric, e)
 
 
-def publish_sqs_metric(region, queue_name, metric, value=1, units="Count"):
+def publish_sqs_metric(
+    region: str, queue_name: str, metric: str, value: float = 1, unit: str = "Count"
+):
     """
     Publishes the metrics for SQS to CloudWatch using the namespace "AWS/SQS"
     See also: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html
@@ -52,7 +54,7 @@ def publish_sqs_metric(region, queue_name, metric, value=1, units="Count"):
     :param queue_name The name of the queue
     :param metric The metric name to be used
     :param value The value of the metric data, default: 1
-    :param units The unit of the metric data, default: "Count"
+    :param unit The unit of the metric data, default: "Count"
     """
     cw_client = aws_stack.connect_to_service("cloudwatch", region_name=region)
     try:
@@ -62,7 +64,7 @@ def publish_sqs_metric(region, queue_name, metric, value=1, units="Count"):
                 {
                     "MetricName": metric,
                     "Dimensions": [{"Name": "QueueName", "Value": queue_name}],
-                    "Unit": units,
+                    "Unit": unit,
                     "Timestamp": datetime.utcnow().replace(tzinfo=timezone.utc),
                     "Value": value,
                 }

--- a/localstack/utils/cloudwatch/cloudwatch_util.py
+++ b/localstack/utils/cloudwatch/cloudwatch_util.py
@@ -44,6 +44,34 @@ def publish_lambda_metric(metric, value, kwargs):
         LOG.info('Unable to put metric data for metric "%s" to CloudWatch: %s', metric, e)
 
 
+def publish_sqs_metric(region, queue_name, metric, value=1, units="Count"):
+    """
+    Publishes the metrics for SQS to CloudWatch using the namespace "AWS/SQS"
+    See also: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html
+    :param region The region that should be used for CloudWatch
+    :param queue_name The name of the queue
+    :param metric The metric name to be used
+    :param value The value of the metric data, default: 1
+    :param units The unit of the metric data, default: "Count"
+    """
+    cw_client = aws_stack.connect_to_service("cloudwatch", region_name=region)
+    try:
+        cw_client.put_metric_data(
+            Namespace="AWS/SQS",
+            MetricData=[
+                {
+                    "MetricName": metric,
+                    "Dimensions": [{"Name": "QueueName", "Value": queue_name}],
+                    "Unit": units,
+                    "Timestamp": datetime.utcnow().replace(tzinfo=timezone.utc),
+                    "Value": value,
+                }
+            ],
+        )
+    except Exception as e:
+        LOG.info(f'Unable to put metric data for metric "{metric}" to CloudWatch: {e}')
+
+
 def publish_lambda_duration(time_before, kwargs):
     time_after = now_utc()
     publish_lambda_metric("Duration", time_after - time_before, kwargs)

--- a/tests/integration/test_cloudwatch.snapshot.json
+++ b/tests/integration/test_cloudwatch.snapshot.json
@@ -600,7 +600,7 @@
     }
   },
   "tests/integration/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created": {
-    "recorded-date": "15-11-2022, 18:00:04",
+    "recorded-date": "17-11-2022, 14:40:11",
     "recorded-content": {
       "get_metric_data": {
         "Messages": [],
@@ -621,6 +621,42 @@
             "Timestamps": "timestamp",
             "Values": [
               5.0
+            ]
+          },
+          {
+            "Id": "empty_receives",
+            "Label": "NumberOfEmptyReceives",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_metric_data_2": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "num_msg_received",
+            "Label": "NumberOfMessagesReceived",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          },
+          {
+            "Id": "num_msg_deleted",
+            "Label": "NumberOfMessagesDeleted",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
             ]
           }
         ],

--- a/tests/integration/test_cloudwatch.snapshot.json
+++ b/tests/integration/test_cloudwatch.snapshot.json
@@ -598,5 +598,37 @@
         }
       }
     }
+  },
+  "tests/integration/test_cloudwatch.py::TestCloudwatch::test_aws_sqs_metrics_created": {
+    "recorded-date": "15-11-2022, 18:00:04",
+    "recorded-content": {
+      "get_metric_data": {
+        "Messages": [],
+        "MetricDataResults": [
+          {
+            "Id": "sent",
+            "Label": "NumberOfMessagesSent",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              1.0
+            ]
+          },
+          {
+            "Id": "sent_size",
+            "Label": "SentMessageSize",
+            "StatusCode": "Complete",
+            "Timestamps": "timestamp",
+            "Values": [
+              5.0
+            ]
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR addresses issue #7131 by sending SQS metrics to cloudwatch.
The metrics are defined in the [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-available-cloudwatch-metrics.html).

Limitations:
* `ApproximateAgeOfOldestMessage` is currently not considered
* Other `Approximate[...]` metrics are scheduled to be send every minute (on AWS the timeframe might be longer, but for LocalStack it probably makes sense to make the metrics available sooner)


