### PR TITLE
Improve support for ApiGW to StepFunctions service integration

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -461,7 +461,7 @@ class StepFunctionIntegration(BackendIntegration):
         )
         action = uri.split("/")[-1]
 
-        if invocation_context.integration.get("type") == "AWS_PROXY":
+        if invocation_context.integration.get("IntegrationType") == "AWS_PROXY":
             payload = self._create_request_parameters(invocation_context)
         elif APPLICATION_JSON in invocation_context.integration.get("requestTemplates", {}):
             payload = self.request_templates.render(invocation_context)

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -535,5 +535,5 @@ class StepFunctionIntegration(BackendIntegration):
         rendered_input = VtlTemplate().render_vtl(request_parameters.get("Input"), variables)
         return {
             "stateMachineArn": request_parameters.get("StateMachineArn"),
-            "input": rendered_input
+            "input": rendered_input,
         }

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -4,8 +4,9 @@ import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from http import HTTPStatus
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
+from moto.apigatewayv2.exceptions import BadRequestException
 from requests import Response
 
 from localstack import config
@@ -438,6 +439,20 @@ class MockIntegration(BackendIntegration):
 
 
 class StepFunctionIntegration(BackendIntegration):
+    @classmethod
+    def _validate_required_params(cls, request_parameters: Dict[str, Any]) -> None:
+        if not request_parameters:
+            raise BadRequestException("Missing required parameters")
+        # stateMachineArn and input are required
+        state_machine_arn_param = request_parameters.get("StateMachineArn")
+        input_param = request_parameters.get("Input")
+
+        if not state_machine_arn_param:
+            raise BadRequestException("StateMachineArn")
+
+        if not input_param:
+            raise BadRequestException("Input")
+
     def invoke(self, invocation_context: ApiInvocationContext):
         uri = (
             invocation_context.integration.get("uri")
@@ -446,7 +461,9 @@ class StepFunctionIntegration(BackendIntegration):
         )
         action = uri.split("/")[-1]
 
-        if APPLICATION_JSON in invocation_context.integration.get("requestTemplates", {}):
+        if invocation_context.integration.get("type") == "AWS_PROXY":
+            payload = self._create_request_parameters(invocation_context)
+        elif APPLICATION_JSON in invocation_context.integration.get("requestTemplates", {}):
             payload = self.request_templates.render(invocation_context)
             payload = json.loads(payload)
         else:
@@ -501,3 +518,22 @@ class StepFunctionIntegration(BackendIntegration):
         invocation_context.response = response
         response._content = self.response_templates.render(invocation_context)
         return response
+
+    def _create_request_parameters(self, invocation_context):
+        request_parameters = invocation_context.integration.get("requestParameters", {})
+        self._validate_required_params(request_parameters)
+
+        variables = {
+            "request": {
+                "header": invocation_context.headers,
+                "querystring": invocation_context.query_params(),
+                "body": invocation_context.data_as_string(),
+                "context": invocation_context.context or {},
+                "stage_variables": invocation_context.stage_variables or {},
+            }
+        }
+        rendered_input = VtlTemplate().render_vtl(request_parameters.get("Input"), variables)
+        return {
+            "stateMachineArn": request_parameters.get("StateMachineArn"),
+            "input": rendered_input
+        }

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1508,7 +1508,9 @@ class TestAPIGateway:
         assert "/pets/{petId}" in paths
 
     @pytest.mark.aws_validated
-    @pytest.mark.parametrize("action", ["StartExecution", "DeleteStateMachine"])
+    @pytest.mark.parametrize(
+        "action", ["StartExecution", "StartSyncExecution", "DeleteStateMachine"]
+    )
     def test_apigateway_with_step_function_integration(
         self,
         action,
@@ -1610,19 +1612,22 @@ class TestAPIGateway:
 
         test_data = {"test": "test-value"}
         url = api_invoke_url(api_id=rest_api, stage="dev", path="/")
+
+        req_template = {
+            "application/json": """
+            {
+            "input": "$util.escapeJavaScript($input.json('$'))",
+            "stateMachineArn": "%s"
+            }
+            """
+            % sm_arn
+        }
         match action:
             case "StartExecution":
-                req_template = {
-                    "application/json": """
-                            #set($data = $util.escapeJavaScript($input.json('$')))
-                            {"input": "$data", "stateMachineArn": "%s"}
-                        """
-                    % sm_arn
-                }
                 _prepare_integration(req_template, response_template={})
                 apigateway_client.create_deployment(restApiId=rest_api, stageName="dev")
-                # invoke stepfunction via API GW, assert results
 
+                # invoke stepfunction via API GW, assert results
                 def _invoke_start_step_function():
                     resp = requests.post(url, data=json.dumps(test_data))
                     assert resp.ok
@@ -1634,13 +1639,9 @@ class TestAPIGateway:
 
             case "StartSyncExecution":
                 resp_template = {APPLICATION_JSON: "$input.path('$.output')"}
-                _prepare_integration({}, resp_template)
+                _prepare_integration(req_template, resp_template)
                 apigateway_client.create_deployment(restApiId=rest_api, stageName="dev")
-                input_data = {
-                    "input": json.dumps(test_data),
-                    "name": "MyExecution",
-                    "stateMachineArn": sm_arn,
-                }
+                input_data = {"input": json.dumps(test_data), "name": "MyExecution"}
 
                 def _invoke_start_sync_step_function():
                     input_data["name"] += "1"

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1509,7 +1509,7 @@ class TestAPIGateway:
 
     @pytest.mark.aws_validated
     @pytest.mark.parametrize(
-        "action", ["StartExecution", "StartSyncExecution", "DeleteStateMachine"]
+        "action", ["StartExecution", "DeleteStateMachine"]
     )
     def test_apigateway_with_step_function_integration(
         self,

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1508,9 +1508,7 @@ class TestAPIGateway:
         assert "/pets/{petId}" in paths
 
     @pytest.mark.aws_validated
-    @pytest.mark.parametrize(
-        "action", ["StartExecution", "DeleteStateMachine"]
-    )
+    @pytest.mark.parametrize("action", ["StartExecution", "DeleteStateMachine"])
     def test_apigateway_with_step_function_integration(
         self,
         action,


### PR DESCRIPTION
Issue #7124


https://docs.aws.amazon.com/step-functions/latest/dg/tutorial-api-gateway.html

# Terraform samples

- https://github.com/localstack/localstack-terraform-samples/tree/master/apigateway-step-functions-integration
- https://github.com/localstack/localstack-terraform-samples/tree/master/apigatewayv2-step-functions-integration

# Not covered

- Passthrough templates, for cases where the input is not transformed via request templates (REST) or request parameters (HTTP)