### PR TITLE
remove walrus operator from profiles.py

### DIFF
--- a/localstack/cli/profiles.py
+++ b/localstack/cli/profiles.py
@@ -10,7 +10,8 @@ def set_profile_from_sys_argv():
     Reads the --profile flag from sys.argv and then sets the 'CONFIG_PROFILE' os variable accordingly. This is later
     picked up by ``localstack.config``.
     """
-    if profile := parse_profile_argument(sys.argv):
+    profile = parse_profile_argument(sys.argv)
+    if profile:
         os.environ["CONFIG_PROFILE"] = profile.strip()
 
 


### PR DESCRIPTION
For Python 3.7 compatibility, we need to remove the walrus operator from `cli/profiles.py`. This seems to have evaded our CLI tests as it is imported and called outside of the `cli` creation. 