### PR TITLE
Cross-account attributes for Stores

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,10 @@
 # HTTP framework
 /localstack/http/ @thrau
 
+# Stores
+/localstack/services/stores.py @viren-nadkarni
+/tests/unit/test_stores.py @viren-nadkarni
+
 # Dockerfile
 /Dockerfile @alexrashed
 /Dockerfile.rh @alexrashed

--- a/localstack/services/stores.py
+++ b/localstack/services/stores.py
@@ -311,7 +311,7 @@ class AccountRegionBundle(dict, Generic[BaseStoreType]):
         """
         # For safety, clear all referenced region bundles, if any
         for region_bundle in self.values():
-            region_bundle.reset()
+            region_bundle.reset(_reset_universal=True)
 
         self._universal.clear()
 

--- a/localstack/services/stores.py
+++ b/localstack/services/stores.py
@@ -5,7 +5,7 @@ Stores provide storage for AWS service providers and are analogous to Moto's Bac
 
 By convention, Stores are to be defined in `models` submodule of the service
 by subclassing BaseStore e.g. `localstack.services.sqs.models.SqsStore`
-Also by convention, cross-region attributes are declared in CAPITAL_CASE
+Also by convention, cross-region and cross-account attributes are declared in CAPITAL_CASE
 
     class SqsStore(BaseStore):
         queues: dict[str, SqsQueue] =  LocalAttribute(default=dict)
@@ -114,6 +114,47 @@ class CrossRegionAttribute:
             )
 
 
+class CrossAccountAttribute:
+    """
+    Descriptor protocol for marking a store attributes as shared across all regions and accounts.
+
+    This should be used for resources that are identified by ARNs.
+    """
+
+    def __init__(self, default: Union[Callable, int, float, str, bool, None]):
+        """
+        :param default: The default value assigned to the cross-account attribute.
+            This must be a scalar or a callable.
+        """
+        self.default = default
+
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, obj: BaseStoreType, objtype=None) -> Any:
+        self._check_account_store_association(obj)
+
+        if self.name not in obj._universal.keys():
+            if isinstance(self.default, Callable):
+                obj._universal[self.name] = self.default()
+            else:
+                obj._universal[self.name] = self.default
+
+        return obj._universal[self.name]
+
+    def __set__(self, obj: BaseStoreType, value: Any):
+        self._check_account_store_association(obj)
+
+        obj._universal[self.name] = value
+
+    def _check_account_store_association(self, obj):
+        if not hasattr(obj, "_universal"):
+            # Raise if a Store is instantiated outside an AccountRegionBundle
+            raise AttributeError(
+                "Could not resolve cross-account attribute because there is no associated AccountRegionBundle"
+            )
+
+
 #
 # Base models
 #
@@ -123,6 +164,12 @@ class BaseStore:
     """
     Base class for defining stores for LocalStack providers.
     """
+
+    _service_name: str
+    _account_id: str
+    _region_name: str
+    _global: dict
+    _universal: dict
 
     def __repr__(self):
         try:
@@ -154,16 +201,20 @@ class RegionBundle(dict, Generic[BaseStoreType]):
         account_id: str,
         validate: bool = True,
         lock: RLock = None,
+        universal: dict = None,
     ):
         self.store = store
         self.account_id = account_id
         self.service_name = service_name
         self.validate = validate
         self.lock = lock or RLock()
+        self._universal = universal
 
         self.valid_regions = get_valid_regions_for_service(service_name)
 
-        # Keeps track of all cross-region attributes
+        # Keeps track of all cross-region attributes. This dict is maintained at
+        # a region level (hence in RegionBundle). A ref is passed to every store
+        # intialised in this region so that backref is possible.
         self._global = {}
 
     def __getitem__(self, region_name) -> BaseStoreType:
@@ -178,6 +229,7 @@ class RegionBundle(dict, Generic[BaseStoreType]):
                 store_obj = self.store()
 
                 store_obj._global = self._global
+                store_obj._universal = self._universal
                 store_obj._service_name = self.service_name
                 store_obj._account_id = self.account_id
                 store_obj._region_name = region_name
@@ -186,8 +238,12 @@ class RegionBundle(dict, Generic[BaseStoreType]):
 
         return super().__getitem__(region_name)
 
-    def reset(self):
-        """Clear all store data."""
+    def reset(self, _reset_universal: bool = False):
+        """
+        Clear all store data.
+
+        This only deletes the data held in the stores. All instantiated stores are retained.
+        """
         # For safety, clear data in all referenced store instances, if any
         for store_inst in self.values():
             attrs = list(store_inst.__dict__.keys())
@@ -195,6 +251,9 @@ class RegionBundle(dict, Generic[BaseStoreType]):
                 # reset the cross-region attributes
                 if attr == "_global":
                     store_inst._global.clear()
+
+                if attr == "_universal" and _reset_universal:
+                    store_inst._universal.clear()
 
                 # reset the local attributes
                 elif attr.startswith(LOCAL_ATTR_PREFIX):
@@ -222,6 +281,11 @@ class AccountRegionBundle(dict, Generic[BaseStoreType]):
         self.validate = validate
         self.lock = RLock()
 
+        # Keeps track of all cross-account attributes. This dict is maintained at
+        # the account level (hence in AccountRegionBundle). A ref is passed to
+        # every region bundle, which in turn passes it to every store in it.
+        self._universal = {}
+
     def __getitem__(self, account_id: str) -> RegionBundle[BaseStoreType]:
         if self.validate and not re.match(r"\d{12}", account_id):
             raise ValueError(f"'{account_id}' is not a valid AWS account ID")
@@ -234,15 +298,22 @@ class AccountRegionBundle(dict, Generic[BaseStoreType]):
                     account_id=account_id,
                     validate=self.validate,
                     lock=self.lock,
+                    universal=self._universal,
                 )
 
         return super().__getitem__(account_id)
 
     def reset(self):
-        """Clear all store data."""
+        """
+        Clear all store data.
+
+        This only deletes the data held in the stores. All instantiated stores are retained.
+        """
         # For safety, clear all referenced region bundles, if any
         for region_bundle in self.values():
             region_bundle.reset()
+
+        self._universal.clear()
 
         with self.lock:
             self.clear()

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -26,6 +26,7 @@ from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
+    CrossAccountAttribute,
     CrossRegionAttribute,
     LocalAttribute,
 )
@@ -1916,6 +1917,7 @@ def pytest_collection_modifyitems(config: Config, items: list[Item]):
 @pytest.fixture
 def sample_stores() -> AccountRegionBundle:
     class SampleStore(BaseStore):
+        CROSS_ACCOUNT_ATTR = CrossAccountAttribute(default=list)
         CROSS_REGION_ATTR = CrossRegionAttribute(default=list)
         region_specific_attr = LocalAttribute(default=list)
 

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -18,24 +18,45 @@ class TestStores:
 
         store1.region_specific_attr.extend([1, 2, 3])
         store1.CROSS_REGION_ATTR.extend(["a", "b", "c"])
+        store1.CROSS_ACCOUNT_ATTR.extend([100j, 200j, 300j])
         store2.region_specific_attr.extend([4, 5, 6])
+        store2.CROSS_ACCOUNT_ATTR.extend([400j])
         store3.region_specific_attr.extend([7, 8, 9])
         store3.CROSS_REGION_ATTR.extend([0.1, 0.2, 0.3])
+        store3.CROSS_ACCOUNT_ATTR.extend([500j])
+
+        # Ensure all stores are affected by cross-account attributes
+        assert store1.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j, 500j]
+        assert store2.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j, 500j]
+        assert store3.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j, 500j]
+
+        assert store1.CROSS_ACCOUNT_ATTR.pop() == 500j
+
+        assert store2.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j]
+        assert store3.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j]
 
         # Ensure other account stores are not affected by RegionBundle reset
+        # Ensure cross-account attributes are not affected by RegionBundle reset
         sample_stores[account1].reset()
 
         assert store1.region_specific_attr == []
         assert store1.CROSS_REGION_ATTR == []
+        assert store1.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j]
         assert store2.region_specific_attr == []
         assert store2.CROSS_REGION_ATTR == []
+        assert store2.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j]
         assert store3.region_specific_attr == [7, 8, 9]
         assert store3.CROSS_REGION_ATTR == [0.1, 0.2, 0.3]
+        assert store3.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j, 400j]
 
+        # Ensure AccountRegionBundle reset
         sample_stores.reset()
 
+        assert store1.CROSS_ACCOUNT_ATTR == []
+        assert store2.CROSS_ACCOUNT_ATTR == []
         assert store3.region_specific_attr == []
         assert store3.CROSS_REGION_ATTR == []
+        assert store3.CROSS_ACCOUNT_ATTR == []
 
         # Ensure essential properties are retained after reset
         assert store1._region_name == eu_region
@@ -104,6 +125,19 @@ class TestStores:
             == id(backend2_eu._global)
             == id(sample_stores[account2]._global)
             != id(backend1_ap._global)
+        )
+
+        # Ensure cross-account data sharing
+        backend1_eu.CROSS_ACCOUNT_ATTR.extend([100j, 200j, 300j])
+        assert backend1_ap.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j]
+        assert backend1_eu.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j]
+        assert backend2_ap.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j]
+        assert backend2_eu.CROSS_ACCOUNT_ATTR == [100j, 200j, 300j]
+        assert (
+            id(backend1_ap._universal)
+            == id(backend1_eu._universal)
+            == id(backend2_ap._universal)
+            == id(backend2_eu._universal)
         )
 
     def test_valid_regions(self):


### PR DESCRIPTION
This PR adds a new descriptor protocol to mark certain store attributes as cross-account. This will be used for resources like S3 bucket names, DNS names, etc. which must be unique across all region and all accounts.

This will also be useful for the new internal AWS client. For services that allow resource-level IAM policy attachment, it is possible to retrieve the resources by the ARN. The ARN uniquely identifies the resource -- it has the account ID and region as part of itself. This makes using the `CrossAccountAttribute` suited for such resources, and furthermore allows operations to support resource operations based on ARNs.

Closes localstack/localstack-ext#1132