### PR TITLE
SQS - MaxNumberOfMessages check

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -597,6 +597,9 @@ SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
 # Strategy used when creating SQS queue urls. can be "off", "domain", or "path"
 SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "off"
 
+# Disable the check for MaxNumberOfMessage in SQS ReceiveMessage
+SQS_DISABLE_MAX_NUMBER_OF_MESSAGE_LIMIT = is_env_true("SQS_DISABLE_MAX_NUMBER_OF_MESSAGE_LIMIT")
+
 # host under which the LocalStack services are available from Lambda Docker containers
 HOSTNAME_FROM_LAMBDA = os.environ.get("HOSTNAME_FROM_LAMBDA", "").strip()
 

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -87,6 +87,8 @@ from localstack.utils.time import now
 
 LOG = logging.getLogger(__name__)
 
+MAX_NUMBER_OF_MESSAGES = 10
+
 
 def assert_queue_name(queue_name: str, fifo: bool = False):
     if queue_name.endswith(".fifo"):
@@ -808,6 +810,13 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
             wait_time_seconds = queue.wait_time_seconds
 
         num = max_number_of_messages or 1
+
+        if num < 1 or num > MAX_NUMBER_OF_MESSAGES:
+            raise InvalidParameterValue(
+                f"Value {num} for parameter MaxNumberOfMessages is invalid. "
+                f"Reason: Must be between 1 and 10, if provided."
+            )
+
         # backdoor to get all messages
         if num == -1:
             num = queue.visible.qsize()

--- a/tests/integration/test_sqs.snapshot.json
+++ b/tests/integration/test_sqs.snapshot.json
@@ -634,5 +634,22 @@
         }
       }
     }
+  },
+  "tests/integration/test_sqs.py::TestSqsProvider::test_send_receive_max_number_of_messages": {
+    "recorded-date": "29-12-2022, 08:55:47",
+    "recorded-content": {
+      "send_max_number_of_messages": {
+        "Error": {
+          "Code": "InvalidParameterValue",
+          "Detail": null,
+          "Message": "Value 11 for parameter MaxNumberOfMessages is invalid. Reason: Must be between 1 and 10, if provided.",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Adding a simple check for `MaxNumberOfMessages` in `ReceiveMessage`. It came up while having a look at #7397.