### PR TITLE
Fix apigateway export type oas3 => oas30

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -930,7 +930,7 @@ class OpenApiExporter:
     exporters: Dict[str, TypeExporter]
 
     def __init__(self):
-        self.exporters = {"swagger": self._swagger_export, "oas3": self._oas3_export}
+        self.exporters = {"swagger": self._swagger_export, "oas30": self._oas30_export}
         self.export_formats = {"application/json": "to_dict", "application/yaml": "to_yaml"}
 
     def export_api(
@@ -973,7 +973,7 @@ class OpenApiExporter:
 
         return getattr(spec, self.export_formats.get(export_format))()
 
-    def _oas3_export(self, api_id: str, stage: str, export_format: str) -> str:
+    def _oas30_export(self, api_id: str, stage: str, export_format: str) -> str:
         """
         https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
         """

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -799,13 +799,13 @@ def test_export_swagger_openapi(apigateway_client):
     assert all(k in spec_object.keys() for k in optional_keys)
 
 
-def test_export_oas3_openapi(apigateway_client):
+def test_export_oas30_openapi(apigateway_client):
     spec_file = load_file(TEST_IMPORT_PETSTORE_SWAGGER)
     response = apigateway_client.import_rest_api(failOnWarnings=True, body=spec_file)
     assert response.get("ResponseMetadata").get("HTTPStatusCode") == 201
 
     response = apigateway_client.get_export(
-        restApiId=response["id"], stageName="local", exportType="oas3"
+        restApiId=response["id"], stageName="local", exportType="oas30"
     )
     spec_object = json.loads(response["body"].read())
     # required keys


### PR DESCRIPTION
Localstack is expecting the API Gateway `GetExport` `export_type` for OpenAPI v3 to be `oas3` instead of `oas30`.

See https://docs.aws.amazon.com/apigateway/latest/api/API_GetExport.html
> **export_type**
> The type of export. Acceptable values are '**oas30**' for OpenAPI 3.0.x and 'swagger' for Swagger/OpenAPI 2.0.