### PR TITLE
Add support for CloudFormation update-termination-protection

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -184,7 +184,7 @@ def check_not_found_exception(e, resource_type, resource, resource_status=None):
     markers_hit = [m for m in markers if m in str(e)]
     if not markers_hit:
         LOG.warning(
-            "Unexpected error retrieving details for resource type %s: Exception: %s - %s - status: %s",
+            "Unexpected error processing resource type %s: Exception: %s - %s - status: %s",
             resource_type,
             str(e),
             resource,

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -29,6 +29,7 @@ from localstack.aws.api.cloudformation import (
     DescribeStackSetOutput,
     DescribeStacksOutput,
     DisableRollback,
+    EnableTerminationProtection,
     ExecuteChangeSetOutput,
     ExecutionStatus,
     ExportName,
@@ -60,6 +61,7 @@ from localstack.aws.api.cloudformation import (
     UpdateStackOutput,
     UpdateStackSetInput,
     UpdateStackSetOutput,
+    UpdateTerminationProtectionOutput,
     ValidateTemplateInput,
     ValidateTemplateOutput,
 )
@@ -307,6 +309,18 @@ class CloudformationProvider(CloudformationApi):
         # these do not appear in the output
         result.pop("Capabilities", None)
         return result
+
+    def update_termination_protection(
+        self,
+        context: RequestContext,
+        enable_termination_protection: EnableTerminationProtection,
+        stack_name: StackNameOrId,
+    ) -> UpdateTerminationProtectionOutput:
+        stack = find_stack(stack_name)
+        if not stack:
+            raise ValidationError(f"Stack '{stack_name}' does not exist.")
+        stack.metadata["EnableTerminationProtection"] = enable_termination_protection
+        return UpdateTerminationProtectionOutput(StackId=stack.stack_id)
 
     @handler("CreateChangeSet", expand=False)
     def create_change_set(

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -488,5 +488,80 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/api/test_stacks.py::test_update_termination_protection": {
+    "recorded-date": "04-01-2023, 16:23:22",
+    "recorded-content": {
+      "describe-stack-1": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": true,
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Parameters": [
+              {
+                "ParameterKey": "ApiName",
+                "ParameterValue": "<parameter-value:1>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-stack-2": {
+        "Stacks": [
+          {
+            "Capabilities": [
+              "CAPABILITY_AUTO_EXPAND",
+              "CAPABILITY_IAM",
+              "CAPABILITY_NAMED_IAM"
+            ],
+            "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+            "CreationTime": "datetime",
+            "DisableRollback": false,
+            "DriftInformation": {
+              "StackDriftStatus": "NOT_CHECKED"
+            },
+            "EnableTerminationProtection": false,
+            "LastUpdatedTime": "datetime",
+            "NotificationARNs": [],
+            "Parameters": [
+              {
+                "ParameterKey": "ApiName",
+                "ParameterValue": "<parameter-value:1>"
+              }
+            ],
+            "RollbackConfiguration": {},
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+            "StackName": "<stack-name:1>",
+            "StackStatus": "CREATE_COMPLETE",
+            "Tags": []
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Add support for the CloudFormation `update-termination-protection` API (this is a requirement that has come up recently with a CDK stack that relies on this functionality). The PR also adds a simple snapshot test.