### PR TITLE
fix: return headers correctly inside a VTL template in apigateway

### DIFF
--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -185,7 +185,10 @@ class Templates:
                 "params": {
                     "path": api_context.path_params,
                     "querystring": api_context.query_params(),
-                    "header": api_context.headers,
+                    # Sometimes we get a werkzeug.datastructures.Headers object, sometimes a dict
+                    # depending on the request. We need to convert to a dict to be able to render
+                    # the template.
+                    "header": dict(api_context.headers),
                 },
             },
         }


### PR DESCRIPTION
Fixes an issue where the VTL template headers would be returned with a serialized python object instead of a dict. 

Note: werkzeug.datastructures.Headers object is dict casting compatible - 

<img width="538" alt="image" src="https://user-images.githubusercontent.com/16493770/211314524-7eb87e10-e64d-46c6-ac2b-a7be4a6d0ca0.png">
