### PR TITLE
fix: messages are sent out of order in SNS fifo topics -> SQS fifo queues

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -573,8 +573,8 @@ class FifoQueue(SqsQueue):
 
         # Check if we have information about when this message was sent so we can keep it in order
         # when putting it back into the queue
-        if 'Attributes' in message and 'SentTimestamp' in message['Attributes']:
-            message_timestamp = message['Attributes']['SentTimestamp']
+        if "Attributes" in message and "SentTimestamp" in message["Attributes"]:
+            message_timestamp = message["Attributes"]["SentTimestamp"]
 
         fifo_message = SqsMessage(
             message_timestamp,

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -569,8 +569,15 @@ class FifoQueue(SqsQueue):
                 "explicitly "
             )
 
+        message_timestamp = time.time()
+
+        # Check if we have information about when this message was sent so we can keep it in order
+        # when putting it back into the queue
+        if 'Attributes' in message and 'SentTimestamp' in message['Attributes']:
+            message_timestamp = message['Attributes']['SentTimestamp']
+
         fifo_message = SqsMessage(
-            time.time(),
+            message_timestamp,
             message,
             message_deduplication_id=dedup_id,
             message_group_id=message_group_id,


### PR DESCRIPTION
This PR fixes an issue when setting up FIFO SNS topics that publish messages to FIFO SQS queues.

**Issue description**
The issue is that when publishing to FIFO SNS topics sending messages to it's subscribers was an async operation, meaning that if multiple messages were sent in short succession, SQS would receive these messages out of order.
In addition, SQS treated the time the messages were received as the ordering method for the messages. In the case that a message was received by SNS, we can use the `SentTimestamp` as the correct ordering method instead of the time received to better ensure correct ordering in FIFO queues.

**The downside to this PR:**
Seems like localstack SNS publishing is pretty slow, when you have multiple subscribers from the FIFO SNS topic, publishing may take a couple of seconds, slowing down FIFO SNS topics.

**Better solution might be:**
Keep a priority queue or a mutex in FIFO SNS topics and send messages in a thread according to the queue/mutex, while releasing the client to move on. There will still be a delay for the messages to arrive in the SQS queue but at least it will not be client blocking, but it might push the issue to the client's end requiring it to handle the delay (?)
See this alternate solution using mutex locks here - https://github.com/amitassaraf/localstack/commit/3cebf501cd9d61ec76f9df6a0630ddfb99ebe33f 

**Summary**
At Landa, the company I work at, we currently swallow this delay in order to ensure the correct ordering of the messages. For your consideration whether localstack needs this change or not.

In addition, I saw that there is an SNS refactor PR that is open that might conflict with this fix, https://github.com/localstack/localstack/pull/7267 