### PR TITLE
remove base64 decoding of SQS Binary msg attributes already done by ASF parser

### DIFF
--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -1,4 +1,3 @@
-import base64
 import copy
 import hashlib
 import json
@@ -1131,7 +1130,7 @@ def _create_message_attribute_hash(message_attributes) -> Optional[str]:
             )
         elif attr_value.get("BinaryValue"):
             hash.update(bytearray([BINARY_TYPE_FIELD_INDEX]))
-            decoded_binary_value = base64.b64decode(attr_value.get("BinaryValue"))
+            decoded_binary_value = attr_value.get("BinaryValue")
             MotoMessage.update_binary_length_and_value(hash, decoded_binary_value)
         # string_list_value, binary_list_value type is not implemented, reserved for the future use.
         # See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -608,5 +608,31 @@
         }
       }
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_send_message_with_binary_attributes": {
+    "recorded-date": "22-12-2022, 16:28:53",
+    "recorded-content": {
+      "binary-attrs-msg": {
+        "Messages": [
+          {
+            "Body": "test",
+            "MD5OfBody": "098f6bcd4621d373cade4e832627b4f6",
+            "MD5OfMessageAttributes": "8cbe4db156db8a94db8b801b7addb984",
+            "MessageAttributes": {
+              "attr1": {
+                "BinaryValue": "b'traceparent\\x1e00-774062d6c37081a5a0b9b5b88e30627c-2d2482211f6489da-01'",
+                "DataType": "Binary"
+              }
+            },
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR removes the base64 decoding of binary message attributes in SQS, as the parser would already take care of this.

We can see a reproducible example in #7381 

The parser takes care of it here:
https://github.com/localstack/localstack/blob/162a21f993ba565b6b748e5ba491262d214a4550/localstack/aws/protocol/parser.py#L292-L293

And the type of the `BinaryValue` is defined in the specs as:
```json
"Binary":{"type":"blob"},
```
```json
"BinaryValue":{
    "shape":"Binary",
    "documentation":"<p>Binary type attributes can store any binary data, such as compressed data, encrypted data, or images.</p>"
}
```

Now that the SQS legacy provider has been deleted, we can safely assume all requests are "ASF parsed". 

_fixes #7381_
