### PR TITLE
Update Kinesis Mock to 0.3.0

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -552,6 +552,9 @@ LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
 # limit in which to kinesis-mock will start throwing exceptions
 KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
 
+# limit in which to kinesis-mock will start throwing exceptions
+ON_DEMAND_STREAM_COUNT_LIMIT = os.environ.get("ON_DEMAND_STREAM_COUNT_LIMIT", "").strip() or "10"
+
 # delay in kinesis-mock response when making changes to streams
 KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -553,9 +553,9 @@ LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
 KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
 
 # limit in which to kinesis-mock will start throwing exceptions
-KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT = os.environ.get(
-    "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT", ""
-).strip() or "10"
+KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT = (
+    os.environ.get("KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT", "").strip() or "10"
+)
 
 # delay in kinesis-mock response when making changes to streams
 KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"
@@ -752,6 +752,7 @@ CONFIG_ENV_VARS = [
     "KINESIS_ERROR_PROBABILITY",
     "KINESIS_INITIALIZE_STREAMS",
     "KINESIS_MOCK_PERSIST_INTERVAL",
+    "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT",
     "LAMBDA_CODE_EXTRACT_TIME",
     "LAMBDA_CONTAINER_REGISTRY",
     "LAMBDA_DOCKER_DNS",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -553,7 +553,9 @@ LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
 KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
 
 # limit in which to kinesis-mock will start throwing exceptions
-KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT = os.environ.get("KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT", "").strip() or "10"
+KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT = os.environ.get(
+    "KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT", ""
+).strip() or "10"
 
 # delay in kinesis-mock response when making changes to streams
 KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -553,7 +553,7 @@ LAMBDA_JAVA_OPTS = os.environ.get("LAMBDA_JAVA_OPTS", "").strip()
 KINESIS_SHARD_LIMIT = os.environ.get("KINESIS_SHARD_LIMIT", "").strip() or "100"
 
 # limit in which to kinesis-mock will start throwing exceptions
-ON_DEMAND_STREAM_COUNT_LIMIT = os.environ.get("ON_DEMAND_STREAM_COUNT_LIMIT", "").strip() or "10"
+KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT = os.environ.get("KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT", "").strip() or "10"
 
 # delay in kinesis-mock response when making changes to streams
 KINESIS_LATENCY = os.environ.get("KINESIS_LATENCY", "").strip() or "500"

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -67,7 +67,7 @@ class KinesisMockServer(Server):
             # LocalStack uses only one - the insecure one. Block the secure port to avoid conflicts.
             "KINESIS_MOCK_TLS_PORT": get_free_tcp_port(),
             "SHARD_LIMIT": config.KINESIS_SHARD_LIMIT,
-            "ON_DEMAND_STREAM_COUNT_LIMIT": config.ON_DEMAND_STREAM_COUNT_LIMIT,
+            "ON_DEMAND_STREAM_COUNT_LIMIT": config.KINESIS_ON_DEMAND_STREAM_COUNT_LIMIT,
             "AWS_ACCOUNT_ID": self._account_id,
         }
 

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -67,6 +67,7 @@ class KinesisMockServer(Server):
             # LocalStack uses only one - the insecure one. Block the secure port to avoid conflicts.
             "KINESIS_MOCK_TLS_PORT": get_free_tcp_port(),
             "SHARD_LIMIT": config.KINESIS_SHARD_LIMIT,
+            "ON_DEMAND_STREAM_COUNT_LIMIT": config.ON_DEMAND_STREAM_COUNT_LIMIT,
             "AWS_ACCOUNT_ID": self._account_id,
         }
 
@@ -80,6 +81,7 @@ class KinesisMockServer(Server):
             "MERGE_SHARDS_DURATION",
             "SPLIT_SHARD_DURATION",
             "UPDATE_SHARD_COUNT_DURATION",
+            "UPDATE_STREAM_MODE_DURATION",
         ]
         for param in latency_params:
             env_vars[param] = self._latency

--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -6,7 +6,7 @@ from localstack import config
 from localstack.packages import GitHubReleaseInstaller, Package, PackageInstaller
 from localstack.utils.platform import get_arch, get_os
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.2.6"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.3.0"
 
 
 class KinesisMockPackage(Package):


### PR DESCRIPTION
See https://github.com/etspaceman/kinesis-mock/releases/tag/0.3.0

This adds the UpdateStreamMode API, as well as updates to a few other request/response bodies with information from the stream mode. 

Also see https://docs.aws.amazon.com/kinesis/latest/APIReference/API_UpdateStreamMode.html
