### PR TITLE
[minor] Check SSL cert file content to make startup more reliable

### DIFF
--- a/localstack/utils/crypto.py
+++ b/localstack/utils/crypto.py
@@ -6,7 +6,7 @@ import threading
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from .files import TMP_FILES, load_file, new_tmp_file, save_file
+from .files import TMP_FILES, file_exists_not_empty, load_file, new_tmp_file, save_file
 from .strings import short_uid, to_bytes, to_str
 from .sync import synchronized
 
@@ -58,7 +58,7 @@ def generate_ssl_cert(
         save_file(cert_file_name, cert_content)
         return cert_file_name, key_file_name
 
-    if target_file and not overwrite and os.path.exists(target_file):
+    if target_file and not overwrite and file_exists_not_empty(target_file):
         try:
             cert_file_name, key_file_name = store_cert_key_files(target_file)
         except Exception as e:


### PR DESCRIPTION
Small fix to check that the content of the downloaded SSL cert file is non-empty, to make the startup more reliable. Discovered this issue during a time of bad network connectivity, where the SSL cert file was created on disk, but the download failed and hence the file had empty content.

```
File "/opt/code/localstack/localstack/services/generic_proxy.py", line 585, in create_ssl_cert
return generate_ssl_cert(cert_pem_file, serial_number=serial_number)
File "/opt/code/localstack/localstack/utils/sync.py", line 101, in _wrapper
return wrapped(*args, **kwargs)
File "/opt/code/localstack/localstack/utils/crypto.py", line 70, in generate_ssl_cert
cert_file_name, key_file_name = store_cert_key_files(target_file_tmp)
File "/opt/code/localstack/localstack/utils/crypto.py", line 50, in store_cert_key_files
key_start = key_start.group(0)
AttributeError: 'NoneType' object has no attribute 'group'
```