### PR TITLE
remove pins for werkzeug, flask, and quart

### DIFF
--- a/localstack/aws/handlers/legacy.py
+++ b/localstack/aws/handlers/legacy.py
@@ -28,8 +28,9 @@ def push_request_context(_chain: HandlerChain, context: RequestContext, _respons
 
     from localstack.utils.aws import request_context
 
-    quart.globals._request_ctx_stack.push(context)
-    flask.globals._request_ctx_stack.push(context)
+    # set the request context variable and hackily set the reset token on our internal request context
+    context._legacy_quart_cv_request_token = quart.globals._cv_request.set(context)
+    context._legacy_flask_cv_request_token = flask.globals._cv_request.set(context)
     request_context.THREAD_LOCAL.request_context = context.request
 
 
@@ -40,8 +41,9 @@ def pop_request_context(_chain: HandlerChain, _context: RequestContext, _respons
 
     from localstack.utils.aws import request_context
 
-    quart.globals._request_ctx_stack.pop()
-    flask.globals._request_ctx_stack.pop()
+    # reset the request context based on the token stored at the request context
+    quart.globals._cv_request.reset(_context._legacy_quart_cv_request_token)
+    flask.globals._cv_request.reset(_context._legacy_flask_cv_request_token)
     request_context.THREAD_LOCAL.request_context = None
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ runtime =
     dnslib>=0.9.10
     dnspython>=1.16.0
     docker==5.0.0
-    flask==2.1.3
+    flask>=2.2.2
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12
     hypercorn==0.14.2
@@ -84,11 +84,11 @@ runtime =
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pyopenssl==22.0.0
-    Quart==0.17
+    Quart>=0.18.0
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
     # TODO: remove werkzeug&flask version pins once we can upgrade to latest versions
-    Werkzeug==2.1.2
+    Werkzeug>=2.2.2
     xmltodict>=0.11.0
     awscrt>=0.13.14
     vosk==0.3.43


### PR DESCRIPTION
This PR removes the pins for `werkzeug`, `flask`, and `Quart` introduced in #6514 and #6593.

TODO:
- [x] Remove pins.
- [ ] Fix usage of removed request context stack (for both flask and quart).
- [ ] Ensure all tests are green.