### PR TITLE
remove ProxyListener in tests

### DIFF
--- a/tests/integration/awslambda/test_lambda_whitebox.py
+++ b/tests/integration/awslambda/test_lambda_whitebox.py
@@ -19,9 +19,11 @@ from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.testing.aws.lambda_utils import is_new_provider
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import load_file, retry, run_safe, short_uid, to_bytes, to_str
+from localstack.utils.files import load_file
+from localstack.utils.functions import run_safe
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
-from localstack.utils.sync import poll_condition
+from localstack.utils.strings import short_uid, to_bytes, to_str
+from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import create_lambda_archive
 
 from .test_lambda import (

--- a/tests/integration/awslambda/test_lambda_whitebox.py
+++ b/tests/integration/awslambda/test_lambda_whitebox.py
@@ -8,27 +8,20 @@ import unittest
 
 import pytest
 from botocore.exceptions import ClientError
+from pytest_httpserver import HTTPServer
+from werkzeug import Request, Response
 
 import localstack.services.awslambda.lambda_api
 from localstack import config
 from localstack.services.awslambda import lambda_api, lambda_executors
 from localstack.services.awslambda.lambda_api import do_set_function_code, use_docker
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
-from localstack.services.generic_proxy import ProxyListener
-from localstack.services.infra import start_proxy
 from localstack.testing.aws.lambda_utils import is_new_provider
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
-from localstack.utils.common import (
-    get_free_tcp_port,
-    get_service_protocol,
-    load_file,
-    retry,
-    run_safe,
-    short_uid,
-    to_bytes,
-    to_str,
-)
+from localstack.utils.common import load_file, retry, run_safe, short_uid, to_bytes, to_str
+from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.sync import poll_condition
 from localstack.utils.testutil import create_lambda_archive
 
 from .test_lambda import (
@@ -95,57 +88,67 @@ class TestLambdaFallbackUrl(unittest.TestCase):
 
     def test_forward_to_fallback_url_http(self):
         lambda_client = aws_stack.create_external_boto_client("lambda")
-
-        class MyUpdateListener(ProxyListener):
-            def forward_request(self, method, path, data, headers):
-                records.append({"data": data, "headers": headers, "method": method, "path": path})
-                return lambda_result
-
         lambda_result = {"result": "test123"}
-        local_port = get_free_tcp_port()
-        proxy = start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
 
-        local_url = f"{get_service_protocol()}://localhost:{local_port}"
+        def _handler(_request: Request):
+            return Response(json.dumps(lambda_result), mimetype="application/json")
 
-        # test 1: forward to LAMBDA_FALLBACK_URL
-        records = []
-        self._run_forward_to_fallback_url(local_url)
-        items_after = len(records)
-        for record in records:
-            self.assertIn("non-existing-lambda", record["headers"]["lambda-function-name"])
-        self.assertEqual(3, items_after)
+        with HTTPServer() as server:
 
-        # create test Lambda
-        lambda_name = f"test-{short_uid()}"
-        testutil.create_lambda_function(
-            handler_file=TEST_LAMBDA_PYTHON,
-            func_name=lambda_name,
-            libs=TEST_LAMBDA_LIBS,
-        )
-        lambda_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
+            server.expect_request("").respond_with_handler(_handler)
+            http_endpoint = server.url_for("/")
+            wait_for_port_open(server.port)
 
-        # test 2: forward to LAMBDA_FORWARD_URL
-        records = []
-        inv_results = self._run_forward_to_fallback_url(
-            local_url, lambda_name=lambda_name, fallback=False
-        )
-        items_after = len(records)
-        for record in records:
-            headers = record["headers"]
-            self.assertIn("/lambda/", headers["Authorization"])
-            self.assertEqual("POST", record["method"])
-            self.assertIn("/functions/%s/invocations" % lambda_name, record["path"])
-            self.assertTrue(headers.get("X-Amz-Client-Context"))
-            self.assertEqual("RequestResponse", headers.get("X-Amz-Invocation-Type"))
-            self.assertEqual({"foo": "bar"}, json.loads(to_str(record["data"])))
-        self.assertEqual(3, items_after)
-        # assert result payload matches
-        response_payload = inv_results[0]["Payload"].read()
-        self.assertEqual(lambda_result, json.loads(response_payload))
+            # test 1: forward to LAMBDA_FALLBACK_URL
+            self._run_forward_to_fallback_url(http_endpoint)
 
-        # clean up / shutdown
-        lambda_client.delete_function(FunctionName=lambda_name)
-        proxy.stop()
+            poll_condition(lambda: len(server.log) >= 3, timeout=10)
+
+            for request, _ in server.log:
+                # event = request.get_json(force=True)
+                self.assertIn("non-existing-lambda", request.headers["lambda-function-name"])
+
+            self.assertEqual(3, len(server.log))
+            server.clear_log()
+
+            try:
+                # create test Lambda
+                lambda_name = f"test-{short_uid()}"
+                testutil.create_lambda_function(
+                    handler_file=TEST_LAMBDA_PYTHON,
+                    func_name=lambda_name,
+                    libs=TEST_LAMBDA_LIBS,
+                )
+                lambda_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
+
+                # test 2: forward to LAMBDA_FORWARD_URL
+                inv_results = self._run_forward_to_fallback_url(
+                    http_endpoint, lambda_name=lambda_name, fallback=False
+                )
+
+                poll_condition(lambda: len(server.log) >= 3, timeout=10)
+
+                for request, _ in server.log:
+                    event = request.get_json(force=True)
+                    headers = request.headers
+                    self.assertIn("/lambda/", headers["Authorization"])
+                    self.assertEqual("POST", request.method)
+                    self.assertIn(f"/functions/{lambda_name}/invocations", request.path)
+                    self.assertTrue(headers.get("X-Amz-Client-Context"))
+                    self.assertEqual("RequestResponse", headers.get("X-Amz-Invocation-Type"))
+                    self.assertEqual({"foo": "bar"}, event)
+
+                self.assertEqual(3, len(server.log))
+                server.clear_log()
+
+                # assert result payload matches
+                response_payload = inv_results[0]["Payload"].read()
+                self.assertEqual(lambda_result, json.loads(response_payload))
+            finally:
+                # clean up / shutdown
+                lambda_client.delete_function(FunctionName=lambda_name)
+
+        wait_for_port_closed(server.port)
 
     def test_adding_fallback_function_name_in_headers(self):
         lambda_client = aws_stack.create_external_boto_client("lambda")

--- a/tests/integration/awslambda/test_lambda_whitebox.py
+++ b/tests/integration/awslambda/test_lambda_whitebox.py
@@ -21,7 +21,7 @@ from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
 from localstack.utils.files import load_file
 from localstack.utils.functions import run_safe
-from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_bytes, to_str
 from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import create_lambda_archive
@@ -88,69 +88,65 @@ class TestLambdaFallbackUrl(unittest.TestCase):
         items_after = num_items()
         self.assertEqual(items_before + 3, items_after)
 
-    def test_forward_to_fallback_url_http(self):
+    def test_forward_to_fallback_url_http(self, httpserver: HTTPServer):
         lambda_client = aws_stack.create_external_boto_client("lambda")
         lambda_result = {"result": "test123"}
 
         def _handler(_request: Request):
             return Response(json.dumps(lambda_result), mimetype="application/json")
 
-        with HTTPServer() as server:
+        httpserver.expect_request("").respond_with_handler(_handler)
+        http_endpoint = httpserver.url_for("/")
+        wait_for_port_open(httpserver.port)
 
-            server.expect_request("").respond_with_handler(_handler)
-            http_endpoint = server.url_for("/")
-            wait_for_port_open(server.port)
+        # test 1: forward to LAMBDA_FALLBACK_URL
+        self._run_forward_to_fallback_url(http_endpoint)
 
-            # test 1: forward to LAMBDA_FALLBACK_URL
-            self._run_forward_to_fallback_url(http_endpoint)
+        poll_condition(lambda: len(httpserver.log) >= 3, timeout=10)
 
-            poll_condition(lambda: len(server.log) >= 3, timeout=10)
+        for request, _ in httpserver.log:
+            # event = request.get_json(force=True)
+            self.assertIn("non-existing-lambda", request.headers["lambda-function-name"])
 
-            for request, _ in server.log:
-                # event = request.get_json(force=True)
-                self.assertIn("non-existing-lambda", request.headers["lambda-function-name"])
+        self.assertEqual(3, len(httpserver.log))
+        httpserver.clear_log()
 
-            self.assertEqual(3, len(server.log))
-            server.clear_log()
+        lambda_name = f"test-{short_uid()}"
+        try:
+            # create test Lambda
+            testutil.create_lambda_function(
+                handler_file=TEST_LAMBDA_PYTHON,
+                func_name=lambda_name,
+                libs=TEST_LAMBDA_LIBS,
+            )
+            lambda_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
 
-            try:
-                # create test Lambda
-                lambda_name = f"test-{short_uid()}"
-                testutil.create_lambda_function(
-                    handler_file=TEST_LAMBDA_PYTHON,
-                    func_name=lambda_name,
-                    libs=TEST_LAMBDA_LIBS,
-                )
-                lambda_client.get_waiter("function_active_v2").wait(FunctionName=lambda_name)
+            # test 2: forward to LAMBDA_FORWARD_URL
+            inv_results = self._run_forward_to_fallback_url(
+                http_endpoint, lambda_name=lambda_name, fallback=False
+            )
 
-                # test 2: forward to LAMBDA_FORWARD_URL
-                inv_results = self._run_forward_to_fallback_url(
-                    http_endpoint, lambda_name=lambda_name, fallback=False
-                )
+            poll_condition(lambda: len(httpserver.log) >= 3, timeout=10)
 
-                poll_condition(lambda: len(server.log) >= 3, timeout=10)
+            for request, _ in httpserver.log:
+                event = request.get_json(force=True)
+                headers = request.headers
+                self.assertIn("/lambda/", headers["Authorization"])
+                self.assertEqual("POST", request.method)
+                self.assertIn(f"/functions/{lambda_name}/invocations", request.path)
+                self.assertTrue(headers.get("X-Amz-Client-Context"))
+                self.assertEqual("RequestResponse", headers.get("X-Amz-Invocation-Type"))
+                self.assertEqual({"foo": "bar"}, event)
 
-                for request, _ in server.log:
-                    event = request.get_json(force=True)
-                    headers = request.headers
-                    self.assertIn("/lambda/", headers["Authorization"])
-                    self.assertEqual("POST", request.method)
-                    self.assertIn(f"/functions/{lambda_name}/invocations", request.path)
-                    self.assertTrue(headers.get("X-Amz-Client-Context"))
-                    self.assertEqual("RequestResponse", headers.get("X-Amz-Invocation-Type"))
-                    self.assertEqual({"foo": "bar"}, event)
+            self.assertEqual(3, len(httpserver.log))
+            httpserver.clear_log()
 
-                self.assertEqual(3, len(server.log))
-                server.clear_log()
-
-                # assert result payload matches
-                response_payload = inv_results[0]["Payload"].read()
-                self.assertEqual(lambda_result, json.loads(response_payload))
-            finally:
-                # clean up / shutdown
-                lambda_client.delete_function(FunctionName=lambda_name)
-
-        wait_for_port_closed(server.port)
+            # assert result payload matches
+            response_payload = inv_results[0]["Payload"].read()
+            self.assertEqual(lambda_result, json.loads(response_payload))
+        finally:
+            # clean up / shutdown
+            lambda_client.delete_function(FunctionName=lambda_name)
 
     def test_adding_fallback_function_name_in_headers(self):
         lambda_client = aws_stack.create_external_boto_client("lambda")

--- a/tests/integration/cloudformation/test_cloudformation_ui.py
+++ b/tests/integration/cloudformation/test_cloudformation_ui.py
@@ -1,0 +1,18 @@
+import pytest
+import requests
+
+from localstack import config
+
+CLOUDFORMATION_UI_PATH = "/_localstack/cloudformation/deploy"
+
+
+@pytest.mark.only_localstack
+class TestCloudFormationUi:
+    def test_get_cloudformation_ui(self):
+        cfn_ui_url = config.get_edge_url() + CLOUDFORMATION_UI_PATH
+        response = requests.get(cfn_ui_url)
+
+        # we simply test that the UI is available at the right path and that it returns HTML.
+        assert response.ok
+        assert "content-type" in response.headers
+        assert b"Localstack" in response.content

--- a/tests/integration/cloudformation/test_cloudformation_ui.py
+++ b/tests/integration/cloudformation/test_cloudformation_ui.py
@@ -15,4 +15,5 @@ class TestCloudFormationUi:
         # we simply test that the UI is available at the right path and that it returns HTML.
         assert response.ok
         assert "content-type" in response.headers
-        assert b"Localstack" in response.content
+        # this is a bit fragile but assert that the file returned contains at least something related to the UI
+        assert b"LocalStack" in response.content

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -12,8 +12,9 @@ import xmltodict
 from botocore.exceptions import ClientError
 from jsonpatch import apply_patch
 from moto.apigateway import apigateway_backends
-from requests.models import Response
+from pytest_httpserver import HTTPServer
 from requests.structures import CaseInsensitiveDict
+from werkzeug import Request, Response
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
@@ -22,7 +23,6 @@ from localstack.aws.handlers import cors
 from localstack.config import get_edge_url
 from localstack.constants import (
     APPLICATION_JSON,
-    HEADER_LOCALSTACK_REQUEST_URL,
     LOCALHOST_HOSTNAME,
     TEST_AWS_ACCOUNT_ID,
     TEST_AWS_REGION_NAME,
@@ -37,14 +37,14 @@ from localstack.services.apigateway.helpers import (
     path_based_url,
 )
 from localstack.services.awslambda.lambda_api import add_event_source, use_docker
-from localstack.services.generic_proxy import ProxyListener
-from localstack.services.infra import start_proxy
 from localstack.utils import testutil
 from localstack.utils.aws import arns, aws_stack, queries
 from localstack.utils.aws import resources as resource_util
-from localstack.utils.common import clone, get_free_tcp_port, json_safe, load_file
-from localstack.utils.common import safe_requests as requests
-from localstack.utils.common import select_attributes, short_uid, to_str
+from localstack.utils.collections import select_attributes
+from localstack.utils.files import load_file
+from localstack.utils.http import safe_requests as requests
+from localstack.utils.json import clone, json_safe
+from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import retry
 from tests.integration.apigateway_fixtures import (
     _client,
@@ -124,6 +124,23 @@ ApiGatewayLambdaProxyIntegrationTestResult = namedtuple(
         "path_with_replace",
     ],
 )
+
+
+@pytest.fixture(scope="function")
+def echo_http_server(httpserver: HTTPServer):
+    def _echo(request: Request) -> Response:
+        result = {
+            "data": request.data or "{}",
+            "headers": dict(request.headers),
+            "request_url": request.url,
+        }
+        response_body = json.dumps(json_safe(result))
+        return Response(response_body, status=200)
+
+    httpserver.expect_request("").respond_with_handler(_echo)
+    http_endpoint = httpserver.url_for("/")
+
+    yield http_endpoint
 
 
 class TestAPIGateway:
@@ -519,14 +536,11 @@ class TestAPIGateway:
         assert response.headers["Access-Control-Allow-Origin"] == "*"
 
     @pytest.mark.parametrize("int_type", ["custom", "proxy"])
-    def test_api_gateway_http_integrations(self, int_type, monkeypatch):
+    def test_api_gateway_http_integrations(self, int_type, echo_http_server, monkeypatch):
         monkeypatch.setattr(config, "DISABLE_CUSTOM_CORS_APIGATEWAY", False)
 
-        test_port = get_free_tcp_port()
-        backend_url = "http://localhost:%s%s" % (test_port, self.API_PATH_HTTP_BACKEND)
-
-        # start test HTTP backend
-        proxy = self.start_http_backend(test_port)
+        backend_base_url = echo_http_server
+        backend_url = f"{backend_base_url}/{self.API_PATH_HTTP_BACKEND}"
 
         # create API Gateway and connect it to the HTTP_PROXY/HTTP backend
         result = self.connect_api_gateway_to_http(
@@ -572,9 +586,6 @@ class TestAPIGateway:
         expected = custom_result if int_type == "custom" else data
         assert expected == content["data"]
         assert ctype == headers["content-type"]
-
-        # clean up
-        proxy.stop()
 
     @pytest.mark.parametrize("use_hostname", [True, False])
     @pytest.mark.parametrize("disable_custom_cors", [True, False])
@@ -1648,13 +1659,14 @@ class TestAPIGateway:
                 retry(_invoke_step_function, retries=15, sleep=0.8)
 
     def test_api_gateway_http_integration_with_path_request_parameter(
-        self, apigateway_client, create_rest_apigw
+        self,
+        apigateway_client,
+        create_rest_apigw,
+        echo_http_server,
     ):
-        test_port = get_free_tcp_port()
-        backend_url = "http://localhost:%s/person/{id}" % test_port
-
         # start test HTTP backend
-        proxy = self.start_http_backend(test_port)
+        backend_base_url = echo_http_server
+        backend_url = backend_base_url + "/person/{id}"
 
         # create rest api
         api_id, _, _ = create_rest_apigw(name="test")
@@ -1695,7 +1707,7 @@ class TestAPIGateway:
             assert 200 == result.status_code
             assert re.search(
                 "http://.*localhost.*/person/123",
-                content["headers"].get(HEADER_LOCALSTACK_REQUEST_URL),
+                content["request_url"],
             )
 
         for use_hostname in [True, False]:
@@ -1708,8 +1720,6 @@ class TestAPIGateway:
                     use_ssl=use_ssl,
                 )
                 _test_invoke(url)
-
-        proxy.stop()
 
     def _get_invoke_endpoint(
         self, api_id, stage="test", path="/", use_hostname=False, use_ssl=False
@@ -2004,23 +2014,6 @@ class TestAPIGateway:
         assert 200 == response.get("status")
         assert "response from" in json.loads(response.get("body")).get("body")
         assert "val123" in json.loads(response.get("body")).get("body")
-
-    @staticmethod
-    def start_http_backend(test_port):
-        # test listener for target HTTP backend
-        class TestListener(ProxyListener):
-            def forward_request(self, **kwargs):
-                response = Response()
-                response.status_code = 200
-                result = {
-                    "data": kwargs.get("data") or "{}",
-                    "headers": dict(kwargs.get("headers")),
-                }
-                response._content = json.dumps(json_safe(result))
-                return response
-
-        proxy = start_proxy(test_port, update_listener=TestListener())
-        return proxy
 
     @staticmethod
     def create_api_gateway_and_deploy(

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -18,7 +18,6 @@ from localstack.services.events.provider import _get_events_tmp_dir
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import arns, aws_stack, resources
 from localstack.utils.files import load_file
-from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_str
 from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
@@ -595,7 +594,6 @@ class TestEvents:
     ):
         httpserver.expect_request("").respond_with_data(b"", 200)
         http_endpoint = httpserver.url_for("/")
-        wait_for_port_open(httpserver.port)
 
         topic_name = f"topic-{short_uid()}"
         queue_name = f"queue-{short_uid()}"
@@ -727,7 +725,6 @@ class TestEvents:
 
         httpserver.expect_request("").respond_with_handler(_handler)
         http_endpoint = httpserver.url_for("/")
-        wait_for_port_open(httpserver.port)
 
         if auth.get("type") == "OAUTH_CLIENT_CREDENTIALS":
             auth["parameters"]["AuthorizationEndpoint"] = http_endpoint

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -17,9 +17,10 @@ from localstack.aws.api.lambda_ import Runtime
 from localstack.services.events.provider import _get_events_tmp_dir
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.aws import arns, aws_stack, resources
-from localstack.utils.common import load_file, retry, short_uid, to_str, wait_for_port_open
-from localstack.utils.net import wait_for_port_closed
-from localstack.utils.sync import poll_condition
+from localstack.utils.files import load_file
+from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.strings import short_uid, to_str
+from localstack.utils.sync import poll_condition, retry
 from localstack.utils.testutil import check_expected_lambda_log_events_length
 
 from .awslambda.test_lambda import TEST_LAMBDA_PYTHON_ECHO
@@ -706,6 +707,7 @@ class TestEvents:
         target_ids = [topic_target_id, sm_target_id, queue_target_id, fifo_queue_target_id]
         self.cleanup(None, rule_name, target_ids=target_ids, queue_url=queue_url)
         stepfunctions_client.delete_state_machine(stateMachineArn=state_machine_arn)
+        wait_for_port_closed(server.port)
 
     @pytest.mark.parametrize("auth", API_DESTINATION_AUTHS)
     def test_api_destinations(self, events_client, auth):

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -8,7 +8,7 @@ from pytest_httpserver import HTTPServer
 from localstack import config
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import lambda_function_arn
-from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_bytes, to_str
 from localstack.utils.sync import poll_condition, retry
 
@@ -33,100 +33,97 @@ def handler(event, context):
 
 
 @pytest.mark.parametrize("lambda_processor_enabled", [True, False])
-def test_firehose_http(lambda_processor_enabled: bool, create_lambda_function):
-    with HTTPServer() as server:
-        server.expect_request("").respond_with_data(b"", 200)
-        http_endpoint = server.url_for("/")
-        wait_for_port_open(server.port)
-        if lambda_processor_enabled:
-            # create processor func
-            func_name = f"proc-{short_uid()}"
-            create_lambda_function(handler_file=PROCESSOR_LAMBDA, func_name=func_name)
+def test_firehose_http(
+    lambda_processor_enabled: bool, create_lambda_function, httpserver: HTTPServer
+):
+    httpserver.expect_request("").respond_with_data(b"", 200)
+    http_endpoint = httpserver.url_for("/")
+    wait_for_port_open(httpserver.port)
+    if lambda_processor_enabled:
+        # create processor func
+        func_name = f"proc-{short_uid()}"
+        create_lambda_function(handler_file=PROCESSOR_LAMBDA, func_name=func_name)
 
-        # define firehose configs
-        # records = []
-        http_destination_update = {
-            "EndpointConfiguration": {"Url": http_endpoint, "Name": "test_update"}
+    # define firehose configs
+    # records = []
+    http_destination_update = {
+        "EndpointConfiguration": {"Url": http_endpoint, "Name": "test_update"}
+    }
+    http_destination = {
+        "EndpointConfiguration": {"Url": http_endpoint},
+        "S3BackupMode": "FailedDataOnly",
+        "S3Configuration": {
+            "RoleARN": "arn:.*",
+            "BucketARN": "arn:.*",
+            "Prefix": "",
+            "ErrorOutputPrefix": "",
+            "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 60},
+        },
+    }
+
+    if lambda_processor_enabled:
+        http_destination["ProcessingConfiguration"] = {
+            "Enabled": True,
+            "Processors": [
+                {
+                    "Type": "Lambda",
+                    "Parameters": [
+                        {
+                            "ParameterName": "LambdaArn",
+                            "ParameterValue": lambda_function_arn(func_name),
+                        }
+                    ],
+                }
+            ],
         }
-        http_destination = {
-            "EndpointConfiguration": {"Url": http_endpoint},
-            "S3BackupMode": "FailedDataOnly",
-            "S3Configuration": {
-                "RoleARN": "arn:.*",
-                "BucketARN": "arn:.*",
-                "Prefix": "",
-                "ErrorOutputPrefix": "",
-                "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 60},
-            },
-        }
 
-        if lambda_processor_enabled:
-            http_destination["ProcessingConfiguration"] = {
-                "Enabled": True,
-                "Processors": [
-                    {
-                        "Type": "Lambda",
-                        "Parameters": [
-                            {
-                                "ParameterName": "LambdaArn",
-                                "ParameterValue": lambda_function_arn(func_name),
-                            }
-                        ],
-                    }
-                ],
-            }
+    # create firehose stream with http destination
+    firehose = aws_stack.create_external_boto_client("firehose")
+    stream_name = "firehose_" + short_uid()
+    stream = firehose.create_delivery_stream(
+        DeliveryStreamName=stream_name,
+        HttpEndpointDestinationConfiguration=http_destination,
+    )
+    assert stream
+    stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
+    stream_description = stream_description["DeliveryStreamDescription"]
+    destination_description = stream_description["Destinations"][0][
+        "HttpEndpointDestinationDescription"
+    ]
+    assert len(stream_description["Destinations"]) == 1
+    assert destination_description["EndpointConfiguration"]["Url"] == http_endpoint
 
-        # create firehose stream with http destination
-        firehose = aws_stack.create_external_boto_client("firehose")
-        stream_name = "firehose_" + short_uid()
-        stream = firehose.create_delivery_stream(
-            DeliveryStreamName=stream_name,
-            HttpEndpointDestinationConfiguration=http_destination,
-        )
-        assert stream
-        stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
-        stream_description = stream_description["DeliveryStreamDescription"]
-        destination_description = stream_description["Destinations"][0][
-            "HttpEndpointDestinationDescription"
-        ]
-        assert len(stream_description["Destinations"]) == 1
-        assert destination_description["EndpointConfiguration"]["Url"] == http_endpoint
+    # put record
+    msg_text = "Hello World!"
+    firehose.put_record(DeliveryStreamName=stream_name, Record={"Data": msg_text})
 
-        # put record
-        msg_text = "Hello World!"
-        firehose.put_record(DeliveryStreamName=stream_name, Record={"Data": msg_text})
+    # wait for the result to arrive with proper content
+    assert poll_condition(lambda: len(httpserver.log) >= 1, timeout=5)
+    request, _ = httpserver.log[0]
+    record = request.get_json(force=True)
+    received_record = record["records"][0]
+    received_record_data = to_str(base64.b64decode(to_bytes(received_record["data"])))
+    assert received_record_data == f"{msg_text}{'-processed' if lambda_processor_enabled else ''}"
 
-        # wait for the result to arrive with proper content
-        assert poll_condition(lambda: len(server.log) >= 1, timeout=5)
-        request, _ = server.log[0]
-        record = request.get_json(force=True)
-        received_record = record["records"][0]
-        received_record_data = to_str(base64.b64decode(to_bytes(received_record["data"])))
-        assert (
-            received_record_data == f"{msg_text}{'-processed' if lambda_processor_enabled else ''}"
-        )
+    # update stream destination
+    destination_id = stream_description["Destinations"][0]["DestinationId"]
+    version_id = stream_description["VersionId"]
+    firehose.update_destination(
+        DeliveryStreamName=stream_name,
+        DestinationId=destination_id,
+        CurrentDeliveryStreamVersionId=version_id,
+        HttpEndpointDestinationUpdate=http_destination_update,
+    )
+    stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
+    stream_description = stream_description["DeliveryStreamDescription"]
+    destination_description = stream_description["Destinations"][0][
+        "HttpEndpointDestinationDescription"
+    ]
+    assert destination_description["EndpointConfiguration"]["Name"] == "test_update"
 
-        # update stream destination
-        destination_id = stream_description["Destinations"][0]["DestinationId"]
-        version_id = stream_description["VersionId"]
-        firehose.update_destination(
-            DeliveryStreamName=stream_name,
-            DestinationId=destination_id,
-            CurrentDeliveryStreamVersionId=version_id,
-            HttpEndpointDestinationUpdate=http_destination_update,
-        )
-        stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
-        stream_description = stream_description["DeliveryStreamDescription"]
-        destination_description = stream_description["Destinations"][0][
-            "HttpEndpointDestinationDescription"
-        ]
-        assert destination_description["EndpointConfiguration"]["Name"] == "test_update"
-
-        # delete stream
-        stream = firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
-        assert stream["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-    wait_for_port_closed(server.port)
+    # delete stream
+    stream = firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
+    assert stream["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
 class TestFirehoseIntegration:

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -3,22 +3,14 @@ import json
 
 import pytest as pytest
 import requests
+from pytest_httpserver import HTTPServer
 
 from localstack import config
-from localstack.services.generic_proxy import ProxyListener
-from localstack.services.infra import start_proxy
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import lambda_function_arn
-from localstack.utils.common import (
-    get_free_tcp_port,
-    get_service_protocol,
-    poll_condition,
-    retry,
-    short_uid,
-    to_bytes,
-    to_str,
-    wait_for_port_open,
-)
+from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.strings import short_uid, to_bytes, to_str
+from localstack.utils.sync import poll_condition, retry
 
 PROCESSOR_LAMBDA = """
 def handler(event, context):
@@ -42,105 +34,99 @@ def handler(event, context):
 
 @pytest.mark.parametrize("lambda_processor_enabled", [True, False])
 def test_firehose_http(lambda_processor_enabled: bool, create_lambda_function):
-    class MyUpdateListener(ProxyListener):
-        def forward_request(self, method, path, data, headers):
-            data_received = dict(json.loads(data.decode("utf-8")))
-            records.append(data_received)
-            return 200
+    with HTTPServer() as server:
+        server.expect_request("").respond_with_data(b"", 200)
+        http_endpoint = server.url_for("/")
+        wait_for_port_open(server.port)
+        if lambda_processor_enabled:
+            # create processor func
+            func_name = f"proc-{short_uid()}"
+            create_lambda_function(handler_file=PROCESSOR_LAMBDA, func_name=func_name)
 
-    if lambda_processor_enabled:
-        # create processor func
-        func_name = f"proc-{short_uid()}"
-        create_lambda_function(handler_file=PROCESSOR_LAMBDA, func_name=func_name)
-
-    # define firehose configs
-    local_port = get_free_tcp_port()
-    endpoint = "{}://{}:{}".format(get_service_protocol(), config.LOCALSTACK_HOSTNAME, local_port)
-    records = []
-    http_destination_update = {"EndpointConfiguration": {"Url": endpoint, "Name": "test_update"}}
-    http_destination = {
-        "EndpointConfiguration": {"Url": endpoint},
-        "S3BackupMode": "FailedDataOnly",
-        "S3Configuration": {
-            "RoleARN": "arn:.*",
-            "BucketARN": "arn:.*",
-            "Prefix": "",
-            "ErrorOutputPrefix": "",
-            "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 60},
-        },
-    }
-
-    if lambda_processor_enabled:
-        http_destination["ProcessingConfiguration"] = {
-            "Enabled": True,
-            "Processors": [
-                {
-                    "Type": "Lambda",
-                    "Parameters": [
-                        {
-                            "ParameterName": "LambdaArn",
-                            "ParameterValue": lambda_function_arn(func_name),
-                        }
-                    ],
-                }
-            ],
+        # define firehose configs
+        # records = []
+        http_destination_update = {
+            "EndpointConfiguration": {"Url": http_endpoint, "Name": "test_update"}
+        }
+        http_destination = {
+            "EndpointConfiguration": {"Url": http_endpoint},
+            "S3BackupMode": "FailedDataOnly",
+            "S3Configuration": {
+                "RoleARN": "arn:.*",
+                "BucketARN": "arn:.*",
+                "Prefix": "",
+                "ErrorOutputPrefix": "",
+                "BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 60},
+            },
         }
 
-    # start proxy server
-    start_proxy(local_port, backend_url=None, update_listener=MyUpdateListener())
-    wait_for_port_open(local_port)
+        if lambda_processor_enabled:
+            http_destination["ProcessingConfiguration"] = {
+                "Enabled": True,
+                "Processors": [
+                    {
+                        "Type": "Lambda",
+                        "Parameters": [
+                            {
+                                "ParameterName": "LambdaArn",
+                                "ParameterValue": lambda_function_arn(func_name),
+                            }
+                        ],
+                    }
+                ],
+            }
 
-    # create firehose stream with http destination
-    firehose = aws_stack.create_external_boto_client("firehose")
-    stream_name = "firehose_" + short_uid()
-    stream = firehose.create_delivery_stream(
-        DeliveryStreamName=stream_name,
-        HttpEndpointDestinationConfiguration=http_destination,
-    )
-    assert stream
-    stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
-    stream_description = stream_description["DeliveryStreamDescription"]
-    destination_description = stream_description["Destinations"][0][
-        "HttpEndpointDestinationDescription"
-    ]
-    assert len(stream_description["Destinations"]) == 1
-    assert (
-        destination_description["EndpointConfiguration"]["Url"] == f"http://localhost:{local_port}"
-    )
+        # create firehose stream with http destination
+        firehose = aws_stack.create_external_boto_client("firehose")
+        stream_name = "firehose_" + short_uid()
+        stream = firehose.create_delivery_stream(
+            DeliveryStreamName=stream_name,
+            HttpEndpointDestinationConfiguration=http_destination,
+        )
+        assert stream
+        stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
+        stream_description = stream_description["DeliveryStreamDescription"]
+        destination_description = stream_description["Destinations"][0][
+            "HttpEndpointDestinationDescription"
+        ]
+        assert len(stream_description["Destinations"]) == 1
+        assert destination_description["EndpointConfiguration"]["Url"] == http_endpoint
 
-    # put record
-    msg_text = "Hello World!"
-    firehose.put_record(DeliveryStreamName=stream_name, Record={"Data": msg_text})
+        # put record
+        msg_text = "Hello World!"
+        firehose.put_record(DeliveryStreamName=stream_name, Record={"Data": msg_text})
 
-    # wait for the result to arrive with proper content
-    def _assert_record():
-        received_record = records[0]["records"][0]
+        # wait for the result to arrive with proper content
+        assert poll_condition(lambda: len(server.log) >= 1, timeout=5)
+        request, _ = server.log[0]
+        record = request.get_json(force=True)
+        received_record = record["records"][0]
         received_record_data = to_str(base64.b64decode(to_bytes(received_record["data"])))
         assert (
             received_record_data == f"{msg_text}{'-processed' if lambda_processor_enabled else ''}"
         )
 
-    retry(_assert_record, retries=5, sleep=1)
+        # update stream destination
+        destination_id = stream_description["Destinations"][0]["DestinationId"]
+        version_id = stream_description["VersionId"]
+        firehose.update_destination(
+            DeliveryStreamName=stream_name,
+            DestinationId=destination_id,
+            CurrentDeliveryStreamVersionId=version_id,
+            HttpEndpointDestinationUpdate=http_destination_update,
+        )
+        stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
+        stream_description = stream_description["DeliveryStreamDescription"]
+        destination_description = stream_description["Destinations"][0][
+            "HttpEndpointDestinationDescription"
+        ]
+        assert destination_description["EndpointConfiguration"]["Name"] == "test_update"
 
-    # update stream destination
-    destination_id = stream_description["Destinations"][0]["DestinationId"]
-    version_id = stream_description["VersionId"]
-    firehose.update_destination(
-        DeliveryStreamName=stream_name,
-        DestinationId=destination_id,
-        CurrentDeliveryStreamVersionId=version_id,
-        HttpEndpointDestinationUpdate=http_destination_update,
-    )
-    stream_description = firehose.describe_delivery_stream(DeliveryStreamName=stream_name)
-    stream_description = stream_description["DeliveryStreamDescription"]
-    destination_description = stream_description["Destinations"][0][
-        "HttpEndpointDestinationDescription"
-    ]
-    assert destination_description["EndpointConfiguration"]["Name"] == "test_update"
+        # delete stream
+        stream = firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
+        assert stream["ResponseMetadata"]["HTTPStatusCode"] == 200
 
-    # delete stream
-    stream = firehose.delete_delivery_stream(DeliveryStreamName=stream_name)
-    assert stream["ResponseMetadata"]["HTTPStatusCode"] == 200
+    wait_for_port_closed(server.port)
 
 
 class TestFirehoseIntegration:

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -8,7 +8,6 @@ from pytest_httpserver import HTTPServer
 from localstack import config
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import lambda_function_arn
-from localstack.utils.net import wait_for_port_open
 from localstack.utils.strings import short_uid, to_bytes, to_str
 from localstack.utils.sync import poll_condition, retry
 
@@ -38,7 +37,6 @@ def test_firehose_http(
 ):
     httpserver.expect_request("").respond_with_data(b"", 200)
     http_endpoint = httpserver.url_for("/")
-    wait_for_port_open(httpserver.port)
     if lambda_processor_enabled:
         # create processor func
         func_name = f"proc-{short_uid()}"

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -20,7 +20,6 @@ from localstack.utils.crypto import (
 from localstack.utils.files import load_file, new_tmp_file, rm_rf
 from localstack.utils.http import download
 from localstack.utils.json import FileMappedDocument
-from localstack.utils.net import wait_for_port_closed, wait_for_port_open
 from localstack.utils.run import run
 from localstack.utils.sync import poll_condition, synchronized
 from localstack.utils.tail import FileListener
@@ -260,24 +259,23 @@ def test_generate_ssl_cert():
     rm_rf(key_file_name)
 
 
-def test_download_with_timeout():
+def test_download_with_timeout(httpserver: HTTPServer):
     def _handler(_: Request) -> Response:
         time.sleep(2)
         return Response(b"", status=200)
 
     tmp_file = new_tmp_file()
-    # not using the fixture as it seems the test is not cleaning up afterwards, maybe because of unittest
-    with HTTPServer() as server:
-        server.expect_request("/").respond_with_data(b"tmp_file", status=200)
-        server.expect_request("/sleep").respond_with_handler(_handler)
-        http_endpoint = server.url_for("/")
-        wait_for_port_open(server.port)
+    httpserver.expect_request("/").respond_with_data(b"tmp_file", status=200)
+    httpserver.expect_request("/sleep").respond_with_handler(_handler)
+    http_endpoint = httpserver.url_for("/")
 
-        download(http_endpoint, tmp_file)
-        assert load_file(tmp_file) == "tmp_file"
-        with pytest.raises(TimeoutError):
-            download(f"{http_endpoint}/sleep", tmp_file, timeout=1)
+    download(http_endpoint, tmp_file)
+    assert load_file(tmp_file) == "tmp_file"
+    with pytest.raises(TimeoutError):
+        download(f"{http_endpoint}/sleep", tmp_file, timeout=1)
 
     # clean up
     rm_rf(tmp_file)
-    wait_for_port_closed(server.port)
+    # it seems this test is not properly cleaning up for other unit tests, this step is normally not necessary,
+    # the fixture should take care of it
+    httpserver.clear()

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -9,24 +9,21 @@ import pytest
 from pytest_httpserver import HTTPServer
 from werkzeug import Request, Response
 
-from localstack.utils.common import (
+from localstack.utils.collections import is_none_or_empty
+from localstack.utils.crypto import (
     PEM_CERT_END,
     PEM_CERT_START,
     PEM_KEY_END_REGEX,
     PEM_KEY_START_REGEX,
-    FileListener,
-    FileMappedDocument,
-    download,
     generate_ssl_cert,
-    is_none_or_empty,
-    load_file,
-    new_tmp_file,
-    poll_condition,
-    rm_rf,
-    run,
-    synchronized,
 )
+from localstack.utils.files import load_file, new_tmp_file, rm_rf
+from localstack.utils.http import download
+from localstack.utils.json import FileMappedDocument
 from localstack.utils.net import wait_for_port_closed, wait_for_port_open
+from localstack.utils.run import run
+from localstack.utils.sync import poll_condition, synchronized
+from localstack.utils.tail import FileListener
 
 
 class SynchronizedTest(unittest.TestCase):

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -20,7 +20,7 @@ from localstack.utils.crypto import (
 from localstack.utils.files import load_file, new_tmp_file, rm_rf
 from localstack.utils.http import download
 from localstack.utils.json import FileMappedDocument
-from localstack.utils.net import wait_for_port_open
+from localstack.utils.net import wait_for_port_closed, wait_for_port_open
 from localstack.utils.run import run
 from localstack.utils.sync import poll_condition, synchronized
 from localstack.utils.tail import FileListener
@@ -260,21 +260,24 @@ def test_generate_ssl_cert():
     rm_rf(key_file_name)
 
 
-def test_download_with_timeout(httpserver: HTTPServer):
+def test_download_with_timeout():
     def _handler(_: Request) -> Response:
         time.sleep(2)
         return Response(b"", status=200)
 
     tmp_file = new_tmp_file()
-    httpserver.expect_request("/").respond_with_data(b"tmp_file", status=200)
-    httpserver.expect_request("/sleep").respond_with_handler(_handler)
-    http_endpoint = httpserver.url_for("/")
-    wait_for_port_open(httpserver.port)
+    # not using the fixture as it seems the test is not cleaning up afterwards, maybe because of unittest
+    with HTTPServer() as server:
+        server.expect_request("/").respond_with_data(b"tmp_file", status=200)
+        server.expect_request("/sleep").respond_with_handler(_handler)
+        http_endpoint = server.url_for("/")
+        wait_for_port_open(server.port)
 
-    download(http_endpoint, tmp_file)
-    assert load_file(tmp_file) == "tmp_file"
-    with pytest.raises(TimeoutError):
-        download(f"{http_endpoint}/sleep", tmp_file, timeout=1)
+        download(http_endpoint, tmp_file)
+        assert load_file(tmp_file) == "tmp_file"
+        with pytest.raises(TimeoutError):
+            download(f"{http_endpoint}/sleep", tmp_file, timeout=1)
 
     # clean up
     rm_rf(tmp_file)
+    wait_for_port_closed(server.port)


### PR DESCRIPTION
This PR is the start list of tests to migrate from using the `ProxyListener`.

This PR mostly refactors tests using the `ProxyListener`, to use pytest `httpserver` fixture instead.

- [x] `test_forward_to_fallback_url_http#MyUpdateListener(ProxyListener)`
- [x] `test_api_destinations#HttpEndpointListener(ProxyListener)`
- [x] `test_scheduled_expression_events#HttpEndpointListener(ProxyListener)`
- [x] `test_firehose_http#MyUpdateListener(ProxyListener)`
- [x] `TestAPIGateway#start_http_backend#TestListener(ProxyListener)`
- [x] `test_download_with_timeout#DownloadListener(ProxyListener)`

We also had some tests validating the CloudFormation UI to help deploy a template, which is migrated into a `Resource` test and an integration test in the CloudFormation test module.
- [x] `test_cloudformation_ui#LocalstackResourceHandler(ProxyListener)`

There still some usage of `ProxyListener` via `testutil#proxy_server` method, but it tests its internals and will be removed once we fully remove it.

- `testutil.py#proxy_server (test utils function)`
    -  used in `TestRouterListener` which is migrated
    - used in `TestAwsApiListener` which can be deleted
    - used in `LocalstackResourceHandler` which is migrated
- `TestLocalstackResourceHandlerIntegration#test_fallthrough#RaiseError(ProxyListener)`
    - using `LocalstackResourceHandler` which is migrated

note: took the opportunity to clean up some `utils.common` imports.