### PR TITLE
CFn refactoring Pt.4

### DIFF
--- a/localstack/services/cloudformation/api_utils.py
+++ b/localstack/services/cloudformation/api_utils.py
@@ -1,0 +1,92 @@
+import logging
+import re
+from urllib.parse import urlparse
+
+from requests.structures import CaseInsensitiveDict
+
+from localstack import config, constants
+from localstack.services.cloudformation.engine.template_preparer import transform_template
+from localstack.services.s3 import s3_listener, s3_utils
+from localstack.utils.aws import aws_stack
+from localstack.utils.functions import run_safe
+from localstack.utils.http import safe_requests
+from localstack.utils.strings import to_str
+
+LOG = logging.getLogger(__name__)
+
+
+def prepare_template_body(req_data: dict) -> str | bytes | None:  # TODO: mutating and returning
+    template_url = req_data.get("TemplateURL")
+    if template_url:
+        req_data["TemplateURL"] = convert_s3_to_local_url(template_url)
+    url = req_data.get("TemplateURL", "")
+    if is_local_service_url(url):
+        modified_template_body = get_template_body(req_data)
+        if modified_template_body:
+            req_data.pop("TemplateURL", None)
+            req_data["TemplateBody"] = modified_template_body
+    body = get_template_body(req_data)
+    modified_template_body = transform_template(body)
+    if modified_template_body:
+        req_data["TemplateBody"] = modified_template_body
+    return modified_template_body
+
+
+def get_template_body(req_data: dict) -> str:
+    body = req_data.get("TemplateBody")
+    if body:
+        return body
+    url = req_data.get("TemplateURL")
+    if url:
+        response = run_safe(lambda: safe_requests.get(url, verify=False))
+        # check error codes, and code 301 - fixes https://github.com/localstack/localstack/issues/1884
+        status_code = 0 if response is None else response.status_code
+        if response is None or status_code == 301 or status_code >= 400:
+            # check if this is an S3 URL, then get the file directly from there
+            url = convert_s3_to_local_url(url)
+            if is_local_service_url(url):
+                parsed_path = urlparse(url).path.lstrip("/")
+                parts = parsed_path.partition("/")
+                client = aws_stack.connect_to_service("s3")
+                LOG.debug(
+                    "Download CloudFormation template content from local S3: %s - %s",
+                    parts[0],
+                    parts[2],
+                )
+                result = client.get_object(Bucket=parts[0], Key=parts[2])
+                body = to_str(result["Body"].read())
+                return body
+            raise Exception(
+                "Unable to fetch template body (code %s) from URL %s" % (status_code, url)
+            )
+        return to_str(response.content)
+    raise Exception("Unable to get template body from input: %s" % req_data)
+
+
+def is_local_service_url(url: str) -> bool:
+    if not url:
+        return False
+    candidates = (
+        constants.LOCALHOST,
+        constants.LOCALHOST_HOSTNAME,
+        config.LOCALSTACK_HOSTNAME,
+        config.HOSTNAME_EXTERNAL,
+    )
+    if any(re.match(r"^[^:]+://[^:/]*%s([:/]|$)" % host, url) for host in candidates):
+        return True
+    host = url.split("://")[-1].split("/")[0]
+    return "localhost" in host
+
+
+def convert_s3_to_local_url(url: str) -> str:
+    url_parsed = urlparse(url)
+    path = url_parsed.path
+
+    headers = CaseInsensitiveDict({"Host": url_parsed.netloc})
+    bucket_name = s3_utils.extract_bucket_name(headers, path)
+    key_name = s3_utils.extract_key_name(headers, path)
+
+    # note: make sure to normalize the bucket name here!
+    bucket_name = s3_listener.normalize_bucket_name(bucket_name)
+    local_url = f"{config.service_url('s3')}/{bucket_name}/{key_name}"
+    return local_url

--- a/localstack/services/cloudformation/deployment_utils.py
+++ b/localstack/services/cloudformation/deployment_utils.py
@@ -8,7 +8,6 @@ from localstack.utils import common
 from localstack.utils.common import select_attributes, short_uid
 
 # placeholders
-PLACEHOLDER_RESOURCE_NAME = "__resource_name__"
 PLACEHOLDER_AWS_NO_VALUE = "__aws_no_value__"
 
 

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -340,17 +340,6 @@ class Stack:
         """Returns the (mutable) dict of stack outputs."""
         return self.template.setdefault("Outputs", {})
 
-    # FIXME: unused?
-    # @property
-    # def nested_stacks(self):
-    #     """Return a list of nested stacks that have been deployed by this stack."""
-    #     result = [
-    #         r for r in self.template_resources.values() if r["Type"] == "AWS::CloudFormation::Stack"
-    #     ]
-    #     result = [find_stack(r["Properties"].get("StackName")) for r in result]
-    #     result = [r for r in result if r]
-    #     return result
-
     @property
     def status(self):
         return self.metadata["StackStatus"]

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -15,9 +15,8 @@ LOG = logging.getLogger(__name__)
 class StackSet:
     """A stack set contains multiple stack instances."""
 
-    def __init__(self, metadata=None):
-        if metadata is None:
-            metadata = {}
+    # FIXME: confusing name. metadata is the complete incoming request object
+    def __init__(self, metadata: dict):
         self.metadata = metadata
         # list of stack instances
         self.stack_instances = []
@@ -32,9 +31,8 @@ class StackSet:
 class StackInstance:
     """A stack instance belongs to a stack set and is specific to a region / account ID."""
 
-    def __init__(self, metadata=None):
-        if metadata is None:
-            metadata = {}
+    # FIXME: confusing name. metadata is the complete incoming request object
+    def __init__(self, metadata: dict):
         self.metadata = metadata
         # reference to the deployed stack belonging to this stack instance
         self.stack = None

--- a/localstack/services/cloudformation/engine/policy_loader.py
+++ b/localstack/services/cloudformation/engine/policy_loader.py
@@ -1,0 +1,18 @@
+import logging
+
+from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
+
+from localstack.utils.aws import aws_stack
+
+LOG = logging.getLogger(__name__)
+
+
+policy_loader = None
+
+
+def create_policy_loader() -> ManagedPolicyLoader:
+    global policy_loader
+    if not policy_loader:
+        iam_client = aws_stack.connect_to_service("iam")
+        policy_loader = ManagedPolicyLoader(iam_client=iam_client)
+    return policy_loader

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -112,25 +112,6 @@ def get_service_name(resource):
     return parts[1].lower()
 
 
-# FIXME: remove
-# def get_resource_name(resource):
-#     properties = resource.get("Properties") or {}
-#     name = properties.get("Name")
-#     if name:
-#         return name
-#
-#     # try to extract name via resource class
-#     res_type = canonical_resource_type(get_resource_type(resource))
-#     model_class = RESOURCE_MODELS.get(res_type)
-#     if model_class:
-#         instance = model_class(resource)
-#         name = instance.get_resource_name()
-#
-#     if not name:
-#         LOG.debug('Unable to extract name for resource type "%s"', res_type)
-#     return name
-
-
 def get_client(resource: dict, func_config: dict):
     resource_type = get_resource_type(resource)
     service = get_service_name(resource)

--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -3,7 +3,7 @@ import json
 import logging
 import re
 import traceback
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 import botocore
 
@@ -64,7 +64,7 @@ UPDATEABLE_RESOURCES = [
 STATIC_REFS = ["AWS::Region", "AWS::Partition", "AWS::StackName", "AWS::AccountId"]
 
 # maps resource type string to model class
-RESOURCE_MODELS = {
+RESOURCE_MODELS: dict[str, Type[GenericBaseModel]] = {
     model.cloudformation_type(): model for model in get_all_subclasses(GenericBaseModel)
 }
 

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -5,7 +5,6 @@ import re
 from urllib.parse import urlparse
 
 import boto3
-import moto.cloudformation.utils
 import yaml
 from requests.structures import CaseInsensitiveDict
 from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
@@ -113,9 +112,6 @@ def parse_template(template: str) -> dict:
     try:
         return json.loads(template)
     except Exception:
-        yaml.add_multi_constructor(
-            "", moto.cloudformation.utils.yaml_tag_constructor, Loader=NoDatesSafeLoader
-        )  # TODO: remove moto dependency here
         try:
             return clone_safe(yaml.safe_load(template))
         except Exception:

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -4,6 +4,7 @@ import os
 
 import boto3
 import yaml
+from moto.cloudformation.utils import yaml_tag_constructor
 from samtranslator.translator.transform import transform as transform_sam
 
 from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
@@ -24,6 +25,8 @@ def parse_template(template: str) -> dict:
     try:
         return json.loads(template)
     except Exception:
+        # FIXME: removing this still breaks all short-hand intrinsic functions :|
+        yaml.add_multi_constructor("", yaml_tag_constructor, Loader=NoDatesSafeLoader)
         try:
             return clone_safe(yaml.safe_load(template))
         except Exception:

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -1,22 +1,14 @@
 import json
 import logging
 import os
-import re
-from urllib.parse import urlparse
 
 import boto3
 import yaml
-from requests.structures import CaseInsensitiveDict
-from samtranslator.translator.managed_policy_translator import ManagedPolicyLoader
 from samtranslator.translator.transform import transform as transform_sam
 
-from localstack import config, constants
-from localstack.services.s3 import s3_listener, s3_utils
+from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
 from localstack.utils.aws import aws_stack
-from localstack.utils.functions import run_safe
-from localstack.utils.http import safe_requests
 from localstack.utils.json import clone_safe
-from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 
@@ -26,86 +18,6 @@ NoDatesSafeLoader.yaml_implicit_resolvers = {
     k: [r for r in v if r[0] != "tag:yaml.org,2002:timestamp"]
     for k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
 }
-
-policy_loader = None
-
-
-def _create_loader() -> ManagedPolicyLoader:
-    global policy_loader
-    if not policy_loader:
-        iam_client = aws_stack.connect_to_service("iam")
-        policy_loader = ManagedPolicyLoader(iam_client=iam_client)
-    return policy_loader
-
-
-# FIXME: this should be a separate step
-def transform_template(req_data: dict) -> str | None:
-    """only returns string when parsing SAM template, otherwise None"""
-    template_body = get_template_body(req_data)
-    parsed = parse_template(template_body)
-    if parsed.get("Transform") == "AWS::Serverless-2016-10-31":
-
-        # Note: we need to fix boto3 region, otherwise AWS SAM transformer fails
-        region_before = os.environ.get("AWS_DEFAULT_REGION")
-        if boto3.session.Session().region_name is None:
-            os.environ["AWS_DEFAULT_REGION"] = aws_stack.get_region()
-        loader = _create_loader()
-        try:
-            transformed = transform_sam(parsed, {}, loader)
-            return json.dumps(transformed)
-        finally:
-            os.environ.pop("AWS_DEFAULT_REGION", None)
-            if region_before is not None:
-                os.environ["AWS_DEFAULT_REGION"] = region_before
-
-
-# FIXME: don't operate on request dict directly
-def prepare_template_body(req_data: dict) -> str | bytes | None:  # TODO: mutating and returning
-    template_url = req_data.get("TemplateURL")
-    if template_url:
-        req_data["TemplateURL"] = convert_s3_to_local_url(template_url)
-    url = req_data.get("TemplateURL", "")
-    if is_local_service_url(url):
-        modified_template_body = get_template_body(req_data)
-        if modified_template_body:
-            req_data.pop("TemplateURL", None)
-            req_data["TemplateBody"] = modified_template_body
-    modified_template_body = transform_template(req_data)
-    if modified_template_body:
-        req_data["TemplateBody"] = modified_template_body
-    return modified_template_body
-
-
-# FIXME: don't operate on request dict directly
-def get_template_body(req_data: dict) -> str:
-    body = req_data.get("TemplateBody")
-    if body:
-        return body
-    url = req_data.get("TemplateURL")
-    if url:
-        response = run_safe(lambda: safe_requests.get(url, verify=False))
-        # check error codes, and code 301 - fixes https://github.com/localstack/localstack/issues/1884
-        status_code = 0 if response is None else response.status_code
-        if response is None or status_code == 301 or status_code >= 400:
-            # check if this is an S3 URL, then get the file directly from there
-            url = convert_s3_to_local_url(url)
-            if is_local_service_url(url):
-                parsed_path = urlparse(url).path.lstrip("/")
-                parts = parsed_path.partition("/")
-                client = aws_stack.connect_to_service("s3")
-                LOG.debug(
-                    "Download CloudFormation template content from local S3: %s - %s",
-                    parts[0],
-                    parts[2],
-                )
-                result = client.get_object(Bucket=parts[0], Key=parts[2])
-                body = to_str(result["Body"].read())
-                return body
-            raise Exception(
-                "Unable to fetch template body (code %s) from URL %s" % (status_code, url)
-            )
-        return to_str(response.content)
-    raise Exception("Unable to get template body from input: %s" % req_data)
 
 
 def parse_template(template: str) -> dict:
@@ -127,30 +39,21 @@ def template_to_json(template: str) -> str:
     return json.dumps(template)
 
 
-def is_local_service_url(url: str) -> bool:
-    if not url:
-        return False
-    candidates = (
-        constants.LOCALHOST,
-        constants.LOCALHOST_HOSTNAME,
-        config.LOCALSTACK_HOSTNAME,
-        config.HOSTNAME_EXTERNAL,
-    )
-    if any(re.match(r"^[^:]+://[^:/]*%s([:/]|$)" % host, url) for host in candidates):
-        return True
-    host = url.split("://")[-1].split("/")[0]
-    return "localhost" in host
+def transform_template(template_body: str) -> str | None:
+    """only returns string when parsing SAM template, otherwise None"""
+    # template_body = get_template_body(req_data) # FIXME
+    parsed = parse_template(template_body)
+    if parsed.get("Transform") == "AWS::Serverless-2016-10-31":
 
-
-def convert_s3_to_local_url(url: str) -> str:
-    url_parsed = urlparse(url)
-    path = url_parsed.path
-
-    headers = CaseInsensitiveDict({"Host": url_parsed.netloc})
-    bucket_name = s3_utils.extract_bucket_name(headers, path)
-    key_name = s3_utils.extract_key_name(headers, path)
-
-    # note: make sure to normalize the bucket name here!
-    bucket_name = s3_listener.normalize_bucket_name(bucket_name)
-    local_url = f"{config.service_url('s3')}/{bucket_name}/{key_name}"
-    return local_url
+        # Note: we need to fix boto3 region, otherwise AWS SAM transformer fails
+        region_before = os.environ.get("AWS_DEFAULT_REGION")
+        if boto3.session.Session().region_name is None:
+            os.environ["AWS_DEFAULT_REGION"] = aws_stack.get_region()
+        loader = create_policy_loader()
+        try:
+            transformed = transform_sam(parsed, {}, loader)
+            return json.dumps(transformed)
+        finally:
+            os.environ.pop("AWS_DEFAULT_REGION", None)
+            if region_before is not None:
+                os.environ["AWS_DEFAULT_REGION"] = region_before

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -76,42 +76,6 @@ def prepare_template_body(req_data) -> str | bytes | None:  # TODO: mutating and
     return modified_template_body
 
 
-def validate_template(req_data):
-    # TODO implement actual validation logic
-    # Note: if we enable this via moto, ensure that we have cfnlint module available (adds ~58MB in size :/)
-    response_content = """
-        <Capabilities></Capabilities>
-        <CapabilitiesReason></CapabilitiesReason>
-        <DeclaredTransforms></DeclaredTransforms>
-        <Description>{description}</Description>
-        <Parameters>
-            {parameters}
-        </Parameters>
-    """
-    template_body = get_template_body(req_data)
-    valid_template = json.loads(template_to_json(template_body))
-    parameters = "".join(
-        [
-            """
-        <member>
-            <ParameterKey>{pk}</ParameterKey>
-            <DefaultValue>{dv}</DefaultValue>
-            <NoEcho>{echo}</NoEcho>
-            <Description>{desc}</Description>
-        </member>
-        """.format(
-                pk=k, dv=v.get("Default", ""), echo=False, desc=v.get("Description", "")
-            )
-            for k, v in valid_template.get("Parameters", {}).items()
-        ]
-    )
-
-    resp = response_content.format(
-        parameters=parameters, description=valid_template.get("Description", "")
-    )
-    return resp
-
-
 def get_template_body(req_data):
     body = req_data.get("TemplateBody")
     if body:

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -122,7 +122,7 @@ def parse_template(template: str) -> dict:
                 raise
 
 
-def template_to_json(template) -> str:
+def template_to_json(template: str) -> str:
     template = parse_template(template)
     return json.dumps(template)
 

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -232,7 +232,7 @@ class GatewayResource(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         props = self.props
-        api_id = props.get("RestApiId") or self.resource_id
+        api_id = props.get("RestApiId") or self.logical_resource_id
         api_id = self.resolve_refs_recursively(stack_name, api_id, resources)
         parent_id = self.resolve_refs_recursively(stack_name, props.get("ParentId"), resources)
 
@@ -458,7 +458,7 @@ class GatewayStage(GenericBaseModel):
         return "AWS::ApiGateway::Stage"
 
     def fetch_state(self, stack_name, resources):
-        api_id = self.props.get("RestApiId") or self.resource_id
+        api_id = self.props.get("RestApiId") or self.logical_resource_id
         api_id = self.resolve_refs_recursively(stack_name, api_id, resources)
         if not api_id:
             return None

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -73,7 +73,7 @@ class DynamoDBTable(GenericBaseModel):
         return self.props.get("TableName")
 
     def fetch_state(self, stack_name, resources):
-        table_name = self.props.get("TableName") or self.resource_id
+        table_name = self.props.get("TableName") or self.logical_resource_id
         table_name = self.resolve_refs_recursively(stack_name, table_name, resources)
         return aws_stack.connect_to_service("dynamodb").describe_table(TableName=table_name)
 

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -41,7 +41,7 @@ class ElasticsearchDomain(GenericBaseModel):
         )
 
     def _domain_name(self):
-        return self.props.get("DomainName") or self.resource_id
+        return self.props.get("DomainName") or self.logical_resource_id
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -8,7 +8,6 @@ from botocore.exceptions import ClientError
 from localstack.services.awslambda.lambda_api import IAM_POLICY_VERSION
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
-    PLACEHOLDER_RESOURCE_NAME,
     dump_json_params,
     generate_default_name,
     param_defaults,
@@ -73,9 +72,6 @@ class IAMUser(GenericBaseModel):
         return "AWS::IAM::User"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("UserName")
-
-    def get_resource_name(self):
         return self.props.get("UserName")
 
     def fetch_state(self, stack_name, resources):
@@ -223,9 +219,6 @@ class IAMRole(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::IAM::Role"
-
-    def get_resource_name(self):
-        return self.props.get("RoleName")
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
         role_name = self.properties.get("RoleName")
@@ -385,7 +378,7 @@ class IAMRole(GenericBaseModel):
                             ),
                             "AssumeRolePolicyDocument",
                         ),
-                        {"RoleName": PLACEHOLDER_RESOURCE_NAME},
+                        {"RoleName": "RoleName"},
                     ),
                 },
                 {"function": IAMRole._post_create},
@@ -604,9 +597,6 @@ class IAMGroup(GenericBaseModel):
         return "AWS::IAM::Group"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("GroupName")
-
-    def get_resource_name(self):
         return self.props.get("GroupName")
 
     def fetch_state(self, stack_name, resources):

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -9,7 +9,7 @@ class FirehoseDeliveryStream(GenericBaseModel):
         return "AWS::KinesisFirehose::DeliveryStream"
 
     def fetch_state(self, stack_name, resources):
-        stream_name = self.props.get("DeliveryStreamName") or self.resource_id
+        stream_name = self.props.get("DeliveryStreamName") or self.logical_resource_id
         stream_name = self.resolve_refs_recursively(stack_name, stream_name, resources)
         return aws_stack.connect_to_service("firehose").describe_delivery_stream(
             DeliveryStreamName=stream_name

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -36,7 +36,7 @@ class OpenSearchDomain(GenericBaseModel):
         return aws_stack.connect_to_service("opensearch").describe_domain(DomainName=domain_name)
 
     def _domain_name(self):
-        return self.props.get("DomainName") or self.resource_id
+        return self.props.get("DomainName") or self.logical_resource_id
 
     @staticmethod
     def get_deploy_templates():

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -27,7 +27,7 @@ class S3BucketPolicy(GenericBaseModel):
         return policy and md5(canonical_json(json.loads(policy)))
 
     def fetch_state(self, stack_name, resources):
-        bucket_name = self.props.get("Bucket") or self.resource_id
+        bucket_name = self.props.get("Bucket") or self.logical_resource_id
         bucket_name = self.resolve_refs_recursively(stack_name, bucket_name, resources)
         return aws_stack.connect_to_service("s3").get_bucket_policy(Bucket=bucket_name)
 
@@ -229,4 +229,4 @@ class S3Bucket(GenericBaseModel):
         return bucket_name
 
     def _get_bucket_name(self):
-        return self.props.get("BucketName") or self.resource_id
+        return self.props.get("BucketName") or self.logical_resource_id

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -6,7 +6,6 @@ from botocore.exceptions import ClientError
 from localstack.constants import S3_STATIC_WEBSITE_HOSTNAME, S3_VIRTUAL_HOSTNAME
 from localstack.services.cloudformation.cfn_utils import rename_params
 from localstack.services.cloudformation.deployment_utils import (
-    PLACEHOLDER_RESOURCE_NAME,
     dump_json_params,
     generate_default_name,
 )
@@ -49,9 +48,6 @@ class S3Bucket(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::S3::Bucket"
-
-    def get_resource_name(self):
-        return self.normalize_bucket_name(self.props.get("BucketName"))
 
     @staticmethod
     def normalize_bucket_name(bucket_name):
@@ -105,7 +101,7 @@ class S3Bucket(GenericBaseModel):
 
             # construct final result
             result = {
-                "Bucket": params.get("BucketName") or PLACEHOLDER_RESOURCE_NAME,
+                "Bucket": params.get("BucketName"),
                 "NotificationConfiguration": {
                     "LambdaFunctionConfigurations": lambda_configs,
                     "QueueConfigurations": queue_configs,

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -29,7 +29,7 @@ class SecretsManagerSecret(GenericBaseModel):
         return super(SecretsManagerSecret, self).get_cfn_attribute(attribute_name)
 
     def fetch_state(self, stack_name, resources):
-        secret_name = self.props.get("Name") or self.resource_id
+        secret_name = self.props.get("Name") or self.logical_resource_id
         secret_name = self.resolve_refs_recursively(stack_name, secret_name, resources)
         result = aws_stack.connect_to_service("secretsmanager").describe_secret(
             SecretId=secret_name

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -82,7 +82,7 @@ class SQSQueue(GenericBaseModel):
         except Exception as e:
             if "NonExistentQueue" in str(e):
                 raise DependencyNotYetSatisfied(
-                    resource_ids=self.resource_id, message="Unable to get queue: %s" % e
+                    resource_ids=self.logical_resource_id, message="Unable to get queue: %s" % e
                 )
         if attribute == "Arn":
             return arns.sqs_queue_arn(props.get("QueueName"))

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -4,7 +4,6 @@ import logging
 from botocore.exceptions import ClientError
 
 from localstack.services.cloudformation.deployment_utils import (
-    PLACEHOLDER_RESOURCE_NAME,
     generate_default_name,
     params_list_to_dict,
     params_select_attributes,
@@ -71,9 +70,6 @@ class SQSQueue(GenericBaseModel):
     def cloudformation_type(cls):
         return "AWS::SQS::Queue"
 
-    def get_resource_name(self):
-        return self.props.get("QueueName")
-
     def get_physical_resource_id(self, attribute=None, **kwargs):
         queue_url = None
         props = self.props
@@ -133,7 +129,7 @@ class SQSQueue(GenericBaseModel):
             "create": {
                 "function": "create_queue",
                 "parameters": {
-                    "QueueName": ["QueueName", PLACEHOLDER_RESOURCE_NAME],
+                    "QueueName": "QueueName",
                     "Attributes": params_select_attributes(
                         "ContentBasedDeduplication",
                         "DelaySeconds",

--- a/localstack/services/cloudformation/models/ssm.py
+++ b/localstack/services/cloudformation/models/ssm.py
@@ -15,10 +15,10 @@ class SSMParameter(GenericBaseModel):
         return "AWS::SSM::Parameter"
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
-        return self.props.get("Name") or self.resource_id
+        return self.props.get("Name") or self.logical_resource_id
 
     def fetch_state(self, stack_name, resources):
-        param_name = self.props.get("Name") or self.resource_id
+        param_name = self.props.get("Name") or self.logical_resource_id
         param_name = self.resolve_refs_recursively(stack_name, param_name, resources)
         return aws_stack.connect_to_service("ssm").get_parameter(Name=param_name)["Parameter"]
 

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -56,7 +56,7 @@ class SFNStateMachine(GenericBaseModel):
         return self.props.get("stateMachineArn")
 
     def fetch_state(self, stack_name, resources):
-        sm_name = self.props.get("StateMachineName") or self.resource_id
+        sm_name = self.props.get("StateMachineName") or self.logical_resource_id
         sm_name = self.resolve_refs_recursively(stack_name, sm_name, resources)
         sfn_client = aws_stack.connect_to_service("stepfunctions")
         state_machines = sfn_client.list_state_machines()["stateMachines"]

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -25,7 +25,7 @@ class SFNActivity(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_arn(result, resource_id, resources):
+        def _store_arn(result, resource_id, resources, resource_type):
             resources[resource_id]["PhysicalResourceId"] = result["activityArn"]
 
         return {

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -2,10 +2,7 @@ import logging
 import re
 from typing import Dict
 
-from localstack.services.cloudformation.deployment_utils import (
-    PLACEHOLDER_RESOURCE_NAME,
-    generate_default_name,
-)
+from localstack.services.cloudformation.deployment_utils import generate_default_name
 from localstack.services.cloudformation.service_models import GenericBaseModel
 from localstack.utils.aws import aws_stack
 from localstack.utils.common import to_str
@@ -28,13 +25,13 @@ class SFNActivity(GenericBaseModel):
 
     @staticmethod
     def get_deploy_templates():
-        def _store_arn(result, resource_id, resources, resource_type):
+        def _store_arn(result, resource_id, resources):
             resources[resource_id]["PhysicalResourceId"] = result["activityArn"]
 
         return {
             "create": {
                 "function": "create_activity",
-                "parameters": {"name": ["Name", PLACEHOLDER_RESOURCE_NAME], "tags": "Tags"},
+                "parameters": {"name": "Name", "tags": "Tags"},
                 "result_handler": _store_arn,
             },
             "delete": {
@@ -48,9 +45,6 @@ class SFNStateMachine(GenericBaseModel):
     @staticmethod
     def cloudformation_type():
         return "AWS::StepFunctions::StateMachine"
-
-    def get_resource_name(self):
-        return self.props.get("StateMachineName")
 
     def get_physical_resource_id(self, attribute=None, **kwargs):
         return self.props.get("stateMachineArn")
@@ -107,7 +101,7 @@ class SFNStateMachine(GenericBaseModel):
                 return definition_str
 
             return {
-                "name": params.get("StateMachineName", PLACEHOLDER_RESOURCE_NAME),
+                "name": params.get("StateMachineName"),
                 "definition": _get_definition(params),
                 "roleArn": params.get("RoleArn"),
                 "type": params.get("StateMachineType", None),

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -130,6 +130,8 @@ class InternalFailure(CommonServiceException):
 class CloudformationProvider(CloudformationApi):
     @handler("CreateStack", expand=False)
     def create_stack(self, context: RequestContext, request: CreateStackInput) -> CreateStackOutput:
+
+        # TODO: test what happens when both TemplateUrl and Body are specified
         state = get_cloudformation_store()
         api_utils.prepare_template_body(request)  # TODO: avoid mutating request directly
         template = template_preparer.parse_template(request["TemplateBody"])

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional, TypedDict
 
 from localstack import config
 from localstack.utils.aws import aws_stack
@@ -24,6 +25,11 @@ class DependencyNotYetSatisfied(Exception):
         self.resource_ids = resource_ids
 
 
+class ResourceJson(TypedDict):
+    Type: str
+    Properties: dict
+
+
 class GenericBaseModel:
     """Abstract base class representing a resource model class in LocalStack.
     This class keeps references to a combination of (1) the CF resource
@@ -34,7 +40,7 @@ class GenericBaseModel:
     e.g., fetching the latest deployment state, getting the resource name, etc.
     """
 
-    def __init__(self, resource_json, region_name=None, **params):
+    def __init__(self, resource_json: dict, region_name: Optional[str] = None, **params):
         # self.stack_name = stack_name # TODO: add stack name to params
         self.region_name = region_name or aws_stack.get_region()
         self.resource_json = resource_json

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -67,7 +67,7 @@ class GenericBaseModel:
 
     # TODO: change the signature to pass in a Stack instance (instead of stack_name and resources)
     def fetch_state(self, stack_name, resources):
-        """Fetch the latest deployment state of this resource, or return None if not currently deployed."""
+        """Fetch the latest deployment state of this resource, or return None if not currently deployed (NOTE: THIS IS NOT ALWAYS TRUE)."""
         return None
 
     # TODO: change the signature to pass in a Stack instance (instead of stack_name and resources)
@@ -149,7 +149,7 @@ class GenericBaseModel:
         return self.resource_json.get("LogicalResourceId")
 
     @property
-    def props(self):
+    def props(self) -> dict:
         """Return a copy of (1) the resource properties (from the template), combined with
         (2) the current deployment state properties of the resource."""
         result = dict(self.properties)
@@ -158,7 +158,7 @@ class GenericBaseModel:
 
     # TODO: remove after -ext does not depend on this anymore
     @property
-    def resource_id(self):
+    def resource_id(self) -> str:
         """Return the logical resource ID of this resource (i.e., the ref. name within the stack's resources)."""
         return self.resource_json["LogicalResourceId"]
 

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -126,10 +126,6 @@ class GenericBaseModel:
             self.fetch_and_update_state(*args, **kwargs)
         return self.state
 
-    def set_resource_state(self, state):
-        """Set the deployment state of this resource."""
-        self.state = state or {}
-
     def update_state(self, details):
         """Update the deployment state of this resource (existing attributes will be overwritten)."""
         details = details or {}

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -5,7 +5,6 @@ from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
 
 from localstack import config
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import camel_to_snake_case
 
 LOG = logging.getLogger(__name__)
 
@@ -163,28 +162,6 @@ class GenericBaseModel:
     def resource_id(self):
         """Return the logical resource ID of this resource (i.e., the ref. name within the stack's resources)."""
         return self.resource_json["LogicalResourceId"]
-
-    @classmethod
-    def update_from_cloudformation_json(
-        cls, original_resource, new_resource_name, cloudformation_json, region_name
-    ):
-        props = cloudformation_json.get("Properties", {})
-        for key, val in props.items():
-            snake_key = camel_to_snake_case(key)
-            lower_key = key.lower()
-            for candidate in [key, lower_key, snake_key]:
-                if hasattr(original_resource, candidate) or candidate == snake_key:
-                    setattr(original_resource, candidate, val)
-                    break
-        return original_resource
-
-    @classmethod
-    def create_from_cloudformation_json(cls, resource_name, resource_json, region_name):
-        return cls(
-            resource_name=resource_name,
-            resource_json=resource_json,
-            region_name=region_name,
-        )
 
     @classmethod
     def resolve_refs_recursively(cls, stack_name, value, resources):

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -154,6 +154,7 @@ class GenericBaseModel:
         result.update(self.state or {})
         return result
 
+    # TODO: remove after -ext does not depend on this anymore
     @property
     def resource_id(self):
         """Return the logical resource ID of this resource (i.e., the ref. name within the stack's resources)."""

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -56,10 +56,6 @@ class GenericBaseModel:
     # ABSTRACT BASE METHODS
     # ----------------------
 
-    def get_resource_name(self):
-        """Return the name of this resource, based on its properties (to be overwritten by subclasses)"""
-        return None
-
     # TODO: this shouldn't have an attribute parameter
     def get_physical_resource_id(self, attribute=None, **kwargs):
         """Determine the physical resource ID (Ref) of this resource (to be overwritten by subclasses)"""

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1,8 +1,5 @@
 import logging
 
-# TODO: remove
-from moto.cloudformation.exceptions import UnformattedGetAttTemplateException
-
 from localstack import config
 from localstack.utils.aws import aws_stack
 
@@ -105,8 +102,7 @@ class GenericBaseModel:
         props = self.props
         if attribute_name in props:
             return props.get(attribute_name)
-
-        raise UnformattedGetAttTemplateException()
+        return None
 
     # ---------------------
     # GENERIC UTIL METHODS

--- a/tests/integration/cloudformation/resources/test_sqs.py
+++ b/tests/integration/cloudformation/resources/test_sqs.py
@@ -19,6 +19,7 @@ def test_sqs_queue_policy(sqs_client, deploy_cfn_template):
     )  # just kind of a smoke test to see if its set
 
 
+@pytest.mark.aws_validated
 def test_sqs_fifo_queue_generates_valid_name(deploy_cfn_template):
     result = deploy_cfn_template(
         template_path=os.path.join(
@@ -29,12 +30,14 @@ def test_sqs_fifo_queue_generates_valid_name(deploy_cfn_template):
     assert ".fifo" in result.outputs["FooQueueName"]
 
 
+# FIXME: doesn't work on AWS. (known bug in cloudformation: https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/165)
 def test_sqs_non_fifo_queue_generates_valid_name(deploy_cfn_template):
     result = deploy_cfn_template(
         template_path=os.path.join(
             os.path.dirname(__file__), "../../templates/sqs_fifo_autogenerate_name.yaml"
         ),
         template_mapping={"is_fifo": "false"},
+        max_wait=240,
     )
     assert ".fifo" not in result.outputs["FooQueueName"]
 

--- a/tests/unit/test_cloudformation.py
+++ b/tests/unit/test_cloudformation.py
@@ -1,11 +1,12 @@
 import re
 from typing import Dict
 
+import localstack.services.cloudformation.api_utils
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
     remove_none_values,
 )
-from localstack.services.cloudformation.engine import template_deployer, template_preparer
+from localstack.services.cloudformation.engine import template_deployer
 from localstack.services.cloudformation.engine.entities import Stack
 from localstack.services.cloudformation.models.stepfunctions import _apply_substitutions
 
@@ -52,9 +53,9 @@ def test_is_local_service_url():
         "http://mybucket.s3.us-east-1.amazonaws.com",
     ]
     for url in local_urls:
-        assert template_preparer.is_local_service_url(url)
+        assert localstack.services.cloudformation.api_utils.is_local_service_url(url)
     for url in remote_urls:
-        assert not template_preparer.is_local_service_url(url)
+        assert not localstack.services.cloudformation.api_utils.is_local_service_url(url)
 
 
 def test_apply_substitutions():

--- a/tests/unit/test_cloudformation.py
+++ b/tests/unit/test_cloudformation.py
@@ -1,7 +1,7 @@
 import re
 from typing import Dict
 
-import localstack.services.cloudformation.api_utils
+from localstack.services.cloudformation.api_utils import is_local_service_url
 from localstack.services.cloudformation.deployment_utils import (
     PLACEHOLDER_AWS_NO_VALUE,
     remove_none_values,
@@ -53,9 +53,9 @@ def test_is_local_service_url():
         "http://mybucket.s3.us-east-1.amazonaws.com",
     ]
     for url in local_urls:
-        assert localstack.services.cloudformation.api_utils.is_local_service_url(url)
+        assert is_local_service_url(url)
     for url in remote_urls:
-        assert not localstack.services.cloudformation.api_utils.is_local_service_url(url)
+        assert not is_local_service_url(url)
 
 
 def test_apply_substitutions():


### PR DESCRIPTION
## Changes

- Remove `PLACEHOLDER_RESOURCE_NAME` and `GenericBaseModel.get_resource_name`
- Use full resource type names everywhere (e.g. `AWS::SQS::Queue` instead of `SQS::Queue`)
- Use `GenericBaseModel.logical_resource_id` instead of `GenericBaseModel.resource_id`
- Move non-engine utils to `api_utils.py` (like in lambda)
- Move policy loading to `policy_loader.py`
- Remove `nested_stacks` as mentioned in a previous PR