### PR TITLE
Add lock for StepFunction creation to prevent concurrency issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ runtime =
     amazon_kclpy>=2.0.6
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
+    awscrt>=0.13.14
     boto>=2.49.0
     botocore>=1.12.13,<1.28.0
     cbor2>=5.2.0
@@ -83,16 +84,15 @@ runtime =
     moto-ext[all]==4.0.11.post2
     opensearch-py==1.1.0
     pproxy>=2.7.0
+    pymongo>=4.2.0
     pyopenssl==22.0.0
     Quart==0.17
     readerwriterlock>=1.0.7
     requests-aws4auth>=1.0
+    vosk==0.3.43
     # TODO: remove werkzeug&flask version pins once we can upgrade to latest versions
     Werkzeug==2.1.2
     xmltodict>=0.11.0
-    awscrt>=0.13.14
-    vosk==0.3.43
-    pymongo>=4.2.0
 
 # @deprecated - use extra 'runtime' instead.
 full =
@@ -110,6 +110,7 @@ test =
 
 # for developing localstack
 dev =
+    autoflake
     black==22.3.0
     coveralls==3.1.0
     Cython
@@ -117,12 +118,11 @@ dev =
     flake8-black==0.3.2
     flake8-isort==5.0.0
     flake8-quotes>=0.11.0
-    # enables flake8 configuration through pyproject.toml
-    pre-commit==2.13.0
-    pyproject-flake8==3.9.2
     isort==5.9.1
-    pandoc
-    pypandoc
-    autoflake
     networkx>=2.8.4
+    pandoc
+    pre-commit==2.13.0
+    pypandoc
+    # enables flake8 configuration through pyproject.toml
+    pyproject-flake8==3.9.2
     rstr>=3.2.0

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -11,6 +11,7 @@ from localstack.utils.files import load_file
 from localstack.utils.json import clone
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import ShortCircuitWaitException, retry, wait_until
+from localstack.utils.threads import parallelize
 
 from .awslambda.functions import lambda_environment
 from .awslambda.test_lambda import TEST_LAMBDA_ENV, TEST_LAMBDA_PYTHON_ECHO
@@ -498,6 +499,39 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, stepfunctions_client)
         events.delete_event_bus(Name=bus_name)
+
+    def test_create_state_machines_in_parallel(self, stepfunctions_client):
+        """
+        Perform a test that creates a series of state machines in parallel. Without concurrency control, using
+        StepFunctions-Local, the following error is pretty consistently reproducible:
+
+        botocore.errorfactory.InvalidDefinition: An error occurred (InvalidDefinition) when calling the
+        CreateStateMachine operation: Invalid State Machine Definition: ''DUPLICATE_STATE_NAME: Duplicate State name:
+        MissingValue at /States/MissingValue', 'DUPLICATE_STATE_NAME: Duplicate State name: Add at /States/Add''
+        """
+        role_arn = arns.role_arn("sfn_role")
+        definition = clone(STATE_MACHINE_CHOICE)
+        lambda_arn_4 = arns.lambda_function_arn(TEST_LAMBDA_NAME_4)
+        definition["States"]["Add"]["Resource"] = lambda_arn_4
+        definition = json.dumps(definition)
+        results = []
+
+        def _create_sm(*_):
+            sm_name = f"sm-{short_uid()}"
+            result = stepfunctions_client.create_state_machine(
+                name=sm_name, definition=definition, roleArn=role_arn
+            )
+            assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+            results.append(result)
+            stepfunctions_client.describe_state_machine(stateMachineArn=result["stateMachineArn"])
+            stepfunctions_client.list_tags_for_resource(resourceArn=result["stateMachineArn"])
+
+        num_machines = 30
+        parallelize(_create_sm, list(range(num_machines)), size=2)
+        assert len(results) == num_machines
+
+        for machine in results:
+            stepfunctions_client.delete_state_machine(stateMachineArn=machine["stateMachineArn"])
 
 
 TEST_STATE_MACHINE = {

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -500,7 +500,7 @@ class TestStateMachine:
         cleanup(sm_arn, state_machines_before, stepfunctions_client)
         events.delete_event_bus(Name=bus_name)
 
-    def test_create_state_machines_in_parallel(self, stepfunctions_client):
+    def test_create_state_machines_in_parallel(self, stepfunctions_client, cleanups):
         """
         Perform a test that creates a series of state machines in parallel. Without concurrency control, using
         StepFunctions-Local, the following error is pretty consistently reproducible:

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -522,7 +522,11 @@ class TestStateMachine:
                 name=sm_name, definition=definition, roleArn=role_arn
             )
             assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
-            cleanups.append(lambda: stepfunctions_client.delete_state_machine(stateMachineArn=result["stateMachineArn"]))
+            cleanups.append(
+                lambda: stepfunctions_client.delete_state_machine(
+                    stateMachineArn=result["stateMachineArn"]
+                )
+            )
             results.append(result)
             stepfunctions_client.describe_state_machine(stateMachineArn=result["stateMachineArn"])
             stepfunctions_client.list_tags_for_resource(resourceArn=result["stateMachineArn"])

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -526,12 +526,15 @@ class TestStateMachine:
             stepfunctions_client.describe_state_machine(stateMachineArn=result["stateMachineArn"])
             stepfunctions_client.list_tags_for_resource(resourceArn=result["stateMachineArn"])
 
-        num_machines = 30
-        parallelize(_create_sm, list(range(num_machines)), size=2)
-        assert len(results) == num_machines
-
-        for machine in results:
-            stepfunctions_client.delete_state_machine(stateMachineArn=machine["stateMachineArn"])
+        try:
+            num_machines = 30
+            parallelize(_create_sm, list(range(num_machines)), size=2)
+            assert len(results) == num_machines
+        finally:
+            for machine in results:
+                stepfunctions_client.delete_state_machine(
+                    stateMachineArn=machine["stateMachineArn"]
+                )
 
 
 TEST_STATE_MACHINE = {

--- a/tests/integration/test_stepfunctions.py
+++ b/tests/integration/test_stepfunctions.py
@@ -522,19 +522,14 @@ class TestStateMachine:
                 name=sm_name, definition=definition, roleArn=role_arn
             )
             assert result["ResponseMetadata"]["HTTPStatusCode"] == 200
+            cleanups.append(lambda: stepfunctions_client.delete_state_machine(stateMachineArn=result["stateMachineArn"]))
             results.append(result)
             stepfunctions_client.describe_state_machine(stateMachineArn=result["stateMachineArn"])
             stepfunctions_client.list_tags_for_resource(resourceArn=result["stateMachineArn"])
 
-        try:
-            num_machines = 30
-            parallelize(_create_sm, list(range(num_machines)), size=2)
-            assert len(results) == num_machines
-        finally:
-            for machine in results:
-                stepfunctions_client.delete_state_machine(
-                    stateMachineArn=machine["stateMachineArn"]
-                )
+        num_machines = 30
+        parallelize(_create_sm, list(range(num_machines)), size=2)
+        assert len(results) == num_machines
 
 
 TEST_STATE_MACHINE = {


### PR DESCRIPTION
Add lock for StepFunction creation to prevent concurrency issues. This issue surfaced while deploying a Terraform script with N number of copies of the same state machine, which then resulted in the following error:

```
botocore.errorfactory.InvalidDefinition: An error occurred (InvalidDefinition) when calling the
        CreateStateMachine operation: Invalid State Machine Definition: ''DUPLICATE_STATE_NAME: Duplicate State name:
        MissingValue at /States/MissingValue', 'DUPLICATE_STATE_NAME: Duplicate State name: Add at /States/Add''
```

Added a simple test that creates a number of state machines in parallel.