### PR TITLE
pin flake8 dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -113,13 +113,13 @@ dev =
     black==22.3.0
     coveralls==3.1.0
     Cython
-    flake8<5.0.0
+    flake8==3.9.2
     flake8-black==0.3.2
     flake8-isort>=4.0.0
     flake8-quotes>=0.11.0
     # enables flake8 configuration through pyproject.toml
     pre-commit==2.13.0
-    pyproject-flake8
+    pyproject-flake8==3.9.2
     isort==5.9.1
     pandoc
     pypandoc

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,7 +115,7 @@ dev =
     Cython
     flake8==3.9.2
     flake8-black==0.3.2
-    flake8-isort>=4.0.0
+    flake8-isort==5.0.0
     flake8-quotes>=0.11.0
     # enables flake8 configuration through pyproject.toml
     pre-commit==2.13.0


### PR DESCRIPTION
This PR pins flake8 dependencies, the critical one is flake8-isort, where the recent 5.0.1 release caused some breakage with the flake8 isort integration.