### PR TITLE
use only MetricDatum to show in raw-endpoint for cloudwatch

### DIFF
--- a/localstack/services/cloudwatch/provider.py
+++ b/localstack/services/cloudwatch/provider.py
@@ -3,7 +3,7 @@ import logging
 from xml.sax.saxutils import escape
 
 from moto.cloudwatch import cloudwatch_backends
-from moto.cloudwatch.models import CloudWatchBackend, FakeAlarm
+from moto.cloudwatch.models import CloudWatchBackend, FakeAlarm, MetricDatum
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException, RequestContext, handler
@@ -267,7 +267,8 @@ class CloudwatchProvider(CloudwatchApi, ServiceLifecycleHook):
         )
         backend = cloudwatch_backends[account_id][region]
         if backend:
-            result = backend.metric_data
+            result = [m for m in backend.metric_data if isinstance(m, MetricDatum)]
+            # TODO handle aggregated metrics as well (MetricAggregatedDatum)
         else:
             result = []
 


### PR DESCRIPTION
Companion PR for [fix in moto upstream](https://github.com/spulec/moto/pull/5793#issuecomment-1362168672).

It can be merged before we update moto-ext: we now filter for a specific class, but the name of the class didn't change.
