### PR TITLE
added lambda function creation validation

### DIFF
--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -512,6 +512,14 @@ def parse_layer_arn(layer_version_arn: str):
     )
 
 
+def validate_lambda_runtime(compatible_runtime: str) -> str | None:
+    if not compatible_runtime:
+        return "Value 'runtime' is required none supplied"
+    if compatible_runtime not in RUNTIMES:
+        return f"Value {compatible_runtime} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+    return None
+
+
 # TODO: save list of valid runtimes somewhere
 def validate_layer_runtime(compatible_runtime: str) -> str | None:
     if compatible_runtime is not None and compatible_runtime not in RUNTIMES:

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -28,6 +28,7 @@ from localstack.constants import APPLICATION_JSON, LOCALHOST_HOSTNAME
 from localstack.http import Request
 from localstack.http import Response as HttpResponse
 from localstack.services.awslambda import lambda_executors
+from localstack.services.awslambda.api_utils import validate_lambda_runtime
 from localstack.services.awslambda.event_source_listeners.event_source_listener import (
     EventSourceListener,
 )
@@ -1210,6 +1211,11 @@ def create_function():
         lambda_function.description = data.get("Description", "")
         lambda_function.handler = data.get("Handler")
         lambda_function.runtime = data.get("Runtime")
+        runtime_validation_error = validate_lambda_runtime(lambda_function.runtime)
+        if runtime_validation_error:
+            return error_response(
+                runtime_validation_error, 400, error_type=INVALID_PARAMETER_VALUE_EXCEPTION
+            )
         try:
             lambda_function.envvars = data.get("Environment", {}).get("Variables", {})
         except InvalidEnvVars as e:


### PR DESCRIPTION
While creating lambda function without adding `runtime` argument - It should throw an exception.

Example 1:
Should result in error.
```
aws lambda create-function --function-name my-function \
--zip-file fileb://code.zip --handler main.lambda_handler --runtime s \
--role arn:aws:iam::054596861717:role/lambda-ex --region us-east-1
```
Example 2:
Should result in error.
```
aws lambda create-function --function-name my-function \
--zip-file fileb://code.zip --handler main.lambda_handler --runtime s \
--role arn:aws:iam::054596861717:role/lambda-ex --region us-east-1
```