### PR TITLE
fix opensearch / elasticsearch cf tempalte type conversions

### DIFF
--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -1,7 +1,8 @@
+from localstack.aws.api.es import CreateElasticsearchDomainRequest
 from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import arns, aws_stack
-from localstack.utils.common import select_attributes
+from localstack.utils.collections import convert_to_typed_dict
 
 
 def es_add_tags_params(params, **kwargs):
@@ -45,21 +46,7 @@ class ElasticsearchDomain(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _create_params(params, **kwargs):
-            attributes = [
-                "AccessPolicies",
-                "AdvancedOptions",
-                "CognitoOptions",
-                "DomainName",
-                "EBSOptions",
-                "ElasticsearchClusterConfig",
-                "ElasticsearchVersion",
-                "EncryptionAtRestOptions",
-                "LogPublishingOptions",
-                "NodeToNodeEncryptionOptions",
-                "SnapshotOptions",
-                "VPCOptions",
-            ]
-            result = select_attributes(params, attributes)
+            result = convert_to_typed_dict(CreateElasticsearchDomainRequest, params)
             result = remove_none_values(result)
             cluster_config = result.get("ElasticsearchClusterConfig")
             if isinstance(cluster_config, dict):

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -6,7 +6,7 @@ from localstack.aws.api.opensearch import (
 from localstack.services.cloudformation.deployment_utils import remove_none_values
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import arns, aws_stack
-from localstack.utils.collections import select_attributes
+from localstack.utils.collections import convert_to_typed_dict
 
 
 # OpenSearch still uses "es" ARNs
@@ -41,14 +41,8 @@ class OpenSearchDomain(GenericBaseModel):
     @staticmethod
     def get_deploy_templates():
         def _create_params(params, **kwargs):
-            # Tags handled outside of creation
-            attributes = [
-                attribute
-                for attribute in CreateDomainRequest.__annotations__.keys()
-                if "Tag" not in attribute
-            ]
-            result = select_attributes(params, attributes)
-            result = remove_none_values(result)
+            params = remove_none_values(params)
+            result = convert_to_typed_dict(CreateDomainRequest, params)
             cluster_config = result.get("ClusterConfig")
             if isinstance(cluster_config, dict):
                 # set defaults required for boto3 calls

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -20,16 +20,14 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_args,
-    get_origin,
 )
 
 import cachetools
 
 if sys.version_info >= (3, 8):
-    from typing import TypedDict
+    from typing import TypedDict, get_args, get_origin
 else:
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict, get_args, get_origin
 
 
 LOG = logging.getLogger(__name__)

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -7,7 +7,22 @@ import logging
 import re
 import sys
 from collections.abc import Mapping
-from typing import Any, Callable, Dict, Iterator, List, Optional, Sized, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sized,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    get_args,
+    get_origin,
+)
 
 import cachetools
 
@@ -426,5 +441,42 @@ def select_from_typed_dict(typed_dict: Type[TypedDict], obj: Dict, filter: bool 
         obj, [*typed_dict.__required_keys__, *typed_dict.__optional_keys__]
     )
     if filter:
-        return {k: v for k, v in selection.items() if v}
+        selection = {k: v for k, v in selection.items() if v}
     return selection
+
+
+T = TypeVar("T", bound=Dict)
+
+
+def convert_to_typed_dict(typed_dict: Type[T], obj: Dict, strict: bool = False) -> T:
+    """
+    Converts the given object to the given typed dict (by calling the type constructors).
+    Limitations:
+    - This does not work for ForwardRefs (type refs in quotes).
+    - If a type is a Union, the first type is used for the conversion.
+    - The conversion fails for types which cannot be instantiated with the constructor.
+
+    :param typed_dict: to convert the given object to
+    :param obj: object to convert matching keys to the types defined in the typed dict
+    :param strict: True if a TypeError should be raised in case the conversion fails
+    :return: obj converted to the typed dict T
+    """
+    result = cast(T, select_from_typed_dict(typed_dict, obj, filter=True))
+    for key, key_type in typed_dict.__annotations__.items():
+        if key in result:
+            # If it's a Union, or optional, we extract the first type argument
+            if get_origin(key_type) in [Union, Optional]:
+                key_type = get_args(key_type)[0]
+            # Use duck-typing to check if the dict is a typed dict
+            if hasattr(key_type, "__required_keys__") and hasattr(key_type, "__optional_keys__"):
+                result[key] = convert_to_typed_dict(key_type, result[key])
+            else:
+                # Otherwise, we call the type's constructor (on a best-effort basis)
+                try:
+                    result[key] = key_type(result[key])
+                except TypeError as e:
+                    if strict:
+                        raise e
+                    else:
+                        LOG.debug("Could not convert %s to %s.", key, key_type)
+    return result

--- a/tests/integration/cloudformation/resources/test_elasticsearch.py
+++ b/tests/integration/cloudformation/resources/test_elasticsearch.py
@@ -14,7 +14,7 @@ Resources:
     Properties:
       DomainName: !Ref "DomainName"
       ElasticsearchClusterConfig:
-        InstanceCount: 1
+        InstanceCount: "1"
         InstanceType: 'm5.large.elasticsearch'
         ZoneAwarenessEnabled: false
         # remaining required attributes (DedicatedMasterType, WarmType) should get filled in by template deployer

--- a/tests/integration/templates/opensearch_domain.yml
+++ b/tests/integration/templates/opensearch_domain.yml
@@ -11,3 +11,5 @@ Resources:
       EngineVersion: OpenSearch_1.0
       ClusterConfig:
         InstanceType: 'm3.medium.search'
+        # test using string types instead of int
+        InstanceCount: "2"

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Union
 
 import pytest
 
@@ -7,6 +7,7 @@ from localstack.utils.collections import (
     HashableList,
     ImmutableDict,
     ImmutableList,
+    convert_to_typed_dict,
     select_from_typed_dict,
 )
 
@@ -108,3 +109,72 @@ def test_hashable_list():
     with pytest.raises(Exception) as exc:
         l1[0] = "foo"
     exc.match("does not support item assignment")
+
+
+def test_convert_to_typed_dict():
+    class TestTypedDict(TypedDict):
+        str_member: str
+        int_member: int
+        dict_member: dict
+
+    test_dict = {"str_member": 1, "int_member": "1", "dict_member": {"inner_member": 1}}
+
+    result = convert_to_typed_dict(TestTypedDict, test_dict)
+    assert isinstance(result, dict)
+    assert result["str_member"] == "1"
+    assert result["int_member"] == 1
+    assert result["dict_member"] == {"inner_member": 1}
+
+
+def test_convert_to_typed_dict_with_union():
+    class TestTypedDict(TypedDict):
+        union_member: Union[str, int]
+
+    test_dict = {"union_member": 1}
+
+    result = convert_to_typed_dict(TestTypedDict, test_dict)
+    assert isinstance(result, dict)
+    assert result["union_member"] == "1"
+
+
+def test_convert_to_typed_dict_with_optional():
+    class TestTypedDict(TypedDict):
+        optional_member: Optional[str]
+
+    test_dict = {"optional_member": 1}
+
+    result = convert_to_typed_dict(TestTypedDict, test_dict)
+    assert isinstance(result, dict)
+    assert result["optional_member"] == "1"
+
+
+def test_convert_to_typed_dict_with_strict_mode():
+    class ClassWithoutValueConstructor:
+        pass
+
+    class TestTypedDict(TypedDict):
+        non_convertable: ClassWithoutValueConstructor
+
+    test_dict = {"non_convertable": ClassWithoutValueConstructor()}
+
+    # ensure the strict conversion fails
+    with pytest.raises(TypeError):
+        convert_to_typed_dict(TestTypedDict, test_dict, strict=True)
+
+    # ensure the non-strict conversion contains the original values
+    result = convert_to_typed_dict(TestTypedDict, test_dict)
+    assert test_dict == result
+
+
+def test_convert_to_typed_dict_with_typed_subdict():
+    class InnerTypedDict(TypedDict):
+        str_member: str
+
+    class TestTypedDict(TypedDict):
+        subdict: InnerTypedDict
+
+    test_dict = {"subdict": {"str_member": 1}}
+
+    result = convert_to_typed_dict(TestTypedDict, test_dict)
+    assert isinstance(result, dict)
+    assert result["subdict"] == {"str_member": "1"}


### PR DESCRIPTION
CloudFormation templates are defines in JSON or YAML. Both have type support for primitive types like string or integer.
However, AWS CloudFormation is not too strict about the types of the different fields, f.e. `ClusterConfig.InstanceCount` can be defined as string instead of integer in `AWS::OpenSearchService::Domain`.

This PR introduces a new utility which performs a best-effort TypedDict conversion.
It can be used with the TypedDicts generated by ASF, and will try to recursively convert the members of a given dict to the types of the members of a specific TypedDict.

`convert_to_typed_dict` is then used in the cloudformation models for elasticsearch and opensearch to fix the described type differences.

Fixes #7282