### PR TITLE
Fix: SES not emitting SNS messages

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -223,6 +223,8 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         context: RequestContext,
         request: SendEmailRequest,
     ) -> SendEmailResponse:
+        response = call_moto(context)
+
         backend = get_ses_backend(context)
         emitter = SNSEmitter(context)
         for event_destination in backend.config_set_event_destination.values():
@@ -235,8 +237,6 @@ class SesProvider(SesApi, ServiceLifecycleHook):
 
             emitter.emit_send_event(request, sns_destination_arn)
             emitter.emit_delivery_event(request, sns_destination_arn)
-
-        response = call_moto(context)
 
         text_part = request["Message"]["Body"].get("Text", {}).get("Data")
         html_part = request["Message"]["Body"].get("Html", {}).get("Data")

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -40,7 +40,7 @@ from localstack.aws.api.ses import (
     VerificationAttributes,
     VerificationStatus,
 )
-from localstack.config import DEFAULT_REGION
+from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.services.internal import get_internal_apis
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
@@ -419,8 +419,13 @@ class SNSEmitter:
 
     @staticmethod
     def _client_for_topic(topic_arn: str) -> SNSClient:
-        region = aws_stack.extract_region_from_arn(topic_arn)
-        if not region:
-            region = DEFAULT_REGION
+        arn_parameters = aws_stack.parse_arn(topic_arn)
+        region = arn_parameters["region"]
+        access_key_id = arn_parameters["account"]
 
-        return aws_stack.connect_to_service("sns", region_name=region)
+        return aws_stack.connect_to_service(
+            "sns",
+            region_name=region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+        )

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1778,7 +1778,7 @@ def ses_configuration_set(ses_client):
 
 
 @pytest.fixture
-def ses_configuration_set_event_destination(ses_client):
+def ses_configuration_set_sns_event_destination(ses_client):
     event_destinations = []
 
     def factory(config_set_name: str, event_destination_name: str, topic_arn: str) -> None:

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1758,6 +1758,68 @@ def events_create_rule(events_client):
 
 
 @pytest.fixture
+def ses_configuration_set(ses_client):
+    configuration_set_names = []
+
+    def factory(name: str) -> None:
+        ses_client.create_configuration_set(
+            ConfigurationSet={
+                "Name": name,
+            },
+        )
+        configuration_set_names.append(name)
+
+    yield factory
+
+    # this endpoint is not implemented for localstack
+    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
+        for configuration_set_name in configuration_set_names:
+            ses_client.delete_configuration_set(ConfigurationSetName=configuration_set_name)
+
+
+@pytest.fixture
+def ses_configuration_set_event_destination(ses_client):
+    event_destinations = []
+
+    def factory(config_set_name: str, event_destination_name: str, topic_arn: str) -> None:
+        ses_client.create_configuration_set_event_destination(
+            ConfigurationSetName=config_set_name,
+            EventDestination={
+                "Name": event_destination_name,
+                "Enabled": True,
+                "MatchingEventTypes": ["send", "bounce", "delivery", "open", "click"],
+                "SNSDestination": {
+                    "TopicARN": topic_arn,
+                },
+            },
+        )
+        event_destinations.append((config_set_name, event_destination_name))
+
+    yield factory
+
+    # this endpoint is not implemented for localstack
+    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
+        for (config_set_name, event_destination_name) in event_destinations:
+            ses_client.delete_configuration_set_event_destination(
+                ConfigurationSetName=config_set_name,
+                EventDestinationName=event_destination_name,
+            )
+
+
+@pytest.fixture
+def ses_verify_identity(ses_client):
+    identities = []
+
+    def factory(email_address: str) -> None:
+        ses_client.verify_email_identity(EmailAddress=email_address)
+
+    yield factory
+
+    for identity in identities:
+        ses_client.delete_identity(Identity=identity)
+
+
+@pytest.fixture
 def cleanups(ec2_client):
     cleanup_fns = []
 

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -250,7 +250,7 @@ class TestSES:
         sns_topic,
         sns_create_sqs_subscription,
         ses_configuration_set,
-        ses_configuration_set_event_destination,
+        ses_configuration_set_sns_event_destination,
         ses_verify_identity,
         sqs_receive_num_messages,
         snapshot,
@@ -282,7 +282,9 @@ class TestSES:
         config_set_name = f"config-set-{short_uid()}"
         ses_configuration_set(config_set_name)
         event_destination_name = f"config-set-event-destination-{short_uid()}"
-        ses_configuration_set_event_destination(config_set_name, event_destination_name, topic_arn)
+        ses_configuration_set_sns_event_destination(
+            config_set_name, event_destination_name, topic_arn
+        )
 
         # send an email to trigger the SNS message and SQS message
         destination = {

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -275,32 +275,6 @@ class TestSES:
         ses_verify_identity(recipient_email_address)
 
         # create queue to listen for for SES -> SNS events
-        queue_arn = sqs_queue_arn(sqs_queue)
-
-        # update queue policy
-        policy = json.dumps(
-            {
-                "Id": f"Policy{short_uid()}",
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Sid": f"stmt{short_uid()}",
-                        "Action": "sqs:*",
-                        "Effect": "Allow",
-                        "Resource": queue_arn,
-                        "Condition": {
-                            "ArnEquals": {
-                                "aws:SourceArn": queue_arn,
-                            },
-                        },
-                        "Principal": "*",
-                    },
-                ],
-            }
-        )
-        sqs_client.set_queue_attributes(QueueUrl=sqs_queue, Attributes={"Policy": policy})
-
-        # Subscribe the queue to the topic
         topic_arn = sns_topic["Attributes"]["TopicArn"]
         sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=sqs_queue)
 

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -224,3 +224,112 @@ class TestSES:
         assert rule_set["Metadata"]["Name"] == rule_set_name
         assert original_rule_set["Rules"] == rule_set["Rules"]
         assert [x["Name"] for x in rule_set["Rules"]] == rule_names
+
+    @pytest.mark.only_localstack
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..Signature",
+            "$..SigningCertURL",
+            "$..TopicArn",
+            "$..UnsubscribeURL",
+            "$..Message.delivery.processingTimeMillis",
+            "$..Message.delivery.reportingMTA",
+            "$..Message.delivery.smtpResponse",
+            "$..Message.mail.messageId",
+            "$..Message.mail.commonHeaders",
+            "$..Message.mail.headers",
+            "$..Message.mail.headersTruncated",
+            "$..Message.mail.tags",
+            "$..Message.mail.timestamp",
+        ]
+    )
+    def test_ses_sns_topic_integration(
+        self,
+        ses_client,
+        sqs_queue,
+        sns_topic,
+        sns_create_sqs_subscription,
+        ses_configuration_set,
+        ses_configuration_set_event_destination,
+        ses_verify_identity,
+        sqs_receive_num_messages,
+        snapshot,
+    ):
+        """
+        Repro for #7184 - test that this test is not runnable in the sandbox account since it
+        requires a
+        validated email address. We do not have support for this yet.
+        """
+        sender_email_address = f"repro-7184-{short_uid()}@example.com"
+        recipient_email_address = f"repro-7184-{short_uid()}@example.com"
+
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.regex(sender_email_address, "<sender-email-address>"),
+                snapshot.transform.regex(recipient_email_address, "<recipient-email-address>"),
+            ]
+            + snapshot.transform.sns_api()
+        )
+
+        ses_verify_identity(sender_email_address)
+        ses_verify_identity(recipient_email_address)
+
+        # create queue to listen for for SES -> SNS events
+        queue_arn = sqs_queue_arn(sqs_queue)
+
+        # update queue policy
+        policy = json.dumps(
+            {
+                "Id": f"Policy{short_uid()}",
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": f"stmt{short_uid()}",
+                        "Action": "sqs:*",
+                        "Effect": "Allow",
+                        "Resource": queue_arn,
+                        "Condition": {
+                            "ArnEquals": {
+                                "aws:SourceArn": queue_arn,
+                            },
+                        },
+                        "Principal": "*",
+                    },
+                ],
+            }
+        )
+        sqs_client.set_queue_attributes(QueueUrl=sqs_queue, Attributes={"Policy": policy})
+
+        # Subscribe the queue to the topic
+        topic_arn = sns_topic["Attributes"]["TopicArn"]
+        sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=sqs_queue)
+
+        # create the config set
+        config_set_name = f"config-set-{short_uid()}"
+        ses_configuration_set(config_set_name)
+        event_destination_name = f"config-set-event-destination-{short_uid()}"
+        ses_configuration_set_event_destination(config_set_name, event_destination_name, topic_arn)
+
+        # send an email to trigger the SNS message and SQS message
+        destination = {
+            "ToAddresses": [recipient_email_address],
+        }
+        message = {
+            "Subject": {
+                "Data": "foo subject",
+            },
+            "Body": {
+                "Text": {
+                    "Data": "saml body",
+                },
+            },
+        }
+        ses_client.send_email(
+            Destination=destination,
+            Message=message,
+            ConfigurationSetName=config_set_name,
+            Source=sender_email_address,
+        )
+
+        messages = sqs_receive_num_messages(sqs_queue, 3)
+        snapshot.match("messages", messages)

--- a/tests/integration/test_ses.snapshot.json
+++ b/tests/integration/test_ses.snapshot.json
@@ -1,0 +1,189 @@
+{
+  "tests/integration/test_ses.py::TestSES::test_ses_sns_topic_integration": {
+    "recorded-date": "21-11-2022, 09:38:18",
+    "recorded-content": {
+      "messages": [
+        {
+          "Type": "Notification",
+          "MessageId": "<uuid:1>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+          "Message": "Successfully validated SNS topic for Amazon SES event publishing.",
+          "Timestamp": "date",
+          "SignatureVersion": "1",
+          "Signature": "<signature>",
+          "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+          "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
+        },
+        {
+          "Type": "Notification",
+          "MessageId": "<uuid:2>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+          "Subject": "Amazon SES Email Event Notification",
+          "Message": {
+            "eventType": "Send",
+            "mail": {
+              "timestamp": "date",
+              "source": "<sender-email-address>",
+              "sourceArn": "arn:aws:ses:<region>:111111111111:identity/<sender-email-address>",
+              "sendingAccountId": "111111111111",
+              "messageId": "01070184998d7f5f-9821ae1c-7289-498a-9e6f-1baf98cc547d-000000",
+              "destination": [
+                "<recipient-email-address>"
+              ],
+              "headersTruncated": false,
+              "headers": [
+                {
+                  "name": "From",
+                  "value": "<sender-email-address>"
+                },
+                {
+                  "name": "To",
+                  "value": "<recipient-email-address>"
+                },
+                {
+                  "name": "Subject",
+                  "value": "foo subject"
+                },
+                {
+                  "name": "MIME-Version",
+                  "value": "1.0"
+                },
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain; charset=UTF-8"
+                },
+                {
+                  "name": "Content-Transfer-Encoding",
+                  "value": "7bit"
+                }
+              ],
+              "commonHeaders": {
+                "from": [
+                  "<sender-email-address>"
+                ],
+                "to": [
+                  "<recipient-email-address>"
+                ],
+                "messageId": "01070184998d7f5f-9821ae1c-7289-498a-9e6f-1baf98cc547d-000000",
+                "subject": "foo subject"
+              },
+              "tags": {
+                "ses:operation": [
+                  "SendEmail"
+                ],
+                "ses:configuration-set": [
+                  "config-set-f721b02c"
+                ],
+                "ses:source-ip": [
+                  "80.189.216.182"
+                ],
+                "ses:from-domain": [
+                  "localstack.cloud"
+                ],
+                "ses:caller-identity": [
+                  "localstack-testing"
+                ]
+              }
+            },
+            "send": {}
+          },
+          "Timestamp": "date",
+          "SignatureVersion": "1",
+          "Signature": "<signature>",
+          "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+          "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
+        },
+        {
+          "Type": "Notification",
+          "MessageId": "<uuid:3>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+          "Subject": "Amazon SES Email Event Notification",
+          "Message": {
+            "eventType": "Delivery",
+            "mail": {
+              "timestamp": "date",
+              "source": "<sender-email-address>",
+              "sourceArn": "arn:aws:ses:<region>:111111111111:identity/<sender-email-address>",
+              "sendingAccountId": "111111111111",
+              "messageId": "01070184998d7f5f-9821ae1c-7289-498a-9e6f-1baf98cc547d-000000",
+              "destination": [
+                "<recipient-email-address>"
+              ],
+              "headersTruncated": false,
+              "headers": [
+                {
+                  "name": "From",
+                  "value": "<sender-email-address>"
+                },
+                {
+                  "name": "To",
+                  "value": "<recipient-email-address>"
+                },
+                {
+                  "name": "Subject",
+                  "value": "foo subject"
+                },
+                {
+                  "name": "MIME-Version",
+                  "value": "1.0"
+                },
+                {
+                  "name": "Content-Type",
+                  "value": "text/plain; charset=UTF-8"
+                },
+                {
+                  "name": "Content-Transfer-Encoding",
+                  "value": "7bit"
+                }
+              ],
+              "commonHeaders": {
+                "from": [
+                  "<sender-email-address>"
+                ],
+                "to": [
+                  "<recipient-email-address>"
+                ],
+                "messageId": "01070184998d7f5f-9821ae1c-7289-498a-9e6f-1baf98cc547d-000000",
+                "subject": "foo subject"
+              },
+              "tags": {
+                "ses:operation": [
+                  "SendEmail"
+                ],
+                "ses:configuration-set": [
+                  "config-set-f721b02c"
+                ],
+                "ses:source-ip": [
+                  "80.189.216.182"
+                ],
+                "ses:from-domain": [
+                  "localstack.cloud"
+                ],
+                "ses:caller-identity": [
+                  "localstack-testing"
+                ],
+                "ses:outgoing-ip": [
+                  "69.169.224.7"
+                ]
+              }
+            },
+            "delivery": {
+              "timestamp": "date",
+              "processingTimeMillis": 497,
+              "recipients": [
+                "<recipient-email-address>"
+              ],
+              "smtpResponse": "250 2.0.0 OK  1669023498 q4-20020adffec4000000b002368e4d5d74si6016172wrs.528 - gsmtp",
+              "reportingMTA": "b224-7.smtp-out.<region>.amazonses.com"
+            }
+          },
+          "Timestamp": "date",
+          "SignatureVersion": "1",
+          "Signature": "<signature>",
+          "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+          "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:3>"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Configure SES to emit SNS messages when configured. This is supported in AWS but not currently implemented in Localstack.

This PR builds on #7214.

Note: support for other `Send*Email` methods follows in PRs:

* #7229
* #7228

#7184