### PR TITLE
SES: publish custom email tags

### DIFF
--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import date, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import pytest
 import requests
@@ -35,6 +35,38 @@ def create_template(ses_client):
 
     for name in created_template_names:
         ses_client.delete_template(TemplateName=name)
+
+
+@pytest.fixture
+def setup_email_addresses(ses_verify_identity):
+    """
+    If the test is running against AWS then assume the email addresses passed are already
+    verified, and passes the given email addresses through. Otherwise, it generates two random
+    email addresses and verifies them.
+    """
+
+    def inner(
+        sender_email_address: Optional[str] = None, recipient_email_address: Optional[str] = None
+    ) -> Tuple[str, str]:
+        if os.getenv("TEST_TARGET") == "AWS_CLOUD":
+            if sender_email_address is None:
+                raise ValueError(
+                    "sender_email_address must be specified to run this test against AWS"
+                )
+            if recipient_email_address is None:
+                raise ValueError(
+                    "recipient_email_address must be specified to run this test against AWS"
+                )
+        else:
+            # overwrite the given parameters with localstack specific ones
+            sender_email_address = f"sender-{short_uid()}@example.com"
+            recipient_email_address = f"recipient-{short_uid()}@example.com"
+            ses_verify_identity(sender_email_address)
+            ses_verify_identity(recipient_email_address)
+
+        return sender_email_address, recipient_email_address
+
+    return inner
 
 
 def sort_mail_sqs_messages(message):
@@ -262,17 +294,17 @@ class TestSES:
         sns_create_sqs_subscription,
         ses_configuration_set,
         ses_configuration_set_sns_event_destination,
-        ses_verify_identity,
         sqs_receive_num_messages,
+        setup_email_addresses,
         snapshot,
     ):
         """
         Repro for #7184 - test that this test is not runnable in the sandbox account since it
-        requires a
-        validated email address. We do not have support for this yet.
+        requires a validated email address. We do not have support for this yet.
         """
-        sender_email_address = f"repro-7184-{short_uid()}@example.com"
-        recipient_email_address = f"repro-7184-{short_uid()}@example.com"
+
+        # add your email addresses in here to verify against AWS
+        sender_email_address, recipient_email_address = setup_email_addresses()
 
         snapshot.add_transformers_list(
             [
@@ -282,9 +314,6 @@ class TestSES:
             ]
             + snapshot.transform.sns_api()
         )
-
-        ses_verify_identity(sender_email_address)
-        ses_verify_identity(recipient_email_address)
 
         # create queue to listen for SES -> SNS events
         topic_arn = sns_topic["Attributes"]["TopicArn"]
@@ -336,7 +365,7 @@ class TestSES:
         delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
         assert delivery_tags["custom-tag"] == ["tag-value"]
 
-    @pytest.mark.only_localstack
+    # @pytest.mark.only_localstack
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -355,15 +384,15 @@ class TestSES:
         ses_configuration_set,
         ses_configuration_set_sns_event_destination,
         ses_email_template,
-        ses_verify_identity,
         sns_create_sqs_subscription,
         sns_create_topic,
         sqs_queue,
         sqs_receive_num_messages,
+        setup_email_addresses,
         snapshot,
     ):
-        sender_email_address = f"repro-7184-{short_uid()}@example.com"
-        recipient_email_address = f"repro-7184-{short_uid()}@example.com"
+        # add your email addresses in here to verify against AWS
+        sender_email_address, recipient_email_address = setup_email_addresses()
 
         snapshot.add_transformers_list(
             [
@@ -373,9 +402,6 @@ class TestSES:
             ]
             + snapshot.transform.sns_api()
         )
-
-        ses_verify_identity(sender_email_address)
-        ses_verify_identity(recipient_email_address)
 
         template_name = f"template-{short_uid()}"
         ses_email_template(template_name, "Test template")
@@ -414,7 +440,14 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
-    @pytest.mark.only_localstack
+        # check the tags manually, since these will be annoying to transform
+        send_tags = json.loads(messages[1]["Message"])["mail"]["tags"]
+        assert send_tags["custom-tag"] == ["tag-value"]
+
+        delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
+        assert delivery_tags["custom-tag"] == ["tag-value"]
+
+    # @pytest.mark.only_localstack
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -432,15 +465,15 @@ class TestSES:
         ses_client,
         ses_configuration_set,
         ses_configuration_set_sns_event_destination,
-        ses_verify_identity,
         sns_create_sqs_subscription,
         sns_create_topic,
         sqs_queue,
         sqs_receive_num_messages,
+        setup_email_addresses,
         snapshot,
     ):
-        sender_email_address = f"repro-7184-{short_uid()}@example.com"
-        recipient_email_address = f"repro-7184-{short_uid()}@example.com"
+        # add your email addresses in here to verify against AWS
+        sender_email_address, recipient_email_address = setup_email_addresses()
 
         snapshot.add_transformers_list(
             [
@@ -450,9 +483,6 @@ class TestSES:
             ]
             + snapshot.transform.sns_api()
         )
-
-        ses_verify_identity(sender_email_address)
-        ses_verify_identity(recipient_email_address)
 
         # create queue to listen for SES -> SNS events
         topic_arn = sns_create_topic()["TopicArn"]
@@ -545,16 +575,14 @@ class TestSES:
         sns_client,
         sns_topic,
         sns_wait_for_topic_delete,
-        ses_verify_identity,
         ses_configuration_set,
         sqs_receive_num_messages,
         ses_configuration_set_sns_event_destination,
+        setup_email_addresses,
         snapshot,
     ):
-        recipient_email_address = "recipient@example.com"
-        sender_email_address = "sender@example.com"
-        ses_verify_identity(sender_email_address)
-        ses_verify_identity(recipient_email_address)
+        # add your email addresses in here to verify against AWS
+        sender_email_address, recipient_email_address = setup_email_addresses()
 
         snapshot.add_transformers_list(
             [

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -274,6 +274,7 @@ class TestSES:
         assert [x["Name"] for x in rule_set["Rules"]] == rule_names
 
     @pytest.mark.only_localstack
+    @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -282,7 +283,12 @@ class TestSES:
             "$..Message.mail.commonHeaders",
             "$..Message.mail.headers",
             "$..Message.mail.headersTruncated",
-            "$..Message.mail.tags",
+            "$..Message.mail.tags.'ses:caller-identity'",
+            "$..Message.mail.tags.'ses:configuration-set'",
+            "$..Message.mail.tags.'ses:from-domain'",
+            "$..Message.mail.tags.'ses:operation'",
+            "$..Message.mail.tags.'ses:outgoing-ip'",
+            "$..Message.mail.tags.'ses:source-ip'",
             "$..Message.mail.timestamp",
         ]
     )
@@ -358,14 +364,8 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
-        # check the tags manually, since these will be annoying to transform
-        send_tags = json.loads(messages[1]["Message"])["mail"]["tags"]
-        assert send_tags["custom-tag"] == ["tag-value"]
-
-        delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
-        assert delivery_tags["custom-tag"] == ["tag-value"]
-
-    # @pytest.mark.only_localstack
+    @pytest.mark.only_localstack
+    @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -374,7 +374,12 @@ class TestSES:
             "$..Message.mail.commonHeaders",
             "$..Message.mail.headers",
             "$..Message.mail.headersTruncated",
-            "$..Message.mail.tags",
+            "$..Message.mail.tags.'ses:caller-identity'",
+            "$..Message.mail.tags.'ses:configuration-set'",
+            "$..Message.mail.tags.'ses:from-domain'",
+            "$..Message.mail.tags.'ses:operation'",
+            "$..Message.mail.tags.'ses:outgoing-ip'",
+            "$..Message.mail.tags.'ses:source-ip'",
             "$..Message.mail.timestamp",
         ]
     )
@@ -440,14 +445,8 @@ class TestSES:
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
-        # check the tags manually, since these will be annoying to transform
-        send_tags = json.loads(messages[1]["Message"])["mail"]["tags"]
-        assert send_tags["custom-tag"] == ["tag-value"]
-
-        delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
-        assert delivery_tags["custom-tag"] == ["tag-value"]
-
-    # @pytest.mark.only_localstack
+    @pytest.mark.only_localstack
+    @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..Message.delivery.processingTimeMillis",
@@ -456,7 +455,12 @@ class TestSES:
             "$..Message.mail.commonHeaders",
             "$..Message.mail.headers",
             "$..Message.mail.headersTruncated",
-            "$..Message.mail.tags",
+            "$..Message.mail.tags.'ses:caller-identity'",
+            "$..Message.mail.tags.'ses:configuration-set'",
+            "$..Message.mail.tags.'ses:from-domain'",
+            "$..Message.mail.tags.'ses:operation'",
+            "$..Message.mail.tags.'ses:outgoing-ip'",
+            "$..Message.mail.tags.'ses:source-ip'",
             "$..Message.mail.timestamp",
         ]
     )
@@ -515,13 +519,6 @@ class TestSES:
         messages = sqs_receive_num_messages(sqs_queue, 3)
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
-
-        # check the tags manually, since these will be annoying to transform
-        send_tags = json.loads(messages[1]["Message"])["mail"]["tags"]
-        assert send_tags["custom-tag"] == ["tag-value"]
-
-        delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
-        assert delivery_tags["custom-tag"] == ["tag-value"]
 
     def test_cannot_create_event_for_no_topic(
         self, ses_configuration_set, ses_client, snapshot, account_id

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -317,11 +317,24 @@ class TestSES:
             Message=message,
             ConfigurationSetName=config_set_name,
             Source=sender_email_address,
+            Tags=[
+                {
+                    "Name": "custom-tag",
+                    "Value": "tag-value",
+                }
+            ],
         )
 
         messages = sqs_receive_num_messages(sqs_queue, 3)
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
+
+        # check the tags manually, since these will be annoying to transform
+        send_tags = json.loads(messages[1]["Message"])["mail"]["tags"]
+        assert send_tags["custom-tag"] == ["tag-value"]
+
+        delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
+        assert delivery_tags["custom-tag"] == ["tag-value"]
 
     @pytest.mark.only_localstack
     @pytest.mark.skip_snapshot_verify(
@@ -389,6 +402,12 @@ class TestSES:
             TemplateData=json.dumps({}),
             ConfigurationSetName=config_set_name,
             Source=sender_email_address,
+            Tags=[
+                {
+                    "Name": "custom-tag",
+                    "Value": "tag-value",
+                }
+            ],
         )
 
         messages = sqs_receive_num_messages(sqs_queue, 3)
@@ -455,11 +474,24 @@ class TestSES:
             },
             ConfigurationSetName=config_set_name,
             Source=sender_email_address,
+            Tags=[
+                {
+                    "Name": "custom-tag",
+                    "Value": "tag-value",
+                }
+            ],
         )
 
         messages = sqs_receive_num_messages(sqs_queue, 3)
         messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
+
+        # check the tags manually, since these will be annoying to transform
+        send_tags = json.loads(messages[1]["Message"])["mail"]["tags"]
+        assert send_tags["custom-tag"] == ["tag-value"]
+
+        delivery_tags = json.loads(messages[2]["Message"])["mail"]["tags"]
+        assert delivery_tags["custom-tag"] == ["tag-value"]
 
     def test_cannot_create_event_for_no_topic(
         self, ses_configuration_set, ses_client, snapshot, account_id

--- a/tests/integration/test_ses.snapshot.json
+++ b/tests/integration/test_ses.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/test_ses.py::TestSES::test_ses_sns_topic_integration_send_email": {
-    "recorded-date": "28-11-2022, 11:48:20",
+    "recorded-date": "14-12-2022, 17:29:13",
     "recorded-content": {
       "messages": [
         {
@@ -72,13 +72,16 @@
                   "SendEmail"
                 ],
                 "ses:configuration-set": [
-                  "config-set-b022b370"
+                  "config-set-88be5780"
                 ],
                 "ses:source-ip": [
                   "80.189.216.182"
                 ],
                 "ses:from-domain": [
                   "gmail.com"
+                ],
+                "custom-tag": [
+                  "tag-value"
                 ],
                 "ses:caller-identity": [
                   "localstack-testing"
@@ -151,7 +154,7 @@
                   "SendEmail"
                 ],
                 "ses:configuration-set": [
-                  "config-set-b022b370"
+                  "config-set-88be5780"
                 ],
                 "ses:source-ip": [
                   "80.189.216.182"
@@ -159,22 +162,25 @@
                 "ses:from-domain": [
                   "gmail.com"
                 ],
+                "custom-tag": [
+                  "tag-value"
+                ],
                 "ses:caller-identity": [
                   "localstack-testing"
                 ],
                 "ses:outgoing-ip": [
-                  "69.169.224.10"
+                  "69.169.224.8"
                 ]
               }
             },
             "delivery": {
               "timestamp": "date",
-              "processingTimeMillis": 623,
+              "processingTimeMillis": 1167,
               "recipients": [
                 "<recipient-email-address>"
               ],
-              "smtpResponse": "250 2.0.0 OK  1669636100 n20-20020a05600c501400b003cf484ba59dsi10504395wmr.122 - gsmtp",
-              "reportingMTA": "b224-10.smtp-out.<region>.amazonses.com"
+              "smtpResponse": "250 2.0.0 OK  1671038953 v10-20020adfa1ca000000b00241d1ecc8c6si1900057wrv.541 - gsmtp",
+              "reportingMTA": "b224-8.smtp-out.<region>.amazonses.com"
             }
           },
           "Timestamp": "date",
@@ -187,7 +193,7 @@
     }
   },
   "tests/integration/test_ses.py::TestSES::test_ses_sns_topic_integration_send_templated_email": {
-    "recorded-date": "28-11-2022, 11:48:15",
+    "recorded-date": "14-12-2022, 17:29:16",
     "recorded-content": {
       "messages": [
         {
@@ -245,13 +251,16 @@
                   "SendTemplatedEmail"
                 ],
                 "ses:configuration-set": [
-                  "config-set-8ed3500d"
+                  "config-set-c17e0219"
                 ],
                 "ses:source-ip": [
                   "80.189.216.182"
                 ],
                 "ses:from-domain": [
                   "gmail.com"
+                ],
+                "custom-tag": [
+                  "tag-value"
                 ],
                 "ses:caller-identity": [
                   "localstack-testing"
@@ -286,7 +295,7 @@
               "headers": [
                 {
                   "name": "Date",
-                  "value": "Mon, 28 Nov 2022 11:48:14 +0000"
+                  "value": "Wed, 14 Dec 2022 17:29:15 +0000"
                 },
                 {
                   "name": "From",
@@ -298,11 +307,11 @@
                 },
                 {
                   "name": "Message-ID",
-                  "value": "<1253528252.927764.1669636094798@ip-10-0-171-26.<region>.compute.internal>"
+                  "value": "<1786912680.12997.1671038955596@ip-10-0-189-31.<region>.compute.internal>"
                 },
                 {
                   "name": "Subject",
-                  "value": "Email template 30e6086e"
+                  "value": "Email template e16fc3f7"
                 },
                 {
                   "name": "MIME-Version",
@@ -321,19 +330,19 @@
                 "from": [
                   "<sender-email-address>"
                 ],
-                "date": "Mon, 28 Nov 2022 11:48:14 +0000",
+                "date": "Wed, 14 Dec 2022 17:29:15 +0000",
                 "to": [
                   "<recipient-email-address>"
                 ],
                 "messageId": "<message-id:1>",
-                "subject": "Email template 30e6086e"
+                "subject": "Email template e16fc3f7"
               },
               "tags": {
                 "ses:operation": [
                   "SendTemplatedEmail"
                 ],
                 "ses:configuration-set": [
-                  "config-set-8ed3500d"
+                  "config-set-c17e0219"
                 ],
                 "ses:source-ip": [
                   "80.189.216.182"
@@ -341,22 +350,25 @@
                 "ses:from-domain": [
                   "gmail.com"
                 ],
+                "custom-tag": [
+                  "tag-value"
+                ],
                 "ses:caller-identity": [
                   "localstack-testing"
                 ],
                 "ses:outgoing-ip": [
-                  "69.169.224.12"
+                  "69.169.224.10"
                 ]
               }
             },
             "delivery": {
               "timestamp": "date",
-              "processingTimeMillis": 776,
+              "processingTimeMillis": 800,
               "recipients": [
                 "<recipient-email-address>"
               ],
-              "smtpResponse": "250 2.0.0 OK  1669636095 g2-20020a5d64e2000000b0024165c0a6a1si8609938wri.49 - gsmtp",
-              "reportingMTA": "b224-12.smtp-out.<region>.amazonses.com"
+              "smtpResponse": "250 2.0.0 OK  1671038956 b13-20020adfde0d000000b0022ac0f59416si1880444wrm.732 - gsmtp",
+              "reportingMTA": "b224-10.smtp-out.<region>.amazonses.com"
             }
           },
           "Timestamp": "date",
@@ -369,7 +381,7 @@
     }
   },
   "tests/integration/test_ses.py::TestSES::test_ses_sns_topic_integration_send_raw_email": {
-    "recorded-date": "28-11-2022, 11:49:35",
+    "recorded-date": "14-12-2022, 17:29:18",
     "recorded-content": {
       "messages": [
         {
@@ -409,10 +421,13 @@
                   "SendRawEmail"
                 ],
                 "ses:configuration-set": [
-                  "config-set-0faf5da7"
+                  "config-set-20c4c21e"
                 ],
                 "ses:source-ip": [
                   "80.189.216.182"
+                ],
+                "custom-tag": [
+                  "tag-value"
                 ],
                 "ses:caller-identity": [
                   "localstack-testing"
@@ -453,27 +468,30 @@
                   "SendRawEmail"
                 ],
                 "ses:configuration-set": [
-                  "config-set-0faf5da7"
+                  "config-set-20c4c21e"
                 ],
                 "ses:source-ip": [
                   "80.189.216.182"
+                ],
+                "custom-tag": [
+                  "tag-value"
                 ],
                 "ses:caller-identity": [
                   "localstack-testing"
                 ],
                 "ses:outgoing-ip": [
-                  "69.169.224.11"
+                  "69.169.224.7"
                 ]
               }
             },
             "delivery": {
               "timestamp": "date",
-              "processingTimeMillis": 684,
+              "processingTimeMillis": 640,
               "recipients": [
                 "<recipient-email-address>"
               ],
-              "smtpResponse": "250 2.0.0 OK  1669636175 p4-20020a05600c358400b003c6f645db8bsi10597375wmq.192 - gsmtp",
-              "reportingMTA": "b224-11.smtp-out.<region>.amazonses.com"
+              "smtpResponse": "250 2.0.0 OK  1671038958 f20-20020a1c6a14000000b003cdb23b6e5dsi1483316wmc.28 - gsmtp",
+              "reportingMTA": "b224-7.smtp-out.<region>.amazonses.com"
             }
           },
           "Timestamp": "date",


### PR DESCRIPTION
This PR adds support for propagating custom tags when sending emails through to SNS.

Note: as per discussion with the reporter, we are focusing on custom tags at this stage. If required we will add the aws-added tags in a follow up PR.

Closes #7323