### PR TITLE
Clean up aws_stack

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -17,7 +17,6 @@ from moto.apigateway.utils import create_id as create_resource_id
 from requests.models import Response
 
 import localstack.utils.aws.queries
-import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import (
@@ -30,6 +29,7 @@ from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.models import ApiGatewayStore, apigateway_stores
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws import resources as resource_utils
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
 from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, THREAD_LOCAL
@@ -485,7 +485,7 @@ def connect_api_gateway_to_sqs(gateway_name, stage_name, queue_arn, path, region
             ],
         }
     ]
-    return localstack.utils.aws.resources.create_api_gateway(
+    return resource_utils.create_api_gateway(
         name=gateway_name,
         resources=resources,
         stage_name=stage_name,

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -16,6 +16,8 @@ from moto.apigateway.models import Authorizer, Integration, Resource, RestAPI, a
 from moto.apigateway.utils import create_id as create_resource_id
 from requests.models import Response
 
+import localstack.utils.aws.queries
+import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import (
@@ -393,7 +395,7 @@ def get_rest_api_paths(rest_api_id, region_name=None):
         path = resource.get("path")
         # TODO: check if this is still required in the general case (can we rely on "path" being
         #  present?)
-        path = path or aws_stack.get_apigateway_path_for_resource(
+        path = path or localstack.utils.aws.queries.get_apigateway_path_for_resource(
             rest_api_id, resource["id"], region_name=region_name
         )
         resource_map[path] = resource
@@ -483,7 +485,7 @@ def connect_api_gateway_to_sqs(gateway_name, stage_name, queue_arn, path, region
             ],
         }
     ]
-    return aws_stack.create_api_gateway(
+    return localstack.utils.aws.resources.create_api_gateway(
         name=gateway_name,
         resources=resources,
         stage_name=stage_name,

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -28,8 +28,8 @@ from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.models import ApiGatewayStore, apigateway_stores
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
-from localstack.utils.aws.aws_stack import parse_arn
 from localstack.utils.aws.request_context import MARKER_APIGW_REQUEST_REGION, THREAD_LOCAL
 from localstack.utils.strings import long_uid
 from localstack.utils.time import TIMESTAMP_FORMAT_TZ, timestamp

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -16,7 +16,6 @@ from moto.apigateway.models import Authorizer, Integration, Resource, RestAPI, a
 from moto.apigateway.utils import create_id as create_resource_id
 from requests.models import Response
 
-import localstack.utils.aws.queries
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import (
@@ -28,7 +27,7 @@ from localstack.constants import (
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.models import ApiGatewayStore, apigateway_stores
 from localstack.utils import common
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import aws_stack, queries
 from localstack.utils.aws import resources as resource_utils
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.aws.aws_responses import requests_error_response_json, requests_response
@@ -395,7 +394,7 @@ def get_rest_api_paths(rest_api_id, region_name=None):
         path = resource.get("path")
         # TODO: check if this is still required in the general case (can we rely on "path" being
         #  present?)
-        path = path or localstack.utils.aws.queries.get_apigateway_path_for_resource(
+        path = path or queries.get_apigateway_path_for_resource(
             rest_api_id, resource["id"], region_name=region_name
         )
         resource_map[path] = resource

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -25,8 +25,8 @@ from localstack.services.apigateway.templates import (
 from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_execution_result
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_responses import LambdaResponse, requests_response
-from localstack.utils.aws.aws_stack import extract_region_from_arn
 from localstack.utils.collections import remove_attributes
 from localstack.utils.common import make_http_request, to_str
 from localstack.utils.http import canonicalize_headers, parse_request_data

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -1,12 +1,12 @@
 from typing import Any, Dict, List
 
-import localstack.utils.aws.arns
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
     CrossRegionAttribute,
     LocalAttribute,
 )
+from localstack.utils.aws import arns
 
 
 class ApiGatewayStore(BaseStore):
@@ -43,7 +43,7 @@ class ApiGatewayStore(BaseStore):
 
         self.account.update(
             {
-                "cloudwatchRoleArn": localstack.utils.aws.arns.role_arn("api-gw-cw-role"),
+                "cloudwatchRoleArn": arns.role_arn("api-gw-cw-role"),
                 "throttleSettings": {"burstLimit": 1000, "rateLimit": 500},
                 "features": ["UsagePlans"],
                 "apiKeyVersion": "1",

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -1,12 +1,12 @@
 from typing import Any, Dict, List
 
+import localstack.utils.aws.arns
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
     CrossRegionAttribute,
     LocalAttribute,
 )
-from localstack.utils.aws import aws_stack
 
 
 class ApiGatewayStore(BaseStore):
@@ -43,7 +43,7 @@ class ApiGatewayStore(BaseStore):
 
         self.account.update(
             {
-                "cloudwatchRoleArn": aws_stack.role_arn("api-gw-cw-role"),
+                "cloudwatchRoleArn": localstack.utils.aws.arns.role_arn("api-gw-cw-role"),
                 "throttleSettings": {"burstLimit": 1000, "rateLimit": 500},
                 "features": ["UsagePlans"],
                 "apiKeyVersion": "1",

--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -3,6 +3,7 @@ import logging
 import time
 from typing import Dict, List, Optional
 
+import localstack.utils.aws.arns
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.services.awslambda.event_source_listeners.adapters import (
     EventSourceAdapter,
@@ -17,7 +18,7 @@ from localstack.services.awslambda.lambda_utils import (
     message_attributes_to_lower,
 )
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import extract_region_from_arn
+from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.threads import FuncThread
 
 LOG = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class SQSEventSourceListener(EventSourceListener):
                     batch_size = max(min(source.get("BatchSize", 1), 10), 1)
 
                     try:
-                        queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
+                        queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(queue_arn)
                         result = sqs_client.receive_message(
                             QueueUrl=queue_url,
                             AttributeNames=["All"],
@@ -98,7 +99,7 @@ class SQSEventSourceListener(EventSourceListener):
             "FunctionResponseTypes", []
         )
         region_name = extract_region_from_arn(queue_arn)
-        queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
+        queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(queue_arn)
         LOG.debug("Sending event from event source %s to Lambda %s", queue_arn, lambda_arn)
         self._send_event_to_lambda(
             queue_arn,

--- a/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/sqs_event_source_listener.py
@@ -3,7 +3,6 @@ import logging
 import time
 from typing import Dict, List, Optional
 
-import localstack.utils.aws.arns
 from localstack.aws.api.lambda_ import InvocationType
 from localstack.services.awslambda.event_source_listeners.adapters import (
     EventSourceAdapter,
@@ -17,7 +16,7 @@ from localstack.services.awslambda.lambda_utils import (
     filter_stream_records,
     message_attributes_to_lower,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.threads import FuncThread
 
@@ -68,7 +67,7 @@ class SQSEventSourceListener(EventSourceListener):
                     batch_size = max(min(source.get("BatchSize", 1), 10), 1)
 
                     try:
-                        queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(queue_arn)
+                        queue_url = arns.sqs_queue_url_for_arn(queue_arn)
                         result = sqs_client.receive_message(
                             QueueUrl=queue_url,
                             AttributeNames=["All"],
@@ -99,7 +98,7 @@ class SQSEventSourceListener(EventSourceListener):
             "FunctionResponseTypes", []
         )
         region_name = extract_region_from_arn(queue_arn)
-        queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(queue_arn)
+        queue_url = arns.sqs_queue_url_for_arn(queue_arn)
         LOG.debug("Sending event from event source %s to Lambda %s", queue_arn, lambda_arn)
         self._send_event_to_lambda(
             queue_arn,

--- a/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/stream_event_source_listener.py
@@ -12,7 +12,7 @@ from localstack.services.awslambda.event_source_listeners.event_source_listener 
     EventSourceListener,
 )
 from localstack.services.awslambda.lambda_utils import filter_stream_records
-from localstack.utils.aws.aws_stack import extract_region_from_arn
+from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.message_forwarding import send_event_to_target
 from localstack.utils.common import long_uid, timestamp_millis
 from localstack.utils.threads import FuncThread

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from flask import Flask, Response, jsonify, request
 
 import localstack.utils.aws.arns
+import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON, LOCALHOST_HOSTNAME
@@ -899,7 +900,7 @@ def forward_to_fallback_url(func_arn, data):
             "payload": {"S": data},
             "function_name": {"S": lambda_name},
         }
-        aws_stack.create_dynamodb_table(table_name, partition_key="id")
+        localstack.utils.aws.resources.create_dynamodb_table(table_name, partition_key="id")
         dynamodb.put_item(TableName=table_name, Item=item)
         return ""
     if re.match(r"^https?://.+", config.LAMBDA_FALLBACK_URL):

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -22,7 +22,6 @@ from urllib.parse import urlparse
 
 from flask import Flask, Response, jsonify, request
 
-import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON, LOCALHOST_HOSTNAME
@@ -56,7 +55,7 @@ from localstack.services.awslambda.lambda_utils import (
 )
 from localstack.services.awslambda.packages import awslambda_go_runtime_package
 from localstack.utils.archives import unzip
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_models import CodeSigningConfig, InvalidEnvVars, LambdaFunction
 from localstack.utils.aws.aws_responses import ResourceNotFoundException
@@ -899,7 +898,7 @@ def forward_to_fallback_url(func_arn, data):
             "payload": {"S": data},
             "function_name": {"S": lambda_name},
         }
-        localstack.utils.aws.resources.create_dynamodb_table(table_name, partition_key="id")
+        resources.create_dynamodb_table(table_name, partition_key="id")
         dynamodb.put_item(TableName=table_name, Item=item)
         return ""
     if re.match(r"^https?://.+", config.LAMBDA_FALLBACK_URL):

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -22,7 +22,6 @@ from urllib.parse import urlparse
 
 from flask import Flask, Response, jsonify, request
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
@@ -57,7 +56,7 @@ from localstack.services.awslambda.lambda_utils import (
 )
 from localstack.services.awslambda.packages import awslambda_go_runtime_package
 from localstack.utils.archives import unzip
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_models import CodeSigningConfig, InvalidEnvVars, LambdaFunction
 from localstack.utils.aws.aws_responses import ResourceNotFoundException
@@ -168,12 +167,12 @@ def func_arn(function_name, remove_qualifier=True):
     parts = function_name.split(":function:")
     if remove_qualifier and len(parts) > 1:
         function_name = "%s:function:%s" % (parts[0], parts[1].split(":")[0])
-    return localstack.utils.aws.arns.lambda_function_arn(function_name)
+    return arns.lambda_function_arn(function_name)
 
 
 def func_qualifier(function_name, qualifier=None):
     store = get_awslambda_store_for_arn(function_name)
-    arn = localstack.utils.aws.arns.lambda_function_arn(function_name)
+    arn = arns.lambda_function_arn(function_name)
     details = store.lambdas.get(arn)
     if not details:
         return details
@@ -426,7 +425,7 @@ def run_lambda(
         sys.stdout = stream
         sys.stderr = stream
     try:
-        func_arn = localstack.utils.aws.arns.fix_arn(func_arn)
+        func_arn = arns.fix_arn(func_arn)
         lambda_function = store.lambdas.get(func_arn)
         if not lambda_function:
             region_name = extract_region_from_arn(func_arn)
@@ -890,7 +889,7 @@ def forward_to_fallback_url(func_arn, data):
     if not config.LAMBDA_FALLBACK_URL:
         return
 
-    lambda_name = localstack.utils.aws.arns.lambda_function_name(func_arn)
+    lambda_name = arns.lambda_function_name(func_arn)
     if config.LAMBDA_FALLBACK_URL.startswith("dynamodb://"):
         table_name = urlparse(config.LAMBDA_FALLBACK_URL.replace("dynamodb://", "http://")).netloc
         dynamodb = aws_stack.connect_to_service("dynamodb")
@@ -942,9 +941,7 @@ def get_lambda_policy(function, qualifier=None):
         docs.append(doc)
 
     # find policy by name
-    policy_name = get_lambda_policy_name(
-        localstack.utils.aws.arns.lambda_function_name(function), qualifier=qualifier
-    )
+    policy_name = get_lambda_policy_name(arns.lambda_function_name(function), qualifier=qualifier)
     policy = [d for d in docs if d["PolicyName"] == policy_name]
     if policy:
         return policy[0]
@@ -2264,7 +2261,7 @@ def create_code_signing_config():
     signing_profile_version_arns = data.get("AllowedPublishers").get("SigningProfileVersionArns")
 
     code_signing_id = "csc-%s" % long_uid().replace("-", "")[0:17]
-    arn = localstack.utils.aws.arns.code_signing_arn(code_signing_id)
+    arn = arns.code_signing_arn(code_signing_id)
 
     store.code_signing_configs[arn] = CodeSigningConfig(
         arn, code_signing_id, signing_profile_version_arns

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 
 from flask import Flask, Response, jsonify, request
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON, LOCALHOST_HOSTNAME
@@ -56,9 +57,9 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.services.awslambda.packages import awslambda_go_runtime_package
 from localstack.utils.archives import unzip
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_models import CodeSigningConfig, InvalidEnvVars, LambdaFunction
 from localstack.utils.aws.aws_responses import ResourceNotFoundException
-from localstack.utils.aws.aws_stack import extract_region_from_arn
 from localstack.utils.common import get_unzipped_size, is_zip_file
 from localstack.utils.container_networking import get_main_container_name
 from localstack.utils.docker_utils import DOCKER_CLIENT
@@ -166,12 +167,12 @@ def func_arn(function_name, remove_qualifier=True):
     parts = function_name.split(":function:")
     if remove_qualifier and len(parts) > 1:
         function_name = "%s:function:%s" % (parts[0], parts[1].split(":")[0])
-    return aws_stack.lambda_function_arn(function_name)
+    return localstack.utils.aws.arns.lambda_function_arn(function_name)
 
 
 def func_qualifier(function_name, qualifier=None):
     store = get_awslambda_store_for_arn(function_name)
-    arn = aws_stack.lambda_function_arn(function_name)
+    arn = localstack.utils.aws.arns.lambda_function_arn(function_name)
     details = store.lambdas.get(arn)
     if not details:
         return details
@@ -424,7 +425,7 @@ def run_lambda(
         sys.stdout = stream
         sys.stderr = stream
     try:
-        func_arn = aws_stack.fix_arn(func_arn)
+        func_arn = localstack.utils.aws.arns.fix_arn(func_arn)
         lambda_function = store.lambdas.get(func_arn)
         if not lambda_function:
             region_name = extract_region_from_arn(func_arn)
@@ -888,7 +889,7 @@ def forward_to_fallback_url(func_arn, data):
     if not config.LAMBDA_FALLBACK_URL:
         return
 
-    lambda_name = aws_stack.lambda_function_name(func_arn)
+    lambda_name = localstack.utils.aws.arns.lambda_function_name(func_arn)
     if config.LAMBDA_FALLBACK_URL.startswith("dynamodb://"):
         table_name = urlparse(config.LAMBDA_FALLBACK_URL.replace("dynamodb://", "http://")).netloc
         dynamodb = aws_stack.connect_to_service("dynamodb")
@@ -941,7 +942,7 @@ def get_lambda_policy(function, qualifier=None):
 
     # find policy by name
     policy_name = get_lambda_policy_name(
-        aws_stack.lambda_function_name(function), qualifier=qualifier
+        localstack.utils.aws.arns.lambda_function_name(function), qualifier=qualifier
     )
     policy = [d for d in docs if d["PolicyName"] == policy_name]
     if policy:
@@ -2262,7 +2263,7 @@ def create_code_signing_config():
     signing_profile_version_arns = data.get("AllowedPublishers").get("SigningProfileVersionArns")
 
     code_signing_id = "csc-%s" % long_uid().replace("-", "")[0:17]
-    arn = aws_stack.code_signing_arn(code_signing_id)
+    arn = localstack.utils.aws.arns.code_signing_arn(code_signing_id)
 
     store.code_signing_configs[arn] = CodeSigningConfig(
         arn, code_signing_id, signing_profile_version_arns

--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -2,11 +2,10 @@ import logging
 
 from moto.awslambda import models as moto_awslambda_models
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.awslambda.lambda_api import handle_lambda_url_invocation
 from localstack.services.edge import ROUTER
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.request_context import AWS_REGION_REGEX
 from localstack.utils.patch import patch
 from localstack.utils.platform import is_linux
@@ -105,12 +104,12 @@ def get_function(fn, self, *args, **kwargs):
         return result
 
     client = aws_stack.connect_to_service("lambda")
-    lambda_name = localstack.utils.aws.arns.lambda_function_name(args[0])
+    lambda_name = arns.lambda_function_name(args[0])
     response = client.get_function(FunctionName=lambda_name)
 
     spec = response["Configuration"]
     spec["Code"] = {"ZipFile": "ZW1wdHkgc3RyaW5n"}
-    region = localstack.utils.aws.arns.extract_region_from_arn(spec["FunctionArn"])
+    region = arns.extract_region_from_arn(spec["FunctionArn"])
     new_function = moto_awslambda_models.LambdaFunction(spec, region)
 
     return new_function

--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -2,6 +2,7 @@ import logging
 
 from moto.awslambda import models as moto_awslambda_models
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.awslambda.lambda_api import handle_lambda_url_invocation
 from localstack.services.edge import ROUTER
@@ -104,12 +105,12 @@ def get_function(fn, self, *args, **kwargs):
         return result
 
     client = aws_stack.connect_to_service("lambda")
-    lambda_name = aws_stack.lambda_function_name(args[0])
+    lambda_name = localstack.utils.aws.arns.lambda_function_name(args[0])
     response = client.get_function(FunctionName=lambda_name)
 
     spec = response["Configuration"]
     spec["Code"] = {"ZipFile": "ZW1wdHkgc3RyaW5n"}
-    region = aws_stack.extract_region_from_arn(spec["FunctionArn"])
+    region = localstack.utils.aws.arns.extract_region_from_arn(spec["FunctionArn"])
     new_function = moto_awslambda_models.LambdaFunction(spec, region)
 
     return new_function

--- a/localstack/services/awslambda/lambda_utils.py
+++ b/localstack/services/awslambda/lambda_utils.py
@@ -16,9 +16,9 @@ from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import FilterCriteria, Runtime
 from localstack.services.awslambda.lambda_models import AwsLambdaStore, awslambda_stores
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.aws.aws_responses import flask_error_response_json
-from localstack.utils.aws.aws_stack import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.container_networking import (
     get_endpoint_for_network,
     get_main_container_network,

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -1,6 +1,7 @@
 import json
 from urllib.parse import urlparse
 
+import localstack.utils.aws.queries
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     lambda_keys_to_lower,
@@ -228,7 +229,7 @@ class GatewayResource(GenericBaseModel):
         if not target_resource:
             return None
 
-        path = aws_stack.get_apigateway_path_for_resource(
+        path = localstack.utils.aws.queries.get_apigateway_path_for_resource(
             api_id, target_resource[0]["id"], resources=api_resources
         )
         result = list(filter(lambda res: res["path"] == path, api_resources))

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -1,14 +1,13 @@
 import json
 from urllib.parse import urlparse
 
-import localstack.utils.aws.queries
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     lambda_keys_to_lower,
     params_list_to_dict,
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import aws_stack, queries
 from localstack.utils.common import keys_to_lower, select_attributes, to_bytes
 
 
@@ -229,7 +228,7 @@ class GatewayResource(GenericBaseModel):
         if not target_resource:
             return None
 
-        path = localstack.utils.aws.queries.get_apigateway_path_for_resource(
+        path = queries.get_apigateway_path_for_resource(
             api_id, target_resource[0]["id"], resources=api_resources
         )
         result = list(filter(lambda res: res["path"] == path, api_resources))

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -3,6 +3,7 @@ import os
 import random
 import string
 
+import localstack.utils.aws.arns
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
@@ -37,7 +38,7 @@ class LambdaFunction(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         func_name = self.props.get("FunctionName")
         if attribute == "Arn":
-            return aws_stack.lambda_function_arn(func_name)
+            return localstack.utils.aws.arns.lambda_function_arn(func_name)
         return func_name
 
     def update_resource(self, new_resource, stack_name, resources):

--- a/localstack/services/cloudformation/models/awslambda.py
+++ b/localstack/services/cloudformation/models/awslambda.py
@@ -3,7 +3,6 @@ import os
 import random
 import string
 
-import localstack.utils.aws.arns
 from localstack.services.awslambda.lambda_utils import get_handler_file_from_name
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
@@ -11,7 +10,7 @@ from localstack.services.cloudformation.deployment_utils import (
 )
 from localstack.services.cloudformation.packages import cloudformation_package
 from localstack.services.cloudformation.service_models import LOG, REF_ID_ATTRS, GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import (
     cp_r,
     is_base64,
@@ -38,7 +37,7 @@ class LambdaFunction(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         func_name = self.props.get("FunctionName")
         if attribute == "Arn":
-            return localstack.utils.aws.arns.lambda_function_arn(func_name)
+            return arns.lambda_function_arn(func_name)
         return func_name
 
     def update_resource(self, new_resource, stack_name, resources):

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
 
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.service_models import GenericBaseModel
+from localstack.utils.aws import arns
 
 LOG = logging.getLogger(__name__)
 
@@ -23,13 +23,13 @@ class ECRRepository(GenericBaseModel):
 
     def get_physical_resource_id(self, attribute, **kwargs):
         repo_name = self.props.get("RepositoryName")
-        return localstack.utils.aws.arns.get_ecr_repository_arn(repo_name)
+        return arns.get_ecr_repository_arn(repo_name)
 
     def fetch_state(self, stack_name, resources):
         repo_name = default_repos_per_stack.get(stack_name)
         if repo_name:
             return {
-                "repositoryArn": localstack.utils.aws.arns.get_ecr_repository_arn(repo_name),
+                "repositoryArn": arns.get_ecr_repository_arn(repo_name),
                 "registryId": "000000000000",
                 "repositoryName": repo_name,
                 "repositoryUri": "http://localhost:4566",

--- a/localstack/services/cloudformation/models/ecr.py
+++ b/localstack/services/cloudformation/models/ecr.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
 
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
 
@@ -23,13 +23,13 @@ class ECRRepository(GenericBaseModel):
 
     def get_physical_resource_id(self, attribute, **kwargs):
         repo_name = self.props.get("RepositoryName")
-        return aws_stack.get_ecr_repository_arn(repo_name)
+        return localstack.utils.aws.arns.get_ecr_repository_arn(repo_name)
 
     def fetch_state(self, stack_name, resources):
         repo_name = default_repos_per_stack.get(stack_name)
         if repo_name:
             return {
-                "repositoryArn": aws_stack.get_ecr_repository_arn(repo_name),
+                "repositoryArn": localstack.utils.aws.arns.get_ecr_repository_arn(repo_name),
                 "registryId": "000000000000",
                 "repositoryName": repo_name,
                 "repositoryUri": "http://localhost:4566",

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -1,12 +1,11 @@
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import select_attributes
 
 
 def es_add_tags_params(params, **kwargs):
-    es_arn = localstack.utils.aws.arns.es_domain_arn(params.get("DomainName"))
+    es_arn = arns.es_domain_arn(params.get("DomainName"))
     tags = params.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
 
@@ -19,13 +18,13 @@ class ElasticsearchDomain(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         domain_name = self._domain_name()
         if attribute == "Arn":
-            return localstack.utils.aws.arns.elasticsearch_domain_arn(domain_name)
+            return arns.elasticsearch_domain_arn(domain_name)
         return domain_name
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "DomainArn":
             domain_name = self._domain_name()
-            return localstack.utils.aws.arns.elasticsearch_domain_arn(domain_name)
+            return arns.elasticsearch_domain_arn(domain_name)
         if attribute_name == "DomainEndpoint":
             domain_status = self.props.get("DomainStatus", {})
             result = domain_status.get("Endpoint")

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -1,3 +1,4 @@
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
@@ -5,7 +6,7 @@ from localstack.utils.common import select_attributes
 
 
 def es_add_tags_params(params, **kwargs):
-    es_arn = aws_stack.es_domain_arn(params.get("DomainName"))
+    es_arn = localstack.utils.aws.arns.es_domain_arn(params.get("DomainName"))
     tags = params.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
 
@@ -18,13 +19,13 @@ class ElasticsearchDomain(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         domain_name = self._domain_name()
         if attribute == "Arn":
-            return aws_stack.elasticsearch_domain_arn(domain_name)
+            return localstack.utils.aws.arns.elasticsearch_domain_arn(domain_name)
         return domain_name
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "DomainArn":
             domain_name = self._domain_name()
-            return aws_stack.elasticsearch_domain_arn(domain_name)
+            return localstack.utils.aws.arns.elasticsearch_domain_arn(domain_name)
         if attribute_name == "DomainEndpoint":
             domain_status = self.props.get("DomainStatus", {})
             result = domain_status.get("Endpoint")

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -1,5 +1,6 @@
 import json
 
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     select_parameters,
@@ -76,7 +77,9 @@ class EventsRule(GenericBaseModel):
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "Arn":
-            return self.params.get("Arn") or aws_stack.events_rule_arn(self.params.get("Name"))
+            return self.params.get("Arn") or localstack.utils.aws.arns.events_rule_arn(
+                self.params.get("Name")
+            )
         return super(EventsRule, self).get_cfn_attribute(attribute_name)
 
     def get_physical_resource_id(self, attribute=None, **kwargs):

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -1,6 +1,5 @@
 import json
 
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     select_parameters,
@@ -11,7 +10,7 @@ from localstack.services.cloudformation.service_models import (
     GenericBaseModel,
 )
 from localstack.utils import common
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import short_uid
 
 
@@ -77,9 +76,7 @@ class EventsRule(GenericBaseModel):
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "Arn":
-            return self.params.get("Arn") or localstack.utils.aws.arns.events_rule_arn(
-                self.params.get("Name")
-            )
+            return self.params.get("Arn") or arns.events_rule_arn(self.params.get("Name"))
         return super(EventsRule, self).get_cfn_attribute(attribute_name)
 
     def get_physical_resource_id(self, attribute=None, **kwargs):

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -5,7 +5,6 @@ import string
 
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.services.awslambda.lambda_api import IAM_POLICY_VERSION
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
@@ -18,7 +17,7 @@ from localstack.services.cloudformation.deployment_utils import (
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.services.iam.provider import SERVICE_LINKED_ROLE_PATH_PREFIX
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import ensure_list
 from localstack.utils.functions import call_safe
 
@@ -31,7 +30,7 @@ class IAMManagedPolicy(GenericBaseModel):
         return "AWS::IAM::ManagedPolicy"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return localstack.utils.aws.arns.policy_arn(self.props["ManagedPolicyName"])
+        return arns.policy_arn(self.props["ManagedPolicyName"])
 
     def fetch_state(self, stack_name, resources):
         return IAMPolicy.get_policy_state(self, stack_name, resources, managed_policy=True)
@@ -233,7 +232,7 @@ class IAMRole(GenericBaseModel):
         if not role_name:
             return role_name
         if attribute == "Arn":
-            return localstack.utils.aws.arns.role_arn(role_name)
+            return arns.role_arn(role_name)
         return role_name
 
     def fetch_state(self, stack_name, resources):
@@ -471,7 +470,7 @@ class IAMPolicy(GenericBaseModel):
                 )
 
         def _delete_params(params, *args, **kwargs):
-            return {"PolicyArn": localstack.utils.aws.arns.policy_arn(params["PolicyName"])}
+            return {"PolicyArn": arns.policy_arn(params["PolicyName"])}
 
         return {
             "create": {
@@ -495,9 +494,7 @@ class IAMPolicy(GenericBaseModel):
         users = props.get("Users", [])
         groups = props.get("Groups", [])
         if managed_policy:
-            result["policy"] = iam.get_policy(
-                PolicyArn=localstack.utils.aws.arns.policy_arn(policy_name)
-            )
+            result["policy"] = iam.get_policy(PolicyArn=arns.policy_arn(policy_name))
         for role in roles:
             role = obj.resolve_refs_recursively(stack_name, role, resources)
             policies = (

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -5,6 +5,7 @@ import string
 
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.services.awslambda.lambda_api import IAM_POLICY_VERSION
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
@@ -30,7 +31,7 @@ class IAMManagedPolicy(GenericBaseModel):
         return "AWS::IAM::ManagedPolicy"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return aws_stack.policy_arn(self.props["ManagedPolicyName"])
+        return localstack.utils.aws.arns.policy_arn(self.props["ManagedPolicyName"])
 
     def fetch_state(self, stack_name, resources):
         return IAMPolicy.get_policy_state(self, stack_name, resources, managed_policy=True)
@@ -232,7 +233,7 @@ class IAMRole(GenericBaseModel):
         if not role_name:
             return role_name
         if attribute == "Arn":
-            return aws_stack.role_arn(role_name)
+            return localstack.utils.aws.arns.role_arn(role_name)
         return role_name
 
     def fetch_state(self, stack_name, resources):
@@ -470,7 +471,7 @@ class IAMPolicy(GenericBaseModel):
                 )
 
         def _delete_params(params, *args, **kwargs):
-            return {"PolicyArn": aws_stack.policy_arn(params["PolicyName"])}
+            return {"PolicyArn": localstack.utils.aws.arns.policy_arn(params["PolicyName"])}
 
         return {
             "create": {
@@ -494,7 +495,9 @@ class IAMPolicy(GenericBaseModel):
         users = props.get("Users", [])
         groups = props.get("Groups", [])
         if managed_policy:
-            result["policy"] = iam.get_policy(PolicyArn=aws_stack.policy_arn(policy_name))
+            result["policy"] = iam.get_policy(
+                PolicyArn=localstack.utils.aws.arns.policy_arn(policy_name)
+            )
         for role in roles:
             role = obj.resolve_refs_recursively(stack_name, role, resources)
             policies = (

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -1,3 +1,4 @@
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import select_parameters
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
@@ -17,7 +18,9 @@ class FirehoseDeliveryStream(GenericBaseModel):
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "Arn":
-            return aws_stack.firehose_stream_arn(self.props.get("DeliveryStreamName"))
+            return localstack.utils.aws.arns.firehose_stream_arn(
+                self.props.get("DeliveryStreamName")
+            )
         return super().get_cfn_attribute(attribute_name)
 
     def get_physical_resource_id(self, attribute=None, **kwargs):

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -1,7 +1,6 @@
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import select_parameters
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 
 
 class FirehoseDeliveryStream(GenericBaseModel):
@@ -18,9 +17,7 @@ class FirehoseDeliveryStream(GenericBaseModel):
 
     def get_cfn_attribute(self, attribute_name):
         if attribute_name == "Arn":
-            return localstack.utils.aws.arns.firehose_stream_arn(
-                self.props.get("DeliveryStreamName")
-            )
+            return arns.firehose_stream_arn(self.props.get("DeliveryStreamName"))
         return super().get_cfn_attribute(attribute_name)
 
     def get_physical_resource_id(self, attribute=None, **kwargs):

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -1,5 +1,6 @@
 import json
 
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
@@ -38,7 +39,9 @@ class KMSKey(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         if attribute in REF_ID_ATTRS:
             return self.physical_resource_id
-        return self.physical_resource_id and aws_stack.kms_key_arn(self.physical_resource_id)
+        return self.physical_resource_id and localstack.utils.aws.arns.kms_key_arn(
+            self.physical_resource_id
+        )
 
     # TODO: try to remove this workaround (ensures idempotency)
     @staticmethod

--- a/localstack/services/cloudformation/models/kms.py
+++ b/localstack/services/cloudformation/models/kms.py
@@ -1,8 +1,7 @@
 import json
 
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.service_models import REF_ID_ATTRS, GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import short_uid
 
 
@@ -39,9 +38,7 @@ class KMSKey(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         if attribute in REF_ID_ATTRS:
             return self.physical_resource_id
-        return self.physical_resource_id and localstack.utils.aws.arns.kms_key_arn(
-            self.physical_resource_id
-        )
+        return self.physical_resource_id and arns.kms_key_arn(self.physical_resource_id)
 
     # TODO: try to remove this workaround (ensures idempotency)
     @staticmethod

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -1,4 +1,3 @@
-import localstack.utils.aws.arns
 from localstack.aws.api.opensearch import (
     CreateDomainRequest,
     OpenSearchPartitionInstanceType,
@@ -6,7 +5,7 @@ from localstack.aws.api.opensearch import (
 )
 from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.collections import select_attributes
 
 
@@ -14,7 +13,7 @@ from localstack.utils.collections import select_attributes
 # See examples in:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html
 def opensearch_add_tags_params(params, **kwargs):
-    es_arn = localstack.utils.aws.arns.es_domain_arn(params.get("DomainName"))
+    es_arn = arns.es_domain_arn(params.get("DomainName"))
     tags = params.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
 
@@ -28,7 +27,7 @@ class OpenSearchDomain(GenericBaseModel):
         domain_name = self._domain_name()
         if attribute == "Arn":
             # As mentioned above, OpenSearch still uses "es" ARNs
-            return localstack.utils.aws.arns.elasticsearch_domain_arn(domain_name)
+            return arns.elasticsearch_domain_arn(domain_name)
         return domain_name
 
     def fetch_state(self, stack_name, resources):

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -1,3 +1,4 @@
+import localstack.utils.aws.arns
 from localstack.aws.api.opensearch import (
     CreateDomainRequest,
     OpenSearchPartitionInstanceType,
@@ -13,7 +14,7 @@ from localstack.utils.collections import select_attributes
 # See examples in:
 # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-opensearchservice-domain.html
 def opensearch_add_tags_params(params, **kwargs):
-    es_arn = aws_stack.es_domain_arn(params.get("DomainName"))
+    es_arn = localstack.utils.aws.arns.es_domain_arn(params.get("DomainName"))
     tags = params.get("Tags", [])
     return {"ARN": es_arn, "TagList": tags}
 
@@ -27,7 +28,7 @@ class OpenSearchDomain(GenericBaseModel):
         domain_name = self._domain_name()
         if attribute == "Arn":
             # As mentioned above, OpenSearch still uses "es" ARNs
-            return aws_stack.elasticsearch_domain_arn(domain_name)
+            return localstack.utils.aws.arns.elasticsearch_domain_arn(domain_name)
         return domain_name
 
     def fetch_state(self, stack_name, resources):

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -3,7 +3,6 @@ import re
 
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.constants import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
@@ -12,7 +11,7 @@ from localstack.services.cloudformation.deployment_utils import (
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.services.s3 import s3_listener, s3_utils
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.cloudformation.cfn_utils import rename_params
 from localstack.utils.common import canonical_json, md5
 from localstack.utils.testutil import delete_all_s3_objects
@@ -226,7 +225,7 @@ class S3Bucket(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         bucket_name = self.props.get("BucketName")
         if attribute == "Arn":
-            return localstack.utils.aws.arns.s3_bucket_arn(bucket_name)
+            return arns.s3_bucket_arn(bucket_name)
         return bucket_name
 
     def _get_bucket_name(self):

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -3,6 +3,7 @@ import re
 
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.constants import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
@@ -225,7 +226,7 @@ class S3Bucket(GenericBaseModel):
     def get_physical_resource_id(self, attribute=None, **kwargs):
         bucket_name = self.props.get("BucketName")
         if attribute == "Arn":
-            return aws_stack.s3_bucket_arn(bucket_name)
+            return localstack.utils.aws.arns.s3_bucket_arn(bucket_name)
         return bucket_name
 
     def _get_bucket_name(self):

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -3,6 +3,7 @@ import logging
 import random
 import string
 
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import (
     REF_ARN_ATTRS,
@@ -130,7 +131,7 @@ class SecretsManagerSecretTargetAttachment(GenericBaseModel):
         return "AWS::SecretsManager::SecretTargetAttachment"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        return aws_stack.secretsmanager_secret_arn(self.props.get("SecretId"))
+        return localstack.utils.aws.arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         # TODO implement?
@@ -143,7 +144,7 @@ class SecretsManagerRotationSchedule(GenericBaseModel):
         return "AWS::SecretsManager::RotationSchedule"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        return aws_stack.secretsmanager_secret_arn(self.props.get("SecretId"))
+        return localstack.utils.aws.arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         # TODO implement?
@@ -156,7 +157,7 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
         return "AWS::SecretsManager::ResourcePolicy"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        return aws_stack.secretsmanager_secret_arn(self.props.get("SecretId"))
+        return localstack.utils.aws.arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         secret_id = self.resolve_refs_recursively(stack_name, self.props.get("SecretId"), resources)

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -3,14 +3,13 @@ import logging
 import random
 import string
 
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import (
     REF_ARN_ATTRS,
     REF_ID_ATTRS,
     GenericBaseModel,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import select_attributes
 
 LOG = logging.getLogger(__name__)
@@ -131,7 +130,7 @@ class SecretsManagerSecretTargetAttachment(GenericBaseModel):
         return "AWS::SecretsManager::SecretTargetAttachment"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        return localstack.utils.aws.arns.secretsmanager_secret_arn(self.props.get("SecretId"))
+        return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         # TODO implement?
@@ -144,7 +143,7 @@ class SecretsManagerRotationSchedule(GenericBaseModel):
         return "AWS::SecretsManager::RotationSchedule"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        return localstack.utils.aws.arns.secretsmanager_secret_arn(self.props.get("SecretId"))
+        return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         # TODO implement?
@@ -157,7 +156,7 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
         return "AWS::SecretsManager::ResourcePolicy"
 
     def get_physical_resource_id(self, attribute, **kwargs):
-        return localstack.utils.aws.arns.secretsmanager_secret_arn(self.props.get("SecretId"))
+        return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
         secret_id = self.resolve_refs_recursively(stack_name, self.props.get("SecretId"), resources)

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -2,13 +2,12 @@ import json
 
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     is_none_or_empty_value,
 )
 from localstack.services.cloudformation.service_models import GenericBaseModel
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import canonicalize_bool_to_str
 
 
@@ -18,7 +17,7 @@ class SNSTopic(GenericBaseModel):
         return "AWS::SNS::Topic"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return localstack.utils.aws.arns.sns_topic_arn(self.props["TopicName"])
+        return arns.sns_topic_arn(self.props["TopicName"])
 
     def fetch_state(self, stack_name, resources):
         topic_name = self.resolve_refs_recursively(stack_name, self.props["TopicName"], resources)

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -2,6 +2,7 @@ import json
 
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import (
     generate_default_name,
     is_none_or_empty_value,
@@ -17,7 +18,7 @@ class SNSTopic(GenericBaseModel):
         return "AWS::SNS::Topic"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return aws_stack.sns_topic_arn(self.props["TopicName"])
+        return localstack.utils.aws.arns.sns_topic_arn(self.props["TopicName"])
 
     def fetch_state(self, stack_name, resources):
         topic_name = self.resolve_refs_recursively(stack_name, self.props["TopicName"], resources)

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -3,6 +3,7 @@ import logging
 
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
     generate_default_name,
@@ -78,14 +79,14 @@ class SQSQueue(GenericBaseModel):
         queue_url = None
         props = self.props
         try:
-            queue_url = aws_stack.get_sqs_queue_url(props.get("QueueName"))
+            queue_url = localstack.utils.aws.arns.get_sqs_queue_url(props.get("QueueName"))
         except Exception as e:
             if "NonExistentQueue" in str(e):
                 raise DependencyNotYetSatisfied(
                     resource_ids=self.resource_id, message="Unable to get queue: %s" % e
                 )
         if attribute == "Arn":
-            return aws_stack.sqs_queue_arn(props.get("QueueName"))
+            return localstack.utils.aws.arns.sqs_queue_arn(props.get("QueueName"))
         return queue_url
 
     def fetch_state(self, stack_name, resources):
@@ -127,7 +128,7 @@ class SQSQueue(GenericBaseModel):
             queue_url = resource.physical_resource_id or props.get("QueueUrl")
             if queue_url:
                 return queue_url
-            return aws_stack.sqs_queue_url_for_arn(props["QueueArn"])
+            return localstack.utils.aws.arns.sqs_queue_url_for_arn(props["QueueArn"])
 
         return {
             "create": {

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -3,7 +3,6 @@ import logging
 
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_RESOURCE_NAME,
     generate_default_name,
@@ -14,7 +13,7 @@ from localstack.services.cloudformation.service_models import (
     DependencyNotYetSatisfied,
     GenericBaseModel,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import short_uid
 
 LOG = logging.getLogger(__name__)
@@ -79,14 +78,14 @@ class SQSQueue(GenericBaseModel):
         queue_url = None
         props = self.props
         try:
-            queue_url = localstack.utils.aws.arns.get_sqs_queue_url(props.get("QueueName"))
+            queue_url = arns.get_sqs_queue_url(props.get("QueueName"))
         except Exception as e:
             if "NonExistentQueue" in str(e):
                 raise DependencyNotYetSatisfied(
                     resource_ids=self.resource_id, message="Unable to get queue: %s" % e
                 )
         if attribute == "Arn":
-            return localstack.utils.aws.arns.sqs_queue_arn(props.get("QueueName"))
+            return arns.sqs_queue_arn(props.get("QueueName"))
         return queue_url
 
     def fetch_state(self, stack_name, resources):
@@ -128,7 +127,7 @@ class SQSQueue(GenericBaseModel):
             queue_url = resource.physical_resource_id or props.get("QueueUrl")
             if queue_url:
                 return queue_url
-            return localstack.utils.aws.arns.sqs_queue_url_for_arn(props["QueueArn"])
+            return arns.sqs_queue_url_for_arn(props["QueueArn"])
 
         return {
             "create": {

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -4,6 +4,7 @@ import re
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
+import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudformation import (
@@ -138,9 +139,9 @@ class Stack:
                 "LogicalResourceId"
             ] = (resource.get("LogicalResourceId") or resource_id)
         # initialize stack template attributes
-        stack_id = self.metadata.get("StackId") or aws_stack.cloudformation_stack_arn(
-            self.stack_name, short_uid()
-        )
+        stack_id = self.metadata.get(
+            "StackId"
+        ) or localstack.utils.aws.arns.cloudformation_stack_arn(self.stack_name, short_uid())
         self.template["StackId"] = self.metadata["StackId"] = stack_id
         self.template["Parameters"] = self.template.get("Parameters") or {}
         self.template["Outputs"] = self.template.get("Outputs") or {}
@@ -474,7 +475,7 @@ class StackChangeSet(Stack):
 
         name = self.metadata["ChangeSetName"]
         if not self.metadata.get("ChangeSetId"):
-            self.metadata["ChangeSetId"] = aws_stack.cf_change_set_arn(
+            self.metadata["ChangeSetId"] = localstack.utils.aws.arns.cf_change_set_arn(
                 name, change_set_id=short_uid()
             )
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -1085,7 +1085,8 @@ class CloudformationProvider(CloudformationApi):
 
         # wait for completion of stack
         for stack in stacks_to_await:
-            aws_stack.await_stack_completion(stack[0], region_name=stack[1])
+            client = aws_stack.connect_to_service("cloudformation", region_name=stack[1])
+            client.get_waiter("stack_create_complete").wait(StackName=stack[0])
 
         # record operation
         operation = {

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -4,7 +4,6 @@ import re
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
-import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudformation import (
@@ -66,7 +65,7 @@ from localstack.aws.api.cloudformation import (
     ValidateTemplateOutput,
 )
 from localstack.services.cloudformation.stores import CloudFormationStore, cloudformation_stores
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.cloudformation import template_deployer, template_preparer
 from localstack.utils.cloudformation.template_deployer import NoStackUpdates
 from localstack.utils.cloudformation.template_preparer import (
@@ -139,9 +138,9 @@ class Stack:
                 "LogicalResourceId"
             ] = (resource.get("LogicalResourceId") or resource_id)
         # initialize stack template attributes
-        stack_id = self.metadata.get(
-            "StackId"
-        ) or localstack.utils.aws.arns.cloudformation_stack_arn(self.stack_name, short_uid())
+        stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
+            self.stack_name, short_uid()
+        )
         self.template["StackId"] = self.metadata["StackId"] = stack_id
         self.template["Parameters"] = self.template.get("Parameters") or {}
         self.template["Outputs"] = self.template.get("Outputs") or {}
@@ -475,9 +474,7 @@ class StackChangeSet(Stack):
 
         name = self.metadata["ChangeSetName"]
         if not self.metadata.get("ChangeSetId"):
-            self.metadata["ChangeSetId"] = localstack.utils.aws.arns.cf_change_set_arn(
-                name, change_set_id=short_uid()
-            )
+            self.metadata["ChangeSetId"] = arns.cf_change_set_arn(name, change_set_id=short_uid())
 
         stack = self.stack = find_stack(self.metadata["StackName"])
         self.metadata["StackId"] = stack.stack_id

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -5,6 +5,7 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, List
 
+import localstack.utils.aws.arns
 from localstack.aws.api.cloudwatch import MetricAlarm, MetricDataQuery, StateValue
 from localstack.utils.aws import aws_stack
 from localstack.utils.scheduler import Scheduler
@@ -116,13 +117,13 @@ class AlarmScheduler:
 
 
 def get_metric_alarm_details_for_alarm_arn(alarm_arn: str) -> MetricAlarm:
-    alarm_name = aws_stack.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
+    alarm_name = localstack.utils.aws.arns.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
     client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
     return client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"][0]
 
 
 def get_cloudwatch_client_for_region_of_alarm(alarm_arn: str) -> "CloudWatchClient":
-    region = aws_stack.extract_region_from_arn(alarm_arn)
+    region = localstack.utils.aws.arns.extract_region_from_arn(alarm_arn)
     return aws_stack.connect_to_service("cloudwatch", region_name=region)
 
 

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -5,9 +5,8 @@ import threading
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, List
 
-import localstack.utils.aws.arns
 from localstack.aws.api.cloudwatch import MetricAlarm, MetricDataQuery, StateValue
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.scheduler import Scheduler
 
 if TYPE_CHECKING:
@@ -117,13 +116,13 @@ class AlarmScheduler:
 
 
 def get_metric_alarm_details_for_alarm_arn(alarm_arn: str) -> MetricAlarm:
-    alarm_name = localstack.utils.aws.arns.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
+    alarm_name = arns.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
     client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
     return client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"][0]
 
 
 def get_cloudwatch_client_for_region_of_alarm(alarm_arn: str) -> "CloudWatchClient":
-    region = localstack.utils.aws.arns.extract_region_from_arn(alarm_arn)
+    region = arns.extract_region_from_arn(alarm_arn)
     return aws_stack.connect_to_service("cloudwatch", region_name=region)
 
 

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -5,7 +5,6 @@ from xml.sax.saxutils import escape
 from moto.cloudwatch import cloudwatch_backends
 from moto.cloudwatch.models import CloudWatchBackend, FakeAlarm
 
-import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudwatch import (
@@ -31,7 +30,7 @@ from localstack.services import moto
 from localstack.services.cloudwatch.alarm_scheduler import AlarmScheduler
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceLifecycleHook
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
 from localstack.utils.patch import patch
 from localstack.utils.sync import poll_condition
@@ -64,7 +63,7 @@ def update_state(target, self, reason, reason_data, state_value):
     else:
         actions = self.insufficient_data_actions
     for action in actions:
-        data = localstack.utils.aws.arns.parse_arn(action)
+        data = arns.parse_arn(action)
         # test for sns - can this be done in a more generic way?
         if data["service"] == "sns":
             service = aws_stack.connect_to_service(data["service"])
@@ -244,7 +243,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     def delete_alarms(self, context: RequestContext, alarm_names: AlarmNames) -> None:
         moto.call_moto(context)
         for alarm_name in alarm_names:
-            arn = localstack.utils.aws.arns.cloudwatch_alarm_arn(alarm_name)
+            arn = arns.cloudwatch_alarm_arn(alarm_name)
             self.alarm_scheduler.delete_scheduler_for_alarm(arn)
 
     def get_raw_metrics(self, request: Request):
@@ -347,7 +346,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         moto.call_moto(context)
 
         name = request.get("AlarmName")
-        arn = localstack.utils.aws.arns.cloudwatch_alarm_arn(name)
+        arn = arns.cloudwatch_alarm_arn(name)
         self.tags.tag_resource(arn, request.get("Tags"))
         self.alarm_scheduler.schedule_metric_alarm(arn)
 

--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -5,6 +5,7 @@ from xml.sax.saxutils import escape
 from moto.cloudwatch import cloudwatch_backends
 from moto.cloudwatch.models import CloudWatchBackend, FakeAlarm
 
+import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
 from localstack.aws.api.cloudwatch import (
@@ -63,7 +64,7 @@ def update_state(target, self, reason, reason_data, state_value):
     else:
         actions = self.insufficient_data_actions
     for action in actions:
-        data = aws_stack.parse_arn(action)
+        data = localstack.utils.aws.arns.parse_arn(action)
         # test for sns - can this be done in a more generic way?
         if data["service"] == "sns":
             service = aws_stack.connect_to_service(data["service"])
@@ -243,7 +244,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
     def delete_alarms(self, context: RequestContext, alarm_names: AlarmNames) -> None:
         moto.call_moto(context)
         for alarm_name in alarm_names:
-            arn = aws_stack.cloudwatch_alarm_arn(alarm_name)
+            arn = localstack.utils.aws.arns.cloudwatch_alarm_arn(alarm_name)
             self.alarm_scheduler.delete_scheduler_for_alarm(arn)
 
     def get_raw_metrics(self, request: Request):
@@ -346,7 +347,7 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         moto.call_moto(context)
 
         name = request.get("AlarmName")
-        arn = aws_stack.cloudwatch_alarm_arn(name)
+        arn = localstack.utils.aws.arns.cloudwatch_alarm_arn(name)
         self.tags.tag_resource(arn, request.get("Tags"))
         self.alarm_scheduler.schedule_metric_alarm(arn)
 

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -12,6 +12,7 @@ from typing import Dict, List
 import requests
 import werkzeug
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws import handlers
 from localstack.aws.accounts import get_aws_account_id
@@ -106,7 +107,7 @@ from localstack.services.dynamodbstreams.dynamodbstreams_api import (
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import extract_account_id_from_arn, extract_region_from_arn
+from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.collections import select_attributes
 from localstack.utils.common import short_uid, to_bytes
 from localstack.utils.json import BytesEncoder, canonical_json
@@ -256,7 +257,7 @@ class SSEUtils:
             if not kms_master_key_id:
                 # this is of course not the actual key for dynamodb, just a better, since existing, mock
                 kms_master_key_id = cls.get_sse_kms_managed_key(account_id, region_name)
-            kms_master_key_id = aws_stack.kms_key_arn(kms_master_key_id)
+            kms_master_key_id = localstack.utils.aws.arns.kms_key_arn(kms_master_key_id)
             return {
                 "Status": "ENABLED",
                 "SSEType": "KMS",  # no other value is allowed here
@@ -1136,7 +1137,11 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
             aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
             region_name=region_name,
         )
-        return aws_stack.dynamodb_table_exists(table_name, client)
+        try:
+            client.describe_table(TableName=table_name)
+        except client.exceptions.ResourceNotFoundException:
+            return False
+        return True
 
     @staticmethod
     def prepare_request_headers(headers: Dict):
@@ -1200,7 +1205,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 new_record["dynamodb"]["NewImage"] = put_request["Item"]
                 if existing_item:
                     new_record["dynamodb"]["OldImage"] = existing_item
-                new_record["eventSourceARN"] = aws_stack.dynamodb_table_arn(table_name)
+                new_record["eventSourceARN"] = localstack.utils.aws.arns.dynamodb_table_arn(
+                    table_name
+                )
                 new_record["dynamodb"]["SizeBytes"] = _get_size_bytes(put_request["Item"])
                 records.append(new_record)
                 i += 1
@@ -1220,7 +1227,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 new_record["dynamodb"]["Keys"] = keys
                 new_record["dynamodb"]["OldImage"] = existing_items[i]
                 new_record["dynamodb"]["NewImage"] = updated_item
-                new_record["eventSourceARN"] = aws_stack.dynamodb_table_arn(table_name)
+                new_record["eventSourceARN"] = localstack.utils.aws.arns.dynamodb_table_arn(
+                    table_name
+                )
                 new_record["dynamodb"]["SizeBytes"] = _get_size_bytes(updated_item)
                 records.append(new_record)
                 i += 1
@@ -1238,7 +1247,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 new_record["dynamodb"]["Keys"] = keys
                 new_record["dynamodb"]["OldImage"] = existing_item
                 new_record["dynamodb"]["SizeBytes"] = _get_size_bytes(existing_items)
-                new_record["eventSourceARN"] = aws_stack.dynamodb_table_arn(table_name)
+                new_record["eventSourceARN"] = localstack.utils.aws.arns.dynamodb_table_arn(
+                    table_name
+                )
                 records.append(new_record)
                 i += 1
         return records
@@ -1284,7 +1295,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                         new_record["dynamodb"]["NewImage"] = put_request["Item"]
                         if existing_item:
                             new_record["dynamodb"]["OldImage"] = existing_item
-                        new_record["eventSourceARN"] = aws_stack.dynamodb_table_arn(table_name)
+                        new_record["eventSourceARN"] = localstack.utils.aws.arns.dynamodb_table_arn(
+                            table_name
+                        )
                         records.append(new_record)
                     if unprocessed_put_items and len(unprocessed_put_items) > i:
                         unprocessed_item = unprocessed_put_items[i]
@@ -1302,7 +1315,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                         new_record["dynamodb"]["Keys"] = keys
                         new_record["dynamodb"]["OldImage"] = existing_items[i]
                         new_record["dynamodb"]["SizeBytes"] = _get_size_bytes(existing_items[i])
-                        new_record["eventSourceARN"] = aws_stack.dynamodb_table_arn(table_name)
+                        new_record["eventSourceARN"] = localstack.utils.aws.arns.dynamodb_table_arn(
+                            table_name
+                        )
                         records.append(new_record)
                     if unprocessed_delete_items and len(unprocessed_delete_items) > i:
                         unprocessed_item = unprocessed_delete_items[i]
@@ -1317,7 +1332,9 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         if records and "eventName" in records[0]:
             if table_name:
                 for record in records:
-                    record["eventSourceARN"] = aws_stack.dynamodb_table_arn(table_name)
+                    record["eventSourceARN"] = localstack.utils.aws.arns.dynamodb_table_arn(
+                        table_name
+                    )
             EventForwarder.forward_to_targets(records, background=True)
 
     def get_record_template(self) -> Dict:
@@ -1408,7 +1425,7 @@ def has_event_sources_or_streams_enabled(table_name: str, cache: Dict = None):
         cache = {}
     if not table_name:
         return
-    table_arn = aws_stack.dynamodb_table_arn(table_name)
+    table_arn = localstack.utils.aws.arns.dynamodb_table_arn(table_name)
     cached = cache.get(table_arn)
     if isinstance(cached, bool):
         return cached

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -6,11 +6,10 @@ from typing import Dict
 
 from bson.json_util import dumps
 
-import localstack.utils.aws.resources
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodbstreams import StreamStatus, StreamViewType
 from localstack.services.dynamodbstreams.models import DynamoDbStreamsStore, dynamodbstreams_stores
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.common import now_utc
 
 DDB_KINESIS_STREAM_NAME_PREFIX = "__ddb_stream_"
@@ -42,7 +41,7 @@ def add_dynamodb_stream(
         store = get_dynamodbstreams_store()
         # create kinesis stream as a backend
         stream_name = get_kinesis_stream_name(table_name)
-        localstack.utils.aws.resources.create_kinesis_stream(stream_name)
+        resources.create_kinesis_stream(stream_name)
         latest_stream_label = latest_stream_label or "latest"
         stream = {
             "StreamArn": arns.dynamodb_stream_arn(

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -7,6 +7,7 @@ from typing import Dict
 from bson.json_util import dumps
 
 import localstack.utils.aws.arns
+import localstack.utils.aws.resources
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodbstreams import StreamStatus, StreamViewType
 from localstack.services.dynamodbstreams.models import DynamoDbStreamsStore, dynamodbstreams_stores
@@ -42,7 +43,7 @@ def add_dynamodb_stream(
         store = get_dynamodbstreams_store()
         # create kinesis stream as a backend
         stream_name = get_kinesis_stream_name(table_name)
-        aws_stack.create_kinesis_stream(stream_name)
+        localstack.utils.aws.resources.create_kinesis_stream(stream_name)
         latest_stream_label = latest_stream_label or "latest"
         stream = {
             "StreamArn": localstack.utils.aws.arns.dynamodb_stream_arn(

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 from bson.json_util import dumps
 
+import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodbstreams import StreamStatus, StreamViewType
 from localstack.services.dynamodbstreams.models import DynamoDbStreamsStore, dynamodbstreams_stores
@@ -44,7 +45,7 @@ def add_dynamodb_stream(
         aws_stack.create_kinesis_stream(stream_name)
         latest_stream_label = latest_stream_label or "latest"
         stream = {
-            "StreamArn": aws_stack.dynamodb_stream_arn(
+            "StreamArn": localstack.utils.aws.arns.dynamodb_stream_arn(
                 table_name=table_name, latest_stream_label=latest_stream_label
             ),
             "TableName": table_name,

--- a/localstack/services/dynamodbstreams/dynamodbstreams_api.py
+++ b/localstack/services/dynamodbstreams/dynamodbstreams_api.py
@@ -6,12 +6,11 @@ from typing import Dict
 
 from bson.json_util import dumps
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.resources
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodbstreams import StreamStatus, StreamViewType
 from localstack.services.dynamodbstreams.models import DynamoDbStreamsStore, dynamodbstreams_stores
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import now_utc
 
 DDB_KINESIS_STREAM_NAME_PREFIX = "__ddb_stream_"
@@ -46,7 +45,7 @@ def add_dynamodb_stream(
         localstack.utils.aws.resources.create_kinesis_stream(stream_name)
         latest_stream_label = latest_stream_label or "latest"
         stream = {
-            "StreamArn": localstack.utils.aws.arns.dynamodb_stream_arn(
+            "StreamArn": arns.dynamodb_stream_arn(
                 table_name=table_name, latest_stream_label=latest_stream_label
             ),
             "TableName": table_name,

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -139,7 +139,9 @@ def get_opensearch_endpoint(domain_arn: str) -> str:
     domain_name = domain_arn.rpartition("/")[2]
     info = opensearch_client.describe_domain(DomainName=domain_name)
     base_domain = info["DomainStatus"]["Endpoint"]
-    endpoint = base_domain if base_domain.startswith("http") else f"https://{base_domain}"
+    # Add the URL scheme "http" if it's not set yet. https might not be enabled for all instances
+    # f.e. when the endpoint strategy is PORT or there is a custom opensearch/elasticsearch instance
+    endpoint = base_domain if base_domain.startswith("http") else f"http://{base_domain}"
     return endpoint
 
 

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -78,13 +78,8 @@ from localstack.services.firehose.mappers import (
 )
 from localstack.services.firehose.models import FirehoseStore, firehose_stores
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import (
-    connect_to_resource,
-    extract_region_from_arn,
-    firehose_stream_arn,
-    get_search_db_connection,
-    s3_bucket_name,
-)
+from localstack.utils.aws.arns import extract_region_from_arn, firehose_stream_arn, s3_bucket_name
+from localstack.utils.aws.aws_stack import connect_to_resource, get_search_db_connection
 from localstack.utils.common import (
     TIMESTAMP_FORMAT_MICROS,
     first_char_to_lower,

--- a/localstack/services/firehose/provider.py
+++ b/localstack/services/firehose/provider.py
@@ -1,11 +1,14 @@
 import base64
 import json
 import logging
+import os
+import re
 import threading
 import time
 import uuid
 from datetime import datetime
 from typing import Dict, List
+from urllib.parse import urlparse
 
 import requests
 
@@ -79,7 +82,6 @@ from localstack.services.firehose.mappers import (
 from localstack.services.firehose.models import FirehoseStore, firehose_stores
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn, firehose_stream_arn, s3_bucket_name
-from localstack.utils.aws.aws_stack import connect_to_resource, get_search_db_connection
 from localstack.utils.common import (
     TIMESTAMP_FORMAT_MICROS,
     first_char_to_lower,
@@ -139,6 +141,42 @@ def get_opensearch_endpoint(domain_arn: str) -> str:
     base_domain = info["DomainStatus"]["Endpoint"]
     endpoint = base_domain if base_domain.startswith("http") else f"https://{base_domain}"
     return endpoint
+
+
+def get_search_db_connection(endpoint: str, region_name: str):
+    """
+    Get a connection to an ElasticSearch or OpenSearch DB
+    :param endpoint: cluster endpoint
+    :param region_name: cluster region e.g. us-east-1
+    """
+    from opensearchpy import OpenSearch, RequestsHttpConnection
+    from requests_aws4auth import AWS4Auth
+
+    verify_certs = False
+    use_ssl = False
+    # use ssl?
+    if "https://" in endpoint:
+        use_ssl = True
+        # TODO remove this condition once ssl certs are available for .es.localhost.localstack.cloud domains
+        endpoint_netloc = urlparse(endpoint).netloc
+        if not re.match(r"^.*(localhost(\.localstack\.cloud)?)(:\d+)?$", endpoint_netloc):
+            verify_certs = True
+
+    LOG.debug("Creating ES client with endpoint %s", endpoint)
+    if "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
+        access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+        secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        session_token = os.environ.get("AWS_SESSION_TOKEN")
+        awsauth = AWS4Auth(access_key, secret_key, region_name, "es", session_token=session_token)
+        connection_class = RequestsHttpConnection
+        return OpenSearch(
+            hosts=[endpoint],
+            verify_certs=verify_certs,
+            use_ssl=use_ssl,
+            connection_class=connection_class,
+            http_auth=awsauth,
+        )
+    return OpenSearch(hosts=[endpoint], verify_certs=verify_certs, use_ssl=use_ssl)
 
 
 class FirehoseProvider(FirehoseApi):
@@ -531,7 +569,7 @@ class FirehoseProvider(FirehoseApi):
         domain_arn = db_description.get("DomainARN")
         cluster_endpoint = db_description.get("ClusterEndpoint")
         if cluster_endpoint is None:
-            cluster_endpoint = aws_stack.get_opensearch_endpoint(domain_arn)
+            cluster_endpoint = get_opensearch_endpoint(domain_arn)
 
         db_connection = get_search_db_connection(cluster_endpoint, region)
         if db_description.get("S3BackupMode") == ElasticsearchS3BackupMode.AllDocuments:
@@ -637,7 +675,7 @@ class FirehoseProvider(FirehoseApi):
         bucket = s3_bucket_name(s3_destination_description["BucketARN"])
         prefix = s3_destination_description.get("Prefix", "")
 
-        s3 = connect_to_resource("s3")
+        s3 = aws_stack.connect_to_resource("s3")
         batched_data = b"".join([base64.b64decode(r.get("Data") or r.get("data")) for r in records])
 
         obj_path = self._get_s3_object_path(stream_name, prefix)

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -8,6 +8,7 @@ import time
 import cbor2
 from requests.models import Response
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import APPLICATION_CBOR, APPLICATION_JSON, HEADER_AMZN_ERROR_TYPE
 from localstack.services.generic_proxy import ProxyListener
@@ -343,7 +344,7 @@ def find_consumer(consumer_arn="", consumer_name="", stream_arn=""):
 def find_stream_for_consumer(consumer_arn):
     kinesis = aws_stack.connect_to_service("kinesis")
     for stream_name in kinesis.list_streams()["StreamNames"]:
-        stream_arn = aws_stack.kinesis_stream_arn(stream_name)
+        stream_arn = localstack.utils.aws.arns.kinesis_stream_arn(stream_name)
         for cons in kinesis.list_stream_consumers(StreamARN=stream_arn)["Consumers"]:
             if cons["ConsumerARN"] == consumer_arn:
                 return stream_name

--- a/localstack/services/kinesis/kinesis_listener.py
+++ b/localstack/services/kinesis/kinesis_listener.py
@@ -8,12 +8,11 @@ import time
 import cbor2
 from requests.models import Response
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import APPLICATION_CBOR, APPLICATION_JSON, HEADER_AMZN_ERROR_TYPE
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.kinesis.provider import KinesisProvider
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_responses import convert_to_binary_event_payload
 from localstack.utils.common import clone, json_safe, now_utc, to_bytes, to_str
 
@@ -344,7 +343,7 @@ def find_consumer(consumer_arn="", consumer_name="", stream_arn=""):
 def find_stream_for_consumer(consumer_arn):
     kinesis = aws_stack.connect_to_service("kinesis")
     for stream_name in kinesis.list_streams()["StreamNames"]:
-        stream_arn = localstack.utils.aws.arns.kinesis_stream_arn(stream_name)
+        stream_arn = arns.kinesis_stream_arn(stream_name)
         for cons in kinesis.list_stream_consumers(StreamARN=stream_arn)["Consumers"]:
             if cons["ConsumerARN"] == consumer_arn:
                 return stream_name

--- a/localstack/services/kinesis/provider.py
+++ b/localstack/services/kinesis/provider.py
@@ -5,7 +5,6 @@ from random import random
 from typing import List
 
 import localstack.services.kinesis.kinesis_starter as starter
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext
@@ -48,7 +47,7 @@ from localstack.aws.api.kinesis import (
 from localstack.constants import LOCALHOST
 from localstack.services.kinesis.models import KinesisStore, kinesis_stores
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.time import now_utc
 
 LOG = logging.getLogger(__name__)
@@ -58,7 +57,7 @@ MAX_SUBSCRIPTION_SECONDS = 300
 def find_stream_for_consumer(consumer_arn):
     kinesis = aws_stack.connect_to_service("kinesis")
     for stream_name in kinesis.list_streams()["StreamNames"]:
-        stream_arn = localstack.utils.aws.arns.kinesis_stream_arn(stream_name)
+        stream_arn = arns.kinesis_stream_arn(stream_name)
         for cons in kinesis.list_stream_consumers(StreamARN=stream_arn)["Consumers"]:
             if cons["ConsumerARN"] == consumer_arn:
                 return stream_name

--- a/localstack/services/kinesis/provider.py
+++ b/localstack/services/kinesis/provider.py
@@ -5,6 +5,7 @@ from random import random
 from typing import List
 
 import localstack.services.kinesis.kinesis_starter as starter
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext
@@ -57,7 +58,7 @@ MAX_SUBSCRIPTION_SECONDS = 300
 def find_stream_for_consumer(consumer_arn):
     kinesis = aws_stack.connect_to_service("kinesis")
     for stream_name in kinesis.list_streams()["StreamNames"]:
-        stream_arn = aws_stack.kinesis_stream_arn(stream_name)
+        stream_arn = localstack.utils.aws.arns.kinesis_stream_arn(stream_name)
         for cons in kinesis.list_stream_consumers(StreamARN=stream_arn)["Consumers"]:
             if cons["ConsumerARN"] == consumer_arn:
                 return stream_name

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -32,7 +32,7 @@ from localstack.aws.api.kms import (
     UnsupportedOperationException,
 )
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
-from localstack.utils.aws.aws_stack import kms_alias_arn, kms_key_arn
+from localstack.utils.aws.arns import kms_alias_arn, kms_key_arn
 from localstack.utils.crypto import decrypt, encrypt
 from localstack.utils.strings import long_uid
 

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -100,7 +100,7 @@ from localstack.services.kms.models import (
     validate_alias_name,
 )
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.aws.aws_stack import kms_alias_arn
+from localstack.utils.aws.arns import kms_alias_arn
 from localstack.utils.collections import PaginatedList
 from localstack.utils.common import select_attributes
 from localstack.utils.strings import short_uid, to_bytes, to_str

--- a/localstack/services/logs/provider.py
+++ b/localstack/services/logs/provider.py
@@ -13,7 +13,6 @@ from moto.logs.models import LogsBackend
 from moto.logs.models import LogStream as MotoLogStream
 from moto.logs.models import logs_backends
 
-import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext
 from localstack.aws.api.logs import (
@@ -26,7 +25,7 @@ from localstack.aws.api.logs import (
 )
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.common import is_number
 from localstack.utils.patch import patch
@@ -96,7 +95,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
         client = aws_stack.connect_to_service(
             "lambda", region_name=extract_region_from_arn(destination_arn)
         )
-        lambda_name = localstack.utils.aws.arns.lambda_function_name(destination_arn)
+        lambda_name = arns.lambda_function_name(destination_arn)
         try:
             client.get_function(FunctionName=lambda_name)
         except Exception:
@@ -106,7 +105,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
 
     elif ":kinesis:" in destination_arn:
         client = aws_stack.connect_to_service("kinesis")
-        stream_name = localstack.utils.aws.arns.kinesis_stream_name(destination_arn)
+        stream_name = arns.kinesis_stream_name(destination_arn)
         try:
             client.describe_stream(StreamName=stream_name)
         except Exception:
@@ -117,7 +116,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
 
     elif ":firehose:" in destination_arn:
         client = aws_stack.connect_to_service("firehose")
-        firehose_name = localstack.utils.aws.arns.firehose_name(destination_arn)
+        firehose_name = arns.firehose_name(destination_arn)
         try:
             client.describe_delivery_stream(DeliveryStreamName=firehose_name)
         except Exception:
@@ -127,7 +126,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
             )
 
     else:
-        service = localstack.utils.aws.arns.extract_service_from_arn(destination_arn)
+        service = arns.extract_service_from_arn(destination_arn)
         raise InvalidParameterException(
             f"PutSubscriptionFilter operation cannot work with destinationArn for vendor {service}"
         )
@@ -187,11 +186,11 @@ def moto_put_log_events(self, log_group_name, log_stream_name, log_events):
             client = aws_stack.connect_to_service(
                 "lambda", region_name=extract_region_from_arn(self.destination_arn)
             )
-            lambda_name = localstack.utils.aws.arns.lambda_function_name(self.destination_arn)
+            lambda_name = arns.lambda_function_name(self.destination_arn)
             client.invoke(FunctionName=lambda_name, Payload=json.dumps(event))
         if ":kinesis:" in self.destination_arn:
             client = aws_stack.connect_to_service("kinesis")
-            stream_name = localstack.utils.aws.arns.kinesis_stream_name(self.destination_arn)
+            stream_name = arns.kinesis_stream_name(self.destination_arn)
             client.put_record(
                 StreamName=stream_name,
                 Data=payload_gz_encoded,
@@ -199,7 +198,7 @@ def moto_put_log_events(self, log_group_name, log_stream_name, log_events):
             )
         if ":firehose:" in self.destination_arn:
             client = aws_stack.connect_to_service("firehose")
-            firehose_name = localstack.utils.aws.arns.firehose_name(self.destination_arn)
+            firehose_name = arns.firehose_name(self.destination_arn)
             client.put_record(
                 DeliveryStreamName=firehose_name,
                 Record={"Data": payload_gz_encoded},

--- a/localstack/services/logs/provider.py
+++ b/localstack/services/logs/provider.py
@@ -13,6 +13,7 @@ from moto.logs.models import LogsBackend
 from moto.logs.models import LogStream as MotoLogStream
 from moto.logs.models import logs_backends
 
+import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext
 from localstack.aws.api.logs import (
@@ -26,7 +27,7 @@ from localstack.aws.api.logs import (
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import extract_region_from_arn
+from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.common import is_number
 from localstack.utils.patch import patch
 
@@ -95,7 +96,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
         client = aws_stack.connect_to_service(
             "lambda", region_name=extract_region_from_arn(destination_arn)
         )
-        lambda_name = aws_stack.lambda_function_name(destination_arn)
+        lambda_name = localstack.utils.aws.arns.lambda_function_name(destination_arn)
         try:
             client.get_function(FunctionName=lambda_name)
         except Exception:
@@ -105,7 +106,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
 
     elif ":kinesis:" in destination_arn:
         client = aws_stack.connect_to_service("kinesis")
-        stream_name = aws_stack.kinesis_stream_name(destination_arn)
+        stream_name = localstack.utils.aws.arns.kinesis_stream_name(destination_arn)
         try:
             client.describe_stream(StreamName=stream_name)
         except Exception:
@@ -116,7 +117,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
 
     elif ":firehose:" in destination_arn:
         client = aws_stack.connect_to_service("firehose")
-        firehose_name = aws_stack.firehose_name(destination_arn)
+        firehose_name = localstack.utils.aws.arns.firehose_name(destination_arn)
         try:
             client.describe_delivery_stream(DeliveryStreamName=firehose_name)
         except Exception:
@@ -126,7 +127,7 @@ def moto_put_subscription_filter(fn, self, *args, **kwargs):
             )
 
     else:
-        service = aws_stack.extract_service_from_arn(destination_arn)
+        service = localstack.utils.aws.arns.extract_service_from_arn(destination_arn)
         raise InvalidParameterException(
             f"PutSubscriptionFilter operation cannot work with destinationArn for vendor {service}"
         )
@@ -186,11 +187,11 @@ def moto_put_log_events(self, log_group_name, log_stream_name, log_events):
             client = aws_stack.connect_to_service(
                 "lambda", region_name=extract_region_from_arn(self.destination_arn)
             )
-            lambda_name = aws_stack.lambda_function_name(self.destination_arn)
+            lambda_name = localstack.utils.aws.arns.lambda_function_name(self.destination_arn)
             client.invoke(FunctionName=lambda_name, Payload=json.dumps(event))
         if ":kinesis:" in self.destination_arn:
             client = aws_stack.connect_to_service("kinesis")
-            stream_name = aws_stack.kinesis_stream_name(self.destination_arn)
+            stream_name = localstack.utils.aws.arns.kinesis_stream_name(self.destination_arn)
             client.put_record(
                 StreamName=stream_name,
                 Data=payload_gz_encoded,
@@ -198,7 +199,7 @@ def moto_put_log_events(self, log_group_name, log_stream_name, log_events):
             )
         if ":firehose:" in self.destination_arn:
             client = aws_stack.connect_to_service("firehose")
-            firehose_name = aws_stack.firehose_name(self.destination_arn)
+            firehose_name = localstack.utils.aws.arns.firehose_name(self.destination_arn)
             client.put_record(
                 DeliveryStreamName=firehose_name,
                 Record={"Data": payload_gz_encoded},

--- a/localstack/services/route53resolver/models.py
+++ b/localstack/services/route53resolver/models.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import localstack.services.route53resolver.utils
 from localstack.aws.api.route53resolver import (
     FirewallConfig,
     FirewallDomainList,
@@ -14,7 +15,6 @@ from localstack.aws.api.route53resolver import (
 )
 from localstack.services.route53resolver.utils import get_firewall_config_id, validate_vpc
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
-from localstack.utils.aws import aws_stack
 
 
 class Route53ResolverStore(BaseStore):
@@ -37,7 +37,7 @@ class Route53ResolverStore(BaseStore):
         firewall_rule_group = self.firewall_rule_groups.get(id)
         if not firewall_rule_group:
             raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"Can't find the resource with ID '{id}'. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return firewall_rule_group
 
@@ -55,7 +55,7 @@ class Route53ResolverStore(BaseStore):
         firewall_rule_group_association = self.firewall_rule_group_associations.get(id)
         if not firewall_rule_group_association:
             raise ResourceNotFoundException(
-                f"[RSLVR-02025] Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"[RSLVR-02025] Can't find the resource with ID '{id}'. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return self.firewall_rule_group_associations.get(id)
 
@@ -80,7 +80,7 @@ class Route53ResolverStore(BaseStore):
         firewall_domain_list = self.firewall_domain_lists.get(id)
         if not firewall_domain_list:
             raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"Can't find the resource with ID '{id}'. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return firewall_domain_list
 
@@ -100,7 +100,7 @@ class Route53ResolverStore(BaseStore):
         )
         if not firewall_rule:
             raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return firewall_rule
 
@@ -118,7 +118,7 @@ class Route53ResolverStore(BaseStore):
         resolver_query_log_config = self.resolver_query_log_configs.get(id)
         if not resolver_query_log_config:
             raise ResourceNotFoundException(
-                f"[RSLVR-01601] The specified query logging configuration doesn't exist. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"[RSLVR-01601] The specified query logging configuration doesn't exist. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return resolver_query_log_config
 
@@ -136,7 +136,7 @@ class Route53ResolverStore(BaseStore):
         resolver_query_log_config_association = self.resolver_query_log_config_associations.get(id)
         if not resolver_query_log_config_association:
             raise ResourceNotFoundException(
-                f"[RSLVR-01601] The specified query logging configuration doesn't exist. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"[RSLVR-01601] The specified query logging configuration doesn't exist. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return resolver_query_log_config_association
 
@@ -152,7 +152,7 @@ class Route53ResolverStore(BaseStore):
                 and association.get("ResourceId") == resource_id
             ):
                 raise ResourceNotFoundException(
-                    f"[RSLVR-01602] The specified query logging configuration association doesn't exist. Trace Id: '{aws_stack.get_trace_id()}'"
+                    f"[RSLVR-01602] The specified query logging configuration association doesn't exist. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
                 )
             association["Status"] = "DELETING"
             association_id = association.get("Id")

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -4,6 +4,7 @@ from moto.ec2.models import ec2_backends
 from moto.route53resolver.models import Route53ResolverBackend as MotoRoute53ResolverBackend
 from moto.route53resolver.models import route53resolver_backends
 
+import localstack.services.route53resolver.utils
 import localstack.utils.aws.arns
 from localstack.aws.api import RequestContext
 from localstack.aws.api.route53resolver import (
@@ -92,7 +93,6 @@ from localstack.services.route53resolver.utils import (
     validate_mutation_protection,
     validate_priority,
 )
-from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.patch import patch
@@ -254,7 +254,7 @@ class Route53ResolverProvider(Route53ResolverApi):
                         firewall_domains.remove(domain)
                     else:
                         raise ValidationException(
-                            f"[RSLVR-02502] The following domains don't exist in the DNS Firewall domain list '{firewall_domain_list_id}'. You can't delete a domain that isn't in a domain list. Example unknown domain: '{domain}'. Trace Id: '{aws_stack.get_trace_id()}'"
+                            f"[RSLVR-02502] The following domains don't exist in the DNS Firewall domain list '{firewall_domain_list_id}'. You can't delete a domain that isn't in a domain list. Example unknown domain: '{domain}'. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
                         )
 
         if operation == FirewallDomainUpdateOperation.REPLACE:
@@ -353,7 +353,7 @@ class Route53ResolverProvider(Route53ResolverApi):
             firewall_rules.append(FirewallRule(firewall_rule))
         if len(firewall_rules) == 0:
             raise ResourceNotFoundException(
-                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"Can't find the resource with ID '{firewall_rule_group_id}'. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
             )
         return ListFirewallRulesResponse(
             FirewallRules=firewall_rules,
@@ -419,7 +419,7 @@ class Route53ResolverProvider(Route53ResolverApi):
                 == firewall_rule_group_id
             ):
                 raise ValidationException(
-                    f"[RSLVR-02302] This DNS Firewall rule group can't be associated to a VPC: '{vpc_id}'. It is already associated to VPC '{firewall_rule_group_id}'. Try again with another VPC or DNS Firewall rule group. Trace Id: '{aws_stack.get_trace_id()}'"
+                    f"[RSLVR-02302] This DNS Firewall rule group can't be associated to a VPC: '{vpc_id}'. It is already associated to VPC '{firewall_rule_group_id}'. Try again with another VPC or DNS Firewall rule group. Trace Id: '{localstack.services.route53resolver.utils.get_trace_id()}'"
                 )
 
         id = get_route53_resolver_firewall_rule_group_association_id()

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -5,7 +5,6 @@ from moto.route53resolver.models import Route53ResolverBackend as MotoRoute53Res
 from moto.route53resolver.models import route53resolver_backends
 
 import localstack.services.route53resolver.utils
-import localstack.utils.aws.arns
 from localstack.aws.api import RequestContext
 from localstack.aws.api.route53resolver import (
     Action,
@@ -93,6 +92,7 @@ from localstack.services.route53resolver.utils import (
     validate_mutation_protection,
     validate_priority,
 )
+from localstack.utils.aws import arns
 from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.patch import patch
@@ -113,7 +113,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         """Create a Firewall Rule Group."""
         store = self.get_store(context.account_id, context.region)
         id = get_route53_resolver_firewall_rule_group_id()
-        arn = localstack.utils.aws.arns.get_route53_resolver_firewall_rule_group_arn(id)
+        arn = arns.get_route53_resolver_firewall_rule_group_arn(id)
         firewall_rule_group = FirewallRuleGroup(
             Id=id,
             Arn=arn,
@@ -175,7 +175,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         """Create a Firewall Domain List."""
         store = self.get_store(context.account_id, context.region)
         id = get_route53_resolver_firewall_domain_list_id()
-        arn = localstack.utils.aws.arns.get_route53_resolver_firewall_domain_list_arn(id)
+        arn = arns.get_route53_resolver_firewall_domain_list_arn(id)
         firewall_domain_list = FirewallDomainList(
             Id=id,
             Arn=arn,
@@ -423,9 +423,7 @@ class Route53ResolverProvider(Route53ResolverApi):
                 )
 
         id = get_route53_resolver_firewall_rule_group_association_id()
-        arn = localstack.utils.aws.arns.get_route53_resolver_firewall_rule_group_associations_arn(
-            id
-        )
+        arn = arns.get_route53_resolver_firewall_rule_group_associations_arn(id)
 
         firewall_rule_group_association = FirewallRuleGroupAssociation(
             Id=id,
@@ -512,7 +510,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         store = self.get_store(context.account_id, context.region)
         validate_destination_arn(destination_arn)
         id = get_resolver_query_log_config_id()
-        arn = localstack.utils.aws.arns.get_resolver_query_log_config_arn(id)
+        arn = arns.get_resolver_query_log_config_arn(id)
         resolver_query_log_config: ResolverQueryLogConfig = ResolverQueryLogConfig(
             Id=id,
             Arn=arn,

--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -4,6 +4,7 @@ from moto.ec2.models import ec2_backends
 from moto.route53resolver.models import Route53ResolverBackend as MotoRoute53ResolverBackend
 from moto.route53resolver.models import route53resolver_backends
 
+import localstack.utils.aws.arns
 from localstack.aws.api import RequestContext
 from localstack.aws.api.route53resolver import (
     Action,
@@ -92,7 +93,7 @@ from localstack.services.route53resolver.utils import (
     validate_priority,
 )
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import extract_account_id_from_arn, extract_region_from_arn
+from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.patch import patch
 
@@ -112,7 +113,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         """Create a Firewall Rule Group."""
         store = self.get_store(context.account_id, context.region)
         id = get_route53_resolver_firewall_rule_group_id()
-        arn = aws_stack.get_route53_resolver_firewall_rule_group_arn(id)
+        arn = localstack.utils.aws.arns.get_route53_resolver_firewall_rule_group_arn(id)
         firewall_rule_group = FirewallRuleGroup(
             Id=id,
             Arn=arn,
@@ -174,7 +175,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         """Create a Firewall Domain List."""
         store = self.get_store(context.account_id, context.region)
         id = get_route53_resolver_firewall_domain_list_id()
-        arn = aws_stack.get_route53_resolver_firewall_domain_list_arn(id)
+        arn = localstack.utils.aws.arns.get_route53_resolver_firewall_domain_list_arn(id)
         firewall_domain_list = FirewallDomainList(
             Id=id,
             Arn=arn,
@@ -422,7 +423,9 @@ class Route53ResolverProvider(Route53ResolverApi):
                 )
 
         id = get_route53_resolver_firewall_rule_group_association_id()
-        arn = aws_stack.get_route53_resolver_firewall_rule_group_associations_arn(id)
+        arn = localstack.utils.aws.arns.get_route53_resolver_firewall_rule_group_associations_arn(
+            id
+        )
 
         firewall_rule_group_association = FirewallRuleGroupAssociation(
             Id=id,
@@ -509,7 +512,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         store = self.get_store(context.account_id, context.region)
         validate_destination_arn(destination_arn)
         id = get_resolver_query_log_config_id()
-        arn = aws_stack.get_resolver_query_log_config_arn(id)
+        arn = localstack.utils.aws.arns.get_resolver_query_log_config_arn(id)
         resolver_query_log_config: ResolverQueryLogConfig = ResolverQueryLogConfig(
             Id=id,
             Arn=arn,

--- a/localstack/services/route53resolver/utils.py
+++ b/localstack/services/route53resolver/utils.py
@@ -3,7 +3,6 @@ import re
 from moto.ec2 import ec2_backends
 
 from localstack.aws.api.route53resolver import ResourceNotFoundException, ValidationException
-from localstack.utils.aws import aws_stack
 from localstack.utils.strings import get_random_hex
 
 
@@ -36,7 +35,7 @@ def validate_priority(priority):
     if priority:
         if priority not in range(100, 9900):
             raise ValidationException(
-                f"[RSLVR-02017] The priority value you provided is reserved. Provide a number between '100' and '9900'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"[RSLVR-02017] The priority value you provided is reserved. Provide a number between '100' and '9900'. Trace Id: '{get_trace_id()}'"
             )
 
 
@@ -44,7 +43,7 @@ def validate_mutation_protection(mutation_protection):
     if mutation_protection:
         if mutation_protection not in ["ENABLED", "DISABLED"]:
             raise ValidationException(
-                f"[RSLVR-02018] The mutation protection value you provided is reserved. Provide a value of 'ENABLED' or 'DISABLED'. Trace Id: '{aws_stack.get_trace_id()}'"
+                f"[RSLVR-02018] The mutation protection value you provided is reserved. Provide a value of 'ENABLED' or 'DISABLED'. Trace Id: '{get_trace_id()}'"
             )
 
 
@@ -52,7 +51,7 @@ def validate_destination_arn(destination_arn):
     arn_pattern = r"arn:aws:(kinesis|logs|s3):?(.*)"
     if not re.match(arn_pattern, destination_arn):
         raise ResourceNotFoundException(
-            f"[RSLVR-01014] An Amazon Resource Name (ARN) for the destination is required. Trace Id: '{aws_stack.get_trace_id()}'"
+            f"[RSLVR-01014] An Amazon Resource Name (ARN) for the destination is required. Trace Id: '{get_trace_id()}'"
         )
 
 
@@ -61,5 +60,9 @@ def validate_vpc(vpc_id: str, region: str, account_id: str):
 
     if vpc_id not in backend.vpcs:
         raise ValidationException(
-            f"[RSLVR-02025] Can't find the resource with ID : '{vpc_id}'. Trace Id: '{aws_stack.get_trace_id()}'"
+            f"[RSLVR-02025] Can't find the resource with ID : '{vpc_id}'. Trace Id: '{get_trace_id()}'"
         )
+
+
+def get_trace_id():
+    return f"1-{get_random_hex(8)}-{get_random_hex(24)}"

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -8,7 +8,6 @@ from urllib.parse import quote
 from botocore.exceptions import ClientError
 from moto.s3.models import FakeBucket, FakeKey
 
-import localstack.utils.aws.arns
 from localstack.aws.api import RequestContext
 from localstack.aws.api.events import PutEventsRequestEntry
 from localstack.aws.api.s3 import (
@@ -36,7 +35,7 @@ from localstack.services.s3.utils import (
     get_bucket_from_moto,
     get_key_from_moto_bucket,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import ArnData, parse_arn
 from localstack.utils.strings import short_uid
 from localstack.utils.time import timestamp_millis
@@ -323,7 +322,7 @@ class SqsNotifier(BaseNotifier):
         parsed_arn = parse_arn(queue_arn)
         sqs_client = aws_stack.connect_to_service("sqs", region_name=parsed_arn["region"])
         try:
-            queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(queue_arn)
+            queue_url = arns.sqs_queue_url_for_arn(queue_arn)
             system_attributes = {}
             if ctx.xray:
                 system_attributes["AWSTraceHeader"] = {
@@ -373,7 +372,7 @@ class SnsNotifier(BaseNotifier):
         message = json.dumps(event_payload)
         topic_arn = config["TopicArn"]
 
-        region_name = localstack.utils.aws.arns.extract_region_from_arn(topic_arn)
+        region_name = arns.extract_region_from_arn(topic_arn)
         sns_client = aws_stack.connect_to_service("sns", region_name=region_name)
         try:
             sns_client.publish(
@@ -414,9 +413,9 @@ class LambdaNotifier(BaseNotifier):
         payload = json.dumps(event_payload)
         lambda_arn = config["LambdaFunctionArn"]
 
-        region_name = localstack.utils.aws.arns.extract_region_from_arn(lambda_arn)
+        region_name = arns.extract_region_from_arn(lambda_arn)
         lambda_client = aws_stack.connect_to_service("lambda", region_name=region_name)
-        lambda_function_config = localstack.utils.aws.arns.lambda_function_name(lambda_arn)
+        lambda_function_config = arns.lambda_function_name(lambda_arn)
         try:
             lambda_client.invoke(
                 FunctionName=lambda_function_config,

--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 from botocore.exceptions import ClientError
 from moto.s3.models import FakeBucket, FakeKey
 
+import localstack.utils.aws.arns
 from localstack.aws.api import RequestContext
 from localstack.aws.api.events import PutEventsRequestEntry
 from localstack.aws.api.s3 import (
@@ -36,7 +37,7 @@ from localstack.services.s3.utils import (
     get_key_from_moto_bucket,
 )
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import ArnData, parse_arn
+from localstack.utils.aws.arns import ArnData, parse_arn
 from localstack.utils.strings import short_uid
 from localstack.utils.time import timestamp_millis
 
@@ -322,7 +323,7 @@ class SqsNotifier(BaseNotifier):
         parsed_arn = parse_arn(queue_arn)
         sqs_client = aws_stack.connect_to_service("sqs", region_name=parsed_arn["region"])
         try:
-            queue_url = aws_stack.sqs_queue_url_for_arn(queue_arn)
+            queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(queue_arn)
             system_attributes = {}
             if ctx.xray:
                 system_attributes["AWSTraceHeader"] = {
@@ -372,7 +373,7 @@ class SnsNotifier(BaseNotifier):
         message = json.dumps(event_payload)
         topic_arn = config["TopicArn"]
 
-        region_name = aws_stack.extract_region_from_arn(topic_arn)
+        region_name = localstack.utils.aws.arns.extract_region_from_arn(topic_arn)
         sns_client = aws_stack.connect_to_service("sns", region_name=region_name)
         try:
             sns_client.publish(
@@ -413,9 +414,9 @@ class LambdaNotifier(BaseNotifier):
         payload = json.dumps(event_payload)
         lambda_arn = config["LambdaFunctionArn"]
 
-        region_name = aws_stack.extract_region_from_arn(lambda_arn)
+        region_name = localstack.utils.aws.arns.extract_region_from_arn(lambda_arn)
         lambda_client = aws_stack.connect_to_service("lambda", region_name=region_name)
-        lambda_function_config = aws_stack.lambda_function_name(lambda_arn)
+        lambda_function_config = localstack.utils.aws.arns.lambda_function_name(lambda_arn)
         try:
             lambda_client.invoke(
                 FunctionName=lambda_function_config,

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -114,7 +114,7 @@ from localstack.services.s3.utils import (
 )
 from localstack.services.s3.website_hosting import register_website_hosting_routes
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import s3_bucket_name
+from localstack.utils.aws.arns import s3_bucket_name
 from localstack.utils.collections import get_safe
 from localstack.utils.patch import patch
 from localstack.utils.strings import short_uid

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -20,7 +20,6 @@ from moto.s3.models import FakeBucket
 from pytz import timezone
 from requests.models import Request, Response
 
-import localstack.utils.aws.arns
 from localstack import config, constants
 from localstack.aws.api import CommonServiceException
 from localstack.config import get_protocol as get_service_protocol
@@ -44,7 +43,7 @@ from localstack.services.s3.s3_utils import (
     uses_host_addressing,
     validate_bucket_name,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_responses import (
     create_sqs_system_attributes,
     is_invalid_html_response,
@@ -354,10 +353,10 @@ def send_notification_for_subscriber(
     message = json.dumps(message)
 
     if notification.get("Queue"):
-        region = localstack.utils.aws.arns.extract_region_from_arn(notification["Queue"])
+        region = arns.extract_region_from_arn(notification["Queue"])
         sqs_client = aws_stack.connect_to_service("sqs", region_name=region)
         try:
-            queue_url = localstack.utils.aws.arns.sqs_queue_url_for_arn(notification["Queue"])
+            queue_url = arns.sqs_queue_url_for_arn(notification["Queue"])
             sqs_client.send_message(
                 QueueUrl=queue_url,
                 MessageBody=message,
@@ -368,7 +367,7 @@ def send_notification_for_subscriber(
                 f"Unable to send notification for S3 bucket \"{bucket_name}\" to SQS queue \"{notification['Queue']}\": {e}",
             )
     if notification.get("Topic"):
-        region = localstack.utils.aws.arns.extract_region_from_arn(notification["Topic"])
+        region = arns.extract_region_from_arn(notification["Topic"])
         sns_client = aws_stack.connect_to_service("sns", region_name=region)
         try:
             sns_client.publish(
@@ -384,7 +383,7 @@ def send_notification_for_subscriber(
     lambda_function_config = notification.get("CloudFunction") or notification.get("LambdaFunction")
     if lambda_function_config:
         # make sure we don't run into a socket timeout
-        region = localstack.utils.aws.arns.extract_region_from_arn(lambda_function_config)
+        region = arns.extract_region_from_arn(lambda_function_config)
         connection_config = botocore.config.Config(read_timeout=300)
         lambda_client = aws_stack.connect_to_service(
             "lambda", config=connection_config, region_name=region

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -13,6 +13,7 @@ from moto.secretsmanager.exceptions import SecretNotFoundException as MotoSecret
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend
 from moto.secretsmanager.responses import SecretsManagerResponse
 
+import localstack.utils.aws.arns
 from localstack.aws.api import CommonServiceException, RequestContext, ServiceResponse, handler
 from localstack.aws.api.secretsmanager import (
     CancelRotateSecretRequest,
@@ -109,7 +110,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         # If secret ARN ends with "-<randomId>" this is removed from the request for upstream compatibility.
         t_secret_id = secret_id
         if secret_id and re.match(r"^arn:", secret_id):
-            arn = aws_stack.parse_arn(secret_id)
+            arn = localstack.utils.aws.arns.parse_arn(secret_id)
             aws_region = aws_stack.get_region()
             if arn["region"] != aws_region:
                 LOG.info(f'Expected request region "{aws_region}" for secret "{secret_id}"')
@@ -672,7 +673,7 @@ def get_arn_binding_for(account_id, region, secret_id):
     k = get_arn_binding_key_for(region, secret_id)
     if k not in SECRET_ARN_STORAGE:
         id_string = short_uid()[:6]
-        arn = aws_stack.secretsmanager_secret_arn(
+        arn = localstack.utils.aws.arns.secretsmanager_secret_arn(
             secret_id, account_id=account_id, region_name=region, random_suffix=id_string
         )
         SECRET_ARN_STORAGE[k] = arn

--- a/localstack/services/secretsmanager/provider.py
+++ b/localstack/services/secretsmanager/provider.py
@@ -13,7 +13,6 @@ from moto.secretsmanager.exceptions import SecretNotFoundException as MotoSecret
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend
 from moto.secretsmanager.responses import SecretsManagerResponse
 
-import localstack.utils.aws.arns
 from localstack.aws.api import CommonServiceException, RequestContext, ServiceResponse, handler
 from localstack.aws.api.secretsmanager import (
     CancelRotateSecretRequest,
@@ -64,7 +63,7 @@ from localstack.aws.api.secretsmanager import (
     ValidateResourcePolicyResponse,
 )
 from localstack.services.moto import call_moto, call_moto_with_request
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.patch import patch
 from localstack.utils.strings import short_uid
 from localstack.utils.time import today_no_time
@@ -110,7 +109,7 @@ class SecretsmanagerProvider(SecretsmanagerApi):
         # If secret ARN ends with "-<randomId>" this is removed from the request for upstream compatibility.
         t_secret_id = secret_id
         if secret_id and re.match(r"^arn:", secret_id):
-            arn = localstack.utils.aws.arns.parse_arn(secret_id)
+            arn = arns.parse_arn(secret_id)
             aws_region = aws_stack.get_region()
             if arn["region"] != aws_region:
                 LOG.info(f'Expected request region "{aws_region}" for secret "{secret_id}"')
@@ -673,7 +672,7 @@ def get_arn_binding_for(account_id, region, secret_id):
     k = get_arn_binding_key_for(region, secret_id)
     if k not in SECRET_ARN_STORAGE:
         id_string = short_uid()[:6]
-        arn = localstack.utils.aws.arns.secretsmanager_secret_arn(
+        arn = arns.secretsmanager_secret_arn(
             secret_id, account_id=account_id, region_name=region, random_suffix=id_string
         )
         SECRET_ARN_STORAGE[k] = arn

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Optional, Protocol
 from moto.ses import ses_backends
 from moto.ses.models import SESBackend
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.ses import (
@@ -46,7 +45,7 @@ from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.services.internal import get_internal_apis
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.files import mkdir
 from localstack.utils.strings import long_uid, to_str
 from localstack.utils.time import timestamp, timestamp_millis
@@ -429,7 +428,7 @@ class SNSEmitter:
 
     @staticmethod
     def _client_for_topic(topic_arn: str) -> SNSClient:
-        arn_parameters = localstack.utils.aws.arns.parse_arn(topic_arn)
+        arn_parameters = arns.parse_arn(topic_arn)
         region = arn_parameters["region"]
         access_key_id = arn_parameters["account"]
 

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Protocol
 from moto.ses import ses_backends
 from moto.ses.models import SESBackend
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.ses import (
@@ -428,7 +429,7 @@ class SNSEmitter:
 
     @staticmethod
     def _client_for_topic(topic_arn: str) -> SNSClient:
-        arn_parameters = aws_stack.parse_arn(topic_arn)
+        arn_parameters = localstack.utils.aws.arns.parse_arn(topic_arn)
         region = arn_parameters["region"]
         access_key_id = arn_parameters["account"]
 

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -19,6 +19,7 @@ from moto.sns.exceptions import DuplicateSnsEndpointError
 from moto.sns.models import MAXIMUM_MESSAGE_LENGTH
 from requests.models import Response as RequestsResponse
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext
@@ -103,8 +104,8 @@ from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sns.models import SnsStore, sns_stores
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_responses import create_sqs_system_attributes
-from localstack.utils.aws.aws_stack import extract_region_from_arn
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
 from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.json import json_safe
@@ -981,7 +982,7 @@ async def message_to_subscriber(
             elif "://" in endpoint:
                 queue_url = endpoint
             else:
-                queue_url = aws_stack.get_sqs_queue_url(endpoint)
+                queue_url = localstack.utils.aws.arns.get_sqs_queue_url(endpoint)
                 subscriber["sqs_queue_url"] = queue_url
 
             message_group_id = req_data.get("MessageGroupId", [""])[0]
@@ -1172,7 +1173,9 @@ async def message_to_subscriber(
             subscriber=subscriber, req_data=req_data, message_id=message_id
         )
         if endpoint:
-            delivery_stream = aws_stack.extract_resource_from_arn(endpoint).split("/")[1]
+            delivery_stream = localstack.utils.aws.arns.extract_resource_from_arn(endpoint).split(
+                "/"
+            )[1]
             firehose_client.put_record(
                 DeliveryStreamName=delivery_stream, Record={"Data": to_bytes(sns_body)}
             )

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -19,7 +19,6 @@ from moto.sns.exceptions import DuplicateSnsEndpointError
 from moto.sns.models import MAXIMUM_MESSAGE_LENGTH
 from requests.models import Response as RequestsResponse
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext
@@ -103,7 +102,7 @@ from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sns.models import SnsStore, sns_stores
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
 from localstack.utils.aws.aws_responses import create_sqs_system_attributes
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
@@ -982,7 +981,7 @@ async def message_to_subscriber(
             elif "://" in endpoint:
                 queue_url = endpoint
             else:
-                queue_url = localstack.utils.aws.arns.get_sqs_queue_url(endpoint)
+                queue_url = arns.get_sqs_queue_url(endpoint)
                 subscriber["sqs_queue_url"] = queue_url
 
             message_group_id = req_data.get("MessageGroupId", [""])[0]
@@ -1173,9 +1172,7 @@ async def message_to_subscriber(
             subscriber=subscriber, req_data=req_data, message_id=message_id
         )
         if endpoint:
-            delivery_stream = localstack.utils.aws.arns.extract_resource_from_arn(endpoint).split(
-                "/"
-            )[1]
+            delivery_stream = arns.extract_resource_from_arn(endpoint).split("/")[1]
             firehose_client.put_record(
                 DeliveryStreamName=delivery_stream, Record={"Data": to_bytes(sns_body)}
             )

--- a/localstack/services/sqs/legacy/sqs_listener.py
+++ b/localstack/services/sqs/legacy/sqs_listener.py
@@ -7,6 +7,7 @@ from moto.sqs.models import TRANSPORT_TYPE_ENCODINGS, Message
 from moto.sqs.utils import parse_message_attributes
 from requests.models import Request
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.config import SQS_PORT_EXTERNAL
@@ -121,7 +122,7 @@ def _fix_dlq_arn_in_attributes(req_data):
     dlq_arn = policy.get("deadLetterTargetArn", "")
     if "://" in dlq_arn:
         # convert queue URL to queue ARN
-        policy["deadLetterTargetArn"] = aws_stack.sqs_queue_arn(dlq_arn)
+        policy["deadLetterTargetArn"] = localstack.utils.aws.arns.sqs_queue_arn(dlq_arn)
         attrs["RedrivePolicy"] = json.dumps(policy)
         return attrs
 

--- a/localstack/services/sqs/legacy/sqs_listener.py
+++ b/localstack/services/sqs/legacy/sqs_listener.py
@@ -7,7 +7,6 @@ from moto.sqs.models import TRANSPORT_TYPE_ENCODINGS, Message
 from moto.sqs.utils import parse_message_attributes
 from requests.models import Request
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.config import SQS_PORT_EXTERNAL
@@ -15,7 +14,7 @@ from localstack.services.generic_proxy import ProxyListener
 from localstack.services.sns.provider import unsubscribe_sqs_queue
 from localstack.services.sqs.legacy.packages import SQS_BACKEND_IMPL
 from localstack.services.sqs.utils import is_sqs_queue_url
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_responses import (
     calculate_crc32,
     make_requests_error,
@@ -122,7 +121,7 @@ def _fix_dlq_arn_in_attributes(req_data):
     dlq_arn = policy.get("deadLetterTargetArn", "")
     if "://" in dlq_arn:
         # convert queue URL to queue ARN
-        policy["deadLetterTargetArn"] = localstack.utils.aws.arns.sqs_queue_arn(dlq_arn)
+        policy["deadLetterTargetArn"] = arns.sqs_queue_arn(dlq_arn)
         attrs["RedrivePolicy"] = json.dumps(policy)
         return attrs
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -78,7 +78,7 @@ from localstack.services.sqs.models import (
 )
 from localstack.services.sqs.utils import generate_message_id
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import parse_arn
+from localstack.utils.aws.arns import parse_arn
 from localstack.utils.cloudwatch.cloudwatch_util import publish_sqs_metric
 from localstack.utils.run import FuncThread
 from localstack.utils.scheduler import Scheduler

--- a/localstack/services/sqs/utils.py
+++ b/localstack/services/sqs/utils.py
@@ -8,7 +8,7 @@ from moto.sqs.models import TRANSPORT_TYPE_ENCODINGS, Message
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.sqs import ReceiptHandleIsInvalid
-from localstack.utils.aws.aws_stack import parse_arn
+from localstack.utils.aws.arns import parse_arn
 from localstack.utils.common import clone
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import long_uid

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -25,8 +25,8 @@ from localstack.testing.aws.cloudformation_utils import load_template_file, rend
 from localstack.testing.aws.util import get_lambda_logs
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import create_dynamodb_table
 from localstack.utils.aws.client import SigningHttpClient
+from localstack.utils.aws.resources import create_dynamodb_table
 from localstack.utils.collections import ensure_list
 from localstack.utils.functions import run_safe
 from localstack.utils.http import safe_requests as requests

--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -1,0 +1,372 @@
+import re
+from typing import Optional, TypedDict
+
+from botocore.utils import InvalidArnException
+
+from localstack.aws.accounts import get_aws_account_id
+from localstack.utils.aws.aws_stack import (
+    LOG,
+    SQS_ARN_TO_URL_CACHE,
+    _arn_parser,
+    connect_to_service,
+    get_environment,
+    get_iam_role,
+    get_region,
+    get_valid_regions,
+)
+
+
+def sqs_queue_url_for_arn(queue_arn):
+    if "://" in queue_arn:
+        return queue_arn
+    if queue_arn in SQS_ARN_TO_URL_CACHE:
+        return SQS_ARN_TO_URL_CACHE[queue_arn]
+
+    try:
+        arn = parse_arn(queue_arn)
+        region_name = arn["region"]
+        queue_name = arn["resource"]
+    except InvalidArnException:
+        region_name = None
+        queue_name = queue_arn
+
+    sqs_client = connect_to_service("sqs", region_name=region_name)
+    result = sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+    SQS_ARN_TO_URL_CACHE[queue_arn] = result
+    return result
+
+
+# TODO: remove and merge with sqs_queue_url_for_arn(..) above!!
+def get_sqs_queue_url(queue_arn: str) -> str:
+    return sqs_queue_url_for_arn(queue_arn)
+
+
+class ArnData(TypedDict):
+    partition: str
+    service: str
+    region: str
+    account: str
+    resource: str
+
+
+def parse_arn(arn: str) -> ArnData:
+    """
+    Uses a botocore ArnParser to parse an arn.
+
+    :param arn: the arn string to parse
+    :returns: a dictionary containing the ARN components
+    :raises InvalidArnException: if the arn is invalid
+    """
+    return _arn_parser.parse_arn(arn)
+
+
+def extract_account_id_from_arn(arn: str) -> Optional[str]:
+    try:
+        return parse_arn(arn).get("account")
+    except InvalidArnException:
+        return None
+
+
+def extract_region_from_arn(arn: str) -> Optional[str]:
+    try:
+        return parse_arn(arn).get("region")
+    except InvalidArnException:
+        return None
+
+
+def extract_service_from_arn(arn: str) -> Optional[str]:
+    try:
+        return parse_arn(arn).get("service")
+    except InvalidArnException:
+        return None
+
+
+def extract_resource_from_arn(arn: str) -> Optional[str]:
+    try:
+        return parse_arn(arn).get("resource")
+    except InvalidArnException:
+        return None
+
+
+def role_arn(role_name, account_id=None, env=None):
+    if not role_name:
+        return role_name
+    if role_name.startswith("arn:aws:iam::"):
+        return role_name
+    account_id = account_id or get_aws_account_id()
+    return "arn:aws:iam::%s:role/%s" % (account_id, role_name)
+
+
+def policy_arn(policy_name, account_id=None):
+    if ":policy/" in policy_name:
+        return policy_name
+    account_id = account_id or get_aws_account_id()
+    return "arn:aws:iam::{}:policy/{}".format(account_id, policy_name)
+
+
+def iam_resource_arn(resource, role=None, env=None):
+    env = get_environment(env)
+    if not role:
+        role = get_iam_role(resource, env=env)
+    return role_arn(role_name=role, account_id=get_aws_account_id())
+
+
+def secretsmanager_secret_arn(secret_id, account_id=None, region_name=None, random_suffix=None):
+    if ":" in (secret_id or ""):
+        return secret_id
+    pattern = "arn:aws:secretsmanager:%s:%s:secret:%s"
+    arn = _resource_arn(secret_id, pattern, account_id=account_id, region_name=region_name)
+    if random_suffix:
+        arn += f"-{random_suffix}"
+    return arn
+
+
+def cloudformation_stack_arn(stack_name, stack_id=None, account_id=None, region_name=None):
+    stack_id = stack_id or "id-123"
+    pattern = "arn:aws:cloudformation:%s:%s:stack/%s/{stack_id}".format(stack_id=stack_id)
+    return _resource_arn(stack_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def cf_change_set_arn(change_set_name, change_set_id=None, account_id=None, region_name=None):
+    change_set_id = change_set_id or "id-456"
+    pattern = "arn:aws:cloudformation:%s:%s:changeSet/%s/{cs_id}".format(cs_id=change_set_id)
+    return _resource_arn(change_set_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def dynamodb_table_arn(table_name, account_id=None, region_name=None):
+    table_name = table_name.split(":table/")[-1]
+    pattern = "arn:aws:dynamodb:%s:%s:table/%s"
+    return _resource_arn(table_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def dynamodb_stream_arn(table_name, latest_stream_label, account_id=None):
+    account_id = account_id or get_aws_account_id()
+    return "arn:aws:dynamodb:%s:%s:table/%s/stream/%s" % (
+        get_region(),
+        account_id,
+        table_name,
+        latest_stream_label,
+    )
+
+
+def cloudwatch_alarm_arn(alarm_name, account_id=None, region_name=None):
+    pattern = "arn:aws:cloudwatch:%s:%s:alarm:%s"
+    return _resource_arn(alarm_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def log_group_arn(group_name, account_id=None, region_name=None):
+    pattern = "arn:aws:logs:%s:%s:log-group:%s"
+    return _resource_arn(group_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def events_rule_arn(rule_name, account_id=None, region_name=None):
+    pattern = "arn:aws:events:%s:%s:rule/%s"
+    return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def lambda_function_arn(function_name, account_id=None, region_name=None):
+    return lambda_function_or_layer_arn(
+        "function", function_name, account_id=account_id, region_name=region_name
+    )
+
+
+def lambda_layer_arn(layer_name, version=None, region_name=None, account_id=None):
+    return lambda_function_or_layer_arn(
+        "layer", layer_name, version=None, account_id=account_id, region_name=region_name
+    )
+
+
+def lambda_function_or_layer_arn(
+    type, entity_name, version=None, account_id=None, region_name=None
+):
+    pattern = "arn:([a-z-]+):lambda:.*:.*:(function|layer):.*"
+    if re.match(pattern, entity_name):
+        return entity_name
+    if ":" in entity_name:
+        client = connect_to_service("lambda")
+        entity_name, _, alias = entity_name.rpartition(":")
+        try:
+            alias_response = client.get_alias(FunctionName=entity_name, Name=alias)
+            version = alias_response["FunctionVersion"]
+
+        except Exception as e:
+            msg = f"Alias {alias} of {entity_name} not found"
+            LOG.info(f"{msg}: {e}")
+            raise Exception(msg)
+
+    account_id = account_id or get_aws_account_id()
+    region_name = region_name or get_region()
+    result = f"arn:aws:lambda:{region_name}:{account_id}:{type}:{entity_name}"
+    if version:
+        result = f"{result}:{version}"
+    return result
+
+
+def lambda_function_name(name_or_arn):
+    if ":" in name_or_arn:
+        arn = parse_arn(name_or_arn)
+        if arn["service"] != "lambda":
+            raise ValueError("arn is not a lambda arn %s" % name_or_arn)
+
+        return parse_arn(name_or_arn)["resource"].split(":")[1]
+    else:
+        return name_or_arn
+
+
+def state_machine_arn(name, account_id=None, region_name=None):
+    pattern = "arn:aws:states:%s:%s:stateMachine:%s"
+    return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
+
+
+def stepfunctions_activity_arn(name, account_id=None, region_name=None):
+    pattern = "arn:aws:states:%s:%s:activity:%s"
+    return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
+
+
+def fix_arn(arn):
+    """Function that attempts to "canonicalize" the given ARN. This includes converting
+    resource names to ARNs, replacing incorrect regions, account IDs, etc."""
+    if arn.startswith("arn:aws:lambda"):
+        parts = arn.split(":")
+        region = parts[3] if parts[3] in get_valid_regions() else get_region()
+        return lambda_function_arn(lambda_function_name(arn), region_name=region)
+    LOG.warning("Unable to fix/canonicalize ARN: %s", arn)
+    return arn
+
+
+def cognito_user_pool_arn(user_pool_id, account_id=None, region_name=None):
+    pattern = "arn:aws:cognito-idp:%s:%s:userpool/%s"
+    return _resource_arn(user_pool_id, pattern, account_id=account_id, region_name=region_name)
+
+
+def kinesis_stream_arn(stream_name, account_id=None, region_name=None):
+    pattern = "arn:aws:kinesis:%s:%s:stream/%s"
+    return _resource_arn(stream_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def elasticsearch_domain_arn(domain_name, account_id=None, region_name=None):
+    pattern = "arn:aws:es:%s:%s:domain/%s"
+    return _resource_arn(domain_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def firehose_stream_arn(stream_name, account_id=None, region_name=None):
+    pattern = "arn:aws:firehose:%s:%s:deliverystream/%s"
+    return _resource_arn(stream_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def es_domain_arn(domain_name, account_id=None, region_name=None):
+    pattern = "arn:aws:es:%s:%s:domain/%s"
+    return _resource_arn(domain_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def kms_key_arn(key_id: str, account_id: str = None, region_name: str = None) -> str:
+    pattern = "arn:aws:kms:%s:%s:key/%s"
+    return _resource_arn(key_id, pattern, account_id=account_id, region_name=region_name)
+
+
+def kms_alias_arn(alias_name: str, account_id: str = None, region_name: str = None):
+    if not alias_name.startswith("alias/"):
+        alias_name = "alias/" + alias_name
+    pattern = "arn:aws:kms:%s:%s:%s"
+    return _resource_arn(alias_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def code_signing_arn(code_signing_id: str, account_id: str = None, region_name: str = None) -> str:
+    pattern = "arn:aws:lambda:%s:%s:code-signing-config:%s"
+    return _resource_arn(code_signing_id, pattern, account_id=account_id, region_name=region_name)
+
+
+def ssm_parameter_arn(param_name: str, account_id: str = None, region_name: str = None) -> str:
+    pattern = "arn:aws:ssm:%s:%s:parameter/%s"
+    param_name = param_name.lstrip("/")
+    return _resource_arn(param_name, pattern, account_id=account_id, region_name=region_name)
+
+
+def s3_bucket_arn(bucket_name_or_arn: str, account_id=None):
+    bucket_name = s3_bucket_name(bucket_name_or_arn)
+    return "arn:aws:s3:::%s" % bucket_name
+
+
+def s3_bucket_name(bucket_name_or_arn: str) -> str:
+    return bucket_name_or_arn.split(":::")[-1]
+
+
+def _resource_arn(name: str, pattern: str, account_id: str = None, region_name: str = None) -> str:
+    if ":" in name:
+        return name
+    account_id = account_id or get_aws_account_id()
+    region_name = region_name or get_region()
+    if len(pattern.split("%s")) == 3:
+        return pattern % (account_id, name)
+    return pattern % (region_name, account_id, name)
+
+
+def sqs_queue_arn(queue_name, account_id=None, region_name=None):
+    account_id = account_id or get_aws_account_id()
+    region_name = region_name or get_region()
+    queue_name = queue_name.split("/")[-1]
+    return "arn:aws:sqs:%s:%s:%s" % (region_name, account_id, queue_name)
+
+
+def apigateway_restapi_arn(api_id, account_id=None, region_name=None):
+    account_id = account_id or get_aws_account_id()
+    region_name = region_name or get_region()
+    return "arn:aws:apigateway:%s:%s:/restapis/%s" % (region_name, account_id, api_id)
+
+
+def sqs_queue_name(queue_arn):
+    if ":" in queue_arn:
+        return parse_arn(queue_arn)["resource"]
+    else:
+        return queue_arn
+
+
+def sns_topic_arn(topic_name, account_id=None):
+    account_id = account_id or get_aws_account_id()
+    return "arn:aws:sns:%s:%s:%s" % (get_region(), account_id, topic_name)
+
+
+def firehose_name(firehose_arn):
+    return firehose_arn.split("/")[-1]
+
+
+def kinesis_stream_name(kinesis_arn):
+    return kinesis_arn.split(":stream/")[-1]
+
+
+def apigateway_invocations_arn(lambda_uri, region_name: str = None):
+    return "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations" % (
+        region_name or get_region(),
+        lambda_uri,
+    )
+
+
+def get_ecr_repository_arn(name, account_id=None, region_name=None):
+    pattern = "arn:aws:ecr:%s:%s:repository/%s"
+    return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
+
+
+def get_route53_resolver_firewall_rule_group_arn(
+    id: str, account_id: str = None, region_name: str = None
+):
+    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group/%s"
+    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
+
+
+def get_route53_resolver_firewall_domain_list_arn(
+    id: str, account_id: str = None, region_name: str = None
+):
+    pattern = "arn:aws:route53resolver:%s:%s:firewall-domain-list/%s"
+    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
+
+
+def get_route53_resolver_firewall_rule_group_associations_arn(
+    id: str, account_id: str = None, region_name: str = None
+):
+    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group-association/%s"
+    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
+
+
+def get_resolver_query_log_config_arn(id: str, account_id: str = None, region_name: str = None):
+    pattern = "arn:aws:route53resolver:%s:%s:resolver-query-log-config/%s"
+    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)

--- a/localstack/utils/aws/arns.py
+++ b/localstack/utils/aws/arns.py
@@ -1,19 +1,21 @@
+import logging
 import re
 from typing import Optional, TypedDict
 
-from botocore.utils import InvalidArnException
+from botocore.utils import ArnParser, InvalidArnException
 
 from localstack.aws.accounts import get_aws_account_id
-from localstack.utils.aws.aws_stack import (
-    LOG,
-    SQS_ARN_TO_URL_CACHE,
-    _arn_parser,
-    connect_to_service,
-    get_environment,
-    get_iam_role,
-    get_region,
-    get_valid_regions,
-)
+from localstack.utils.aws.aws_stack import connect_to_service, get_region, get_valid_regions
+
+# set up logger
+LOG = logging.getLogger(__name__)
+
+# maps SQS queue ARNs to queue URLs
+SQS_ARN_TO_URL_CACHE = {}
+
+# TODO: extract ARN utils into separate file!
+
+_arn_parser = ArnParser()
 
 
 def sqs_queue_url_for_arn(queue_arn):
@@ -104,10 +106,9 @@ def policy_arn(policy_name, account_id=None):
     return "arn:aws:iam::{}:policy/{}".format(account_id, policy_name)
 
 
-def iam_resource_arn(resource, role=None, env=None):
-    env = get_environment(env)
+def iam_resource_arn(resource, role=None):
     if not role:
-        role = get_iam_role(resource, env=env)
+        role = f"role-{resource}"
     return role_arn(role_name=role, account_id=get_aws_account_id())
 
 

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -10,16 +10,17 @@ from typing import Dict, Optional, Union
 from urllib.parse import urlparse
 
 from localstack.aws.accounts import get_aws_access_key_id, get_aws_account_id
+from localstack.utils.aws.arns import extract_region_from_arn, get_sqs_queue_url
 
 if sys.version_info >= (3, 8):
-    from typing import TypedDict
+    pass
 else:
-    from typing_extensions import TypedDict
+    pass
 
 import boto3
 import botocore
 import botocore.config
-from botocore.utils import ArnParser, InvalidArnException
+from botocore.utils import ArnParser
 
 from localstack import config
 from localstack.constants import (
@@ -469,31 +470,6 @@ def inject_region_into_env(env, region):
     env["AWS_REGION"] = region
 
 
-def sqs_queue_url_for_arn(queue_arn):
-    if "://" in queue_arn:
-        return queue_arn
-    if queue_arn in SQS_ARN_TO_URL_CACHE:
-        return SQS_ARN_TO_URL_CACHE[queue_arn]
-
-    try:
-        arn = parse_arn(queue_arn)
-        region_name = arn["region"]
-        queue_name = arn["resource"]
-    except InvalidArnException:
-        region_name = None
-        queue_name = queue_arn
-
-    sqs_client = connect_to_service("sqs", region_name=region_name)
-    result = sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
-    SQS_ARN_TO_URL_CACHE[queue_arn] = result
-    return result
-
-
-# TODO: remove and merge with sqs_queue_url_for_arn(..) above!!
-def get_sqs_queue_url(queue_arn: str) -> str:
-    return sqs_queue_url_for_arn(queue_arn)
-
-
 def extract_region_from_auth_header(headers: Dict[str, str], use_default=True) -> str:
     auth = headers.get("Authorization") or ""
     region = re.sub(r".*Credential=[^/]+/[^/]+/([^/]+)/.*", r"\1", auth)
@@ -525,280 +501,9 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
 _arn_parser = ArnParser()
 
 
-class ArnData(TypedDict):
-    partition: str
-    service: str
-    region: str
-    account: str
-    resource: str
-
-
-def parse_arn(arn: str) -> ArnData:
-    """
-    Uses a botocore ArnParser to parse an arn.
-
-    :param arn: the arn string to parse
-    :returns: a dictionary containing the ARN components
-    :raises InvalidArnException: if the arn is invalid
-    """
-    return _arn_parser.parse_arn(arn)
-
-
-def extract_account_id_from_arn(arn: str) -> Optional[str]:
-    try:
-        return parse_arn(arn).get("account")
-    except InvalidArnException:
-        return None
-
-
-def extract_region_from_arn(arn: str) -> Optional[str]:
-    try:
-        return parse_arn(arn).get("region")
-    except InvalidArnException:
-        return None
-
-
-def extract_service_from_arn(arn: str) -> Optional[str]:
-    try:
-        return parse_arn(arn).get("service")
-    except InvalidArnException:
-        return None
-
-
-def extract_resource_from_arn(arn: str) -> Optional[str]:
-    try:
-        return parse_arn(arn).get("resource")
-    except InvalidArnException:
-        return None
-
-
-def role_arn(role_name, account_id=None, env=None):
-    if not role_name:
-        return role_name
-    if role_name.startswith("arn:aws:iam::"):
-        return role_name
-    account_id = account_id or get_aws_account_id()
-    return "arn:aws:iam::%s:role/%s" % (account_id, role_name)
-
-
-def policy_arn(policy_name, account_id=None):
-    if ":policy/" in policy_name:
-        return policy_name
-    account_id = account_id or get_aws_account_id()
-    return "arn:aws:iam::{}:policy/{}".format(account_id, policy_name)
-
-
-def iam_resource_arn(resource, role=None, env=None):
-    env = get_environment(env)
-    if not role:
-        role = get_iam_role(resource, env=env)
-    return role_arn(role_name=role, account_id=get_aws_account_id())
-
-
 def get_iam_role(resource, env=None):
     env = get_environment(env)
     return "role-%s" % resource
-
-
-def secretsmanager_secret_arn(secret_id, account_id=None, region_name=None, random_suffix=None):
-    if ":" in (secret_id or ""):
-        return secret_id
-    pattern = "arn:aws:secretsmanager:%s:%s:secret:%s"
-    arn = _resource_arn(secret_id, pattern, account_id=account_id, region_name=region_name)
-    if random_suffix:
-        arn += f"-{random_suffix}"
-    return arn
-
-
-def cloudformation_stack_arn(stack_name, stack_id=None, account_id=None, region_name=None):
-    stack_id = stack_id or "id-123"
-    pattern = "arn:aws:cloudformation:%s:%s:stack/%s/{stack_id}".format(stack_id=stack_id)
-    return _resource_arn(stack_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def cf_change_set_arn(change_set_name, change_set_id=None, account_id=None, region_name=None):
-    change_set_id = change_set_id or "id-456"
-    pattern = "arn:aws:cloudformation:%s:%s:changeSet/%s/{cs_id}".format(cs_id=change_set_id)
-    return _resource_arn(change_set_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def dynamodb_table_exists(table_name, client=None):
-    client = client or connect_to_service("dynamodb")
-    paginator = client.get_paginator("list_tables")
-    pages = paginator.paginate(PaginationConfig={"PageSize": 100})
-    for page in pages:
-        table_names = page["TableNames"]
-        if to_str(table_name) in table_names:
-            return True
-    return False
-
-
-def dynamodb_table_arn(table_name, account_id=None, region_name=None):
-    table_name = table_name.split(":table/")[-1]
-    pattern = "arn:aws:dynamodb:%s:%s:table/%s"
-    return _resource_arn(table_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def dynamodb_stream_arn(table_name, latest_stream_label, account_id=None):
-    account_id = account_id or get_aws_account_id()
-    return "arn:aws:dynamodb:%s:%s:table/%s/stream/%s" % (
-        get_region(),
-        account_id,
-        table_name,
-        latest_stream_label,
-    )
-
-
-def cloudwatch_alarm_arn(alarm_name, account_id=None, region_name=None):
-    pattern = "arn:aws:cloudwatch:%s:%s:alarm:%s"
-    return _resource_arn(alarm_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def log_group_arn(group_name, account_id=None, region_name=None):
-    pattern = "arn:aws:logs:%s:%s:log-group:%s"
-    return _resource_arn(group_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def events_rule_arn(rule_name, account_id=None, region_name=None):
-    pattern = "arn:aws:events:%s:%s:rule/%s"
-    return _resource_arn(rule_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def lambda_function_arn(function_name, account_id=None, region_name=None):
-    return lambda_function_or_layer_arn(
-        "function", function_name, account_id=account_id, region_name=region_name
-    )
-
-
-def lambda_layer_arn(layer_name, version=None, region_name=None, account_id=None):
-    return lambda_function_or_layer_arn(
-        "layer", layer_name, version=None, account_id=account_id, region_name=region_name
-    )
-
-
-def lambda_function_or_layer_arn(
-    type, entity_name, version=None, account_id=None, region_name=None
-):
-    pattern = "arn:([a-z-]+):lambda:.*:.*:(function|layer):.*"
-    if re.match(pattern, entity_name):
-        return entity_name
-    if ":" in entity_name:
-        client = connect_to_service("lambda")
-        entity_name, _, alias = entity_name.rpartition(":")
-        try:
-            alias_response = client.get_alias(FunctionName=entity_name, Name=alias)
-            version = alias_response["FunctionVersion"]
-
-        except Exception as e:
-            msg = f"Alias {alias} of {entity_name} not found"
-            LOG.info(f"{msg}: {e}")
-            raise Exception(msg)
-
-    account_id = account_id or get_aws_account_id()
-    region_name = region_name or get_region()
-    result = f"arn:aws:lambda:{region_name}:{account_id}:{type}:{entity_name}"
-    if version:
-        result = f"{result}:{version}"
-    return result
-
-
-def lambda_function_name(name_or_arn):
-    if ":" in name_or_arn:
-        arn = parse_arn(name_or_arn)
-        if arn["service"] != "lambda":
-            raise ValueError("arn is not a lambda arn %s" % name_or_arn)
-
-        return parse_arn(name_or_arn)["resource"].split(":")[1]
-    else:
-        return name_or_arn
-
-
-def state_machine_arn(name, account_id=None, region_name=None):
-    pattern = "arn:aws:states:%s:%s:stateMachine:%s"
-    return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
-
-
-def stepfunctions_activity_arn(name, account_id=None, region_name=None):
-    pattern = "arn:aws:states:%s:%s:activity:%s"
-    return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
-
-
-def fix_arn(arn):
-    """Function that attempts to "canonicalize" the given ARN. This includes converting
-    resource names to ARNs, replacing incorrect regions, account IDs, etc."""
-    if arn.startswith("arn:aws:lambda"):
-        parts = arn.split(":")
-        region = parts[3] if parts[3] in get_valid_regions() else get_region()
-        return lambda_function_arn(lambda_function_name(arn), region_name=region)
-    LOG.warning("Unable to fix/canonicalize ARN: %s", arn)
-    return arn
-
-
-def cognito_user_pool_arn(user_pool_id, account_id=None, region_name=None):
-    pattern = "arn:aws:cognito-idp:%s:%s:userpool/%s"
-    return _resource_arn(user_pool_id, pattern, account_id=account_id, region_name=region_name)
-
-
-def kinesis_stream_arn(stream_name, account_id=None, region_name=None):
-    pattern = "arn:aws:kinesis:%s:%s:stream/%s"
-    return _resource_arn(stream_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def elasticsearch_domain_arn(domain_name, account_id=None, region_name=None):
-    pattern = "arn:aws:es:%s:%s:domain/%s"
-    return _resource_arn(domain_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def firehose_stream_arn(stream_name, account_id=None, region_name=None):
-    pattern = "arn:aws:firehose:%s:%s:deliverystream/%s"
-    return _resource_arn(stream_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def es_domain_arn(domain_name, account_id=None, region_name=None):
-    pattern = "arn:aws:es:%s:%s:domain/%s"
-    return _resource_arn(domain_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def kms_key_arn(key_id: str, account_id: str = None, region_name: str = None) -> str:
-    pattern = "arn:aws:kms:%s:%s:key/%s"
-    return _resource_arn(key_id, pattern, account_id=account_id, region_name=region_name)
-
-
-def kms_alias_arn(alias_name: str, account_id: str = None, region_name: str = None):
-    if not alias_name.startswith("alias/"):
-        alias_name = "alias/" + alias_name
-    pattern = "arn:aws:kms:%s:%s:%s"
-    return _resource_arn(alias_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def code_signing_arn(code_signing_id: str, account_id: str = None, region_name: str = None) -> str:
-    pattern = "arn:aws:lambda:%s:%s:code-signing-config:%s"
-    return _resource_arn(code_signing_id, pattern, account_id=account_id, region_name=region_name)
-
-
-def ssm_parameter_arn(param_name: str, account_id: str = None, region_name: str = None) -> str:
-    pattern = "arn:aws:ssm:%s:%s:parameter/%s"
-    param_name = param_name.lstrip("/")
-    return _resource_arn(param_name, pattern, account_id=account_id, region_name=region_name)
-
-
-def s3_bucket_arn(bucket_name_or_arn: str, account_id=None):
-    bucket_name = s3_bucket_name(bucket_name_or_arn)
-    return "arn:aws:s3:::%s" % bucket_name
-
-
-def s3_bucket_name(bucket_name_or_arn: str) -> str:
-    return bucket_name_or_arn.split(":::")[-1]
-
-
-def _resource_arn(name: str, pattern: str, account_id: str = None, region_name: str = None) -> str:
-    if ":" in name:
-        return name
-    account_id = account_id or get_aws_account_id()
-    region_name = region_name or get_region()
-    if len(pattern.split("%s")) == 3:
-        return pattern % (account_id, name)
-    return pattern % (region_name, account_id, name)
 
 
 def get_events_target_attributes(target):
@@ -831,45 +536,12 @@ def create_sqs_queue(queue_name, env=None):
     return conn.create_queue(QueueName=queue_name)
 
 
-def sqs_queue_arn(queue_name, account_id=None, region_name=None):
-    account_id = account_id or get_aws_account_id()
-    region_name = region_name or get_region()
-    queue_name = queue_name.split("/")[-1]
-    return "arn:aws:sqs:%s:%s:%s" % (region_name, account_id, queue_name)
-
-
-def apigateway_restapi_arn(api_id, account_id=None, region_name=None):
-    account_id = account_id or get_aws_account_id()
-    region_name = region_name or get_region()
-    return "arn:aws:apigateway:%s:%s:/restapis/%s" % (region_name, account_id, api_id)
-
-
-def sqs_queue_name(queue_arn):
-    if ":" in queue_arn:
-        return parse_arn(queue_arn)["resource"]
-    else:
-        return queue_arn
-
-
-def sns_topic_arn(topic_name, account_id=None):
-    account_id = account_id or get_aws_account_id()
-    return "arn:aws:sns:%s:%s:%s" % (get_region(), account_id, topic_name)
-
-
 def sqs_receive_message(queue_arn):
     region_name = extract_region_from_arn(queue_arn)
     client = connect_to_service("sqs", region_name=region_name)
     queue_url = get_sqs_queue_url(queue_arn)
     response = client.receive_message(QueueUrl=queue_url)
     return response
-
-
-def firehose_name(firehose_arn):
-    return firehose_arn.split("/")[-1]
-
-
-def kinesis_stream_name(kinesis_arn):
-    return kinesis_arn.split(":stream/")[-1]
 
 
 def mock_aws_request_headers(
@@ -1141,13 +813,6 @@ def create_api_gateway_integrations(
             )
 
 
-def apigateway_invocations_arn(lambda_uri, region_name: str = None):
-    return "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations" % (
-        region_name or get_region(),
-        lambda_uri,
-    )
-
-
 def get_opensearch_endpoint(domain_arn: str) -> str:
     """
     Get an OpenSearch cluster endpoint by describing the cluster associated with the domain_arn
@@ -1238,36 +903,5 @@ def kinesis_get_latest_records(stream_name, shard_id, count=10, env=None):
     return result
 
 
-def get_ecr_repository_arn(name, account_id=None, region_name=None):
-    pattern = "arn:aws:ecr:%s:%s:repository/%s"
-    return _resource_arn(name, pattern, account_id=account_id, region_name=region_name)
-
-
-def get_route53_resolver_firewall_rule_group_arn(
-    id: str, account_id: str = None, region_name: str = None
-):
-    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group/%s"
-    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
-
-
-def get_route53_resolver_firewall_domain_list_arn(
-    id: str, account_id: str = None, region_name: str = None
-):
-    pattern = "arn:aws:route53resolver:%s:%s:firewall-domain-list/%s"
-    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
-
-
-def get_route53_resolver_firewall_rule_group_associations_arn(
-    id: str, account_id: str = None, region_name: str = None
-):
-    pattern = "arn:aws:route53resolver:%s:%s:firewall-rule-group-association/%s"
-    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)
-
-
 def get_trace_id():
     return f"1-{get_random_hex(8)}-{get_random_hex(24)}"
-
-
-def get_resolver_query_log_config_arn(id: str, account_id: str = None, region_name: str = None):
-    pattern = "arn:aws:route53resolver:%s:%s:resolver-query-log-config/%s"
-    return _resource_arn(id, pattern, account_id=account_id, region_name=region_name)

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -10,7 +10,6 @@ from typing import Dict, Optional, Union
 from urllib.parse import urlparse
 
 from localstack.aws.accounts import get_aws_access_key_id, get_aws_account_id
-from localstack.utils.aws.arns import extract_region_from_arn, get_sqs_queue_url
 
 if sys.version_info >= (3, 8):
     pass
@@ -20,14 +19,12 @@ else:
 import boto3
 import botocore
 import botocore.config
-from botocore.utils import ArnParser
 
 from localstack import config
 from localstack.constants import (
     APPLICATION_AMZ_JSON_1_0,
     APPLICATION_AMZ_JSON_1_1,
     APPLICATION_X_WWW_FORM_URLENCODED,
-    AWS_REGION_US_EAST_1,
     ENV_DEV,
     HEADER_LOCALSTACK_ACCOUNT_ID,
     LOCALHOST,
@@ -37,12 +34,8 @@ from localstack.constants import (
     TEST_AWS_ACCESS_KEY_ID,
     TEST_AWS_SECRET_ACCESS_KEY,
 )
-from localstack.utils.aws.aws_models import KinesisStream
-from localstack.utils.collections import pick_attributes
-from localstack.utils.functions import run_safe
 from localstack.utils.http import make_http_request
-from localstack.utils.strings import get_random_hex, is_string, is_string_or_bytes, to_str
-from localstack.utils.sync import poll_condition
+from localstack.utils.strings import is_string, is_string_or_bytes, to_str
 
 # AWS environment variable names
 ENV_ACCESS_KEY = "AWS_ACCESS_KEY_ID"
@@ -67,11 +60,6 @@ BOTO_CLIENTS_CACHE = {}
 # Assume role loop seconds
 DEFAULT_TIMER_LOOP_SECONDS = 60 * 50
 
-# maps SQS queue ARNs to queue URLs
-SQS_ARN_TO_URL_CACHE = {}
-
-# List of parameters with additional event target parameters
-EVENT_TARGET_PARAMETERS = ["$.SqsParameters", "$.KinesisParameters"]
 
 # cached value used to determine the DNS status of the S3 hostname (whether it can be resolved properly)
 CACHE_S3_HOSTNAME_DNS_STATUS = None
@@ -496,54 +484,6 @@ def extract_access_key_id_from_auth_header(headers: Dict[str, str]) -> Optional[
             return access_id[0]
 
 
-# TODO: extract ARN utils into separate file!
-
-_arn_parser = ArnParser()
-
-
-def get_iam_role(resource, env=None):
-    env = get_environment(env)
-    return "role-%s" % resource
-
-
-def get_events_target_attributes(target):
-    return pick_attributes(target, EVENT_TARGET_PARAMETERS)
-
-
-def get_or_create_bucket(bucket_name: str, s3_client=None):
-    s3_client = s3_client or connect_to_service("s3")
-    try:
-        return s3_client.head_bucket(Bucket=bucket_name)
-    except Exception:
-        return create_s3_bucket(bucket_name, s3_client=s3_client)
-
-
-def create_s3_bucket(bucket_name: str, s3_client=None):
-    """Creates a bucket in the region that is associated with the current request
-    context, or with the given boto3 S3 client, if specified."""
-    s3_client = s3_client or connect_to_service("s3")
-    region = s3_client.meta.region_name
-    kwargs = {}
-    if region != AWS_REGION_US_EAST_1:
-        kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
-    return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
-
-
-def create_sqs_queue(queue_name, env=None):
-    env = get_environment(env)
-    # queue
-    conn = connect_to_service("sqs", env=env)
-    return conn.create_queue(QueueName=queue_name)
-
-
-def sqs_receive_message(queue_arn):
-    region_name = extract_region_from_arn(queue_arn)
-    client = connect_to_service("sqs", region_name=region_name)
-    queue_url = get_sqs_queue_url(queue_arn)
-    response = client.receive_message(QueueUrl=queue_url)
-    return response
-
-
 def mock_aws_request_headers(
     service="dynamodb", region_name=None, access_key=None, internal=False
 ) -> Dict[str, str]:
@@ -581,6 +521,7 @@ def inject_region_into_auth_headers(region, headers):
         headers["Authorization"] = auth_header
 
 
+# TODO: is this still useful?
 def dynamodb_get_item_raw(request):
     headers = mock_aws_request_headers()
     headers["X-Amz-Target"] = "DynamoDB_20120810.GetItem"
@@ -593,244 +534,6 @@ def dynamodb_get_item_raw(request):
     new_item = new_item.text
     new_item = new_item and json.loads(new_item)
     return new_item
-
-
-def create_dynamodb_table(
-    table_name: str,
-    partition_key: str,
-    stream_view_type: str = None,
-    region_name: str = None,
-    client=None,
-    wait_for_active: bool = True,
-):
-    """Utility method to create a DynamoDB table"""
-
-    dynamodb = client or connect_to_service("dynamodb", region_name=region_name)
-    stream_spec = {"StreamEnabled": False}
-    key_schema = [{"AttributeName": partition_key, "KeyType": "HASH"}]
-    attr_defs = [{"AttributeName": partition_key, "AttributeType": "S"}]
-    if stream_view_type is not None:
-        stream_spec = {"StreamEnabled": True, "StreamViewType": stream_view_type}
-    table = None
-    try:
-        table = dynamodb.create_table(
-            TableName=table_name,
-            KeySchema=key_schema,
-            AttributeDefinitions=attr_defs,
-            BillingMode="PAY_PER_REQUEST",
-            StreamSpecification=stream_spec,
-        )
-    except Exception as e:
-        if "ResourceInUseException" in str(e):
-            # Table already exists -> return table reference
-            return connect_to_resource("dynamodb", region_name=region_name).Table(table_name)
-        if "AccessDeniedException" in str(e):
-            raise
-
-    def _is_active():
-        return dynamodb.describe_table(TableName=table_name)["Table"]["TableStatus"] == "ACTIVE"
-
-    if wait_for_active:
-        poll_condition(_is_active)
-
-    return table
-
-
-def get_apigateway_integration(api_id, method, path, env=None):
-    apigateway = connect_to_service(service_name="apigateway", client=True, env=env)
-
-    resources = apigateway.get_resources(restApiId=api_id, limit=100)
-    resource_id = None
-    for r in resources["items"]:
-        if r["path"] == path:
-            resource_id = r["id"]
-    if not resource_id:
-        raise Exception('Unable to find apigateway integration for path "%s"' % path)
-
-    integration = apigateway.get_integration(
-        restApiId=api_id, resourceId=resource_id, httpMethod=method
-    )
-    return integration
-
-
-def get_apigateway_resource_for_path(api_id, path, parent=None, resources=None):
-    if resources is None:
-        apigateway = connect_to_service(service_name="apigateway")
-        resources = apigateway.get_resources(restApiId=api_id, limit=100)
-    if not isinstance(path, list):
-        path = path.split("/")
-    if not path:
-        return parent
-    for resource in resources:
-        if resource["pathPart"] == path[0] and (not parent or parent["id"] == resource["parentId"]):
-            return get_apigateway_resource_for_path(
-                api_id, path[1:], parent=resource, resources=resources
-            )
-    return None
-
-
-def get_apigateway_path_for_resource(
-    api_id, resource_id, path_suffix="", resources=None, region_name=None
-):
-    if resources is None:
-        apigateway = connect_to_service(service_name="apigateway", region_name=region_name)
-        resources = apigateway.get_resources(restApiId=api_id, limit=100)["items"]
-    target_resource = list(filter(lambda res: res["id"] == resource_id, resources))[0]
-    path_part = target_resource.get("pathPart", "")
-    if path_suffix:
-        if path_part:
-            path_suffix = "%s/%s" % (path_part, path_suffix)
-    else:
-        path_suffix = path_part
-    parent_id = target_resource.get("parentId")
-    if not parent_id:
-        return "/%s" % path_suffix
-    return get_apigateway_path_for_resource(
-        api_id,
-        parent_id,
-        path_suffix=path_suffix,
-        resources=resources,
-        region_name=region_name,
-    )
-
-
-def create_api_gateway(
-    name,
-    description=None,
-    resources=None,
-    stage_name=None,
-    enabled_api_keys=None,
-    env=None,
-    usage_plan_name=None,
-    region_name=None,
-    auth_creator_func=None,  # function that receives an api_id and returns an authorizer_id
-    client=None,
-):
-    if enabled_api_keys is None:
-        enabled_api_keys = []
-    if not client:
-        client = connect_to_service("apigateway", env=env, region_name=region_name)
-    resources = resources or []
-    stage_name = stage_name or "testing"
-    usage_plan_name = usage_plan_name or "Basic Usage"
-    description = description or 'Test description for API "%s"' % name
-
-    LOG.info('Creating API resources under API Gateway "%s".', name)
-    api = client.create_rest_api(name=name, description=description)
-    api_id = api["id"]
-
-    auth_id = None
-    if auth_creator_func:
-        auth_id = auth_creator_func(api_id)
-
-    resources_list = client.get_resources(restApiId=api_id)
-    root_res_id = resources_list["items"][0]["id"]
-    # add API resources and methods
-    for path, methods in resources.items():
-        # create resources recursively
-        parent_id = root_res_id
-        for path_part in path.split("/"):
-            api_resource = client.create_resource(
-                restApiId=api_id, parentId=parent_id, pathPart=path_part
-            )
-            parent_id = api_resource["id"]
-        # add methods to the API resource
-        for method in methods:
-            kwargs = {"authorizerId": auth_id} if auth_id else {}
-            client.put_method(
-                restApiId=api_id,
-                resourceId=api_resource["id"],
-                httpMethod=method["httpMethod"],
-                authorizationType=method.get("authorizationType") or "NONE",
-                apiKeyRequired=method.get("apiKeyRequired") or False,
-                requestParameters=method.get("requestParameters") or {},
-                requestModels=method.get("requestModels") or {},
-                **kwargs,
-            )
-            # create integrations for this API resource/method
-            integrations = method["integrations"]
-            create_api_gateway_integrations(
-                api_id,
-                api_resource["id"],
-                method,
-                integrations,
-                env=env,
-                region_name=region_name,
-                client=client,
-            )
-    # deploy the API gateway
-    client.create_deployment(restApiId=api_id, stageName=stage_name)
-    return api
-
-
-def create_api_gateway_integrations(
-    api_id, resource_id, method, integrations=None, env=None, region_name=None, client=None
-):
-    if integrations is None:
-        integrations = []
-    if not client:
-        client = connect_to_service("apigateway", env=env, region_name=region_name)
-    for integration in integrations:
-        req_templates = integration.get("requestTemplates") or {}
-        res_templates = integration.get("responseTemplates") or {}
-        success_code = integration.get("successCode") or "200"
-        client_error_code = integration.get("clientErrorCode") or "400"
-        server_error_code = integration.get("serverErrorCode") or "500"
-        request_parameters = integration.get("requestParameters") or {}
-        # create integration
-        client.put_integration(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod=method["httpMethod"],
-            integrationHttpMethod=method.get("integrationHttpMethod") or method["httpMethod"],
-            type=integration["type"],
-            uri=integration["uri"],
-            requestTemplates=req_templates,
-            requestParameters=request_parameters,
-        )
-        response_configs = [
-            {"pattern": "^2.*", "code": success_code, "res_templates": res_templates},
-            {"pattern": "^4.*", "code": client_error_code, "res_templates": {}},
-            {"pattern": "^5.*", "code": server_error_code, "res_templates": {}},
-        ]
-        # create response configs
-        for response_config in response_configs:
-            # create integration response
-            client.put_integration_response(
-                restApiId=api_id,
-                resourceId=resource_id,
-                httpMethod=method["httpMethod"],
-                statusCode=response_config["code"],
-                responseTemplates=response_config["res_templates"],
-                selectionPattern=response_config["pattern"],
-            )
-            # create method response
-            client.put_method_response(
-                restApiId=api_id,
-                resourceId=resource_id,
-                httpMethod=method["httpMethod"],
-                statusCode=response_config["code"],
-            )
-
-
-def get_opensearch_endpoint(domain_arn: str) -> str:
-    """
-    Get an OpenSearch cluster endpoint by describing the cluster associated with the domain_arn
-    :param domain_arn: ARN of the cluster.
-    :returns: cluster endpoint
-    :raises: ValueError if the domain_arn is malformed
-    """
-    region_name = extract_region_from_arn(domain_arn)
-    if region_name is None:
-        raise ValueError("unable to parse region from opensearch domain ARN")
-    opensearch_client = connect_to_service(service_name="opensearch", region_name=region_name)
-    domain_name = domain_arn.rpartition("/")[2]
-    info = opensearch_client.describe_domain(DomainName=domain_name)
-    base_domain = info["DomainStatus"]["Endpoint"]
-    # Add the URL scheme "http" if it's not set yet. https might not be enabled for all instances
-    # f.e. when the endpoint strategy is PORT or there is a custom opensearch/elasticsearch instance
-    endpoint = base_domain if base_domain.startswith("http") else f"http://{base_domain}"
-    return endpoint
 
 
 def get_search_db_connection(endpoint: str, region_name: str):
@@ -867,41 +570,3 @@ def get_search_db_connection(endpoint: str, region_name: str):
             http_auth=awsauth,
         )
     return OpenSearch(hosts=[endpoint], verify_certs=verify_certs, use_ssl=use_ssl)
-
-
-def create_kinesis_stream(stream_name, shards=1, env=None, delete=False):
-    env = get_environment(env)
-    stream = KinesisStream(id=stream_name, num_shards=shards)
-    conn = connect_to_service("kinesis", env=env)
-    stream.connect(conn)
-    if delete:
-        run_safe(lambda: stream.destroy(), print_error=False)
-    stream.create()
-    # Note: Returning the stream without awaiting its creation (via wait_for()) to avoid API call timeouts/retries.
-    return stream
-
-
-def kinesis_get_latest_records(stream_name, shard_id, count=10, env=None):
-    kinesis = connect_to_service("kinesis", env=env)
-    result = []
-    response = kinesis.get_shard_iterator(
-        StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"
-    )
-    shard_iterator = response["ShardIterator"]
-    while shard_iterator:
-        records_response = kinesis.get_records(ShardIterator=shard_iterator)
-        records = records_response["Records"]
-        for record in records:
-            try:
-                record["Data"] = to_str(record["Data"])
-            except Exception:
-                pass
-        result.extend(records)
-        shard_iterator = records_response["NextShardIterator"] if records else False
-        while len(result) > count:
-            result.pop(0)
-    return result
-
-
-def get_trace_id():
-    return f"1-{get_random_hex(8)}-{get_random_hex(24)}"

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -3,6 +3,7 @@ import logging
 import uuid
 from typing import Dict, List
 
+import localstack.utils.aws.arns
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.strings import convert_to_printable_chars, first_char_to_upper
@@ -32,7 +33,7 @@ def _send_to_dead_letter_queue(source_arn: str, dlq_arn: str, event: Dict, error
     LOG.info("Sending failed execution %s to dead letter queue %s", source_arn, dlq_arn)
     messages = _prepare_messages_to_dlq(source_arn, event, error)
     if ":sqs:" in dlq_arn:
-        queue_url = aws_stack.get_sqs_queue_url(dlq_arn)
+        queue_url = localstack.utils.aws.arns.get_sqs_queue_url(dlq_arn)
         sqs_client = aws_stack.connect_to_service("sqs")
         error = None
         result_code = None

--- a/localstack/utils/aws/dead_letter_queue.py
+++ b/localstack/utils/aws/dead_letter_queue.py
@@ -3,8 +3,7 @@ import logging
 import uuid
 from typing import Dict, List
 
-import localstack.utils.aws.arns
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.strings import convert_to_printable_chars, first_char_to_upper
 
@@ -33,7 +32,7 @@ def _send_to_dead_letter_queue(source_arn: str, dlq_arn: str, event: Dict, error
     LOG.info("Sending failed execution %s to dead letter queue %s", source_arn, dlq_arn)
     messages = _prepare_messages_to_dlq(source_arn, event, error)
     if ":sqs:" in dlq_arn:
-        queue_url = localstack.utils.aws.arns.get_sqs_queue_url(dlq_arn)
+        queue_url = arns.get_sqs_queue_url(dlq_arn)
         sqs_client = aws_stack.connect_to_service("sqs")
         error = None
         result_code = None

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -9,13 +9,13 @@ from moto.events.models import events_backends
 
 from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.utils import collections
-from localstack.utils.aws.aws_stack import (
-    connect_to_service,
+from localstack.utils.aws.arns import (
     extract_account_id_from_arn,
     extract_region_from_arn,
     firehose_name,
     get_sqs_queue_url,
 )
+from localstack.utils.aws.aws_stack import connect_to_service
 from localstack.utils.http import add_path_parameters_to_url, add_query_params_to_url
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.strings import to_bytes, to_str

--- a/localstack/utils/aws/queries.py
+++ b/localstack/utils/aws/queries.py
@@ -1,0 +1,91 @@
+from localstack.utils.aws.arns import extract_region_from_arn, get_sqs_queue_url
+from localstack.utils.aws.aws_stack import connect_to_service
+from localstack.utils.strings import to_str
+
+
+def sqs_receive_message(queue_arn):
+    region_name = extract_region_from_arn(queue_arn)
+    client = connect_to_service("sqs", region_name=region_name)
+    queue_url = get_sqs_queue_url(queue_arn)
+    response = client.receive_message(QueueUrl=queue_url)
+    return response
+
+
+def get_apigateway_integration(api_id, method, path, env=None):
+    apigateway = connect_to_service(service_name="apigateway", client=True, env=env)
+
+    resources = apigateway.get_resources(restApiId=api_id, limit=100)
+    resource_id = None
+    for r in resources["items"]:
+        if r["path"] == path:
+            resource_id = r["id"]
+    if not resource_id:
+        raise Exception('Unable to find apigateway integration for path "%s"' % path)
+
+    integration = apigateway.get_integration(
+        restApiId=api_id, resourceId=resource_id, httpMethod=method
+    )
+    return integration
+
+
+def get_apigateway_resource_for_path(api_id, path, parent=None, resources=None):
+    if resources is None:
+        apigateway = connect_to_service(service_name="apigateway")
+        resources = apigateway.get_resources(restApiId=api_id, limit=100)
+    if not isinstance(path, list):
+        path = path.split("/")
+    if not path:
+        return parent
+    for resource in resources:
+        if resource["pathPart"] == path[0] and (not parent or parent["id"] == resource["parentId"]):
+            return get_apigateway_resource_for_path(
+                api_id, path[1:], parent=resource, resources=resources
+            )
+    return None
+
+
+def get_apigateway_path_for_resource(
+    api_id, resource_id, path_suffix="", resources=None, region_name=None
+):
+    if resources is None:
+        apigateway = connect_to_service(service_name="apigateway", region_name=region_name)
+        resources = apigateway.get_resources(restApiId=api_id, limit=100)["items"]
+    target_resource = list(filter(lambda res: res["id"] == resource_id, resources))[0]
+    path_part = target_resource.get("pathPart", "")
+    if path_suffix:
+        if path_part:
+            path_suffix = "%s/%s" % (path_part, path_suffix)
+    else:
+        path_suffix = path_part
+    parent_id = target_resource.get("parentId")
+    if not parent_id:
+        return "/%s" % path_suffix
+    return get_apigateway_path_for_resource(
+        api_id,
+        parent_id,
+        path_suffix=path_suffix,
+        resources=resources,
+        region_name=region_name,
+    )
+
+
+def kinesis_get_latest_records(stream_name, shard_id, count=10, env=None):
+    kinesis = connect_to_service("kinesis", env=env)
+    result = []
+    response = kinesis.get_shard_iterator(
+        StreamName=stream_name, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON"
+    )
+    shard_iterator = response["ShardIterator"]
+    while shard_iterator:
+        records_response = kinesis.get_records(ShardIterator=shard_iterator)
+        records = records_response["Records"]
+        for record in records:
+            try:
+                record["Data"] = to_str(record["Data"])
+            except Exception:
+                pass
+        result.extend(records)
+        shard_iterator = records_response["NextShardIterator"] if records else False
+        while len(result) > count:
+            result.pop(0)
+    return result

--- a/localstack/utils/aws/resources.py
+++ b/localstack/utils/aws/resources.py
@@ -1,0 +1,208 @@
+from localstack.constants import AWS_REGION_US_EAST_1
+from localstack.utils.aws.aws_models import KinesisStream
+from localstack.utils.aws.aws_stack import (
+    LOG,
+    connect_to_resource,
+    connect_to_service,
+    get_environment,
+)
+from localstack.utils.functions import run_safe
+from localstack.utils.sync import poll_condition
+
+
+def create_sqs_queue(queue_name, env=None):
+    env = get_environment(env)
+    # queue
+    conn = connect_to_service("sqs", env=env)
+    return conn.create_queue(QueueName=queue_name)
+
+
+def get_or_create_bucket(bucket_name: str, s3_client=None):
+    s3_client = s3_client or connect_to_service("s3")
+    try:
+        return s3_client.head_bucket(Bucket=bucket_name)
+    except Exception:
+        return create_s3_bucket(bucket_name, s3_client=s3_client)
+
+
+def create_s3_bucket(bucket_name: str, s3_client=None):
+    """Creates a bucket in the region that is associated with the current request
+    context, or with the given boto3 S3 client, if specified."""
+    s3_client = s3_client or connect_to_service("s3")
+    region = s3_client.meta.region_name
+    kwargs = {}
+    if region != AWS_REGION_US_EAST_1:
+        kwargs = {"CreateBucketConfiguration": {"LocationConstraint": region}}
+    return s3_client.create_bucket(Bucket=bucket_name, **kwargs)
+
+
+def create_dynamodb_table(
+    table_name: str,
+    partition_key: str,
+    stream_view_type: str = None,
+    region_name: str = None,
+    client=None,
+    wait_for_active: bool = True,
+):
+    """Utility method to create a DynamoDB table"""
+
+    dynamodb = client or connect_to_service("dynamodb", region_name=region_name)
+    stream_spec = {"StreamEnabled": False}
+    key_schema = [{"AttributeName": partition_key, "KeyType": "HASH"}]
+    attr_defs = [{"AttributeName": partition_key, "AttributeType": "S"}]
+    if stream_view_type is not None:
+        stream_spec = {"StreamEnabled": True, "StreamViewType": stream_view_type}
+    table = None
+    try:
+        table = dynamodb.create_table(
+            TableName=table_name,
+            KeySchema=key_schema,
+            AttributeDefinitions=attr_defs,
+            BillingMode="PAY_PER_REQUEST",
+            StreamSpecification=stream_spec,
+        )
+    except Exception as e:
+        if "ResourceInUseException" in str(e):
+            # Table already exists -> return table reference
+            return connect_to_resource("dynamodb", region_name=region_name).Table(table_name)
+        if "AccessDeniedException" in str(e):
+            raise
+
+    def _is_active():
+        return dynamodb.describe_table(TableName=table_name)["Table"]["TableStatus"] == "ACTIVE"
+
+    if wait_for_active:
+        poll_condition(_is_active)
+
+    return table
+
+
+def create_api_gateway(
+    name,
+    description=None,
+    resources=None,
+    stage_name=None,
+    enabled_api_keys=None,
+    env=None,
+    usage_plan_name=None,
+    region_name=None,
+    auth_creator_func=None,  # function that receives an api_id and returns an authorizer_id
+    client=None,
+):
+    if enabled_api_keys is None:
+        enabled_api_keys = []
+    if not client:
+        client = connect_to_service("apigateway", env=env, region_name=region_name)
+    resources = resources or []
+    stage_name = stage_name or "testing"
+    usage_plan_name = usage_plan_name or "Basic Usage"
+    description = description or 'Test description for API "%s"' % name
+
+    LOG.info('Creating API resources under API Gateway "%s".', name)
+    api = client.create_rest_api(name=name, description=description)
+    api_id = api["id"]
+
+    auth_id = None
+    if auth_creator_func:
+        auth_id = auth_creator_func(api_id)
+
+    resources_list = client.get_resources(restApiId=api_id)
+    root_res_id = resources_list["items"][0]["id"]
+    # add API resources and methods
+    for path, methods in resources.items():
+        # create resources recursively
+        parent_id = root_res_id
+        for path_part in path.split("/"):
+            api_resource = client.create_resource(
+                restApiId=api_id, parentId=parent_id, pathPart=path_part
+            )
+            parent_id = api_resource["id"]
+        # add methods to the API resource
+        for method in methods:
+            kwargs = {"authorizerId": auth_id} if auth_id else {}
+            client.put_method(
+                restApiId=api_id,
+                resourceId=api_resource["id"],
+                httpMethod=method["httpMethod"],
+                authorizationType=method.get("authorizationType") or "NONE",
+                apiKeyRequired=method.get("apiKeyRequired") or False,
+                requestParameters=method.get("requestParameters") or {},
+                requestModels=method.get("requestModels") or {},
+                **kwargs,
+            )
+            # create integrations for this API resource/method
+            integrations = method["integrations"]
+            create_api_gateway_integrations(
+                api_id,
+                api_resource["id"],
+                method,
+                integrations,
+                env=env,
+                region_name=region_name,
+                client=client,
+            )
+    # deploy the API gateway
+    client.create_deployment(restApiId=api_id, stageName=stage_name)
+    return api
+
+
+def create_api_gateway_integrations(
+    api_id, resource_id, method, integrations=None, env=None, region_name=None, client=None
+):
+    if integrations is None:
+        integrations = []
+    if not client:
+        client = connect_to_service("apigateway", env=env, region_name=region_name)
+    for integration in integrations:
+        req_templates = integration.get("requestTemplates") or {}
+        res_templates = integration.get("responseTemplates") or {}
+        success_code = integration.get("successCode") or "200"
+        client_error_code = integration.get("clientErrorCode") or "400"
+        server_error_code = integration.get("serverErrorCode") or "500"
+        request_parameters = integration.get("requestParameters") or {}
+        # create integration
+        client.put_integration(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod=method["httpMethod"],
+            integrationHttpMethod=method.get("integrationHttpMethod") or method["httpMethod"],
+            type=integration["type"],
+            uri=integration["uri"],
+            requestTemplates=req_templates,
+            requestParameters=request_parameters,
+        )
+        response_configs = [
+            {"pattern": "^2.*", "code": success_code, "res_templates": res_templates},
+            {"pattern": "^4.*", "code": client_error_code, "res_templates": {}},
+            {"pattern": "^5.*", "code": server_error_code, "res_templates": {}},
+        ]
+        # create response configs
+        for response_config in response_configs:
+            # create integration response
+            client.put_integration_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=method["httpMethod"],
+                statusCode=response_config["code"],
+                responseTemplates=response_config["res_templates"],
+                selectionPattern=response_config["pattern"],
+            )
+            # create method response
+            client.put_method_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=method["httpMethod"],
+                statusCode=response_config["code"],
+            )
+
+
+def create_kinesis_stream(stream_name, shards=1, env=None, delete=False):
+    env = get_environment(env)
+    stream = KinesisStream(id=stream_name, num_shards=shards)
+    conn = connect_to_service("kinesis", env=env)
+    stream.connect(conn)
+    if delete:
+        run_safe(lambda: stream.destroy(), print_error=False)
+    stream.create()
+    # Note: Returning the stream without awaiting its creation (via wait_for()) to avoid API call timeouts/retries.
+    return stream

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -11,10 +11,9 @@ from urllib.parse import urlparse
 from amazon_kclpy import kcl
 from amazon_kclpy.v2 import processor
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import LOCALHOST, LOCALSTACK_ROOT_FOLDER, LOCALSTACK_VENV_FOLDER
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_models import KinesisStream
 from localstack.utils.files import TMP_FILES, chmod_r, rm_rf, save_file
 from localstack.utils.kinesis import kclipy_helper
@@ -284,7 +283,7 @@ def get_stream_info(
     env = aws_stack.get_environment(env)
     props_file = os.path.join(tempfile.gettempdir(), "kclipy.%s.properties" % short_uid())
     # make sure to convert stream ARN to stream name
-    stream_name = localstack.utils.aws.arns.kinesis_stream_name(stream_name)
+    stream_name = arns.kinesis_stream_name(stream_name)
     app_name = "%s%s" % (stream_name, ddb_lease_table_suffix)
     stream_info = {
         "name": stream_name,
@@ -333,7 +332,7 @@ def start_kcl_client_process(
         log_subscribers = []
     env = aws_stack.get_environment(env)
     # make sure to convert stream ARN to stream name
-    stream_name = localstack.utils.aws.arns.kinesis_stream_name(stream_name)
+    stream_name = arns.kinesis_stream_name(stream_name)
     if aws_stack.is_local_env(env):
         # disable CBOR protocol, enforce use of plain JSON
         env_vars["AWS_CBOR_DISABLE"] = "true"

--- a/localstack/utils/kinesis/kinesis_connector.py
+++ b/localstack/utils/kinesis/kinesis_connector.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from amazon_kclpy import kcl
 from amazon_kclpy.v2 import processor
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import LOCALHOST, LOCALSTACK_ROOT_FOLDER, LOCALSTACK_VENV_FOLDER
 from localstack.utils.aws import aws_stack
@@ -283,7 +284,7 @@ def get_stream_info(
     env = aws_stack.get_environment(env)
     props_file = os.path.join(tempfile.gettempdir(), "kclipy.%s.properties" % short_uid())
     # make sure to convert stream ARN to stream name
-    stream_name = aws_stack.kinesis_stream_name(stream_name)
+    stream_name = localstack.utils.aws.arns.kinesis_stream_name(stream_name)
     app_name = "%s%s" % (stream_name, ddb_lease_table_suffix)
     stream_info = {
         "name": stream_name,
@@ -332,7 +333,7 @@ def start_kcl_client_process(
         log_subscribers = []
     env = aws_stack.get_environment(env)
     # make sure to convert stream ARN to stream name
-    stream_name = aws_stack.kinesis_stream_name(stream_name)
+    stream_name = localstack.utils.aws.arns.kinesis_stream_name(stream_name)
     if aws_stack.is_local_env(env):
         # disable CBOR protocol, enforce use of plain JSON
         env_vars["AWS_CBOR_DISABLE"] = "true"

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -10,6 +10,8 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import localstack.utils.aws.arns
+
 try:
     from typing import Literal
 except ImportError:
@@ -331,8 +333,8 @@ def create_lambda_api_gateway_integration(
     # create Lambda
     zip_file = create_lambda_archive(handler_file, get_content=True, runtime=runtime)
     create_lambda_function(func_name=func_name, zip_file=zip_file, runtime=runtime)
-    func_arn = aws_stack.lambda_function_arn(func_name)
-    target_arn = aws_stack.apigateway_invocations_arn(func_arn)
+    func_arn = localstack.utils.aws.arns.lambda_function_arn(func_name)
+    target_arn = localstack.utils.aws.arns.apigateway_invocations_arn(func_arn)
 
     # connect API GW to Lambda
     result = connect_api_gateway_to_http_with_lambda_proxy(
@@ -692,7 +694,7 @@ def list_all_resources(
 
 
 def response_arn_matches_partition(client, response_arn: str) -> bool:
-    parsed_arn = aws_stack.parse_arn(response_arn)
+    parsed_arn = localstack.utils.aws.arns.parse_arn(response_arn)
     return (
         client.meta.partition
         == boto3.session.Session().get_partition_for_region(parsed_arn["region"])

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -10,8 +10,7 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import localstack.utils.aws.resources
-from localstack.utils.aws import arns
+from localstack.utils.aws import arns, resources
 
 try:
     from typing import Literal
@@ -233,7 +232,7 @@ def create_lambda_function(
     lambda_code = {"ZipFile": zip_file}
     if len(zip_file) > MAX_LAMBDA_ARCHIVE_UPLOAD_SIZE:
         s3 = aws_stack.connect_to_service("s3")
-        localstack.utils.aws.resources.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
+        resources.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
         asset_key = f"{short_uid()}.zip"
         s3.upload_fileobj(
             Fileobj=io.BytesIO(zip_file), Bucket=LAMBDA_ASSETS_BUCKET_NAME, Key=asset_key
@@ -305,7 +304,7 @@ def connect_api_gateway_to_http_with_lambda_proxy(
                 "integrations": [{"type": "AWS_PROXY", "uri": target_uri, "httpMethod": int_meth}],
             }
         )
-    return localstack.utils.aws.resources.create_api_gateway(
+    return resources.create_api_gateway(
         name=gateway_name,
         resources=resources,
         stage_name=stage_name,

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import localstack.utils.aws.arns
+import localstack.utils.aws.resources
 
 try:
     from typing import Literal
@@ -232,7 +233,7 @@ def create_lambda_function(
     lambda_code = {"ZipFile": zip_file}
     if len(zip_file) > MAX_LAMBDA_ARCHIVE_UPLOAD_SIZE:
         s3 = aws_stack.connect_to_service("s3")
-        aws_stack.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
+        localstack.utils.aws.resources.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
         asset_key = f"{short_uid()}.zip"
         s3.upload_fileobj(
             Fileobj=io.BytesIO(zip_file), Bucket=LAMBDA_ASSETS_BUCKET_NAME, Key=asset_key
@@ -304,7 +305,7 @@ def connect_api_gateway_to_http_with_lambda_proxy(
                 "integrations": [{"type": "AWS_PROXY", "uri": target_uri, "httpMethod": int_meth}],
             }
         )
-    return aws_stack.create_api_gateway(
+    return localstack.utils.aws.resources.create_api_gateway(
         name=gateway_name,
         resources=resources,
         stage_name=stage_name,

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -10,8 +10,8 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.resources
+from localstack.utils.aws import arns
 
 try:
     from typing import Literal
@@ -334,8 +334,8 @@ def create_lambda_api_gateway_integration(
     # create Lambda
     zip_file = create_lambda_archive(handler_file, get_content=True, runtime=runtime)
     create_lambda_function(func_name=func_name, zip_file=zip_file, runtime=runtime)
-    func_arn = localstack.utils.aws.arns.lambda_function_arn(func_name)
-    target_arn = localstack.utils.aws.arns.apigateway_invocations_arn(func_arn)
+    func_arn = arns.lambda_function_arn(func_name)
+    target_arn = arns.apigateway_invocations_arn(func_arn)
 
     # connect API GW to Lambda
     result = connect_api_gateway_to_http_with_lambda_proxy(
@@ -695,7 +695,7 @@ def list_all_resources(
 
 
 def response_arn_matches_partition(client, response_arn: str) -> bool:
-    parsed_arn = localstack.utils.aws.arns.parse_arn(response_arn)
+    parsed_arn = arns.parse_arn(response_arn)
     return (
         client.meta.partition
         == boto3.session.Session().get_partition_for_region(parsed_arn["region"])

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -10,7 +10,8 @@ import time
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from localstack.utils.aws import arns, resources
+from localstack.utils.aws import arns
+from localstack.utils.aws import resources as resource_utils
 
 try:
     from typing import Literal
@@ -232,7 +233,7 @@ def create_lambda_function(
     lambda_code = {"ZipFile": zip_file}
     if len(zip_file) > MAX_LAMBDA_ARCHIVE_UPLOAD_SIZE:
         s3 = aws_stack.connect_to_service("s3")
-        resources.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
+        resource_utils.get_or_create_bucket(LAMBDA_ASSETS_BUCKET_NAME)
         asset_key = f"{short_uid()}.zip"
         s3.upload_fileobj(
             Fileobj=io.BytesIO(zip_file), Bucket=LAMBDA_ASSETS_BUCKET_NAME, Key=asset_key
@@ -304,7 +305,7 @@ def connect_api_gateway_to_http_with_lambda_proxy(
                 "integrations": [{"type": "AWS_PROXY", "uri": target_uri, "httpMethod": int_meth}],
             }
         )
-    return resources.create_api_gateway(
+    return resource_utils.create_api_gateway(
         name=gateway_name,
         resources=resources,
         stage_name=stage_name,

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -20,11 +20,11 @@ import requests
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.aws.api.lambda_ import Architecture, Runtime
 from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active, is_old_provider
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
 from localstack.utils.files import load_file
 from localstack.utils.strings import long_uid, short_uid, to_str
 from localstack.utils.sync import wait_until
@@ -1861,7 +1861,7 @@ class TestLambdaPermissions:
                 Action="lambda:InvokeFunction",
                 StatementId="s3",
                 Principal="s3.amazonaws.com",
-                SourceArn=aws_stack.s3_bucket_arn("test-bucket"),
+                SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
             )
         snapshot.match("add_permission_fn_doesnotexist", e.value.response)
 
@@ -1901,7 +1901,7 @@ class TestLambdaPermissions:
             Action=action,
             StatementId=sid,
             Principal=principal,
-            SourceArn=aws_stack.s3_bucket_arn("test-bucket"),
+            SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
         )
         snapshot.match("add_permission", resp)
 
@@ -1939,7 +1939,7 @@ class TestLambdaPermissions:
             Action=action,
             StatementId=sid_2,
             Principal=principal_2,
-            SourceArn=aws_stack.s3_bucket_arn("test-bucket"),
+            SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
         )
         snapshot.match("add_permission_2", permission_2_add)
         policy_response = lambda_client.get_policy(

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -20,11 +20,11 @@ import requests
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.aws.api.lambda_ import Architecture, Runtime
 from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active, is_old_provider
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
+from localstack.utils.aws import arns
 from localstack.utils.files import load_file
 from localstack.utils.strings import long_uid, short_uid, to_str
 from localstack.utils.sync import wait_until
@@ -1861,7 +1861,7 @@ class TestLambdaPermissions:
                 Action="lambda:InvokeFunction",
                 StatementId="s3",
                 Principal="s3.amazonaws.com",
-                SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
+                SourceArn=arns.s3_bucket_arn("test-bucket"),
             )
         snapshot.match("add_permission_fn_doesnotexist", e.value.response)
 
@@ -1901,7 +1901,7 @@ class TestLambdaPermissions:
             Action=action,
             StatementId=sid,
             Principal=principal,
-            SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
+            SourceArn=arns.s3_bucket_arn("test-bucket"),
         )
         snapshot.match("add_permission", resp)
 
@@ -1939,7 +1939,7 @@ class TestLambdaPermissions:
             Action=action,
             StatementId=sid_2,
             Principal=principal_2,
-            SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
+            SourceArn=arns.s3_bucket_arn("test-bucket"),
         )
         snapshot.match("add_permission_2", permission_2_add)
         policy_response = lambda_client.get_policy(

--- a/tests/integration/awslambda/test_lambda_legacy.py
+++ b/tests/integration/awslambda/test_lambda_legacy.py
@@ -4,6 +4,7 @@ import os.path
 
 import pytest
 
+import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.services.awslambda import lambda_api
@@ -85,7 +86,7 @@ class TestLambdaLegacyProvider:
                 Action=action,
                 StatementId=sid,
                 Principal=principal,
-                SourceArn=aws_stack.s3_bucket_arn("test-bucket"),
+                SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
             )
             assert "Statement" in resp
 
@@ -107,7 +108,7 @@ class TestLambdaLegacyProvider:
             assert lambda_api.func_arn(function_name) == statements[i]["Resource"]
             assert principal == statements[i]["Principal"]["Service"]
             assert (
-                aws_stack.s3_bucket_arn("test-bucket")
+                localstack.utils.aws.arns.s3_bucket_arn("test-bucket")
                 == statements[i]["Condition"]["ArnLike"]["AWS:SourceArn"]
             )
             # check statement_ids in reverse order
@@ -139,7 +140,7 @@ class TestLambdaLegacyProvider:
             Action=action,
             StatementId=sid,
             Principal=principal,
-            SourceArn=aws_stack.s3_bucket_arn("test-bucket"),
+            SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
         )
 
         # fetch lambda policy
@@ -151,7 +152,7 @@ class TestLambdaLegacyProvider:
         assert lambda_arn == policy["Statement"][0]["Resource"]
         assert principal == policy["Statement"][0]["Principal"]["Service"]
         assert (
-            aws_stack.s3_bucket_arn("test-bucket")
+            localstack.utils.aws.arns.s3_bucket_arn("test-bucket")
             == policy["Statement"][0]["Condition"]["ArnLike"]["AWS:SourceArn"]
         )
 

--- a/tests/integration/awslambda/test_lambda_legacy.py
+++ b/tests/integration/awslambda/test_lambda_legacy.py
@@ -4,7 +4,6 @@ import os.path
 
 import pytest
 
-import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.services.awslambda import lambda_api
@@ -19,7 +18,7 @@ from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.testing.pytest.fixtures import skip_if_pro_enabled
 from localstack.utils import testutil
 from localstack.utils.archives import download_and_extract
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.files import load_file
 from localstack.utils.platform import get_arch, get_os
 from localstack.utils.strings import short_uid, to_bytes, to_str
@@ -86,7 +85,7 @@ class TestLambdaLegacyProvider:
                 Action=action,
                 StatementId=sid,
                 Principal=principal,
-                SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
+                SourceArn=arns.s3_bucket_arn("test-bucket"),
             )
             assert "Statement" in resp
 
@@ -108,7 +107,7 @@ class TestLambdaLegacyProvider:
             assert lambda_api.func_arn(function_name) == statements[i]["Resource"]
             assert principal == statements[i]["Principal"]["Service"]
             assert (
-                localstack.utils.aws.arns.s3_bucket_arn("test-bucket")
+                arns.s3_bucket_arn("test-bucket")
                 == statements[i]["Condition"]["ArnLike"]["AWS:SourceArn"]
             )
             # check statement_ids in reverse order
@@ -140,7 +139,7 @@ class TestLambdaLegacyProvider:
             Action=action,
             StatementId=sid,
             Principal=principal,
-            SourceArn=localstack.utils.aws.arns.s3_bucket_arn("test-bucket"),
+            SourceArn=arns.s3_bucket_arn("test-bucket"),
         )
 
         # fetch lambda policy
@@ -152,7 +151,7 @@ class TestLambdaLegacyProvider:
         assert lambda_arn == policy["Statement"][0]["Resource"]
         assert principal == policy["Statement"][0]["Principal"]["Service"]
         assert (
-            localstack.utils.aws.arns.s3_bucket_arn("test-bucket")
+            arns.s3_bucket_arn("test-bucket")
             == policy["Statement"][0]["Condition"]["ArnLike"]["AWS:SourceArn"]
         )
 

--- a/tests/integration/cloudformation/resources/test_events.py
+++ b/tests/integration/cloudformation/resources/test_events.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-import localstack.utils.aws.arns
+from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import wait_until
 
@@ -221,7 +221,7 @@ def test_cfn_handle_events_rule(events_client, deploy_cfn_template):
     rs = events_client.list_rules(NamePrefix=rule_prefix)
     assert rule_name in [rule["Name"] for rule in rs["Rules"]]
 
-    target_arn = localstack.utils.aws.arns.s3_bucket_arn(bucket_name)  # TODO: !
+    target_arn = arns.s3_bucket_arn(bucket_name)  # TODO: !
     rs = events_client.list_targets_by_rule(Rule=rule_name)
     assert target_arn in [target["Arn"] for target in rs["Targets"]]
 
@@ -236,7 +236,7 @@ def test_cfn_handle_events_rule_without_name(events_client, deploy_cfn_template)
     rule_names = [rule["Name"] for rule in rs["Rules"]]
 
     stack = deploy_cfn_template(
-        template=TEST_TEMPLATE_18 % localstack.utils.aws.arns.role_arn("sfn_role"),  # TODO: !
+        template=TEST_TEMPLATE_18 % arns.role_arn("sfn_role"),  # TODO: !
     )
 
     rs = events_client.list_rules()

--- a/tests/integration/cloudformation/resources/test_events.py
+++ b/tests/integration/cloudformation/resources/test_events.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-from localstack.utils.aws import aws_stack
+import localstack.utils.aws.arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import wait_until
 
@@ -221,7 +221,7 @@ def test_cfn_handle_events_rule(events_client, deploy_cfn_template):
     rs = events_client.list_rules(NamePrefix=rule_prefix)
     assert rule_name in [rule["Name"] for rule in rs["Rules"]]
 
-    target_arn = aws_stack.s3_bucket_arn(bucket_name)  # TODO: !
+    target_arn = localstack.utils.aws.arns.s3_bucket_arn(bucket_name)  # TODO: !
     rs = events_client.list_targets_by_rule(Rule=rule_name)
     assert target_arn in [target["Arn"] for target in rs["Targets"]]
 
@@ -236,7 +236,7 @@ def test_cfn_handle_events_rule_without_name(events_client, deploy_cfn_template)
     rule_names = [rule["Name"] for rule in rs["Rules"]]
 
     stack = deploy_cfn_template(
-        template=TEST_TEMPLATE_18 % aws_stack.role_arn("sfn_role"),  # TODO: !
+        template=TEST_TEMPLATE_18 % localstack.utils.aws.arns.role_arn("sfn_role"),  # TODO: !
     )
 
     rs = events_client.list_rules()

--- a/tests/integration/cloudformation/resources/test_legacy.py
+++ b/tests/integration/cloudformation/resources/test_legacy.py
@@ -7,8 +7,8 @@ import yaml
 from botocore.exceptions import ClientError
 from botocore.parsers import ResponseParserError
 
-import localstack.utils.aws.arns
 from localstack.aws.accounts import get_aws_account_id
+from localstack.utils.aws import arns
 from localstack.utils.cloudformation import template_preparer
 from localstack.utils.common import load_file, short_uid
 from localstack.utils.testutil import create_zip_file, list_all_resources
@@ -320,7 +320,7 @@ class TestCloudFormation:
         role = rs["Roles"][0]
         assert role["RoleName"] == role_name
 
-        result = iam_client.get_policy(PolicyArn=localstack.utils.aws.arns.policy_arn(policy_name))
+        result = iam_client.get_policy(PolicyArn=arns.policy_arn(policy_name))
         assert result["Policy"]["PolicyName"] == policy_name
 
         # clean up
@@ -368,7 +368,7 @@ class TestCloudFormation:
         bucket_name = f"target-{short_uid()}"
         queue_name = f"queue-{short_uid()}"
         # the queue is always created in us-east-1
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
         if create_bucket_first:
             s3_client.create_bucket(
                 Bucket=bucket_name,
@@ -410,7 +410,7 @@ class TestCloudFormation:
         resource = rs["items"][0]
 
         uri = resource["resourceMethods"]["GET"]["methodIntegration"]["uri"]
-        lambda_arn = localstack.utils.aws.arns.lambda_function_arn(lambda_func_names[0])  # TODO
+        lambda_arn = arns.lambda_function_arn(lambda_func_names[0])  # TODO
         assert lambda_arn in uri
 
     # TODO: refactor
@@ -598,9 +598,7 @@ class TestCloudFormation:
         assert "VpcId" in outputs
         assert outputs["VpcId"].get("export") == f"{environment}-vpc-id"
 
-        topic_arn = localstack.utils.aws.arns.sns_topic_arn(
-            f"{environment}-slack-sns-topic"
-        )  # TODO(!)
+        topic_arn = arns.sns_topic_arn(f"{environment}-slack-sns-topic")  # TODO(!)
         assert "TopicArn" in outputs
         assert outputs["TopicArn"].get("export") == topic_arn
 
@@ -644,9 +642,7 @@ class TestCloudFormation:
         # assert creation of further resources
         resp = sns_client.list_topics()
         topic_arns = [tp["TopicArn"] for tp in resp["Topics"]]
-        assert (
-            localstack.utils.aws.arns.sns_topic_arn("companyname-slack-topic") in topic_arns
-        )  # TODO: manual ARN
+        assert arns.sns_topic_arn("companyname-slack-topic") in topic_arns  # TODO: manual ARN
         # TODO: fix assertions, to make tests parallelizable!
         metric_alarms_after = cloudwatch_client.describe_alarms().get("MetricAlarms", [])
         composite_alarms_after = cloudwatch_client.describe_alarms().get("CompositeAlarms", [])
@@ -850,11 +846,9 @@ class TestCloudFormation:
         stack_name = f"stack-{short_uid()}"
         deploy_cfn_template(stack_name=stack_name, template=TEST_TEMPLATE_29 % queue_name)
 
-        tags = sqs_client.list_queue_tags(
-            QueueUrl=localstack.utils.aws.arns.get_sqs_queue_url(queue_name)
-        )
+        tags = sqs_client.list_queue_tags(QueueUrl=arns.get_sqs_queue_url(queue_name))
         test_tag = tags["Tags"]["test"]
-        assert test_tag == localstack.utils.aws.arns.ssm_parameter_arn("cdk-bootstrap/q123/version")
+        assert test_tag == arns.ssm_parameter_arn("cdk-bootstrap/q123/version")
 
 
 # Note: DO NOT ADD TEST CASES HERE

--- a/tests/integration/cloudformation/test_engine.py
+++ b/tests/integration/cloudformation/test_engine.py
@@ -4,8 +4,8 @@ import os
 
 import pytest
 
+import localstack.utils.aws.arns
 from localstack.testing.aws.cloudformation_utils import load_template_raw
-from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
 from localstack.utils.sync import wait_until
 
@@ -233,7 +233,7 @@ class TestImports:
         output = [out["OutputValue"] for out in outputs if out["OutputKey"] == "MessageQueueUrl1"][
             0
         ]
-        assert aws_stack.sqs_queue_arn(queue_url1) == output  # TODO
+        assert localstack.utils.aws.arns.sqs_queue_arn(queue_url1) == output  # TODO
         output = [out["OutputValue"] for out in outputs if out["OutputKey"] == "MessageQueueUrl2"][
             0
         ]

--- a/tests/integration/cloudformation/test_engine.py
+++ b/tests/integration/cloudformation/test_engine.py
@@ -4,8 +4,8 @@ import os
 
 import pytest
 
-import localstack.utils.aws.arns
 from localstack.testing.aws.cloudformation_utils import load_template_raw
+from localstack.utils.aws import arns
 from localstack.utils.common import short_uid
 from localstack.utils.sync import wait_until
 
@@ -233,7 +233,7 @@ class TestImports:
         output = [out["OutputValue"] for out in outputs if out["OutputKey"] == "MessageQueueUrl1"][
             0
         ]
-        assert localstack.utils.aws.arns.sqs_queue_arn(queue_url1) == output  # TODO
+        assert arns.sqs_queue_arn(queue_url1) == output  # TODO
         output = [out["OutputValue"] for out in outputs if out["OutputKey"] == "MessageQueueUrl2"][
             0
         ]

--- a/tests/integration/s3/test_s3_notifications_lambda.py
+++ b/tests/integration/s3/test_s3_notifications_lambda.py
@@ -4,9 +4,9 @@ import os
 import pytest
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.config import LEGACY_S3_PROVIDER
 from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active
-from localstack.utils.aws import aws_stack
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
@@ -253,7 +253,7 @@ class TestS3NotificationsToLambda:
         # set valid but not-existing lambda
         config["LambdaFunctionConfigurations"][0][
             "LambdaFunctionArn"
-        ] = f"{aws_stack.lambda_function_arn('my-lambda', account_id=account_id)}"
+        ] = f"{localstack.utils.aws.arns.lambda_function_arn('my-lambda', account_id=account_id)}"
         with pytest.raises(ClientError) as e:
             s3_client.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_lambda.py
+++ b/tests/integration/s3/test_s3_notifications_lambda.py
@@ -4,9 +4,9 @@ import os
 import pytest
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.config import LEGACY_S3_PROVIDER
 from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active
+from localstack.utils.aws import arns
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
@@ -253,7 +253,7 @@ class TestS3NotificationsToLambda:
         # set valid but not-existing lambda
         config["LambdaFunctionConfigurations"][0][
             "LambdaFunctionArn"
-        ] = f"{localstack.utils.aws.arns.lambda_function_arn('my-lambda', account_id=account_id)}"
+        ] = f"{arns.lambda_function_arn('my-lambda', account_id=account_id)}"
         with pytest.raises(ClientError) as e:
             s3_client.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_sns.py
+++ b/tests/integration/s3/test_s3_notifications_sns.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Dict, List
 import pytest
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.config import LEGACY_S3_PROVIDER
+from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
 
@@ -28,7 +28,7 @@ def create_sns_bucket_notification(
     events: List["EventType"],
 ):
     """A NotificationFactory."""
-    bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(bucket_name)
+    bucket_arn = arns.s3_bucket_arn(bucket_name)
 
     policy = {
         "Version": "2012-10-17",
@@ -246,7 +246,7 @@ class TestS3NotificationsToSns:
                 {
                     "Id": "id123",
                     "Events": ["s3:ObjectCreated:*"],
-                    "TopicArn": f"{localstack.utils.aws.arns.sns_topic_arn('my-topic', account_id=account_id)}",
+                    "TopicArn": f"{arns.sns_topic_arn('my-topic', account_id=account_id)}",
                 }
             ]
         }
@@ -296,7 +296,7 @@ class TestS3NotificationsToSns:
         # set valid but not-existing topic
         config["TopicConfigurations"][0][
             "TopicArn"
-        ] = f"{localstack.utils.aws.arns.sns_topic_arn('my-topic', account_id=account_id)}"
+        ] = f"{arns.sns_topic_arn('my-topic', account_id=account_id)}"
         with pytest.raises(ClientError) as e:
             s3_client.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_sns.py
+++ b/tests/integration/s3/test_s3_notifications_sns.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Dict, List
 import pytest
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.config import LEGACY_S3_PROVIDER
-from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition
 
@@ -28,7 +28,7 @@ def create_sns_bucket_notification(
     events: List["EventType"],
 ):
     """A NotificationFactory."""
-    bucket_arn = aws_stack.s3_bucket_arn(bucket_name)
+    bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(bucket_name)
 
     policy = {
         "Version": "2012-10-17",
@@ -246,7 +246,7 @@ class TestS3NotificationsToSns:
                 {
                     "Id": "id123",
                     "Events": ["s3:ObjectCreated:*"],
-                    "TopicArn": f"{aws_stack.sns_topic_arn('my-topic', account_id=account_id)}",
+                    "TopicArn": f"{localstack.utils.aws.arns.sns_topic_arn('my-topic', account_id=account_id)}",
                 }
             ]
         }
@@ -296,7 +296,7 @@ class TestS3NotificationsToSns:
         # set valid but not-existing topic
         config["TopicConfigurations"][0][
             "TopicArn"
-        ] = f"{aws_stack.sns_topic_arn('my-topic', account_id=account_id)}"
+        ] = f"{localstack.utils.aws.arns.sns_topic_arn('my-topic', account_id=account_id)}"
         with pytest.raises(ClientError) as e:
             s3_client.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -8,8 +8,8 @@ import requests
 from boto3.s3.transfer import KB, TransferConfig
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack.config import LEGACY_S3_PROVIDER
-from localstack.utils.aws import aws_stack
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition, retry
 
@@ -53,7 +53,7 @@ def get_queue_arn(sqs_client, queue_url: str) -> str:
 def set_policy_for_queue(sqs_client, queue_url, bucket_name):
     queue_arn = get_queue_arn(sqs_client, queue_url)
     assert queue_arn
-    bucket_arn = aws_stack.s3_bucket_arn(bucket_name)
+    bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(bucket_name)
 
     policy = {
         "Version": "2012-10-17",
@@ -888,7 +888,7 @@ class TestS3NotificationsToSQS:
         # set valid but not-existing queue
         config["QueueConfigurations"][0][
             "QueueArn"
-        ] = f"{aws_stack.sqs_queue_arn('my-queue', account_id=account_id)}"
+        ] = f"{localstack.utils.aws.arns.sqs_queue_arn('my-queue', account_id=account_id)}"
         with pytest.raises(ClientError) as e:
             s3_client.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/s3/test_s3_notifications_sqs.py
+++ b/tests/integration/s3/test_s3_notifications_sqs.py
@@ -8,8 +8,8 @@ import requests
 from boto3.s3.transfer import KB, TransferConfig
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack.config import LEGACY_S3_PROVIDER
+from localstack.utils.aws import arns
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition, retry
 
@@ -53,7 +53,7 @@ def get_queue_arn(sqs_client, queue_url: str) -> str:
 def set_policy_for_queue(sqs_client, queue_url, bucket_name):
     queue_arn = get_queue_arn(sqs_client, queue_url)
     assert queue_arn
-    bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(bucket_name)
+    bucket_arn = arns.s3_bucket_arn(bucket_name)
 
     policy = {
         "Version": "2012-10-17",
@@ -888,7 +888,7 @@ class TestS3NotificationsToSQS:
         # set valid but not-existing queue
         config["QueueConfigurations"][0][
             "QueueArn"
-        ] = f"{localstack.utils.aws.arns.sqs_queue_arn('my-queue', account_id=account_id)}"
+        ] = f"{arns.sqs_queue_arn('my-queue', account_id=account_id)}"
         with pytest.raises(ClientError) as e:
             s3_client.put_bucket_notification_configuration(
                 Bucket=bucket_name,

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -16,7 +16,6 @@ from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 
 import localstack.utils.aws.queries
-import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.handlers import cors
@@ -47,7 +46,7 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import select_attributes, short_uid, to_str
@@ -209,9 +208,7 @@ class TestAPIGateway:
 
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
-        stream = localstack.utils.aws.resources.create_kinesis_stream(
-            self.TEST_STREAM_KINESIS_API_GW
-        )
+        stream = resources.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
         stream.wait_for()
 
         # create API Gateway and connect it to the target stream
@@ -252,7 +249,7 @@ class TestAPIGateway:
     def test_api_gateway_sqs_integration_with_event_source(self):
         # create target SQS stream
         queue_name = f"queue-{short_uid()}"
-        queue_url = localstack.utils.aws.resources.create_sqs_queue(queue_name)["QueueUrl"]
+        queue_url = resources.create_sqs_queue(queue_name)["QueueUrl"]
 
         # create API Gateway and connect it to the target queue
         result = connect_api_gateway_to_sqs(
@@ -299,7 +296,7 @@ class TestAPIGateway:
     def test_api_gateway_sqs_integration(self):
         # create target SQS stream
         queue_name = f"queue-{short_uid()}"
-        localstack.utils.aws.resources.create_sqs_queue(queue_name)
+        resources.create_sqs_queue(queue_name)
 
         # create API Gateway and connect it to the target queue
         result = connect_api_gateway_to_sqs(
@@ -1718,7 +1715,7 @@ class TestAPIGateway:
         api_id, _, _ = create_rest_apigw(name=apigateway_name)
 
         try:
-            localstack.utils.aws.resources.get_or_create_bucket(bucket_name)
+            resources.get_or_create_bucket(bucket_name)
             s3_client.put_object(
                 Bucket=bucket_name,
                 Key=object_name,
@@ -1881,7 +1878,7 @@ class TestAPIGateway:
                 },
             ]
         }
-        return localstack.utils.aws.resources.create_api_gateway(
+        return resources.create_api_gateway(
             name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
         )
 
@@ -1913,7 +1910,7 @@ class TestAPIGateway:
             }
             for method in methods
         ]
-        return localstack.utils.aws.resources.create_api_gateway(
+        return resources.create_api_gateway(
             name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
         )
 
@@ -2021,9 +2018,7 @@ class TestAPIGateway:
 
         kwargs = {}
         if integration_type == "AWS_PROXY":
-            localstack.utils.aws.resources.create_dynamodb_table(
-                "MusicCollection", partition_key="id"
-            )
+            resources.create_dynamodb_table("MusicCollection", partition_key="id")
             kwargs[
                 "uri"
             ] = "arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection"

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -15,7 +15,6 @@ from moto.apigateway import apigateway_backends
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.queries
 import localstack.utils.aws.resources
 from localstack import config
@@ -48,7 +47,7 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import select_attributes, short_uid, to_str
@@ -267,7 +266,7 @@ class TestAPIGateway:
         self.create_lambda_function(self.TEST_LAMBDA_SQS_HANDLER_NAME)
         event_source_data = {
             "FunctionName": self.TEST_LAMBDA_SQS_HANDLER_NAME,
-            "EventSourceArn": localstack.utils.aws.arns.sqs_queue_arn(queue_name),
+            "EventSourceArn": arns.sqs_queue_arn(queue_name),
             "Enabled": True,
         }
         add_event_source(event_source_data)
@@ -380,7 +379,7 @@ class TestAPIGateway:
             handler_file=TEST_LAMBDA_AWS_PROXY,
             runtime=LAMBDA_RUNTIME_PYTHON39,
         )
-        lambda_arn = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+        lambda_arn = arns.lambda_function_arn(fn_name)
 
         api_id, _, root = create_rest_apigw(name="aws lambda api")
         resource_id, _ = create_rest_resource(
@@ -647,7 +646,7 @@ class TestAPIGateway:
         """
         self.create_lambda_function(fn_name)
         # create API Gateway and connect it to the Lambda proxy backend
-        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+        lambda_uri = arns.lambda_function_arn(fn_name)
         invocation_uri = "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations"
         target_uri = invocation_uri % (aws_stack.get_region(), lambda_uri)
 
@@ -766,7 +765,7 @@ class TestAPIGateway:
         testutil.create_lambda_function(
             handler_file=TEST_LAMBDA_NODEJS, func_name=fn_name, runtime=LAMBDA_RUNTIME_NODEJS12X
         )
-        lambda_arn = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+        lambda_arn = arns.lambda_function_arn(fn_name)
 
         spec_file = load_file(TEST_IMPORT_REST_API_ASYNC_LAMBDA)
         spec_file = spec_file.replace("${lambda_invocation_arn}", lambda_arn)
@@ -835,8 +834,8 @@ class TestAPIGateway:
         # create Lambda function
         lambda_name = f"apigw-lambda-{short_uid()}"
         self.create_lambda_function(lambda_name)
-        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
-        target_uri = localstack.utils.aws.arns.apigateway_invocations_arn(lambda_uri)
+        lambda_uri = arns.lambda_function_arn(lambda_name)
+        target_uri = arns.apigateway_invocations_arn(lambda_uri)
 
         # create REST API
         api_id, _, _ = create_rest_apigw(name="test-api", description="")
@@ -933,7 +932,7 @@ class TestAPIGateway:
             handler="apigw_502.handler",
         )
 
-        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
+        lambda_uri = arns.lambda_function_arn(lambda_name)
         target_uri = f"arn:aws:apigateway:{aws_stack.get_region()}:lambda:path/2015-03-31/functions/{lambda_uri}/invocations"
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway",
@@ -963,8 +962,8 @@ class TestAPIGateway:
         self.create_lambda_function(fn_name)
 
         # create API Gateway and connect it to the Lambda proxy backend
-        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(fn_name)
-        target_uri = localstack.utils.aws.arns.apigateway_invocations_arn(lambda_uri)
+        lambda_uri = arns.lambda_function_arn(fn_name)
+        target_uri = arns.apigateway_invocations_arn(lambda_uri)
 
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway3",
@@ -996,7 +995,7 @@ class TestAPIGateway:
         # create Lambda function
         lambda_name = f"apigw-lambda-{short_uid()}"
         self.create_lambda_function(lambda_name)
-        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
+        lambda_uri = arns.lambda_function_arn(lambda_name)
 
         # create REST API
         api_id, _, _ = create_rest_apigw(name="test-api", description="")
@@ -1497,11 +1496,11 @@ class TestAPIGateway:
             func_name=fn_name,
             runtime=LAMBDA_RUNTIME_PYTHON36,
         )
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
 
         # create state machine definition
         definition = clone(state_machine_def)
-        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+        lambda_arn_1 = arns.lambda_function_arn(fn_name)
         definition["States"]["step1"]["Resource"] = lambda_arn_1
         definition = json.dumps(definition)
 
@@ -1794,7 +1793,7 @@ class TestAPIGateway:
             handler="apigw_integration.handler",
         )
 
-        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
+        lambda_uri = arns.lambda_function_arn(lambda_name)
         target_uri = f"arn:aws:apigateway:{aws_stack.get_region()}:lambda:path/2015-03-31/functions/{lambda_uri}/invocations"
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway",
@@ -1823,7 +1822,7 @@ class TestAPIGateway:
         )
 
         test_role = "test-s3-role"
-        role_arn = localstack.utils.aws.arns.role_arn(role_name=test_role)
+        role_arn = arns.role_arn(role_name=test_role)
         resources = apigw_client.get_resources(restApiId=api_id)
         # using the root resource '/' directly for this test
         root_resource_id = resources["items"][0]["id"]
@@ -1932,7 +1931,7 @@ class TestAPIGateway:
         testutil.create_lambda_function(
             handler_file=TEST_LAMBDA_NODEJS, func_name=fn_name, runtime=LAMBDA_RUNTIME_NODEJS12X
         )
-        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+        lambda_arn_1 = arns.lambda_function_arn(fn_name)
 
         # create REST API and test resource
         rest_api_id, _, _ = create_rest_apigw(name="test", description="test")
@@ -2217,7 +2216,7 @@ def test_apigateway_rust_lambda(
     apigateway_client.put_method_response(
         restApiId=rest_api_id, resourceId=root_resource_id, httpMethod="GET", statusCode="200"
     )
-    lambda_target_uri = localstack.utils.aws.arns.apigateway_invocations_arn(
+    lambda_target_uri = arns.apigateway_invocations_arn(
         lambda_uri=lambda_arn, region_name=apigateway_client.meta.region_name
     )
     apigateway_client.put_integration(
@@ -2291,12 +2290,8 @@ def test_rest_api_multi_region(method, url_function):
         runtime=LAMBDA_RUNTIME_NODEJS14X,
         region_name="us-west-1",
     )
-    lambda_eu_arn = localstack.utils.aws.arns.lambda_function_arn(
-        lambda_name, region_name="eu-west-1"
-    )
-    uri_eu = localstack.utils.aws.arns.apigateway_invocations_arn(
-        lambda_eu_arn, region_name="eu-west-1"
-    )
+    lambda_eu_arn = arns.lambda_function_arn(lambda_name, region_name="eu-west-1")
+    uri_eu = arns.apigateway_invocations_arn(lambda_eu_arn, region_name="eu-west-1")
 
     integration_uri, _ = create_rest_api_integration(
         apigateway_client_eu,
@@ -2308,12 +2303,8 @@ def test_rest_api_multi_region(method, url_function):
         uri=uri_eu,
     )
 
-    lambda_us_arn = localstack.utils.aws.arns.lambda_function_arn(
-        lambda_name, region_name="us-west-1"
-    )
-    uri_us = localstack.utils.aws.arns.apigateway_invocations_arn(
-        lambda_us_arn, region_name="us-west-1"
-    )
+    lambda_us_arn = arns.lambda_function_arn(lambda_name, region_name="us-west-1")
+    uri_us = arns.apigateway_invocations_arn(lambda_us_arn, region_name="us-west-1")
 
     integration_uri, _ = create_rest_api_integration(
         apigateway_client_us,
@@ -2404,7 +2395,7 @@ def test_tag_api(apigateway_client, create_rest_apigw):
     api_id, _, _ = create_rest_apigw(name=api_name, tags={TAG_KEY_CUSTOM_ID: "c0stIOm1d"})
     assert api_id == "c0stIOm1d"
 
-    api_arn = localstack.utils.aws.arns.apigateway_restapi_arn(api_id=api_id)
+    api_arn = arns.apigateway_restapi_arn(api_id=api_id)
     apigateway_client.tag_resource(resourceArn=api_arn, tags=tags)
 
     # receive and assert tags

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -15,6 +15,7 @@ from moto.apigateway import apigateway_backends
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.handlers import cors
@@ -262,7 +263,7 @@ class TestAPIGateway:
         self.create_lambda_function(self.TEST_LAMBDA_SQS_HANDLER_NAME)
         event_source_data = {
             "FunctionName": self.TEST_LAMBDA_SQS_HANDLER_NAME,
-            "EventSourceArn": aws_stack.sqs_queue_arn(queue_name),
+            "EventSourceArn": localstack.utils.aws.arns.sqs_queue_arn(queue_name),
             "Enabled": True,
         }
         add_event_source(event_source_data)
@@ -375,7 +376,7 @@ class TestAPIGateway:
             handler_file=TEST_LAMBDA_AWS_PROXY,
             runtime=LAMBDA_RUNTIME_PYTHON39,
         )
-        lambda_arn = aws_stack.lambda_function_arn(fn_name)
+        lambda_arn = localstack.utils.aws.arns.lambda_function_arn(fn_name)
 
         api_id, _, root = create_rest_apigw(name="aws lambda api")
         resource_id, _ = create_rest_resource(
@@ -642,7 +643,7 @@ class TestAPIGateway:
         """
         self.create_lambda_function(fn_name)
         # create API Gateway and connect it to the Lambda proxy backend
-        lambda_uri = aws_stack.lambda_function_arn(fn_name)
+        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(fn_name)
         invocation_uri = "arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations"
         target_uri = invocation_uri % (aws_stack.get_region(), lambda_uri)
 
@@ -761,7 +762,7 @@ class TestAPIGateway:
         testutil.create_lambda_function(
             handler_file=TEST_LAMBDA_NODEJS, func_name=fn_name, runtime=LAMBDA_RUNTIME_NODEJS12X
         )
-        lambda_arn = aws_stack.lambda_function_arn(fn_name)
+        lambda_arn = localstack.utils.aws.arns.lambda_function_arn(fn_name)
 
         spec_file = load_file(TEST_IMPORT_REST_API_ASYNC_LAMBDA)
         spec_file = spec_file.replace("${lambda_invocation_arn}", lambda_arn)
@@ -830,8 +831,8 @@ class TestAPIGateway:
         # create Lambda function
         lambda_name = f"apigw-lambda-{short_uid()}"
         self.create_lambda_function(lambda_name)
-        lambda_uri = aws_stack.lambda_function_arn(lambda_name)
-        target_uri = aws_stack.apigateway_invocations_arn(lambda_uri)
+        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
+        target_uri = localstack.utils.aws.arns.apigateway_invocations_arn(lambda_uri)
 
         # create REST API
         api_id, _, _ = create_rest_apigw(name="test-api", description="")
@@ -928,7 +929,7 @@ class TestAPIGateway:
             handler="apigw_502.handler",
         )
 
-        lambda_uri = aws_stack.lambda_function_arn(lambda_name)
+        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
         target_uri = f"arn:aws:apigateway:{aws_stack.get_region()}:lambda:path/2015-03-31/functions/{lambda_uri}/invocations"
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway",
@@ -958,8 +959,8 @@ class TestAPIGateway:
         self.create_lambda_function(fn_name)
 
         # create API Gateway and connect it to the Lambda proxy backend
-        lambda_uri = aws_stack.lambda_function_arn(fn_name)
-        target_uri = aws_stack.apigateway_invocations_arn(lambda_uri)
+        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+        target_uri = localstack.utils.aws.arns.apigateway_invocations_arn(lambda_uri)
 
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway3",
@@ -991,7 +992,7 @@ class TestAPIGateway:
         # create Lambda function
         lambda_name = f"apigw-lambda-{short_uid()}"
         self.create_lambda_function(lambda_name)
-        lambda_uri = aws_stack.lambda_function_arn(lambda_name)
+        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
 
         # create REST API
         api_id, _, _ = create_rest_apigw(name="test-api", description="")
@@ -1492,11 +1493,11 @@ class TestAPIGateway:
             func_name=fn_name,
             runtime=LAMBDA_RUNTIME_PYTHON36,
         )
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
 
         # create state machine definition
         definition = clone(state_machine_def)
-        lambda_arn_1 = aws_stack.lambda_function_arn(fn_name)
+        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(fn_name)
         definition["States"]["step1"]["Resource"] = lambda_arn_1
         definition = json.dumps(definition)
 
@@ -1789,7 +1790,7 @@ class TestAPIGateway:
             handler="apigw_integration.handler",
         )
 
-        lambda_uri = aws_stack.lambda_function_arn(lambda_name)
+        lambda_uri = localstack.utils.aws.arns.lambda_function_arn(lambda_name)
         target_uri = f"arn:aws:apigateway:{aws_stack.get_region()}:lambda:path/2015-03-31/functions/{lambda_uri}/invocations"
         result = testutil.connect_api_gateway_to_http_with_lambda_proxy(
             "test_gateway",
@@ -1818,7 +1819,7 @@ class TestAPIGateway:
         )
 
         test_role = "test-s3-role"
-        role_arn = aws_stack.role_arn(role_name=test_role)
+        role_arn = localstack.utils.aws.arns.role_arn(role_name=test_role)
         resources = apigw_client.get_resources(restApiId=api_id)
         # using the root resource '/' directly for this test
         root_resource_id = resources["items"][0]["id"]
@@ -1927,7 +1928,7 @@ class TestAPIGateway:
         testutil.create_lambda_function(
             handler_file=TEST_LAMBDA_NODEJS, func_name=fn_name, runtime=LAMBDA_RUNTIME_NODEJS12X
         )
-        lambda_arn_1 = aws_stack.lambda_function_arn(fn_name)
+        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(fn_name)
 
         # create REST API and test resource
         rest_api_id, _, _ = create_rest_apigw(name="test", description="test")
@@ -2210,7 +2211,7 @@ def test_apigateway_rust_lambda(
     apigateway_client.put_method_response(
         restApiId=rest_api_id, resourceId=root_resource_id, httpMethod="GET", statusCode="200"
     )
-    lambda_target_uri = aws_stack.apigateway_invocations_arn(
+    lambda_target_uri = localstack.utils.aws.arns.apigateway_invocations_arn(
         lambda_uri=lambda_arn, region_name=apigateway_client.meta.region_name
     )
     apigateway_client.put_integration(
@@ -2284,8 +2285,12 @@ def test_rest_api_multi_region(method, url_function):
         runtime=LAMBDA_RUNTIME_NODEJS14X,
         region_name="us-west-1",
     )
-    lambda_eu_arn = aws_stack.lambda_function_arn(lambda_name, region_name="eu-west-1")
-    uri_eu = aws_stack.apigateway_invocations_arn(lambda_eu_arn, region_name="eu-west-1")
+    lambda_eu_arn = localstack.utils.aws.arns.lambda_function_arn(
+        lambda_name, region_name="eu-west-1"
+    )
+    uri_eu = localstack.utils.aws.arns.apigateway_invocations_arn(
+        lambda_eu_arn, region_name="eu-west-1"
+    )
 
     integration_uri, _ = create_rest_api_integration(
         apigateway_client_eu,
@@ -2297,8 +2302,12 @@ def test_rest_api_multi_region(method, url_function):
         uri=uri_eu,
     )
 
-    lambda_us_arn = aws_stack.lambda_function_arn(lambda_name, region_name="us-west-1")
-    uri_us = aws_stack.apigateway_invocations_arn(lambda_us_arn, region_name="us-west-1")
+    lambda_us_arn = localstack.utils.aws.arns.lambda_function_arn(
+        lambda_name, region_name="us-west-1"
+    )
+    uri_us = localstack.utils.aws.arns.apigateway_invocations_arn(
+        lambda_us_arn, region_name="us-west-1"
+    )
 
     integration_uri, _ = create_rest_api_integration(
         apigateway_client_us,
@@ -2389,7 +2398,7 @@ def test_tag_api(apigateway_client, create_rest_apigw):
     api_id, _, _ = create_rest_apigw(name=api_name, tags={TAG_KEY_CUSTOM_ID: "c0stIOm1d"})
     assert api_id == "c0stIOm1d"
 
-    api_arn = aws_stack.apigateway_restapi_arn(api_id=api_id)
+    api_arn = localstack.utils.aws.arns.apigateway_restapi_arn(api_id=api_id)
     apigateway_client.tag_resource(resourceArn=api_arn, tags=tags)
 
     # receive and assert tags

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -15,7 +15,6 @@ from moto.apigateway import apigateway_backends
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 
-import localstack.utils.aws.queries
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.handlers import cors
@@ -46,7 +45,7 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack, resources
+from localstack.utils.aws import arns, aws_stack, queries, resources
 from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import select_attributes, short_uid, to_str
@@ -317,7 +316,7 @@ class TestAPIGateway:
         result = requests.post(url, data=json.dumps(test_data))
         assert 200 == result.status_code
 
-        messages = localstack.utils.aws.queries.sqs_receive_message(queue_name)["Messages"]
+        messages = queries.sqs_receive_message(queue_name)["Messages"]
         assert 1 == len(messages)
         assert test_data == json.loads(base64.b64decode(messages[0]["Body"]))
 

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -45,7 +45,8 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack, queries, resources
+from localstack.utils.aws import arns, aws_stack, queries
+from localstack.utils.aws import resources as resource_util
 from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
 from localstack.utils.common import safe_requests as requests
 from localstack.utils.common import select_attributes, short_uid, to_str
@@ -207,7 +208,7 @@ class TestAPIGateway:
 
     def test_api_gateway_kinesis_integration(self):
         # create target Kinesis stream
-        stream = resources.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
+        stream = resource_util.create_kinesis_stream(self.TEST_STREAM_KINESIS_API_GW)
         stream.wait_for()
 
         # create API Gateway and connect it to the target stream
@@ -248,7 +249,7 @@ class TestAPIGateway:
     def test_api_gateway_sqs_integration_with_event_source(self):
         # create target SQS stream
         queue_name = f"queue-{short_uid()}"
-        queue_url = resources.create_sqs_queue(queue_name)["QueueUrl"]
+        queue_url = resource_util.create_sqs_queue(queue_name)["QueueUrl"]
 
         # create API Gateway and connect it to the target queue
         result = connect_api_gateway_to_sqs(
@@ -295,7 +296,7 @@ class TestAPIGateway:
     def test_api_gateway_sqs_integration(self):
         # create target SQS stream
         queue_name = f"queue-{short_uid()}"
-        resources.create_sqs_queue(queue_name)
+        resource_util.create_sqs_queue(queue_name)
 
         # create API Gateway and connect it to the target queue
         result = connect_api_gateway_to_sqs(
@@ -1714,7 +1715,7 @@ class TestAPIGateway:
         api_id, _, _ = create_rest_apigw(name=apigateway_name)
 
         try:
-            resources.get_or_create_bucket(bucket_name)
+            resource_util.get_or_create_bucket(bucket_name)
             s3_client.put_object(
                 Bucket=bucket_name,
                 Key=object_name,
@@ -1877,7 +1878,7 @@ class TestAPIGateway:
                 },
             ]
         }
-        return resources.create_api_gateway(
+        return resource_util.create_api_gateway(
             name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
         )
 
@@ -1909,7 +1910,7 @@ class TestAPIGateway:
             }
             for method in methods
         ]
-        return resources.create_api_gateway(
+        return resource_util.create_api_gateway(
             name=gateway_name, resources=resources, stage_name=self.TEST_STAGE_NAME
         )
 
@@ -2017,7 +2018,7 @@ class TestAPIGateway:
 
         kwargs = {}
         if integration_type == "AWS_PROXY":
-            resources.create_dynamodb_table("MusicCollection", partition_key="id")
+            resource_util.create_dynamodb_table("MusicCollection", partition_key="id")
             kwargs[
                 "uri"
             ] = "arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection"

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -3,10 +3,9 @@ import json
 import pytest
 import requests
 
-import localstack.utils.aws.arns
 from localstack.services.apigateway.helpers import path_based_url
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 from localstack.utils.testutil import create_lambda_function
@@ -57,7 +56,7 @@ def test_lambda_aws_integration(apigateway_client, create_rest_apigw):
         handler="lambda_hello_world.handler",
         runtime=LAMBDA_RUNTIME_PYTHON39,
     )
-    lambda_arn = localstack.utils.aws.arns.lambda_function_arn(fn_name)
+    lambda_arn = arns.lambda_function_arn(fn_name)
 
     api_id, _, root = create_rest_apigw(name="aws lambda api")
     resource_id, _ = create_rest_resource(

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import requests
 
+import localstack.utils.aws.arns
 from localstack.services.apigateway.helpers import path_based_url
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.utils.aws import aws_stack
@@ -56,7 +57,7 @@ def test_lambda_aws_integration(apigateway_client, create_rest_apigw):
         handler="lambda_hello_world.handler",
         runtime=LAMBDA_RUNTIME_PYTHON39,
     )
-    lambda_arn = aws_stack.lambda_function_arn(fn_name)
+    lambda_arn = localstack.utils.aws.arns.lambda_function_arn(fn_name)
 
     api_id, _, root = create_rest_apigw(name="aws lambda api")
     resource_id, _ = create_rest_resource(

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 from dateutil.tz import tzutc
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.cloudwatch.provider import PATH_GET_RAW_METRICS
 from localstack.utils.aws import aws_stack
@@ -241,7 +242,7 @@ class TestCloudwatch:
             ComparisonOperator="GreaterThanThreshold",
         )
         assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
-        alarm_arn = aws_stack.cloudwatch_alarm_arn(alarm_name)
+        alarm_arn = localstack.utils.aws.arns.cloudwatch_alarm_arn(alarm_name)
 
         tags = [{"Key": "tag1", "Value": "foo"}, {"Key": "tag2", "Value": "bar"}]
         response = cloudwatch_client.tag_resource(ResourceARN=alarm_arn, Tags=tags)
@@ -740,7 +741,7 @@ class TestCloudwatch:
         sqs_arn = sqs_client.get_queue_attributes(QueueUrl=sqs_url, AttributeNames=["QueueArn"])[
             "Attributes"
         ]["QueueArn"]
-        queue_name = aws_stack.sqs_queue_name(sqs_arn)
+        queue_name = localstack.utils.aws.arns.sqs_queue_name(sqs_arn)
         # this should trigger the metric "NumberOfEmptyReceives"
         sqs_client.receive_message(QueueUrl=sqs_url)
 

--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -8,10 +8,9 @@ import pytest
 import requests
 from dateutil.tz import tzutc
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.cloudwatch.provider import PATH_GET_RAW_METRICS
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import retry, short_uid, to_str
 from localstack.utils.sync import poll_condition
 
@@ -242,7 +241,7 @@ class TestCloudwatch:
             ComparisonOperator="GreaterThanThreshold",
         )
         assert 200 == response["ResponseMetadata"]["HTTPStatusCode"]
-        alarm_arn = localstack.utils.aws.arns.cloudwatch_alarm_arn(alarm_name)
+        alarm_arn = arns.cloudwatch_alarm_arn(alarm_name)
 
         tags = [{"Key": "tag1", "Value": "foo"}, {"Key": "tag2", "Value": "bar"}]
         response = cloudwatch_client.tag_resource(ResourceARN=alarm_arn, Tags=tags)
@@ -741,7 +740,7 @@ class TestCloudwatch:
         sqs_arn = sqs_client.get_queue_attributes(QueueUrl=sqs_url, AttributeNames=["QueueArn"])[
             "Attributes"
         ]["QueueArn"]
-        queue_name = localstack.utils.aws.arns.sqs_queue_name(sqs_arn)
+        queue_name = arns.sqs_queue_name(sqs_arn)
         # this should trigger the metric "NumberOfEmptyReceives"
         sqs_client.receive_message(QueueUrl=sqs_url)
 

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -10,6 +10,8 @@ from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import STRING
 
 import localstack.utils.aws.arns
+import localstack.utils.aws.queries
+import localstack.utils.aws.resources
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.snapshots.transformer import SortingTransformer
@@ -46,7 +48,9 @@ def transcribe_snapshot_transformer(snapshot):
 class TestDynamoDB:
     @pytest.mark.only_localstack
     def test_non_ascii_chars(self, dynamodb):
-        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
+        localstack.utils.aws.resources.create_dynamodb_table(
+            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY
+        )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
         # write some items containing non-ASCII characters
@@ -71,7 +75,9 @@ class TestDynamoDB:
 
     @pytest.mark.only_localstack
     def test_large_data_download(self, dynamodb):
-        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME_2, partition_key=PARTITION_KEY)
+        localstack.utils.aws.resources.create_dynamodb_table(
+            TEST_DDB_TABLE_NAME_2, partition_key=PARTITION_KEY
+        )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_2)
 
         # Create a large amount of items
@@ -89,7 +95,9 @@ class TestDynamoDB:
 
     @pytest.mark.only_localstack
     def test_time_to_live(self, dynamodb):
-        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME_3, partition_key=PARTITION_KEY)
+        localstack.utils.aws.resources.create_dynamodb_table(
+            TEST_DDB_TABLE_NAME_3, partition_key=PARTITION_KEY
+        )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_3)
 
         # Insert some items to the table
@@ -189,7 +197,7 @@ class TestDynamoDB:
         ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
         kinesis = aws_stack.create_external_boto_client("kinesis")
         table_name = f"ddb-{short_uid()}"
-        aws_stack.create_dynamodb_table(
+        localstack.utils.aws.resources.create_dynamodb_table(
             table_name,
             partition_key=PARTITION_KEY,
             stream_view_type="NEW_AND_OLD_IMAGES",
@@ -228,7 +236,9 @@ class TestDynamoDB:
     @pytest.mark.only_localstack
     def test_multiple_update_expressions(self, dynamodb):
         dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
-        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
+        localstack.utils.aws.resources.create_dynamodb_table(
+            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY
+        )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
         item_id = short_uid()
@@ -432,7 +442,7 @@ class TestDynamoDB:
 
     @pytest.mark.aws_validated
     def test_return_values_in_put_item(self, dynamodb, dynamodb_client, snapshot):
-        aws_stack.create_dynamodb_table(
+        localstack.utils.aws.resources.create_dynamodb_table(
             TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY, client=dynamodb_client
         )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
@@ -474,7 +484,7 @@ class TestDynamoDB:
     @pytest.mark.aws_validated
     def test_empty_and_binary_values(self, dynamodb, dynamodb_client, snapshot):
         table_name = f"table-{short_uid()}"
-        aws_stack.create_dynamodb_table(
+        localstack.utils.aws.resources.create_dynamodb_table(
             table_name=table_name, partition_key=PARTITION_KEY, client=dynamodb_client
         )
         table = dynamodb.Table(table_name)
@@ -837,7 +847,7 @@ class TestDynamoDB:
         dynamodb.delete_item(TableName=table_name, Key={"Username": {"S": "Fred"}})
 
         def _fetch_records():
-            records = aws_stack.kinesis_get_latest_records(
+            records = localstack.utils.aws.queries.kinesis_get_latest_records(
                 stream_name, shard_id=stream_description["Shards"][0]["ShardId"]
             )
             assert len(records) == 3
@@ -953,7 +963,9 @@ class TestDynamoDB:
 
     @pytest.mark.only_localstack
     def test_global_tables(self):
-        aws_stack.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
+        localstack.utils.aws.resources.create_dynamodb_table(
+            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY
+        )
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         # create global table

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -10,12 +10,11 @@ from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import STRING
 
 import localstack.utils.aws.queries
-import localstack.utils.aws.resources
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.common import json_safe, long_uid, retry, short_uid
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
@@ -47,9 +46,7 @@ def transcribe_snapshot_transformer(snapshot):
 class TestDynamoDB:
     @pytest.mark.only_localstack
     def test_non_ascii_chars(self, dynamodb):
-        localstack.utils.aws.resources.create_dynamodb_table(
-            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY
-        )
+        resources.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
         # write some items containing non-ASCII characters
@@ -74,9 +71,7 @@ class TestDynamoDB:
 
     @pytest.mark.only_localstack
     def test_large_data_download(self, dynamodb):
-        localstack.utils.aws.resources.create_dynamodb_table(
-            TEST_DDB_TABLE_NAME_2, partition_key=PARTITION_KEY
-        )
+        resources.create_dynamodb_table(TEST_DDB_TABLE_NAME_2, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_2)
 
         # Create a large amount of items
@@ -94,9 +89,7 @@ class TestDynamoDB:
 
     @pytest.mark.only_localstack
     def test_time_to_live(self, dynamodb):
-        localstack.utils.aws.resources.create_dynamodb_table(
-            TEST_DDB_TABLE_NAME_3, partition_key=PARTITION_KEY
-        )
+        resources.create_dynamodb_table(TEST_DDB_TABLE_NAME_3, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME_3)
 
         # Insert some items to the table
@@ -196,7 +189,7 @@ class TestDynamoDB:
         ddbstreams = aws_stack.create_external_boto_client("dynamodbstreams")
         kinesis = aws_stack.create_external_boto_client("kinesis")
         table_name = f"ddb-{short_uid()}"
-        localstack.utils.aws.resources.create_dynamodb_table(
+        resources.create_dynamodb_table(
             table_name,
             partition_key=PARTITION_KEY,
             stream_view_type="NEW_AND_OLD_IMAGES",
@@ -235,9 +228,7 @@ class TestDynamoDB:
     @pytest.mark.only_localstack
     def test_multiple_update_expressions(self, dynamodb):
         dynamodb_client = aws_stack.create_external_boto_client("dynamodb")
-        localstack.utils.aws.resources.create_dynamodb_table(
-            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY
-        )
+        resources.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
 
         item_id = short_uid()
@@ -441,7 +432,7 @@ class TestDynamoDB:
 
     @pytest.mark.aws_validated
     def test_return_values_in_put_item(self, dynamodb, dynamodb_client, snapshot):
-        localstack.utils.aws.resources.create_dynamodb_table(
+        resources.create_dynamodb_table(
             TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY, client=dynamodb_client
         )
         table = dynamodb.Table(TEST_DDB_TABLE_NAME)
@@ -483,7 +474,7 @@ class TestDynamoDB:
     @pytest.mark.aws_validated
     def test_empty_and_binary_values(self, dynamodb, dynamodb_client, snapshot):
         table_name = f"table-{short_uid()}"
-        localstack.utils.aws.resources.create_dynamodb_table(
+        resources.create_dynamodb_table(
             table_name=table_name, partition_key=PARTITION_KEY, client=dynamodb_client
         )
         table = dynamodb.Table(table_name)
@@ -962,9 +953,7 @@ class TestDynamoDB:
 
     @pytest.mark.only_localstack
     def test_global_tables(self):
-        localstack.utils.aws.resources.create_dynamodb_table(
-            TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY
-        )
+        resources.create_dynamodb_table(TEST_DDB_TABLE_NAME, partition_key=PARTITION_KEY)
         dynamodb = aws_stack.create_external_boto_client("dynamodb")
 
         # create global table

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -9,6 +9,7 @@ import pytest
 from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import STRING
 
+import localstack.utils.aws.arns
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.snapshots.transformer import SortingTransformer
@@ -1369,7 +1370,7 @@ class TestDynamoDB:
 
         kms_master_key_id = long_uid()
         sse_specification = {"Enabled": True, "SSEType": "KMS", "KMSMasterKeyId": kms_master_key_id}
-        kms_master_key_arn = aws_stack.kms_key_arn(kms_master_key_id)
+        kms_master_key_arn = localstack.utils.aws.arns.kms_key_arn(kms_master_key_id)
 
         result = dynamodb_create_table_with_parameters(
             TableName=table_name,

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -9,14 +9,13 @@ import pytest
 from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import STRING
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.queries
 import localstack.utils.aws.resources
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import json_safe, long_uid, retry, short_uid
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
@@ -1382,7 +1381,7 @@ class TestDynamoDB:
 
         kms_master_key_id = long_uid()
         sse_specification = {"Enabled": True, "SSEType": "KMS", "KMSMasterKeyId": kms_master_key_id}
-        kms_master_key_arn = localstack.utils.aws.arns.kms_key_arn(kms_master_key_id)
+        kms_master_key_arn = arns.kms_key_arn(kms_master_key_id)
 
         result = dynamodb_create_table_with_parameters(
             TableName=table_name,

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -9,12 +9,11 @@ import pytest
 from boto3.dynamodb.conditions import Key
 from boto3.dynamodb.types import STRING
 
-import localstack.utils.aws.queries
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.services.dynamodbstreams.dynamodbstreams_api import get_kinesis_stream_name
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack, resources
+from localstack.utils.aws import arns, aws_stack, queries, resources
 from localstack.utils.common import json_safe, long_uid, retry, short_uid
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
@@ -837,7 +836,7 @@ class TestDynamoDB:
         dynamodb.delete_item(TableName=table_name, Key={"Username": {"S": "Fred"}})
 
         def _fetch_records():
-            records = localstack.utils.aws.queries.kinesis_get_latest_records(
+            records = queries.kinesis_get_latest_records(
                 stream_name, shard_id=stream_description["Shards"][0]["ShardId"]
             )
             assert len(records) == 3

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -9,6 +9,7 @@ import xmltodict
 from quart import request as quart_request
 from requests.models import Request as RequestsRequest
 
+import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL
@@ -83,7 +84,7 @@ class TestEdgeAPI:
     def _invoke_dynamodb_via_edge_go_sdk(self, edge_url):
         client = aws_stack.create_external_boto_client("dynamodb")
         table_name = f"t-{short_uid()}"
-        aws_stack.create_dynamodb_table(table_name, "id")
+        localstack.utils.aws.resources.create_dynamodb_table(table_name, "id")
 
         # emulate a request sent from the AWS Go SDK v2
         headers = {

--- a/tests/integration/test_edge.py
+++ b/tests/integration/test_edge.py
@@ -9,7 +9,6 @@ import xmltodict
 from quart import request as quart_request
 from requests.models import Request as RequestsRequest
 
-import localstack.utils.aws.resources
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON, HEADER_LOCALSTACK_EDGE_URL
@@ -21,7 +20,7 @@ from localstack.services.generic_proxy import (
     update_path_in_url,
 )
 from localstack.services.messages import Request, Response
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import aws_stack, resources
 from localstack.utils.common import get_free_tcp_port, short_uid, to_str
 from localstack.utils.xml import strip_xmlns
 
@@ -84,7 +83,7 @@ class TestEdgeAPI:
     def _invoke_dynamodb_via_edge_go_sdk(self, edge_url):
         client = aws_stack.create_external_boto_client("dynamodb")
         table_name = f"t-{short_uid()}"
-        localstack.utils.aws.resources.create_dynamodb_table(table_name, "id")
+        resources.create_dynamodb_table(table_name, "id")
 
         # emulate a request sent from the AWS Go SDK v2
         headers = {

--- a/tests/integration/test_error_injection.py
+++ b/tests/integration/test_error_injection.py
@@ -2,6 +2,7 @@ import pytest
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.resources
 from localstack import config
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import short_uid
@@ -14,7 +15,7 @@ class TestErrorInjection:
     def test_kinesis_error_injection(self, monkeypatch, kinesis_client, wait_for_stream_ready):
         kinesis = aws_stack.create_external_boto_client("kinesis", config=self.retry_config())
         stream_name = f"stream-{short_uid()}"
-        aws_stack.create_kinesis_stream(stream_name)
+        localstack.utils.aws.resources.create_kinesis_stream(stream_name)
         wait_for_stream_ready(stream_name)
 
         try:
@@ -96,7 +97,9 @@ class TestErrorInjection:
         # set max_attempts=1 to speed up the test execution
         dynamodb = aws_stack.connect_to_resource("dynamodb", config=self.retry_config())
         table_name = f"table-{short_uid()}"
-        aws_stack.create_dynamodb_table(table_name, partition_key=PARTITION_KEY)
+        localstack.utils.aws.resources.create_dynamodb_table(
+            table_name, partition_key=PARTITION_KEY
+        )
         return dynamodb.Table(table_name)
 
     def retry_config(self):

--- a/tests/integration/test_error_injection.py
+++ b/tests/integration/test_error_injection.py
@@ -2,9 +2,8 @@ import pytest
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.resources
 from localstack import config
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import aws_stack, resources
 from localstack.utils.common import short_uid
 
 from .test_integration import PARTITION_KEY
@@ -15,7 +14,7 @@ class TestErrorInjection:
     def test_kinesis_error_injection(self, monkeypatch, kinesis_client, wait_for_stream_ready):
         kinesis = aws_stack.create_external_boto_client("kinesis", config=self.retry_config())
         stream_name = f"stream-{short_uid()}"
-        localstack.utils.aws.resources.create_kinesis_stream(stream_name)
+        resources.create_kinesis_stream(stream_name)
         wait_for_stream_ready(stream_name)
 
         try:
@@ -97,9 +96,7 @@ class TestErrorInjection:
         # set max_attempts=1 to speed up the test execution
         dynamodb = aws_stack.connect_to_resource("dynamodb", config=self.retry_config())
         table_name = f"table-{short_uid()}"
-        localstack.utils.aws.resources.create_dynamodb_table(
-            table_name, partition_key=PARTITION_KEY
-        )
+        resources.create_dynamodb_table(table_name, partition_key=PARTITION_KEY)
         return dynamodb.Table(table_name)
 
     def retry_config(self):

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Tuple
 import pytest
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
@@ -336,7 +337,7 @@ class TestEvents:
         topic_arn = sns_client.create_topic(Name=topic_name)["TopicArn"]
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
 
         sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
 
@@ -530,7 +531,7 @@ class TestEvents:
         endpoint = "{}://{}:{}".format(
             get_service_protocol(), config.LOCALSTACK_HOSTNAME, local_port
         )
-        sm_role_arn = aws_stack.role_arn("sfn_role")
+        sm_role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
         sm_name = "state-machine-{}".format(short_uid())
         topic_target_id = "target-{}".format(short_uid())
         sm_target_id = "target-{}".format(short_uid())
@@ -563,8 +564,8 @@ class TestEvents:
             QueueName=fifo_queue_name,
             Attributes={"FifoQueue": "true", "ContentBasedDeduplication": "true"},
         )["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
-        fifo_queue_arn = aws_stack.sqs_queue_arn(fifo_queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        fifo_queue_arn = localstack.utils.aws.arns.sqs_queue_arn(fifo_queue_name)
 
         event = {"env": "testing"}
 
@@ -847,8 +848,8 @@ class TestEvents:
         stream = firehose_client.create_delivery_stream(
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
-                "RoleARN": aws_stack.iam_resource_arn("firehose"),
-                "BucketARN": aws_stack.s3_bucket_arn(s3_bucket),
+                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
+                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(s3_bucket),
                 "Prefix": s3_prefix,
             },
         )
@@ -907,7 +908,7 @@ class TestEvents:
 
         sqs_client = aws_stack.create_external_boto_client("sqs", region_name="eu-west-1")
         sqs_client.create_queue(QueueName=queue_name)
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
 
         events_client.create_event_bus(Name=bus_name)
 
@@ -942,7 +943,7 @@ class TestEvents:
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
         stream_name = "stream-{}".format(short_uid())
-        stream_arn = aws_stack.kinesis_stream_arn(stream_name)
+        stream_arn = localstack.utils.aws.arns.kinesis_stream_arn(stream_name)
 
         kinesis_client.create_stream(StreamName=stream_name, ShardCount=1)
 
@@ -1014,7 +1015,7 @@ class TestEvents:
         bus_name = f"bus-{short_uid()}"
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
 
         events_client.create_event_bus(Name=bus_name)
         events_client.put_rule(
@@ -1073,10 +1074,10 @@ class TestEvents:
         bus_name = "bus-{}".format(short_uid())
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
 
         queue_url_1 = sqs_client.create_queue(QueueName=queue_name_1)["QueueUrl"]
-        queue_arn_1 = aws_stack.sqs_queue_arn(queue_name_1)
+        queue_arn_1 = localstack.utils.aws.arns.sqs_queue_arn(queue_name_1)
 
         events_client.create_event_bus(Name=bus_name)
 
@@ -1163,7 +1164,7 @@ class TestEvents:
         # create queue
         queue_name = "queue-{}".format(short_uid())
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
 
         # put rule listening on SSM changes
         ssm_prefix = "/test/local/"
@@ -1211,7 +1212,7 @@ class TestEvents:
         target_id = f"target-{short_uid()}"
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = aws_stack.sqs_queue_arn(queue_name)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
 
         pattern = {
             "Source": [{"exists": True}],

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -10,6 +10,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 import localstack.utils.aws.arns
+import localstack.utils.aws.resources
 from localstack import config
 from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
@@ -842,7 +843,7 @@ class TestEvents:
         bus_name = "bus-{}".format(short_uid())
 
         # create firehose target bucket
-        aws_stack.get_or_create_bucket(s3_bucket)
+        localstack.utils.aws.resources.get_or_create_bucket(s3_bucket)
 
         # create firehose delivery stream to s3
         stream = firehose_client.create_delivery_stream(

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Tuple
 import pytest
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.resources
 from localstack import config
 from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
@@ -17,7 +16,7 @@ from localstack.services.events.provider import _get_events_tmp_dir
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.common import (
     get_free_tcp_port,
@@ -842,7 +841,7 @@ class TestEvents:
         bus_name = "bus-{}".format(short_uid())
 
         # create firehose target bucket
-        localstack.utils.aws.resources.get_or_create_bucket(s3_bucket)
+        resources.get_or_create_bucket(s3_bucket)
 
         # create firehose delivery stream to s3
         stream = firehose_client.create_delivery_stream(

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Tuple
 import pytest
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.resources
 from localstack import config
 from localstack.services.apigateway.helpers import extract_query_string_params
@@ -18,7 +17,7 @@ from localstack.services.events.provider import _get_events_tmp_dir
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.common import (
     get_free_tcp_port,
@@ -338,7 +337,7 @@ class TestEvents:
         topic_arn = sns_client.create_topic(Name=topic_name)["TopicArn"]
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
 
         sns_subscription(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
 
@@ -532,7 +531,7 @@ class TestEvents:
         endpoint = "{}://{}:{}".format(
             get_service_protocol(), config.LOCALSTACK_HOSTNAME, local_port
         )
-        sm_role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        sm_role_arn = arns.role_arn("sfn_role")
         sm_name = "state-machine-{}".format(short_uid())
         topic_target_id = "target-{}".format(short_uid())
         sm_target_id = "target-{}".format(short_uid())
@@ -565,8 +564,8 @@ class TestEvents:
             QueueName=fifo_queue_name,
             Attributes={"FifoQueue": "true", "ContentBasedDeduplication": "true"},
         )["QueueUrl"]
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
-        fifo_queue_arn = localstack.utils.aws.arns.sqs_queue_arn(fifo_queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
+        fifo_queue_arn = arns.sqs_queue_arn(fifo_queue_name)
 
         event = {"env": "testing"}
 
@@ -849,8 +848,8 @@ class TestEvents:
         stream = firehose_client.create_delivery_stream(
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
-                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
-                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(s3_bucket),
+                "RoleARN": arns.iam_resource_arn("firehose"),
+                "BucketARN": arns.s3_bucket_arn(s3_bucket),
                 "Prefix": s3_prefix,
             },
         )
@@ -909,7 +908,7 @@ class TestEvents:
 
         sqs_client = aws_stack.create_external_boto_client("sqs", region_name="eu-west-1")
         sqs_client.create_queue(QueueName=queue_name)
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
 
         events_client.create_event_bus(Name=bus_name)
 
@@ -944,7 +943,7 @@ class TestEvents:
         target_id = "target-{}".format(short_uid())
         bus_name = "bus-{}".format(short_uid())
         stream_name = "stream-{}".format(short_uid())
-        stream_arn = localstack.utils.aws.arns.kinesis_stream_arn(stream_name)
+        stream_arn = arns.kinesis_stream_arn(stream_name)
 
         kinesis_client.create_stream(StreamName=stream_name, ShardCount=1)
 
@@ -1016,7 +1015,7 @@ class TestEvents:
         bus_name = f"bus-{short_uid()}"
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
 
         events_client.create_event_bus(Name=bus_name)
         events_client.put_rule(
@@ -1075,10 +1074,10 @@ class TestEvents:
         bus_name = "bus-{}".format(short_uid())
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
 
         queue_url_1 = sqs_client.create_queue(QueueName=queue_name_1)["QueueUrl"]
-        queue_arn_1 = localstack.utils.aws.arns.sqs_queue_arn(queue_name_1)
+        queue_arn_1 = arns.sqs_queue_arn(queue_name_1)
 
         events_client.create_event_bus(Name=bus_name)
 
@@ -1165,7 +1164,7 @@ class TestEvents:
         # create queue
         queue_name = "queue-{}".format(short_uid())
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
 
         # put rule listening on SSM changes
         ssm_prefix = "/test/local/"
@@ -1213,7 +1212,7 @@ class TestEvents:
         target_id = f"target-{short_uid()}"
 
         queue_url = sqs_client.create_queue(QueueName=queue_name)["QueueUrl"]
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name)
+        queue_arn = arns.sqs_queue_arn(queue_name)
 
         pattern = {
             "Source": [{"exists": True}],

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -4,12 +4,11 @@ import json
 import pytest as pytest
 import requests
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import lambda_function_arn
 from localstack.utils.common import (
     get_free_tcp_port,
@@ -170,7 +169,7 @@ class TestFirehoseIntegration:
             es_arn = es_create_response["DomainStatus"]["ARN"]
 
             # create s3 backup bucket arn
-            bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(s3_bucket)
+            bucket_arn = arns.s3_bucket_arn(s3_bucket)
 
             # create kinesis stream
             kinesis_create_stream(StreamName=stream_name, ShardCount=2)
@@ -282,7 +281,7 @@ class TestFirehoseIntegration:
             opensearch_arn = opensearch_create_response["DomainStatus"]["ARN"]
 
             # create s3 backup bucket arn
-            bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(s3_bucket)
+            bucket_arn = arns.s3_bucket_arn(s3_bucket)
 
             # create kinesis stream
             kinesis_create_stream(StreamName=stream_name, ShardCount=2)
@@ -383,7 +382,7 @@ class TestFirehoseIntegration:
         cleanups,
     ):
 
-        bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(s3_bucket)
+        bucket_arn = arns.s3_bucket_arn(s3_bucket)
         stream_name = f"test-stream-{short_uid()}"
         log_group_name = f"group{short_uid()}"
         role_arn = "arn:aws:iam::000000000000:role/Firehose-Role"

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -4,12 +4,13 @@ import json
 import pytest as pytest
 import requests
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import lambda_function_arn
+from localstack.utils.aws.arns import lambda_function_arn
 from localstack.utils.common import (
     get_free_tcp_port,
     get_service_protocol,
@@ -169,7 +170,7 @@ class TestFirehoseIntegration:
             es_arn = es_create_response["DomainStatus"]["ARN"]
 
             # create s3 backup bucket arn
-            bucket_arn = aws_stack.s3_bucket_arn(s3_bucket)
+            bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(s3_bucket)
 
             # create kinesis stream
             kinesis_create_stream(StreamName=stream_name, ShardCount=2)
@@ -281,7 +282,7 @@ class TestFirehoseIntegration:
             opensearch_arn = opensearch_create_response["DomainStatus"]["ARN"]
 
             # create s3 backup bucket arn
-            bucket_arn = aws_stack.s3_bucket_arn(s3_bucket)
+            bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(s3_bucket)
 
             # create kinesis stream
             kinesis_create_stream(StreamName=stream_name, ShardCount=2)
@@ -382,7 +383,7 @@ class TestFirehoseIntegration:
         cleanups,
     ):
 
-        bucket_arn = aws_stack.s3_bucket_arn(s3_bucket)
+        bucket_arn = localstack.utils.aws.arns.s3_bucket_arn(s3_bucket)
         stream_name = f"test-stream-{short_uid()}"
         log_group_name = f"group{short_uid()}"
         role_arn = "arn:aws:iam::000000000000:role/Firehose-Role"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,10 +9,9 @@ from datetime import datetime, timedelta
 
 import pytest
 
-import localstack.utils.aws.arns
 from localstack.testing.aws.util import get_lambda_logs
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import (
     clone,
     load_file,
@@ -91,8 +90,8 @@ class TestIntegration:
         stream = firehose_create_delivery_stream(
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
-                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
-                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(bucket_name),
+                "RoleARN": arns.iam_resource_arn("firehose"),
+                "BucketARN": arns.s3_bucket_arn(bucket_name),
                 "Prefix": s3_prefix,
             },
             Tags=TEST_TAGS,
@@ -128,8 +127,8 @@ class TestIntegration:
         stream = firehose_create_delivery_stream(
             DeliveryStreamName=stream_name,
             ExtendedS3DestinationConfiguration={
-                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
-                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(bucket_name),
+                "RoleARN": arns.iam_resource_arn("firehose"),
+                "BucketARN": arns.s3_bucket_arn(bucket_name),
                 "Prefix": s3_prefix,
             },
             Tags=TEST_TAGS,
@@ -166,15 +165,13 @@ class TestIntegration:
         stream = firehose_client.create_delivery_stream(
             DeliveryStreamType="KinesisStreamAsSource",
             KinesisStreamSourceConfiguration={
-                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
-                "KinesisStreamARN": localstack.utils.aws.arns.kinesis_stream_arn(
-                    kinesis_stream_name
-                ),
+                "RoleARN": arns.iam_resource_arn("firehose"),
+                "KinesisStreamARN": arns.kinesis_stream_arn(kinesis_stream_name),
             },
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
-                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
-                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(TEST_BUCKET_NAME),
+                "RoleARN": arns.iam_resource_arn("firehose"),
+                "BucketARN": arns.s3_bucket_arn(TEST_BUCKET_NAME),
                 "Prefix": s3_prefix,
             },
         )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
+import localstack.utils.aws.arns
 from localstack.testing.aws.util import get_lambda_logs
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -90,8 +91,8 @@ class TestIntegration:
         stream = firehose_create_delivery_stream(
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
-                "RoleARN": aws_stack.iam_resource_arn("firehose"),
-                "BucketARN": aws_stack.s3_bucket_arn(bucket_name),
+                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
+                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(bucket_name),
                 "Prefix": s3_prefix,
             },
             Tags=TEST_TAGS,
@@ -127,8 +128,8 @@ class TestIntegration:
         stream = firehose_create_delivery_stream(
             DeliveryStreamName=stream_name,
             ExtendedS3DestinationConfiguration={
-                "RoleARN": aws_stack.iam_resource_arn("firehose"),
-                "BucketARN": aws_stack.s3_bucket_arn(bucket_name),
+                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
+                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(bucket_name),
                 "Prefix": s3_prefix,
             },
             Tags=TEST_TAGS,
@@ -165,13 +166,15 @@ class TestIntegration:
         stream = firehose_client.create_delivery_stream(
             DeliveryStreamType="KinesisStreamAsSource",
             KinesisStreamSourceConfiguration={
-                "RoleARN": aws_stack.iam_resource_arn("firehose"),
-                "KinesisStreamARN": aws_stack.kinesis_stream_arn(kinesis_stream_name),
+                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
+                "KinesisStreamARN": localstack.utils.aws.arns.kinesis_stream_arn(
+                    kinesis_stream_name
+                ),
             },
             DeliveryStreamName=stream_name,
             S3DestinationConfiguration={
-                "RoleARN": aws_stack.iam_resource_arn("firehose"),
-                "BucketARN": aws_stack.s3_bucket_arn(TEST_BUCKET_NAME),
+                "RoleARN": localstack.utils.aws.arns.iam_resource_arn("firehose"),
+                "BucketARN": localstack.utils.aws.arns.s3_bucket_arn(TEST_BUCKET_NAME),
                 "Prefix": s3_prefix,
             },
         )

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -8,6 +8,7 @@ import requests
 from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.resources
 from localstack import config, constants
 from localstack.services.kinesis import provider as kinesis_provider
 from localstack.utils.aws import aws_stack
@@ -425,7 +426,7 @@ class TestKinesisPythonClient:
 
         # start Kinesis client
         stream_name = f"test-foobar-{short_uid()}"
-        aws_stack.create_kinesis_stream(stream_name, delete=True)
+        localstack.utils.aws.resources.create_kinesis_stream(stream_name, delete=True)
         process = kinesis_connector.listen_to_kinesis(
             stream_name=stream_name,
             listener_func=process_records,

--- a/tests/integration/test_kinesis.py
+++ b/tests/integration/test_kinesis.py
@@ -8,10 +8,9 @@ import requests
 from botocore.config import Config as BotoConfig
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.resources
 from localstack import config, constants
 from localstack.services.kinesis import provider as kinesis_provider
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import aws_stack, resources
 from localstack.utils.common import poll_condition, retry, select_attributes, short_uid
 from localstack.utils.kinesis import kinesis_connector
 
@@ -426,7 +425,7 @@ class TestKinesisPythonClient:
 
         # start Kinesis client
         stream_name = f"test-foobar-{short_uid()}"
-        localstack.utils.aws.resources.create_kinesis_stream(stream_name, delete=True)
+        resources.create_kinesis_stream(stream_name, delete=True)
         process = kinesis_connector.listen_to_kinesis(
             stream_name=stream_name,
             listener_func=process_records,

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -5,12 +5,12 @@ import re
 
 import pytest
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import APPLICATION_AMZ_JSON_1_1
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
 from localstack.utils.common import now_utc, poll_condition, retry, short_uid
 
 from .awslambda.test_lambda import TEST_LAMBDA_LIBS, TEST_LAMBDA_PYTHON_ECHO
@@ -217,7 +217,7 @@ class TestCloudWatchLogs:
             logGroupName=logs_log_group,
             filterName="test",
             filterPattern="",
-            destinationArn=aws_stack.lambda_function_arn(
+            destinationArn=localstack.utils.aws.arns.lambda_function_arn(
                 test_lambda_name, account_id=account_id, region_name=config.DEFAULT_REGION
             ),
         )

--- a/tests/integration/test_logs.py
+++ b/tests/integration/test_logs.py
@@ -5,12 +5,12 @@ import re
 
 import pytest
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import APPLICATION_AMZ_JSON_1_1
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON36
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.utils import testutil
+from localstack.utils.aws import arns
 from localstack.utils.common import now_utc, poll_condition, retry, short_uid
 
 from .awslambda.test_lambda import TEST_LAMBDA_LIBS, TEST_LAMBDA_PYTHON_ECHO
@@ -217,7 +217,7 @@ class TestCloudWatchLogs:
             logGroupName=logs_log_group,
             filterName="test",
             filterPattern="",
-            destinationArn=localstack.utils.aws.arns.lambda_function_arn(
+            destinationArn=arns.lambda_function_arn(
                 test_lambda_name, account_id=account_id, region_name=config.DEFAULT_REGION
             ),
         )

--- a/tests/integration/test_multiregion.py
+++ b/tests/integration/test_multiregion.py
@@ -4,12 +4,11 @@ import unittest
 
 import requests
 
-import localstack.utils.aws.arns
 import localstack.utils.aws.queries
 from localstack import config
 from localstack.constants import PATH_USER_REQUEST
 from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import short_uid, to_str
 
 REGION1 = "us-east-1"
@@ -62,7 +61,7 @@ class TestMultiRegion(unittest.TestCase):
         api_name3 = "a-%s" % short_uid()
         queue_name1 = "q-%s" % short_uid()
         sqs_1.create_queue(QueueName=queue_name1)
-        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name1, region_name=REGION1)
+        queue_arn = arns.sqs_queue_arn(queue_name1, region_name=REGION1)
         result = connect_api_gateway_to_sqs(
             api_name3, stage_name="test", queue_arn=queue_arn, path="/data", region_name=REGION3
         )

--- a/tests/integration/test_multiregion.py
+++ b/tests/integration/test_multiregion.py
@@ -4,11 +4,10 @@ import unittest
 
 import requests
 
-import localstack.utils.aws.queries
 from localstack import config
 from localstack.constants import PATH_USER_REQUEST
 from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import arns, aws_stack, queries
 from localstack.utils.common import short_uid, to_str
 
 REGION1 = "us-east-1"
@@ -74,7 +73,7 @@ class TestMultiRegion(unittest.TestCase):
         test_data = {"foo": "bar"}
         result = requests.post(url, data=json.dumps(test_data))
         self.assertEqual(result.status_code, 200)
-        messages = localstack.utils.aws.queries.sqs_receive_message(queue_arn)["Messages"]
+        messages = queries.sqs_receive_message(queue_arn)["Messages"]
         self.assertEqual(len(messages), 1)
         self.assertEqual(
             json.loads(to_str(base64.b64decode(to_str(messages[0]["Body"])))), test_data

--- a/tests/integration/test_multiregion.py
+++ b/tests/integration/test_multiregion.py
@@ -5,6 +5,7 @@ import unittest
 import requests
 
 import localstack.utils.aws.arns
+import localstack.utils.aws.queries
 from localstack import config
 from localstack.constants import PATH_USER_REQUEST
 from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs
@@ -74,7 +75,7 @@ class TestMultiRegion(unittest.TestCase):
         test_data = {"foo": "bar"}
         result = requests.post(url, data=json.dumps(test_data))
         self.assertEqual(result.status_code, 200)
-        messages = aws_stack.sqs_receive_message(queue_arn)["Messages"]
+        messages = localstack.utils.aws.queries.sqs_receive_message(queue_arn)["Messages"]
         self.assertEqual(len(messages), 1)
         self.assertEqual(
             json.loads(to_str(base64.b64decode(to_str(messages[0]["Body"])))), test_data

--- a/tests/integration/test_multiregion.py
+++ b/tests/integration/test_multiregion.py
@@ -4,6 +4,7 @@ import unittest
 
 import requests
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.constants import PATH_USER_REQUEST
 from localstack.services.apigateway.helpers import connect_api_gateway_to_sqs
@@ -60,7 +61,7 @@ class TestMultiRegion(unittest.TestCase):
         api_name3 = "a-%s" % short_uid()
         queue_name1 = "q-%s" % short_uid()
         sqs_1.create_queue(QueueName=queue_name1)
-        queue_arn = aws_stack.sqs_queue_arn(queue_name1, region_name=REGION1)
+        queue_arn = localstack.utils.aws.arns.sqs_queue_arn(queue_name1, region_name=REGION1)
         result = connect_api_gateway_to_sqs(
             api_name3, stage_name="test", queue_arn=queue_arn, path="/data", region_name=REGION3
         )

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -4,8 +4,7 @@ import unittest
 
 import pytest
 
-import localstack.utils.aws.arns
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import retry, run
 from localstack.utils.testutil import get_lambda_log_events
 
@@ -118,9 +117,9 @@ class TestServerless(unittest.TestCase):
         self.assertEqual(1, len(events))
         event_source_arn = events[0]["EventSourceArn"]
 
-        self.assertEqual(event_source_arn, localstack.utils.aws.arns.sqs_queue_arn(queue_name))
+        self.assertEqual(event_source_arn, arns.sqs_queue_arn(queue_name))
         result = sqs_client.get_queue_attributes(
-            QueueUrl=localstack.utils.aws.arns.get_sqs_queue_url(queue_name),
+            QueueUrl=arns.get_sqs_queue_url(queue_name),
             AttributeNames=[
                 "RedrivePolicy",
             ],
@@ -169,7 +168,7 @@ class TestServerless(unittest.TestCase):
             self.assertIn(method, proxy_resource["resourceMethods"])
             resource_method = proxy_resource["resourceMethods"][method]
             self.assertIn(
-                localstack.utils.aws.arns.lambda_function_arn(function_name),
+                arns.lambda_function_arn(function_name),
                 resource_method["methodIntegration"]["uri"],
             )
 

--- a/tests/integration/test_serverless.py
+++ b/tests/integration/test_serverless.py
@@ -4,6 +4,7 @@ import unittest
 
 import pytest
 
+import localstack.utils.aws.arns
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import retry, run
 from localstack.utils.testutil import get_lambda_log_events
@@ -117,9 +118,9 @@ class TestServerless(unittest.TestCase):
         self.assertEqual(1, len(events))
         event_source_arn = events[0]["EventSourceArn"]
 
-        self.assertEqual(event_source_arn, aws_stack.sqs_queue_arn(queue_name))
+        self.assertEqual(event_source_arn, localstack.utils.aws.arns.sqs_queue_arn(queue_name))
         result = sqs_client.get_queue_attributes(
-            QueueUrl=aws_stack.get_sqs_queue_url(queue_name),
+            QueueUrl=localstack.utils.aws.arns.get_sqs_queue_url(queue_name),
             AttributeNames=[
                 "RedrivePolicy",
             ],
@@ -168,7 +169,7 @@ class TestServerless(unittest.TestCase):
             self.assertIn(method, proxy_resource["resourceMethods"])
             resource_method = proxy_resource["resourceMethods"][method]
             self.assertIn(
-                aws_stack.lambda_function_arn(function_name),
+                localstack.utils.aws.arns.lambda_function_arn(function_name),
                 resource_method["methodIntegration"]["uri"],
             )
 

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -9,14 +9,13 @@ import pytest
 import requests
 from botocore.exceptions import ClientError
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
 from localstack.services.sqs.constants import DEFAULT_MAXIMUM_MESSAGE_SIZE
 from localstack.services.sqs.models import sqs_stores
 from localstack.testing.snapshots.transformer import GenericTransformer
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.common import poll_condition, retry, short_uid, to_str
 
 from .awslambda.functions import lambda_integration
@@ -1758,9 +1757,7 @@ class TestSqsProvider:
 
         # create arn
         url_parts = dl_queue_url.split("/")
-        dl_target_arn = localstack.utils.aws.arns.sqs_queue_arn(
-            url_parts[-1], account_id=url_parts[len(url_parts) - 2]
-        )
+        dl_target_arn = arns.sqs_queue_arn(url_parts[-1], account_id=url_parts[len(url_parts) - 2])
 
         policy = {"deadLetterTargetArn": dl_target_arn, "maxReceiveCount": 1}
         queue_url = sqs_create_queue(
@@ -1789,16 +1786,12 @@ class TestSqsProvider:
         queue_names = [f"q-{short_uid()}", f"q-{short_uid()}", f"q-{short_uid()}"]
         for queue_name in queue_names:
             sqs_create_queue(QueueName=queue_name, Attributes={"VisibilityTimeout": "0"})
-        queue_urls = [
-            localstack.utils.aws.arns.get_sqs_queue_url(queue_name) for queue_name in queue_names
-        ]
+        queue_urls = [arns.get_sqs_queue_url(queue_name) for queue_name in queue_names]
 
         # set redrive policies
         for idx, queue_name in enumerate(queue_names[:2]):
             policy = {
-                "deadLetterTargetArn": localstack.utils.aws.arns.sqs_queue_arn(
-                    queue_names[idx + 1]
-                ),
+                "deadLetterTargetArn": arns.sqs_queue_arn(queue_names[idx + 1]),
                 "maxReceiveCount": 1,
             }
             sqs_client.set_queue_attributes(

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 from botocore.exceptions import ClientError
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.lambda_ import Runtime
@@ -1757,7 +1758,7 @@ class TestSqsProvider:
 
         # create arn
         url_parts = dl_queue_url.split("/")
-        dl_target_arn = aws_stack.sqs_queue_arn(
+        dl_target_arn = localstack.utils.aws.arns.sqs_queue_arn(
             url_parts[-1], account_id=url_parts[len(url_parts) - 2]
         )
 
@@ -1788,12 +1789,16 @@ class TestSqsProvider:
         queue_names = [f"q-{short_uid()}", f"q-{short_uid()}", f"q-{short_uid()}"]
         for queue_name in queue_names:
             sqs_create_queue(QueueName=queue_name, Attributes={"VisibilityTimeout": "0"})
-        queue_urls = [aws_stack.get_sqs_queue_url(queue_name) for queue_name in queue_names]
+        queue_urls = [
+            localstack.utils.aws.arns.get_sqs_queue_url(queue_name) for queue_name in queue_names
+        ]
 
         # set redrive policies
         for idx, queue_name in enumerate(queue_names[:2]):
             policy = {
-                "deadLetterTargetArn": aws_stack.sqs_queue_arn(queue_names[idx + 1]),
+                "deadLetterTargetArn": localstack.utils.aws.arns.sqs_queue_arn(
+                    queue_names[idx + 1]
+                ),
                 "maxReceiveCount": 1,
             }
             sqs_client.set_queue_attributes(

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -4,10 +4,9 @@ import os
 
 import pytest
 
-import localstack.utils.aws.arns
 from localstack.services.events.provider import TEST_EVENTS_CACHE
 from localstack.utils import testutil
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.files import load_file
 from localstack.utils.json import clone
 from localstack.utils.strings import short_uid
@@ -266,10 +265,10 @@ def get_machine_arn(sm_name, sfn_client):
 class TestStateMachine:
     def test_create_choice_state_machine(self, stepfunctions_client):
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
 
         definition = clone(STATE_MACHINE_CHOICE)
-        lambda_arn_4 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_4)
+        lambda_arn_4 = arns.lambda_function_arn(TEST_LAMBDA_NAME_4)
         definition["States"]["Add"]["Resource"] = lambda_arn_4
         definition = json.dumps(definition)
         sm_name = f"choice-{short_uid()}"
@@ -307,9 +306,9 @@ class TestStateMachine:
         test_output = [{"Hello": name} for name in names]
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_MAP)
-        lambda_arn_3 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_3)
+        lambda_arn_3 = arns.lambda_function_arn(TEST_LAMBDA_NAME_3)
         definition["States"]["ExampleMapState"]["Iterator"]["States"]["CallLambda"][
             "Resource"
         ] = lambda_arn_3
@@ -344,10 +343,10 @@ class TestStateMachine:
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_BASIC)
-        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_1)
-        lambda_arn_2 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_2)
+        lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_1)
+        lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_2)
         definition["States"]["step1"]["Resource"] = lambda_arn_1
         definition["States"]["step2"]["Resource"] = lambda_arn_2
         definition = json.dumps(definition)
@@ -382,10 +381,10 @@ class TestStateMachine:
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_CATCH)
-        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_1)
-        lambda_arn_2 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_2)
+        lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_1)
+        lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_2)
         definition["States"]["Start"]["Parameters"]["FunctionName"] = lambda_arn_1
         definition["States"]["ErrorHandler"]["Resource"] = lambda_arn_2
         definition["States"]["Final"]["Resource"] = lambda_arn_2
@@ -418,10 +417,10 @@ class TestStateMachine:
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_INTRINSIC_FUNCS)
-        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_5)
-        lambda_arn_2 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_5)
+        lambda_arn_1 = arns.lambda_function_arn(TEST_LAMBDA_NAME_5)
+        lambda_arn_2 = arns.lambda_function_arn(TEST_LAMBDA_NAME_5)
         if isinstance(definition["States"]["state1"].get("Parameters"), dict):
             definition["States"]["state1"]["Parameters"]["lambda_params"][
                 "FunctionName"
@@ -465,7 +464,7 @@ class TestStateMachine:
         definition["States"]["step1"]["Parameters"]["Entries"][0]["EventBusName"] = bus_name
         definition = json.dumps(definition)
         sm_name = f"events-{short_uid()}"
-        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
+        role_arn = arns.role_arn("sfn_role")
         stepfunctions_client.create_state_machine(
             name=sm_name, definition=definition, roleArn=role_arn
         )
@@ -548,7 +547,7 @@ def test_multiregion_nested(region_name, statemachine_definition):
     client1 = aws_stack.create_external_boto_client("stepfunctions", region_name=region_name)
     # create state machine
     child_machine_name = f"sf-child-{short_uid()}"
-    role = localstack.utils.aws.arns.role_arn("sfn_role")
+    role = arns.role_arn("sfn_role")
     child_machine_result = client1.create_state_machine(
         name=child_machine_name, definition=json.dumps(TEST_STATE_MACHINE), roleArn=role
     )
@@ -556,7 +555,7 @@ def test_multiregion_nested(region_name, statemachine_definition):
 
     # create parent state machine
     name = f"sf-parent-{short_uid()}"
-    role = localstack.utils.aws.arns.role_arn("sfn_role")
+    role = arns.role_arn("sfn_role")
     result = client1.create_state_machine(
         name=name,
         definition=json.dumps(statemachine_definition).replace(

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+import localstack.utils.aws.arns
 from localstack.services.events.provider import TEST_EVENTS_CACHE
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -265,10 +266,10 @@ def get_machine_arn(sm_name, sfn_client):
 class TestStateMachine:
     def test_create_choice_state_machine(self, stepfunctions_client):
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
 
         definition = clone(STATE_MACHINE_CHOICE)
-        lambda_arn_4 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_4)
+        lambda_arn_4 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_4)
         definition["States"]["Add"]["Resource"] = lambda_arn_4
         definition = json.dumps(definition)
         sm_name = f"choice-{short_uid()}"
@@ -306,9 +307,9 @@ class TestStateMachine:
         test_output = [{"Hello": name} for name in names]
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_MAP)
-        lambda_arn_3 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_3)
+        lambda_arn_3 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_3)
         definition["States"]["ExampleMapState"]["Iterator"]["States"]["CallLambda"][
             "Resource"
         ] = lambda_arn_3
@@ -343,10 +344,10 @@ class TestStateMachine:
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_BASIC)
-        lambda_arn_1 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_1)
-        lambda_arn_2 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_2)
+        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_1)
+        lambda_arn_2 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_2)
         definition["States"]["step1"]["Resource"] = lambda_arn_1
         definition["States"]["step2"]["Resource"] = lambda_arn_2
         definition = json.dumps(definition)
@@ -381,10 +382,10 @@ class TestStateMachine:
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_CATCH)
-        lambda_arn_1 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_1)
-        lambda_arn_2 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_2)
+        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_1)
+        lambda_arn_2 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_2)
         definition["States"]["Start"]["Parameters"]["FunctionName"] = lambda_arn_1
         definition["States"]["ErrorHandler"]["Resource"] = lambda_arn_2
         definition["States"]["Final"]["Resource"] = lambda_arn_2
@@ -417,10 +418,10 @@ class TestStateMachine:
         state_machines_before = stepfunctions_client.list_state_machines()["stateMachines"]
 
         # create state machine
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
         definition = clone(STATE_MACHINE_INTRINSIC_FUNCS)
-        lambda_arn_1 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_5)
-        lambda_arn_2 = aws_stack.lambda_function_arn(TEST_LAMBDA_NAME_5)
+        lambda_arn_1 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_5)
+        lambda_arn_2 = localstack.utils.aws.arns.lambda_function_arn(TEST_LAMBDA_NAME_5)
         if isinstance(definition["States"]["state1"].get("Parameters"), dict):
             definition["States"]["state1"]["Parameters"]["lambda_params"][
                 "FunctionName"
@@ -464,7 +465,7 @@ class TestStateMachine:
         definition["States"]["step1"]["Parameters"]["Entries"][0]["EventBusName"] = bus_name
         definition = json.dumps(definition)
         sm_name = f"events-{short_uid()}"
-        role_arn = aws_stack.role_arn("sfn_role")
+        role_arn = localstack.utils.aws.arns.role_arn("sfn_role")
         stepfunctions_client.create_state_machine(
             name=sm_name, definition=definition, roleArn=role_arn
         )
@@ -547,7 +548,7 @@ def test_multiregion_nested(region_name, statemachine_definition):
     client1 = aws_stack.create_external_boto_client("stepfunctions", region_name=region_name)
     # create state machine
     child_machine_name = f"sf-child-{short_uid()}"
-    role = aws_stack.role_arn("sfn_role")
+    role = localstack.utils.aws.arns.role_arn("sfn_role")
     child_machine_result = client1.create_state_machine(
         name=child_machine_name, definition=json.dumps(TEST_STATE_MACHINE), roleArn=role
     )
@@ -555,7 +556,7 @@ def test_multiregion_nested(region_name, statemachine_definition):
 
     # create parent state machine
     name = f"sf-parent-{short_uid()}"
-    role = aws_stack.role_arn("sfn_role")
+    role = localstack.utils.aws.arns.role_arn("sfn_role")
     result = client1.create_state_machine(
         name=name,
         definition=json.dumps(statemachine_definition).replace(

--- a/tests/performance/test_sqs_performance.py
+++ b/tests/performance/test_sqs_performance.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-from localstack.utils.aws.aws_stack import create_external_boto_client, get_sqs_queue_url
+from localstack.utils.aws.arns import get_sqs_queue_url
+from localstack.utils.aws.aws_stack import create_external_boto_client
 
 QUEUE_NAME = "test-perf-3610"
 NUM_MESSAGES = 300

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -6,6 +6,7 @@ import time
 import unittest
 from unittest import mock
 
+import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.awslambda import lambda_api, lambda_executors, lambda_utils
@@ -72,7 +73,7 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(lambda_api.get_function("myFunction").get_data())
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                aws_stack.lambda_function_arn("myFunction"),
+                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
             )
 
     def test_get_function_two_functions_with_similar_names_match_by_name(self):
@@ -82,11 +83,12 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(lambda_api.get_function("myFunction").get_data())
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                aws_stack.lambda_function_arn("myFunction"),
+                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
             )
             result = json.loads(lambda_api.get_function("myFunctions").get_data())
             self.assertEqual(
-                result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunctions")
+                result["Configuration"]["FunctionArn"],
+                localstack.utils.aws.arns.lambda_function_arn("myFunctions"),
             )
 
     def test_get_function_two_functions_with_similar_names_match_by_arn(self):
@@ -94,16 +96,22 @@ class TestLambdaAPI(unittest.TestCase):
             self._create_function("myFunctions")
             self._create_function("myFunction")
             result = json.loads(
-                lambda_api.get_function(aws_stack.lambda_function_arn("myFunction")).get_data()
+                lambda_api.get_function(
+                    localstack.utils.aws.arns.lambda_function_arn("myFunction")
+                ).get_data()
             )
             self.assertEqual(
-                result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunction")
+                result["Configuration"]["FunctionArn"],
+                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
             )
             result = json.loads(
-                lambda_api.get_function(aws_stack.lambda_function_arn("myFunctions")).get_data()
+                lambda_api.get_function(
+                    localstack.utils.aws.arns.lambda_function_arn("myFunctions")
+                ).get_data()
             )
             self.assertEqual(
-                result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunctions")
+                result["Configuration"]["FunctionArn"],
+                localstack.utils.aws.arns.lambda_function_arn("myFunctions"),
             )
 
     def test_get_function_two_functions_with_similar_names_match_by_partial_arn(self):
@@ -116,7 +124,8 @@ class TestLambdaAPI(unittest.TestCase):
                 ).get_data()
             )
             self.assertEqual(
-                result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunction")
+                result["Configuration"]["FunctionArn"],
+                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
             )
             result = json.loads(
                 lambda_api.get_function(
@@ -124,7 +133,8 @@ class TestLambdaAPI(unittest.TestCase):
                 ).get_data()
             )
             self.assertEqual(
-                result["Configuration"]["FunctionArn"], aws_stack.lambda_function_arn("myFunctions")
+                result["Configuration"]["FunctionArn"],
+                localstack.utils.aws.arns.lambda_function_arn("myFunctions"),
             )
 
     def test_get_event_source_mapping(self):
@@ -766,7 +776,9 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_get_container_name(self):
         executor = lambda_executors.EXECUTOR_CONTAINERS_REUSE
-        name = executor.get_container_name(aws_stack.lambda_function_arn("my_function_name"))
+        name = executor.get_container_name(
+            localstack.utils.aws.arns.lambda_function_arn("my_function_name")
+        )
         self.assertIn(
             f"_lambda_arn_aws_lambda_{aws_stack.get_region()}_{get_aws_account_id()}_function_my_function_name",
             name,
@@ -1153,9 +1165,13 @@ class TestLambdaStore:
 
         for region in ["us-east-1", "us-east-1", "eu-central-1"]:
             # check lookup for function ARNs
-            _lookup(aws_stack.lambda_function_arn("myfunc", region_name=region), region)
+            _lookup(
+                localstack.utils.aws.arns.lambda_function_arn("myfunc", region_name=region), region
+            )
             # check lookup for layer ARNs
-            _lookup(aws_stack.lambda_layer_arn("mylayer", region_name=region), region)
+            _lookup(
+                localstack.utils.aws.arns.lambda_layer_arn("mylayer", region_name=region), region
+            )
 
 
 class TestLambdaUtils:

--- a/tests/unit/test_lambda.py
+++ b/tests/unit/test_lambda.py
@@ -6,7 +6,6 @@ import time
 import unittest
 from unittest import mock
 
-import localstack.utils.aws.arns
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.awslambda import lambda_api, lambda_executors, lambda_utils
@@ -17,7 +16,7 @@ from localstack.services.awslambda.lambda_utils import (
     get_awslambda_store,
     get_awslambda_store_for_arn,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.aws_models import LambdaFunction
 from localstack.utils.common import isoformat_milliseconds, mkdir, new_tmp_dir, save_file
 
@@ -73,7 +72,7 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(lambda_api.get_function("myFunction").get_data())
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
+                arns.lambda_function_arn("myFunction"),
             )
 
     def test_get_function_two_functions_with_similar_names_match_by_name(self):
@@ -83,12 +82,12 @@ class TestLambdaAPI(unittest.TestCase):
             result = json.loads(lambda_api.get_function("myFunction").get_data())
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
+                arns.lambda_function_arn("myFunction"),
             )
             result = json.loads(lambda_api.get_function("myFunctions").get_data())
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunctions"),
+                arns.lambda_function_arn("myFunctions"),
             )
 
     def test_get_function_two_functions_with_similar_names_match_by_arn(self):
@@ -96,22 +95,18 @@ class TestLambdaAPI(unittest.TestCase):
             self._create_function("myFunctions")
             self._create_function("myFunction")
             result = json.loads(
-                lambda_api.get_function(
-                    localstack.utils.aws.arns.lambda_function_arn("myFunction")
-                ).get_data()
+                lambda_api.get_function(arns.lambda_function_arn("myFunction")).get_data()
             )
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
+                arns.lambda_function_arn("myFunction"),
             )
             result = json.loads(
-                lambda_api.get_function(
-                    localstack.utils.aws.arns.lambda_function_arn("myFunctions")
-                ).get_data()
+                lambda_api.get_function(arns.lambda_function_arn("myFunctions")).get_data()
             )
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunctions"),
+                arns.lambda_function_arn("myFunctions"),
             )
 
     def test_get_function_two_functions_with_similar_names_match_by_partial_arn(self):
@@ -125,7 +120,7 @@ class TestLambdaAPI(unittest.TestCase):
             )
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunction"),
+                arns.lambda_function_arn("myFunction"),
             )
             result = json.loads(
                 lambda_api.get_function(
@@ -134,7 +129,7 @@ class TestLambdaAPI(unittest.TestCase):
             )
             self.assertEqual(
                 result["Configuration"]["FunctionArn"],
-                localstack.utils.aws.arns.lambda_function_arn("myFunctions"),
+                arns.lambda_function_arn("myFunctions"),
             )
 
     def test_get_event_source_mapping(self):
@@ -776,9 +771,7 @@ class TestLambdaAPI(unittest.TestCase):
 
     def test_get_container_name(self):
         executor = lambda_executors.EXECUTOR_CONTAINERS_REUSE
-        name = executor.get_container_name(
-            localstack.utils.aws.arns.lambda_function_arn("my_function_name")
-        )
+        name = executor.get_container_name(arns.lambda_function_arn("my_function_name"))
         self.assertIn(
             f"_lambda_arn_aws_lambda_{aws_stack.get_region()}_{get_aws_account_id()}_function_my_function_name",
             name,
@@ -1165,13 +1158,9 @@ class TestLambdaStore:
 
         for region in ["us-east-1", "us-east-1", "eu-central-1"]:
             # check lookup for function ARNs
-            _lookup(
-                localstack.utils.aws.arns.lambda_function_arn("myfunc", region_name=region), region
-            )
+            _lookup(arns.lambda_function_arn("myfunc", region_name=region), region)
             # check lookup for layer ARNs
-            _lookup(
-                localstack.utils.aws.arns.lambda_layer_arn("mylayer", region_name=region), region
-            )
+            _lookup(arns.lambda_layer_arn("mylayer", region_name=region), region)
 
 
 class TestLambdaUtils:

--- a/tests/unit/utils/aws/test_aws_stack.py
+++ b/tests/unit/utils/aws/test_aws_stack.py
@@ -2,24 +2,19 @@ import pytest
 from botocore.utils import InvalidArnException
 
 from localstack.utils.aws.arns import extract_region_from_arn, lambda_function_name, parse_arn
-from localstack.utils.aws.aws_stack import (
-    ENV_ACCESS_KEY,
-    ENV_SECRET_KEY,
-    inject_region_into_env,
-    inject_test_credentials_into_env,
-)
+from localstack.utils.aws.aws_stack import inject_region_into_env, inject_test_credentials_into_env
 
 
 def test_inject_test_credentials_into_env_already_with_none_adds_both():
     env = {}
     inject_test_credentials_into_env(env)
-    assert env.get(ENV_ACCESS_KEY) == "test"
-    assert env.get(ENV_SECRET_KEY) == "test"
+    assert env.get("AWS_ACCESS_KEY_ID") == "test"
+    assert env.get("AWS_SECRET_ACCESS_KEY") == "test"
 
 
 def test_inject_test_credentials_into_env_already_with_access_key_does_nothing():
     access_key = "an-access-key"
-    expected_env = {ENV_ACCESS_KEY: access_key}
+    expected_env = {"AWS_ACCESS_KEY_ID": access_key}
     env = expected_env.copy()
     inject_test_credentials_into_env(env)
     assert env == expected_env
@@ -27,7 +22,7 @@ def test_inject_test_credentials_into_env_already_with_access_key_does_nothing()
 
 def test_inject_test_credentials_into_env_already_with_secret_key_does_nothing():
     secret_key = "a-secret-key"
-    expected_env = {ENV_SECRET_KEY: secret_key}
+    expected_env = {"AWS_SECRET_ACCESS_KEY": secret_key}
     env = expected_env.copy()
     inject_test_credentials_into_env(env)
     assert env == expected_env

--- a/tests/unit/utils/aws/test_aws_stack.py
+++ b/tests/unit/utils/aws/test_aws_stack.py
@@ -1,14 +1,12 @@
 import pytest
 from botocore.utils import InvalidArnException
 
+from localstack.utils.aws.arns import extract_region_from_arn, lambda_function_name, parse_arn
 from localstack.utils.aws.aws_stack import (
     ENV_ACCESS_KEY,
     ENV_SECRET_KEY,
-    extract_region_from_arn,
     inject_region_into_env,
     inject_test_credentials_into_env,
-    lambda_function_name,
-    parse_arn,
 )
 
 


### PR DESCRIPTION
Preliminary cleanup of `aws_stack.py` to split up the file. Will avoid some headaches later when we work on this in parallel.


- move arn utils to separate file
- remove unnecessary utils and replace with more idiomatic versions