### PR TITLE
add on_platform_shutdown method to extension interface

### DIFF
--- a/localstack/extensions/api/extension.py
+++ b/localstack/extensions/api/extension.py
@@ -84,3 +84,9 @@ class Extension(BaseExtension):
         Called when LocalStack is ready and the Ready marker has been printed.
         """
         pass
+
+    def on_platform_shutdown(self):
+        """
+        Called when LocalStack is shutting down. Can be used to close any resources (threads, processes, sockets, etc.).
+        """
+        pass


### PR DESCRIPTION
Adds a method to the Extension interface to hook into the shutdown procedure of LocalStack.