### PR TITLE
fix: correct status when updating an updated stack

### DIFF
--- a/localstack/utils/cloudformation/template_deployer.py
+++ b/localstack/utils/cloudformation/template_deployer.py
@@ -1066,7 +1066,11 @@ class TemplateDeployer:
             raise
 
     def apply_change_set(self, change_set):
-        action = "UPDATE" if change_set.stack.status == "CREATE_COMPLETE" else "CREATE"
+        action = (
+            "UPDATE"
+            if change_set.stack.status in {"CREATE_COMPLETE", "UPDATE_COMPLETE"}
+            else "CREATE"
+        )
         change_set.stack.set_stack_status(f"{action}_IN_PROGRESS")
 
         # update attributes that the stack inherits from the changeset

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -428,10 +428,19 @@ def test_prevent_resource_deletion(deploy_cfn_template, cfn_client, sns_client, 
     sns_client.get_topic_attributes(TopicArn=stack.outputs["TopicArn"])
 
 
-def test_updating_an_updated_stack_sets_status(deploy_cfn_template, cfn_client):
+@pytest.mark.aws_validated
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        # parameters may be out of order
+        "$..Stacks..Parameters",
+    ]
+)
+def test_updating_an_updated_stack_sets_status(deploy_cfn_template, cfn_client, snapshot):
     """
     The status of a stack that has been updated twice should be "UPDATE_COMPLETE"
     """
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+
     # need multiple templates to support updates to the stack
     template_1 = load_file(
         os.path.join(os.path.dirname(__file__), "../../templates/stack_update_1.yaml")
@@ -443,12 +452,52 @@ def test_updating_an_updated_stack_sets_status(deploy_cfn_template, cfn_client):
         os.path.join(os.path.dirname(__file__), "../../templates/stack_update_3.yaml")
     )
 
-    stack = deploy_cfn_template(template=template_1)
+    topic_1_name = f"topic-1-{short_uid()}"
+    topic_2_name = f"topic-2-{short_uid()}"
+    topic_3_name = f"topic-3-{short_uid()}"
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.regex(topic_1_name, "topic-1"),
+            snapshot.transform.regex(topic_2_name, "topic-2"),
+            snapshot.transform.regex(topic_3_name, "topic-3"),
+        ]
+    )
+
+    parameters = {
+        "Topic1Name": topic_1_name,
+        "Topic2Name": topic_2_name,
+        "Topic3Name": topic_3_name,
+    }
+
+    def wait_for(waiter_type: str) -> None:
+        cfn_client.get_waiter(waiter_type).wait(
+            StackName=stack.stack_name,
+            WaiterConfig={
+                "Delay": 5,
+                "MaxAttempts": 5,
+            },
+        )
+
+    stack = deploy_cfn_template(template=template_1, parameters=parameters)
+    wait_for("stack_create_complete")
+
     # update the stack
-    deploy_cfn_template(template=template_2, is_update=True, stack_name=stack.stack_name)
+    deploy_cfn_template(
+        template=template_2,
+        is_update=True,
+        stack_name=stack.stack_name,
+        parameters=parameters,
+    )
+    wait_for("stack_update_complete")
 
     # update the stack again
-    deploy_cfn_template(template=template_3, is_update=True, stack_name=stack.stack_name)
+    deploy_cfn_template(
+        template=template_3,
+        is_update=True,
+        stack_name=stack.stack_name,
+        parameters=parameters,
+    )
+    wait_for("stack_update_complete")
 
     res = cfn_client.describe_stacks(StackName=stack.stack_name)
-    assert res["Stacks"][0]["StackStatus"] == "UPDATE_COMPLETE"
+    snapshot.match("describe-result", res)

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -440,5 +440,53 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/api/test_stacks.py::test_updating_an_updated_stack_sets_status": {
+    "recorded-date": "02-12-2022, 11:19:41",
+    "recorded-content": {
+      "describe-result": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Parameters": [
+              {
+                "ParameterKey": "Topic2Name",
+                "ParameterValue": "topic-2"
+              },
+              {
+                "ParameterKey": "Topic1Name",
+                "ParameterValue": "topic-1"
+              },
+              {
+                "ParameterKey": "Topic3Name",
+                "ParameterValue": "topic-3"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "UPDATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/stack_update_1.yaml
+++ b/tests/integration/templates/stack_update_1.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: sns-topic-simple
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete

--- a/tests/integration/templates/stack_update_1.yaml
+++ b/tests/integration/templates/stack_update_1.yaml
@@ -1,8 +1,15 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Topic1Name:
+    Type: String
+  Topic2Name:
+    Type: String
+  Topic3Name:
+    Type: String
 Resources:
-  topic123:
+  topic1:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: sns-topic-simple
+      TopicName: !Ref Topic1Name
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete

--- a/tests/integration/templates/stack_update_2.yaml
+++ b/tests/integration/templates/stack_update_2.yaml
@@ -1,0 +1,13 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: sns-topic-simple
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+
+  bucket123:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: bucket123

--- a/tests/integration/templates/stack_update_2.yaml
+++ b/tests/integration/templates/stack_update_2.yaml
@@ -1,13 +1,21 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Topic1Name:
+    Type: String
+  Topic2Name:
+    Type: String
+  Topic3Name:
+    Type: String
 Resources:
-  topic123:
+  topic1:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: sns-topic-simple
+      TopicName: !Ref Topic1Name
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
-
-  bucket123:
-    Type: AWS::S3::Bucket
+  topic2:
+    Type: AWS::SNS::Topic
     Properties:
-      BucketName: bucket123
+      TopicName: !Ref Topic2Name
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete

--- a/tests/integration/templates/stack_update_3.yaml
+++ b/tests/integration/templates/stack_update_3.yaml
@@ -1,18 +1,27 @@
 AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Topic1Name:
+    Type: String
+  Topic2Name:
+    Type: String
+  Topic3Name:
+    Type: String
 Resources:
-  topic123:
+  topic1:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: sns-topic-simple
+      TopicName: !Ref Topic1Name
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
-
-  bucket123:
-    Type: AWS::S3::Bucket
+  topic2:
+    Type: AWS::SNS::Topic
     Properties:
-      BucketName: bucket123
-
-  bucket456:
-    Type: AWS::S3::Bucket
+      TopicName: !Ref Topic2Name
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  topic3:
+    Type: AWS::SNS::Topic
     Properties:
-      BucketName: bucket456
+      TopicName: !Ref Topic3Name
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete

--- a/tests/integration/templates/stack_update_3.yaml
+++ b/tests/integration/templates/stack_update_3.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: sns-topic-simple
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+
+  bucket123:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: bucket123
+
+  bucket456:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: bucket456


### PR DESCRIPTION
This PR fixes an issue with updating updated stacks. After deploying a stack three (!!) times, the stack status would go through

1. `CREATE_COMPLETE`
2. `UPDATE_COMPLETE`
3. `CREATE_COMPLETE`

which is not correct. This impacted AWS SAM since it would be waiting for `UPDATE_COMPLETE` for an update operation, and would hang/timeout. With this change, the stack status is correctly returned to `cloudformation.describe_stacks` as `UPDATE_COMPLETE`.

Closes #6155