### PR TITLE
bump moto-ext to 4.0.12.post3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ runtime =
     jsonpatch>=1.24,<2.0
     jsonpath-rw>=1.4.0,<2.0.0
     localstack-ext[runtime]>=1.3.2.dev,<1.4
-    moto-ext[all]==4.0.12.post2
+    moto-ext[all]==4.0.12.post3
     opensearch-py==1.1.0
     pproxy>=2.7.0
     pymongo>=4.2.0


### PR DESCRIPTION
This new post release of Moto-ext contains 2 fix/features:
- https://github.com/localstack/moto/pull/62
- https://github.com/localstack/moto/pull/63

Allowing those 2 LocalStack PR to build on top:
- https://github.com/localstack/localstack/pull/7408
- https://github.com/localstack/localstack/pull/7409

Which will fix 2 bugs/feature requests. 

Note: I'll cherry pick this commit in the 2 PR to try running the CI pipeline, to check if everything is good. 