### PR TITLE
fix --profile flag of CLI so config profiles are loaded correctly

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -45,9 +45,8 @@ def _setup_cli_debug():
 @click.option("--debug", is_flag=True, help="Enable CLI debugging mode")
 @click.option("--profile", type=str, help="Set the configuration profile")
 def localstack(debug, profile):
-    if profile:
-        os.environ["CONFIG_PROFILE"] = profile
-        config.CONFIG_PROFILE = profile
+    # --profile is read manually in localstack.cli.main because it needs to be read before localstack.config is read
+
     if debug:
         _setup_cli_debug()
 

--- a/localstack/cli/main.py
+++ b/localstack/cli/main.py
@@ -1,5 +1,10 @@
 def main():
-    # initialize repositories
+    # config profiles are the first thing that need to be loaded
+    from .profiles import set_profile_from_sys_argv
+
+    set_profile_from_sys_argv()
+
+    # initialize CLI plugins
     from .localstack import create_with_plugins
 
     cli = create_with_plugins()

--- a/localstack/cli/profiles.py
+++ b/localstack/cli/profiles.py
@@ -26,6 +26,9 @@ def parse_profile_argument(args) -> Optional[str]:
         if arg.startswith("--profile="):
             return arg[10:]
         if arg == "--profile":
-            return arg[i + 1]
+            try:
+                return arg[i + 1]
+            except KeyError:
+                return None
 
     return None

--- a/localstack/cli/profiles.py
+++ b/localstack/cli/profiles.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from typing import Optional
+
+# important: this needs to be free of localstack imports
+
+
+def set_profile_from_sys_argv():
+    """
+    Reads the --profile flag from sys.argv and then sets the 'CONFIG_PROFILE' os variable accordingly. This is later
+    picked up by ``localstack.config``.
+    """
+    if profile := parse_profile_argument(sys.argv):
+        os.environ["CONFIG_PROFILE"] = profile.strip()
+
+
+def parse_profile_argument(args) -> Optional[str]:
+    """
+    Lightweight arg parsing to find ``--profile <config>``, or ``--profile=<config>`` and return the value of
+    ``<config>`` from the given arguments.
+
+    :param args: list of CLI arguments
+    :returns: the value of ``--profile``.
+    """
+    for i, arg in enumerate(args):
+        if arg.startswith("--profile="):
+            return arg[10:]
+        if arg == "--profile":
+            return arg[i + 1]
+
+    return None


### PR DESCRIPTION
This PR introduces a pre-processing of CLI flags to make sure config profiles are loaded correctly. Previously, config profiles beyond `default.env` did not work at all, because `localstack.config` (and subsequently the config profiles) was loaded *before* the CLI was created and `--profile=...` was parsed. This is a fundamental issue with our current import paths.

Tested locally, and we should put proper bootstrap tests on the roadmap for when we rework the pipeline.