### PR TITLE
Deprecate `localstack-light` and `localstack-full`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,17 +166,23 @@ RUN make freeze > requirements-runtime.txt
 RUN echo /var/lib/localstack/lib/extensions/python_venv/lib/python3.10/site-packages > localstack-extensions-venv.pth && \
     mv localstack-extensions-venv.pth .venv/lib/python*/site-packages/
 
+# base-community: Stage which will contain the community-version starting from 2.0.0
+FROM base as base-community
+RUN touch /usr/lib/localstack/.community-version
 
 # base-pro: Stage which will contain the pro-version starting from 2.0.0
 FROM base as base-pro
 RUN touch /usr/lib/localstack/.pro-version
 
 # base-light: Stage which does not add additional dependencies (like elasticsearch)
+# FIXME deprecated
 FROM base as base-light
 RUN touch /usr/lib/localstack/.light-version
 
 # base-full: Stage which adds additional dependencies to avoid installing them at runtime (f.e. elasticsearch)
+# FIXME deprecated
 FROM base as base-full
+RUN touch /usr/lib/localstack/.full-version
 
 # Install Elasticsearch
 # https://github.com/pires/docker-elasticsearch/issues/56

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,11 @@ docker-build-light: 	  ## Build Light Docker image
 	make DOCKER_BUILD_FLAGS="--build-arg IMAGE_TYPE=light --load" \
 	  TAG=$(IMAGE_NAME_LIGHT) docker-build
 
-docker-build-pro: 	  ## Build Light Docker image
+docker-build-community:   ## Build Community Docker image
+	make DOCKER_BUILD_FLAGS="--build-arg IMAGE_TYPE=community --load" \
+	  TAG=$(IMAGE_NAME) docker-build
+
+docker-build-pro: 	  	  ## Build Pro Docker image
 	make DOCKER_BUILD_FLAGS="--build-arg IMAGE_TYPE=pro --load" \
 	  TAG=$(IMAGE_NAME_PRO) docker-build
 
@@ -143,9 +147,9 @@ docker-push-master: 	  ## Push a single platform-specific Docker image to regist
 	)
 
 docker-push-master-all:		## Push Docker images of localstack, localstack-pro, localstack-light, and localstack-full
-	make SOURCE_IMAGE_NAME=$(IMAGE_NAME_LIGHT) TARGET_IMAGE_NAME=$(IMAGE_NAME) docker-push-master
-	make SOURCE_IMAGE_NAME=$(IMAGE_NAME_LIGHT) TARGET_IMAGE_NAME=$(IMAGE_NAME_LIGHT) docker-push-master
+	make SOURCE_IMAGE_NAME=$(IMAGE_NAME) TARGET_IMAGE_NAME=$(IMAGE_NAME) docker-push-master
 	make SOURCE_IMAGE_NAME=$(IMAGE_NAME_PRO) TARGET_IMAGE_NAME=$(IMAGE_NAME_PRO) docker-push-master
+	make SOURCE_IMAGE_NAME=$(IMAGE_NAME_LIGHT) TARGET_IMAGE_NAME=$(IMAGE_NAME_LIGHT) docker-push-master
 	make SOURCE_IMAGE_NAME=$(IMAGE_NAME_FULL) TARGET_IMAGE_NAME=$(IMAGE_NAME_FULL) docker-push-master
 
 MANIFEST_IMAGE_NAME ?= $(IMAGE_NAME)

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -28,6 +28,19 @@ if [[ $LOCALSTACK_API_KEY ]] && [[ ! -f /usr/lib/localstack/.pro-version ]]; the
     echo "============================================================================"
     echo ""
 fi
+if [[ -f /usr/lib/localstack/.light-version ]] || [[ -f /usr/lib/localstack/.full-version ]]; then
+    echo "ERROR"
+    echo "============================================================================"
+    echo "  It seems you are using a deprecated image (-light or -full image)."
+    echo "  Future versions will not be supplied in these image tags."
+    echo "  To fix this error, use localstack/localstack-pro or localstack/localstack "
+    echo "  instead."
+    echo ""
+    echo "  See: <deprecation-gh-issue>"
+    echo "============================================================================"
+    echo ""
+    exit 1
+fi
 
 # FIXME: deprecation path for legacy directories
 # the Dockerfile creates .marker file that will be overwritten if a volume is mounted into /tmp/localstack


### PR DESCRIPTION
- [x] Add markers for localstack-full and localstack-light (if not present)
- [x] Show a deprecation warning whenever localstack-light or localstack-full are used (but not when localstack/localstack is used).

To be merged after https://github.com/localstack/localstack/pull/7249