### PR TITLE
Add hot reloading for new lambda provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
           name: Test ASF Lambda provider
           environment:
             PROVIDER_OVERRIDE_LAMBDA: "asf"
-            TEST_PATH: "tests/integration/awslambda/test_lambda.py tests/integration/awslambda/test_lambda_api.py tests/integration/awslambda/test_lambda_common.py tests/integration/awslambda/test_lambda_integration_sqs.py tests/integration/cloudformation/resources/test_lambda.py tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py tests/integration/awslambda/test_lambda_integration_kinesis.py"
+            TEST_PATH: "tests/integration/awslambda/test_lambda.py tests/integration/awslambda/test_lambda_api.py tests/integration/awslambda/test_lambda_common.py tests/integration/awslambda/test_lambda_integration_sqs.py tests/integration/cloudformation/resources/test_lambda.py tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py tests/integration/awslambda/test_lambda_integration_kinesis.py tests/integration/awslambda/test_lambda_developer_tools.py"
             PYTEST_ARGS: "--reruns 3 --junitxml=target/reports/lambda_asf.xml -o junit_suite_name='lambda_asf'"
             COVERAGE_ARGS: "-p"
           command: make test-coverage

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -199,7 +199,9 @@ S3_STATIC_WEBSITE_HOSTNAME = "s3-website.%s" % LOCALHOST_HOSTNAME
 DEFAULT_DEVELOP_PORT = 5678
 
 # Default bucket name of the s3 bucket used for local lambda development
-DEFAULT_BUCKET_MARKER_LOCAL = "__local__"
+# This name should be accepted by all IaC tools, so should respect s3 bucket naming conventions
+DEFAULT_BUCKET_MARKER_LOCAL = "hot-reloading-bucket"
+OLD_DEFAULT_BUCKET_MARKER_LOCAL = "__local__"
 
 # user that starts the opensearch process if the current user is root
 OS_USER_OPENSEARCH = "localstack"

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -200,8 +200,8 @@ DEFAULT_DEVELOP_PORT = 5678
 
 # Default bucket name of the s3 bucket used for local lambda development
 # This name should be accepted by all IaC tools, so should respect s3 bucket naming conventions
-DEFAULT_BUCKET_MARKER_LOCAL = "hot-reloading-bucket"
-OLD_DEFAULT_BUCKET_MARKER_LOCAL = "__local__"
+DEFAULT_BUCKET_MARKER_LOCAL = "hot-reload"
+LEGACY_DEFAULT_BUCKET_MARKER_LOCAL = "__local__"
 
 # user that starts the opensearch process if the current user is root
 OS_USER_OPENSEARCH = "localstack"

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -23,7 +23,7 @@ from localstack.services.awslambda.lambda_utils import (
     get_main_endpoint_from_container,
 )
 from localstack.services.awslambda.packages import awslambda_runtime_package
-from localstack.utils.container_utils.container_client import ContainerConfiguration
+from localstack.utils.container_utils.container_client import ContainerConfiguration, VolumeMappings
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
 from localstack.utils.strings import truncate
 
@@ -219,6 +219,26 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             network=network,
             entrypoint=RAPID_ENTRYPOINT,
         )
+        if self.function_version.config.package_type == PackageType.Zip:
+            if self.function_version.config.code.has_to_be_mounted():
+                # this basically means hot reloading
+                container_config.env_vars["LOCALSTACK_HOT_RELOADING_ENABLED"] = "1"
+                if container_config.volumes is None:
+                    container_config.volumes = VolumeMappings()
+                container_config.volumes.append(
+                    (
+                        str(self.function_version.config.code.get_unzipped_code_location()),
+                        "/var/task",
+                    )
+                )
+            else:
+                container_config.copy_folders.append(
+                    (
+                        f"{str(self.function_version.config.code.get_unzipped_code_location())}/.",
+                        "/var/task",
+                    )
+                )
+
         lambda_hooks.start_docker_executor.run(container_config, self.function_version)
 
         if not container_config.image_name:
@@ -232,15 +252,10 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             CONTAINER_CLIENT.copy_into_container(
                 self.id, str(get_runtime_client_path()), RAPID_ENTRYPOINT
             )
-        if self.function_version.config.package_type == PackageType.Zip:
-            if not config.LAMBDA_PREBUILD_IMAGES:
-                CONTAINER_CLIENT.copy_into_container(
-                    self.id,
-                    f"{str(self.function_version.config.code.get_unzipped_code_location())}/.",
-                    "/var/task",
-                )
-                for source, target in container_config.copy_folders:
-                    CONTAINER_CLIENT.copy_into_container(self.id, source, target)
+        if not config.LAMBDA_PREBUILD_IMAGES:
+            # copy_folders should be empty here if package type is not zip
+            for source, target in container_config.copy_folders:
+                CONTAINER_CLIENT.copy_into_container(self.id, source, target)
 
         CONTAINER_CLIENT.start_container(self.id)
         self.ip = CONTAINER_CLIENT.get_container_ipv4_for_network(

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -224,7 +224,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             entrypoint=RAPID_ENTRYPOINT,
         )
         if self.function_version.config.package_type == PackageType.Zip:
-            if self.function_version.config.code.has_to_be_mounted():
+            if self.function_version.config.code.is_hot_reloading():
                 # this basically means hot reloading
                 container_config.env_vars["LOCALSTACK_HOT_RELOADING_ENABLED"] = "1"
                 if container_config.volumes is None:

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -23,7 +23,11 @@ from localstack.services.awslambda.lambda_utils import (
     get_main_endpoint_from_container,
 )
 from localstack.services.awslambda.packages import awslambda_runtime_package
-from localstack.utils.container_utils.container_client import ContainerConfiguration, VolumeMappings
+from localstack.utils.container_utils.container_client import (
+    ContainerConfiguration,
+    VolumeBind,
+    VolumeMappings,
+)
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
 from localstack.utils.strings import truncate
 
@@ -226,9 +230,10 @@ class DockerRuntimeExecutor(RuntimeExecutor):
                 if container_config.volumes is None:
                     container_config.volumes = VolumeMappings()
                 container_config.volumes.append(
-                    (
+                    VolumeBind(
                         str(self.function_version.config.code.get_unzipped_code_location()),
                         "/var/task",
+                        read_only=True,
                     )
                 )
             else:

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -305,8 +305,6 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         lambda_hooks.prepare_docker_executor.run(function_version)
         if function_version.config.code:
             function_version.config.code.prepare_for_execution()
-            for layer in function_version.config.layers:
-                layer.code.prepare_for_execution()
             image_name = resolver.get_image_for_runtime(function_version.config.runtime)
             if image_name not in PULLED_IMAGES:
                 CONTAINER_CLIENT.pull_image(image_name)

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -225,7 +225,6 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         )
         if self.function_version.config.package_type == PackageType.Zip:
             if self.function_version.config.code.is_hot_reloading():
-                # this basically means hot reloading
                 container_config.env_vars["LOCALSTACK_HOT_RELOADING_ENABLED"] = "1"
                 if container_config.volumes is None:
                     container_config.volumes = VolumeMappings()

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -7,7 +7,7 @@ import random
 import uuid
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from hashlib import sha256
-from pathlib import Path
+from pathlib import PurePosixPath, PureWindowsPath
 from threading import RLock
 from typing import TYPE_CHECKING, Dict, Optional
 
@@ -384,12 +384,10 @@ def store_lambda_archive(
 
 def create_hot_reloading_code(path: str) -> HotReloadingCode:
     # TODO extract into other function
-    if not Path(path).is_absolute():
+    if not PurePosixPath(path).is_absolute() and not PureWindowsPath(path).is_absolute():
         raise InvalidParameterValueException(
-            "When using hot reloading, the archive key has to be an absolute path! Your archive key: %s",
-            path,
+            f"When using hot reloading, the archive key has to be an absolute path! Your archive key: {path}",
         )
-    # TODO fix types
     return HotReloadingCode(host_path=path)
 
 
@@ -412,7 +410,6 @@ def store_s3_bucket_archive(
     :param account_id: account id the archive should be stored for
     :return: S3 Code object representing the archive stored in S3
     """
-    # TODO change test-bucket-for-hot-reloading to actual bucket
     if archive_bucket == config.BUCKET_MARKER_LOCAL:
         return create_hot_reloading_code(path=archive_key)
     s3_client: "S3Client" = aws_stack.connect_to_service("s3")

--- a/localstack/services/awslambda/lambda_api.py
+++ b/localstack/services/awslambda/lambda_api.py
@@ -244,12 +244,12 @@ def build_mapping_obj(data) -> Dict:
 def is_hot_reloading(code: dict) -> bool:
     bucket_name = code.get("S3Bucket")
     if (
-        bucket_name == constants.OLD_DEFAULT_BUCKET_MARKER_LOCAL
+        bucket_name == constants.LEGACY_DEFAULT_BUCKET_MARKER_LOCAL
         and bucket_name != config.BUCKET_MARKER_LOCAL
     ):
         LOG.warning(
             "Please note that using %s as local bucket marker is deprecated. Please use %s or set the config option 'BUCKET_MARKER_LOCAL'",
-            constants.OLD_DEFAULT_BUCKET_MARKER_LOCAL,
+            constants.LEGACY_DEFAULT_BUCKET_MARKER_LOCAL,
             constants.DEFAULT_BUCKET_MARKER_LOCAL,
         )
         return True
@@ -597,8 +597,7 @@ def set_archive_code(
     is_local_mount = is_hot_reloading(code)
 
     if is_local_mount and config.LAMBDA_REMOTE_DOCKER:
-        msg = "Please note that Lambda mounts cannot be used with LAMBDA_REMOTE_DOCKER=1"
-        raise Exception(msg)
+        raise Exception("Please note that Lambda mounts cannot be used with LAMBDA_REMOTE_DOCKER=1")
 
     # Stop/remove any containers that this arn uses.
     LAMBDA_EXECUTOR.cleanup(lambda_arn)

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -9,7 +9,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.6-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.7-pre"
 
 # GO Lambda runtime
 GO_RUNTIME_VERSION = "0.4.0"
@@ -21,7 +21,7 @@ class AWSLambdaRuntimePackage(Package):
         super().__init__(name="AwsLambda", default_version=default_version)
 
     def get_versions(self) -> List[str]:
-        return ["v0.1.6-pre", "v0.1.5-pre", "v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
+        return ["v0.1.7-pre", "v0.1.6-pre", "v0.1.5-pre", "v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return AWSLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -284,7 +284,7 @@ class VolumeBind:
 
     host_dir: str
     container_dir: str
-    options: Optional[List[str]] = None
+    read_only: bool = False
 
     def to_str(self) -> str:
         args = []
@@ -297,8 +297,8 @@ class VolumeBind:
 
         args.append(self.container_dir)
 
-        if self.options:
-            args.append(self.options)
+        if self.read_only:
+            args.append("ro")
 
         return ":".join(args)
 
@@ -689,7 +689,7 @@ class ContainerClient(metaclass=ABCMeta):
         tty: bool = False,
         detach: bool = False,
         command: Optional[Union[List[str], str]] = None,
-        mount_volumes: Optional[List[SimpleVolumeBind]] = None,
+        mount_volumes: Optional[Union[VolumeMappings, List[SimpleVolumeBind]]] = None,
         ports: Optional[PortMappings] = None,
         env_vars: Optional[Dict[str, str]] = None,
         user: Optional[str] = None,
@@ -972,12 +972,22 @@ class Util:
 
     @staticmethod
     def convert_mount_list_to_dict(
-        mount_volumes: List[SimpleVolumeBind],
+        mount_volumes: List[SimpleVolumeBind] | VolumeMappings,
     ) -> Dict[str, Dict[str, str]]:
         """Converts a List of (host_path, container_path) tuples to a Dict suitable as volume argument for docker sdk"""
+
+        def _map_to_dict(paths: SimpleVolumeBind | VolumeBind):
+            if isinstance(paths, VolumeBind):
+                return str(paths.host_dir), {
+                    "bind": paths.container_dir,
+                    "mode": "ro" if paths.read_only else "rw",
+                }
+            else:
+                return str(paths[0]), {"bind": paths[1], "mode": "rw"}
+
         return dict(
             map(
-                lambda paths: (str(paths[0]), {"bind": paths[1], "mode": "rw"}),
+                _map_to_dict,
                 mount_volumes,
             )
         )

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -972,7 +972,7 @@ class Util:
 
     @staticmethod
     def convert_mount_list_to_dict(
-        mount_volumes: List[SimpleVolumeBind] | VolumeMappings,
+        mount_volumes: Union[List[SimpleVolumeBind], VolumeMappings],
     ) -> Dict[str, Dict[str, str]]:
         """Converts a List of (host_path, container_path) tuples to a Dict suitable as volume argument for docker sdk"""
 

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -22,6 +22,7 @@ from localstack.utils.container_utils.container_client import (
     RegistryConnectionError,
     SimpleVolumeBind,
     Util,
+    VolumeBind,
 )
 from localstack.utils.run import run
 from localstack.utils.strings import to_str
@@ -628,8 +629,8 @@ class CmdDockerClient(ContainerClient):
         if mount_volumes:
             cmd += [
                 volume
-                for host_path, docker_path in dict(mount_volumes).items()
-                for volume in ["-v", f"{host_path}:{docker_path}"]
+                for mount_volume in mount_volumes
+                for volume in ["-v", self._map_to_volume_param(mount_volume)]
             ]
         if interactive:
             cmd.append("--interactive")
@@ -664,3 +665,20 @@ class CmdDockerClient(ContainerClient):
         if command:
             cmd += command if isinstance(command, List) else [command]
         return cmd, env_file
+
+    @staticmethod
+    def _map_to_volume_param(mount_volume: SimpleVolumeBind | VolumeBind) -> str:
+        """
+        Maps the mount volume, to a parameter for the -v docker cli argument.
+
+        Examples:
+        (host_path, container_path) -> host_path:container_path
+        VolumeBind(host_dir=host_path, container_dir=container_path, read_only=True) -> host_path:container_path:ro
+
+        :param mount_volume: Either a SimpleVolumeBind, in essence a tuple (host_dir, container_dir), or a VolumeBind object
+        :return: String which is passable as parameter to the docker cli -v option
+        """
+        if isinstance(mount_volume, VolumeBind):
+            return mount_volume.to_str()
+        else:
+            return f"{mount_volume[0]}:{mount_volume[1]}"

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -667,7 +667,7 @@ class CmdDockerClient(ContainerClient):
         return cmd, env_file
 
     @staticmethod
-    def _map_to_volume_param(mount_volume: SimpleVolumeBind | VolumeBind) -> str:
+    def _map_to_volume_param(mount_volume: Union[SimpleVolumeBind, VolumeBind]) -> str:
         """
         Maps the mount volume, to a parameter for the -v docker cli argument.
 

--- a/tests/integration/awslambda/functions/hot-reloading/nodejs/handler.mjs
+++ b/tests/integration/awslambda/functions/hot-reloading/nodejs/handler.mjs
@@ -1,0 +1,11 @@
+const testConstant = "value1";
+let testCounter = 0;
+
+export const handler = async(event) => {
+    testCounter++;
+
+    return {
+        counter: testCounter,
+        constant: testConstant,
+    };
+};

--- a/tests/integration/awslambda/functions/hot-reloading/python/handler.py
+++ b/tests/integration/awslambda/functions/hot-reloading/python/handler.py
@@ -1,0 +1,8 @@
+CONSTANT_VARIABLE = "value1"
+COUNTER = 0
+
+
+def handler(event, context):
+    global COUNTER
+    COUNTER += 1
+    return {"counter": COUNTER, "constant": CONSTANT_VARIABLE}

--- a/tests/integration/awslambda/test_lambda_developer_tools.py
+++ b/tests/integration/awslambda/test_lambda_developer_tools.py
@@ -1,0 +1,78 @@
+import json
+import os
+import time
+
+import pytest
+from integration.awslambda.test_lambda import THIS_FOLDER
+
+from localstack import config
+from localstack.aws.api.lambda_ import Runtime
+from localstack.testing.aws.lambda_utils import is_old_provider
+from localstack.utils.docker_utils import get_host_path_for_path_in_docker
+from localstack.utils.files import load_file, mkdir
+from localstack.utils.strings import short_uid
+
+HOT_RELOADING_NODEJS_HANDLER = os.path.join(
+    THIS_FOLDER, "functions/hot-reloading/nodejs/handler.mjs"
+)
+HOT_RELOADING_PYTHON_HANDLER = os.path.join(
+    THIS_FOLDER, "functions/hot-reloading/python/handler.py"
+)
+
+
+class TestHotReloading:
+    @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
+    @pytest.mark.parametrize(
+        "runtime,handler_file,handler_filename",
+        [
+            (Runtime.nodejs18_x, HOT_RELOADING_NODEJS_HANDLER, "handler.mjs"),
+            (Runtime.python3_9, HOT_RELOADING_PYTHON_HANDLER, "handler.py"),
+        ],
+    )
+    def test_hot_reloading(
+        self,
+        create_lambda_function_aws,
+        lambda_client,
+        runtime,
+        handler_file,
+        handler_filename,
+        lambda_su_role,
+    ):
+        """Test hot reloading of lambda code"""
+        function_name = f"test-hot-reloading-{short_uid()}"
+        hot_reloading_bucket = "test-bucket-for-hot-reloading"
+        tmp_path = config.dirs.tmp
+        hot_reloading_dir_path = os.path.join(tmp_path, f"hot-reload-{short_uid()}")
+        mkdir(hot_reloading_dir_path)
+        function_content = load_file(handler_file)
+        with open(os.path.join(hot_reloading_dir_path, handler_filename), mode="wt") as f:
+            f.write(function_content)
+
+        mount_path = get_host_path_for_path_in_docker(hot_reloading_dir_path)
+        create_lambda_function_aws(
+            FunctionName=function_name,
+            Handler="handler.handler",
+            Code={"S3Bucket": hot_reloading_bucket, "S3Key": mount_path},
+            Role=lambda_su_role,
+            Runtime=runtime,
+        )
+        response = lambda_client.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.loads(response["Payload"].read())
+        assert response_dict["counter"] == 1
+        assert response_dict["constant"] == "value1"
+        response = lambda_client.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.loads(response["Payload"].read())
+        assert response_dict["counter"] == 2
+        assert response_dict["constant"] == "value1"
+        with open(os.path.join(hot_reloading_dir_path, handler_filename), mode="wt") as f:
+            f.write(function_content.replace("value1", "value2"))
+        # we have to sleep here, since the hot reloading is debounced with 500ms
+        time.sleep(0.6)
+        response = lambda_client.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.loads(response["Payload"].read())
+        assert response_dict["counter"] == 1
+        assert response_dict["constant"] == "value2"
+        response = lambda_client.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.loads(response["Payload"].read())
+        assert response_dict["counter"] == 2
+        assert response_dict["constant"] == "value2"

--- a/tests/integration/awslambda/test_lambda_developer_tools.py
+++ b/tests/integration/awslambda/test_lambda_developer_tools.py
@@ -40,7 +40,7 @@ class TestHotReloading:
     ):
         """Test hot reloading of lambda code"""
         function_name = f"test-hot-reloading-{short_uid()}"
-        hot_reloading_bucket = "test-bucket-for-hot-reloading"
+        hot_reloading_bucket = config.BUCKET_MARKER_LOCAL
         tmp_path = config.dirs.tmp
         hot_reloading_dir_path = os.path.join(tmp_path, f"hot-reload-{short_uid()}")
         mkdir(hot_reloading_dir_path)

--- a/tests/integration/awslambda/test_lambda_developer_tools.py
+++ b/tests/integration/awslambda/test_lambda_developer_tools.py
@@ -3,7 +3,6 @@ import os
 import time
 
 import pytest
-from integration.awslambda.test_lambda import THIS_FOLDER
 
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
@@ -11,6 +10,7 @@ from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.utils.docker_utils import get_host_path_for_path_in_docker
 from localstack.utils.files import load_file, mkdir, rm_rf
 from localstack.utils.strings import short_uid
+from tests.integration.awslambda.test_lambda import THIS_FOLDER
 
 HOT_RELOADING_NODEJS_HANDLER = os.path.join(
     THIS_FOLDER, "functions/hot-reloading/nodejs/handler.mjs"

--- a/tests/integration/awslambda/test_lambda_developer_tools.py
+++ b/tests/integration/awslambda/test_lambda_developer_tools.py
@@ -79,4 +79,21 @@ class TestHotReloading:
         response_dict = json.loads(response["Payload"].read())
         assert response_dict["counter"] == 2
         assert response_dict["constant"] == "value2"
-        # TODO test subdirs
+
+        # test subdirs
+        test_folder = os.path.join(hot_reloading_dir_path, "test-folder")
+        mkdir(test_folder)
+        # make sure the creation of the folder triggered reload
+        time.sleep(0.6)
+        response = lambda_client.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.loads(response["Payload"].read())
+        assert response_dict["counter"] == 1
+        assert response_dict["constant"] == "value2"
+        # now writing something in the new folder to check if it will reload
+        with open(os.path.join(test_folder, "test-file"), mode="wt") as f:
+            f.write("test-content")
+        time.sleep(0.6)
+        response = lambda_client.invoke(FunctionName=function_name, Payload=b"{}")
+        response_dict = json.loads(response["Payload"].read())
+        assert response_dict["counter"] == 1
+        assert response_dict["constant"] == "value2"


### PR DESCRIPTION
## Motivation

For efficient lambda development, we have to provide an easy solution to hot reload lambda functions, especially those of interpreted languages (like python and nodejs).
However, we want to make it available for all managed runtimes.
It should also only reset the environments if a change is detected, to prevent unnecessary initializations.

## Breaking Changes with Fallbacks

* Change of the default hot-reloading bucket marker, from `__local__` to `hot-reload`. The current provider will continue to support the `__local__` marker for now, the new one will only support the new one. Would move the deprecation to 1.4 and the removal to 2.0.

## Other Changes

* Add hot-reloading support
* Allow VolumeBind objects to be used directly in docker client, and add option for read only mounts (necessary for hot reloading)
* Add test for hot reloading

Fixes #7200