### PR TITLE
fix passing event from default eventbus to custom eventbus

### DIFF
--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -84,6 +84,7 @@ def send_event_to_target(
                         "Source": event.get("source"),
                         "DetailType": event.get("detail-type"),
                         "Detail": json.dumps(event.get("detail", {})),
+                        "Resources": event.get("resources", []),
                     }
                 ]
             )

--- a/localstack/utils/aws/message_forwarding.py
+++ b/localstack/utils/aws/message_forwarding.py
@@ -83,7 +83,7 @@ def send_event_to_target(
                         "EventBusName": eventbus_name,
                         "Source": event.get("source"),
                         "DetailType": event.get("detail-type"),
-                        "Detail": event.get("detail"),
+                        "Detail": json.dumps(event.get("detail", {})),
                     }
                 ]
             )

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1451,6 +1451,9 @@ class TestEvents:
         )
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        condition=lambda: config.LEGACY_S3_PROVIDER, path="$..Messages..Body.detail.object.etag"
+    )
     def test_put_events_to_default_eventbus_for_custom_eventbus(
         self,
         events_client,

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -2,6 +2,7 @@
 import base64
 import json
 import os
+import time
 import uuid
 from datetime import datetime
 from typing import Dict, List, Tuple
@@ -15,6 +16,7 @@ from localstack.services.apigateway.helpers import extract_query_string_params
 from localstack.services.events.provider import _get_events_tmp_dir
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.infra import start_proxy
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.aws.aws_responses import requests_response
 from localstack.utils.common import (
@@ -68,6 +70,83 @@ API_DESTINATION_AUTHS = [
         },
     },
 ]
+
+EVENT_BUS_ROLE = {
+    "Statement": {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {"Service": "events.amazonaws.com"},
+        "Action": "sts:AssumeRole",
+    }
+}
+
+
+@pytest.fixture
+def events_allow_event_rule_to_sqs_queue(sqs_client):
+    def _allow_event_rule(sqs_queue_url, sqs_queue_arn, event_rule_arn) -> None:
+        # allow event rule to write to sqs queue
+        sqs_client.set_queue_attributes(
+            QueueUrl=sqs_queue_url,
+            Attributes={
+                "Policy": json.dumps(
+                    {
+                        "Statement": [
+                            {
+                                "Sid": "AllowEventsToQueue",
+                                "Effect": "Allow",
+                                "Principal": {"Service": "events.amazonaws.com"},
+                                "Action": "sqs:SendMessage",
+                                "Resource": sqs_queue_arn,
+                                "Condition": {"ArnEquals": {"aws:SourceArn": event_rule_arn}},
+                            }
+                        ]
+                    }
+                )
+            },
+        )
+
+    return _allow_event_rule
+
+
+@pytest.fixture
+def events_put_rule(events_client):
+    rules = []
+
+    def _factory(**kwargs):
+        if "Name" not in kwargs:
+            kwargs["Name"] = f"rule-{short_uid()}"
+
+        resp = events_client.put_rule(**kwargs)
+        rules.append((kwargs["Name"], kwargs.get("EventBusName", "default")))
+        return resp
+
+    yield _factory
+
+    for rule, event_bus_name in rules:
+        targets_response = events_client.list_targets_by_rule(
+            Rule=rule, EventBusName=event_bus_name
+        )
+        if targets := targets_response["Targets"]:
+            targets_ids = [target["Id"] for target in targets]
+            events_client.remove_targets(Rule=rule, EventBusName=event_bus_name, Ids=targets_ids)
+        events_client.delete_rule(Name=rule, EventBusName=event_bus_name)
+
+
+@pytest.fixture
+def events_create_event_bus(events_client):
+    event_buses = []
+
+    def _factory(**kwargs):
+        if "Name" not in kwargs:
+            kwargs["Name"] = f"event-bus-{short_uid()}"
+        resp = events_client.create_event_bus(**kwargs)
+        event_buses.append(kwargs["Name"])
+        return resp
+
+    yield _factory
+
+    for event_bus in event_buses:
+        events_client.delete_event_bus(Name=event_bus)
 
 
 class TestEvents:
@@ -1371,101 +1450,140 @@ class TestEvents:
             log_group_name=log_group_name,
         )
 
+    @pytest.mark.aws_validated
     def test_put_events_to_default_eventbus_for_custom_eventbus(
-        self, events_client, sqs_client, sqs_create_queue, sqs_queue_arn
+        self,
+        events_client,
+        events_create_event_bus,
+        events_put_rule,
+        sqs_client,
+        sqs_create_queue,
+        sqs_queue_arn,
+        create_role,
+        create_policy,
+        events_allow_event_rule_to_sqs_queue,
+        s3_client,
+        s3_bucket,
+        snapshot,
+        iam_client,
     ):
-        default_bus_rule_name = f"default-bus-rule-{short_uid()}"
-        custom_bus_rule_name = f"custom-bus-rule-{short_uid()}"
-        default_bus_target_id = f"target-default-b-{short_uid()}"
-        custom_bus_target_id = f"target-custom-b-{short_uid()}"
-        custom_bus_name = f"eventbus-{short_uid()}"
-        fake_bucket_name = f"fake-bucket-{short_uid()}"
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        snapshot.add_transformer(snapshot.transform.sqs_api())
+        snapshot.add_transformer(snapshot.transform.resource_name())
+        snapshot.add_transformers_list(
+            [
+                snapshot.transform.key_value("MD5OfBody"),
+                snapshot.transform.jsonpath("$..detail.bucket.name", "bucket-name"),
+                snapshot.transform.jsonpath("$..detail.object.key", "key-name"),
+                snapshot.transform.jsonpath(
+                    "$..detail.object.sequencer", "object-sequencer", reference_replacement=False
+                ),
+                snapshot.transform.jsonpath(
+                    "$..detail.request-id", "request-id", reference_replacement=False
+                ),
+                snapshot.transform.jsonpath(
+                    "$..detail.requester", "<requester>", reference_replacement=False
+                ),
+                snapshot.transform.jsonpath("$..detail.source-ip-address", "ip-address"),
+            ]
+        )
+        default_bus_rule_name = f"test-default-bus-rule-{short_uid()}"
+        custom_bus_rule_name = f"test-custom-bus-rule-{short_uid()}"
+        default_bus_target_id = f"test-target-default-b-{short_uid()}"
+        custom_bus_target_id = f"test-target-custom-b-{short_uid()}"
+        custom_bus_name = f"test-eventbus-{short_uid()}"
+
+        role = f"test-eventbus-role-{short_uid()}"
+        policy_name = f"test-eventbus-role-policy-{short_uid()}"
+
+        s3_client.put_bucket_notification_configuration(
+            Bucket=s3_bucket, NotificationConfiguration={"EventBridgeConfiguration": {}}
+        )
 
         queue_url = sqs_create_queue()
         queue_arn = sqs_queue_arn(queue_url)
 
-        custom_event_bus = events_client.create_event_bus(Name=custom_bus_name)
+        custom_event_bus = events_create_event_bus(Name=custom_bus_name)
+        snapshot.match("create-custom-event-bus", custom_event_bus)
         custom_event_bus_arn = custom_event_bus["EventBusArn"]
 
-        events_client.put_rule(
+        event_bus_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "events:PutEvents", "Resource": custom_event_bus_arn}
+            ],
+        }
+
+        role_response = create_role(
+            RoleName=role, AssumeRolePolicyDocument=json.dumps(EVENT_BUS_ROLE)
+        )
+        role_arn = role_response["Role"]["Arn"]
+        policy_arn = create_policy(
+            PolicyName=policy_name, PolicyDocument=json.dumps(event_bus_policy)
+        )["Policy"]["Arn"]
+        iam_client.attach_role_policy(RoleName=role, PolicyArn=policy_arn)
+        if is_aws_cloud():
+            # wait for the policy to be properly attached
+            time.sleep(20)
+
+        rule_on_default_bus = events_put_rule(
             Name=default_bus_rule_name,
-            EventBusName="default",
             EventPattern='{"detail-type":["Object Created"],"source":["aws.s3"]}',
             State="ENABLED",
         )
+        snapshot.match("create-rule-1", rule_on_default_bus)
 
         custom_bus_rule_event_pattern = {
             "detail": {
-                "bucket": {"name": [fake_bucket_name]},
+                "bucket": {"name": [s3_bucket]},
                 "object": {"key": [{"prefix": "delivery/"}]},
             },
             "detail-type": ["Object Created"],
             "source": ["aws.s3"],
         }
 
-        events_client.put_rule(
+        rule_on_custom_bus = events_put_rule(
             Name=custom_bus_rule_name,
             EventBusName=custom_bus_name,
             EventPattern=json.dumps(custom_bus_rule_event_pattern),
             State="ENABLED",
         )
+        rule_on_custom_bus_arn = rule_on_custom_bus["RuleArn"]
+        snapshot.match("create-rule-2", rule_on_custom_bus)
 
-        events_client.put_targets(
-            Rule=default_bus_rule_name,
-            EventBusName="default",
-            Targets=[{"Id": default_bus_target_id, "Arn": custom_event_bus_arn}],
+        events_allow_event_rule_to_sqs_queue(
+            sqs_queue_url=queue_url, sqs_queue_arn=queue_arn, event_rule_arn=rule_on_custom_bus_arn
         )
 
-        events_client.put_targets(
+        resp = events_client.put_targets(
+            Rule=default_bus_rule_name,
+            Targets=[
+                {"Id": default_bus_target_id, "Arn": custom_event_bus_arn, "RoleArn": role_arn}
+            ],
+        )
+        snapshot.match("put-target-1", resp)
+
+        resp = events_client.put_targets(
             Rule=custom_bus_rule_name,
             EventBusName=custom_bus_name,
             Targets=[{"Id": custom_bus_target_id, "Arn": queue_arn}],
         )
-        fake_s3_event = {
-            "Source": "aws.s3",
-            "DetailType": "Object Created",
-            "Detail": json.dumps(
-                {
-                    "version": "0",
-                    "bucket": {
-                        "name": fake_bucket_name,
-                    },
-                    "object": {
-                        "key": "delivery/test.txt",
-                        "size": 9,
-                        "etag": "2cc62706a09ea477faf28a0105f01fe9",
-                        "sequencer": "0062E99A88DC407460",
-                    },
-                    "request-id": "RKREYG1RN2X92YX6",
-                    "requester": "074255357339",
-                    "source-ip-address": "127.0.0.1",
-                    "reason": "PutObject",
-                }
-            ),
-        }
+        snapshot.match("put-target-2", resp)
 
-        events_client.put_events(Entries=[fake_s3_event])
+        s3_client.put_object(Bucket=s3_bucket, Key="delivery/test.txt", Body=b"data")
 
         def get_message():
-            resp = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=1)
-            return resp["Messages"]
+            recv_msg = sqs_client.receive_message(QueueUrl=queue_url, WaitTimeSeconds=5)
+            return recv_msg["Messages"]
 
-        messages = retry(get_message, retries=3, sleep=0.5)
+        retries = 20 if is_aws_cloud() else 3
+        messages = retry(get_message, retries=retries, sleep=0.5)
         assert len(messages) == 1
+        snapshot.match("get-events", {"Messages": messages})
 
         received_event = json.loads(messages[0]["Body"])
-        print(received_event)
 
         self.assert_valid_event(received_event)
-        assert received_event["detail"] == json.loads(fake_s3_event["Detail"])
-
-        # clean up
-        self.cleanup(
-            bus_name=custom_bus_name,
-            rule_name=custom_bus_rule_name,
-            target_ids=custom_bus_target_id,
-        )
-        self.cleanup(rule_name=default_bus_rule_name, target_ids=default_bus_target_id)
 
     def _get_queue_arn(self, queue_url, sqs_client):
         queue_attrs = sqs_client.get_queue_attributes(

--- a/tests/integration/test_events.snapshot.json
+++ b/tests/integration/test_events.snapshot.json
@@ -1,0 +1,81 @@
+{
+  "tests/integration/test_events.py::TestEvents::test_put_events_to_default_eventbus_for_custom_eventbus": {
+    "recorded-date": "22-12-2022, 01:50:01",
+    "recorded-content": {
+      "create-custom-event-bus": {
+        "EventBusArn": "arn:aws:events:<region>:111111111111:event-bus/<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-rule-1": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-rule-2": {
+        "RuleArn": "arn:aws:events:<region>:111111111111:rule/<resource:1>/<resource:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-target-1": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-target-2": {
+        "FailedEntries": [],
+        "FailedEntryCount": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-events": {
+        "Messages": [
+          {
+            "Body": {
+              "version": "0",
+              "id": "<uuid:1>",
+              "detail-type": "Object Created",
+              "source": "aws.s3",
+              "account": "111111111111",
+              "time": "date",
+              "region": "<region>",
+              "resources": [
+                "arn:aws:s3:::<bucket-name:1>"
+              ],
+              "detail": {
+                "version": "0",
+                "bucket": {
+                  "name": "<bucket-name:1>"
+                },
+                "object": {
+                  "key": "<key-name:1>",
+                  "size": 4,
+                  "etag": "8d777f385d3dfec8815d20f7496026dc",
+                  "sequencer": "object-sequencer"
+                },
+                "request-id": "request-id",
+                "requester": "<requester>",
+                "source-ip-address": "<ip-address:1>",
+                "reason": "PutObject"
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This issue arose in a support ticket.

When passing a message from the `default` event bus of EventBridge to a custom one with a rule, we would first `json.loads` the event `Details` then pass it down the chain for it to be sent again through `put_events` if the target was an event bus. However, we would not `json.dumps` it again after it being decoded, so we would try to send a `dict` in the `put_event Entries` parameter, which would raise a silent exception. 

See here for the code decoding the JSON details before calling `localstack.services.events.provider.process_events` which calls `localstack.utils.aws.message_forwarding.send_event_to_target` where the fix is:
https://github.com/localstack/localstack/blob/05aa3907cd2166823ee2bb10d145227e8383115b/localstack/services/events/provider.py#L468-L486

The chain is S3 notification -> default EventBridge event bus -> rule on default eventbridge bus -> custom eventbridge bus -> SQS queue. 

```
2022-12-20T23:11:49.182  INFO --- [   asgi_gw_0] l.services.events.provider : Unable to send event notification {'version': '0', 'id': 'a26463c1-9f3e-4e9b-a4f0-0475d478ab9a', 'detail-type': 'Object Created', 'sou... to target {'Arn': 'arn:aws:events:us-west-2:000000000000:event-bus/custom-event-bus', 'Id': 'terraform-20221220230701396700000002', 'RoleArn': 'arn:aws:iam::000000000000:role/service-role/custom-role'}: Parameter validation failed:
Invalid type for parameter Entries[0].Detail, value: {'version': '0', 'bucket': {'name': 'bucket-name'}, 'object': {'key': 'delivery/test.txt', 'size': 212, 'etag': '"ef34c94690f8a66f9e9880c01f6e6818"', 'sequencer': '0062E99A88DC407460'}, 'request-id': 'RKREYG1RN2X92YX6', 'requester': '074255357339', 'source-ip-address': '127.0.0.1', 'reason': 'PutObject'}, type: <class 'dict'>, valid types: <class 'str'>
```

The added test is the sample of the user, taken from Terraform and put into boto3 commands.  