### PR TITLE
Add JRE java.security modules to enable bigdata libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ jdk.zipfs,\
 jdk.httpserver,jdk.management,\
 # MQ Broker requires management agent
 jdk.management.agent,\
+# required for Spark/Hadoop
+java.security.jgss,jdk.security.auth,\
 # Elasticsearch 7+ crashes without Thai Segmentation support
 jdk.localedata --include-locales en,th \
     --compress 2 --strip-debug --no-header-files --no-man-pages --output /usr/lib/jvm/java-11 && \


### PR DESCRIPTION
Add `java.security.*` modules to JRE - these modules are required to run certain components like Spark/Hadoop inside the main container.

This change adds apprx. ~8-10MB (uncompressed) to the image. Build before (1711803587 bytes): 
```
localstack/localstack                                                   latest                                                                       ab65bfe50469   5 minutes ago       1.71GB
```
Build after (1719584564 bytes):
```
REPOSITORY                                                                   TAG                                                                          IMAGE ID       CREATED          SIZE
localstack/localstack                                                   latest                                                                       d3e918e5c44d   59 minutes ago   1.72GB
```