### PR TITLE
Add lambda permission behavior test

### DIFF
--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -691,7 +691,7 @@ class TestLambdaPermissions:
         create_lambda_function(
             func_name=function_name,
             zip_file=testutil.create_zip_file(TEST_LAMBDA_URL, get_content=True),
-            runtime=Runtime.nodejs14_x,
+            runtime=Runtime.nodejs18_x,
             handler="lambda_url.handler",
         )
         url_config = lambda_client.create_function_url_config(

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -680,6 +680,33 @@ class TestLambdaURL:
         assert result.status_code == 502
 
 
+@pytest.mark.skip(reason="Not yet implemented")
+class TestLambdaPermissions:
+    @pytest.mark.aws_validated
+    def test_lambda_permission_url_invocation(
+        self, create_lambda_function, lambda_client, snapshot
+    ):
+
+        function_name = f"test-function-{short_uid()}"
+        create_lambda_function(
+            func_name=function_name,
+            zip_file=testutil.create_zip_file(TEST_LAMBDA_URL, get_content=True),
+            runtime=Runtime.nodejs14_x,
+            handler="lambda_url.handler",
+        )
+        url_config = lambda_client.create_function_url_config(
+            FunctionName=function_name,
+            AuthType="NONE",
+        )
+
+        # Intentionally missing add_permission for invoking lambda function
+
+        url = url_config["FunctionUrl"]
+        result = safe_requests.post(url, data="text", headers={"Content-Type": "text/plain"})
+        assert result.status_code == 403
+        snapshot.match("lambda_url_invocation_missing_permission", result.text)
+
+
 class TestLambdaFeatures:
     @pytest.fixture(
         params=[("python3.9", TEST_LAMBDA_PYTHON_ECHO), ("nodejs16.x", TEST_LAMBDA_NODEJS_ECHO)],

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -2175,5 +2175,13 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaPermissions::test_lambda_permission_url_invocation": {
+    "recorded-date": "06-01-2023, 16:03:25",
+    "recorded-content": {
+      "lambda_url_invocation_missing_permission": {
+        "Message": "Forbidden"
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -2177,7 +2177,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaPermissions::test_lambda_permission_url_invocation": {
-    "recorded-date": "06-01-2023, 16:03:25",
+    "recorded-date": "10-01-2023, 09:11:18",
     "recorded-content": {
       "lambda_url_invocation_missing_permission": {
         "Message": "Forbidden"


### PR DESCRIPTION
Follow up from lambda permission PR https://github.com/localstack/localstack/pull/7336

Having an AWS-validated test case ready is useful for implementing actual permission policy logic.