### PR TITLE
Supported Python version in README is outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ LocalStack also provides additional features to make your life as a cloud develo
 
 ## Requirements
 
-* `python` (Python 3.7 up to 3.10 supported)
+* `python` (Python 3.8 up to 3.10 supported)
 * `pip` (Python package manager)
 * `Docker`
 


### PR DESCRIPTION
Running the localstack locally with Python 3.7 results in a syntax error.

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.7/bin/localstack", line 23, in <module>
    main()
  File "/Library/Frameworks/Python.framework/Versions/3.7/bin/localstack", line 19, in main
    main.main()
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/localstack/cli/main.py", line 3, in main
    from .profiles import set_profile_from_sys_argv
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/localstack/cli/profiles.py", line 13
    if profile := parse_profile_argument(sys.argv):
                ^
SyntaxError: invalid syntax
```

The colon equal operator (`:=`) was added from Python 3.8. https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions. The documentation seems outdated.


**Please refer to the contribution guidelines in the README when submitting PRs.**
