### PR TITLE
Fix deploy of DDB with ContributorInsightsSpecification

### DIFF
--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -22,27 +22,26 @@ def get_ddb_provisioned_throughput(params, **kwargs):
     return args
 
 
-def get_ddb_global_sec_indexes(params, **kwargs):
-    args = params.get("GlobalSecondaryIndexes")
+def get_ddb_global_sec_indexes(params: dict, **kwargs) -> list | None:
+    args: list = params.get("GlobalSecondaryIndexes")
     is_ondemand = params.get("BillingMode") == "PAY_PER_REQUEST"
-    if args:
-        for index in args:
-            provisioned_throughput = index.get("ProvisionedThroughput")
-            if is_ondemand and provisioned_throughput is None:
-                pass  # optional for API calls
-            elif provisioned_throughput is not None:
-                # convert types
-                if isinstance(provisioned_throughput["ReadCapacityUnits"], str):
-                    provisioned_throughput["ReadCapacityUnits"] = int(
-                        provisioned_throughput["ReadCapacityUnits"]
-                    )
-                if isinstance(provisioned_throughput["WriteCapacityUnits"], str):
-                    provisioned_throughput["WriteCapacityUnits"] = int(
-                        provisioned_throughput["WriteCapacityUnits"]
-                    )
-            else:
-                raise Exception("Can't specify ProvisionedThroughput with PAY_PER_REQUEST")
+    if not args:
+        return
 
+    for index in args:
+        # we ignore ContributorInsightsSpecification as not supported yet in DynamoDB and CloudWatch
+        index.pop("ContributorInsightsSpecification", None)
+        provisioned_throughput = index.get("ProvisionedThroughput")
+        if is_ondemand and provisioned_throughput is None:
+            pass  # optional for API calls
+        elif provisioned_throughput is not None:
+            # convert types
+            if isinstance((read_units := provisioned_throughput["ReadCapacityUnits"]), str):
+                provisioned_throughput["ReadCapacityUnits"] = int(read_units)
+            if isinstance((write_units := provisioned_throughput["WriteCapacityUnits"]), str):
+                provisioned_throughput["WriteCapacityUnits"] = int(write_units)
+        else:
+            raise Exception("Can't specify ProvisionedThroughput with PAY_PER_REQUEST")
     return args
 
 

--- a/tests/integration/templates/deploy_template_3.yaml
+++ b/tests/integration/templates/deploy_template_3.yaml
@@ -66,6 +66,8 @@ Resources:
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5
+        ContributorInsightsSpecification:
+          Enabled: True
 Outputs:
   Name:
     Value:


### PR DESCRIPTION
Addresses #7007 by removing the `ContributorInsightsSpecification` key (we do not currently implement the related APIs in DynamoDB) while building the global secondary indexes. 