### PR TITLE
Update lambda java lib to 0.2.22

### DIFF
--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -101,10 +101,10 @@ URL_LOCALSTACK_FAT_JAR = (
 
 class AWSLambdaJavaPackage(Package):
     def __init__(self):
-        super().__init__("LambdaJavaLibs", "0.2.21")
+        super().__init__("LambdaJavaLibs", "0.2.22")
 
     def get_versions(self) -> List[str]:
-        return ["0.2.21"]
+        return ["0.2.22", "0.2.21"]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return AWSLambdaJavaPackageInstaller("lambda-java-libs", version)


### PR DESCRIPTION
## Problem
With #6603 we removed the `"sqs": True` part of sqs payloads.
While this is correct in terms of parity, this broke the lambda-java-utils (https://github.com/localstack/localstack-java-utils) library we use for local lambda execution, which depended on that attribute.

## Solution
* The new version of localstack-java-utils uses an attribute which is supposed to be in the payload to determine SQS events, which fixes the execution of these handlers in LocalStack.

It is not a good fix, since we should not rely on the data layout for this, but it fixes the regression.

Fixes #6995

Relevant localstack-java-utils PR: localstack/localstack-java-utils#98