### PR TITLE
fix ASF S3 issue when host header has subdomains

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -31,7 +31,7 @@ from localstack.services.s3.utils import (
     S3_VIRTUAL_HOST_FORWARDED_HEADER,
     _create_invalid_argument_exc,
     capitalize_header_name_from_snake_case,
-    uses_host_addressing,
+    forwarded_from_virtual_host_addressed_request,
 )
 from localstack.utils.strings import to_bytes
 
@@ -534,7 +534,7 @@ class S3SigV4SignatureContext:
         self.signed_headers = sig_headers
         self.request_query_string = qs
 
-        if uses_host_addressing(self._headers):
+        if forwarded_from_virtual_host_addressed_request(self._headers):
             netloc = self._headers.get(S3_VIRTUAL_HOST_FORWARDED_HEADER)
             self.host = netloc
             self._original_host = netloc

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1146,6 +1146,22 @@ def apply_moto_patches():
         """
         return get_safe(self.querystring, "$.x-id.0") == "DeleteObjects" or fn(self)
 
+    @patch(moto_s3_responses.S3ResponseInstance.parse_bucket_name_from_url, pass_target=False)
+    def parse_bucket_name_from_url(self, request, url):
+        """
+        Requests going to moto will never be subdomain based, as they passed through the VirtualHost forwarder.
+        We know the bucket is in the path, we can directly return it.
+        """
+        path = urlparse(url).path
+        return path.split("/")[1]
+
+    @patch(moto_s3_responses.S3ResponseInstance.subdomain_based_buckets, pass_target=False)
+    def subdomain_based_buckets(self, request):
+        """
+        Requests going to moto will never be subdomain based, as they passed through the VirtualHost forwarder
+        """
+        return False
+
 
 def register_custom_handlers():
     serve_custom_service_request_handlers.append(s3_presigned_url_request_handler)

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -147,7 +147,7 @@ def is_valid_canonical_id(canonical_id: str) -> bool:
         return False
 
 
-def uses_host_addressing(headers: Dict[str, str]) -> bool:
+def forwarded_from_virtual_host_addressed_request(headers: Dict[str, str]) -> bool:
     """
     Determines if the request was forwarded from a v-host addressing style into a path one
     """

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -22,6 +22,7 @@ import requests
 import xmltodict
 from boto3.s3.transfer import KB, TransferConfig
 from botocore import UNSIGNED
+from botocore.auth import SigV4Auth
 from botocore.client import Config
 from botocore.exceptions import ClientError
 
@@ -777,7 +778,7 @@ class TestS3:
         snapshot.match("exc", e.value.response)
 
     @pytest.mark.aws_validated
-    def test_create_bucket_via_host_name(self, s3_vhost_client):
+    def test_create_bucket_via_host_name(self, s3_vhost_client, s3_client):
         # TODO check redirection (happens in AWS because of region name), should it happen in LS?
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility
         bucket_name = f"test-{short_uid()}"
@@ -1903,6 +1904,25 @@ class TestS3:
         response = requests.get(download_url)
         assert response.status_code == 200
         assert to_str(response.content) == content
+
+    @pytest.mark.only_localstack
+    def test_s3_hostname_with_subdomain(self, aws_http_client_factory):
+        """
+        This particular test validates the fix for localstack#7424
+        Moto would still validate with the `host` header if buckets where subdomain based even though in the new ASF
+        provider, every request was forwarded by the VirtualHost proxy.
+        """
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+        endpoint_url = _endpoint_url()
+        # this will represent a ListBuckets call, calling the base endpoint
+        resp = s3_http_client.get(endpoint_url)
+        assert resp.ok
+        assert b"<Bucket" in resp.content
+
+        # the same ListBuckets call, but with subdomain based `host` header
+        resp = s3_http_client.get(endpoint_url, headers={"host": "aws.test.local"})
+        assert resp.ok
+        assert b"<Bucket" in resp.content
 
     @pytest.mark.skip_offline
     @pytest.mark.aws_validated

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -778,7 +778,7 @@ class TestS3:
         snapshot.match("exc", e.value.response)
 
     @pytest.mark.aws_validated
-    def test_create_bucket_via_host_name(self, s3_vhost_client, s3_client):
+    def test_create_bucket_via_host_name(self, s3_vhost_client):
         # TODO check redirection (happens in AWS because of region name), should it happen in LS?
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility
         bucket_name = f"test-{short_uid()}"
@@ -1916,6 +1916,7 @@ class TestS3:
         endpoint_url = _endpoint_url()
         # this will represent a ListBuckets call, calling the base endpoint
         resp = s3_http_client.get(endpoint_url)
+        assert resp.ok
         assert resp.ok
         assert b"<Bucket" in resp.content
 

--- a/tests/unit/test_s3.py
+++ b/tests/unit/test_s3.py
@@ -480,7 +480,7 @@ class TestS3UtilsAsf:
     # region is optional in localstack
     # the requested has been forwarded by the router, and S3_VIRTUAL_HOST_FORWARDED_HEADER has been added with the
     # original host header
-    def test_uses_host_address(self):
+    def test_forwarded_from_virtual_host_addressed_request(self):
         host_header = s3_utils_asf.S3_VIRTUAL_HOST_FORWARDED_HEADER
         addresses = [
             ({host_header: f"https://aws.{LOCALHOST}:4566"}, False),
@@ -511,7 +511,10 @@ class TestS3UtilsAsf:
             ({host_header: "s3.eu-west-1.amazonaws.com"}, False),
         ]
         for headers, expected_result in addresses:
-            assert s3_utils_asf.uses_host_addressing(headers) == expected_result
+            assert (
+                s3_utils_asf.forwarded_from_virtual_host_addressed_request(headers)
+                == expected_result
+            )
 
     def test_is_valid_canonical_id(self):
         canonical_ids = [


### PR DESCRIPTION
This PR fixes #7424 
The issue stems from the fact that the host header contains subdomains, which moto mistakes for a virtual host addressed request. 
Some patches were skipped while migrating S3 to ASF.
Thanks for the `S3VirtualHostProxyHandler`, those patches are now greatly simplified as we know for sure that requests forwarded to moto are path addressed in 100% of cases. And if they don't pass through, ASF could not parse them anyway. 

I've created a small test case which would fail before the fix. 