### PR TITLE
add kms key validation in ASF S3 with feature flag

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -664,6 +664,8 @@ WINDOWS_DOCKER_MOUNT_PREFIX = os.environ.get("WINDOWS_DOCKER_MOUNT_PREFIX", "/ho
 
 # whether to skip S3 presign URL signature validation (TODO: currently enabled, until all issues are resolved)
 S3_SKIP_SIGNATURE_VALIDATION = is_env_not_false("S3_SKIP_SIGNATURE_VALIDATION")
+# whether to skip S3 validation of provided KMS key
+S3_SKIP_KMS_KEY_VALIDATION = is_env_not_false("S3_SKIP_KMS_KEY_VALIDATION")
 
 # user-defined lambda executor mode
 LAMBDA_EXECUTOR = os.environ.get("LAMBDA_EXECUTOR", "").strip()
@@ -810,6 +812,7 @@ CONFIG_ENV_VARS = [
     "PERSISTENCE",
     "REQUESTS_CA_BUNDLE",
     "S3_SKIP_SIGNATURE_VALIDATION",
+    "S3_SKIP_KMS_KEY_VALIDATION",
     "SERVICES",
     "SKIP_INFRA_DOWNLOADS",
     "SKIP_SSL_CERT_DOWNLOAD",

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -214,7 +214,9 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket):
         arn = parse_arn(kms_key)
         region_name = arn["region"]
         if region_name != bucket.region_name:
-            raise
+            raise CommonServiceException(
+                code="KMS.NotFoundException", message=f"Invalid arn {region_name}"
+            )
         # multi account unsupported yet
     except InvalidArnException:
         pass

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -20,7 +20,7 @@ from localstack.aws.api.s3 import (
     ObjectKey,
     Permission,
 )
-from localstack.utils.aws import aws_stack
+from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.strings import checksum_crc32, checksum_crc32c, hash_sha1, hash_sha256
 
@@ -228,7 +228,9 @@ def validate_kms_key_id(kms_key: str, bucket: FakeBucket):
         key_id = kms_key
         # recreate the ARN manually with the bucket region and bucket owner
         # if the KMS key is cross-account, user should provide an ARN and not a KeyId
-        kms_key = f"arn:aws:kms:{bucket.region_name}:{bucket.account_id}:key/{key_id}"
+        kms_key = arns.kms_key_arn(
+            key_id=key_id, account_id=bucket.account_id, region_name=bucket.region_name
+        )
 
     # we validate the Key Id is a valid one
     if not PATTERN_UUID.match(key_id):

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -933,6 +933,7 @@ def kms_create_key(create_boto_client):
 
     for region, key_id in key_ids:
         try:
+            # shortest amount of time you can schedule the deletion
             create_boto_client("kms", region).schedule_key_deletion(
                 KeyId=key_id, PendingWindowInDays=7
             )
@@ -959,6 +960,7 @@ def kms_replicate_key(create_boto_client):
 
     for region_to, key_id in key_ids:
         try:
+            # shortest amount of time you can schedule the deletion
             create_boto_client("kms", region_to).schedule_key_deletion(
                 KeyId=key_id, PendingWindowInDays=7
             )

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4009,9 +4009,27 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key": {
-    "recorded-date": "09-01-2023, 11:20:50",
+    "recorded-date": "09-01-2023, 14:54:21",
     "recorded-content": {
-      "put-obj-different-region-kms-key": {
+      "create-kms-key": {
+        "AWSAccountId": "111111111111",
+        "Arn": "arn:aws:kms:<region>:111111111111:key/<uuid:1>",
+        "CreationDate": "datetime",
+        "CustomerMasterKeySpec": "SYMMETRIC_DEFAULT",
+        "Description": "<description:1>",
+        "Enabled": true,
+        "EncryptionAlgorithms": [
+          "SYMMETRIC_DEFAULT"
+        ],
+        "KeyId": "<uuid:1>",
+        "KeyManager": "CUSTOMER",
+        "KeySpec": "SYMMETRIC_DEFAULT",
+        "KeyState": "Enabled",
+        "KeyUsage": "ENCRYPT_DECRYPT",
+        "MultiRegion": false,
+        "Origin": "AWS_KMS"
+      },
+      "put-obj-wrong-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
           "Message": "Invalid keyId fake-key-id"
@@ -4021,10 +4039,40 @@
           "HTTPStatusCode": 400
         }
       },
-      "put-obj-wrong-kms-key": {
+      "put-obj-wrong-kms-key-real-uuid": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Key 'arn:aws:kms:us-west-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-wrong-kms-key-real-uuid-arn": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Key 'arn:aws:kms:us-west-2:111111111111:key/134f2428-cec1-4b25-a1ae-9048164dba47' does not exist"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-different-region-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
           "Message": "Invalid arn <region>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-different-region-kms-key-no-arn": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Key 'arn:aws:kms:us-west-2:111111111111:key/<uuid:1>' does not exist"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4009,12 +4009,22 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key": {
-    "recorded-date": "06-01-2023, 17:51:31",
+    "recorded-date": "09-01-2023, 11:20:50",
     "recorded-content": {
-      "put-obj-wrong-kms-key": {
+      "put-obj-different-region-kms-key": {
         "Error": {
           "Code": "KMS.NotFoundException",
           "Message": "Invalid keyId fake-key-id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put-obj-wrong-kms-key": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Invalid arn <region>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4007,5 +4007,40 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_s3_sse_validate_kms_key": {
+    "recorded-date": "06-01-2023, 17:51:31",
+    "recorded-content": {
+      "put-obj-wrong-kms-key": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Invalid keyId fake-key-id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-multipart-wrong-kms-key": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Invalid keyId fake-key-id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "copy-obj-wrong-kms-key": {
+        "Error": {
+          "Code": "KMS.NotFoundException",
+          "Message": "Invalid keyId fake-key-id"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR introduces a validation issue reported in #7177 
However, I'll introduce this feature behind a feature flag to not slow down users not creating KMS keys while testing. It will need an entry in the docs once merged.
To enable this feature, the user needs to set `S3_SKIP_KMS_KEY_VALIDATION=0`. 

This PR will check the existence of the KMS key provided in `PutObject`, `CopyObject` and `CreateMultipartUpload` operations. A next step in a following PR would be to also validate it in `PutBucketEncryption` if it is done in AWS. 

This PR allowed us to uncover some bugs in KMS implementation of `DescribeKey`, see #7463, which might allow to reuse the error message of KMS. 

_fixes #7177_

edit: doc PR here: https://github.com/localstack/docs/pull/440