### PR TITLE
Port Lambda URL invocation support to ASF provider

### DIFF
--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -186,7 +186,7 @@ def build_statement(
     source_account: Optional[str] = None,  # TODO: test & implement
     principal_org_id: Optional[str] = None,  # TODO: test & implement
     event_source_token: Optional[str] = None,  # TODO: test & implement
-    auth_type: Optional[FunctionUrlAuthType] = None,  # TODO: test & implement
+    auth_type: Optional[FunctionUrlAuthType] = None,
 ) -> dict[str, Any]:
     statement = {
         "Sid": statement_id,
@@ -203,6 +203,9 @@ def build_statement(
 
     if source_arn:
         statement["Condition"] = {"ArnLike": {"AWS:SourceArn": source_arn}}
+
+    if auth_type:
+        statement["Condition"] = {"StringEquals": {"lambda:FunctionUrlAuthType": auth_type}}
 
     return statement
 

--- a/localstack/services/awslambda/urlrouter.py
+++ b/localstack/services/awslambda/urlrouter.py
@@ -1,0 +1,197 @@
+import base64
+import json
+import logging
+import urllib
+from datetime import datetime
+from http import HTTPStatus
+
+from localstack import config
+from localstack.aws.api import HttpResponse
+from localstack.aws.api.lambda_ import InvocationType
+from localstack.http import Request, Router
+from localstack.http.dispatcher import Handler
+from localstack.services.awslambda.api_utils import FULL_FN_ARN_PATTERN
+from localstack.services.awslambda.invocation.lambda_models import InvocationError, InvocationResult
+from localstack.services.awslambda.invocation.lambda_service import LambdaService
+from localstack.services.awslambda.invocation.models import lambda_stores
+from localstack.utils.aws.request_context import AWS_REGION_REGEX
+from localstack.utils.strings import long_uid, to_bytes, to_str
+from localstack.utils.time import TIMESTAMP_READABLE_FORMAT, mktime, timestamp
+
+LOG = logging.getLogger(__name__)
+
+
+class FunctionUrlRouter:
+
+    router: Router[Handler]
+    lambda_service: LambdaService
+
+    def __init__(self, router: Router[Handler], lambda_service: LambdaService):
+        self.router = router
+        self.registered = False
+        self.lambda_service = lambda_service
+
+    def register_routes(self) -> None:
+        if self.registered:
+            LOG.debug("Skipped Lambda URL route registration (routes already registered).")
+            return
+        self.registered = True
+
+        LOG.debug("Registering parameterized Lambda routes.")
+
+        self.router.add(
+            "/",
+            host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",
+            endpoint=self.handle_lambda_url_invocation,
+            defaults={"path": ""},
+        )
+        self.router.add(
+            "/<path:path>",
+            host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",
+            endpoint=self.handle_lambda_url_invocation,
+        )
+
+    def handle_lambda_url_invocation(
+        self, request: Request, api_id: str, region: str, **url_params: dict[str, str]
+    ) -> HttpResponse:
+        response = HttpResponse(headers={"Content-type": "application/json"})
+
+        lambda_url_config = None
+        try:
+            for account_id in lambda_stores.keys():
+                store = lambda_stores[account_id][region]
+                for fn in store.functions.values():
+                    for url_config in fn.function_url_configs.values():
+                        if url_config.url_id == api_id:
+                            lambda_url_config = url_config
+        except IndexError as e:
+            LOG.warning(f"Lambda URL ({api_id}) not found: {e}")
+            response.set_json({"Message": None})
+            response.status = "404"
+            return response
+
+        event = event_for_lambda_url(
+            api_id, request.full_path, request.data, request.headers, request.method
+        )
+
+        match = FULL_FN_ARN_PATTERN.search(lambda_url_config.function_arn).groupdict()
+
+        result_ft = self.lambda_service.invoke(
+            function_name=match.get("function_name"),
+            qualifier=match.get("qualifier"),
+            account_id=match.get("account_id"),
+            region=match.get("region_name"),
+            invocation_type=InvocationType.RequestResponse,
+            client_context="{}",  # TODO: test
+            payload=to_bytes(json.dumps(event)),
+        )
+        result = result_ft.result(timeout=900)
+
+        if isinstance(result, InvocationError):
+            response = HttpResponse("Internal Server Error", HTTPStatus.BAD_GATEWAY)
+        else:
+            response = lambda_result_to_response(result)
+        return response
+
+
+def event_for_lambda_url(api_id: str, path: str, data, headers, method: str) -> dict:
+    raw_path = path.split("?")[0]
+    raw_query_string = path.split("?")[1] if len(path.split("?")) > 1 else ""
+    query_string_parameters = (
+        {} if not raw_query_string else dict(urllib.parse.parse_qsl(raw_query_string))
+    )
+
+    now = datetime.utcnow()
+    readable = timestamp(time=now, format=TIMESTAMP_READABLE_FORMAT)
+    if not any(char in readable for char in ["+", "-"]):
+        readable += "+0000"
+
+    source_ip = headers.get("Remote-Addr", "")
+    request_context = {
+        "accountId": "anonymous",
+        "apiId": api_id,
+        "domainName": headers.get("Host", ""),
+        "domainPrefix": api_id,
+        "http": {
+            "method": method,
+            "path": raw_path,
+            "protocol": "HTTP/1.1",
+            "sourceIp": source_ip,
+            "userAgent": headers.get("User-Agent", ""),
+        },
+        "requestId": long_uid(),
+        "routeKey": "$default",
+        "stage": "$default",
+        "time": readable,
+        "timeEpoch": mktime(ts=now, millis=True),
+    }
+
+    content_type = headers.get("Content-Type", "").lower()
+    content_type_is_text = any(text_type in content_type for text_type in ["text", "json", "xml"])
+
+    is_base64_encoded = not (data.isascii() and content_type_is_text) if data else False
+    body = base64.b64encode(data).decode() if is_base64_encoded else data
+    if isinstance(body, bytes):
+        body = to_str(body)
+
+    ignored_headers = ["connection", "x-localstack-tgt-api", "x-localstack-request-url"]
+    event_headers = {k.lower(): v for k, v in headers.items() if k.lower() not in ignored_headers}
+
+    event_headers.update(
+        {
+            "x-amzn-tls-cipher-suite": "ECDHE-RSA-AES128-GCM-SHA256",
+            "x-amzn-tls-version": "TLSv1.2",
+            "x-forwarded-proto": "http",
+            "x-forwarded-for": source_ip,
+            "x-forwarded-port": str(config.EDGE_PORT),
+        }
+    )
+
+    event = {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": raw_path,
+        "rawQueryString": raw_query_string,
+        "headers": event_headers,
+        "queryStringParameters": query_string_parameters,
+        "requestContext": request_context,
+        "body": body,
+        "isBase64Encoded": is_base64_encoded,
+    }
+
+    if not data:
+        event.pop("body")
+
+    return event
+
+
+def lambda_result_to_response(result: InvocationResult):
+    response = HttpResponse()
+
+    # Set default headers
+    response.headers.update(
+        {
+            "Content-Type": "application/json",
+            "Connection": "keep-alive",
+            "x-amzn-requestid": long_uid(),
+            "x-amzn-trace-id": long_uid(),
+        }
+    )
+
+    parsed_result = json.loads(to_str(result.payload))
+
+    if isinstance(parsed_result.get("headers"), dict):
+        response.headers.update(parsed_result.get("headers"))
+
+    if "body" not in parsed_result:
+        response.data = json.dumps(parsed_result)
+    elif isinstance(parsed_result.get("body"), dict):
+        response.data = json.dumps(parsed_result.get("body"))
+    elif parsed_result.get("isBase64Encoded", False):
+        body_bytes = to_bytes(to_str(parsed_result.get("body", "")))
+        decoded_body_bytes = base64.b64decode(body_bytes)
+        response.data = decoded_body_bytes
+    else:
+        response.data = parsed_result.get("body")
+
+    return response

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -2071,5 +2071,78 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
+    "recorded-date": "22-11-2022, 22:55:11",
+    "recorded-content": {
+      "get_fn_result": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "code-sha256",
+          "CodeSize": 241,
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_lambda_url_config": {
+        "AuthType": "NONE",
+        "CreationTime": "date",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionUrl": "function-url",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "add_permission": {
+        "Statement": {
+          "Sid": "urlPermission",
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "lambda:InvokeFunctionUrl",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "Condition": {
+            "StringEquals": {
+              "lambda:FunctionUrlAuthType": "NONE"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -48,7 +48,6 @@ def test_lambda_w_dynamodb_event_filter(
     retry(_assert_single_lambda_call, retries=30)
 
 
-@pytest.mark.skipif(condition=is_new_provider(), reason="not implemented yet")
 @pytest.mark.skip_snapshot_verify(
     paths=[
         "$..Metadata",


### PR DESCRIPTION
Mostly C&P of existing code with the intention of decoupling it from the legacy provider since going forward changes should be focused on the ASF provider anyway and some of the mapping concepts don't apply anymore. 

Also:
- Now supports a correct response for unhandled exceptions and added a corresponding test.
- Added a router class that follows the design of  the router for the apigateway ASF provider.