### PR TITLE
Allow more flexibility for lambda hot-reloading paths

### DIFF
--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -47,6 +47,8 @@ COPY code/ /var/task
 
 PULLED_IMAGES: set[str] = set()
 
+HOT_RELOADING_ENV_VARIABLE = "LOCALSTACK_HOT_RELOADING_PATHS"
+
 
 def get_image_name_for_function(function_version: FunctionVersion) -> str:
     return f"localstack/lambda-{function_version.id.qualified_arn().replace(':', '_').replace('$', '_').lower()}"
@@ -225,7 +227,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         )
         if self.function_version.config.package_type == PackageType.Zip:
             if self.function_version.config.code.is_hot_reloading():
-                container_config.env_vars["LOCALSTACK_HOT_RELOADING_ENABLED"] = "1"
+                container_config.env_vars[HOT_RELOADING_ENV_VARIABLE] = "/var/task"
                 if container_config.volumes is None:
                     container_config.volumes = VolumeMappings()
                 container_config.volumes.append(

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -9,7 +9,7 @@ from localstack.utils.platform import get_arch
 
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
-LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.7-pre"
+LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.8-pre"
 
 # GO Lambda runtime
 GO_RUNTIME_VERSION = "0.4.0"
@@ -21,7 +21,15 @@ class AWSLambdaRuntimePackage(Package):
         super().__init__(name="AwsLambda", default_version=default_version)
 
     def get_versions(self) -> List[str]:
-        return ["v0.1.7-pre", "v0.1.6-pre", "v0.1.5-pre", "v0.1.4-pre", "v0.1.1-pre", "v0.1-pre"]
+        return [
+            "v0.1.8-pre",
+            "v0.1.7-pre",
+            "v0.1.6-pre",
+            "v0.1.5-pre",
+            "v0.1.4-pre",
+            "v0.1.1-pre",
+            "v0.1-pre",
+        ]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return AWSLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)

--- a/tests/integration/awslambda/test_lambda_developer_tools.py
+++ b/tests/integration/awslambda/test_lambda_developer_tools.py
@@ -20,8 +20,8 @@ HOT_RELOADING_PYTHON_HANDLER = os.path.join(
 )
 
 
+@pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
 class TestHotReloading:
-    @pytest.mark.skipif(condition=is_old_provider(), reason="Focussing on the new provider")
     @pytest.mark.parametrize(
         "runtime,handler_file,handler_filename",
         [


### PR DESCRIPTION
## Motivation
We want to be able to watch arbitrary paths to allow hot reload, for more advanced features, like layer hot reloading.

## Changes
* Update LRI to v0.1.8-pre to get support for specifying arbitrary paths to be watched for changes (and reloading after a change)
* Skip the whole test class instead of just a test, as it seems to fit better for the functionality

Depends on localstack/lambda-runtime-init#8