### PR TITLE
add SNS FilterPolicyScope MessageBody

### DIFF
--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -80,9 +80,11 @@ class SnsSubscription(TypedDict):
     SubscriptionArn: subscriptionARN
     PendingConfirmation: Literal["true", "false"]
     Owner: Optional[str]
+    SubscriptionPrincipal: Optional[str]
     FilterPolicy: Optional[str]
     FilterPolicyScope: Literal["MessageAttributes", "MessageBody"]
     RawMessageDelivery: Literal["true", "false"]
+    ConfirmationWasAuthenticated: Literal["true", "false"]
 
 
 class SnsStore(BaseStore):

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -4,7 +4,6 @@ from typing import Dict, List
 
 from botocore.utils import InvalidArnException
 from moto.sns import sns_backends
-from moto.sns.exceptions import DuplicateSnsEndpointError
 from moto.sns.models import MAXIMUM_MESSAGE_LENGTH
 from moto.sns.utils import is_e164
 
@@ -351,45 +350,22 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if not sub:
             raise NotFoundException("Subscription does not exist")
 
-        if attribute_name not in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
-            raise InvalidParameterException("Invalid parameter: AttributeName")
+        validate_subscription_attribute(
+            attribute_name=attribute_name,
+            attribute_value=attribute_value,
+            topic_arn=sub["TopicArn"],
+        )
+        try:
+            call_moto(context)
+        except CommonServiceException as e:
+            # Moto errors don't send the "Type": "Sender" field in their SNS exception
+            if e.code == "InvalidParameter":
+                raise InvalidParameterException(e.message)
+            raise
 
         if attribute_name == "FilterPolicy":
             store = self.get_store()
-            try:
-                filter_policy = json.loads(attribute_value or "{}")
-            except json.JSONDecodeError:
-                raise InvalidParameterException(
-                    "Invalid parameter: FilterPolicy: failed to parse JSON."
-                )
-            store.subscription_filter_policy[subscription_arn] = filter_policy
-            pass
-        elif attribute_name == "RawMessageDelivery":
-            # TODO: only for SQS and https(s) subs, + firehose
-            pass
-
-        elif attribute_name == "RedrivePolicy":
-            try:
-                dlq_target_arn = json.loads(attribute_value).get("deadLetterTargetArn", "")
-            except json.JSONDecodeError:
-                raise InvalidParameterException(
-                    "Invalid parameter: RedrivePolicy: failed to parse JSON."
-                )
-            try:
-                parsed_arn = parse_arn(dlq_target_arn)
-            except InvalidArnException:
-                raise InvalidParameterException(
-                    "Invalid parameter: RedrivePolicy: deadLetterTargetArn is an invalid arn"
-                )
-
-            if sub["TopicArn"].endswith(".fifo"):
-                if (
-                    not parsed_arn["resource"].endswith(".fifo")
-                    or "sqs" not in parsed_arn["service"]
-                ):
-                    raise InvalidParameterException(
-                        "Invalid parameter: RedrivePolicy: must use a FIFO queue as DLQ for a FIFO topic"
-                    )
+            store.subscription_filter_policy[subscription_arn] = json.loads(attribute_value)
 
         sub[attribute_name] = attribute_value
 
@@ -412,6 +388,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             for i in v:
                 if i["TopicArn"] == topic_arn:
                     i["PendingConfirmation"] = "false"
+                    i["ConfirmationWasAuthenticated"] = "true"
 
         return ConfirmSubscriptionResponse(SubscriptionArn=sub_arn)
 
@@ -462,7 +439,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         result = None
         try:
             result = call_moto(context)
-        except DuplicateSnsEndpointError:
+        except CommonServiceException:
             # TODO: this was unclear in the old provider, check against aws and moto
             moto_sns_backend = sns_backends[context.account_id][context.region]
             for e in moto_sns_backend.platform_endpoints.values():
@@ -515,7 +492,12 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if not sub:
             raise NotFoundException(f"Subscription with arn {subscription_arn} not found")
         # todo fix some attributes by moto see snapshot
-        return GetSubscriptionAttributesResponse(Attributes=sub)
+        removed_attrs = ["sqs_queue_url"]
+        if "FilterPolicyScope" in sub and "FilterPolicy" not in sub:
+            removed_attrs.append("FilterPolicyScope")
+
+        attributes = {k: v for k, v in sub.items() if k not in removed_attrs}
+        return GetSubscriptionAttributesResponse(Attributes=attributes)
 
     def list_subscriptions(
         self, context: RequestContext, next_token: nextToken = None
@@ -669,10 +651,15 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             raise InvalidParameterException(
                 "Invalid parameter: Invalid parameter: Endpoint Reason: Please use FIFO SQS queue"
             )
+        if attributes:
+            for attr_name, attr_value in attributes.items():
+                validate_subscription_attribute(
+                    attribute_name=attr_name, attribute_value=attr_value, topic_arn=topic_arn
+                )
 
         moto_response = call_moto(context)
         subscription_arn = moto_response.get("SubscriptionArn")
-        filter_policy = moto_response.get("FilterPolicy")
+
         store = self.get_store()
         topic_subs = store.sns_subscriptions[topic_arn] = (
             store.sns_subscriptions.get(topic_arn) or []
@@ -684,8 +671,6 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 return SubscribeResponse(
                     SubscriptionArn=existing_topic_subscription["SubscriptionArn"]
                 )
-        if filter_policy:
-            store.subscription_filter_policy[subscription_arn] = json.loads(filter_policy)
 
         subscription = {
             # http://docs.aws.amazon.com/cli/latest/reference/sns/get-subscription-attributes.html
@@ -693,11 +678,17 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             "Endpoint": endpoint,
             "Protocol": protocol,
             "SubscriptionArn": subscription_arn,
-            "FilterPolicy": filter_policy,
             "PendingConfirmation": "true",
+            "Owner": context.account_id,
+            "RawMessageDelivery": "false",  # default value, will be overriden if set
         }
         if attributes:
             subscription.update(attributes)
+            if "FilterPolicy" in attributes:
+                store.subscription_filter_policy[subscription_arn] = json.loads(
+                    attributes["FilterPolicy"]
+                )
+
         topic_subs.append(subscription)
 
         if subscription_arn not in store.subscription_status:
@@ -805,6 +796,59 @@ def _get_tags(topic_arn):
 
 def is_raw_message_delivery(susbcriber):
     return susbcriber.get("RawMessageDelivery") in ("true", True, "True")
+
+
+def validate_subscription_attribute(
+    attribute_name: str, attribute_value: str, topic_arn: str
+) -> None:
+    """
+    Validate the subscription attribute to be set.
+    See: ?????? TODO:
+    :param attribute_name: the subscription attribute name, must be in VALID_SUBSCRIPTION_ATTR_NAME
+    :param attribute_value: the subscription attribute value
+    :param topic_arn:
+    :raises InvalidParameterException
+    :return: the decoded attribute value if JSON encoded, or the string value
+    """
+    if attribute_name not in sns_constants.VALID_SUBSCRIPTION_ATTR_NAME:
+        raise InvalidParameterException("Invalid parameter: AttributeName")
+
+    if attribute_name == "FilterPolicy":
+        try:
+            json.loads(attribute_value or "{}")
+        except json.JSONDecodeError:
+            raise InvalidParameterException(
+                "Invalid parameter: FilterPolicy: failed to parse JSON."
+            )
+        # TODO: validate the FilterPolicy? currently done by moto
+    elif attribute_name == "FilterPolicyScope":
+        if attribute_value not in ("MessageAttributes", "MessageBody"):
+            raise InvalidParameterException(
+                f"Invalid parameter: FilterPolicyScope: Invalid value [{attribute_value}]. Please use either MessageBody or MessageAttributes"
+            )
+    elif attribute_name == "RawMessageDelivery":
+        # TODO: only for SQS and https(s) subs, + firehose
+        return
+
+    elif attribute_name == "RedrivePolicy":
+        try:
+            dlq_target_arn = json.loads(attribute_value).get("deadLetterTargetArn", "")
+        except json.JSONDecodeError:
+            raise InvalidParameterException(
+                "Invalid parameter: RedrivePolicy: failed to parse JSON."
+            )
+        try:
+            parsed_arn = parse_arn(dlq_target_arn)
+        except InvalidArnException:
+            raise InvalidParameterException(
+                "Invalid parameter: RedrivePolicy: deadLetterTargetArn is an invalid arn"
+            )
+
+        if topic_arn.endswith(".fifo"):
+            if not parsed_arn["resource"].endswith(".fifo") or "sqs" not in parsed_arn["service"]:
+                raise InvalidParameterException(
+                    "Invalid parameter: RedrivePolicy: must use a FIFO queue as DLQ for a FIFO topic"
+                )
 
 
 def validate_message_attributes(message_attributes: MessageAttributeMap) -> None:

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -868,8 +868,7 @@ class SubscriptionFilter:
         if not filter_policy:
             return True
 
-        for criteria in filter_policy:
-            conditions = filter_policy.get(criteria)
+        for criteria, conditions in filter_policy.items():
             attribute = message_attributes.get(criteria)
 
             if not self._evaluate_filter_policy_conditions(
@@ -878,6 +877,28 @@ class SubscriptionFilter:
                 return False
 
         return True
+
+    # def check_filter_policy_on_message_body(self, filter_policy, message_body):
+    #     if not filter_policy:
+    #         return True
+    #
+    #     try:
+    #         body = json.loads(message_body)
+    #     except json.JSONDecodeError:
+    #         # Filter policies for the message body assume that the message payload is a well-formed JSON object.
+    #         # See https://docs.aws.amazon.com/sns/latest/dg/sns-message-filtering.html
+    #         return False
+    #
+    #     for criteria in filter_policy:
+    #         conditions = filter_policy.get(criteria)
+    #         attribute = message_attributes.get(criteria)
+    #
+    #         if not self._evaluate_filter_policy_conditions(
+    #             conditions, attribute, message_attributes, criteria
+    #         ):
+    #             return False
+    #
+    #     return True
 
     def _evaluate_filter_policy_conditions(
         self, conditions, attribute, message_attributes, criteria

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -947,8 +947,8 @@ class SubscriptionFilter:
         elif (must_exist := condition.get("exists")) is not None:
             # if must_exists is True then field_exists must be True
             # if must_exists is False then fields_exists must be False
-            # we can use the XOR operator
-            return must_exist ^ field_exists
+            # we can use the XNOR operator
+            return not must_exist ^ field_exists
         elif value is None:
             # the remaining conditions require the value to not be None
             return False

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -909,7 +909,7 @@ class SubscriptionFilter:
         The value of "object" is a dict, we need to evaluate this level of the filter policy.
         We pass the nested property values (the dict) as well as the values of the payload's field to the recursive
         function, to evaluate the conditions on the same level of depth.
-        We then these parameters:
+        We now have these parameters to the function:
         filter_policy = {
             "key": [{"prefix": "auto-"}],
             "nested_key": [{"exists": False}],
@@ -933,7 +933,6 @@ class SubscriptionFilter:
             else:
                 # else, values represents the list of conditions of the filter policy
                 for condition in values:
-                    print(condition)
                     if not self._evaluate_condition(
                         payload.get(field_name), condition, field_exists=field_name in payload
                     ):
@@ -976,8 +975,7 @@ class SubscriptionFilter:
         elif (must_exist := condition.get("exists")) is not None:
             # if must_exists is True then field_exists must be True
             # if must_exists is False then fields_exists must be False
-            # we can use the XNOR operator
-            return not must_exist ^ field_exists
+            return must_exist == field_exists
         elif value is None:
             # the remaining conditions require the value to not be None
             return False

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -970,7 +970,7 @@ class SubscriptionFilter:
         return False
 
     def _evaluate_condition(self, value, condition, field_exists: bool):
-        if type(condition) is not dict:
+        if not isinstance(condition, dict):
             return value == condition
         elif (must_exist := condition.get("exists")) is not None:
             # if must_exists is True then field_exists must be True

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -709,19 +709,15 @@ def sns_allow_topic_sqs_queue(sqs_client):
 
 
 @pytest.fixture
-def sns_create_sqs_subscription(sns_client, sqs_client, sns_allow_topic_sqs_queue):
+def sns_create_sqs_subscription(sns_client, sqs_client, sns_allow_topic_sqs_queue, sqs_queue_arn):
     subscriptions = []
 
-    def _factory(topic_arn: str, queue_url: str) -> Dict[str, str]:
-        queue_arn = sqs_client.get_queue_attributes(
-            QueueUrl=queue_url, AttributeNames=["QueueArn"]
-        )["Attributes"]["QueueArn"]
+    def _factory(topic_arn: str, queue_url: str, **kwargs) -> Dict[str, str]:
+        queue_arn = sqs_queue_arn(queue_url=queue_url)
 
         # connect sns topic to sqs
         subscription = sns_client.subscribe(
-            TopicArn=topic_arn,
-            Protocol="sqs",
-            Endpoint=queue_arn,
+            TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn, **kwargs
         )
         subscription_arn = subscription["SubscriptionArn"]
 

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -188,12 +188,6 @@ class TestSNSProvider:
         snapshot.match("exception", e.value.response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-        ]
-    )
     def test_attribute_raw_subscribe(
         self,
         sqs_client,
@@ -247,13 +241,6 @@ class TestSNSProvider:
         snapshot.match("messages-response", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-            "$..Attributes.RawMessageDelivery",
-        ]
-    )
     def test_filter_policy(
         self,
         sns_client,
@@ -321,14 +308,6 @@ class TestSNSProvider:
         assert num_msgs_2 == num_msgs_1
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-            "$..Attributes.RawMessageDelivery",  # todo: fix me (not added to response if false)
-            "$..Attributes.sqs_queue_url",  # todo: fix me: added by moto? illegal?
-        ]
-    )
     def test_exists_filter_policy(
         self,
         sns_client,
@@ -453,13 +432,6 @@ class TestSNSProvider:
         assert num_msgs_4 == num_msgs_3
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-            "$..Attributes.RawMessageDelivery",
-        ]
-    )
     def test_subscribe_sqs_queue(
         self,
         sns_client,
@@ -632,13 +604,6 @@ class TestSNSProvider:
         retry(check_subscription, retries=PUBLICATION_RETRIES, sleep=PUBLICATION_TIMEOUT)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Owner",
-            "$..ConfirmationWasAuthenticated",
-            "$..RawMessageDelivery",
-        ]
-    )
     def test_sqs_topic_subscription_confirmation(
         self, sns_client, sns_create_topic, sqs_create_queue, sns_create_sqs_subscription, snapshot
     ):
@@ -801,13 +766,6 @@ class TestSNSProvider:
         assert json.loads(message["Message"])["message"] == "test_redrive_policy"
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Owner",
-            "$..ConfirmationWasAuthenticated",
-            "$..RawMessageDelivery",
-        ]
-    )
     def test_redrive_policy_lambda_subscription(
         self,
         sns_client,
@@ -1171,13 +1129,6 @@ class TestSNSProvider:
         snapshot.match("wrong-endpoint", e.value.response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-            "$..Attributes.sqs_queue_url",
-        ]
-    )
     def test_publish_sqs_from_sns(
         self,
         sns_client,
@@ -1251,12 +1202,6 @@ class TestSNSProvider:
         }
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-        ]
-    )
     def test_publish_batch_messages_from_sns_to_sqs(
         self,
         sns_client,
@@ -1365,8 +1310,6 @@ class TestSNSProvider:
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
-            "$.sub-attrs-raw-true.Attributes.Owner",
-            "$.sub-attrs-raw-true.Attributes.ConfirmationWasAuthenticated",
             "$.topic-attrs.Attributes.DeliveryPolicy",
             "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
             "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
@@ -1500,8 +1443,6 @@ class TestSNSProvider:
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
-            "$.sub-attrs-raw-true.Attributes.Owner",
-            "$.sub-attrs-raw-true.Attributes.ConfirmationWasAuthenticated",
             "$.topic-attrs.Attributes.DeliveryPolicy",
             "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
             "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
@@ -1654,12 +1595,6 @@ class TestSNSProvider:
         snapshot.match("messages-in-dlq", {"Messages": messages})
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-        ]
-    )
     def test_publish_batch_exceptions(
         self,
         sns_client,
@@ -1790,14 +1725,6 @@ class TestSNSProvider:
         snapshot.match("topic-1", topic1)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-            "$..Attributes.RawMessageDelivery",
-            "$..Subscriptions..Owner",
-        ]
-    )
     def test_not_found_error_on_set_subscription_attributes(
         self,
         sns_client,
@@ -1807,7 +1734,6 @@ class TestSNSProvider:
         sns_subscription,
         snapshot,
     ):
-
         topic_arn = sns_create_topic()["TopicArn"]
         queue_url = sqs_create_queue()
         queue_arn = sqs_queue_arn(queue_url)
@@ -2450,12 +2376,7 @@ class TestSNSProvider:
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
-            "$..Attributes.Owner",
-            "$..Attributes.ConfirmationWasAuthenticated",
-            "$..Attributes.SubscriptionPrincipal",
-            "$..Attributes.RawMessageDelivery",
-            "$..Attributes.sqs_queue_url",
-            "$..Subscriptions..Owner",
+            "$..Attributes.SubscriptionPrincipal"
         ]
     )
     def test_subscription_after_failure_to_deliver(

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1921,8 +1921,8 @@ class TestSNSProvider:
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=[
-            "$.invalid-json-redrive-policy.Error.Message",  # message contains java trace in AWS
-            "$.invalid-json-filter-policy.Error.Message",  # message contains java trace in AWS
+            "$.invalid-json-redrive-policy.Error.Message",  # message contains java trace in AWS, assert instead
+            "$.invalid-json-filter-policy.Error.Message",  # message contains java trace in AWS, assert instead
         ]
     )
     def test_validate_set_sub_attributes(
@@ -1965,6 +1965,10 @@ class TestSNSProvider:
                 AttributeValue="{invalidjson}",
             )
         snapshot.match("invalid-json-redrive-policy", e.value.response)
+        assert (
+            e.value.response["Error"]["Message"]
+            == "Invalid parameter: RedrivePolicy: failed to parse JSON."
+        )
 
         with pytest.raises(ClientError) as e:
             sns_client.set_subscription_attributes(
@@ -1973,6 +1977,10 @@ class TestSNSProvider:
                 AttributeValue="{invalidjson}",
             )
         snapshot.match("invalid-json-filter-policy", e.value.response)
+        assert (
+            e.value.response["Error"]["Message"]
+            == "Invalid parameter: FilterPolicy: failed to parse JSON."
+        )
 
     @pytest.mark.aws_validated
     def test_empty_sns_message(
@@ -3006,6 +3014,11 @@ class TestSNSProvider:
         snapshot.match("sub-attrs-after-setting-nested-policy", subscription_attrs)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$.sub-filter-policy-rule-no-list.Error.Message",  # message contains java trace in AWS, assert instead
+        ]
+    )
     def test_sub_filter_policy_nested_property_constraints(
         self,
         sns_client,
@@ -3071,6 +3084,10 @@ class TestSNSProvider:
                 AttributeValue=json.dumps(flat_filter_policy),
             )
         snapshot.match("sub-filter-policy-rule-no-list", e.value.response)
+        assert (
+            e.value.response["Error"]["Message"]
+            == 'Invalid parameter: FilterPolicy: "key_a" must be an object or an array'
+        )
 
     @pytest.mark.aws_validated
     @pytest.mark.parametrize("raw_message_delivery", [True, False])

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -3062,6 +3062,16 @@ class TestSNSProvider:
             )
         snapshot.match("sub-filter-policy-max-attr-keys", e.value.response)
 
+        flat_filter_policy = {"key_a": "value_one"}
+        # Rules should be contained in a list
+        with pytest.raises(ClientError) as e:
+            sns_client.set_subscription_attributes(
+                SubscriptionArn=subscription_arn,
+                AttributeName="FilterPolicy",
+                AttributeValue=json.dumps(flat_filter_policy),
+            )
+        snapshot.match("sub-filter-policy-rule-no-list", e.value.response)
+
     @pytest.mark.aws_validated
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
     def test_filter_policy_on_message_body(

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2860,7 +2860,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[True]": {
-    "recorded-date": "30-12-2022, 19:10:16",
+    "recorded-date": "02-01-2023, 20:03:47",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -2889,7 +2889,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[False]": {
-    "recorded-date": "30-12-2022, 19:10:28",
+    "recorded-date": "02-01-2023, 20:03:59",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2742,5 +2742,212 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_set_subscription_filter_policy_scope": {
+    "recorded-date": "30-12-2022, 18:19:59",
+    "recorded-content": {
+      "sub-attrs-default": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-attrs-filter-scope-body": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "sub-attrs-filter-scope-error": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicyScope: Invalid value [RandomValue]. Please use either MessageBody or MessageAttributes",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "sub-attrs-after-setting-policy": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "attr": [
+              "match-this"
+            ]
+          },
+          "FilterPolicyScope": "MessageBody",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_sub_filter_policy_nested_property": {
+    "recorded-date": "30-12-2022, 18:38:05",
+    "recorded-content": {
+      "sub-filter-policy-nested-error": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Filter policy scope MessageAttributes does not support nested filter policy",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "sub-attrs-after-setting-nested-policy": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "object": {
+              "key": [
+                {
+                  "prefix": "auto-"
+                }
+              ]
+            }
+          },
+          "FilterPolicyScope": "MessageBody",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[True]": {
+    "recorded-date": "30-12-2022, 19:10:16",
+    "recorded-content": {
+      "recv-init": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-passed-msg": {
+        "Messages": [
+          {
+            "Body": {
+              "object": {
+                "key": "auto-test"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:1>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[False]": {
+    "recorded-date": "30-12-2022, 19:10:28",
+    "recorded-content": {
+      "recv-init": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-passed-msg": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object\": {\"key\": \"auto-test\"}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_sub_filter_policy_nested_property_constraints": {
+    "recorded-date": "30-12-2022, 19:34:24",
+    "recorded-content": {
+      "sub-filter-policy-nested-error-too-many-combinations": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: Filter policy is too complex",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "sub-filter-policy-max-attr-keys": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: Filter policy can not have more than 5 keys",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2924,7 +2924,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_sub_filter_policy_nested_property_constraints": {
-    "recorded-date": "30-12-2022, 19:34:24",
+    "recorded-date": "04-01-2023, 17:41:42",
     "recorded-content": {
       "sub-filter-policy-nested-error-too-many-combinations": {
         "Error": {
@@ -2941,6 +2941,17 @@
         "Error": {
           "Code": "InvalidParameter",
           "Message": "Invalid parameter: FilterPolicy: Filter policy can not have more than 5 keys",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "sub-filter-policy-rule-no-list": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: FilterPolicy: \"key_a\" must be an object or an array\n at [Source: (String)\"{\"key_a\":\"value_one\"}\"; line: 1, column: 11]",
           "Type": "Sender"
         },
         "ResponseMetadata": {


### PR DESCRIPTION
AWS recently added a new feature to SNS (around end of November 22), concerning the `FilterPolicy` of subscriptions.
Previously, when filtering messages going to be fanned out to subscribers, we could only filter on `MessageAttributes`. However, this was a limitation especially between their own integrations: S3 notifications for example. You don't have a say in how the event looks, and can't add message attributes.
They introduced the `FilterPolicyScope` subscription attribute, and you can now choose between `MessageAttributes` (the default) and `MessageBody`. This will require the body to be a parsable JSON string, but you can now filter based on the message body.

You can read more with examples here:
https://aws.amazon.com/blogs/compute/introducing-payload-based-message-filtering-for-amazon-sns/

This PR needs https://github.com/localstack/moto/pull/62 to be able to run (add the `FilterPolicyScope` attribute in the validated subscriptions attributes and implements the logic to validate nested properties in the `FilterPolicy`)

This PR implements:
- all the AWS validated tests for this new feature, as well as validations tests.
- validation of parameters, a small fix for saving the filter policy at the right place (it was never returned by moto)
- the new filtering behaviour in the new `SubscriptionFilter` class. 
- small fix of returned field when listing subscriptions attributes and saving correct fields when creating the sub
- clean up the `skip_snapshot_verify` for SNS after those fixes

_fixes #7398_