### PR TITLE
Mark flaky terraform tests as xfail

### DIFF
--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -143,6 +143,7 @@ class TestTerraform:
         assert function_mapping["EventSourceArn"] == queue_arn
 
     @pytest.mark.skip_offline
+    @pytest.mark.xfail("flaky")
     def test_apigateway(self, apigateway_client):
         rest_apis = apigateway_client.get_rest_apis()
 
@@ -187,6 +188,7 @@ class TestTerraform:
         assert len(certs) == 1
 
     @pytest.mark.skip_offline
+    @pytest.mark.xfail("flaky")
     def test_apigateway_escaped_policy(self, apigateway_client):
         rest_apis = apigateway_client.get_rest_apis()
 

--- a/tests/integration/test_terraform.py
+++ b/tests/integration/test_terraform.py
@@ -143,7 +143,7 @@ class TestTerraform:
         assert function_mapping["EventSourceArn"] == queue_arn
 
     @pytest.mark.skip_offline
-    @pytest.mark.xfail("flaky")
+    @pytest.mark.xfail(reason="flaky")
     def test_apigateway(self, apigateway_client):
         rest_apis = apigateway_client.get_rest_apis()
 
@@ -188,7 +188,7 @@ class TestTerraform:
         assert len(certs) == 1
 
     @pytest.mark.skip_offline
-    @pytest.mark.xfail("flaky")
+    @pytest.mark.xfail(reason="flaky")
     def test_apigateway_escaped_policy(self, apigateway_client):
         rest_apis = apigateway_client.get_rest_apis()
 


### PR DESCRIPTION
Marks two notoriously flaky tests as xfail to avoid having to restart the CI all the time.

There seem to be a few other apigw related flakes still detected by CircleCI: https://app.circleci.com/insights/github/localstack/localstack/workflows/main/tests?branch=master 
/cc @calvernaz 