### PR TITLE
fix/missing parameters for sam

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -188,7 +188,8 @@ class Stack:
         if outputs:
             result["Outputs"] = outputs
         params = self.stack_parameters()
-        result["Parameters"] = params or []
+        if params:
+            result["Parameters"] = params
         if not result.get("DriftInformation"):
             result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
         for attr in ["Capabilities", "Tags", "NotificationARNs"]:
@@ -719,6 +720,7 @@ class CloudformationProvider(CloudformationApi):
             stack = Stack(request, template)
 
         result: GetTemplateSummaryOutput = stack.describe_details()
+        result["Parameters"] = result.get("Parameters") or []
         id_summaries = defaultdict(list)
         for resource_id, resource in stack.template_resources.items():
             res_type = resource["Type"]

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -187,8 +187,7 @@ class Stack:
         if outputs:
             result["Outputs"] = outputs
         params = self.stack_parameters()
-        if params:
-            result["Parameters"] = params
+        result["Parameters"] = params or []
         if not result.get("DriftInformation"):
             result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
         for attr in ["Capabilities", "Tags", "NotificationARNs"]:

--- a/tests/integration/cloudformation/api/test_get_template_summary.py
+++ b/tests/integration/cloudformation/api/test_get_template_summary.py
@@ -1,0 +1,11 @@
+import os
+
+
+def test_get_template_summary(deploy_cfn_template, cfn_client):
+    deployment = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/sns_topic_simple.yaml"
+        )
+    )
+    res = cfn_client.get_template_summary(StackName=deployment.stack_name)
+    assert "Parameters" in res

--- a/tests/integration/cloudformation/api/test_get_template_summary.py
+++ b/tests/integration/cloudformation/api/test_get_template_summary.py
@@ -1,11 +1,22 @@
 import os
 
+import pytest
 
-def test_get_template_summary(deploy_cfn_template, cfn_client):
+
+@pytest.mark.aws_validated
+@pytest.mark.skip_snapshot_verify(paths=["$..ResourceIdentifierSummaries..ResourceIdentifiers"])
+def test_get_template_summary(deploy_cfn_template, cfn_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+    snapshot.add_transformer(snapshot.transform.sns_api())
+
     deployment = deploy_cfn_template(
         template_path=os.path.join(
-            os.path.dirname(__file__), "../../templates/sns_topic_simple.yaml"
+            # This template has no parameters, and so shows the issue
+            os.path.dirname(__file__),
+            "../../templates/sns_topic_simple.yaml",
         )
     )
+
     res = cfn_client.get_template_summary(StackName=deployment.stack_name)
-    assert "Parameters" in res
+
+    snapshot.match("template-summary", res)

--- a/tests/integration/cloudformation/api/test_get_template_summary.snapshot.json
+++ b/tests/integration/cloudformation/api/test_get_template_summary.snapshot.json
@@ -1,0 +1,29 @@
+{
+  "tests/integration/cloudformation/api/test_get_template_summary.py::test_get_template_summary": {
+    "recorded-date": "30-11-2022, 14:27:17",
+    "recorded-content": {
+      "template-summary": {
+        "Parameters": [],
+        "ResourceIdentifierSummaries": [
+          {
+            "LogicalResourceIds": [
+              "topic123"
+            ],
+            "ResourceIdentifiers": [
+              "TopicArn"
+            ],
+            "ResourceType": "AWS::SNS::Topic"
+          }
+        ],
+        "ResourceTypes": [
+          "AWS::SNS::Topic"
+        ],
+        "Version": "2010-09-09",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Outputs `Parameters` from `cloudformation.get_template_summary` - this is a required piece of information for SAM. This error is only triggered when there are no parameters in the template. Otherwise, the parameters _are_ returned.

We add a single snapshot test that handles one case. This is likely to not be complete as far as CloudFormation is concerned, but it's a huge surface area to tackle, and there is a project in the works to re-do CloudFormation.

Note: we don't verify `$..ResourceIdentifierSummaries..ResourceIdentifiers` as this also requires a refactoring of CloudFormation: the field groups stack resources by their type, and for each type lists the identifier, e.g. `TopicArn` for SNS topics. This state is likely per-resource, and could ideally be part of the autogeneraiton of stack resource definitions (TBD). It does not really have a place here just yet.

Unfortunately this PR does not fully enable SAM support due to https://github.com/localstack/localstack/issues/6155

Closes #6974
