### PR TITLE
feat: support deletion of configuration set and configuration set event destinations

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -190,7 +190,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         # TODO: contribute upstream?
         backend = get_ses_backend(context)
         backend.config_set.pop(configuration_set_name, None)
-        return {}
+        return DeleteConfigurationSetResponse()
 
     @handler("DeleteConfigurationSetEventDestination")
     def delete_configuration_set_event_destination(
@@ -203,7 +203,7 @@ class SesProvider(SesApi, ServiceLifecycleHook):
         # TODO: contribute upstream?
         backend = get_ses_backend(context)
         backend.config_set_event_destination.pop(configuration_set_name, None)
-        return {}
+        return DeleteConfigurationSetEventDestinationResponse()
 
     @handler("ListTemplates")
     def list_templates(

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -17,9 +17,12 @@ from localstack.aws.api.ses import (
     CloneReceiptRuleSetResponse,
     ConfigurationSetName,
     CreateConfigurationSetEventDestinationResponse,
+    DeleteConfigurationSetEventDestinationResponse,
+    DeleteConfigurationSetResponse,
     DeleteTemplateResponse,
     Destination,
     EventDestination,
+    EventDestinationName,
     GetIdentityVerificationAttributesResponse,
     IdentityList,
     IdentityVerificationAttributes,
@@ -178,6 +181,29 @@ class SesProvider(SesApi, ServiceLifecycleHook):
             emitter.emit_create_configuration_set_event_destination_test_message(sns_topic_arn)
 
         return result
+
+    @handler("DeleteConfigurationSet")
+    def delete_configuration_set(
+        self, context: RequestContext, configuration_set_name: ConfigurationSetName
+    ) -> DeleteConfigurationSetResponse:
+        # not implemented in moto
+        # TODO: contribute upstream?
+        backend = get_ses_backend(context)
+        backend.config_set.pop(configuration_set_name, None)
+        return {}
+
+    @handler("DeleteConfigurationSetEventDestination")
+    def delete_configuration_set_event_destination(
+        self,
+        context: RequestContext,
+        configuration_set_name: ConfigurationSetName,
+        event_destination_name: EventDestinationName,
+    ) -> DeleteConfigurationSetEventDestinationResponse:
+        # not implemented in moto
+        # TODO: contribute upstream?
+        backend = get_ses_backend(context)
+        backend.config_set_event_destination.pop(configuration_set_name, None)
+        return {}
 
     @handler("ListTemplates")
     def list_templates(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1779,10 +1779,8 @@ def ses_configuration_set(ses_client):
 
     yield factory
 
-    # this endpoint is not implemented for localstack
-    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
-        for configuration_set_name in configuration_set_names:
-            ses_client.delete_configuration_set(ConfigurationSetName=configuration_set_name)
+    for configuration_set_name in configuration_set_names:
+        ses_client.delete_configuration_set(ConfigurationSetName=configuration_set_name)
 
 
 @pytest.fixture
@@ -1805,13 +1803,11 @@ def ses_configuration_set_sns_event_destination(ses_client):
 
     yield factory
 
-    # this endpoint is not implemented for localstack
-    if os.environ.get("TEST_TARGET") == "AWS_CLOUD":
-        for (config_set_name, event_destination_name) in event_destinations:
-            ses_client.delete_configuration_set_event_destination(
-                ConfigurationSetName=config_set_name,
-                EventDestinationName=event_destination_name,
-            )
+    for (config_set_name, event_destination_name) in event_destinations:
+        ses_client.delete_configuration_set_event_destination(
+            ConfigurationSetName=config_set_name,
+            EventDestinationName=event_destination_name,
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
Proper management of SES resources require deletion of AWS resources. Deletion of configuration sets and configuration set event destinations were not supported by localstack.

*Note: these resources are not implemented in `moto` either, so we have to implement the logic in request handlers. We manipulate the `moto` state within the handlers since `moto` does not do it for us 😂*

These changes are well tested as part of #7207 and that PR must be merged first.