### PR TITLE
fix SNS flaky test test_subscription_after_failure_to_deliver

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -2211,7 +2211,8 @@ class TestSNSProvider:
         message = "test_dlq_after_sqs_endpoint_deleted"
         sns_client.publish(TopicArn=topic_arn, Message=message)
         # to avoid race condition, publish is async and the redrive policy can be in effect before the actual publish
-        time.sleep(1)
+        # there isn't a proper way to check that the message has been published before setting the RedrivePolicy
+        time.sleep(3)
 
         # check the subscription is still there after we deleted the queue
         subscriptions = sns_client.list_subscriptions_by_topic(TopicArn=topic_arn)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -38,6 +38,16 @@ PUBLICATION_RETRIES = 4
 @pytest.fixture(autouse=True)
 def sns_snapshot_transformer(snapshot):
     snapshot.add_transformer(snapshot.transform.sns_api())
+    # FIXME: AWS added a new field to subscriptions responses. It has an ARN in the response, which creates
+    # a <resource:id> that we're missing. Regenerate all snapshots without this transformer once this is implemented.
+    snapshot.add_transformer(
+        snapshot.transform.key_value(
+            "SubscriptionPrincipal",
+            value_replacement="<sub-principal>",
+            reference_replacement=False,
+        ),
+        priority=-1,
+    )
 
 
 @pytest.fixture
@@ -2160,6 +2170,7 @@ class TestSNSProvider:
         paths=[
             "$..Attributes.Owner",
             "$..Attributes.ConfirmationWasAuthenticated",
+            "$..Attributes.SubscriptionPrincipal",
             "$..Attributes.RawMessageDelivery",
             "$..Attributes.sqs_queue_url",
             "$..Subscriptions..Owner",
@@ -2175,6 +2186,7 @@ class TestSNSProvider:
         sqs_queue_exists,
         sns_create_sqs_subscription,
         sns_allow_topic_sqs_queue,
+        sqs_receive_num_messages,
         snapshot,
     ):
         topic_arn = sns_create_topic()["TopicArn"]
@@ -2207,17 +2219,35 @@ class TestSNSProvider:
         )
 
         sqs_client.delete_queue(QueueUrl=queue_url)
+
+        # setting up a second queue to be able to poll and know approximately when the message on the deleted queue
+        # have been published
+        queue_test_url = sqs_create_queue()
+        test_subscription = sns_create_sqs_subscription(
+            topic_arn=topic_arn, queue_url=queue_test_url
+        )
+        test_subscription_arn = test_subscription["SubscriptionArn"]
         # try to send a message before setting a DLQ
         message = "test_dlq_after_sqs_endpoint_deleted"
         sns_client.publish(TopicArn=topic_arn, Message=message)
+
         # to avoid race condition, publish is async and the redrive policy can be in effect before the actual publish
-        # there isn't a proper way to check that the message has been published before setting the RedrivePolicy
-        time.sleep(3)
+        # we wait until the 2nd subscription received the message
+        poll_condition(
+            lambda: sqs_receive_num_messages(
+                queue_url=queue_test_url, expected_messages=1, max_iterations=2
+            ),
+            timeout=10,
+        )
+        sns_client.unsubscribe(SubscriptionArn=test_subscription_arn)
+        # we still wait a bit to be sure the message is well published
+        time.sleep(1)
 
         # check the subscription is still there after we deleted the queue
         subscriptions = sns_client.list_subscriptions_by_topic(TopicArn=topic_arn)
         snapshot.match("subscriptions", subscriptions)
 
+        # set the RedrivePolicy with a DLQ. Subsequent failing messages to the subscription should go there
         sns_client.set_subscription_attributes(
             SubscriptionArn=subscription_arn,
             AttributeName="RedrivePolicy",

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -1492,7 +1492,7 @@
     "recorded-content": {}
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_subscription_after_failure_to_deliver": {
-    "recorded-date": "10-08-2022, 17:04:52",
+    "recorded-date": "20-12-2022, 20:25:24",
     "recorded-content": {
       "subscriptions-attrs": {
         "Attributes": {
@@ -1503,6 +1503,7 @@
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
         },
         "ResponseMetadata": {
@@ -1535,10 +1536,6 @@
         }
       },
       "subscriptions": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Subscriptions": [
           {
             "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
@@ -1547,7 +1544,11 @@
             "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
             "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
           }
-        ]
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "subscriptions-attrs-with-redrive": {
         "Attributes": {
@@ -1561,6 +1562,7 @@
             "deadLetterTargetArn": "arn:aws:sqs:<region>:111111111111:<resource:4>"
           },
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
         },
         "ResponseMetadata": {


### PR DESCRIPTION
It seems we had a flaky test run here: [circleCI run](https://app.circleci.com/pipelines/github/localstack/localstack/11427/workflows/da8762f4-382a-4346-baf5-a57e5a5ffb4f/jobs/79436/tests)

We had an issue before where we would delete the subscription after failing to deliver. This test checks for this regression.

What we do is we create an SNS topic, set a subscription with an SQS queue, test that it works, then delete the queue.
It should then fail to publish. We then waited 1 second (now 3) before setting a `RedrivePolicy` with a dead letter queue to then try publishing again and see that it arrives in the DLQ. 

What happens apparently is that 1 second is not enough, and that the asynchronous publishing part took more than 1 second, which made the message arrive in the DLQ because it was already configured.
