### PR TITLE
fix elasticsearch bind host and firehose connectivity

### DIFF
--- a/localstack/services/opensearch/cluster_manager.py
+++ b/localstack/services/opensearch/cluster_manager.py
@@ -298,7 +298,9 @@ class MultiClusterManager(ClusterManager):
             if engine_type == EngineType.OpenSearch:
                 return OpensearchCluster(port=port, host=EDGE_BIND_HOST, arn=arn, version=version)
             else:
-                return ElasticsearchCluster(port=port, host=LOCALHOST, arn=arn, version=version)
+                return ElasticsearchCluster(
+                    port=port, host=EDGE_BIND_HOST, arn=arn, version=version
+                )
 
 
 class SingletonClusterManager(ClusterManager):

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -1162,7 +1162,9 @@ def get_opensearch_endpoint(domain_arn: str) -> str:
     domain_name = domain_arn.rpartition("/")[2]
     info = opensearch_client.describe_domain(DomainName=domain_name)
     base_domain = info["DomainStatus"]["Endpoint"]
-    endpoint = base_domain if base_domain.startswith("http") else f"https://{base_domain}"
+    # Add the URL scheme "http" if it's not set yet. https might not be enabled for all instances
+    # f.e. when the endpoint strategy is PORT or there is a custom opensearch/elasticsearch instance
+    endpoint = base_domain if base_domain.startswith("http") else f"http://{base_domain}"
     return endpoint
 
 


### PR DESCRIPTION
This PR fixes two small issues with the connectivity to elasticsearch:
- Fixes the bind host configuration for elasticsearch instances when using the endpoint strategy `PORT`.
  - Migrates a fix by @silv-io in #6638 for opensearch to elasticsearch.
- Fixes a small issue with the connectivity from firehose to elasticsearch when using a strategy which does not expose an HTTPS endpoint (i.e. when using the endpoint strategy `PORT` or providing a custom endpoint).