### PR TITLE
add tests for multipart SSE fields and S3 KMS BucketKeyEnabled

### DIFF
--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1371,6 +1371,14 @@ def apply_moto_patches():
         if val := resp_headers.get(bucket_key_enabled, ""):
             resp_headers[bucket_key_enabled] = str(val).lower()
 
+        # KMS key should be returned in ARN format
+        # the key should be in the same region as the bucket
+        # the owner can change but multi-account is not currently supported in S3
+        # FIXME: implement key validation while setting the key
+        if kms_key_id := resp_headers.get("x-amz-server-side-encryption-aws-kms-key-id"):
+            kms_key_id = f"arn:aws:kms:{self.region}:{self.current_account}:key/{kms_key_id}"
+            resp_headers["x-amz-server-side-encryption-aws-kms-key-id"] = kms_key_id
+
         return status_code, resp_headers, key_value
 
     @patch(moto_s3_responses.S3Response._bucket_response_head)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1371,14 +1371,6 @@ def apply_moto_patches():
         if val := resp_headers.get(bucket_key_enabled, ""):
             resp_headers[bucket_key_enabled] = str(val).lower()
 
-        # KMS key should be returned in ARN format
-        # the key should be in the same region as the bucket
-        # the owner can change but multi-account is not currently supported in S3
-        # FIXME: implement key validation while setting the key
-        if kms_key_id := resp_headers.get("x-amz-server-side-encryption-aws-kms-key-id"):
-            kms_key_id = f"arn:aws:kms:{self.region}:{self.current_account}:key/{kms_key_id}"
-            resp_headers["x-amz-server-side-encryption-aws-kms-key-id"] = kms_key_id
-
         return status_code, resp_headers, key_value
 
     @patch(moto_s3_responses.S3Response._bucket_response_head)

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -196,6 +196,39 @@ def s3_multipart_upload(s3_client):
 
 
 @pytest.fixture
+def s3_multipart_upload_with_snapshot(s3_client, snapshot):
+    def perform_multipart_upload(
+        bucket: str, key: str, data: bytes, snapshot_prefix: str, **kwargs
+    ):
+        create_multipart_resp = s3_client.create_multipart_upload(Bucket=bucket, Key=key, **kwargs)
+        snapshot.match(f"{snapshot_prefix}-create-multipart", create_multipart_resp)
+        upload_id = create_multipart_resp["UploadId"]
+
+        # Write contents to memory rather than a file.
+        upload_file_object = BytesIO(data)
+
+        response = s3_client.upload_part(
+            Bucket=bucket,
+            Key=key,
+            Body=upload_file_object,
+            PartNumber=1,
+            UploadId=upload_id,
+        )
+        snapshot.match(f"{snapshot_prefix}-upload-part", response)
+
+        response = s3_client.complete_multipart_upload(
+            Bucket=bucket,
+            Key=key,
+            MultipartUpload={"Parts": [{"ETag": response["ETag"], "PartNumber": 1}]},
+            UploadId=upload_id,
+        )
+        snapshot.match(f"{snapshot_prefix}-compete-multipart", response)
+        return response
+
+    return perform_multipart_upload
+
+
+@pytest.fixture
 def create_tmp_folder_lambda():
     cleanup_folders = []
 
@@ -3637,6 +3670,185 @@ class TestS3:
         # TODO: not applied yet, just check that the status is the same (not raising NotImplemented)
         response = aws_client.s3.list_multipart_uploads(Bucket=s3_bucket, Delimiter="/")
         snapshot.match("list-uploads-delimiter", response)
+
+    @pytest.mark.aws_validated
+    # there is currently no server side encryption is place in LS, ETag will be different
+    @pytest.mark.skip_snapshot_verify(paths=["$..ETag"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider, paths=["$..ContentLanguage", "$..SSEKMSKeyId", "$..VersionId"]
+    )
+    def test_s3_multipart_upload_sse(
+        self,
+        s3_client,
+        s3_bucket,
+        s3_multipart_upload_with_snapshot,
+        kms_create_key,
+        snapshot,
+    ):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.resource_name("SSEKMSKeyId"),
+                snapshot.transform.key_value(
+                    "Bucket", reference_replacement=False, value_replacement="<bucket>"
+                ),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("Location"),
+            ]
+        )
+
+        key_name = "test-sse-field-multipart"
+        data = b"test-sse"
+        key_id = kms_create_key()["KeyId"]
+        # if you only pass the key id, the key must be in the same region and account as the bucket
+        # otherwise, pass the ARN (always same region)
+        # but the response always return the ARN
+
+        s3_multipart_upload_with_snapshot(
+            bucket=s3_bucket,
+            key=key_name,
+            data=data,
+            snapshot_prefix="multi-sse",
+            BucketKeyEnabled=True,
+            SSEKMSKeyId=key_id,
+            ServerSideEncryption="aws:kms",
+        )
+
+        response = s3_client.get_object(Bucket=s3_bucket, Key=key_name)
+        snapshot.match("get-obj", response)
+
+    @pytest.mark.aws_validated
+    # there is currently no server side encryption is place in LS, ETag will be different
+    @pytest.mark.skip_snapshot_verify(paths=["$..ETag"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider,
+        paths=["$..ContentLanguage", "$..SSEKMSKeyId", "$..VersionId", "$..KMSMasterKeyID"],
+    )
+    def test_s3_sse_bucket_key_default(
+        self,
+        s3_client,
+        s3_bucket,
+        kms_create_key,
+        snapshot,
+    ):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.resource_name("SSEKMSKeyId"),
+                snapshot.transform.key_value(
+                    "Bucket", reference_replacement=False, value_replacement="<bucket>"
+                ),
+                snapshot.transform.key_value("Location"),
+            ]
+        )
+        key_before_set = "test-sse-bucket-before"
+        key_after_set = "test-sse-bucket-after"
+        data = b"test-sse"
+        key_id = kms_create_key()["KeyId"]
+        response = s3_client.put_object(Bucket=s3_bucket, Key=key_before_set, Body=data)
+        snapshot.match("put-obj-default-before-setting", response)
+
+        response = s3_client.get_object(Bucket=s3_bucket, Key=key_before_set)
+        snapshot.match("get-obj-default-before-setting", response)
+
+        response = s3_client.put_bucket_encryption(
+            Bucket=s3_bucket,
+            ServerSideEncryptionConfiguration={
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                            "KMSMasterKeyID": key_id,
+                        },
+                        "BucketKeyEnabled": True,
+                    }
+                ]
+            },
+        )
+        snapshot.match("put-bucket-encryption", response)
+
+        response = s3_client.get_bucket_encryption(Bucket=s3_bucket)
+        snapshot.match("get-bucket-encryption", response)
+
+        # verify that setting BucketKeyEnabled didn't affect existing keys
+        response = s3_client.get_object(Bucket=s3_bucket, Key=key_before_set)
+        snapshot.match("get-obj-default-after-setting", response)
+
+        # set a new key and see the configuration is in effect
+        response = s3_client.put_object(Bucket=s3_bucket, Key=key_after_set, Body=data)
+        snapshot.match("put-obj-after-setting", response)
+
+        response = s3_client.get_object(Bucket=s3_bucket, Key=key_after_set)
+        snapshot.match("get-obj-after-setting", response)
+
+    @pytest.mark.aws_validated
+    # there is currently no server side encryption is place in LS, ETag will be different
+    @pytest.mark.skip_snapshot_verify(paths=["$..ETag"])
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider,
+        paths=["$..ContentLanguage", "$..SSEKMSKeyId", "$..VersionId", "$..KMSMasterKeyID"],
+    )
+    def test_s3_sse_default_kms_key(
+        self,
+        s3_client,
+        s3_create_bucket,
+        snapshot,
+    ):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.resource_name("SSEKMSKeyId"),
+                snapshot.transform.key_value(
+                    "Bucket", reference_replacement=False, value_replacement="<bucket>"
+                ),
+                snapshot.transform.key_value("UploadId"),
+                snapshot.transform.key_value("Location"),
+            ]
+        )
+        bucket_1 = s3_create_bucket()
+        bucket_2 = s3_create_bucket()
+        key_name = "test-sse-default-key"
+        data = b"test-sse"
+        response = s3_client.put_object(
+            Bucket=bucket_1, Key=key_name, Body=data, ServerSideEncryption="aws:kms"
+        )
+        snapshot.match("put-obj-default-kms-s3-key", response)
+
+        response = s3_client.get_object(Bucket=bucket_1, Key=key_name)
+        snapshot.match("get-obj-default-kms-s3-key", response)
+
+        # validate that the AWS managed key is the same between buckets
+        response = s3_client.put_object(
+            Bucket=bucket_2, Key=key_name, Body=data, ServerSideEncryption="aws:kms"
+        )
+        snapshot.match("put-obj-default-kms-s3-key-bucket-2", response)
+
+        response = s3_client.get_object(Bucket=bucket_2, Key=key_name)
+        snapshot.match("get-obj-default-kms-s3-key-bucket-2", response)
+
+        response = s3_client.put_bucket_encryption(
+            Bucket=bucket_1,
+            ServerSideEncryptionConfiguration={
+                "Rules": [
+                    {
+                        "ApplyServerSideEncryptionByDefault": {
+                            "SSEAlgorithm": "aws:kms",
+                        },
+                        "BucketKeyEnabled": True,
+                    }
+                ]
+            },
+        )
+        snapshot.match("put-bucket-encryption-default-kms-s3-key", response)
+
+        response = s3_client.get_bucket_encryption(Bucket=bucket_1)
+        snapshot.match("get-bucket-encryption-default-kms-s3-key", response)
+
+        key_name = "test-sse-default-key-from-bucket"
+        response = s3_client.put_object(
+            Bucket=bucket_1, Key=key_name, Body=data, ServerSideEncryption="aws:kms"
+        )
+        snapshot.match("put-obj-default-kms-s3-key-from-bucket", response)
+
+        response = s3_client.get_object(Bucket=bucket_1, Key=key_name)
+        snapshot.match("get-obj-default-kms-s3-key-from-bucket", response)
 
 
 class TestS3TerraformRawRequests:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3673,6 +3673,9 @@ class TestS3:
 
     @pytest.mark.aws_validated
     # there is currently no server side encryption is place in LS, ETag will be different
+    @pytest.mark.skip(
+        reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882"
+    )
     @pytest.mark.skip_snapshot_verify(paths=["$..ETag"])
     @pytest.mark.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..ContentLanguage", "$..SSEKMSKeyId", "$..VersionId"]
@@ -3717,6 +3720,9 @@ class TestS3:
         snapshot.match("get-obj", response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip(
+        reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882"
+    )
     # there is currently no server side encryption is place in LS, ETag will be different
     @pytest.mark.skip_snapshot_verify(paths=["$..ETag"])
     @pytest.mark.skip_snapshot_verify(
@@ -3780,6 +3786,9 @@ class TestS3:
         snapshot.match("get-obj-after-setting", response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip(
+        reason="Behaviour not implemented yet: https://github.com/localstack/localstack/issues/6882"
+    )
     # there is currently no server side encryption is place in LS, ETag will be different
     @pytest.mark.skip_snapshot_verify(paths=["$..ETag"])
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5607,5 +5607,249 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_multipart_upload_sse": {
+    "recorded-date": "06-01-2023, 12:33:21",
+    "recorded-content": {
+      "multi-sse-create-multipart": {
+        "Bucket": "<bucket>",
+        "BucketKeyEnabled": true,
+        "Key": "test-sse-field-multipart",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "multi-sse-upload-part": {
+        "BucketKeyEnabled": true,
+        "ETag": "\"e5b777bd84e33bb0c7d7b62a6cca337e\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "multi-sse-compete-multipart": {
+        "Bucket": "<bucket>",
+        "BucketKeyEnabled": true,
+        "ETag": "\"971d087b5588546cc61a5baa8477e1ae-1\"",
+        "Key": "test-sse-field-multipart",
+        "Location": "<location:1>",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "BucketKeyEnabled": true,
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"971d087b5588546cc61a5baa8477e1ae-1\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_bucket_key_default": {
+    "recorded-date": "06-01-2023, 15:30:19",
+    "recorded-content": {
+      "put-obj-default-before-setting": {
+        "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-default-before-setting": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-encryption": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-encryption": {
+        "ServerSideEncryptionConfiguration": {
+          "Rules": [
+            {
+              "ApplyServerSideEncryptionByDefault": {
+                "KMSMasterKeyID": "<SSEKMSKeyId:1>",
+                "SSEAlgorithm": "aws:kms"
+              },
+              "BucketKeyEnabled": true
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-default-after-setting": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-after-setting": {
+        "BucketKeyEnabled": true,
+        "ETag": "\"705e009dee3d80005d93ac26ae992116\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-after-setting": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "BucketKeyEnabled": true,
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"705e009dee3d80005d93ac26ae992116\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_default_kms_key": {
+    "recorded-date": "06-01-2023, 16:15:07",
+    "recorded-content": {
+      "put-obj-default-kms-s3-key": {
+        "ETag": "\"5a9df639fe71cea30139a29bfbad7b73\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-default-kms-s3-key": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"5a9df639fe71cea30139a29bfbad7b73\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-default-kms-s3-key-bucket-2": {
+        "ETag": "\"825a1c84ed161aae720bc0c4c358af89\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-default-kms-s3-key-bucket-2": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"825a1c84ed161aae720bc0c4c358af89\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-bucket-encryption-default-kms-s3-key": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-bucket-encryption-default-kms-s3-key": {
+        "ServerSideEncryptionConfiguration": {
+          "Rules": [
+            {
+              "ApplyServerSideEncryptionByDefault": {
+                "SSEAlgorithm": "aws:kms"
+              },
+              "BucketKeyEnabled": true
+            }
+          ]
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-default-kms-s3-key-from-bucket": {
+        "BucketKeyEnabled": true,
+        "ETag": "\"0e2f89c81bb2533221b4662f12094f0c\"",
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-obj-default-kms-s3-key-from-bucket": {
+        "AcceptRanges": "bytes",
+        "Body": "test-sse",
+        "BucketKeyEnabled": true,
+        "ContentLength": 8,
+        "ContentType": "binary/octet-stream",
+        "ETag": "\"0e2f89c81bb2533221b4662f12094f0c\"",
+        "LastModified": "datetime",
+        "Metadata": {},
+        "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
+        "ServerSideEncryption": "aws:kms",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5609,7 +5609,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_multipart_upload_sse": {
-    "recorded-date": "06-01-2023, 12:33:21",
+    "recorded-date": "03-04-2023, 22:15:25",
     "recorded-content": {
       "multi-sse-create-multipart": {
         "Bucket": "<bucket>",
@@ -5625,7 +5625,7 @@
       },
       "multi-sse-upload-part": {
         "BucketKeyEnabled": true,
-        "ETag": "\"e5b777bd84e33bb0c7d7b62a6cca337e\"",
+        "ETag": "\"366ca6af9c03448ebf507675d7a27ecd\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5636,7 +5636,7 @@
       "multi-sse-compete-multipart": {
         "Bucket": "<bucket>",
         "BucketKeyEnabled": true,
-        "ETag": "\"971d087b5588546cc61a5baa8477e1ae-1\"",
+        "ETag": "\"ff65e9b5cbf8e4e5e26d7f39dc4418b1-1\"",
         "Key": "test-sse-field-multipart",
         "Location": "<location:1>",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5652,7 +5652,7 @@
         "BucketKeyEnabled": true,
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"971d087b5588546cc61a5baa8477e1ae-1\"",
+        "ETag": "\"ff65e9b5cbf8e4e5e26d7f39dc4418b1-1\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5665,10 +5665,11 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_bucket_key_default": {
-    "recorded-date": "06-01-2023, 15:30:19",
+    "recorded-date": "03-04-2023, 22:15:50",
     "recorded-content": {
       "put-obj-default-before-setting": {
         "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -5682,6 +5683,7 @@
         "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -5718,6 +5720,7 @@
         "ETag": "\"42832cdec7083e70a9cd6f2d5852e004\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -5725,7 +5728,7 @@
       },
       "put-obj-after-setting": {
         "BucketKeyEnabled": true,
-        "ETag": "\"705e009dee3d80005d93ac26ae992116\"",
+        "ETag": "\"da640409167cd01aaeb9ca47d4e20e5d\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5739,7 +5742,7 @@
         "BucketKeyEnabled": true,
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"705e009dee3d80005d93ac26ae992116\"",
+        "ETag": "\"da640409167cd01aaeb9ca47d4e20e5d\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5752,10 +5755,10 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_default_kms_key": {
-    "recorded-date": "06-01-2023, 16:15:07",
+    "recorded-date": "03-04-2023, 22:16:19",
     "recorded-content": {
       "put-obj-default-kms-s3-key": {
-        "ETag": "\"5a9df639fe71cea30139a29bfbad7b73\"",
+        "ETag": "\"dbcc38f7b88c4c92ee5f9484d181ff51\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5768,7 +5771,7 @@
         "Body": "test-sse",
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"5a9df639fe71cea30139a29bfbad7b73\"",
+        "ETag": "\"dbcc38f7b88c4c92ee5f9484d181ff51\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5779,7 +5782,7 @@
         }
       },
       "put-obj-default-kms-s3-key-bucket-2": {
-        "ETag": "\"825a1c84ed161aae720bc0c4c358af89\"",
+        "ETag": "\"9c8f3cc18cd06e60966725b1c5996554\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5792,7 +5795,7 @@
         "Body": "test-sse",
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"825a1c84ed161aae720bc0c4c358af89\"",
+        "ETag": "\"9c8f3cc18cd06e60966725b1c5996554\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
@@ -5826,7 +5829,7 @@
       },
       "put-obj-default-kms-s3-key-from-bucket": {
         "BucketKeyEnabled": true,
-        "ETag": "\"0e2f89c81bb2533221b4662f12094f0c\"",
+        "ETag": "\"671ef6aeba0f69c2391cf0a1b094d0aa\"",
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",
         "ServerSideEncryption": "aws:kms",
         "ResponseMetadata": {
@@ -5840,7 +5843,7 @@
         "BucketKeyEnabled": true,
         "ContentLength": 8,
         "ContentType": "binary/octet-stream",
-        "ETag": "\"0e2f89c81bb2533221b4662f12094f0c\"",
+        "ETag": "\"671ef6aeba0f69c2391cf0a1b094d0aa\"",
         "LastModified": "datetime",
         "Metadata": {},
         "SSEKMSKeyId": "arn:aws:kms:<region>:111111111111:key/<SSEKMSKeyId:1>",


### PR DESCRIPTION
Implement AWS validated tests for #6882.

The fix was worked on in moto here (https://github.com/localstack/moto/pull/65) but an issue with the tests prevented me for merging at the time. I will come back to this later on, but we can merge the added tests and skip for now. 
