### PR TITLE
remove requests version pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     python-dotenv>=0.19.1
     pyyaml>=5.1
     rich>=12.3.0
-    requests>=2.20.0
+    requests>=2.26.0
     semver>=2.10
     stevedore>=3.4.0
     # needed for python3.7 compat of stevedore

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     python-dotenv>=0.19.1
     pyyaml>=5.1
     rich>=12.3.0
-    requests>=2.20.0,<2.26
+    requests>=2.20.0
     semver>=2.10
     stevedore>=3.4.0
     # needed for python3.7 compat of stevedore

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     python-dotenv>=0.19.1
     pyyaml>=5.1
     rich>=12.3.0
-    requests>=2.26.0
+    requests>=2.20.0
     semver>=2.10
     stevedore>=3.4.0
     # needed for python3.7 compat of stevedore

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ runtime =
     pyopenssl==22.0.0
     Quart==0.17
     readerwriterlock>=1.0.7
-    requests-aws4auth==0.9
+    requests-aws4auth>=1.0
     # TODO: remove werkzeug&flask version pins once we can upgrade to latest versions
     Werkzeug==2.1.2
     xmltodict>=0.11.0


### PR DESCRIPTION
We are currently pinning requests < 2.26, because lambda tests failed over 1 year ago.
This PR tries to remove this pin to check test failures.

CircleCI will probably not pick up the changes immediately due to the -ext pin, though.

Fixes #7078