### PR TITLE
implement resource tag api for cloudwatch logs

### DIFF
--- a/localstack/services/logs/models.py
+++ b/localstack/services/logs/models.py
@@ -3,15 +3,10 @@ from typing import Dict
 from moto.logs.models import LogsBackend as MotoLogsBackend
 from moto.logs.models import logs_backends as moto_logs_backend
 
-from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
 from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
-from localstack.utils.aws import aws_stack
 
 
-def get_moto_logs_backend(account_id: str = None, region_name: str = None) -> MotoLogsBackend:
-    account_id = account_id or DEFAULT_AWS_ACCOUNT_ID
-    region_name = region_name or aws_stack.get_region()
-
+def get_moto_logs_backend(account_id: str, region_name: str) -> MotoLogsBackend:
     return moto_logs_backend[account_id][region_name]
 
 

--- a/localstack/services/logs/models.py
+++ b/localstack/services/logs/models.py
@@ -1,0 +1,24 @@
+from typing import Dict
+
+from moto.logs.models import LogsBackend as MotoLogsBackend
+from moto.logs.models import logs_backends as moto_logs_backend
+
+from localstack.constants import DEFAULT_AWS_ACCOUNT_ID
+from localstack.services.stores import AccountRegionBundle, BaseStore, CrossRegionAttribute
+from localstack.utils.aws import aws_stack
+
+
+def get_moto_logs_backend(account_id: str = None, region_name: str = None) -> MotoLogsBackend:
+    account_id = account_id or DEFAULT_AWS_ACCOUNT_ID
+    region_name = region_name or aws_stack.get_region()
+
+    return moto_logs_backend[account_id][region_name]
+
+
+class LogsStore(BaseStore):
+
+    # maps resource ARN to tags
+    TAGS: Dict[str, Dict[str, str]] = CrossRegionAttribute(default=dict)
+
+
+logs_stores = AccountRegionBundle("logs", LogsStore)

--- a/tests/integration/test_logs.snapshot.json
+++ b/tests/integration/test_logs.snapshot.json
@@ -64,5 +64,83 @@
         }
       ]
     }
+  },
+  "tests/integration/test_logs.py::TestCloudWatchLogs::test_list_tags_log_group": {
+    "recorded-date": "22-12-2022, 17:46:54",
+    "recorded-content": {
+      "list_tags_after_create_log_group": {
+        "tags": {
+          "env": "testing1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_log_group_after_tag_resource": {
+        "tags": {
+          "env": "testing1",
+          "test1": "val1",
+          "test2": "val2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource_after_tag_resource": {
+        "tags": {
+          "env": "testing1",
+          "test1": "val1",
+          "test2": "val2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_log_group_after_tag_log_group": {
+        "tags": {
+          "env": "testing1",
+          "test1": "val1",
+          "test2": "val2",
+          "test3": "val3"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource_after_tag_log_group": {
+        "tags": {
+          "env": "testing1",
+          "test1": "val1",
+          "test2": "val2",
+          "test3": "val3"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_log_group_after_untag": {
+        "tags": {
+          "test2": "val2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list_tags_for_resource_after_untag": {
+        "tags": {
+          "test2": "val2"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR tackles the new API for resource tagging in cloudwatch logs, which was not yet implemented.
It is part of a fix for https://github.com/localstack/localstack/issues/7378.

The implementation relies on https://github.com/localstack/localstack/pull/7086 where the botocore/boto3 lib is upgraded.

The PR includes:
* new store for logs
* implementation of new resource-tagging APIs
* override old tagging APIs (previously handled by moto), for easier accessing of tags (both APIs should return the same output)
* snapshot test


**TODO**
- [ ] rebase with master (currently based on #7086)


