### PR TITLE
add in-memory ASF request dispatching for boto clients

### DIFF
--- a/localstack/aws/client.py
+++ b/localstack/aws/client.py
@@ -3,16 +3,54 @@ import io
 import logging
 from datetime import datetime
 from typing import Dict, Iterable, Optional
+from urllib.parse import urlsplit
 
+from botocore import awsrequest
+from botocore.endpoint import Endpoint
 from botocore.model import OperationModel
 from botocore.parsers import ResponseParser, ResponseParserFactory
-from werkzeug import Response
+from werkzeug.datastructures import Headers
 
-from localstack.aws.api import CommonServiceException, ServiceException, ServiceResponse
+from localstack.http import Request, Response
 from localstack.runtime import hooks
 from localstack.utils.patch import patch
+from localstack.utils.strings import to_str
+
+from .api import CommonServiceException, RequestContext, ServiceException, ServiceResponse
+from .gateway import Gateway
 
 LOG = logging.getLogger(__name__)
+
+
+def create_http_request(aws_request: awsrequest.AWSPreparedRequest) -> Request:
+    """
+    Create an ASF HTTP Request from a botocore AWSPreparedRequest.
+
+    :param aws_request: the botocore prepared request
+    :return: a new Request
+    """
+    split_url = urlsplit(aws_request.url)
+    host = split_url.netloc.split(":")
+    if len(host) == 1:
+        server = (to_str(host[0]), None)
+    elif len(host) == 2:
+        server = (to_str(host[0]), int(host[1]))
+    else:
+        raise ValueError
+
+    # prepare the RequestContext
+    headers = Headers()
+    for k, v in aws_request.headers.items():
+        headers[k] = v
+
+    return Request(
+        method=aws_request.method,
+        path=split_url.path,
+        query_string=split_url.query,
+        headers=headers,
+        body=aws_request.body,
+        server=server,
+    )
 
 
 class _ResponseStream(io.RawIOBase):
@@ -27,6 +65,10 @@ class _ResponseStream(io.RawIOBase):
         self.response = response
         self.iterator = response.iter_encoded()
         self._buf = None
+
+    def stream(self) -> Iterable[bytes]:
+        # adds compatibility for botocore's client-side AWSResponse.raw attribute.
+        return self.iterator
 
     def readable(self):
         return True
@@ -220,3 +262,57 @@ def raise_service_exception(response: Response, parsed_response: Dict) -> None:
     """
     if service_exception := parse_service_exception(response, parsed_response):
         raise service_exception
+
+
+@patch(Endpoint.create_request)
+def _create_and_enrich_request(
+    fn, self: Endpoint, params: dict, operation_model: OperationModel = None
+):
+    """
+    Patch that adds the botocore operation model and request parameters to a newly created AWSPreparedRequest, which normaly only holds low-level HTTP request information. This
+    """
+    request: awsrequest.AWSPreparedRequest = fn(self, params, operation_model)
+
+    request.params = params
+    request.operation_model = operation_model
+
+    return request
+
+
+class GatewayShortCircuit:
+    gateway: Gateway
+
+    def __init__(self, gateway: Gateway):
+        self.gateway = gateway
+
+    def __call__(
+        self, event_name: str, request: awsrequest.AWSPreparedRequest, **kwargs
+    ) -> awsrequest.AWSResponse:
+        # extract extra data from enriched AWSPreparedRequest
+        params = request.params
+        operation: OperationModel = request.operation_model
+
+        # create request
+        context = RequestContext()
+        context.request = create_http_request(request)
+        context.service = operation.service_model
+        context.operation = operation
+        context.service_request = params["body"]
+
+        # perform request
+        response = Response()
+        self.gateway.handle(context, response)
+
+        # transform Werkzeug response to client-side botocore response
+        aws_response = awsrequest.AWSResponse(
+            url=context.request.url,
+            status_code=response.status_code,
+            headers=response.headers,
+            raw=_ResponseStream(response),
+        )
+
+        return aws_response
+
+    @staticmethod
+    def modify_client(client, gateway):
+        client.meta.events.register_first("before-send.*.*", GatewayShortCircuit(gateway))

--- a/localstack/aws/gateway.py
+++ b/localstack/aws/gateway.py
@@ -25,16 +25,18 @@ class Gateway:
         self.response_handlers = list()
         self.exception_handlers = list()
 
+    def handle(self, context: RequestContext, response: Response) -> None:
+        """Exposes the same interface as ``HandlerChain.handle``."""
+        return self.new_chain().handle(context, response)
+
     def new_chain(self) -> HandlerChain:
         return HandlerChain(self.request_handlers, self.response_handlers, self.exception_handlers)
 
     def process(self, request: Request, response: Response):
-        chain = self.new_chain()
-
         context = RequestContext()
         context.request = request
 
-        chain.handle(context, response)
+        self.handle(context, response)
 
     def accept(self, request: WebSocketRequest):
         response = Response(status=101)

--- a/localstack/aws/serving/edge.py
+++ b/localstack/aws/serving/edge.py
@@ -3,8 +3,8 @@ from typing import List
 
 from localstack.config import HostAndPort
 from localstack.http.hypercorn import GatewayServer
+from localstack.runtime import components
 from localstack.runtime.shutdown import ON_AFTER_SERVICE_SHUTDOWN_HANDLERS
-from localstack.services.plugins import SERVICE_PLUGINS
 
 LOG = logging.getLogger(__name__)
 
@@ -16,12 +16,8 @@ def serve_gateway(
     Implementation of the edge.do_start_edge_proxy interface to start a Hypercorn server instance serving the
     LocalstackAwsGateway.
     """
-    from localstack.aws.app import LocalstackAwsGateway
-
-    gateway = LocalstackAwsGateway(SERVICE_PLUGINS)
-
     # start serving gateway
-    server = GatewayServer(gateway, listen, use_ssl)
+    server = GatewayServer(components.gateway(), listen, use_ssl)
     server.start()
 
     # with the current way the infrastructure is started, this is the easiest way to shut down the server correctly

--- a/localstack/runtime/components.py
+++ b/localstack/runtime/components.py
@@ -1,0 +1,15 @@
+from localstack.utils.objects import singleton_factory
+
+
+@singleton_factory
+def service_manager():
+    from localstack.services.plugins import SERVICE_PLUGINS
+
+    return SERVICE_PLUGINS
+
+
+@singleton_factory
+def gateway():
+    from localstack.aws.app import LocalstackAwsGateway
+
+    return LocalstackAwsGateway(service_manager())

--- a/localstack/utils/aws/aws_stack.py
+++ b/localstack/utils/aws/aws_stack.py
@@ -354,6 +354,12 @@ def connect_to_service(
             event_system = new_client.meta.events
             event_system.register_first("before-sign.*.*", _handler)
 
+            # this make the client call the gateway directly
+            from localstack.aws.client import GatewayShortCircuit
+            from localstack.runtime import components
+
+            GatewayShortCircuit.modify_client(new_client, components.gateway())
+
         if cache:
             BOTO_CLIENTS_CACHE[cache_key] = new_client
 

--- a/tests/unit/aws/test_client.py
+++ b/tests/unit/aws/test_client.py
@@ -1,7 +1,8 @@
+import boto3
 import pytest
 
-from localstack.aws.api import ServiceException
-from localstack.aws.client import _ResponseStream, parse_service_exception
+from localstack.aws.api import RequestContext, ServiceException
+from localstack.aws.client import GatewayShortCircuit, _ResponseStream, parse_service_exception
 from localstack.http import Response
 
 
@@ -58,3 +59,57 @@ class TestResponseStream:
             assert next(stream) == b"bar"
             with pytest.raises(StopIteration):
                 next(stream)
+
+
+class TestGatewayShortCircuit:
+    def test_query_request(self):
+        class MockGateway:
+            def handle(self, context: RequestContext, response: Response):
+                assert context.operation.name == "DeleteQueue"
+                assert context.service.service_name == "sqs"
+                assert context.service_request == {
+                    "QueueUrl": "http://example.com/queue",
+                    "Action": "DeleteQueue",
+                    "Version": "2012-11-05",
+                }
+
+                response.data = b"<DeleteQueueResponse><ResponseMetadata><RequestId></RequestId></ResponseMetadata></DeleteQueueResponse>"
+                response.status_code = 200
+
+        gateway = MockGateway()
+
+        client = boto3.client("sqs")
+        GatewayShortCircuit.modify_client(client, gateway)
+
+        response = client.delete_queue(QueueUrl="http://example.com/queue")
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+    def test_query_exception(self):
+        class MockGateway:
+            def handle(self, context: RequestContext, response: Response):
+                raise ValueError("oh noes")
+
+        gateway = MockGateway()
+
+        client = boto3.client("sqs")
+        GatewayShortCircuit.modify_client(client, gateway)
+
+        # FIXME currently, exceptions in the gateway will be handed down to the client and not translated into 500
+        #  errors
+        with pytest.raises(ValueError):
+            client.list_queues()
+
+    def test_query_response(self):
+        class MockGateway:
+            def handle(self, context: RequestContext, response: Response):
+                response.data = b"<ListQueuesResponse><ListQueuesResult><QueueUrl>http://example.com/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId></RequestId></ResponseMetadata></ListQueuesResponse>"
+                response.status_code = 202
+
+        gateway = MockGateway()
+
+        client = boto3.client("sqs")
+        GatewayShortCircuit.modify_client(client, gateway)
+
+        response = client.list_queues()
+        assert response["QueueUrls"] == ["http://example.com/queue"]
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 202


### PR DESCRIPTION
This PR adds code to make calls from boto clients directly to a Gateway without an HTTP server roundtrip. This can make internal calls much faster because they don't require IO.

The mechanism used to achieve this is botocore's `before-send` event, which can be used to short-circuit the request logic by returning a response from the event handler, before the HTTP request is even made.

I did some basic refactoring to make this easier, including:
* created `localstack.runtime.components` as a place for runtime-level singleton components
* added a new method to `Gateway` with the signature `def handle(self, context: RequestContext, response: Response)`, which now makes the Gateway a drop-in replacement for a handler chain (and easier to call if you want to invoke it with a pre-existing RequestContext).

### TODO:
- [X] basic PoC implementation
- [ ] integration with the client factory and `connect_to`
- [ ] more benchmarks to see whether/where this is really useful
- [ ] more unit tests for different protocols
- [ ] documentation
