### PR TITLE
Implement Lambda ASF container image CRUD and docker runtime executor hooks

### DIFF
--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -374,6 +374,20 @@ def map_config_out(
             {"Arn": layer.layer_version_arn, "CodeSize": layer.code.code_size}
             for layer in version.config.layers
         ]
+    if version.config.image_config:
+        image_config_response = {}
+        if version.config.image_config.command:
+            image_config_response["Command"] = version.config.image_config.command
+        if version.config.image_config.entrypoint:
+            image_config_response["EntryPoint"] = version.config.image_config.entrypoint
+        if version.config.image_config.working_directory:
+            image_config_response[
+                "WorkingDirectory"
+            ] = version.config.image_config.working_directory
+        optional_kwargs["ImageConfigResponse"] = image_config_response
+    if version.config.code:
+        optional_kwargs["CodeSize"] = version.config.code.code_size
+        optional_kwargs["CodeSha256"] = version.config.code.code_sha256
 
     func_conf = FunctionConfiguration(
         RevisionId=version.config.revision_id,
@@ -388,8 +402,6 @@ def map_config_out(
         Timeout=version.config.timeout,
         Runtime=version.config.runtime,
         Handler=version.config.handler,
-        CodeSize=version.config.code.code_size,
-        CodeSha256=version.config.code.code_sha256,
         MemorySize=version.config.memory_size,
         PackageType=version.config.package_type,
         TracingConfig=TracingConfig(Mode=version.config.tracing_config_mode),

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -14,6 +14,8 @@ from localstack.aws.api.lambda_ import (
     EphemeralStorage,
     FunctionConfiguration,
     FunctionUrlAuthType,
+    ImageConfig,
+    ImageConfigResponse,
     InvalidParameterValueException,
     LayerVersionContentOutput,
     PublishLayerVersionResponse,
@@ -375,19 +377,21 @@ def map_config_out(
             for layer in version.config.layers
         ]
     if version.config.image_config:
-        image_config_response = {}
+        image_config = ImageConfig()
         if version.config.image_config.command:
-            image_config_response["Command"] = version.config.image_config.command
+            image_config["Command"] = version.config.image_config.command
         if version.config.image_config.entrypoint:
-            image_config_response["EntryPoint"] = version.config.image_config.entrypoint
+            image_config["EntryPoint"] = version.config.image_config.entrypoint
         if version.config.image_config.working_directory:
-            image_config_response[
-                "WorkingDirectory"
-            ] = version.config.image_config.working_directory
-        optional_kwargs["ImageConfigResponse"] = image_config_response
+            image_config["WorkingDirectory"] = version.config.image_config.working_directory
+        if image_config:
+            optional_kwargs["ImageConfigResponse"] = ImageConfigResponse(ImageConfig=image_config)
     if version.config.code:
         optional_kwargs["CodeSize"] = version.config.code.code_size
         optional_kwargs["CodeSha256"] = version.config.code.code_sha256
+    elif version.config.image:
+        optional_kwargs["CodeSize"] = 0
+        optional_kwargs["CodeSha256"] = version.config.image.code_sha256
 
     func_conf = FunctionConfiguration(
         RevisionId=version.config.revision_id,

--- a/localstack/services/awslambda/hooks.py
+++ b/localstack/services/awslambda/hooks.py
@@ -1,0 +1,7 @@
+from localstack.runtime.hooks import hook_spec
+
+HOOKS_LAMBDA_START_DOCKER_EXECUTOR = "localstack.hooks.lambda_start_docker_executor"
+HOOKS_LAMBDA_PREPARE_DOCKER_EXECUTOR = "localstack.hooks.lambda_prepare_docker_executors"
+
+start_docker_executor = hook_spec(HOOKS_LAMBDA_START_DOCKER_EXECUTOR)
+prepare_docker_executor = hook_spec(HOOKS_LAMBDA_PREPARE_DOCKER_EXECUTOR)

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import logging
 import shutil
@@ -6,6 +7,8 @@ from pathlib import Path
 from typing import Dict, Literal, Optional
 
 from localstack import config
+from localstack.aws.api.lambda_ import PackageType
+from localstack.runtime.hooks import hook_spec
 from localstack.services.awslambda.invocation.executor_endpoint import (
     ExecutorEndpoint,
     ServiceEndpoint,
@@ -23,6 +26,13 @@ from localstack.services.awslambda.packages import awslambda_runtime_package
 from localstack.utils.container_utils.container_client import ContainerConfiguration
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
 from localstack.utils.strings import truncate
+
+# Hook definitions
+HOOKS_LAMBDA_START_DOCKER_EXECUTOR = "localstack.hooks.lambda_start_docker_executor"
+HOOKS_LAMBDA_PREPARE_DOCKER_EXECUTOR = "localstack.hooks.lambda_prepare_docker_executors"
+
+start_docker_executor = hook_spec(HOOKS_LAMBDA_START_DOCKER_EXECUTOR)
+prepare_docker_executor = hook_spec(HOOKS_LAMBDA_PREPARE_DOCKER_EXECUTOR)
 
 LOG = logging.getLogger(__name__)
 
@@ -96,6 +106,11 @@ def prepare_image(target_path: Path, function_version: FunctionVersion) -> None:
             )
 
 
+@dataclasses.dataclass
+class LambdaContainerConfiguration(ContainerConfiguration):
+    copy_folders: list[tuple[str, str]] = dataclasses.field(default_factory=list)
+
+
 class DockerRuntimeExecutor(RuntimeExecutor):
     ip: Optional[str]
     executor_endpoint: Optional[ExecutorEndpoint]
@@ -135,23 +150,35 @@ class DockerRuntimeExecutor(RuntimeExecutor):
     def start(self, env_vars: dict[str, str]) -> None:
         self.executor_endpoint.start()
         network = self._get_network_for_executor()
-        container_config = ContainerConfiguration(
-            image_name=self.get_image(),
+        container_config = LambdaContainerConfiguration(
+            image_name=None,
             name=self.id,
             env_vars=env_vars,
             network=network,
             entrypoint=RAPID_ENTRYPOINT,
         )
+        start_docker_executor.run(container_config, self.function_version)
+
+        if not container_config.image_name:
+            container_config.image_name = self.get_image()
+
         CONTAINER_CLIENT.create_container_from_config(container_config)
-        if not config.LAMBDA_PREBUILD_IMAGES:
+        if (
+            not config.LAMBDA_PREBUILD_IMAGES
+            or self.function_version.config.package_type != PackageType.Zip
+        ):
             CONTAINER_CLIENT.copy_into_container(
                 self.id, str(get_runtime_client_path()), RAPID_ENTRYPOINT
             )
-            CONTAINER_CLIENT.copy_into_container(
-                self.id,
-                f"{str(self.function_version.config.code.get_unzipped_code_location())}/.",
-                "/var/task",
-            )
+        if self.function_version.config.package_type == PackageType.Zip:
+            if not config.LAMBDA_PREBUILD_IMAGES:
+                CONTAINER_CLIENT.copy_into_container(
+                    self.id,
+                    f"{str(self.function_version.config.code.get_unzipped_code_location())}/.",
+                    "/var/task",
+                )
+                for source, target in container_config.copy_folders:
+                    CONTAINER_CLIENT.copy_into_container(self.id, source, target)
 
         CONTAINER_CLIENT.start_container(self.id)
         self.ip = CONTAINER_CLIENT.get_container_ipv4_for_network(
@@ -193,19 +220,23 @@ class DockerRuntimeExecutor(RuntimeExecutor):
     @classmethod
     def prepare_version(cls, function_version: FunctionVersion) -> None:
         time_before = time.perf_counter()
-        function_version.config.code.prepare_for_execution()
-        target_path = function_version.config.code.get_unzipped_code_location()
-        image_name = get_image_for_runtime(function_version.config.runtime)
-        if image_name not in PULLED_IMAGES:
-            CONTAINER_CLIENT.pull_image(image_name)
-            PULLED_IMAGES.add(image_name)
-        if config.LAMBDA_PREBUILD_IMAGES:
-            prepare_image(target_path, function_version)
-        LOG.debug(
-            "Version preparation of version %s took %0.2fms",
-            function_version.qualified_arn,
-            (time.perf_counter() - time_before) * 1000,
-        )
+        prepare_docker_executor.run(function_version)
+        if function_version.config.code:
+            function_version.config.code.prepare_for_execution()
+            for layer in function_version.config.layers:
+                layer.code.prepare_for_execution()
+            image_name = get_image_for_runtime(function_version.config.runtime)
+            if image_name not in PULLED_IMAGES:
+                CONTAINER_CLIENT.pull_image(image_name)
+                PULLED_IMAGES.add(image_name)
+            if config.LAMBDA_PREBUILD_IMAGES:
+                target_path = function_version.config.code.get_unzipped_code_location()
+                prepare_image(target_path, function_version)
+            LOG.debug(
+                "Version preparation of version %s took %0.2fms",
+                function_version.qualified_arn,
+                (time.perf_counter() - time_before) * 1000,
+            )
 
     @classmethod
     def cleanup_version(cls, function_version: FunctionVersion) -> None:

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -204,6 +204,17 @@ class S3Code:
 
 
 @dataclasses.dataclass
+class ImageCode:
+    image_uri: str
+    repository_type: str
+    code_sha256: str
+
+    @property
+    def resolved_image_uri(self):
+        return f"{self.image_uri.rpartition(':')[0]}@sha256:{self.code_sha256}"
+
+
+@dataclasses.dataclass
 class DeadLetterConfig:
     target_arn: str
 
@@ -490,7 +501,7 @@ class VersionFunctionConfiguration:
     last_modified: str  # ISO string
     state: VersionState
 
-    image: Optional[str] = None
+    image: Optional[ImageCode] = None
     image_config: Optional[ImageConfig] = None
     last_update: Optional[UpdateStatus] = None
     revision_id: str = dataclasses.field(init=False, default_factory=long_uid)

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -490,6 +490,7 @@ class VersionFunctionConfiguration:
     last_modified: str  # ISO string
     state: VersionState
 
+    image: Optional[str] = None
     image_config: Optional[ImageConfig] = None
     last_update: Optional[UpdateStatus] = None
     revision_id: str = dataclasses.field(init=False, default_factory=long_uid)

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -203,7 +203,7 @@ class S3Code:
             )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class ImageCode:
     image_uri: str
     repository_type: str
@@ -225,7 +225,7 @@ class FileSystemConfig:
     local_mount_path: str
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class ImageConfig:
     working_directory: str
     command: list[str] = dataclasses.field(default_factory=list)

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -422,7 +422,7 @@ def store_image_code(image_uri: str) -> ImageCode:
     try:
         code_sha256 = CONTAINER_CLIENT.inspect_image(image_name=image_uri)["RepoDigests"][
             0
-        ].partition(":")[2]
+        ].rpartition(":")[2]
     except Exception as e:
         LOG.debug(
             "Cannot inspect image %s. Is this image and/or docker available: %s", image_uri, e

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -27,6 +27,7 @@ from localstack.services.awslambda.invocation.lambda_models import (
     LAMBDA_LIMITS_CODE_SIZE_UNZIPPED_DEFAULT,
     Function,
     FunctionVersion,
+    ImageCode,
     Invocation,
     InvocationResult,
     S3Code,
@@ -37,6 +38,8 @@ from localstack.services.awslambda.invocation.models import lambda_stores
 from localstack.services.awslambda.invocation.version_manager import LambdaVersionManager
 from localstack.utils.archives import get_unzipped_size, is_zip_file
 from localstack.utils.aws import aws_stack
+from localstack.utils.container_utils.container_client import ContainerException
+from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
 from localstack.utils.strings import to_str
 
 if TYPE_CHECKING:
@@ -402,3 +405,26 @@ def store_s3_bucket_archive(
     return store_lambda_archive(
         archive_file, function_name=function_name, region_name=region_name, account_id=account_id
     )
+
+
+def store_image_code(image_uri: str) -> ImageCode:
+    """
+    Creates an image code by inspecting the provided image
+
+    :param image_uri: Image URI of the image to inspect
+    :return: Image code object
+    """
+    code_sha256 = "<cannot-find-image>"
+    try:
+        CONTAINER_CLIENT.pull_image(docker_image=image_uri)
+    except ContainerException:
+        LOG.debug("Cannot pull image %s. Maybe only available locally?", image_uri)
+    try:
+        code_sha256 = CONTAINER_CLIENT.inspect_image(image_name=image_uri)["RepoDigests"][
+            0
+        ].partition(":")[2]
+    except Exception as e:
+        LOG.debug(
+            "Cannot inspect image %s. Is this image and/or docker available: %s", image_uri, e
+        )
+    return ImageCode(image_uri=image_uri, code_sha256=code_sha256, repository_type="ECR")

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -407,7 +407,7 @@ def store_s3_bucket_archive(
     )
 
 
-def store_image_code(image_uri: str) -> ImageCode:
+def create_image_code(image_uri: str) -> ImageCode:
     """
     Creates an image code by inspecting the provided image
 

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -166,9 +166,9 @@ from localstack.services.awslambda.invocation.lambda_models import (
 )
 from localstack.services.awslambda.invocation.lambda_service import (
     LambdaService,
+    create_image_code,
     destroy_code_if_not_used,
     lambda_stores,
-    store_image_code,
     store_lambda_archive,
     store_s3_bucket_archive,
 )
@@ -529,7 +529,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 image = request_code.get("ImageUri")
                 if not image:
                     raise ServiceException("Gotta have an image when package type is image")
-                image = store_image_code(image_uri=image)
+                image = create_image_code(image_uri=image)
 
                 image_config_req = request.get("ImageConfig", {})
                 image_config = ImageConfig(
@@ -729,7 +729,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             )
         elif image := request.get("ImageUri"):
             code = None
-            image = store_image_code(image_uri=image)
+            image = create_image_code(image_uri=image)
         else:
             raise ServiceException("Gotta have s3 bucket or zip file or image")
 

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -531,12 +531,12 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     raise ServiceException("Gotta have an image when package type is image")
                 image = store_image_code(image_uri=image)
 
-                if image_config_req := request.get("ImageConfig"):
-                    image_config = ImageConfig(
-                        command=image_config_req.get("Command"),
-                        entrypoint=image_config_req.get("EntryPoint"),
-                        working_directory=image_config_req.get("WorkingDirectory"),
-                    )
+                image_config_req = request.get("ImageConfig", {})
+                image_config = ImageConfig(
+                    command=image_config_req.get("Command"),
+                    entrypoint=image_config_req.get("EntryPoint"),
+                    working_directory=image_config_req.get("WorkingDirectory"),
+                )
 
             version = FunctionVersion(
                 id=arn,

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from mypy_boto3_dynamodb import DynamoDBClient, DynamoDBServiceResource
     from mypy_boto3_dynamodbstreams import DynamoDBStreamsClient
     from mypy_boto3_ec2 import EC2Client
+    from mypy_boto3_ecr import ECRClient
     from mypy_boto3_es import ElasticsearchServiceClient
     from mypy_boto3_events import EventBridgeClient
     from mypy_boto3_firehose import FirehoseClient
@@ -399,6 +400,11 @@ def route53resolver_client() -> "Route53ResolverClient":
 @pytest.fixture(scope="class")
 def transcribe_client() -> "TranscribeClient":
     return _client("transcribe")
+
+
+@pytest.fixture(scope="class")
+def ecr_client() -> "ECRClient":
+    return _client("ecr")
 
 
 @pytest.fixture

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -773,6 +773,17 @@ class ContainerClient(metaclass=ABCMeta):
         """
         pass
 
+    @abstractmethod
+    def login(self, username: str, password: str, registry: Optional[str] = None) -> None:
+        """
+        Login into an OCI registry
+
+        :param username: Username for the registry
+        :param password: Password / token for the registry
+        :param registry: Registry url
+        """
+        pass
+
 
 class Util:
     MAX_ENV_ARGS_LENGTH = 20000

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -462,6 +462,19 @@ class CmdDockerClient(ContainerClient):
                     "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
                 ) from e
 
+    def login(self, username: str, password: str, registry: Optional[str] = None) -> None:
+        cmd = self._docker_cmd()
+        # TODO specify password via stdin
+        cmd += ["login", "-u", username, "-p", password]
+        if registry:
+            cmd.append(registry)
+        try:
+            run(cmd)
+        except subprocess.CalledProcessError as e:
+            raise ContainerException(
+                "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
+            ) from e
+
     def has_docker(self) -> bool:
         try:
             run(self._docker_cmd() + ["ps"])

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -679,3 +679,10 @@ class SdkDockerClient(ContainerClient):
             raise NoSuchContainer(container_name_or_id)
         except APIError as e:
             raise ContainerException() from e
+
+    def login(self, username: str, password: str, registry: Optional[str] = None) -> None:
+        LOG.debug("Docker login for %s", username)
+        try:
+            self.client().login(username, password=password, registry=registry, reauth=True)
+        except APIError as e:
+            raise ContainerException() from e

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -10,6 +10,7 @@ API-focused tests only. Don't add tests for asynchronous, blocking or implicit b
 import base64
 import io
 import json
+import logging
 import os
 from hashlib import sha256
 from io import BytesIO
@@ -22,9 +23,11 @@ from botocore.exceptions import ClientError
 
 from localstack.aws.api.lambda_ import Architecture, Runtime
 from localstack.testing.aws.lambda_utils import _await_dynamodb_table_active, is_old_provider
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils import testutil
 from localstack.utils.aws import arns
+from localstack.utils.docker_utils import DOCKER_CLIENT
 from localstack.utils.files import load_file
 from localstack.utils.strings import long_uid, short_uid, to_str
 from localstack.utils.sync import wait_until
@@ -35,6 +38,8 @@ from tests.integration.awslambda.test_lambda import (
     TEST_LAMBDA_PYTHON_ECHO,
     TEST_LAMBDA_PYTHON_VERSION,
 )
+
+LOG = logging.getLogger(__name__)
 
 KB = 1024
 
@@ -521,6 +526,179 @@ class TestLambdaFunction:
 
         snapshot.match("list_all", list_all)
         snapshot.match("list_default", list_default)
+
+
+@pytest.mark.skipif(is_old_provider(), reason="focusing on new provider")
+class TestLambdaImages:
+    @pytest.fixture(scope="class")
+    def login_docker_client(self, ecr_client):
+        if not is_aws_cloud():
+            return
+        auth_data = ecr_client.get_authorization_token()
+        # if check is necessary since registry login data is not available at LS before min. 1 repository is created
+        if auth_data["authorizationData"]:
+            auth_data = auth_data["authorizationData"][0]
+            decoded_auth_token = str(
+                base64.decodebytes(bytes(auth_data["authorizationToken"], "utf-8")), "utf-8"
+            )
+            username, password = decoded_auth_token.split(":")
+            DOCKER_CLIENT.login(
+                username=username, password=password, registry=auth_data["proxyEndpoint"]
+            )
+
+    @pytest.fixture(scope="class")
+    def test_image(self, ecr_client, login_docker_client):
+        repository_names = []
+        image_names = []
+
+        def _create_test_image(base_image: str):
+            if is_aws_cloud():
+                repository_name = f"test-repo-{short_uid()}"
+                repository_uri = ecr_client.create_repository(repositoryName=repository_name)[
+                    "repository"
+                ]["repositoryUri"]
+                image_name = f"{repository_uri}:latest"
+                repository_names.append(repository_name)
+            else:
+                image_name = f"test-image-{short_uid()}:latest"
+            image_names.append(image_name)
+
+            DOCKER_CLIENT.pull_image(base_image)
+            DOCKER_CLIENT.tag_image(base_image, image_name)
+            if is_aws_cloud():
+                DOCKER_CLIENT.push_image(image_name)
+            return image_name
+
+        yield _create_test_image
+
+        for image_name in image_names:
+            try:
+                DOCKER_CLIENT.remove_image(image=image_name, force=True)
+            except Exception as e:
+                LOG.debug("Error cleaning up image %s: %s", image_name, e)
+
+        for repository_name in repository_names:
+            try:
+                image_ids = ecr_client.list_images(repositoryName=repository_name)["imageIds"]
+                ecr_client.batch_delete_image(repositoryName=repository_name, imageIds=image_ids)
+                ecr_client.delete_repository(repositoryName=repository_name)
+            except Exception as e:
+                LOG.debug("Error cleaning up repository %s: %s", repository_name, e)
+
+    @pytest.mark.aws_validated
+    def test_lambda_image_crud(
+        self, lambda_client, create_lambda_function_aws, lambda_su_role, test_image, snapshot
+    ):
+        image = test_image("alpine")
+        repo_uri = image.rpartition(":")[0]
+        snapshot.add_transformer(snapshot.transform.regex(repo_uri, "<repo_uri>"))
+        function_name = f"test-function-{short_uid()}"
+        create_image_response = create_lambda_function_aws(
+            FunctionName=function_name,
+            Role=lambda_su_role,
+            Code={"ImageUri": image},
+            PackageType="Image",
+            Environment={"Variables": {"CUSTOM_ENV": "test"}},
+        )
+        snapshot.match("create-image-response", create_image_response)
+        lambda_client.get_waiter("function_active_v2").wait(FunctionName=function_name)
+        get_function_response = lambda_client.get_function(FunctionName=function_name)
+        snapshot.match("get-function-code-response", get_function_response)
+        get_function_config_response = lambda_client.get_function_configuration(
+            FunctionName=function_name
+        )
+        snapshot.match("get-function-config-response", get_function_config_response)
+
+        # try update to a zip file - should fail
+        with pytest.raises(ClientError) as e:
+            lambda_client.update_function_code(
+                FunctionName=function_name,
+                ZipFile=create_lambda_archive(load_file(TEST_LAMBDA_PYTHON_ECHO), get_content=True),
+            )
+        snapshot.match("image-to-zipfile-error", e.value.response)
+
+        image_2 = test_image("debian")
+        repo_uri_2 = image_2.rpartition(":")[0]
+        snapshot.add_transformer(snapshot.transform.regex(repo_uri_2, "<repo_uri_2>"))
+        update_function_code_response = lambda_client.update_function_code(
+            FunctionName=function_name, ImageUri=image_2
+        )
+        snapshot.match("update-function-code-response", update_function_code_response)
+        lambda_client.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+
+        get_function_response = lambda_client.get_function(FunctionName=function_name)
+        snapshot.match("get-function-code-response-after-update", get_function_response)
+        get_function_config_response = lambda_client.get_function_configuration(
+            FunctionName=function_name
+        )
+        snapshot.match("get-function-config-response-after-update", get_function_config_response)
+
+    @pytest.mark.aws_validated
+    def test_lambda_image_and_image_config_crud(
+        self, lambda_client, create_lambda_function_aws, lambda_su_role, test_image, snapshot
+    ):
+        image = test_image("alpine")
+        repo_uri = image.rpartition(":")[0]
+        snapshot.add_transformer(snapshot.transform.regex(repo_uri, "<repo_uri>"))
+        # Create another lambda with image config
+        function_name = f"test-function-{short_uid()}"
+        image_config = {
+            "EntryPoint": ["sh"],
+            "Command": ["-c", "echo test"],
+            "WorkingDirectory": "/app1",
+        }
+        create_image_response = create_lambda_function_aws(
+            FunctionName=function_name,
+            Role=lambda_su_role,
+            Code={"ImageUri": image},
+            PackageType="Image",
+            ImageConfig=image_config,
+            Environment={"Variables": {"CUSTOM_ENV": "test"}},
+        )
+        snapshot.match("create-image-with-config-response", create_image_response)
+        lambda_client.get_waiter("function_active_v2").wait(FunctionName=function_name)
+        get_function_response = lambda_client.get_function(FunctionName=function_name)
+        snapshot.match("get-function-code-with-config-response", get_function_response)
+        get_function_config_response = lambda_client.get_function_configuration(
+            FunctionName=function_name
+        )
+        snapshot.match("get-function-config-with-config-response", get_function_config_response)
+
+        # update image config
+        new_image_config = {
+            "Command": ["-c", "echo test1"],
+            "WorkingDirectory": "/app1",
+        }
+        update_function_config_response = lambda_client.update_function_configuration(
+            FunctionName=function_name, ImageConfig=new_image_config
+        )
+        snapshot.match("update-function-code-response", update_function_config_response)
+        lambda_client.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+
+        get_function_response = lambda_client.get_function(FunctionName=function_name)
+        snapshot.match("get-function-code-response-after-update", get_function_response)
+        get_function_config_response = lambda_client.get_function_configuration(
+            FunctionName=function_name
+        )
+        snapshot.match("get-function-config-response-after-update", get_function_config_response)
+
+        # update to empty image config
+        update_function_config_response = lambda_client.update_function_configuration(
+            FunctionName=function_name, ImageConfig={}
+        )
+        snapshot.match(
+            "update-function-code-delete-imageconfig-response", update_function_config_response
+        )
+        lambda_client.get_waiter("function_updated_v2").wait(FunctionName=function_name)
+
+        get_function_response = lambda_client.get_function(FunctionName=function_name)
+        snapshot.match("get-function-code-response-after-delete-imageconfig", get_function_response)
+        get_function_config_response = lambda_client.get_function_configuration(
+            FunctionName=function_name
+        )
+        snapshot.match(
+            "get-function-config-response-after-delete-imageconfig", get_function_config_response
+        )
 
 
 @pytest.mark.skipif(is_old_provider(), reason="focusing on new provider")

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -8592,5 +8592,190 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_zip_file_to_image": {
+    "recorded-date": "01-12-2022, 13:34:38",
+    "recorded-content": {
+      "create-image-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.9",
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-function-code-response": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.9",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "zipfile-to-image-error": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Please don't provide ImageUri when updating a function with packageType Zip."
+        },
+        "Type": "User",
+        "message": "Please don't provide ImageUri when updating a function with packageType Zip.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "get-function-code-response-after-update": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-response-after-update": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.9",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -7954,5 +7954,643 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_crud": {
+    "recorded-date": "30-11-2022, 20:38:27",
+    "recorded-content": {
+      "create-image-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-function-code-response": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": 0,
+          "Description": "",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "image-to-zipfile-error": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Please provide ImageUri when updating a function with packageType Image."
+        },
+        "Type": "User",
+        "message": "Please provide ImageUri when updating a function with packageType Image.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-function-code-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:2>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:3>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-code-response-after-update": {
+        "Code": {
+          "ImageUri": "<repo_uri_2>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri_2>@sha256:<code-sha256:2>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:2>",
+          "CodeSize": 0,
+          "Description": "",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:4>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-response-after-update": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:2>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:4>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_and_image_config_crud": {
+    "recorded-date": "30-11-2022, 21:35:01",
+    "recorded-content": {
+      "create-image-with-config-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "ImageConfigResponse": {
+          "ImageConfig": {
+            "Command": [
+              "-c",
+              "echo test"
+            ],
+            "EntryPoint": [
+              "sh"
+            ],
+            "WorkingDirectory": "/app1"
+          }
+        },
+        "LastModified": "date",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Pending",
+        "StateReason": "The function is being created.",
+        "StateReasonCode": "Creating",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-function-code-with-config-response": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": 0,
+          "Description": "",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "ImageConfigResponse": {
+            "ImageConfig": {
+              "Command": [
+                "-c",
+                "echo test"
+              ],
+              "EntryPoint": [
+                "sh"
+              ],
+              "WorkingDirectory": "/app1"
+            }
+          },
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-with-config-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "ImageConfigResponse": {
+          "ImageConfig": {
+            "Command": [
+              "-c",
+              "echo test"
+            ],
+            "EntryPoint": [
+              "sh"
+            ],
+            "WorkingDirectory": "/app1"
+          }
+        },
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-function-code-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "ImageConfigResponse": {
+          "ImageConfig": {
+            "Command": [
+              "-c",
+              "echo test1"
+            ],
+            "WorkingDirectory": "/app1"
+          }
+        },
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:3>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-code-response-after-update": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": 0,
+          "Description": "",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "ImageConfigResponse": {
+            "ImageConfig": {
+              "Command": [
+                "-c",
+                "echo test1"
+              ],
+              "WorkingDirectory": "/app1"
+            }
+          },
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:4>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-response-after-update": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "ImageConfigResponse": {
+          "ImageConfig": {
+            "Command": [
+              "-c",
+              "echo test1"
+            ],
+            "WorkingDirectory": "/app1"
+          }
+        },
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:4>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-function-code-delete-imageconfig-response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:5>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-code-response-after-delete-imageconfig": {
+        "Code": {
+          "ImageUri": "<repo_uri>:latest",
+          "RepositoryType": "ECR",
+          "ResolvedImageUri": "<repo_uri>@sha256:<code-sha256:1>"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": 0,
+          "Description": "",
+          "Environment": {
+            "Variables": {
+              "CUSTOM_ENV": "test"
+            }
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Image",
+          "RevisionId": "<uuid:6>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "State": "Active",
+          "Timeout": 3,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-function-config-response-after-delete-imageconfig": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": 0,
+        "Description": "",
+        "Environment": {
+          "Variables": {
+            "CUSTOM_ENV": "test"
+          }
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Image",
+        "RevisionId": "<uuid:6>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "State": "Active",
+        "Timeout": 3,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Motivation
Current implementation of the new lambda provider is missing relevant features regarding ImageUri CRUD.
Even though container image execution is a LocalStack Pro feature, the basic CRUD functionality should be in community, on the one hand to prevent tools which use them from throwing errors based on invalid API responses, and for the other to make a implementation easier for pro.

## Changes
* Added lambda image / imageconfig crud
* add tests
* Move deployment package specific code behind guards, so they are only executed if needed
* Add hooks to hook into from pro, to support container images and layers