### PR TITLE
CFn refactoring pt.3

### DIFF
--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -179,7 +179,11 @@ def function_name_qualifier_and_region_from_arn(arn: str) -> tuple[str, str | No
     :param arn: Given arn (or name)
     :return: tuple with (name, qualifier, region). Qualifier and region are none if missing
     """
-    return FUNCTION_NAME_REGEX.match(arn).group("name", "qualifier", "region")
+
+    try:
+        return FUNCTION_NAME_REGEX.match(arn).group("name", "qualifier", "region")
+    except Exception as e:
+        print(e)
 
 
 def get_name_and_qualifier(

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -179,11 +179,7 @@ def function_name_qualifier_and_region_from_arn(arn: str) -> tuple[str, str | No
     :param arn: Given arn (or name)
     :return: tuple with (name, qualifier, region). Qualifier and region are none if missing
     """
-
-    try:
-        return FUNCTION_NAME_REGEX.match(arn).group("name", "qualifier", "region")
-    except Exception as e:
-        print(e)
+    return FUNCTION_NAME_REGEX.match(arn).group("name", "qualifier", "region")
 
 
 def get_name_and_qualifier(

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -123,7 +123,7 @@ class Stack:
         ]
         result = select_attributes(self.metadata, attrs)
         result["Tags"] = self.tags
-        outputs = self.outputs_list()
+        outputs = self.resolved_outputs
         if outputs:
             result["Outputs"] = outputs
         params = self.stack_parameters()
@@ -280,29 +280,6 @@ class Stack:
 
         result = set()
         recurse_object(self.resources, _collect)
-        return result
-
-    def outputs_list(self) -> List[Dict]:
-        """Returns a copy of the outputs of this stack."""
-        result = []
-        for k, details in self.outputs.items():
-            value = None
-            try:
-                # template_deployer.resolve_refs_recursively(self, details)  # FIXME
-                value = details["Value"]
-            except Exception as e:
-                LOG.debug("Unable to resolve references in stack outputs: %s - %s", details, e)
-            exports = details.get("Export") or {}
-            export = exports.get("Name")
-            # export = template_deployer.resolve_refs_recursively(self, export)  # FIXME
-            description = details.get("Description")
-            entry = {
-                "OutputKey": k,
-                "OutputValue": value,
-                "Description": description,
-                "ExportName": export,
-            }
-            result.append(entry)
         return result
 
     # TODO: check if metadata already populated/resolved and use it if possible (avoid unnecessary re-resolving)

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -1,0 +1,415 @@
+from typing import Any, Dict, List
+
+from localstack.services.cloudformation.provider import LOG, find_stack, get_cloudformation_store
+from localstack.utils.aws import arns, aws_stack
+from localstack.utils.collections import select_attributes
+from localstack.utils.json import clone_safe
+from localstack.utils.objects import recurse_object
+from localstack.utils.strings import long_uid, short_uid
+from localstack.utils.time import timestamp_millis
+
+
+class StackSet:
+    """A stack set contains multiple stack instances."""
+
+    def __init__(self, metadata=None):
+        if metadata is None:
+            metadata = {}
+        self.metadata = metadata
+        # list of stack instances
+        self.stack_instances = []
+        # maps operation ID to stack set operation details
+        self.operations = {}
+
+    @property
+    def stack_set_name(self):
+        return self.metadata.get("StackSetName")
+
+
+class StackInstance:
+    """A stack instance belongs to a stack set and is specific to a region / account ID."""
+
+    def __init__(self, metadata=None):
+        if metadata is None:
+            metadata = {}
+        self.metadata = metadata
+        # reference to the deployed stack belonging to this stack instance
+        self.stack = None
+
+
+class Stack:
+    def __init__(self, metadata=None, template=None, template_body=None):
+        if template is None:
+            template = {}
+        self.metadata = metadata or {}
+        self.template = template or {}
+        self.template_body = template_body
+        self._template_raw = clone_safe(self.template)
+        self.template_original = clone_safe(self.template)
+        # initialize resources
+        for resource_id, resource in self.template_resources.items():
+            resource["LogicalResourceId"] = self.template_original["Resources"][resource_id][
+                "LogicalResourceId"
+            ] = (resource.get("LogicalResourceId") or resource_id)
+        # initialize stack template attributes
+        stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
+            self.stack_name, short_uid()
+        )
+        self.template["StackId"] = self.metadata["StackId"] = stack_id
+        self.template["Parameters"] = self.template.get("Parameters") or {}
+        self.template["Outputs"] = self.template.get("Outputs") or {}
+        self.template["Conditions"] = self.template.get("Conditions") or {}
+        # initialize metadata
+        self.metadata["Parameters"] = self.metadata.get("Parameters") or []
+        self.metadata["StackStatus"] = "CREATE_IN_PROGRESS"
+        self.metadata["CreationTime"] = self.metadata.get("CreationTime") or timestamp_millis()
+        self.metadata["LastUpdatedTime"] = self.metadata["CreationTime"]
+        self.metadata.setdefault("Description", self.template.get("Description"))
+        self.metadata.setdefault("RollbackConfiguration", {})
+        self.metadata.setdefault("DisableRollback", False)
+        self.metadata.setdefault("EnableTerminationProtection", False)
+        # maps resource id to resource state
+        self._resource_states = {}
+        # list of stack events
+        self.events = []
+        # list of stack change sets
+        self.change_sets = []
+
+    def describe_details(self):
+        attrs = [
+            "StackId",
+            "StackName",
+            "Description",
+            "StackStatusReason",
+            "StackStatus",
+            "Capabilities",
+            "ParentId",
+            "RootId",
+            "RoleARN",
+            "CreationTime",
+            "DeletionTime",
+            "LastUpdatedTime",
+            "ChangeSetId",
+            "RollbackConfiguration",
+            "DisableRollback",
+            "EnableTerminationProtection",
+            "DriftInformation",
+        ]
+        result = select_attributes(self.metadata, attrs)
+        result["Tags"] = self.tags
+        outputs = self.outputs_list()
+        if outputs:
+            result["Outputs"] = outputs
+        params = self.stack_parameters()
+        if params:
+            result["Parameters"] = params
+        if not result.get("DriftInformation"):
+            result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
+        for attr in ["Capabilities", "Tags", "NotificationARNs"]:
+            result.setdefault(attr, [])
+        return result
+
+    def set_stack_status(self, status):
+        self.metadata["StackStatus"] = status
+        if "FAILED" in status:
+            self.metadata["StackStatusReason"] = "Deployment failed"
+        self.add_stack_event(self.stack_name, self.stack_id, status)
+
+    def set_time_attribute(self, attribute, new_time=None):
+        self.metadata[attribute] = new_time or timestamp_millis()
+
+    def add_stack_event(self, resource_id: str, physical_res_id: str, status: str):
+        event = {
+            "EventId": long_uid(),
+            "Timestamp": timestamp_millis(),
+            "StackId": self.stack_id,
+            "StackName": self.stack_name,
+            "LogicalResourceId": resource_id,
+            "PhysicalResourceId": physical_res_id,
+            "ResourceStatus": status,
+            "ResourceType": "AWS::CloudFormation::Stack",
+        }
+        self.events.insert(0, event)
+
+    def set_resource_status(self, resource_id: str, status: str, physical_res_id: str = None):
+        """Update the deployment status of the given resource ID and publish a corresponding stack event."""
+        self._set_resource_status_details(resource_id, physical_res_id=physical_res_id)
+        state = self.resource_states.setdefault(resource_id, {})
+        state["PreviousResourceStatus"] = state.get("ResourceStatus")
+        state["ResourceStatus"] = status
+        state["LastUpdatedTimestamp"] = timestamp_millis()
+        self.add_stack_event(resource_id, physical_res_id, status)
+
+    def _set_resource_status_details(self, resource_id: str, physical_res_id: str = None):
+        """Helper function to ensure that the status details for the given resource ID are up-to-date."""
+        resource = self.resources.get(resource_id)
+        if resource is None or resource.get("Type") == "Parameter":
+            # make sure we delete the states for any non-existing/deleted resources
+            self._resource_states.pop(resource_id, None)
+            return
+        state = self._resource_states.setdefault(resource_id, {})
+        attr_defaults = (
+            ("LogicalResourceId", resource_id),
+            ("PhysicalResourceId", physical_res_id),
+        )
+        for res in [resource, state]:
+            for attr, default in attr_defaults:
+                res[attr] = res.get(attr) or default
+        state["StackName"] = state.get("StackName") or self.stack_name
+        state["StackId"] = state.get("StackId") or self.stack_id
+        state["ResourceType"] = state.get("ResourceType") or self.resources[resource_id].get("Type")
+        state["Timestamp"] = timestamp_millis()
+        return state
+
+    def resource_status(self, resource_id: str):
+        result = self._lookup(self.resource_states, resource_id)
+        return result
+
+    def latest_template_raw(self):
+        if self.change_sets:
+            return self.change_sets[-1]._template_raw
+        return self._template_raw
+
+    @property
+    def resource_states(self):
+        for resource_id in list(self._resource_states.keys()):
+            self._set_resource_status_details(resource_id)
+        return self._resource_states
+
+    @property
+    def stack_name(self):
+        return self.metadata["StackName"]
+
+    @property
+    def stack_id(self):
+        return self.metadata["StackId"]
+
+    # TODO: potential performance issues due to many stack_parameters calls (cache or limit actual invocations)
+    @property
+    def resources(self):  # TODO: not actually resources, split apart
+        """Return dict of resources, parameters, conditions, and other stack metadata."""
+        result = dict(self.template_resources)
+
+        # add stack params (without defaults)
+        stack_params = self._resolve_stack_parameters(defaults=False, existing=result)
+        result.update(stack_params)
+
+        # TODO: conditions and mappings don't really belong here and should be handled separately
+        for name, value in self.conditions.items():
+            if name not in result:
+                result[name] = {
+                    "Type": "Parameter",
+                    "LogicalResourceId": name,
+                    "Properties": {"Value": value},
+                }
+        for name, value in self.mappings.items():
+            if name not in result:
+                result[name] = {
+                    "Type": "Parameter",
+                    "LogicalResourceId": name,
+                    "Properties": {"Value": value},
+                }
+
+        stack_params = self._resolve_stack_parameters(defaults=True, existing=result)
+        result.update(stack_params)
+
+        return result
+
+    def _resolve_stack_parameters(
+        self, defaults=True, existing: Dict[str, Dict] = None
+    ) -> Dict[str, Dict]:
+        """Resolve the parameter values of this stack, skipping the params already present in `existing`"""
+        existing = existing or {}
+        result = {}
+        for param in self.stack_parameters(defaults=defaults):
+            param_key = param["ParameterKey"]
+            if param_key not in existing:
+                resolved_value = param.get("ResolvedValue")
+                prop_value = (
+                    resolved_value if resolved_value is not None else param.get("ParameterValue")
+                )
+                result[param["ParameterKey"]] = {
+                    "Type": "Parameter",
+                    "LogicalResourceId": param_key,
+                    "Properties": {"Value": prop_value},
+                }
+        return result
+
+    @property
+    def template_resources(self):
+        return self.template.setdefault("Resources", {})
+
+    @property
+    def tags(self):
+        return self.metadata.get("Tags", [])
+
+    @property
+    def imports(self):
+        def _collect(o, **kwargs):
+            if isinstance(o, dict):
+                import_val = o.get("Fn::ImportValue")
+                if import_val:
+                    result.add(import_val)
+            return o
+
+        result = set()
+        recurse_object(self.resources, _collect)
+        return result
+
+    def outputs_list(self) -> List[Dict]:
+        """Returns a copy of the outputs of this stack."""
+        result = []
+        for k, details in self.outputs.items():
+            value = None
+            try:
+                # template_deployer.resolve_refs_recursively(self, details)  # FIXME
+                value = details["Value"]
+            except Exception as e:
+                LOG.debug("Unable to resolve references in stack outputs: %s - %s", details, e)
+            exports = details.get("Export") or {}
+            export = exports.get("Name")
+            # export = template_deployer.resolve_refs_recursively(self, export)  # FIXME
+            description = details.get("Description")
+            entry = {
+                "OutputKey": k,
+                "OutputValue": value,
+                "Description": description,
+                "ExportName": export,
+            }
+            result.append(entry)
+        return result
+
+    # TODO: check if metadata already populated/resolved and use it if possible (avoid unnecessary re-resolving)
+    def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
+        result = {}
+        # add default template parameter values
+        if defaults:
+            for key, value in self.template_parameters.items():
+                param_value = value.get("Default")
+                result[key] = {
+                    "ParameterKey": key,
+                    "ParameterValue": param_value,
+                }
+                # TODO: extract dynamic parameter resolving
+                # TODO: support different types and refactor logic to use metadata (here not yet populated properly)
+                param_type = value.get("Type", "")
+                if not param_type:
+                    if param_type == "AWS::SSM::Parameter::Value<String>":
+                        ssm_client = aws_stack.connect_to_service("ssm")
+                        resolved_value = ssm_client.get_parameter(Name=param_value)["Parameter"][
+                            "Value"
+                        ]
+                        result[key]["ResolvedValue"] = resolved_value
+                    elif param_type.startswith("AWS::"):
+                        LOG.info(
+                            f"Parameter Type '{param_type}' is currently not supported. Coming soon, stay tuned!"
+                        )
+                    else:
+                        # lets assume we support the normal CFn parameters
+                        pass
+
+        # add stack parameters
+        result.update({p["ParameterKey"]: p for p in self.metadata["Parameters"]})
+        # add parameters of change sets
+        for change_set in self.change_sets:
+            for param in change_set.metadata["Parameters"]:
+                if not param.get("UsePreviousValue"):
+                    result.update({param["ParameterKey"]: param})
+        result = list(result.values())
+        return result
+
+    @property
+    def template_parameters(self):
+        return self.template["Parameters"]
+
+    @property
+    def conditions(self):
+        """Returns the (mutable) dict of stack conditions."""
+        return self.template.setdefault("Conditions", {})
+
+    @property
+    def mappings(self):
+        """Returns the (mutable) dict of stack mappings."""
+        return self.template.setdefault("Mappings", {})
+
+    @property
+    def outputs(self):
+        """Returns the (mutable) dict of stack outputs."""
+        return self.template.setdefault("Outputs", {})
+
+    @property
+    def exports_map(self):
+        result = {}
+        for export in get_cloudformation_store().exports:
+            result[export["Name"]] = export
+        return result
+
+    @property
+    def nested_stacks(self):
+        """Return a list of nested stacks that have been deployed by this stack."""
+        result = [
+            r for r in self.template_resources.values() if r["Type"] == "AWS::CloudFormation::Stack"
+        ]
+        result = [find_stack(r["Properties"].get("StackName")) for r in result]
+        result = [r for r in result if r]
+        return result
+
+    @property
+    def status(self):
+        return self.metadata["StackStatus"]
+
+    @property
+    def resource_types(self):
+        return [r.get("Type") for r in self.template_resources.values()]
+
+    def resource(self, resource_id):
+        return self._lookup(self.resources, resource_id)
+
+    def _lookup(self, resource_map, resource_id):
+        resource = resource_map.get(resource_id)
+        if not resource:
+            raise Exception(
+                'Unable to find details for resource "%s" in stack "%s"'
+                % (resource_id, self.stack_name)
+            )
+        return resource
+
+    def copy(self):
+        return Stack(metadata=dict(self.metadata), template=dict(self.template))
+
+
+class StackChangeSet(Stack):
+    def __init__(self, params=None, template=None):
+        if template is None:
+            template = {}
+        if params is None:
+            params = {}
+        super(StackChangeSet, self).__init__(params, template)
+
+        name = self.metadata["ChangeSetName"]
+        if not self.metadata.get("ChangeSetId"):
+            self.metadata["ChangeSetId"] = arns.cf_change_set_arn(name, change_set_id=short_uid())
+
+        stack = self.stack = find_stack(self.metadata["StackName"])
+        self.metadata["StackId"] = stack.stack_id
+        self.metadata["Status"] = "CREATE_PENDING"
+
+    @property
+    def change_set_id(self):
+        return self.metadata["ChangeSetId"]
+
+    @property
+    def change_set_name(self):
+        return self.metadata["ChangeSetName"]
+
+    @property
+    def resources(self):
+        return dict(self.stack.resources)
+
+    @property
+    def changes(self):
+        result = self.metadata["Changes"] = self.metadata.get("Changes", [])
+        return result
+
+    def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
+        return self.stack.stack_parameters(defaults=defaults)

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1398,7 +1398,6 @@ class TemplateDeployer:
             raise NoStackUpdates("No updates are to be performed.")
 
         # merge stack outputs and conditions
-        # TODO: ???
         existing_stack.outputs.update(new_stack.outputs)
         existing_stack.conditions.update(new_stack.conditions)
 

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -23,6 +23,7 @@ from localstack.services.cloudformation.service_models import (
     DependencyNotYetSatisfied,
     GenericBaseModel,
 )
+from localstack.services.cloudformation.stores import exports_map
 from localstack.utils.aws import aws_stack
 from localstack.utils.collections import merge_recursive
 from localstack.utils.functions import prevent_stack_overflow, run_safe
@@ -80,17 +81,6 @@ def lambda_get_params():
 
 # maps resource types to functions and parameters for creation
 RESOURCE_TO_FUNCTION = {}
-
-
-# ----------------
-# UTILITY METHODS
-# ----------------
-
-
-def find_stack(stack_name):
-    from localstack.services.cloudformation.provider import find_stack as api_find_stack
-
-    return api_find_stack(stack_name)
 
 
 # ---------------------
@@ -546,13 +536,14 @@ def _resolve_refs_recursively(stack, value):
 
         if stripped_fn_lower == "importvalue":
             import_value_key = resolve_refs_recursively(stack, value[keys_list[0]])
-            stack_export = stack.exports_map.get(import_value_key) or {}
+            exports = exports_map()
+            stack_export = exports.get(import_value_key) or {}
             if not stack_export.get("Value"):
                 LOG.info(
                     'Unable to find export "%s" in stack "%s", existing export names: %s',
                     import_value_key,
                     stack.stack_name,
-                    list(stack.exports_map.keys()),
+                    list(exports.keys()),
                 )
                 return None
             return stack_export["Value"]
@@ -976,7 +967,9 @@ def get_action_name_for_resource_change(res_change: str) -> str:
 
 
 # TODO: this shouldn't be called for stack parameters
-def determine_resource_physical_id(resource_id, stack=None, attribute=None):
+def determine_resource_physical_id(resource_id, stack=None, attribute: Optional[str] = None):
+    assert resource_id and isinstance(resource_id, str)
+
     resources = stack.resources
     stack_name = stack.stack_name
     resource = resources.get(resource_id, {})
@@ -1405,6 +1398,7 @@ class TemplateDeployer:
             raise NoStackUpdates("No updates are to be performed.")
 
         # merge stack outputs and conditions
+        # TODO: ???
         existing_stack.outputs.update(new_stack.outputs)
         existing_stack.conditions.update(new_stack.conditions)
 
@@ -1518,6 +1512,9 @@ class TemplateDeployer:
         for delete in deletes:
             stack.template["Resources"].pop(delete["ResourceChange"]["LogicalResourceId"], None)
 
+        # resolve outputs
+        stack.resolved_outputs = resolve_outputs(stack)
+
         return changes_done
 
     def prepare_should_deploy_change(self, resource_id, change, stack, new_resources):
@@ -1583,3 +1580,27 @@ class TemplateDeployer:
         self.update_resource_details(resource_id, result, stack=stack, action=stack_action)
 
         return result
+
+
+# FIXME: resolve_refs_recursively should not be needed, the resources themselves should have those values available already
+def resolve_outputs(stack) -> List[Dict]:
+    result = []
+    for k, details in stack.outputs.items():
+        value = None
+        try:
+            resolve_refs_recursively(stack, details)
+            value = details["Value"]
+        except Exception as e:
+            LOG.debug("Unable to resolve references in stack outputs: %s - %s", details, e)
+        exports = details.get("Export") or {}
+        export = exports.get("Name")
+        export = resolve_refs_recursively(stack, export)
+        description = details.get("Description")
+        entry = {
+            "OutputKey": k,
+            "OutputValue": value,
+            "Description": description,
+            "ExportName": export,
+        }
+        result.append(entry)
+    return result

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1340,7 +1340,7 @@ class TemplateDeployer:
         append_to_changeset=False,
         filter_unchanged_resources=False,
     ):
-        from localstack.services.cloudformation.provider import StackChangeSet
+        from localstack.services.cloudformation.engine.entities import StackChangeSet
 
         old_resources = existing_stack.template["Resources"]
         new_resources = new_stack.template["Resources"]
@@ -1414,7 +1414,7 @@ class TemplateDeployer:
         )
 
     def apply_changes_in_loop(self, changes, stack, action=None, new_stack=None):
-        from localstack.services.cloudformation.provider import StackChangeSet
+        from localstack.services.cloudformation.engine.entities import StackChangeSet
 
         def _run(*args):
             try:

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -18,6 +18,7 @@ from localstack.services.cloudformation.deployment_utils import (
     remove_none_values,
 )
 from localstack.services.cloudformation.engine import template_preparer
+from localstack.services.cloudformation.engine.entities import StackChangeSet
 from localstack.services.cloudformation.service_models import (
     KEY_RESOURCE_STATE,
     DependencyNotYetSatisfied,
@@ -1333,8 +1334,6 @@ class TemplateDeployer:
         append_to_changeset=False,
         filter_unchanged_resources=False,
     ):
-        from localstack.services.cloudformation.engine.entities import StackChangeSet
-
         old_resources = existing_stack.template["Resources"]
         new_resources = new_stack.template["Resources"]
         deletes = [val for key, val in old_resources.items() if key not in new_resources]
@@ -1407,8 +1406,6 @@ class TemplateDeployer:
         )
 
     def apply_changes_in_loop(self, changes, stack, action=None, new_stack=None):
-        from localstack.services.cloudformation.engine.entities import StackChangeSet
-
         def _run(*args):
             try:
                 self.do_apply_changes_in_loop(changes, stack)

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -20,6 +20,8 @@ class CloudFormationStack(GenericBaseModel):
         child_stack_name = self.props["StackName"]
         child_stack_name = self.resolve_refs_recursively(stack_name, child_stack_name, resources)
         result = client.describe_stacks(StackName=child_stack_name)
+        # probably not the best way to wait in a blocking manner here but the current implementation requires it
+        client.get_waiter("stack_create_complete").wait(StackName=child_stack_name)
         result = (result.get("Stacks") or [None])[0]
         return result
 
@@ -65,6 +67,7 @@ class CloudFormationStack(GenericBaseModel):
                 "StackName": nested_stack_name,
                 "TemplateURL": params.get("TemplateURL"),
                 "Parameters": stack_params,
+                # "Outputs":
             }
             return result
 

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -256,13 +256,13 @@ class IAMRole(GenericBaseModel):
                 dummy_resources = {
                     resource_id: {"Properties": {"RoleName": _states.get("RoleName")}}
                 }
-                self._pre_delete(resource_id, dummy_resources, None, None, None)
+                IAMRole._pre_delete(resource_id, dummy_resources, None, None, None)
                 client.delete_role(RoleName=_states.get("RoleName"))
                 role = client.create_role(
                     RoleName=props.get("RoleName"),
                     AssumeRolePolicyDocument=str(props_policy),
                 )
-                self._post_create(resource_id, resources, None, None, None)
+                IAMRole._post_create(resource_id, resources, None, None, None)
                 return role["Role"]
 
         return client.update_role(
@@ -325,6 +325,7 @@ class IAMRole(GenericBaseModel):
                 PolicyDocument=doc,
             )
 
+    @staticmethod
     def _pre_delete(resource_id, resources, resource_type, func, stack_name):
         """detach managed policies from role before deleting"""
         iam_client = aws_stack.connect_to_service("iam")

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -3,7 +3,7 @@ import logging
 import re
 from collections import defaultdict
 from copy import deepcopy
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
@@ -66,6 +66,12 @@ from localstack.aws.api.cloudformation import (
     ValidateTemplateOutput,
 )
 from localstack.services.cloudformation.engine import template_deployer, template_preparer
+from localstack.services.cloudformation.engine.entities import (
+    Stack,
+    StackChangeSet,
+    StackInstance,
+    StackSet,
+)
 from localstack.services.cloudformation.engine.template_deployer import NoStackUpdates
 from localstack.services.cloudformation.engine.template_preparer import (
     get_template_body,
@@ -73,12 +79,10 @@ from localstack.services.cloudformation.engine.template_preparer import (
     template_to_json,
 )
 from localstack.services.cloudformation.stores import CloudFormationStore, cloudformation_stores
-from localstack.utils.aws import arns, aws_stack
+from localstack.utils.aws import aws_stack
 from localstack.utils.collections import remove_attributes, select_attributes
-from localstack.utils.json import clone, clone_safe
-from localstack.utils.objects import recurse_object
-from localstack.utils.strings import long_uid, short_uid
-from localstack.utils.time import timestamp_millis
+from localstack.utils.json import clone
+from localstack.utils.strings import short_uid
 
 LOG = logging.getLogger(__name__)
 
@@ -94,412 +98,6 @@ def get_cloudformation_store(account_id: str = None, region: str = None) -> Clou
     return cloudformation_stores[account_id or get_aws_account_id()][
         region or aws_stack.get_region()
     ]
-
-
-class StackSet:
-    """A stack set contains multiple stack instances."""
-
-    def __init__(self, metadata=None):
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
-        # list of stack instances
-        self.stack_instances = []
-        # maps operation ID to stack set operation details
-        self.operations = {}
-
-    @property
-    def stack_set_name(self):
-        return self.metadata.get("StackSetName")
-
-
-class StackInstance:
-    """A stack instance belongs to a stack set and is specific to a region / account ID."""
-
-    def __init__(self, metadata=None):
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
-        # reference to the deployed stack belonging to this stack instance
-        self.stack = None
-
-
-class Stack:
-    def __init__(self, metadata=None, template=None, template_body=None):
-        if template is None:
-            template = {}
-        self.metadata = metadata or {}
-        self.template = template or {}
-        self.template_body = template_body
-        self._template_raw = clone_safe(self.template)
-        self.template_original = clone_safe(self.template)
-        # initialize resources
-        for resource_id, resource in self.template_resources.items():
-            resource["LogicalResourceId"] = self.template_original["Resources"][resource_id][
-                "LogicalResourceId"
-            ] = (resource.get("LogicalResourceId") or resource_id)
-        # initialize stack template attributes
-        stack_id = self.metadata.get("StackId") or arns.cloudformation_stack_arn(
-            self.stack_name, short_uid()
-        )
-        self.template["StackId"] = self.metadata["StackId"] = stack_id
-        self.template["Parameters"] = self.template.get("Parameters") or {}
-        self.template["Outputs"] = self.template.get("Outputs") or {}
-        self.template["Conditions"] = self.template.get("Conditions") or {}
-        # initialize metadata
-        self.metadata["Parameters"] = self.metadata.get("Parameters") or []
-        self.metadata["StackStatus"] = "CREATE_IN_PROGRESS"
-        self.metadata["CreationTime"] = self.metadata.get("CreationTime") or timestamp_millis()
-        self.metadata["LastUpdatedTime"] = self.metadata["CreationTime"]
-        self.metadata.setdefault("Description", self.template.get("Description"))
-        self.metadata.setdefault("RollbackConfiguration", {})
-        self.metadata.setdefault("DisableRollback", False)
-        self.metadata.setdefault("EnableTerminationProtection", False)
-        # maps resource id to resource state
-        self._resource_states = {}
-        # list of stack events
-        self.events = []
-        # list of stack change sets
-        self.change_sets = []
-
-    def describe_details(self):
-        attrs = [
-            "StackId",
-            "StackName",
-            "Description",
-            "StackStatusReason",
-            "StackStatus",
-            "Capabilities",
-            "ParentId",
-            "RootId",
-            "RoleARN",
-            "CreationTime",
-            "DeletionTime",
-            "LastUpdatedTime",
-            "ChangeSetId",
-            "RollbackConfiguration",
-            "DisableRollback",
-            "EnableTerminationProtection",
-            "DriftInformation",
-        ]
-        result = select_attributes(self.metadata, attrs)
-        result["Tags"] = self.tags
-        outputs = self.outputs_list()
-        if outputs:
-            result["Outputs"] = outputs
-        params = self.stack_parameters()
-        if params:
-            result["Parameters"] = params
-        if not result.get("DriftInformation"):
-            result["DriftInformation"] = {"StackDriftStatus": "NOT_CHECKED"}
-        for attr in ["Capabilities", "Tags", "NotificationARNs"]:
-            result.setdefault(attr, [])
-        return result
-
-    def set_stack_status(self, status):
-        self.metadata["StackStatus"] = status
-        if "FAILED" in status:
-            self.metadata["StackStatusReason"] = "Deployment failed"
-        self.add_stack_event(self.stack_name, self.stack_id, status)
-
-    def set_time_attribute(self, attribute, new_time=None):
-        self.metadata[attribute] = new_time or timestamp_millis()
-
-    def add_stack_event(self, resource_id: str, physical_res_id: str, status: str):
-        event = {
-            "EventId": long_uid(),
-            "Timestamp": timestamp_millis(),
-            "StackId": self.stack_id,
-            "StackName": self.stack_name,
-            "LogicalResourceId": resource_id,
-            "PhysicalResourceId": physical_res_id,
-            "ResourceStatus": status,
-            "ResourceType": "AWS::CloudFormation::Stack",
-        }
-        self.events.insert(0, event)
-
-    def set_resource_status(self, resource_id: str, status: str, physical_res_id: str = None):
-        """Update the deployment status of the given resource ID and publish a corresponding stack event."""
-        self._set_resource_status_details(resource_id, physical_res_id=physical_res_id)
-        state = self.resource_states.setdefault(resource_id, {})
-        state["PreviousResourceStatus"] = state.get("ResourceStatus")
-        state["ResourceStatus"] = status
-        state["LastUpdatedTimestamp"] = timestamp_millis()
-        self.add_stack_event(resource_id, physical_res_id, status)
-
-    def _set_resource_status_details(self, resource_id: str, physical_res_id: str = None):
-        """Helper function to ensure that the status details for the given resource ID are up-to-date."""
-        resource = self.resources.get(resource_id)
-        if resource is None or resource.get("Type") == "Parameter":
-            # make sure we delete the states for any non-existing/deleted resources
-            self._resource_states.pop(resource_id, None)
-            return
-        state = self._resource_states.setdefault(resource_id, {})
-        attr_defaults = (
-            ("LogicalResourceId", resource_id),
-            ("PhysicalResourceId", physical_res_id),
-        )
-        for res in [resource, state]:
-            for attr, default in attr_defaults:
-                res[attr] = res.get(attr) or default
-        state["StackName"] = state.get("StackName") or self.stack_name
-        state["StackId"] = state.get("StackId") or self.stack_id
-        state["ResourceType"] = state.get("ResourceType") or self.resources[resource_id].get("Type")
-        state["Timestamp"] = timestamp_millis()
-        return state
-
-    def resource_status(self, resource_id: str):
-        result = self._lookup(self.resource_states, resource_id)
-        return result
-
-    def latest_template_raw(self):
-        if self.change_sets:
-            return self.change_sets[-1]._template_raw
-        return self._template_raw
-
-    @property
-    def resource_states(self):
-        for resource_id in list(self._resource_states.keys()):
-            self._set_resource_status_details(resource_id)
-        return self._resource_states
-
-    @property
-    def stack_name(self):
-        return self.metadata["StackName"]
-
-    @property
-    def stack_id(self):
-        return self.metadata["StackId"]
-
-    # TODO: potential performance issues due to many stack_parameters calls (cache or limit actual invocations)
-    @property
-    def resources(self):  # TODO: not actually resources, split apart
-        """Return dict of resources, parameters, conditions, and other stack metadata."""
-        result = dict(self.template_resources)
-
-        # add stack params (without defaults)
-        stack_params = self._resolve_stack_parameters(defaults=False, existing=result)
-        result.update(stack_params)
-
-        # TODO: conditions and mappings don't really belong here and should be handled separately
-        for name, value in self.conditions.items():
-            if name not in result:
-                result[name] = {
-                    "Type": "Parameter",
-                    "LogicalResourceId": name,
-                    "Properties": {"Value": value},
-                }
-        for name, value in self.mappings.items():
-            if name not in result:
-                result[name] = {
-                    "Type": "Parameter",
-                    "LogicalResourceId": name,
-                    "Properties": {"Value": value},
-                }
-
-        stack_params = self._resolve_stack_parameters(defaults=True, existing=result)
-        result.update(stack_params)
-
-        return result
-
-    def _resolve_stack_parameters(
-        self, defaults=True, existing: Dict[str, Dict] = None
-    ) -> Dict[str, Dict]:
-        """Resolve the parameter values of this stack, skipping the params already present in `existing`"""
-        existing = existing or {}
-        result = {}
-        for param in self.stack_parameters(defaults=defaults):
-            param_key = param["ParameterKey"]
-            if param_key not in existing:
-                resolved_value = param.get("ResolvedValue")
-                prop_value = (
-                    resolved_value if resolved_value is not None else param.get("ParameterValue")
-                )
-                result[param["ParameterKey"]] = {
-                    "Type": "Parameter",
-                    "LogicalResourceId": param_key,
-                    "Properties": {"Value": prop_value},
-                }
-        return result
-
-    @property
-    def template_resources(self):
-        return self.template.setdefault("Resources", {})
-
-    @property
-    def tags(self):
-        return self.metadata.get("Tags", [])
-
-    @property
-    def imports(self):
-        def _collect(o, **kwargs):
-            if isinstance(o, dict):
-                import_val = o.get("Fn::ImportValue")
-                if import_val:
-                    result.add(import_val)
-            return o
-
-        result = set()
-        recurse_object(self.resources, _collect)
-        return result
-
-    def outputs_list(self) -> List[Dict]:
-        """Returns a copy of the outputs of this stack."""
-        result = []
-        for k, details in self.outputs.items():
-            value = None
-            try:
-                template_deployer.resolve_refs_recursively(self, details)
-                value = details["Value"]
-            except Exception as e:
-                LOG.debug("Unable to resolve references in stack outputs: %s - %s", details, e)
-            exports = details.get("Export") or {}
-            export = exports.get("Name")
-            export = template_deployer.resolve_refs_recursively(self, export)
-            description = details.get("Description")
-            entry = {
-                "OutputKey": k,
-                "OutputValue": value,
-                "Description": description,
-                "ExportName": export,
-            }
-            result.append(entry)
-        return result
-
-    # TODO: check if metadata already populated/resolved and use it if possible (avoid unnecessary re-resolving)
-    def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
-        result = {}
-        # add default template parameter values
-        if defaults:
-            for key, value in self.template_parameters.items():
-                param_value = value.get("Default")
-                result[key] = {
-                    "ParameterKey": key,
-                    "ParameterValue": param_value,
-                }
-                # TODO: extract dynamic parameter resolving
-                # TODO: support different types and refactor logic to use metadata (here not yet populated properly)
-                param_type = value.get("Type", "")
-                if not param_type:
-                    if param_type == "AWS::SSM::Parameter::Value<String>":
-                        ssm_client = aws_stack.connect_to_service("ssm")
-                        resolved_value = ssm_client.get_parameter(Name=param_value)["Parameter"][
-                            "Value"
-                        ]
-                        result[key]["ResolvedValue"] = resolved_value
-                    elif param_type.startswith("AWS::"):
-                        LOG.info(
-                            f"Parameter Type '{param_type}' is currently not supported. Coming soon, stay tuned!"
-                        )
-                    else:
-                        # lets assume we support the normal CFn parameters
-                        pass
-
-        # add stack parameters
-        result.update({p["ParameterKey"]: p for p in self.metadata["Parameters"]})
-        # add parameters of change sets
-        for change_set in self.change_sets:
-            for param in change_set.metadata["Parameters"]:
-                if not param.get("UsePreviousValue"):
-                    result.update({param["ParameterKey"]: param})
-        result = list(result.values())
-        return result
-
-    @property
-    def template_parameters(self):
-        return self.template["Parameters"]
-
-    @property
-    def conditions(self):
-        """Returns the (mutable) dict of stack conditions."""
-        return self.template.setdefault("Conditions", {})
-
-    @property
-    def mappings(self):
-        """Returns the (mutable) dict of stack mappings."""
-        return self.template.setdefault("Mappings", {})
-
-    @property
-    def outputs(self):
-        """Returns the (mutable) dict of stack outputs."""
-        return self.template.setdefault("Outputs", {})
-
-    @property
-    def exports_map(self):
-        result = {}
-        for export in get_cloudformation_store().exports:
-            result[export["Name"]] = export
-        return result
-
-    @property
-    def nested_stacks(self):
-        """Return a list of nested stacks that have been deployed by this stack."""
-        result = [
-            r for r in self.template_resources.values() if r["Type"] == "AWS::CloudFormation::Stack"
-        ]
-        result = [find_stack(r["Properties"].get("StackName")) for r in result]
-        result = [r for r in result if r]
-        return result
-
-    @property
-    def status(self):
-        return self.metadata["StackStatus"]
-
-    @property
-    def resource_types(self):
-        return [r.get("Type") for r in self.template_resources.values()]
-
-    def resource(self, resource_id):
-        return self._lookup(self.resources, resource_id)
-
-    def _lookup(self, resource_map, resource_id):
-        resource = resource_map.get(resource_id)
-        if not resource:
-            raise Exception(
-                'Unable to find details for resource "%s" in stack "%s"'
-                % (resource_id, self.stack_name)
-            )
-        return resource
-
-    def copy(self):
-        return Stack(metadata=dict(self.metadata), template=dict(self.template))
-
-
-class StackChangeSet(Stack):
-    def __init__(self, params=None, template=None):
-        if template is None:
-            template = {}
-        if params is None:
-            params = {}
-        super(StackChangeSet, self).__init__(params, template)
-
-        name = self.metadata["ChangeSetName"]
-        if not self.metadata.get("ChangeSetId"):
-            self.metadata["ChangeSetId"] = arns.cf_change_set_arn(name, change_set_id=short_uid())
-
-        stack = self.stack = find_stack(self.metadata["StackName"])
-        self.metadata["StackId"] = stack.stack_id
-        self.metadata["Status"] = "CREATE_PENDING"
-
-    @property
-    def change_set_id(self):
-        return self.metadata["ChangeSetId"]
-
-    @property
-    def change_set_name(self):
-        return self.metadata["ChangeSetName"]
-
-    @property
-    def resources(self):
-        return dict(self.stack.resources)
-
-    @property
-    def changes(self):
-        result = self.metadata["Changes"] = self.metadata.get("Changes", [])
-        return result
-
-    def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
-        return self.stack.stack_parameters(defaults=defaults)
 
 
 def clone_stack_params(stack_params):
@@ -736,105 +334,6 @@ class CloudformationProvider(CloudformationApi):
         result.pop("Capabilities", None)
         return result
 
-    @handler("ValidateTemplate", expand=False)
-    def validate_template(
-        self, context: RequestContext, request: ValidateTemplateInput
-    ) -> ValidateTemplateOutput:
-        try:
-            # TODO implement actual validation logic
-            template_body = get_template_body(request)
-            valid_template = json.loads(template_to_json(template_body))
-
-            parameters = [
-                TemplateParameter(
-                    ParameterKey=k,
-                    DefaultValue=v.get("Default", ""),
-                    NoEcho=False,
-                    Description=v.get("Description", ""),
-                )
-                for k, v in valid_template.get("Parameters", {}).items()
-            ]
-
-            return ValidateTemplateOutput(
-                Description=valid_template.get("Description"), Parameters=parameters
-            )
-        except Exception as e:
-            LOG.exception("Error validating template")
-            raise ValidationError("Template Validation Error") from e
-
-    @handler("CreateStackSet", expand=False)
-    def create_stack_set(
-        self, context: RequestContext, request: CreateStackSetInput
-    ) -> CreateStackSetOutput:
-        state = get_cloudformation_store()
-        stack_set = StackSet(request)
-        stack_set_id = short_uid()
-        stack_set.metadata["StackSetId"] = stack_set_id
-        state.stack_sets[stack_set_id] = stack_set
-
-        return CreateStackSetOutput(StackSetId=stack_set_id)
-
-    @handler("DescribeStackSet")
-    def describe_stack_set(
-        self, context: RequestContext, stack_set_name: StackSetName, call_as: CallAs = None
-    ) -> DescribeStackSetOutput:
-        state = get_cloudformation_store()
-        result = [
-            sset.metadata
-            for sset in state.stack_sets.values()
-            if sset.stack_set_name == stack_set_name
-        ]
-        if not result:
-            return not_found_error(f'Unable to find stack set "{stack_set_name}"')
-
-        return DescribeStackSetOutput(StackSet=result[0])
-
-    @handler("UpdateStackSet", expand=False)
-    def update_stack_set(
-        self, context: RequestContext, request: UpdateStackSetInput
-    ) -> UpdateStackSetOutput:
-        state = get_cloudformation_store()
-        set_name = request.get("StackSetName")
-        stack_set = [sset for sset in state.stack_sets.values() if sset.stack_set_name == set_name]
-        if not stack_set:
-            return not_found_error(f'Stack set named "{set_name}" does not exist')
-        stack_set = stack_set[0]
-        stack_set.metadata.update(request)
-        op_id = request.get("OperationId") or short_uid()
-        operation = {
-            "OperationId": op_id,
-            "StackSetId": stack_set.metadata["StackSetId"],
-            "Action": "UPDATE",
-            "Status": "SUCCEEDED",
-        }
-        stack_set.operations[op_id] = operation
-        return UpdateStackSetOutput(OperationId=op_id)
-
-    @handler("DeleteStackSet")
-    def delete_stack_set(
-        self, context: RequestContext, stack_set_name: StackSetName, call_as: CallAs = None
-    ) -> DeleteStackSetOutput:
-        state = get_cloudformation_store()
-        stack_set = [
-            sset for sset in state.stack_sets.values() if sset.stack_set_name == stack_set_name
-        ]
-
-        if not stack_set:
-            return not_found_error(f'Stack set named "{stack_set_name}" does not exist')
-
-        for instance in stack_set[0].stack_instances:
-            deployer = template_deployer.TemplateDeployer(instance.stack)
-            deployer.delete_stack()
-        return DeleteStackSetOutput()
-
-    @handler("ListStackSets", expand=False)
-    def list_stack_sets(
-        self, context: RequestContext, request: ListStackSetsInput
-    ) -> ListStackSetsOutput:
-        state = get_cloudformation_store()
-        result = [sset.metadata for sset in state.stack_sets.values()]
-        return ListStackSetsOutput(Summaries=result)
-
     @handler("CreateChangeSet", expand=False)
     def create_change_set(
         self, context: RequestContext, request: CreateChangeSetInput
@@ -1040,83 +539,6 @@ class CloudformationProvider(CloudformationApi):
         result = [cs.metadata for cs in stack.change_sets]
         return ListChangeSetsOutput(Summaries=result)
 
-    @handler("CreateStackInstances", expand=False)
-    def create_stack_instances(
-        self,
-        context: RequestContext,
-        request: CreateStackInstancesInput,
-    ) -> CreateStackInstancesOutput:
-        state = get_cloudformation_store()
-
-        set_name = request.get("StackSetName")
-        stack_set = [sset for sset in state.stack_sets.values() if sset.stack_set_name == set_name]
-
-        if not stack_set:
-            return not_found_error(f'Stack set named "{set_name}" does not exist')
-
-        stack_set = stack_set[0]
-        op_id = request.get("OperationId") or short_uid()
-        sset_meta = stack_set.metadata
-        accounts = request["Accounts"]
-        regions = request["Regions"]
-
-        stacks_to_await = []
-        for account in accounts:
-            for region in regions:
-                # deploy new stack
-                LOG.debug('Deploying instance for stack set "%s" in region "%s"', set_name, region)
-                cf_client = aws_stack.connect_to_service("cloudformation", region_name=region)
-                kwargs = select_attributes(sset_meta, ["TemplateBody"]) or select_attributes(
-                    sset_meta, ["TemplateURL"]
-                )
-                stack_name = f"sset-{set_name}-{account}"
-                result = cf_client.create_stack(StackName=stack_name, **kwargs)
-                stacks_to_await.append((stack_name, region))
-                # store stack instance
-                instance = {
-                    "StackSetId": sset_meta["StackSetId"],
-                    "OperationId": op_id,
-                    "Account": account,
-                    "Region": region,
-                    "StackId": result["StackId"],
-                    "Status": "CURRENT",
-                    "StackInstanceStatus": {"DetailedStatus": "SUCCEEDED"},
-                }
-                instance = StackInstance(instance)
-                stack_set.stack_instances.append(instance)
-
-        # wait for completion of stack
-        for stack in stacks_to_await:
-            client = aws_stack.connect_to_service("cloudformation", region_name=stack[1])
-            client.get_waiter("stack_create_complete").wait(StackName=stack[0])
-
-        # record operation
-        operation = {
-            "OperationId": op_id,
-            "StackSetId": stack_set.metadata["StackSetId"],
-            "Action": "CREATE",
-            "Status": "SUCCEEDED",
-        }
-        stack_set.operations[op_id] = operation
-
-        return CreateStackInstancesOutput(OperationId=op_id)
-
-    @handler("ListStackInstances", expand=False)
-    def list_stack_instances(
-        self,
-        context: RequestContext,
-        request: ListStackInstancesInput,
-    ) -> ListStackInstancesOutput:
-        set_name = request.get("StackSetName")
-        state = get_cloudformation_store()
-        stack_set = [sset for sset in state.stack_sets.values() if sset.stack_set_name == set_name]
-        if not stack_set:
-            return not_found_error(f'Stack set named "{set_name}" does not exist')
-
-        stack_set = stack_set[0]
-        result = [inst.metadata for inst in stack_set.stack_instances]
-        return ListStackInstancesOutput(Summaries=result)
-
     @handler("ListExports")
     def list_exports(
         self, context: RequestContext, next_token: NextToken = None
@@ -1199,6 +621,48 @@ class CloudformationProvider(CloudformationApi):
 
         return ListStackResourcesOutput(StackResourceSummaries=resources)
 
+    @handler("ValidateTemplate", expand=False)
+    def validate_template(
+        self, context: RequestContext, request: ValidateTemplateInput
+    ) -> ValidateTemplateOutput:
+        try:
+            # TODO implement actual validation logic
+            template_body = get_template_body(request)
+            valid_template = json.loads(template_to_json(template_body))
+
+            parameters = [
+                TemplateParameter(
+                    ParameterKey=k,
+                    DefaultValue=v.get("Default", ""),
+                    NoEcho=False,
+                    Description=v.get("Description", ""),
+                )
+                for k, v in valid_template.get("Parameters", {}).items()
+            ]
+
+            return ValidateTemplateOutput(
+                Description=valid_template.get("Description"), Parameters=parameters
+            )
+        except Exception as e:
+            LOG.exception("Error validating template")
+            raise ValidationError("Template Validation Error") from e
+
+    # =======================================
+    # =============  Stack Set  =============
+    # =======================================
+
+    @handler("CreateStackSet", expand=False)
+    def create_stack_set(
+        self, context: RequestContext, request: CreateStackSetInput
+    ) -> CreateStackSetOutput:
+        state = get_cloudformation_store()
+        stack_set = StackSet(request)
+        stack_set_id = short_uid()
+        stack_set.metadata["StackSetId"] = stack_set_id
+        state.stack_sets[stack_set_id] = stack_set
+
+        return CreateStackSetOutput(StackSetId=stack_set_id)
+
     @handler("DescribeStackSetOperation")
     def describe_stack_set_operation(
         self,
@@ -1228,3 +692,141 @@ class CloudformationProvider(CloudformationApi):
             )
 
         return DescribeStackSetOperationOutput(StackSetOperation=result)
+
+    @handler("DescribeStackSet")
+    def describe_stack_set(
+        self, context: RequestContext, stack_set_name: StackSetName, call_as: CallAs = None
+    ) -> DescribeStackSetOutput:
+        state = get_cloudformation_store()
+        result = [
+            sset.metadata
+            for sset in state.stack_sets.values()
+            if sset.stack_set_name == stack_set_name
+        ]
+        if not result:
+            return not_found_error(f'Unable to find stack set "{stack_set_name}"')
+
+        return DescribeStackSetOutput(StackSet=result[0])
+
+    @handler("ListStackSets", expand=False)
+    def list_stack_sets(
+        self, context: RequestContext, request: ListStackSetsInput
+    ) -> ListStackSetsOutput:
+        state = get_cloudformation_store()
+        result = [sset.metadata for sset in state.stack_sets.values()]
+        return ListStackSetsOutput(Summaries=result)
+
+    @handler("UpdateStackSet", expand=False)
+    def update_stack_set(
+        self, context: RequestContext, request: UpdateStackSetInput
+    ) -> UpdateStackSetOutput:
+        state = get_cloudformation_store()
+        set_name = request.get("StackSetName")
+        stack_set = [sset for sset in state.stack_sets.values() if sset.stack_set_name == set_name]
+        if not stack_set:
+            return not_found_error(f'Stack set named "{set_name}" does not exist')
+        stack_set = stack_set[0]
+        stack_set.metadata.update(request)
+        op_id = request.get("OperationId") or short_uid()
+        operation = {
+            "OperationId": op_id,
+            "StackSetId": stack_set.metadata["StackSetId"],
+            "Action": "UPDATE",
+            "Status": "SUCCEEDED",
+        }
+        stack_set.operations[op_id] = operation
+        return UpdateStackSetOutput(OperationId=op_id)
+
+    @handler("DeleteStackSet")
+    def delete_stack_set(
+        self, context: RequestContext, stack_set_name: StackSetName, call_as: CallAs = None
+    ) -> DeleteStackSetOutput:
+        state = get_cloudformation_store()
+        stack_set = [
+            sset for sset in state.stack_sets.values() if sset.stack_set_name == stack_set_name
+        ]
+
+        if not stack_set:
+            return not_found_error(f'Stack set named "{stack_set_name}" does not exist')
+
+        for instance in stack_set[0].stack_instances:
+            deployer = template_deployer.TemplateDeployer(instance.stack)
+            deployer.delete_stack()
+        return DeleteStackSetOutput()
+
+    @handler("CreateStackInstances", expand=False)
+    def create_stack_instances(
+        self,
+        context: RequestContext,
+        request: CreateStackInstancesInput,
+    ) -> CreateStackInstancesOutput:
+        state = get_cloudformation_store()
+
+        set_name = request.get("StackSetName")
+        stack_set = [sset for sset in state.stack_sets.values() if sset.stack_set_name == set_name]
+
+        if not stack_set:
+            return not_found_error(f'Stack set named "{set_name}" does not exist')
+
+        stack_set = stack_set[0]
+        op_id = request.get("OperationId") or short_uid()
+        sset_meta = stack_set.metadata
+        accounts = request["Accounts"]
+        regions = request["Regions"]
+
+        stacks_to_await = []
+        for account in accounts:
+            for region in regions:
+                # deploy new stack
+                LOG.debug('Deploying instance for stack set "%s" in region "%s"', set_name, region)
+                cf_client = aws_stack.connect_to_service("cloudformation", region_name=region)
+                kwargs = select_attributes(sset_meta, ["TemplateBody"]) or select_attributes(
+                    sset_meta, ["TemplateURL"]
+                )
+                stack_name = f"sset-{set_name}-{account}"
+                result = cf_client.create_stack(StackName=stack_name, **kwargs)
+                stacks_to_await.append((stack_name, region))
+                # store stack instance
+                instance = {
+                    "StackSetId": sset_meta["StackSetId"],
+                    "OperationId": op_id,
+                    "Account": account,
+                    "Region": region,
+                    "StackId": result["StackId"],
+                    "Status": "CURRENT",
+                    "StackInstanceStatus": {"DetailedStatus": "SUCCEEDED"},
+                }
+                instance = StackInstance(instance)
+                stack_set.stack_instances.append(instance)
+
+        # wait for completion of stack
+        for stack in stacks_to_await:
+            client = aws_stack.connect_to_service("cloudformation", region_name=stack[1])
+            client.get_waiter("stack_create_complete").wait(StackName=stack[0])
+
+        # record operation
+        operation = {
+            "OperationId": op_id,
+            "StackSetId": stack_set.metadata["StackSetId"],
+            "Action": "CREATE",
+            "Status": "SUCCEEDED",
+        }
+        stack_set.operations[op_id] = operation
+
+        return CreateStackInstancesOutput(OperationId=op_id)
+
+    @handler("ListStackInstances", expand=False)
+    def list_stack_instances(
+        self,
+        context: RequestContext,
+        request: ListStackInstancesInput,
+    ) -> ListStackInstancesOutput:
+        set_name = request.get("StackSetName")
+        state = get_cloudformation_store()
+        stack_set = [sset for sset in state.stack_sets.values() if sset.stack_set_name == set_name]
+        if not stack_set:
+            return not_found_error(f'Stack set named "{set_name}" does not exist')
+
+        stack_set = stack_set[0]
+        result = [inst.metadata for inst in stack_set.stack_instances]
+        return ListStackInstancesOutput(Summaries=result)

--- a/localstack/services/cloudformation/stores.py
+++ b/localstack/services/cloudformation/stores.py
@@ -8,6 +8,7 @@ LOG = logging.getLogger(__name__)
 
 
 class CloudFormationStore(BaseStore):
+    # FIXME: use stack name as ID instead ?
     # maps stack ID to stack details
     stacks: Dict[str, Stack] = LocalAttribute(default=dict)
 

--- a/localstack/services/cloudformation/stores.py
+++ b/localstack/services/cloudformation/stores.py
@@ -2,8 +2,7 @@ import logging
 from typing import Dict, Optional
 
 from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.api.cloudformation import Stack, StackSet
-from localstack.services.cloudformation.engine.entities import StackChangeSet
+from localstack.services.cloudformation.engine.entities import Stack, StackChangeSet, StackSet
 from localstack.services.stores import AccountRegionBundle, BaseStore, LocalAttribute
 from localstack.utils.aws import aws_stack
 
@@ -25,7 +24,7 @@ class CloudFormationStore(BaseStore):
         exports = []
         output_keys = {}
         for stack_id, stack in self.stacks.items():
-            for output in stack.outputs_list():
+            for output in stack.resolved_outputs:
                 export_name = output.get("ExportName")
                 if not export_name:
                     continue

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -291,6 +291,7 @@ def test_lambda_vpc(deploy_cfn_template, lambda_client):
     lambda_client.invoke(FunctionName=fn_name, LogType="Tail", Payload=b"{}")
 
 
+@pytest.mark.xfail(condition=is_new_provider(), reason="fails/times out with new provider")
 @pytest.mark.skip_snapshot_verify(
     paths=[
         "$..Policy.PolicyArn",

--- a/tests/integration/cloudformation/resources/test_legacy.py
+++ b/tests/integration/cloudformation/resources/test_legacy.py
@@ -9,6 +9,7 @@ from botocore.parsers import ResponseParserError
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.services.cloudformation.engine import template_preparer
+from localstack.testing.aws.lambda_utils import is_new_provider
 from localstack.utils.aws import arns
 from localstack.utils.common import load_file, short_uid
 from localstack.utils.testutil import create_zip_file, list_all_resources
@@ -414,6 +415,7 @@ class TestCloudFormation:
         assert lambda_arn in uri
 
     # TODO: refactor
+    @pytest.mark.xfail(condition=is_new_provider(), reason="fails/times out")
     def test_update_lambda_function(
         self, lambda_client, cfn_client, s3_client, s3_create_bucket, deploy_cfn_template
     ):

--- a/tests/integration/templates/template28.yaml
+++ b/tests/integration/templates/template28.yaml
@@ -4,6 +4,9 @@ Parameters:
     Type: String
     Default: 'companyname-ci'
 
+  Ec2KeyPairName:
+    Type: String
+
   RegmonSnsTopicSendEmails:
     Default: false
     Type: String
@@ -85,7 +88,7 @@ Resources:
       InstanceType: "t3.small"
       # The following image is initialised in EC2 Pro provider init hook
       ImageId: ami-a33ac4f1069a
-      KeyName: key-pair-foo123
+      KeyName: !Ref Ec2KeyPairName
       IamInstanceProfile: !Ref InstanceProfile
       SecurityGroupIds:
       - Ref: PublicSG

--- a/tests/unit/test_cloudformation.py
+++ b/tests/unit/test_cloudformation.py
@@ -6,8 +6,8 @@ from localstack.services.cloudformation.deployment_utils import (
     remove_none_values,
 )
 from localstack.services.cloudformation.engine import template_deployer, template_preparer
+from localstack.services.cloudformation.engine.entities import Stack
 from localstack.services.cloudformation.models.stepfunctions import _apply_substitutions
-from localstack.services.cloudformation.provider import Stack
 
 
 def test_resolve_references():


### PR DESCRIPTION
The goal here is to untangle the resources, methods, modules, etc. a bit and reduce complexity.
Removing circular dependencies here allows us to properly add types in the `template_deployer` to facilitate further refactoring efforts.

## Changes

- Move Stack, StackChangeSet, StackSet, StackInstance from `provider.py` to separate file
- Remove dependencies from those moved classes to any other cfn modules. Fix circular dependencies
- Temporarily disable (commented out) `Stack.nested_stacks`. If the pipeline is green this will be removed in a follow-up PR.
- Stack outputs are resolved *once* after applying changes. `Stack.outputs_list` has been removed (functionality moved to `template_deployer.resolve_outputs` temporarily.
- Grouped stack set operations in `provider.py` and moved to the end of the class

## Next up

In follow-up PRs:
- Introduce more typing for utils and template_deployer
- Reduce code paths where possible
- Introduction of cfn-lint
- Migrate 'entitites' to be more data-focused and remove custom logic
- Remove inheritance between Stack/StackChangeSet