### PR TITLE
fix opensearch multiregion support

### DIFF
--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -1,0 +1,12 @@
+import pytest
+
+from localstack.services.opensearch.provider import OpensearchProvider
+
+
+def test_opensearch_get_store_raises_exception():
+    """
+    Tests if OpensearchProvider.get_store raises an error if the region is not given and cannot be determined from
+    the request context (i.e. we're not within a request scoped thread).
+    """
+    with pytest.raises(AssertionError):
+        OpensearchProvider.get_store()


### PR DESCRIPTION
When creating an OpenSearch domain in a different region than the default one, the startup monitor failed (since it selected the wrong store, and in turn did not find the domain to change the status for). As a result, the `Processing` status is never set to `false` (indicating that the domain creation was successful / has finished).

This PR addresses this issue by:
- Explicitly setting the region when using `OpensearchProvider.get_store` outside of a request-scoped thread (i.e. the startup monitor thread).
- Raising an `AssertionError` in case `OpensearchProvider.get_store` does not get an explicit region nor is run in a request-scoped thread (i.e. `get_region_from_request_context` returns `None`).