### PR TITLE
fix asgi/wsgi werkzeug compatibility for multi-part uploads

### DIFF
--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2704,6 +2704,9 @@ class TestS3PresignedUrl:
         snapshot.match("get_object", response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        reason="failing sporadically with new HTTP gateway (only in CI)",
+    )
     def test_post_object_with_files(self, s3_client, s3_bucket):
         object_key = "test-presigned-post-key"
 

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2704,13 +2704,12 @@ class TestS3PresignedUrl:
         snapshot.match("get_object", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(
-        reason="failing sporadically with new HTTP gateway (only in CI)",
-    )
     def test_post_object_with_files(self, s3_client, s3_bucket):
         object_key = "test-presigned-post-key"
 
-        body = b"something body"
+        body = (
+            b"0" * 70_000
+        )  # make sure the payload size is large to force chunking in our internal implementation
 
         presigned_request = s3_client.generate_presigned_post(
             Bucket=s3_bucket,


### PR DESCRIPTION
This PR adds a band-aid for the issue described in https://github.com/pallets/werkzeug/issues/2558.

It should fix/address (cc @bentsku @pinzon)
* #6588
* #7247
* #7256

The problem manifested mostly in S3 pre-signed POST, where the combination of payloads larger than the buffer size in werkzeug's [MultiPartParser](https://github.com/pallets/werkzeug/blob/eef696b15c5e9fc20ed718f6685a3f21f2fbc3b8/src/werkzeug/formparser.py#L348) would force chunking, and further down the line would cause the issue described in the upstream issue report I linked.

I added a unit test, which created the following traceback:

```
Traceback (most recent call last):
  File "/home/thomas/workspace/localstack/localstack/tests/unit/http_/test_asgi.py", line 222, in app
    for k, file_storage in request.files.items():
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/utils.py", line 107, in __get__
    value = self.fget(obj)  # type: ignore
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/wrappers/request.py", line 480, in files
    self._load_form_data()
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/wrappers/request.py", line 266, in _load_form_data
    data = parser.parse(
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/formparser.py", line 263, in parse
    return parse_func(self, stream, mimetype, content_length, options)
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/formparser.py", line 140, in wrapper
    return f(self, stream, *args, **kwargs)
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/formparser.py", line 290, in _parse_multipart
    form, files = parser.parse(stream, boundary, content_length)
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/formparser.py", line 418, in parse
    for data in iterator:
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/wsgi.py", line 653, in _make_chunk_iter
    item = _read(buffer_size)
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/wsgi.py", line 925, in read
    return self.on_disconnect()
  File "/home/thomas/workspace/localstack/localstack/.venv/lib/python3.10/site-packages/werkzeug/wsgi.py", line 893, in on_disconnect
    raise ClientDisconnected()
```

The patch is a temporary solution that should be removed once the upstream issue is fixed.