### PR TITLE
fix: update flake8 git url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         name: isort (pyi)
         types: [pyi]
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
The flake8 gitlab mirror has been deleted. This patch updates the pre-commit hook url to point to the github repo.

https://www.youtube.com/watch?v=1FIgj9Q5e6A
