### PR TITLE
update rebase action to consider all release/* branches

### DIFF
--- a/.github/workflows/rebase-release-prs.yml
+++ b/.github/workflows/rebase-release-prs.yml
@@ -4,12 +4,29 @@ on:
     branches:
     - master
 jobs:
+  find-release-branches:
+    runs-on: ubuntu-latest
+    name: "find release branches"
+    steps:
+    - name: find release branches
+      id: find-release-branches
+      uses: actions/github-script@v6
+      with:
+        script: |
+          // find all refs in the repo starting with "release/"
+          const refs = await github.rest.git.listMatchingRefs({owner: "localstack", repo: "localstack-ext", ref: "heads/release/"})
+          // extract the ref name of every ref entry in the data field of the response
+          // remove the "refs/heads/" prefix and add the organization prefix for the rebase action
+          // f.e. ["localstack:release/v1.3", "localstack:release/v2"]
+          return refs.data.map(ref => "localstack:" + ref.ref.substring(11))
+    outputs:
+      matrix: ${{ steps.find-release-branches.outputs.result }}
   rebase:
+    runs-on: ubuntu-latest
+    needs: "find-release-branches"
     strategy:
       matrix:
-        # TODO use a pattern here (once there's a clear branch name pattern)
-        head: ['localstack:v1']
-    runs-on: ubuntu-latest
+        head: ${{ fromJson(needs.find-release-branches.outputs.matrix) }}
     steps:
       - uses: peter-evans/rebase@v2
         with:

--- a/.github/workflows/rebase-release-targeting-prs.yml
+++ b/.github/workflows/rebase-release-targeting-prs.yml
@@ -2,8 +2,7 @@ name: Rebase PRs targeting release branches
 on:
   push:
     branches:
-    # TODO use a better pattern here (once there's a clear branch name pattern)
-    - 'v[0-9]+'
+    - 'release/*'
 jobs:
   rebase:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, the new 1.3 release branch is not recognized by the rebase workflow.
This PR changes the workflow such that it considers branches with a `release/` prefix as release branches and:
- Rebases the release branch for each commit on the master.
- Rebases branches targeting the release branch for each commit on the release branch.

Unfortunately, [peter-evans/rebase](https://github.com/peter-evans/rebase) does not accept wildcards in the `head` param (you can only set wildcards for "sections", i.e. act across all orgs or all refs, but not filter within the refs).
This is why we build a simple matrix workflow where each release branch is one matrix param value.
The release branches are detected using [github-script](https://github.com/actions/github-script).