### PR TITLE
Fix missing message sort in SES tests

### DIFF
--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -37,6 +37,17 @@ def create_template(ses_client):
         ses_client.delete_template(TemplateName=name)
 
 
+def sort_mail_sqs_messages(message):
+    if "Successfully validated" in message["Message"]:
+        return 0
+    elif json.loads(message["Message"])["eventType"] == "Send":
+        return 1
+    elif json.loads(message["Message"])["eventType"] == "Delivery":
+        return 2
+    else:
+        raise ValueError("bad")
+
+
 class TestSES:
     def test_list_templates(self, ses_client, create_template):
         create_template(Template=TEST_TEMPLATE_ATTRIBUTES)
@@ -309,19 +320,7 @@ class TestSES:
         )
 
         messages = sqs_receive_num_messages(sqs_queue, 3)
-        # the messages may arrive out of order so sort
-
-        def sort_fn(message):
-            if "Successfully validated" in message["Message"]:
-                return 0
-            elif json.loads(message["Message"])["eventType"] == "Send":
-                return 1
-            elif json.loads(message["Message"])["eventType"] == "Delivery":
-                return 2
-            else:
-                raise ValueError("bad")
-
-        messages.sort(key=sort_fn)
+        messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
     @pytest.mark.only_localstack
@@ -393,19 +392,7 @@ class TestSES:
         )
 
         messages = sqs_receive_num_messages(sqs_queue, 3)
-        # the messages may arrive out of order so sort
-
-        def sort_fn(message):
-            if "Successfully validated" in message["Message"]:
-                return 0
-            elif json.loads(message["Message"])["eventType"] == "Send":
-                return 1
-            elif json.loads(message["Message"])["eventType"] == "Delivery":
-                return 2
-            else:
-                raise ValueError("bad")
-
-        messages.sort(key=sort_fn)
+        messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
     @pytest.mark.only_localstack
@@ -471,19 +458,7 @@ class TestSES:
         )
 
         messages = sqs_receive_num_messages(sqs_queue, 3)
-        # the messages may arrive out of order so sort
-
-        def sort_fn(message):
-            if "Successfully validated" in message["Message"]:
-                return 0
-            elif json.loads(message["Message"])["eventType"] == "Send":
-                return 1
-            elif json.loads(message["Message"])["eventType"] == "Delivery":
-                return 2
-            else:
-                raise ValueError("bad")
-
-        messages.sort(key=sort_fn)
+        messages.sort(key=sort_mail_sqs_messages)
         snapshot.match("messages", messages)
 
     def test_cannot_create_event_for_no_topic(


### PR DESCRIPTION
The messages were previously sorted before comparing with the snapshot, but something got lost in a failed merge commit in the past and missed. This PR adds the missing message sorting before comparing with the snapshot to prevent flaky test runs.

- fix: sort messages before comparing with raw email
- refactor: extract sorting function
