### PR TITLE
Bugfix: DynamoDB BatchWriteItems in multi-accounts

### DIFF
--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -206,3 +206,10 @@ OS_USER_OPENSEARCH = "localstack"
 
 # output string that indicates that the stack is ready
 READY_MARKER_OUTPUT = "Ready."
+
+# Regex for `Credential` field in the Authorization header in AWS signature version v4
+# The format is as follows:
+#   Credential=<access-key-id>/<date>/<region-name>/<service-name>/aws4_request
+# eg.
+#   Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request
+AUTH_CREDENTIAL_REGEX = r"Credential=(?P<access_key_id>[a-zA-Z0-9-_.]{1,})/(?P<date>\d{8})/(?P<region_name>[a-z0-9-]{1,})/(?P<service_name>[a-z0-9]{1,})/"

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -88,7 +88,7 @@ from localstack.aws.api.dynamodb import (
 )
 from localstack.aws.forwarder import HttpFallbackDispatcher, get_request_forwarder_http
 from localstack.aws.proxy import AwsApiListener
-from localstack.constants import LOCALHOST, TEST_AWS_SECRET_ACCESS_KEY
+from localstack.constants import AUTH_CREDENTIAL_REGEX, LOCALHOST, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.http import Response
 from localstack.services.dynamodb import server
 from localstack.services.dynamodb.models import DynamoDBStore, dynamodb_stores
@@ -118,10 +118,6 @@ LOG = logging.getLogger(__name__)
 
 # action header prefix
 ACTION_PREFIX = "DynamoDB_20120810."
-
-# Credential regex in the Authorization header
-# Credential=<access-key-id>/<date>/<aws-region>/<aws-service>/aws4_request
-AUTH_CREDENTIAL_REGEX = r"Credential=([a-zA-Z0-9-_]{1,})/(\d{8})/([a-z0-9-]{1,})/([a-z0-9]{1,})/"
 
 # list of actions subject to throughput limitations
 READ_THROTTLED_ACTIONS = [

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -7,6 +7,7 @@ from moto.core.exceptions import JsonRESTError
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodb import ResourceNotFoundException
+from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.utils.aws import aws_stack
 from localstack.utils.json import canonical_json
 from localstack.utils.testutil import list_all_resources
@@ -95,7 +96,12 @@ class ItemFinder:
         from localstack.services.dynamodb.provider import ValidationException
 
         table_name = table_name or put_item["TableName"]
-        ddb_client = aws_stack.connect_to_service("dynamodb")
+        ddb_client = aws_stack.connect_to_service(
+            "dynamodb",
+            aws_access_key_id=get_aws_account_id(),
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+            region_name=aws_stack.get_region(),
+        )
 
         search_key = {}
         if "Key" in put_item:

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -79,7 +79,12 @@ class SchemaExtractor:
         schema = SCHEMA_CACHE.get(key)
         if not schema:
             # TODO: consider making in-memory lookup instead of API call
-            ddb_client = aws_stack.connect_to_service("dynamodb")
+            ddb_client = aws_stack.connect_to_service(
+                "dynamodb",
+                aws_access_key_id=get_aws_account_id(),
+                aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+                region_name=aws_stack.get_region(),
+            )
             try:
                 schema = ddb_client.describe_table(TableName=table_name)
                 SCHEMA_CACHE[key] = schema
@@ -153,7 +158,12 @@ class ItemFinder:
 
     @staticmethod
     def get_all_table_items(table_name: str) -> List:
-        ddb_client = aws_stack.connect_to_service("dynamodb")
+        ddb_client = aws_stack.connect_to_service(
+            "dynamodb",
+            aws_access_key_id=get_aws_account_id(),
+            aws_secret_access_key=TEST_AWS_SECRET_ACCESS_KEY,
+            region_name=aws_stack.get_region(),
+        )
         dynamodb_kwargs = {"TableName": table_name}
         all_items = list_all_resources(
             lambda kwargs: ddb_client.scan(**{**kwargs, **dynamodb_kwargs}),

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -9,7 +9,7 @@ from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api.dynamodb import ResourceNotFoundException
 from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_stack import dynamodb_table_arn
+from localstack.utils.aws.arns import dynamodb_table_arn
 from localstack.utils.json import canonical_json
 from localstack.utils.testutil import list_all_resources
 

--- a/tests/unit/test_dynamodb.py
+++ b/tests/unit/test_dynamodb.py
@@ -10,8 +10,12 @@ def test_fix_region_in_headers():
     for region_name in ["local", "localhost"]:
         headers = aws_stack.mock_aws_request_headers("dynamodb", region_name=region_name)
         assert aws_stack.get_region() not in headers.get("Authorization")
-        DynamoDBProvider.prepare_request_headers(headers)
-        assert aws_stack.get_region() in headers.get("Authorization")
+
+        # Ensure that the correct namespacing key is passed as Access Key ID to DynamoDB Local
+        DynamoDBProvider.prepare_request_headers(
+            headers, account_id="000011112222", region_name="ap-south-1"
+        )
+        assert "000011112222apsouth1" in headers.get("Authorization")
 
 
 def test_lookup_via_item_set():


### PR DESCRIPTION
### Summary

This PR fixes additional issues with DynamoDB multi-accounts implementation.

1. The regex for `Credentials` field in `Authorization` header can now accept `-` and `_` characters. See https://github.com/localstack/localstack/issues/7233. We modify this header before forwarding the request to DynamoDB Local to achieve namespacing.
2. Update helpers to explictly take account and region to correctly perfrom global table operations. In DynamoDB, global tables are tables that are replicated across multiple regions. In LS, instead of actually replicating the table, we modify the request context to point to the original region. This means that Boto clients must also be created with the region where the table exists, and not necessarily the region from the request.

### Tests

Update integration test to assert that the context region modification happens correctly.
