### PR TITLE
return all messages for sqs queue in case max_number_of_message equals -1

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -809,6 +809,10 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             wait_time_seconds = queue.wait_time_seconds
 
         num = max_number_of_messages or 1
+        # backdoor to get all messages
+        if num == -1:
+            num = queue.visible.qsize()
+
         block = True if wait_time_seconds else False
         # collect messages
         messages = []


### PR DESCRIPTION
This PR enables us to call sqs.receive_message with `max_number_of_messages -1` to receive all messages of the queue.