### PR TITLE
Fix error logging in companion ref detection

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -74,7 +74,7 @@ jobs:
                   if (error.status == 404) {
                     return false
                   } else {
-                    // another (unexpected) error ocurred, raise the error
+                    // another (unexpected) error occurred, raise the error
                     throw new Error(`Fetching companion refs failed: ${JSON.stringify(error)}`)
                   }
               }

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -75,7 +75,7 @@ jobs:
                     return false
                   } else {
                     // another (unexpected) error occurred, raise the error
-                    throw new Error(`Fetching companion refs failed: ${JSON.stringify(error)}`)
+                    throw new Error(`Fetching companion refs failed: ${error}`)
                   }
               }
             }


### PR DESCRIPTION
The issue was initially observed when the access token expired: https://github.com/localstack/localstack/actions/runs/3530759350/jobs/5923109632#step:3:70