### PR TITLE
only set HOST_TMP_FOLDER (deprecated) for legacy directories

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -566,7 +566,6 @@ def configure_container(container: LocalstackContainer):
         if value is not None:
             container.env_vars[env_var] = value
     container.env_vars["DOCKER_HOST"] = f"unix://{config.DOCKER_SOCK}"
-    container.env_vars["HOST_TMP_FOLDER"] = config.dirs.functions  # TODO: rename env var
 
     # TODO this is default now, remove once a considerate time is passed
     # to activate proper signal handling
@@ -597,6 +596,9 @@ def configure_volume_mounts(container: LocalstackContainer):
 
     # shared tmp folder
     container.volumes.add(VolumeBind(source_dirs.tmp, target_dirs.tmp))
+
+    # set the HOST_TMP_FOLDER for the legacy dirs / legacy lambda function mounting
+    container.env_vars["HOST_TMP_FOLDER"] = source_dirs.functions
 
     # data_dir mounting and environment variables
     if source_dirs.data:


### PR DESCRIPTION
`HOST_TMP_FOLDER` has been deprecated with 1.0.0, but the CLI still sets the environment variable to avoid breaking the usage of the legacy directory mode (where this env var is still be used).
Version 1.3.0 introduced proper deprecation warnings when deprecated environment variables are used (see #7197).
This caused the following deprecation warning on every startup of localstack with the CLI:
```
WARN --- [  MainThread] localstack.deprecations    : HOST_TMP_FOLDER is deprecated (since 1.0.0) and will be removed in upcoming releases of LocalStack! Please remove this environment variable.
```

This PR changes the container configuration by the CLI such that by default (if the legacy directory mode is not set), the `HOST_TMP_FOLDER` is also not set. It is only set if the legacy directory mode is enabled.
This avoids the deprecation warning on a default startup using the CLI.