### PR TITLE
fix cloudwatch tests by filtering alarm names

### DIFF
--- a/tests/integration/test_cloudwatch.py
+++ b/tests/integration/test_cloudwatch.py
@@ -335,7 +335,7 @@ class TestCloudwatch:
         results = cloudwatch_client.list_metrics(Namespace="AWS/EC2")["Metrics"]
         assert 2 == len(results)
 
-    def test_put_metric_alarm_escape_character(self, cloudwatch_client):
+    def test_put_metric_alarm_escape_character(self, cloudwatch_client, cleanups):
         cloudwatch_client.put_metric_alarm(
             AlarmName="cpu-mon",
             AlarmDescription="<",
@@ -348,10 +348,10 @@ class TestCloudwatch:
             EvaluationPeriods=1,
             AlarmActions=["arn:aws:sns:us-east-1:111122223333:MyTopic"],
         )
+        cleanups.append(lambda: cloudwatch_client.delete_alarms(AlarmNames=["cpu-mon"]))
 
-        result = cloudwatch_client.describe_alarms()
+        result = cloudwatch_client.describe_alarms(AlarmNames=["cpu-mon"])
         assert result.get("MetricAlarms")[0]["AlarmDescription"] == "<"
-        cloudwatch_client.delete_alarms(AlarmNames=["cpu-mon"])
 
     def test_set_alarm(
         self, sns_client, cloudwatch_client, sqs_client, sns_create_topic, sqs_create_queue


### PR DESCRIPTION
## Motivation
Currently, on master, tests are failing due to the put_metric_alarm_escape_character test failing.
Since it describes all alarms in the describe_alarms check, and just takes the first, it is very possible a leftover alarm from another test failing this one.

## Changes
* use cleanups fixture for cleanup of this alarm
* filter describe alarms so the first returned alarm should always be the just-created one.