### PR TITLE
wip: add support for s3 notification - ObjectAcl

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -40,6 +40,7 @@ from localstack.aws.api.s3 import (
     GetBucketRequestPaymentOutput,
     GetBucketRequestPaymentRequest,
     GetBucketWebsiteOutput,
+    GetObjectAclOutput,
     GetObjectAttributesOutput,
     GetObjectAttributesParts,
     GetObjectAttributesRequest,
@@ -62,12 +63,15 @@ from localstack.aws.api.s3 import (
     ObjectIdentifier,
     ObjectKey,
     ObjectLockToken,
+    ObjectVersionId,
     PostResponse,
     PutBucketAclRequest,
     PutBucketLifecycleConfigurationRequest,
     PutBucketLifecycleRequest,
     PutBucketRequestPaymentRequest,
     PutBucketVersioningRequest,
+    PutObjectAclOutput,
+    PutObjectAclRequest,
     PutObjectOutput,
     PutObjectRequest,
     PutObjectTaggingOutput,
@@ -647,7 +651,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: PutBucketAclRequest,
     ) -> None:
-        validate_bucket_canned_acl(request.get("ACL"))
+        validate_canned_acl(request.get("ACL"))
+        # TODO: validate -> If you use ACL, you cannot use other access control-specific headers in your request.
 
         grant_keys = [
             "GrantFullControl",
@@ -664,6 +669,61 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             validate_acl_acp(acp)
 
         call_moto(context)
+
+    def get_object_acl(
+        self,
+        context: RequestContext,
+        bucket: BucketName,
+        key: ObjectKey,
+        version_id: ObjectVersionId = None,
+        request_payer: RequestPayer = None,
+        expected_bucket_owner: AccountId = None,
+    ) -> GetObjectAclOutput:
+        response: GetObjectAclOutput = call_moto(context)
+
+        for grant in response["Grants"]:
+            grantee = grant.get("Grantee", {})
+            if grantee.get("ID") == MOTO_CANONICAL_USER_ID:
+                # adding the DisplayName used by moto for the owner
+                grantee["DisplayName"] = "webfile"
+
+        return response
+
+    @handler("PutObjectAcl", expand=False)
+    def put_object_acl(
+        self,
+        context: RequestContext,
+        request: PutObjectAclRequest,
+    ) -> PutObjectAclOutput:
+        validate_canned_acl(request.get("ACL"))
+
+        grant_keys = [
+            "GrantFullControl",
+            "GrantRead",
+            "GrantReadACP",
+            "GrantWrite",
+            "GrantWriteACP",
+        ]
+        for key in grant_keys:
+            if grantees_values := request.get(key, ""):  # noqa
+                validate_grantee_in_headers(key, grantees_values)
+
+        if acp := request.get("AccessControlPolicy"):
+            validate_acl_acp(acp)
+
+        moto_backend = get_moto_s3_backend(context)
+        key = get_key_from_moto_bucket(
+            get_bucket_from_moto(moto_backend, bucket=request["Bucket"]), key=request["Key"]
+        )
+        acl = key.acl.to_config_dict()
+
+        response: PutObjectOutput = call_moto(context)
+        new_acl = key.acl.to_config_dict()
+
+        if acl != new_acl:
+            self._notify(context)
+
+        return response
 
     @handler("PutBucketVersioning", expand=False)
     def put_bucket_versioning(
@@ -856,7 +916,7 @@ def validate_bucket_name(bucket: BucketName) -> None:
         raise ex
 
 
-def validate_bucket_canned_acl(canned_acl: str) -> None:
+def validate_canned_acl(canned_acl: str) -> None:
     """
     Validate the canned ACL value, or raise an Exception
     """

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -633,7 +633,7 @@ class TestS3:
         snapshot.match("expected_error", e.value.response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(path="$..RequestID")
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, path="$..RequestID")
     def test_delete_bucket_no_such_bucket(self, s3_client, snapshot):
         with pytest.raises(ClientError) as e:
             s3_client.delete_bucket(Bucket=f"does-not-exist-{short_uid()}")
@@ -768,7 +768,9 @@ class TestS3:
         snapshot.match("exc", e.value.response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..Error.Key", "$..Error.RequestID"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider, paths=["$..Error.Key", "$..Error.RequestID"]
+    )
     def test_range_key_not_exists(self, s3_client, s3_bucket, snapshot):
         key = "my-key"
         with pytest.raises(ClientError) as e:
@@ -928,7 +930,7 @@ class TestS3:
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..AcceptRanges"])
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
     def test_s3_copy_metadata_replace(self, s3_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
 
@@ -961,7 +963,7 @@ class TestS3:
         snapshot.match("head_object_copy", head_object)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..AcceptRanges"])
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
     def test_s3_copy_content_type_and_metadata(self, s3_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         object_key = "source-object"
@@ -1004,13 +1006,14 @@ class TestS3:
         snapshot.match("head_object_second_copy", head_object)
 
     @pytest.mark.aws_validated
-    @pytest.mark.xfail(
-        reason="wrong behaviour, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html"
+    # behaviour is wrong in Legacy, we inherit Bucket ACL
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider,
+        paths=["$..Grants..Grantee.DisplayName", "$.permission-acl-key1.Grants"],
     )
     def test_s3_multipart_upload_acls(
         self, s3_client, s3_create_bucket, s3_multipart_upload, snapshot
     ):
-        # The basis for this test is wrong - see:
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html
         # > Bucket and object permissions are independent of each other. An object does not inherit the permissions
         # > from its bucket. For example, if you create a bucket and grant write access to a user, you can't access
@@ -1783,8 +1786,7 @@ class TestS3:
         )
 
     @pytest.mark.aws_validated
-    # TODO LocalStack adds this RequestID to the error response
-    @pytest.mark.skip_snapshot_verify(paths=["$..Error.RequestID"])
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..Error.RequestID"])
     def test_precondition_failed_error(self, s3_client, s3_create_bucket, snapshot):
         bucket = f"bucket-{short_uid()}"
 
@@ -1906,7 +1908,7 @@ class TestS3:
 
     @pytest.mark.skip_offline
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..AcceptRanges"])
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
     def test_s3_lambda_integration(
         self,
         lambda_client,
@@ -2212,7 +2214,7 @@ class TestS3:
         snapshot.match("list-objects", resp)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..AcceptRanges"])
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..AcceptRanges"])
     def test_upload_big_file(self, s3_client, s3_create_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         bucket_name = f"bucket-{short_uid()}"
@@ -2991,7 +2993,9 @@ class TestS3PresignedUrl:
         assert response.headers.get("content-length") == str(len(body))
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(paths=["$..Expires", "$..AcceptRanges"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider, paths=["$..Expires", "$..AcceptRanges"]
+    )
     def test_put_url_metadata(self, s3_client, s3_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         # Object metadata should be passed as query params via presigned URL

--- a/tests/integration/s3/test_s3_notifications_eventbridge.py
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.py
@@ -8,6 +8,89 @@ from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
 
 
+@pytest.fixture
+def basic_event_bridge_rule_to_sqs_queue(
+    s3_client,
+    s3_create_bucket,
+    events_create_rule,
+    sqs_create_queue,
+    sqs_queue_arn,
+    sqs_client,
+    events_client,
+):
+    bus_name = "default"
+    queue_name = f"test-queue-{short_uid()}"
+    bucket_name = f"test-bucket-{short_uid()}"
+    rule_name = f"test-rule-{short_uid()}"
+    target_id = f"test-target-{short_uid()}"
+
+    s3_create_bucket(Bucket=bucket_name)
+    s3_client.put_bucket_notification_configuration(
+        Bucket=bucket_name, NotificationConfiguration={"EventBridgeConfiguration": {}}
+    )
+
+    pattern = {
+        "source": ["aws.s3"],
+        "detail-type": [
+            "Object Created",
+            "Object Deleted",
+            "Object Restore Initiated",
+            "Object Restore Completed",
+            "Object Restore Expired",
+            "Object Tags Added",
+            "Object Tags Deleted",
+            "Object ACL Updated",
+            "Object Storage Class Changed",
+            "Object Access Tier Changed",
+        ],
+        "detail": {"bucket": {"name": [bucket_name]}},
+    }
+    rule_arn = events_create_rule(Name=rule_name, EventBusName=bus_name, EventPattern=pattern)
+
+    queue_url = sqs_create_queue(QueueName=queue_name)
+    queue_arn = sqs_queue_arn(queue_url)
+    queue_policy = {
+        "Statement": [
+            {
+                "Sid": "EventsToMyQueue",
+                "Effect": "Allow",
+                "Principal": {"Service": "events.amazonaws.com"},
+                "Action": "sqs:SendMessage",
+                "Resource": queue_arn,
+                "Condition": {"ArnEquals": {"aws:SourceArn": rule_arn}},
+            }
+        ]
+    }
+    sqs_client.set_queue_attributes(
+        QueueUrl=queue_url,
+        Attributes={"Policy": json.dumps(queue_policy), "ReceiveMessageWaitTimeSeconds": "5"},
+    )
+    events_client.put_targets(Rule=rule_name, Targets=[{"Id": target_id, "Arn": queue_arn}])
+
+    return bucket_name, queue_url
+
+
+@pytest.fixture(autouse=True)
+def s3_event_bridge_notification(snapshot):
+    snapshot.add_transformer(snapshot.transform.s3_api())
+    snapshot.add_transformers_list(
+        [
+            snapshot.transform.jsonpath("$..detail.bucket.name", "bucket-name"),
+            snapshot.transform.jsonpath("$..detail.object.key", "key-name"),
+            snapshot.transform.jsonpath(
+                "$..detail.object.sequencer", "object-sequencer", reference_replacement=False
+            ),
+            snapshot.transform.jsonpath(
+                "$..detail.request-id", "request-id", reference_replacement=False
+            ),
+            snapshot.transform.jsonpath(
+                "$..detail.requester", "<requester>", reference_replacement=False
+            ),
+            snapshot.transform.jsonpath("$..detail.source-ip-address", "ip-address"),
+        ]
+    )
+
+
 class TestS3NotificationsToEventBridge:
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
@@ -16,87 +99,17 @@ class TestS3NotificationsToEventBridge:
     def test_object_created_put(
         self,
         s3_client,
-        s3_create_bucket,
         sqs_client,
-        sqs_create_queue,
-        sqs_queue_arn,
-        events_client,
-        events_create_rule,
+        basic_event_bridge_rule_to_sqs_queue,
         snapshot,
     ):
-
-        bus_name = "default"
-        queue_name = f"test-queue-{short_uid()}"
-        bucket_name = f"test-bucket-{short_uid()}"
-        rule_name = f"test-rule-{short_uid()}"
-        target_id = f"test-target-{short_uid()}"
-
-        s3_create_bucket(Bucket=bucket_name)
-        s3_client.put_bucket_notification_configuration(
-            Bucket=bucket_name, NotificationConfiguration={"EventBridgeConfiguration": {}}
-        )
-
-        pattern = {
-            "source": ["aws.s3"],
-            "detail-type": [
-                "Object Created",
-                "Object Deleted",
-                "Object Restore Initiated",
-                "Object Restore Completed",
-                "Object Restore Expired",
-                "Object Tags Added",
-                "Object Tags Deleted",
-                "Object ACL Updated",
-                "Object Storage Class Changed",
-                "Object Access Tier Changed",
-            ],
-            "detail": {"bucket": {"name": [bucket_name]}},
-        }
-        rule_arn = events_create_rule(Name=rule_name, EventBusName=bus_name, EventPattern=pattern)
-
-        queue_url = sqs_create_queue(QueueName=queue_name)
-        queue_arn = sqs_queue_arn(queue_url)
-        queue_policy = {
-            "Statement": [
-                {
-                    "Sid": "EventsToMyQueue",
-                    "Effect": "Allow",
-                    "Principal": {"Service": "events.amazonaws.com"},
-                    "Action": "sqs:SendMessage",
-                    "Resource": queue_arn,
-                    "Condition": {"ArnEquals": {"aws:SourceArn": rule_arn}},
-                }
-            ]
-        }
-        sqs_client.set_queue_attributes(
-            QueueUrl=queue_url,
-            Attributes={"Policy": json.dumps(queue_policy), "ReceiveMessageWaitTimeSeconds": "5"},
-        )
-        events_client.put_targets(Rule=rule_name, Targets=[{"Id": target_id, "Arn": queue_arn}])
+        bucket_name, queue_url = basic_event_bridge_rule_to_sqs_queue
 
         test_key = "test-key"
         s3_client.put_object(Bucket=bucket_name, Key=test_key, Body=b"data")
         s3_client.delete_object(Bucket=bucket_name, Key=test_key)
 
         messages = {}
-
-        snapshot.add_transformer(snapshot.transform.s3_api())
-        snapshot.add_transformers_list(
-            [
-                snapshot.transform.jsonpath("$..detail.bucket.name", "bucket-name"),
-                snapshot.transform.jsonpath("$..detail.object.key", "key-name"),
-                snapshot.transform.jsonpath(
-                    "$..detail.object.sequencer", "object-sequencer", reference_replacement=False
-                ),
-                snapshot.transform.jsonpath(
-                    "$..detail.request-id", "request-id", reference_replacement=False
-                ),
-                snapshot.transform.jsonpath(
-                    "$..detail.requester", "<requester>", reference_replacement=False
-                ),
-                snapshot.transform.jsonpath("$..detail.source-ip-address", "ip-address"),
-            ]
-        )
 
         def _receive_messages():
             received = sqs_client.receive_message(QueueUrl=queue_url).get("Messages", [])
@@ -111,3 +124,65 @@ class TestS3NotificationsToEventBridge:
 
         snapshot.match("object_deleted", messages.get("Object Deleted"))
         snapshot.match("object_created", messages.get("Object Created"))
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="not implemented")
+    def test_object_put_acl(
+        self,
+        s3_client,
+        sqs_client,
+        basic_event_bridge_rule_to_sqs_queue,
+        snapshot,
+    ):
+
+        # setup fixture
+        bucket_name, queue_url = basic_event_bridge_rule_to_sqs_queue
+        key_name = "my_key_acl"
+
+        s3_client.put_object(Bucket=bucket_name, Key=key_name, Body="something")
+        list_bucket_output = s3_client.list_buckets()
+        owner = list_bucket_output["Owner"]
+
+        # change the ACL to the default one, it should not send an Event. Use canned ACL first
+        s3_client.put_object_acl(Bucket=bucket_name, Key=key_name, ACL="private")
+        # change the ACL, it should not send an Event. Use canned ACL first
+        s3_client.put_object_acl(Bucket=bucket_name, Key=key_name, ACL="public-read")
+        # try changing ACL with Grant
+        s3_client.put_object_acl(
+            Bucket=bucket_name,
+            Key=key_name,
+            GrantRead='uri="http://acs.amazonaws.com/groups/s3/LogDelivery"',
+        )
+        # try changing ACL with ACP
+        acp = {
+            "Owner": owner,
+            "Grants": [
+                {
+                    "Grantee": {"ID": owner["ID"], "Type": "CanonicalUser"},
+                    "Permission": "FULL_CONTROL",
+                },
+                {
+                    "Grantee": {
+                        "URI": "http://acs.amazonaws.com/groups/s3/LogDelivery",
+                        "Type": "Group",
+                    },
+                    "Permission": "WRITE",
+                },
+            ],
+        }
+        s3_client.put_object_acl(Bucket=bucket_name, Key=key_name, AccessControlPolicy=acp)
+
+        messages = []
+
+        def _receive_messages():
+            received = sqs_client.receive_message(QueueUrl=queue_url).get("Messages", [])
+            for msg in received:
+                event_message = json.loads(msg["Body"])
+                messages.append(event_message)
+
+            assert len(messages) == 4
+
+        retries = 10 if is_aws_cloud() else 5
+        retry(_receive_messages, retries=retries, sleep=0.1)
+        messages.sort(key=lambda x: x["time"])
+        snapshot.match("messages", {"messages": messages})

--- a/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_created_put": {
-    "recorded-date": "20-09-2022, 13:06:06",
+    "recorded-date": "31-12-2022, 00:54:03",
     "recorded-content": {
       "object_deleted": {
         "account": "111111111111",
@@ -56,6 +56,118 @@
         "source": "aws.s3",
         "time": "date",
         "version": "0"
+      }
+    }
+  },
+  "tests/integration/s3/test_s3_notifications_eventbridge.py::TestS3NotificationsToEventBridge::test_object_put_acl": {
+    "recorded-date": "31-12-2022, 00:41:34",
+    "recorded-content": {
+      "messages": {
+        "messages": [
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "<key-name:1>",
+                "sequencer": "object-sequencer",
+                "size": 9
+              },
+              "reason": "PutObject",
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "version": "0"
+            },
+            "detail-type": "Object Created",
+            "id": "<uuid:1>",
+            "region": "<region>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          },
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "<key-name:1>"
+              },
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "version": "0"
+            },
+            "detail-type": "Object ACL Updated",
+            "id": "<uuid:2>",
+            "region": "<region>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          },
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "<key-name:1>"
+              },
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "version": "0"
+            },
+            "detail-type": "Object ACL Updated",
+            "id": "<uuid:3>",
+            "region": "<region>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          },
+          {
+            "account": "111111111111",
+            "detail": {
+              "bucket": {
+                "name": "<bucket-name:1>"
+              },
+              "object": {
+                "etag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "<key-name:1>"
+              },
+              "request-id": "request-id",
+              "requester": "<requester>",
+              "source-ip-address": "<ip-address:1>",
+              "version": "0"
+            },
+            "detail-type": "Object ACL Updated",
+            "id": "<uuid:4>",
+            "region": "<region>",
+            "resources": [
+              "arn:aws:s3:::<bucket-name:1>"
+            ],
+            "source": "aws.s3",
+            "time": "date",
+            "version": "0"
+          }
+        ]
       }
     }
   }

--- a/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
+++ b/tests/integration/s3/test_s3_notifications_sqs.snapshot.json
@@ -843,5 +843,110 @@
         ]
       }
     }
+  },
+  "tests/integration/s3/test_s3_notifications_sqs.py::TestS3NotificationsToSQS::test_object_put_acl": {
+    "recorded-date": "30-12-2022, 23:14:21",
+    "recorded-content": {
+      "receive_messages": {
+        "messages": [
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectAcl:Put",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.3",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "my_key_acl"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          },
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectAcl:Put",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.3",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "my_key_acl"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          },
+          {
+            "awsRegion": "<region>",
+            "eventName": "ObjectAcl:Put",
+            "eventSource": "aws:s3",
+            "eventTime": "date",
+            "eventVersion": "2.3",
+            "requestParameters": {
+              "sourceIPAddress": "<ip-address:1>"
+            },
+            "responseElements": {
+              "x-amz-id-2": "amz-id",
+              "x-amz-request-id": "amz-request-id"
+            },
+            "s3": {
+              "bucket": {
+                "arn": "arn:aws:s3:::<resource:1>",
+                "name": "<resource:1>",
+                "ownerIdentity": {
+                  "principalId": "<principal-id:1>"
+                }
+              },
+              "configurationId": "<config-id:1>",
+              "object": {
+                "eTag": "437b930db84b8079c2dd804a71936b5f",
+                "key": "my_key_acl"
+              },
+              "s3SchemaVersion": "1.0"
+            },
+            "userIdentity": {
+              "principalId": "<principal-id:2>"
+            }
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
WIP, will depend on https://github.com/localstack/moto/pull/63 before being able to successfully run.

This PR implements `ObjectAcl` for S3 notifications, and I've added some ACL validation for Object, clean up some `skip_snapshot_verify`, remove an `xfail` thanks to the moto PR above.  