### PR TITLE
Fix stage model patch operations

### DIFF
--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -239,7 +239,7 @@ def apply_patches():
                     api_id, stage = api_stages[i].split(":")
                     api_stages[i] = {"apiId": api_id, "stage": stage}
 
-            return 200, {}, json.dumps(usage_plan)
+            return 200, {}, json.dumps(usage_plan.to_json())
         return apigateway_response_usage_plan_individual_orig(
             self, request, full_url, headers, *args, **kwargs
         )

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -239,7 +239,7 @@ def apply_patches():
                     api_id, stage = api_stages[i].split(":")
                     api_stages[i] = {"apiId": api_id, "stage": stage}
 
-            return 200, {}, json.dumps(usage_plan.to_json())
+            return 200, {}, json.dumps(usage_plan)
         return apigateway_response_usage_plan_individual_orig(
             self, request, full_url, headers, *args, **kwargs
         )
@@ -265,8 +265,9 @@ def apply_patches():
         if isinstance(self, apigateway_models.Stage):
             bool_params = ["cacheClusterEnabled", "tracingEnabled"]
             for bool_param in bool_params:
-                if self.get(bool_param):
-                    self[bool_param] = str_to_bool(self.get(bool_param))
+                if getattr(self, camelcase_to_underscores(bool_param), None):
+                    value = getattr(self, camelcase_to_underscores(bool_param), None)
+                    setattr(self, camelcase_to_underscores(bool_param), str_to_bool(value))
         return self
 
     model_classes = [
@@ -355,10 +356,11 @@ def apply_patches():
             if value is None:
                 return value
             if value_type == bool:
-                return str(value) in ["true", "True"]
+                return str(value) in {"true", "True"}
             return value_type(value)
 
-        method_settings = self["methodSettings"] = self.get("methodSettings") or {}
+        method_settings = getattr(self, camelcase_to_underscores("methodSettings"), {})
+        setattr(self, camelcase_to_underscores("methodSettings"), method_settings)
         for operation in patch_operations:
             path = operation["path"]
             parts = path.strip("/").split("/")
@@ -366,7 +368,7 @@ def apply_patches():
                 if operation["op"] not in ["add", "replace"]:
                     continue
                 key1 = "/".join(parts[:-2])
-                setting_key = "%s/%s" % (parts[-2], parts[-1])
+                setting_key = f"{parts[-2]}/{parts[-1]}"
                 setting_name, setting_type = key_mappings.get(setting_key)
                 keys = [key1]
                 for key in keys:

--- a/tests/integration/apigateway_fixtures.py
+++ b/tests/integration/apigateway_fixtures.py
@@ -166,6 +166,12 @@ def create_rest_api_stage(apigateway_client, **kwargs):
     return response.get("stageName")
 
 
+def update_rest_api_stage(apigateway_client, **kwargs):
+    response = apigateway_client.update_stage(**kwargs)
+    assert_response_is_200(response)
+    return response.get("stageName")
+
+
 def create_cognito_user_pool(cognito_idp, **kwargs):
     response = cognito_idp.create_user_pool(**kwargs)
     assert_response_is_200(response)

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -482,8 +482,7 @@ class TestAPIGateway:
             apigateway_client,
             restApiId=api_id,
             stageName="local",
-            patchOperations=[{"op": "replace", "path": "/cacheClusterEnabled",
-                              "value": "true"}],
+            patchOperations=[{"op": "replace", "path": "/cacheClusterEnabled", "value": "true"}],
         )
         aws_account_id = sts_client.get_caller_identity()["Account"]
         source_arn = f"arn:aws:execute-api:{region_name}:{aws_account_id}:{api_id}/*/*/test"

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -482,7 +482,8 @@ class TestAPIGateway:
             apigateway_client,
             restApiId=api_id,
             stageName="local",
-            patchOperations=[{"op": "replace", "path": "/cacheClusterEnabled", "value": True}],
+            patchOperations=[{"op": "replace", "path": "/cacheClusterEnabled",
+                              "value": "true"}],
         )
         aws_account_id = sts_client.get_caller_identity()["Account"]
         source_arn = f"arn:aws:execute-api:{region_name}:{aws_account_id}:{api_id}/*/*/test"

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -61,6 +61,7 @@ from tests.integration.apigateway_fixtures import (
     get_rest_api_resources,
     put_rest_api,
     update_rest_api_deployment,
+    update_rest_api_stage,
 )
 
 from ..unit.test_apigateway import load_test_resource
@@ -477,6 +478,12 @@ class TestAPIGateway:
             apigateway_client, restApiId=api_id, stageName="local", deploymentId=deployment_id
         )
 
+        update_rest_api_stage(
+            apigateway_client,
+            restApiId=api_id,
+            stageName="local",
+            patchOperations=[{"op": "replace", "path": "/cacheClusterEnabled", "value": True}],
+        )
         aws_account_id = sts_client.get_caller_identity()["Account"]
         source_arn = f"arn:aws:execute-api:{region_name}:{aws_account_id}:{api_id}/*/*/test"
 


### PR DESCRIPTION
The custom patch wasn't adapted to reflect the recent uptake of the new moto model. The fix makes sure we access the correct property from the model.

- Sample https://github.com/localstack/localstack-terraform-samples/tree/master/apigateway-rest-cors

Resolves https://github.com/localstack/localstack/issues/7278
