### PR TITLE
VTL escape javascript 

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -454,6 +454,7 @@ class StepFunctionIntegration(BackendIntegration):
         )
 
         try:
+            # call method on step function client
             method = getattr(client, method_name)
         except AttributeError:
             msg = f"Invalid step function action: {method_name}"

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -10,7 +10,7 @@ from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
 from localstack.utils.json import extract_jsonpath, json_safe
-from localstack.utils.numbers import is_number, to_number
+from localstack.utils.numbers import is_number
 from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
@@ -87,16 +87,15 @@ class VelocityUtilApiGateway(VelocityUtil):
         return unquote_plus(s)
 
     def escapeJavaScript(self, s):
-        try:
-            return json.dumps(json.loads(s))
-        except Exception:
-            primitive_types = (str, int, bool, float, type(None))
-            s = s if isinstance(s, primitive_types) else str(s)
-        if str(s).strip() in {"true", "false"}:
-            s = bool(s)
-        elif s not in [True, False] and is_number(s):
-            s = to_number(s)
-        return json.dumps(s)
+        """
+        Escapes a string that will turn any regular single quotes (') into escaped ones (\').
+        JSON dumps will escape the single quotes.
+        https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
+        """
+        # empty string escapes to empty object
+        if isinstance(s, str) and len(s.strip()) == 0:
+            return "{}"
+        return s if is_number(s) else json.dumps(s)[1:-1]
 
 
 class VelocityInput:

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -92,6 +92,9 @@ class VelocityUtilApiGateway(VelocityUtil):
         JSON dumps will escape the single quotes.
         https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html
         """
+        if not s:
+            return s
+
         # empty string escapes to empty object
         if isinstance(s, str) and len(s.strip()) == 0:
             return "{}"

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -51,7 +51,6 @@ class VtlTemplate:
         # add extensions for common string functions below
 
         class ExtendedString(str):
-
             def __new__(cls, *args, **kwargs):
                 return str.__new__(cls, *args, **kwargs)
 

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -51,8 +51,6 @@ class VtlTemplate:
         # add extensions for common string functions below
 
         class ExtendedString(str):
-            def __new__(cls, *args, **kwargs):
-                return str.__new__(cls, *args, **kwargs)
 
             def trim(self, *args, **kwargs):
                 return ExtendedString(self.strip(*args, **kwargs))

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -51,6 +51,10 @@ class VtlTemplate:
         # add extensions for common string functions below
 
         class ExtendedString(str):
+
+            def __new__(cls, *args, **kwargs):
+                return str.__new__(cls, *args, **kwargs)
+
             def trim(self, *args, **kwargs):
                 return ExtendedString(self.strip(*args, **kwargs))
 

--- a/localstack/utils/aws/templating.py
+++ b/localstack/utils/aws/templating.py
@@ -51,7 +51,6 @@ class VtlTemplate:
         # add extensions for common string functions below
 
         class ExtendedString(str):
-
             def trim(self, *args, **kwargs):
                 return ExtendedString(self.strip(*args, **kwargs))
 

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -45,6 +45,7 @@ from localstack.utils.aws import resources as resource_util
 from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import select_attributes, short_uid, to_str
+from localstack.utils.sync import retry
 from tests.integration.apigateway_fixtures import (
     _client,
     api_invoke_url,
@@ -76,6 +77,22 @@ from .awslambda.test_lambda import (
     TEST_LAMBDA_PYTHON_ECHO,
 )
 
+STEP_FUCTIONS_ASSUME_ROLE_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "states.amazonaws.com"},
+            "Action": "sts:AssumeRole",
+        }
+    ],
+}
+
+APIGATEWAY_STEPFUNCTIONS_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Allow", "Action": "states:*", "Resource": "*"}],
+}
+
 APIGATEWAY_ASSUME_ROLE_POLICY = {
     "Statement": {
         "Sid": "",
@@ -86,7 +103,7 @@ APIGATEWAY_ASSUME_ROLE_POLICY = {
 }
 APIGATEWAY_LAMBDA_POLICY = {
     "Version": "2012-10-17",
-    "Statement": [{"Effect": "Allow", "Action": "lambda:InvokeFunction", "Resource": "*"}],
+    "Statement": [{"Effect": "Allow", "Action": "lambda:*", "Resource": "*"}],
 }
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))
@@ -202,6 +219,7 @@ class TestAPIGateway:
         assert response.ok
         assert response._content == b'{"echo": "foobar", "response": "mocked"}'
 
+    @pytest.mark.skip
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
         stream = resource_util.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
@@ -1476,11 +1494,42 @@ class TestAPIGateway:
         assert "/pets" in paths
         assert "/pets/{petId}" in paths
 
-    def test_step_function_integrations(
-        self, create_rest_apigw, apigateway_client, create_lambda_function
+    @pytest.mark.parametrize(
+        "action", ["StartExecution", "StartSyncExecution", "DeleteStateMachine"]
+    )
+    def test_apigateway_with_step_function_integration(
+        self,
+        action,
+        apigateway_client,
+        sts_client,
+        create_lambda_function,
+        create_rest_apigw,
+        stepfunctions_client,
+        create_iam_role_with_policy,
     ):
-        sfn_client = aws_stack.create_external_boto_client("stepfunctions")
-        lambda_client = aws_stack.create_external_boto_client("lambda")
+        region_name = apigateway_client._client_config.region_name
+        aws_account_id = sts_client.get_caller_identity()["Account"]
+
+        # create lambda
+        fn_name = f"lambda-sfn-apigw-{short_uid()}"
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=fn_name,
+            runtime=Runtime.python3_9,
+        )
+        lambda_arn = arns.lambda_function_arn(
+            function_name=fn_name, account_id=aws_account_id, region_name=region_name
+        )
+
+        # create state machine and permissions for step function to invoke lambda
+        role_name = f"sfn_role-{short_uid()}"
+        role_arn = arns.role_arn(role_name, account_id=aws_account_id)
+        create_iam_role_with_policy(
+            RoleName=role_name,
+            PolicyName=f"sfn-role-policy-{short_uid()}",
+            RoleDefinition=STEP_FUCTIONS_ASSUME_ROLE_POLICY,
+            PolicyDefinition=APIGATEWAY_LAMBDA_POLICY,
+        )
 
         state_machine_name = f"test-{short_uid()}"
         state_machine_def = {
@@ -1490,144 +1539,115 @@ class TestAPIGateway:
                 "step1": {"Type": "Task", "Resource": "__tbd__", "End": True},
             },
         }
-
-        # create state machine
-        fn_name = f"sfn-apigw-{short_uid()}"
-        create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON_ECHO,
-            func_name=fn_name,
-            runtime=Runtime.python3_9,
-        )
-        role_arn = arns.role_arn("sfn_role")
-
-        # create state machine definition
-        definition = clone(state_machine_def)
-        lambda_arn_1 = arns.lambda_function_arn(fn_name)
-        definition["States"]["step1"]["Resource"] = lambda_arn_1
-        definition = json.dumps(definition)
-
-        # create state machine
-        result = sfn_client.create_state_machine(
-            name=state_machine_name, definition=definition, roleArn=role_arn
+        state_machine_def["States"]["step1"]["Resource"] = lambda_arn
+        result = stepfunctions_client.create_state_machine(
+            name=state_machine_name,
+            definition=json.dumps(state_machine_def),
+            roleArn=role_arn,
+            type="EXPRESS",
         )
         sm_arn = result["stateMachineArn"]
 
-        # create REST API and method
-        rest_api, _, _ = create_rest_apigw(name="test", description="test")
-        resources = apigateway_client.get_resources(restApiId=rest_api)
-        root_resource_id = resources["items"][0]["id"]
+        # create REST API with integrations
+        rest_api, _, root_id = create_rest_apigw(
+            name=f"test-{short_uid()}", description="test-step-function-integration"
+        )
         apigateway_client.put_method(
             restApiId=rest_api,
-            resourceId=root_resource_id,
+            resourceId=root_id,
             httpMethod="POST",
             authorizationType="NONE",
         )
+        create_rest_api_method_response(
+            apigateway_client,
+            restApiId=rest_api,
+            resourceId=root_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
 
-        def _prepare_method_integration(
-            integr_kwargs=None, resp_templates=None, action="StartExecution", overwrite=False
-        ):
-            if integr_kwargs is None:
-                integr_kwargs = {}
-            if resp_templates is None:
-                resp_templates = {}
-            if overwrite:
-                apigateway_client.delete_integration(
-                    restApiId=rest_api,
-                    resourceId=resources["items"][0]["id"],
-                    httpMethod="POST",
-                )
-            uri = f"arn:aws:apigateway:{aws_stack.get_region()}:states:action/{action}"
+        # give permission to api gateway to invoke step function
+        uri = f"arn:aws:apigateway:{region_name}:states:action/{action}"
+        assume_role_arn = create_iam_role_with_policy(
+            RoleName=f"role-apigw-{short_uid()}",
+            PolicyName=f"policy-apigw-{short_uid()}",
+            RoleDefinition=APIGATEWAY_ASSUME_ROLE_POLICY,
+            PolicyDefinition=APIGATEWAY_STEPFUNCTIONS_POLICY,
+        )
+
+        def _prepare_integration(request_template=None, response_template=None):
             apigateway_client.put_integration(
                 restApiId=rest_api,
-                resourceId=root_resource_id,
+                resourceId=root_id,
                 httpMethod="POST",
                 integrationHttpMethod="POST",
                 type="AWS",
                 uri=uri,
-                **integr_kwargs,
+                credentials=assume_role_arn,
+                requestTemplates=request_template,
             )
-            if resp_templates:
-                apigateway_client.put_integration_response(
-                    restApiId=rest_api,
-                    resourceId=root_resource_id,
-                    selectionPattern="",
-                    responseTemplates=resp_templates,
-                    httpMethod="POST",
-                    statusCode="200",
-                )
 
-        # STEP 1: test integration with request template
+            apigateway_client.put_integration_response(
+                restApiId=rest_api,
+                resourceId=root_id,
+                selectionPattern="",
+                responseTemplates=response_template,
+                httpMethod="POST",
+                statusCode="200",
+            )
 
-        _prepare_method_integration(
-            integr_kwargs={
-                "requestTemplates": {
+        test_data = {"test": "test-value"}
+        url = api_invoke_url(api_id=rest_api, stage="dev", path="/")
+        match action:
+            case "StartExecution":
+                req_template = {
                     "application/json": """
-                    #set($data = $util.escapeJavaScript($input.json('$')))
-                    {"input": $data, "stateMachineArn": "%s"}
-                    """
+                            #set($data = $util.escapeJavaScript($input.json('$')))
+                            {"input": "$data", "stateMachineArn": "%s"}
+                        """
                     % sm_arn
                 }
-            }
-        )
+                _prepare_integration(req_template, response_template={})
+                apigateway_client.create_deployment(restApiId=rest_api, stageName="dev")
+                # invoke stepfunction via API GW, assert results
 
-        # invoke stepfunction via API GW, assert results
-        apigateway_client.create_deployment(restApiId=rest_api, stageName="dev")
-        url = path_based_url(api_id=rest_api, stage_name="dev", path="/")
-        test_data = {"test": "test-value"}
-        resp = requests.post(url, data=json.dumps(test_data))
-        assert 200 == resp.status_code
-        assert "executionArn" in resp.content.decode()
-        assert "startDate" in resp.content.decode()
+                def _invoke_start_step_function():
+                    resp = requests.post(url, data=json.dumps(test_data))
+                    assert resp.ok
+                    content = json.loads(to_str(resp.content.decode()))
+                    assert "executionArn" in content
+                    assert "startDate" in content
 
-        # STEP 2: test integration without request template
+                retry(_invoke_start_step_function, retries=15, sleep=0.8)
 
-        _prepare_method_integration(overwrite=True)
+            case "StartSyncExecution":
+                resp_template = {APPLICATION_JSON: "$input.path('$.output')"}
+                _prepare_integration({}, resp_template)
+                apigateway_client.create_deployment(restApiId=rest_api, stageName="dev")
+                input_data = {
+                    "input": json.dumps(test_data),
+                    "name": "MyExecution",
+                    "stateMachineArn": sm_arn,
+                }
 
-        test_data_1 = {
-            "input": json.dumps(test_data),
-            "name": "MyExecution",
-            "stateMachineArn": sm_arn,
-        }
+                def _invoke_start_sync_step_function():
+                    input_data["name"] += "1"
+                    resp = requests.post(url, data=json.dumps(input_data))
+                    assert resp.ok
+                    content = json.loads(to_str(resp.content.decode()))
+                    assert test_data == content
 
-        # invoke stepfunction via API GW, assert results
-        resp = requests.post(url, data=json.dumps(test_data_1))
-        assert 200 == resp.status_code
-        assert "executionArn" in resp.content.decode()
-        assert "startDate" in resp.content.decode()
+                retry(_invoke_start_sync_step_function, retries=15, sleep=0.8)
 
-        # STEP 3: test integration with synchronous execution
+            case "DeleteStateMachine":
+                _prepare_integration({}, {})
+                apigateway_client.create_deployment(restApiId=rest_api, stageName="dev")
 
-        _prepare_method_integration(overwrite=True, action="StartSyncExecution")
+                def _invoke_step_function():
+                    resp = requests.post(url, data=json.dumps({"stateMachineArn": sm_arn}))
+                    assert resp.ok
 
-        # invoke stepfunction via API GW, assert results
-        test_data_1["name"] += "1"
-        resp = requests.post(url, data=json.dumps(test_data_1))
-        assert 200 == resp.status_code
-        content = json.loads(to_str(resp.content.decode()))
-        assert "SUCCEEDED" == content.get("status")
-        assert test_data == json.loads(content.get("output"))
-
-        # STEP 4: test integration with synchronous execution and response templates
-
-        resp_templates = {APPLICATION_JSON: "$input.path('$.output')"}
-        _prepare_method_integration(
-            resp_templates=resp_templates, overwrite=True, action="StartSyncExecution"
-        )
-
-        # invoke stepfunction via API GW, assert results
-        test_data_1["name"] += "2"
-        resp = requests.post(url, data=json.dumps(test_data_1))
-        assert 200 == resp.status_code
-        assert test_data == json.loads(to_str(resp.content.decode()))
-
-        _prepare_method_integration(overwrite=True, action="DeleteStateMachine")
-
-        # Remove state machine with API GW
-        resp = requests.post(url, data=json.dumps({"stateMachineArn": sm_arn}))
-        assert 200 == resp.status_code
-
-        # Clean up
-        lambda_client.delete_function(FunctionName=fn_name)
+                retry(_invoke_step_function, retries=15, sleep=0.8)
 
     def test_api_gateway_http_integration_with_path_request_parameter(
         self, apigateway_client, create_rest_apigw

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1494,6 +1494,7 @@ class TestAPIGateway:
         assert "/pets" in paths
         assert "/pets/{petId}" in paths
 
+    @pytest.mark.aws_validated
     @pytest.mark.parametrize(
         "action", ["StartExecution", "DeleteStateMachine"]
     )

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1495,7 +1495,7 @@ class TestAPIGateway:
         assert "/pets/{petId}" in paths
 
     @pytest.mark.parametrize(
-        "action", ["StartExecution", "StartSyncExecution", "DeleteStateMachine"]
+        "action", ["StartExecution", "DeleteStateMachine"]
     )
     def test_apigateway_with_step_function_integration(
         self,

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1495,9 +1495,7 @@ class TestAPIGateway:
         assert "/pets/{petId}" in paths
 
     @pytest.mark.aws_validated
-    @pytest.mark.parametrize(
-        "action", ["StartExecution", "DeleteStateMachine"]
-    )
+    @pytest.mark.parametrize("action", ["StartExecution", "DeleteStateMachine"])
     def test_apigateway_with_step_function_integration(
         self,
         action,

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -77,7 +77,7 @@ from .awslambda.test_lambda import (
     TEST_LAMBDA_PYTHON_ECHO,
 )
 
-STEP_FUCTIONS_ASSUME_ROLE_POLICY = {
+STEPFUNCTIONS_ASSUME_ROLE_POLICY = {
     "Version": "2012-10-17",
     "Statement": [
         {
@@ -219,7 +219,6 @@ class TestAPIGateway:
         assert response.ok
         assert response._content == b'{"echo": "foobar", "response": "mocked"}'
 
-    @pytest.mark.skip
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
         stream = resource_util.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
@@ -1526,7 +1525,7 @@ class TestAPIGateway:
         create_iam_role_with_policy(
             RoleName=role_name,
             PolicyName=f"sfn-role-policy-{short_uid()}",
-            RoleDefinition=STEP_FUCTIONS_ASSUME_ROLE_POLICY,
+            RoleDefinition=STEPFUNCTIONS_ASSUME_ROLE_POLICY,
             PolicyDefinition=APIGATEWAY_LAMBDA_POLICY,
         )
 

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -218,6 +218,7 @@ def test_render_template_values():
         ('{"foo": 123}', '{\\"foo\\": 123}'),
         ('{"foo"": 123}', '{\\"foo\\"\\": 123}'),
         (1, 1),
+        (None, None)
     )
     for string, expected in escape_tests:
         escaped = util.escapeJavaScript(string)

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -218,7 +218,7 @@ def test_render_template_values():
         ('{"foo": 123}', '{\\"foo\\": 123}'),
         ('{"foo"": 123}', '{\\"foo\\"\\": 123}'),
         (1, 1),
-        (None, None)
+        (None, None),
     )
     for string, expected in escape_tests:
         escaped = util.escapeJavaScript(string)

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -217,8 +217,8 @@ def test_render_template_values():
         ('"""', '\\"\\"\\"'),
         ('{"foo": 123}', '{\\"foo\\": 123}'),
         ('{"foo"": 123}', '{\\"foo\\"\\": 123}'),
-        (1, 1),
-        (None, None),
+        (1, "1"),
+        (None, "null"),
     )
     for string, expected in escape_tests:
         escaped = util.escapeJavaScript(string)

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -208,24 +208,20 @@ def test_render_template_values():
     assert decoded == "x=a b"
 
     escape_tests = (
-        ("it's", '"it\'s"'),
-        ("0010", "10"),
+        ("it's", "it's"),
+        ("0010", "0010"),
         ("true", "true"),
-        ("True", '"True"'),
+        ("True", "True"),
         ("1.021", "1.021"),
-        ("'''", "\"'''\""),
-        ('""', '""'),
-        ('"""', '"\\"\\"\\""'),
-        ('{"foo": 123}', '{"foo": 123}'),
-        ('{"foo"": 123}', '"{\\"foo\\"\\": 123}"'),
-        (1, "1"),
-        (True, "true"),
+        ('""', '\\"\\"'),
+        ('"""', '\\"\\"\\"'),
+        ('{"foo": 123}', '{\\"foo\\": 123}'),
+        ('{"foo"": 123}', '{\\"foo\\"\\": 123}'),
+        (1, 1),
     )
     for string, expected in escape_tests:
         escaped = util.escapeJavaScript(string)
         assert escaped == expected
-        # we should be able to json.loads in all of the cases!
-        json.loads(escaped)
 
 
 class TestJSONPatch(unittest.TestCase):
@@ -271,7 +267,7 @@ class TestApplyTemplate(unittest.TestCase):
 
         rendered_request = RequestTemplates().render(api_context=api_context)
 
-        self.assertEqual('"foobar"', rendered_request)
+        self.assertEqual('\\"foobar\\"', rendered_request)
 
     def test_apply_template_no_json_payload(self):
         api_context = ApiInvocationContext(

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -151,7 +151,7 @@ class TestMessageTransformationApiGateway:
         result = ApiGatewayVtlTemplate().render_vtl(template, variables)
         result = re.sub(r"\s+", " ", result).strip()
         result = json.loads(result)
-        assert result == {"p0": True, "p1": {"test": "123"}, "p2": {"foo": "bar", "foo2": "False"}}
+        assert result == {"p0": True, "p1": {"test": "123"}, "p2": {"foo": "bar", "foo2": "false"}}
 
     def test_array_size(self):
         template = "#set($list = $input.path('$.records')) $list.size()"

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -32,11 +32,11 @@ APIGW_TEMPLATE_CONSTRUCT_JSON = """
 {
     #foreach($key in $map.keySet())
         #set( $k = $util.escapeJavaScript($key) )
-        #set( $v = $util.escapeJavaScript($map.get($key)).replaceAll("\\\\'", "'") )
-        $k: $v
+        #set( $v = $util.escapeJavaScript($map.get($key)))
+        "$k": "$v"
         #if( $foreach.hasNext ) , #end
     #end
-}
+} 
 #end
 {
     "p0": true,
@@ -147,11 +147,11 @@ class TestMessageTransformationBasic:
 class TestMessageTransformationApiGateway:
     def test_construct_json_using_define(self):
         template = APIGW_TEMPLATE_CONSTRUCT_JSON
-        data = {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}
-        variables = {"input": {"body": data}}
-        result = ApiGatewayVtlTemplate().render_vtl(template, variables).strip()
+        variables = {"input": {"body": {"p1": {"test": 123}, "p2": {"foo": "bar", "foo2": False}}}}
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables)
+        result = re.sub(r"\s+", " ", result).strip()
         result = json.loads(result)
-        assert result == {"p0": True, **data}
+        assert result == {'p0': True, 'p1': {'test': '123'}, 'p2': {'foo': 'bar', 'foo2': 'False'}}
 
     def test_array_size(self):
         template = "#set($list = $input.path('$.records')) $list.size()"

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -36,7 +36,7 @@ APIGW_TEMPLATE_CONSTRUCT_JSON = """
         "$k": "$v"
         #if( $foreach.hasNext ) , #end
     #end
-} 
+}
 #end
 {
     "p0": true,
@@ -151,7 +151,7 @@ class TestMessageTransformationApiGateway:
         result = ApiGatewayVtlTemplate().render_vtl(template, variables)
         result = re.sub(r"\s+", " ", result).strip()
         result = json.loads(result)
-        assert result == {'p0': True, 'p1': {'test': '123'}, 'p2': {'foo': 'bar', 'foo2': 'False'}}
+        assert result == {"p0": True, "p1": {"test": "123"}, "p2": {"foo": "bar", "foo2": "False"}}
 
     def test_array_size(self):
         template = "#set($list = $input.path('$.records')) $list.size()"


### PR DESCRIPTION
This PR tackles the escape javascript function used on VTL templates by not "double" encoding strings.
I also converted a new test to be AWS-validated.
For example,

```
#set( $body = $input.json("$") )
#define( $loop )
{
    #foreach($e in $map.keySet())
       #set( $k = $e )
       #set( $v = $map.get($k))
       // previously $k and $v weren't wrapped on double-quotes, because of the bug, however it's required (validated on AWS)
       "$k": "$v"
       #if( $foreach.hasNext ) , #end
    #end
}
```

or issues like 

```
""proxy"":
""test""
```
It also organises the step functions integration tests using parameters to ensure APIs are deployed between changes. The previous tests was not working on AWS since an update to REST APIs needed to be deployed.


Resolves https://github.com/localstack/localstack/issues/7188