### PR TITLE
Fix cfn stack leak in test fixture

### DIFF
--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1169,6 +1169,7 @@ def deploy_cfn_template(
         )
         change_set_id = response["Id"]
         stack_id = response["StackId"]
+        state.append({"stack_id": stack_id, "change_set_id": change_set_id})
 
         assert wait_until(is_change_set_created_and_available(change_set_id), _max_wait=60)
         cfn_client.execute_change_set(ChangeSetName=change_set_id)
@@ -1177,8 +1178,6 @@ def deploy_cfn_template(
         outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0].get("Outputs", [])
 
         mapped_outputs = {o["OutputKey"]: o["OutputValue"] for o in outputs}
-
-        state.append({"stack_id": stack_id, "change_set_id": change_set_id})
 
         def _destroy_stack():
             cfn_client.delete_stack(StackName=stack_id)


### PR DESCRIPTION
Minor fix for the `deploy_cfn_template` test fixture.

I've noticed that it sometimes was leaking stacks when testing against AWS since it only added the stack id to its internal cleanup state when it was successfully deployed. A timeout would then cause the deployment to fail (it didn't wait for the completion), so the ID was missing from the cleanups even though on AWS it was still in progress, finished a bit later and then was never cleaned up.