### PR TITLE
add support for CFn IAM::AccessKey update

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -55,6 +55,7 @@ UPDATEABLE_RESOURCES = [
     "AWS::SSM::Parameter",
     "AWS::StepFunctions::StateMachine",
     "AWS::IAM::Role",
+    "AWS::IAM::AccessKey",
     "AWS::EC2::Instance",
 ]
 

--- a/localstack/services/cloudformation/models/iam.py
+++ b/localstack/services/cloudformation/models/iam.py
@@ -204,9 +204,12 @@ class IAMAccessKey(GenericBaseModel):
         # if the serial value is increased, the key must be rotated
         # also if the username is different probably we should have another key
         if new_serial > old_serial or new_user_name != old_user_name:
-            access_key_id = client.create_access_key(UserName=new_user_name,)[
-                "AccessKey"
-            ]["AccessKeyId"]
+            new_access_key_id = client.create_access_key(UserName=new_user_name)["AccessKey"][
+                "AccessKeyId"
+            ]
+
+            client.delete_access_key(UserName=old_user_name, AccessKeyId=access_key_id)
+            access_key_id = new_access_key_id
 
             self.physical_resource_id = access_key_id
             resources[self.resource_id] = access_key_id

--- a/tests/integration/cloudformation/resources/test_iam.py
+++ b/tests/integration/cloudformation/resources/test_iam.py
@@ -136,40 +136,10 @@ def test_iam_user_access_key(deploy_cfn_template, cfn_client, iam_client, snapsh
         template_path=os.path.join(
             os.path.dirname(__file__), "../../templates/iam_access_key.yaml"
         ),
-        parameters={"UserName": user_name, "Status": "Inactive"},
+        parameters={"UserName": user_name, "Status": "Inactive", "Serial": "2"},
     )
     keys = iam_client.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
     snapshot.match("access_key_updated", keys[0])
-
-    # UPDATE_COMPLETE_CLEANUP_IN_PROGRESS can prevent the next update so it's better to make sure the update is complete
-    cfn_client.get_waiter("stack_update_complete").wait(StackName=stack.stack_name)
-
-    # Update Serial
-    deploy_cfn_template(
-        stack_name=stack.stack_name,
-        is_update=True,
-        template_path=os.path.join(
-            os.path.dirname(__file__), "../../templates/iam_access_key.yaml"
-        ),
-        parameters={"UserName": user_name, "Status": "Inactive", "Serial": "2"},
-    )
-    keys = iam_client.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
-    snapshot.match("access_key_serial_updated", keys[0])
-
-    cfn_client.get_waiter("stack_update_complete").wait(StackName=stack.stack_name)
-
-    # Update User
-    user_name = f"{user_name}-updated"
-    deploy_cfn_template(
-        stack_name=stack.stack_name,
-        is_update=True,
-        template_path=os.path.join(
-            os.path.dirname(__file__), "../../templates/iam_access_key.yaml"
-        ),
-        parameters={"UserName": user_name, "Status": "Inactive", "Serial": "2"},
-    )
-    keys = iam_client.list_access_keys(UserName=user_name)["AccessKeyMetadata"]
-    snapshot.match("access_key_user_updated", keys[0])
 
 
 @pytest.mark.aws_validated

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -1,54 +1,6 @@
 {
-  "tests/integration/cloudformation/resources/test_iam.py::test_iam_username_defaultname": {
-    "recorded-date": "31-05-2022, 11:29:45",
-    "recorded-content": {
-      "get_iam_user": {
-        "User": {
-          "Path": "/",
-          "UserName": "<user-name:1>",
-          "UserId": "<user-id:1>",
-          "Arn": "arn:aws:iam::111111111111:user/<user-name:1>",
-          "CreateDate": "datetime"
-        },
-        "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
-        }
-      }
-    }
-  },
-  "tests/integration/cloudformation/resources/test_iam.py::test_managed_policy_with_empty_resource": {
-    "recorded-date": "05-09-2022, 10:01:53",
-    "recorded-content": {
-      "outputs": {
-        "PolicyArn": "arn:aws:iam::111111111111:policy/<resource:1>",
-        "StreamARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:3>/stream/<resource:2>",
-        "TableARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:3>",
-        "TableName": "<resource:3>"
-      },
-      "managed_policy": {
-        "Policy": {
-          "Arn": "arn:aws:iam::111111111111:policy/<resource:1>",
-          "AttachmentCount": 0,
-          "CreateDate": "datetime",
-          "DefaultVersionId": "v1",
-          "IsAttachable": true,
-          "Path": "/",
-          "PermissionsBoundaryUsageCount": 0,
-          "PolicyId": "<policy-id:1>",
-          "PolicyName": "<resource:1>",
-          "Tags": [],
-          "UpdateDate": "datetime"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_user_access_key": {
-    "recorded-date": "30-08-2022, 13:42:39",
+    "recorded-date": "06-01-2023, 11:35:35",
     "recorded-content": {
       "key_outputs": {
         "AccessKeyId": "<key-id:1>",
@@ -59,6 +11,24 @@
         "CreateDate": "datetime",
         "Status": "Active",
         "UserName": "<user-name:1>"
+      },
+      "access_key_updated": {
+        "AccessKeyId": "<key-id:1>",
+        "CreateDate": "datetime",
+        "Status": "Inactive",
+        "UserName": "<user-name:1>"
+      },
+      "access_key_serial_updated": {
+        "AccessKeyId": "<key-id:2>",
+        "CreateDate": "datetime",
+        "Status": "Inactive",
+        "UserName": "<user-name:1>"
+      },
+      "access_key_user_updated": {
+        "AccessKeyId": "<key-id:3>",
+        "CreateDate": "datetime",
+        "Status": "Inactive",
+        "UserName": "<user-name:1>-updated"
       }
     }
   }

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_user_access_key": {
-    "recorded-date": "06-01-2023, 11:35:35",
+    "recorded-date": "06-01-2023, 11:55:42",
     "recorded-content": {
       "key_outputs": {
         "AccessKeyId": "<key-id:1>",
@@ -23,12 +23,6 @@
         "CreateDate": "datetime",
         "Status": "Inactive",
         "UserName": "<user-name:1>"
-      },
-      "access_key_user_updated": {
-        "AccessKeyId": "<key-id:3>",
-        "CreateDate": "datetime",
-        "Status": "Inactive",
-        "UserName": "<user-name:1>-updated"
       }
     }
   }

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -1,4 +1,52 @@
 {
+  "tests/integration/cloudformation/resources/test_iam.py::test_iam_username_defaultname": {
+    "recorded-date": "31-05-2022, 11:29:45",
+    "recorded-content": {
+      "get_iam_user": {
+        "User": {
+          "Path": "/",
+          "UserName": "<user-name:1>",
+          "UserId": "<user-id:1>",
+          "Arn": "arn:aws:iam::111111111111:user/<user-name:1>",
+          "CreateDate": "datetime"
+        },
+        "ResponseMetadata": {
+          "HTTPStatusCode": 200,
+          "HTTPHeaders": {}
+        }
+      }
+    }
+  },
+  "tests/integration/cloudformation/resources/test_iam.py::test_managed_policy_with_empty_resource": {
+    "recorded-date": "05-09-2022, 10:01:53",
+    "recorded-content": {
+      "outputs": {
+        "PolicyArn": "arn:aws:iam::111111111111:policy/<resource:1>",
+        "StreamARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:3>/stream/<resource:2>",
+        "TableARN": "arn:aws:dynamodb:<region>:111111111111:table/<resource:3>",
+        "TableName": "<resource:3>"
+      },
+      "managed_policy": {
+        "Policy": {
+          "Arn": "arn:aws:iam::111111111111:policy/<resource:1>",
+          "AttachmentCount": 0,
+          "CreateDate": "datetime",
+          "DefaultVersionId": "v1",
+          "IsAttachable": true,
+          "Path": "/",
+          "PermissionsBoundaryUsageCount": 0,
+          "PolicyId": "<policy-id:1>",
+          "PolicyName": "<resource:1>",
+          "Tags": [],
+          "UpdateDate": "datetime"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_user_access_key": {
     "recorded-date": "06-01-2023, 11:55:42",
     "recorded-content": {

--- a/tests/integration/templates/iam_access_key.yaml
+++ b/tests/integration/templates/iam_access_key.yaml
@@ -20,10 +20,10 @@ Resources:
     Properties:
       UserName: 
         Ref: UserName
-      Status:
-        Ref: Status
       Serial:
         Ref: Serial
+      Status:
+        Ref: Status
     DependsOn: User
 
 Outputs:

--- a/tests/integration/templates/iam_access_key.yaml
+++ b/tests/integration/templates/iam_access_key.yaml
@@ -1,6 +1,12 @@
 Parameters:
   UserName:
     Type: String
+  Status:
+    Type: String
+    Default: Active
+  Serial:
+    Type: String
+    Default: 1
 
 Resources:
   User:
@@ -14,6 +20,10 @@ Resources:
     Properties:
       UserName: 
         Ref: UserName
+      Status:
+        Ref: Status
+      Serial:
+        Ref: Serial
     DependsOn: User
 
 Outputs:


### PR DESCRIPTION
Addresses #6861

Changes:
- [x] Make access key updatable
- [x] Ignore parameters not used for creation 
- [x] Update access key test

**Note:** at the moment it's not possible to track the changes in the Serial value to trigger a key rotation.
