### PR TITLE
Avoid DynamoDB "Unknown table" error in BatchItemWriter after LocalStack restart

### DIFF
--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -78,11 +78,11 @@ class SchemaExtractor:
         table_def = table_definitions.get(table_name)
         if not table_def:
             # Try fetching from the backend in case table_definitions has been reset
-            schema = cls.get_table_schema(table_name=table_name, account_id=account_id, region_name=region_name)
+            schema = cls.get_table_schema(
+                table_name=table_name, account_id=account_id, region_name=region_name
+            )
             if not schema:
-                raise ResourceNotFoundException(
-                    f"Unknown table: {table_name} not found"
-                )
+                raise ResourceNotFoundException(f"Unknown table: {table_name} not found")
             # Save the schema in the cache
             table_definitions[table_name] = schema["Table"]
             table_def = table_definitions[table_name]

--- a/localstack/services/dynamodb/utils.py
+++ b/localstack/services/dynamodb/utils.py
@@ -77,9 +77,15 @@ class SchemaExtractor:
         ).table_definitions
         table_def = table_definitions.get(table_name)
         if not table_def:
-            raise ResourceNotFoundException(
-                f"Unknown table: {table_name} not found in {table_definitions.keys()}"
-            )
+            # Try fetching from the backend in case table_definitions has been reset
+            schema = cls.get_table_schema(table_name=table_name, account_id=account_id, region_name=region_name)
+            if not schema:
+                raise ResourceNotFoundException(
+                    f"Unknown table: {table_name} not found"
+                )
+            # Save the schema in the cache
+            table_definitions[table_name] = schema["Table"]
+            table_def = table_definitions[table_name]
         return table_def["KeySchema"]
 
     @classmethod


### PR DESCRIPTION
Added a fallback to dynamodb get_key_schema() when the KeySchema information is not present in the Memory Store.

The `table_definition` object that is being used in memory is only filled in by the `create_table` and `update_table`, meaning that when LocalStack restarts, the object are not re-populated. This function will then always fail without this fallback.

Alternatively, this could be a part of the start up by querying all the tables on start up and populate the `table_definitions` dictionary, although I haven't had the time to figure out exactly where that logic would fit.

This PR aims to overcome the latest reports in https://github.com/localstack/localstack/issues/7118.

