### PR TITLE
Add dev config flag for fixing lambda invoke on macOS in host mode

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -646,9 +646,10 @@ LAMBDA_REMOVE_CONTAINERS = (
     os.environ.get("LAMBDA_REMOVE_CONTAINERS", "").lower().strip() not in FALSE_STRINGS
 )
 
-# only for LS developers: expose port when invoking lambdas in host mode for systems that cannot reach the container
-# via IPv4 (e.g., macOS https://docs.docker.com/desktop/networking/#i-cannot-ping-my-containers)
-LAMBDA_ASF_DEV_PORT_EXPOSE = is_env_true("LAMBDA_ASF_DEV_PORT_EXPOSE")
+# DEV | Only for LS developers. Only applicable to new Lambda provider.
+# whether to explicitly expose port in lambda container when invoking functions in host mode for systems that cannot
+# reach the container via its IPv4 (e.g., macOS https://docs.docker.com/desktop/networking/#i-cannot-ping-my-containers)
+LAMBDA_DEV_PORT_EXPOSE = is_env_true("LAMBDA_DEV_PORT_EXPOSE")
 
 # Adding Stepfunctions default port
 LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
@@ -782,7 +783,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_JAVA_OPTS",
     "LAMBDA_REMOTE_DOCKER",
     "LAMBDA_REMOVE_CONTAINERS",
-    "LAMBDA_ASF_DEV_PORT_EXPOSE",
+    "LAMBDA_DEV_PORT_EXPOSE",
     "LAMBDA_RUNTIME_EXECUTOR",
     "LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT",
     "LAMBDA_STAY_OPEN_MODE",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -646,6 +646,10 @@ LAMBDA_REMOVE_CONTAINERS = (
     os.environ.get("LAMBDA_REMOVE_CONTAINERS", "").lower().strip() not in FALSE_STRINGS
 )
 
+# only for LS developers: expose port when invoking lambdas in host mode for systems that cannot reach the container
+# via IPv4 (e.g., macOS https://docs.docker.com/desktop/networking/#i-cannot-ping-my-containers)
+LAMBDA_ASF_DEV_PORT_EXPOSE = is_env_true("LAMBDA_ASF_DEV_PORT_EXPOSE")
+
 # Adding Stepfunctions default port
 LOCAL_PORT_STEPFUNCTIONS = int(os.environ.get("LOCAL_PORT_STEPFUNCTIONS") or 8083)
 # Stepfunctions lambda endpoint override
@@ -778,6 +782,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_JAVA_OPTS",
     "LAMBDA_REMOTE_DOCKER",
     "LAMBDA_REMOVE_CONTAINERS",
+    "LAMBDA_ASF_DEV_PORT_EXPOSE",
     "LAMBDA_RUNTIME_EXECUTOR",
     "LAMBDA_RUNTIME_ENVIRONMENT_TIMEOUT",
     "LAMBDA_STAY_OPEN_MODE",

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -10,6 +10,7 @@ from localstack import config
 from localstack.aws.api.lambda_ import PackageType, Runtime
 from localstack.services.awslambda import hooks as lambda_hooks
 from localstack.services.awslambda.invocation.executor_endpoint import (
+    INVOCATION_PORT,
     ExecutorEndpoint,
     ServiceEndpoint,
 )
@@ -25,10 +26,12 @@ from localstack.services.awslambda.lambda_utils import (
 from localstack.services.awslambda.packages import awslambda_runtime_package
 from localstack.utils.container_utils.container_client import (
     ContainerConfiguration,
+    PortMappings,
     VolumeBind,
     VolumeMappings,
 )
 from localstack.utils.docker_utils import DOCKER_CLIENT as CONTAINER_CLIENT
+from localstack.utils.net import get_free_tcp_port
 from localstack.utils.strings import truncate
 
 LOG = logging.getLogger(__name__)
@@ -208,6 +211,9 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             self.id,
         )
         executor_endpoint = ExecutorEndpoint(self.id, service_endpoint=service_endpoint)
+        if config.LAMBDA_ASF_DEV_PORT_EXPOSE:
+            executor_endpoint.container_address = "localhost"
+            executor_endpoint.container_port = get_free_tcp_port()
         LOG.debug(
             "Finished creating service endpoint for function %s executor %s",
             self.function_version.qualified_arn,
@@ -249,7 +255,10 @@ class DockerRuntimeExecutor(RuntimeExecutor):
 
         if not container_config.image_name:
             container_config.image_name = self.get_image()
-
+        if config.LAMBDA_ASF_DEV_PORT_EXPOSE:
+            if container_config.ports is None:
+                container_config.ports = PortMappings()
+            container_config.ports.add(self.executor_endpoint.container_port, INVOCATION_PORT)
         CONTAINER_CLIENT.create_container_from_config(container_config)
         if (
             not config.LAMBDA_PREBUILD_IMAGES
@@ -264,10 +273,11 @@ class DockerRuntimeExecutor(RuntimeExecutor):
                 CONTAINER_CLIENT.copy_into_container(self.id, source, target)
 
         CONTAINER_CLIENT.start_container(self.id)
-        self.ip = CONTAINER_CLIENT.get_container_ipv4_for_network(
-            container_name_or_id=self.id, container_network=network
-        )
-        self.executor_endpoint.container_address = self.ip
+        if not config.LAMBDA_ASF_DEV_PORT_EXPOSE:
+            self.ip = CONTAINER_CLIENT.get_container_ipv4_for_network(
+                container_name_or_id=self.id, container_network=network
+            )
+            self.executor_endpoint.container_address = self.ip
 
     def stop(self) -> None:
         CONTAINER_CLIENT.stop_container(container_name=self.id, timeout=5)

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -252,7 +252,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
 
         if not container_config.image_name:
             container_config.image_name = self.get_image()
-        if config.LAMBDA_ASF_DEV_PORT_EXPOSE:
+        if config.LAMBDA_DEV_PORT_EXPOSE:
             self.executor_endpoint.container_port = get_free_tcp_port()
             if container_config.ports is None:
                 container_config.ports = PortMappings()
@@ -274,7 +274,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         self.ip = CONTAINER_CLIENT.get_container_ipv4_for_network(
             container_name_or_id=self.id, container_network=network
         )
-        if config.LAMBDA_ASF_DEV_PORT_EXPOSE:
+        if config.LAMBDA_DEV_PORT_EXPOSE:
             self.ip = "127.0.0.1"
         self.executor_endpoint.container_address = self.ip
 

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -275,9 +275,8 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             container_name_or_id=self.id, container_network=network
         )
         if config.LAMBDA_ASF_DEV_PORT_EXPOSE:
-            self.executor_endpoint.container_address = "localhost"
-        else:
-            self.executor_endpoint.container_address = self.ip
+            self.ip = "127.0.0.1"
+        self.executor_endpoint.container_address = self.ip
 
     def stop(self) -> None:
         CONTAINER_CLIENT.stop_container(container_name=self.id, timeout=5)

--- a/localstack/services/awslambda/invocation/executor_endpoint.py
+++ b/localstack/services/awslambda/invocation/executor_endpoint.py
@@ -29,6 +29,7 @@ class InvokeSendError(Exception):
 class ExecutorEndpoint:
     service_endpoint: ServiceEndpoint
     container_address: str
+    container_port: int
     rules: list[Rule]
     endpoint_id: str
     router: Router
@@ -38,9 +39,11 @@ class ExecutorEndpoint:
         endpoint_id: str,
         service_endpoint: ServiceEndpoint,
         container_address: Optional[str] = None,
+        container_port: Optional[int] = INVOCATION_PORT,
     ) -> None:
         self.service_endpoint = service_endpoint
         self.container_address = container_address
+        self.container_port = container_port
         self.rules = []
         self.endpoint_id = endpoint_id
         self.router = ROUTER
@@ -118,7 +121,7 @@ class ExecutorEndpoint:
     def invoke(self, payload: Dict[str, str]) -> None:
         if not self.container_address:
             raise ValueError("Container address not set, but got an invoke.")
-        invocation_url = f"http://{self.container_address}:{INVOCATION_PORT}/invoke"
+        invocation_url = f"http://{self.container_address}:{self.container_port}/invoke"
         response = requests.post(url=invocation_url, json=payload)
         if not response.ok:
             raise InvokeSendError(


### PR DESCRIPTION
Co-authored by @dominikschubert 

## Problem

The new lambda provider requires bi-directional communication (host <=> lambda container), which breaks host mode in macOS because the lambda container is not reachable via IPv4 in bridge mode.
Hence, invoking any lambda fails while the lambda container waits for an invocation (i.e., during `"blocking the credentials service"`) after a connection timeout with the error `Connection to 172.17.0.2 timed out.`

Enable new lambda provider: `PROVIDER_OVERRIDE_LAMBDA=asf`

Relevant test case: `tests.integration.awslambda.test_lambda.TestLambdaFeatures.test_invocation_type_request_response`

## Background

> Docker Desktop can’t route traffic to Linux containers. However, if you’re a Windows user, you can ping the Windows containers. (Source: Docker [I cannot ping my containers](https://docs.docker.com/desktop/networking/#i-cannot-ping-my-containers))

There is also a long discussion thread about this issue in the [moby project](https://github.com/moby/moby/issues/22753#issuecomment-222943352).

## LocalStack Workarounds

- Start LS in a container with bind-mounted code and run tests against it using `TEST_SKIP_LOCALSTACK_START=1`
    - ➖  Debugging doesn’t work
    - ➖ Tests that monkey-patch stuff don’t work
- Execute test in container `TEST_PATH="tests/integration/awslambda/test_lambda_common.py" make test-docker-mount`
    - ➖  cannot install moto using `pip install -e`
    ⇒ delete `-v $$PACKAGES_DIR/moto:/opt/code/localstack/.venv/lib/python3.10/site-packages/moto/` from test-docker-mount-code in the Makefile

Thanks, @dfangl for the hints 🙏 


## Potential macOS networking Workarounds (not tested)

- Blogpost summarizing solutions: https://itecnote.com/tecnote/r-how-to-ping-the-docker-container-from-the-host/
    - ➕ most comprehensive overview
- Docker Toolbox/VirtualBox or Vagrant/Ansible-based setup: https://stackoverflow.com/a/39217691
    - ➖ cumbersome to configure
    - ➖ doesn't support host volume mapping
- shim based fix:  https://github.com/AlmirKadric-Published/docker-tuntap-osx
    - ➖ depends on unmaintained [TunTap](https://tuntaposx.sourceforge.net/)

## Suggested Changes

Introduce a dev config flag `LAMBDA_DEV_PORT_EXPOSE` and conditionally expose a free TCP port in the lambda container.