### PR TITLE
Fix CLI cache permissions by creating volume dir before mounting

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -54,7 +54,7 @@ def localstack(debug, profile):
 
     # overwrite the config variable here to defer import of cache_dir
     if not config.LEGACY_DIRECTORIES and not os.environ.get("LOCALSTACK_VOLUME_DIR", "").strip():
-        config.VOLUME_DIR = cache_dir() / "volume"
+        config.VOLUME_DIR = str(cache_dir() / "volume")
 
 
 @localstack.group(name="config", help="Inspect your LocalStack configuration")
@@ -137,7 +137,7 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
         else:
             console.log("starting LocalStack in Docker mode :whale:")
 
-    bootstrap.prepare_host()
+    bootstrap.prepare_host(console)
 
     if not no_banner and not detached:
         console.rule("LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)")

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -607,12 +607,19 @@ def configure_volume_mounts(container: LocalstackContainer):
 
 
 @log_duration()
-def prepare_host():
+def prepare_host(console):
     """
     Prepare the host environment for running LocalStack, this should be called before start_infra_*.
     """
     if os.environ.get(constants.LOCALSTACK_INFRA_PROCESS) in constants.TRUE_STRINGS:
         return
+
+    try:
+        mkdir(config.VOLUME_DIR)
+    except Exception as e:
+        console.print(f"Error while creating volume dir {config.VOLUME_DIR}: {e}")
+        if config.DEBUG:
+            console.print_exception()
 
     setup_logging()
     hooks.prepare_host.run()
@@ -636,7 +643,7 @@ def start_infra_in_docker():
     #  There are subtle differences across operating systems and terminal emulators when it
     #  comes to handling of CTRL-C - in particular, Linux sends SIGINT to the parent process,
     #  whereas MacOS sends SIGINT to the process group, which can result in multiple SIGINT signals
-    #  being received (e.g., when running the localstack CLI as part of an "npm run .." script).
+    #  being received (e.g., when running the localstack CLI as part of a "npm run .." script).
     #  Hence, using a shutdown handler and synchronization event here, to avoid inconsistencies.
     def shutdown_handler(*args):
         with shutdown_event_lock:


### PR DESCRIPTION
## Problem
Currently, we never properly create the directory specified by `config.VOLUME_DIR`. This can lead to permission errors, if docker creates this folder (and any missing parents) as root.

The default configuration for the CLI is one of these cases, where `~/config/localstack/volume` is created as root, which leads to `~/.config/localstack` not being writable as non root user which in turn leads to problems for `localstack status docker` (due to some cache files being written to that directory).

## Proposed solution
Try to `mkdir` the `VOLUME_DIR` directory (and its parents) instead of letting docker do so, failing non-fatally.
An error message will be printed, but the docker start is not prevented.