### PR TITLE
#7184: Refactor SQS message fixtures

### DIFF
--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -1,8 +1,6 @@
-import json
-
 import pytest
 
-from localstack.utils.common import retry, short_uid, to_str
+from localstack.utils.common import retry, short_uid
 
 PUBLICATION_TIMEOUT = 1
 PUBLICATION_RETRIES = 20
@@ -20,7 +18,14 @@ class TestNotifications:
         finally:
             sqs_client.delete_queue(QueueUrl=queue["QueueUrl"])
 
-    def test_sns_to_sqs(self, sqs_client, sns_client, sqs_create_queue, sns_create_topic):
+    def test_sns_to_sqs(
+        self,
+        sqs_client,
+        sns_client,
+        sqs_create_queue,
+        sns_create_topic,
+        sqs_receive_messages_delete,
+    ):
 
         # create topic and queue
         queue_url = sqs_create_queue()
@@ -47,26 +52,8 @@ class TestNotifications:
         def assert_message():
             # receive, and delete message from SQS
             expected = {"attr1": {"Type": "String", "Value": test_value}}
-            messages = self._receive_messages_delete(queue_url, sqs_client)
-            assert len(messages) == 1
+            messages = sqs_receive_messages_delete(queue_url, expected_messages=1)
             assert messages[0]["TopicArn"] == topic_arn
             assert expected == messages[0]["MessageAttributes"]
 
         retry(assert_message, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
-
-    def _receive_messages_delete(self, queue_url, sqs_client, expected_messages=1):
-
-        response = sqs_client.receive_message(
-            QueueUrl=queue_url, MessageAttributeNames=["All"], VisibilityTimeout=0
-        )
-        messages = []
-        for m in response["Messages"]:
-            message = json.loads(to_str(m["Body"]))
-            if message.get("Event") == "s3:TestEvent":
-                continue
-            messages.append(message)
-        assert len(messages) == expected_messages
-
-        for message in response["Messages"]:
-            sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=message["ReceiptHandle"])
-        return messages

--- a/tests/integration/test_notifications.py
+++ b/tests/integration/test_notifications.py
@@ -24,7 +24,7 @@ class TestNotifications:
         sns_client,
         sqs_create_queue,
         sns_create_topic,
-        sqs_receive_messages_delete,
+        sqs_receive_num_messages,
     ):
 
         # create topic and queue
@@ -52,7 +52,7 @@ class TestNotifications:
         def assert_message():
             # receive, and delete message from SQS
             expected = {"attr1": {"Type": "String", "Value": test_value}}
-            messages = sqs_receive_messages_delete(queue_url, expected_messages=1)
+            messages = sqs_receive_num_messages(queue_url, expected_messages=1)
             assert messages[0]["TopicArn"] == topic_arn
             assert expected == messages[0]["MessageAttributes"]
 


### PR DESCRIPTION
This PR adds SQS fixtures for receiving both a) _some_ messages, and b) a specific number of messages.

These features will support an upcoming PR which adds SES -> SNS integration, using an SQS queue to verify that the messages have been sent.
