### PR TITLE
add HTTP connection reuse for analytics client

### DIFF
--- a/localstack/utils/analytics/client.py
+++ b/localstack/utils/analytics/client.py
@@ -38,6 +38,10 @@ class AnalyticsClient:
         self.endpoint_events = self.api + "/events"
 
         self.localstack_session_id = get_session_id()
+        self.session = requests.Session()
+
+    def close(self):
+        self.session.close()
 
     def start_session(self, metadata: ClientMetadata) -> SessionResponse:
         # FIXME: re-using Event as request object this way is kind of a hack
@@ -45,7 +49,7 @@ class AnalyticsClient:
             "session", EventMetadata(self.localstack_session_id, str(now())), payload=metadata
         )
 
-        response = requests.post(
+        response = self.session.post(
             self.endpoint_session,
             headers=self._create_headers(),
             json=request.asdict(),
@@ -81,7 +85,7 @@ class AnalyticsClient:
             LOG.debug("posting to %s events %s", endpoint, docs)
 
         # FIXME: fault tolerance/timeouts
-        response = requests.post(
+        response = self.session.post(
             endpoint, json={"events": docs}, headers=headers, proxies=get_proxies()
         )
 

--- a/localstack/utils/analytics/publisher.py
+++ b/localstack/utils/analytics/publisher.py
@@ -24,6 +24,9 @@ class Publisher(abc.ABC):
     def publish(self, events: List[Event]):
         raise NotImplementedError
 
+    def close(self):
+        pass
+
 
 class AnalyticsClientPublisher(Publisher):
     client: AnalyticsClient
@@ -34,6 +37,9 @@ class AnalyticsClientPublisher(Publisher):
 
     def publish(self, events: List[Event]):
         self.client.append_events(events)
+
+    def close(self):
+        self.client.close()
 
 
 class Printer(Publisher):
@@ -139,6 +145,7 @@ class PublisherBuffer(EventHandler):
         finally:
             self._stopped.set()
             flush_scheduler.stop()
+            self._publisher.close()
             if config.DEBUG_ANALYTICS:
                 LOG.debug("Exit analytics publisher")
 


### PR DESCRIPTION
This PR adds code to correctly reuse HTTP connections in the analytics client when possible.

Previously, every analytics event would create a new HTTP connection, leading to an excessive amount of new connections on the analytics endpoint. [`requests.Session` does keep-alive by default](https://requests.readthedocs.io/en/latest/user/advanced/?highlight=keep%20alive#keep-alive), so simply using the session object is enough to enable client-side keep alive. The default flush interval of the analytics client is 10 seconds, and it looks like connections are kept this long (or longer) by ELB.

I checked by setting the `urllib3` log level to DEBUG, and observed that fewer connections are created when sending analytics events. Here's what to look for in the log:

```
2022-12-31T01:53:20.000 DEBUG --- [-functhread1] urllib3.connectionpool     : Starting new HTTPS connection (1): analytics.localstack.cloud:443
```

or 
```
2022-12-31T02:01:55.188 DEBUG --- [-functhread9] urllib3.connectionpool     : Resetting dropped connection: analytics.localstack.cloud
```