### PR TITLE
Added after inject hook

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -130,7 +130,7 @@ class ServiceLifecycleHook:
         pass
 
     def on_after_inject(self):
-        """Hook triggered after a new state in injected."""
+        """Hook triggered after new state has been injected into the provider's store."""
         pass
 
     def on_exception(self):

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -129,6 +129,10 @@ class ServiceLifecycleHook:
     def on_before_stop(self):
         pass
 
+    def on_after_inject(self):
+        """Hook triggered after a new state in injected."""
+        pass
+
     def on_exception(self):
         pass
 


### PR DESCRIPTION
More context here: https://github.com/localstack/localstack-ext/pull/1191. Adds a hook to the state lifecycle to be triggered when a new state is loaded into the provider via Cloud Pods. The logic executed with this trigger often requires method proper of the provider.  