### PR TITLE
Add option to customize images used for lambda execution

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -630,6 +630,12 @@ LAMBDA_CONTAINER_REGISTRY = (
     os.environ.get("LAMBDA_CONTAINER_REGISTRY", "").strip() or DEFAULT_LAMBDA_CONTAINER_REGISTRY
 )
 
+# EXPERIMENTAL | Only applicable to new Lambda Provider
+# Allows two options to customize the resolution of Lambda runtime:
+#   1. pattern with <runtime> placeholder, e.g. "custom-repo/lambda-<runtime>:2022"
+#   2. json dict mapping the <runtime> to an image, e.g. '{"python3.9": "custom-repo/lambda-py:thon3.9"}'
+LAMBDA_RUNTIME_IMAGE_MAPPING = os.environ.get("LAMBDA_RUNTIME_IMAGE_MAPPING", "").strip()
+
 # whether to remove containers after Lambdas finished executing
 LAMBDA_REMOVE_CONTAINERS = (
     os.environ.get("LAMBDA_REMOVE_CONTAINERS", "").lower().strip() not in FALSE_STRINGS
@@ -749,6 +755,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_EXECUTOR",
     "LAMBDA_FALLBACK_URL",
     "LAMBDA_FORWARD_URL",
+    "LAMBDA_RUNTIME_IMAGE_MAPPING",
     "LAMBDA_JAVA_OPTS",
     "LAMBDA_REMOTE_DOCKER",
     "LAMBDA_REMOVE_CONTAINERS",

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -29,7 +29,7 @@ from localstack.utils.strings import truncate
 
 LOG = logging.getLogger(__name__)
 
-RUNTIME_REGEX = r"(?P<runtime>[a-z]+)(?P<version>\d+(\.\d+)?(\.al2)?)(?:.*)"
+RUNTIME_REGEX = r"(?P<runtime>[a-z]+)(?P<version>\d+(\.\d+)?(\.al2)?)(?:.*)"  # TODO: any reason this is still here?
 
 IMAGE_PREFIX = "public.ecr.aws/lambda/"
 # IMAGE_PREFIX = "amazon/aws-lambda-"
@@ -80,7 +80,7 @@ class RuntimeImageResolver:
         self._mapping = dict()
 
     def _resolve(self, runtime: Runtime, custom_image_mapping: str = "") -> str:
-        if runtime not in IMAGE_MAPPING.keys():
+        if runtime not in IMAGE_MAPPING:
             raise ValueError(f"Unsupported runtime {runtime}")
 
         if not custom_image_mapping:
@@ -95,6 +95,10 @@ class RuntimeImageResolver:
             mapping: dict = json.loads(custom_image_mapping)
             # at this point we're loading the whole dict to avoid parsing multiple times
             for k, v in mapping.items():
+                if k not in IMAGE_MAPPING:
+                    raise ValueError(
+                        f"Unsupported runtime ({runtime}) provided in LAMBDA_RUNTIME_IMAGE_MAPPING"
+                    )
                 self._mapping[k] = v
 
             if runtime in self._mapping:

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -248,7 +248,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
 
     def stop(self) -> None:
         CONTAINER_CLIENT.stop_container(container_name=self.id, timeout=5)
-        # CONTAINER_CLIENT.remove_container(container_name=self.id)
+        CONTAINER_CLIENT.remove_container(container_name=self.id)
         try:
             self.executor_endpoint.shutdown()
         except Exception as e:

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -29,8 +29,6 @@ from localstack.utils.strings import truncate
 
 LOG = logging.getLogger(__name__)
 
-RUNTIME_REGEX = r"(?P<runtime>[a-z]+)(?P<version>\d+(\.\d+)?(\.al2)?)(?:.*)"  # TODO: any reason this is still here?
-
 IMAGE_PREFIX = "public.ecr.aws/lambda/"
 # IMAGE_PREFIX = "amazon/aws-lambda-"
 

--- a/tests/unit/services/awslambda/test_image_resolver.py
+++ b/tests/unit/services/awslambda/test_image_resolver.py
@@ -37,3 +37,12 @@ def test_default_mapping():
     resolver = RuntimeImageResolver()
     resolved_image = resolver._resolve(Runtime.python3_9)
     assert "custom" not in resolved_image
+
+
+def test_custom_default_mapping():
+    def custom_default(a):
+        return f"custom-{a}"
+
+    resolver = RuntimeImageResolver(default_resolve_fn=custom_default)
+    resolved_image = resolver._resolve(Runtime.python3_9)
+    assert resolved_image == "custom-python3.9"

--- a/tests/unit/services/awslambda/test_image_resolver.py
+++ b/tests/unit/services/awslambda/test_image_resolver.py
@@ -1,0 +1,39 @@
+import json
+
+from localstack.aws.api.lambda_ import Runtime
+from localstack.services.awslambda.invocation.docker_runtime_executor import RuntimeImageResolver
+
+
+def test_custom_pattern_mapping():
+    resolver = RuntimeImageResolver()
+    resolved_image = resolver._resolve(
+        Runtime.python3_9, custom_image_mapping="custom/_<runtime>_:new"
+    )
+    assert resolved_image == "custom/_python3.9_:new"
+
+
+def test_custom_json_mapping():
+    resolver = RuntimeImageResolver()
+    resolved_image = resolver._resolve(
+        Runtime.python3_9,
+        custom_image_mapping=json.dumps({Runtime.python3_9: "custom/py.thon.3:9"}),
+    )
+    assert resolved_image == "custom/py.thon.3:9"
+
+
+def test_custom_json_mapping_fallback():
+    # if the runtime was not in the provided json, it should fall back to default
+    resolver = RuntimeImageResolver()
+    resolved_image = resolver._resolve(
+        Runtime.python3_8,
+        custom_image_mapping=json.dumps({Runtime.python3_9: "custom/py.thon.3:9"}),
+    )
+    assert resolved_image is not None
+    assert resolved_image != "custom/py.thon.3:9"
+    assert "custom" not in resolved_image
+
+
+def test_default_mapping():
+    resolver = RuntimeImageResolver()
+    resolved_image = resolver._resolve(Runtime.python3_9)
+    assert "custom" not in resolved_image


### PR DESCRIPTION
Adds a `RuntimeImageResolver` class and a corresponding new config variable `LAMBDA_RUNTIME_IMAGE_MAPPING`

Copied doc from the class:

> Resolves Lambda runtimes to corresponding docker images
> The default behavior resolves based on a prefix (including the repository) and a suffix (per runtime).
> 
> This can be customized via the LAMBDA_RUNTIME_IMAGE_MAPPING config in 2 distinct ways:
> 
>   Option A: use a pattern string for the config variable that includes the "<runtime>" string
>       e.g. "myrepo/lambda:<runtime>-custom" would resolve the runtime "python3.9" to "myrepo/lambda:python3.9-custom"
> 
>   Option B: use a JSON dict string for the config variable, mapping the runtime to the full image name & tag
>       e.g. {"python3.9": "myrepo/lambda:python3.9-custom", "python3.8": "myotherrepo/pylambda:3.8"}
>   
>       Note that with Option B this will only apply to the runtimes included in the dict.
>       All other (non-included) runtimes will fall back to the default behavior.

sample configurations:

* `LAMBDA_RUNTIME_IMAGE_MAPPING="customrepo/lambda-<runtime>:2022"`
* `LAMBDA_RUNTIME_IMAGE_MAPPING='{"python3.9": "customrepo/lambda-py-thon:3.9"}'`