### PR TITLE
Fix parsing optional parts when resolving a secret

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -452,7 +452,8 @@ def resolve_refs_recursively(stack, value):
                 if "SecretString" in reference_key:
                     parts = reference_key.split(":SecretString:")
                     secret_id = parts[0]
-                    [json_key, version_stage, version_id] = parts[1].split(":")
+                    # json-key, version-stage and version-id are optional.
+                    [json_key, version_stage, version_id] = f"{parts[1]}::".split(":")[:3]
 
                 kwargs = {}  # optional args for get_secret_value
                 if version_id:

--- a/tests/integration/cloudformation/test_engine.py
+++ b/tests/integration/cloudformation/test_engine.py
@@ -326,7 +326,12 @@ class TestSsmParameters:
 
 class TestSecretsManagerParameters:
     @pytest.mark.parametrize(
-        "template_name", ["resolve_secretsmanager_full.yaml", "resolve_secretsmanager.yaml"]
+        "template_name",
+        [
+            "resolve_secretsmanager_full.yaml",
+            "resolve_secretsmanager_partial.yaml",
+            "resolve_secretsmanager.yaml",
+        ],
     )
     def test_resolve_secretsmanager(
         self,

--- a/tests/integration/templates/resolve_secretsmanager_partial.yaml
+++ b/tests/integration/templates/resolve_secretsmanager_partial.yaml
@@ -1,0 +1,27 @@
+Parameters:
+  DynamicParameter:
+    Type: String
+
+Resources:
+  topic69831491:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName:
+        Fn::Join:
+          - ""
+          - - "{{resolve:secretsmanager:arn:"
+            - Ref: AWS::Partition
+            - ":secretsmanager:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":secret:"
+            - Ref: DynamicParameter
+            -  ":SecretString:}}"
+
+Outputs:
+  TopicName:
+    Value:
+      Fn::GetAtt:
+        - topic69831491
+        - TopicName


### PR DESCRIPTION
The dynamic reference for a secret in the SecretsManager includes an optional json-key, version-stage and version-id at the end of the ARN. This changes fixes parsing those optional parts to not raise a ValueError when unpacking missing values.

Fixes #7192 