### PR TITLE
Fix custom id lookup

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -882,10 +882,11 @@ def get_api_account_id_and_region(api_id: str) -> Tuple[Optional[str], Optional[
     """Return the region name for the given REST API ID"""
     for account_id, account in apigateway_backends.items():
         for region_name, region in account.items():
-            if api_id in region.apis:
-                return (account_id, region_name)
-
-    return (None, None)
+            # compare low case keys to avoid case sensitivity issues
+            for key in region.apis.keys():
+                if key.lower() == api_id.lower():
+                    return account_id, region_name
+    return None, None
 
 
 def extract_api_id_from_hostname_in_url(hostname: str) -> str:

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -3,7 +3,11 @@ import logging
 from typing import Dict, Optional, Tuple
 
 from moto.apigateway import models as apigateway_models
-from moto.apigateway.exceptions import NoIntegrationDefined, UsagePlanNotFoundException
+from moto.apigateway.exceptions import (
+    NoIntegrationDefined,
+    RestAPINotFound,
+    UsagePlanNotFoundException,
+)
 from moto.apigateway.responses import APIGatewayResponse
 from moto.core.utils import camelcase_to_underscores
 
@@ -475,8 +479,16 @@ def apply_patches():
             return 201, {}, result[2]
         return result
 
+    def get_rest_api(self, function_id):
+        for key in self.apis.keys():
+            if key.lower() == function_id.lower():
+                return self.apis[key]
+        raise RestAPINotFound()
+
     create_rest_api_orig = apigateway_models.APIGatewayBackend.create_rest_api
     apigateway_models.APIGatewayBackend.create_rest_api = create_rest_api
+    apigateway_models.APIGatewayBackend.get_rest_api = get_rest_api
+
     apigateway_models.Resource.get_integration = apigateway_models_resource_get_integration
     apigateway_response_resource_methods_orig = APIGatewayResponse.resource_methods
     APIGatewayResponse.resource_methods = apigateway_response_resource_methods

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -2374,7 +2374,9 @@ def test_tag_api(apigateway_client, create_rest_apigw):
     tags = {"foo": "bar"}
 
     # add resource tags
-    api_id, _, _ = create_rest_apigw(name=api_name)
+    api_id, _, _ = create_rest_apigw(name=api_name, tags={TAG_KEY_CUSTOM_ID: "c0stIOm1d"})
+    assert api_id == "c0stIOm1d"
+
     api_arn = aws_stack.apigateway_restapi_arn(api_id=api_id)
     apigateway_client.tag_resource(resourceArn=api_arn, tags=tags)
 

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -193,6 +193,13 @@ class TestAPIGateway:
         assert test_id == api_id
         assert apigw_name == name
 
+        spec_file = load_file(TEST_IMPORT_MOCK_INTEGRATION)
+        apigateway_client.put_rest_api(restApiId=test_id, body=spec_file, mode="overwrite")
+
+        url = path_based_url(api_id=test_id, stage_name="latest", path="/echo/foobar")
+        response = requests.get(url)
+        assert response._content == b'{"echo": "foobar", "response": "mocked"}'
+
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
         stream = aws_stack.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)


### PR DESCRIPTION
This PR fixes the API id lookup by ignoring case sensitivity.

The issue reported above manifestastes because our router match transforms the API id into lowercase, which would fail when compared with the string used on the `_custom_id_` tag.

Resolves https://github.com/localstack/localstack/issues/7160
