### PR TITLE
change default timestamp format for querystring

### DIFF
--- a/localstack/aws/protocol/parser.py
+++ b/localstack/aws/protocol/parser.py
@@ -194,6 +194,8 @@ class RequestParser(abc.ABC):
     TIMESTAMP_FORMAT = "iso8601"
     # The default timestamp format for header fields
     HEADER_TIMESTAMP_FORMAT = "rfc822"
+    # The default timestamp format for query fields
+    QUERY_TIMESTAMP_FORMAT = "iso8601"
 
     def __init__(self, service: ServiceModel) -> None:
         super().__init__()
@@ -297,6 +299,8 @@ class RequestParser(abc.ABC):
         timestamp_format = shape.serialization.get("timestampFormat")
         if not timestamp_format and shape.serialization.get("location") == "header":
             timestamp_format = self.HEADER_TIMESTAMP_FORMAT
+        elif not timestamp_format and shape.serialization.get("location") == "querystring":
+            timestamp_format = self.QUERY_TIMESTAMP_FORMAT
         return self._convert_str_to_timestamp(node, timestamp_format)
 
     @_text_content

--- a/tests/unit/aws/protocol/test_parser.py
+++ b/tests/unit/aws/protocol/test_parser.py
@@ -399,6 +399,22 @@ def test_query_parser_no_input_shape_autoscaling_with_botocore():
     )
 
 
+def test_query_parser_iot_with_botocore():
+    """Test if timestamp for 'rest-json' is parsed correctly"""
+    start = datetime(2023, 1, 10, tzinfo=timezone.utc)
+    end = datetime(2023, 1, 11, tzinfo=timezone.utc)
+    _botocore_parser_integration_test(
+        service="iot",
+        action="ListAuditMitigationActionsTasks",
+        endTime=end,
+        startTime=start,
+        expected={
+            "endTime": end,
+            "startTime": start,
+        },
+    )
+
+
 def test_query_parser_cloudformation_with_botocore():
     _botocore_parser_integration_test(
         service="cloudformation",


### PR DESCRIPTION
This PR sets the default timestamp format when parsing query strings timestamps to "iso8601".


When analyzing the responses for the not/implemented coverage tests, I found that a parser issue occurs for `iot` and relates to the timestamp.

I tested the operation `ListAuditMitigationActionsTasks` with different timestamp formats (also using `awscli`) and it seems like it will [always be converted](https://github.com/boto/botocore/blob/develop/botocore/serialize.py#L597) to a date in [iso8601 format](https://github.com/boto/botocore/blob/develop/botocore/serialize.py#L430). 

The operation does not have a `timestampFormat`defined in its shape, and would default to unix-timestamp. But also the unix timestamp is converted in botocore before sending the request:

```
$ awslocal iot list-audit-mitigation-actions-tasks --start-time 1673459237 --end-time 1673459240

An error occurred (InternalError) when calling the ListAuditMitigationActionsTasks operation (reached max retries: 4): exception while calling iot with unknown operation: Traceback (most recent call last):
  File "/opt/code/localstack/localstack/aws/protocol/parser.py", line 262, in _parse_shape
    return handler(request, shape, payload, uri_params) if payload is not None else None
  File "/opt/code/localstack/localstack/aws/protocol/parser.py", line 120, in _get_text_content
    return func(self, request, shape, text, uri_params)
  File "/opt/code/localstack/localstack/aws/protocol/parser.py", line 300, in _parse_timestamp
    return self._convert_str_to_timestamp(node, timestamp_format)
  File "/opt/code/localstack/localstack/aws/protocol/parser.py", line 324, in _convert_str_to_timestamp
    final_value = converter(value)
  File "/opt/code/localstack/localstack/aws/protocol/parser.py", line 333, in _timestamp_unixtimestamp
    return datetime.datetime.utcfromtimestamp(int(timestamp_string))
ValueError: invalid literal for int() with base 10: '2023-01-11T17:47:17Z'
```
