### PR TITLE
Revert stepfunctions package change #7347

### DIFF
--- a/localstack/services/stepfunctions/packages.py
+++ b/localstack/services/stepfunctions/packages.py
@@ -54,6 +54,15 @@ Since the JAR files are platform-independent, you can use the layer digest of an
 
 
 class StepFunctionsLocalPackage(Package):
+    """
+    NOTE: Do NOT update the version here! (It will also have no effect)
+
+    We are currently stuck on 1.7.9 since later versions introduced the generic aws-sdk Task,
+    which introduced additional 300MB+ to the jar file since it includes all AWS Java SDK libs.
+
+    This is blocked until our custom stepfunctions implementation is mature enough to replace it.
+    """
+
     def __init__(self):
         super().__init__("StepFunctionsLocal", "1.7.9")
 

--- a/localstack/services/stepfunctions/packages.py
+++ b/localstack/services/stepfunctions/packages.py
@@ -54,13 +54,11 @@ Since the JAR files are platform-independent, you can use the layer digest of an
 
 
 class StepFunctionsLocalPackage(Package):
-    version: str = "1.12.0"
-
     def __init__(self):
-        super().__init__("StepFunctionsLocal", self.version)
+        super().__init__("StepFunctionsLocal", "1.7.9")
 
     def get_versions(self) -> List[str]:
-        return [self.version]
+        return ["1.7.9"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return StepFunctionsLocalPackageInstaller("stepfunctions-local", version)


### PR DESCRIPTION
Until we have the new stepfunctions implementation ready we're stuck on 1.7.9 since we want to avoid adding additional 300MB+ to our final image size. 

Fortunately the reverted PR was not affecting anything yet since we're not actively using the version string to get the respective files from the image. 
To update the code used for the stepfunctions execution one needs to update the `SFN_IMAGE_LAYER_DIGEST` (see related comment in `localstack/services/stepfunctions/packages.py`).