### PR TITLE
Fix stream event source dates for kinesis and dynamodb streams

### DIFF
--- a/localstack/services/awslambda/event_source_listeners/dynamodb_event_source_listener.py
+++ b/localstack/services/awslambda/event_source_listeners/dynamodb_event_source_listener.py
@@ -41,7 +41,7 @@ class DynamoDBEventSourceListener(StreamEventSourceListener):
         for record in records:
             creation_time = record.get("dynamodb", {}).get("ApproximateCreationDateTime", None)
             if creation_time is not None:
-                record["dynamodb"]["ApproximateCreationDateTime"] = creation_time.timestamp() * 1000
+                record["dynamodb"]["ApproximateCreationDateTime"] = creation_time.timestamp()
             record_payloads.append(
                 {
                     "eventID": record["eventID"],

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
@@ -1,4 +1,5 @@
 import json
+import math
 import time
 
 import pytest
@@ -165,6 +166,11 @@ class TestDynamoDBEventSourceMapping:
 
         event_logs = retry(_send_and_receive_events, retries=3)
         snapshot.match("event_logs", event_logs)
+        # check if the timestamp has the correct format
+        timestamp = event_logs[0]["Records"][0]["dynamodb"]["ApproximateCreationDateTime"]
+        # check if the timestamp has same amount of numbers before the comma as the current timestamp
+        # this will fail in november 2286, if this code is still around by then, read this comment and update to 10
+        assert int(math.log10(timestamp)) == 9
 
     @pytest.mark.aws_validated
     def test_disabled_dynamodb_event_source_mapping(


### PR DESCRIPTION
## Problem
LS multiplies the timestamps for `ApproximateCreationDateTime` (dynamodb) and `approximateArrivalTimestamp` (kinesis) by 1000, so it is provided in milliseconds.

This is, however, not what AWS does, there the value is a posix timestamp, so in seconds. For kinesis, it has millisecond precision, but the integer part still represents seconds.
So basically, the correct formats would be:
kinesis:            `1671562498.449` (currently `1671562498449.0`)
dynamodb:     `1671562498.0` (currently `1671562498000`)

Also, the encryptionType should not be present in the kinesis records of the lambda event. This is basically a repetition of #3346 .

## AWS docs for this behavior
Kinesis provides a hint here: https://docs.aws.amazon.com/kinesis/latest/APIReference/API_GetRecords.html . It says the value has `millisecond precision`, but in this case it is still a POSIX timestamp with the integer part representing seconds, the millisecond precision is provided in the fractional part.

DynamoDB quite clearly state it has to be unix epoch time format here: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_StreamRecord.html

## Changes
* This PR fixes this behavior, and adds assertions regarding the length of the integer part to the tests.
* Remove snapshot ignore of the encryptionType (to assert it being absent)

## Related issues
* #6355
* #6369
Both are locally tested to be fixed.