### PR TITLE
Make /health support HEAD query again

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -85,6 +85,9 @@ class HealthResource:
         result["version"] = constants.VERSION
         return result
 
+    def on_head(self, _request: Request):
+        return Response("ok", 200)
+
     def on_put(self, request: Request):
         data = request.get_json(True, True) or {}
 

--- a/tests/unit/http_/test_dispatcher.py
+++ b/tests/unit/http_/test_dispatcher.py
@@ -22,17 +22,24 @@ class TestResourceDispatcher:
                 requests.append(req)
                 return {"ok": "POST"}
 
+            def on_head(self, req):
+                requests.append(req)
+                return "HEAD/OK"
+
         router.add("/_localstack/health", TestResource())
 
         request1 = Request("GET", "/_localstack/health")
         request2 = Request("POST", "/_localstack/health")
+        request3 = Request("HEAD", "/_localstack/health")
         assert router.dispatch(request1).get_data(True) == "GET/OK"
         assert router.dispatch(request1).get_data(True) == "GET/OK"
         assert router.dispatch(request2).json == {"ok": "POST"}
-        assert len(requests) == 3
+        assert router.dispatch(request3).get_data(True) == "HEAD/OK"
+        assert len(requests) == 4
         assert requests[0] is request1
         assert requests[1] is request1
         assert requests[2] is request2
+        assert requests[3] is request3
 
     def test_dispatch_to_non_existing_method_raises_exception(self):
         router = Router(dispatcher=resource_dispatcher(pass_response=False))


### PR DESCRIPTION
HEAD query support was disabled as part of the refactoring in #4883.

It used to be supported by the following implementation.

```python
def handle(self, method, path, data) -> Optional[Dict]:
    if method == "GET":
        return self.get(path, data)
    if method == "POST":
        return self.post(path, data)
    if method == "PUT":
        return self.put(path, data)

    return {}
```

When using LocalStack in a Docker environment, third-party tools like `wait-for-200` might be used to probe the readiness of the LocalStack service. And some of these tools use HEAD queries by default. In such environments, upgrading from an older version of LocalStack might break some pods accidentally and it's not straightforward to debug because you can only see the following output in your LocalStack logs:

```
2022-11-29T09:03:01.545 ERROR --- [   asgi_gw_1] l.aws.handlers.logging
: exception during call chain: 405 Method Not Allowed: The method is not
allowed for the requested URL.
```

This PR attempts to add HEAD query support back to ease the upgrade for users with such setups.

**Please refer to the contribution guidelines in the README when submitting PRs.**
