### PR TITLE
Lambda revisions

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -435,8 +435,6 @@ class ResourcePolicy:
 class FunctionResourcePolicy:
     # TODO: do we have a typed IAM policy somewhere already?
     # Something like this? localstack_ext.services.iam.policy_engine.models.PolicyDocument
-    # TODO: Can we add a typed PolicyDocument instead?
-    # TODO: Could we store the policy directly in VersionFunctionConfiguration and VersionAlias?
     policy: ResourcePolicy
 
 

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -433,8 +433,6 @@ class ResourcePolicy:
 
 @dataclasses.dataclass
 class FunctionResourcePolicy:
-    # TODO: do we have a typed IAM policy somewhere already?
-    # Something like this? localstack_ext.services.iam.policy_engine.models.PolicyDocument
     policy: ResourcePolicy
 
 

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -433,12 +433,11 @@ class ResourcePolicy:
 
 @dataclasses.dataclass
 class FunctionResourcePolicy:
-    revision_id: str = dataclasses.field(init=False, default_factory=long_uid)
-    policy: ResourcePolicy  # TODO: do we have a typed IAM policy somewhere already?
-
-    @staticmethod
-    def new_revision_id() -> str:
-        return long_uid()
+    # TODO: do we have a typed IAM policy somewhere already?
+    # Something like this? localstack_ext.services.iam.policy_engine.models.PolicyDocument
+    # TODO: Can we add a typed PolicyDocument instead?
+    # TODO: Could we store the policy directly in VersionFunctionConfiguration and VersionAlias?
+    policy: ResourcePolicy
 
 
 @dataclasses.dataclass

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -293,6 +293,8 @@ class LambdaService:
                 return
 
         # TODO is it necessary to get the version again? Should be locked for modification anyway
+        # Without updating the new state, the function would not change to active, last_update would be missing, and
+        # the revision id would not be updated.
         state = lambda_stores[function_version.id.account][function_version.id.region]
         function = state.functions[function_version.id.function_name]
         current_version = function.versions[function_version.id.qualifier]

--- a/localstack/services/awslambda/invocation/version_manager.py
+++ b/localstack/services/awslambda/invocation/version_manager.py
@@ -165,7 +165,8 @@ class LambdaVersionManager(ServiceEndpoint):
             self.log_handler.start_subscriber()
             get_runtime_executor().prepare_version(self.function_version)
 
-            # TODO: check if code + reason should be set here as well? Do waiters return this?
+            # code and reason not set for success scenario because only failed states provide this field:
+            # https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConfiguration.html#SSS-GetFunctionConfiguration-response-LastUpdateStatusReasonCode
             self.state = VersionState(state=State.Active)
             LOG.debug(
                 f"Lambda '{self.function_arn}' (id {self.function_version.config.internal_revision}) changed to active"

--- a/localstack/services/awslambda/invocation/version_manager.py
+++ b/localstack/services/awslambda/invocation/version_manager.py
@@ -165,6 +165,7 @@ class LambdaVersionManager(ServiceEndpoint):
             self.log_handler.start_subscriber()
             get_runtime_executor().prepare_version(self.function_version)
 
+            # TODO: check if code + reason should be set here as well? Do waiters return this?
             self.state = VersionState(state=State.Active)
             LOG.debug(
                 f"Lambda '{self.function_arn}' (id {self.function_version.config.internal_revision}) changed to active"

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1240,7 +1240,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if not (alias := function.aliases.get(name)):
             raise ValueError("Alias not found")  # TODO proper exception
         if revision_id and alias.revision_id != revision_id:
-            raise ValueError("Wrong revision id")  # TODO proper exception
+            raise PreconditionFailedException(
+                "The Revision Id provided does not match the latest Revision Id. "
+                "Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+                Type="User",
+            )
         changes = {}
         if function_version is not None:
             changes |= {"function_version": function_version}

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1719,13 +1719,6 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # check for an already existing policy and any conflicts in existing statements
         existing_policy = resolved_fn.permissions.get(resolved_qualifier)
         if existing_policy:
-            # revision_id = request.get("RevisionId")
-            # if revision_id and existing_policy.revision_id != revision_id:
-            #     raise PreconditionFailedException(
-            #         "The Revision Id provided does not match the latest Revision Id. "
-            #         "Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
-            #         Type="User",
-            #     )
             request_sid = request["StatementId"]
             if request_sid in [s["Sid"] for s in existing_policy.policy.Statement]:
                 # uniqueness scope: statement id needs to be unique per qualified function ($LATEST, version, or alias)

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -2886,7 +2886,6 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         organization_id: OrganizationId = None,
         revision_id: String = None,
     ) -> AddLayerVersionPermissionResponse:
-        # TODO: test for revision_id
         # TODO: add layer ARN as layer_name support
 
         layer_version_arn = api_utils.layer_version_arn(
@@ -2916,6 +2915,13 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         if statement_id in layer_version.policy.statements:
             raise ResourceConflictException(
                 f"The statement id ({statement_id}) provided already exists. Please provide a new statement id, or remove the existing statement.",
+                Type="User",
+            )
+
+        if revision_id and layer_version.policy.revision_id != revision_id:
+            raise PreconditionFailedException(
+                "The Revision Id provided does not match the latest Revision Id. "
+                "Call the GetLayerPolicy API to retrieve the latest Revision Id",
                 Type="User",
             )
 
@@ -2966,8 +2972,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             )
 
         if revision_id and layer_version.policy.revision_id != revision_id:
-            # TODO: add test
-            return
+            raise PreconditionFailedException(
+                "The Revision Id provided does not match the latest Revision Id. "
+                "Call the GetLayerPolicy API to retrieve the latest Revision Id",
+                Type="User",
+            )
 
         if statement_id not in layer_version.policy.statements:
             raise ResourceNotFoundException(

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -645,6 +645,14 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         latest_version = function.latest()
         latest_version_config = latest_version.config
 
+        revision_id = request.get("RevisionId")
+        if revision_id and revision_id != latest_version.config.revision_id:
+            raise PreconditionFailedException(
+                "The Revision Id provided does not match the latest Revision Id. "
+                "Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+                Type="User",
+            )
+
         replace_kwargs = {}
         if "EphemeralStorage" in request:
             replace_kwargs["ephemeral_storage"] = LambdaEphemeralStorage(

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -734,6 +734,15 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 Type="User",
             )
         function = state.functions[function_name]
+
+        revision_id = request.get("RevisionId")
+        if revision_id and revision_id != function.latest().config.revision_id:
+            raise PreconditionFailedException(
+                "The Revision Id provided does not match the latest Revision Id. "
+                "Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+                Type="User",
+            )
+
         # TODO verify if correct combination of code is set
         image = None
         if (

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -284,7 +284,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
     @staticmethod
     def _function_revision_id(resolved_fn: Function, resolved_qualifier: str) -> str:
         if api_utils.qualifier_is_alias(resolved_qualifier):
-            return resolved_fn.aliases[resolved_qualifier].config.revision_id
+            return resolved_fn.aliases[resolved_qualifier].revision_id
         # Assumes that a non-alias is a version
         else:
             return resolved_fn.versions[resolved_qualifier].config.revision_id
@@ -1710,7 +1710,6 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         resolved_fn = self._get_function(function_name, context.account_id, context.region)
         resolved_qualifier, fn_arn = self._resolve_fn_qualifier(resolved_fn, qualifier)
 
-        # TODO: test for alias
         revision_id = request.get("RevisionId")
         if revision_id:
             fn_revision_id = self._function_revision_id(resolved_fn, resolved_qualifier)

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1753,9 +1753,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # TODO: does that need a `with function.lock`? => single .replace would facilitate this
         if api_utils.qualifier_is_alias(resolved_qualifier):
             latest_alias = resolved_fn.aliases[resolved_qualifier]
-            resolved_fn.aliases[resolved_qualifier] = dataclasses.replace(
-                latest_alias, config=dataclasses.replace(latest_alias.config)
-            )
+            resolved_fn.aliases[resolved_qualifier] = dataclasses.replace(latest_alias)
         # Assumes that a non-alias is a version
         else:
             latest_version = resolved_fn.versions[resolved_qualifier]
@@ -1818,9 +1816,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         # TODO: does that need a `with function.lock`? => single .replace would facilitate this
         if api_utils.qualifier_is_alias(resolved_qualifier):
             latest_alias = resolved_fn.aliases[resolved_qualifier]
-            resolved_fn.aliases[resolved_qualifier] = dataclasses.replace(
-                latest_alias, config=dataclasses.replace(latest_alias.config)
-            )
+            resolved_fn.aliases[resolved_qualifier] = dataclasses.replace(latest_alias)
         # Assumes that a non-alias is a version
         else:
             latest_version = resolved_fn.versions[resolved_qualifier]
@@ -1857,7 +1853,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         fn_revision_id = None
         if api_utils.qualifier_is_alias(resolved_qualifier):
             latest_alias = resolved_fn.aliases[resolved_qualifier]
-            fn_revision_id = latest_alias.config.revision_id
+            fn_revision_id = latest_alias.revision_id
         # Assumes that a non-alias is a version
         else:
             latest_version = resolved_fn.versions[resolved_qualifier]

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1754,7 +1754,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         # Update revision id of alias or version
         # TODO: re-evaluate data model to prevent this dirty hack just for bumping the revision id
-        # TODO: does that need a `with function.lock`? => single .replace would facilitate this
+        # TODO: does that need a `with function.lock` for atomic updates of the policy + revision_id?
         if api_utils.qualifier_is_alias(resolved_qualifier):
             latest_alias = resolved_fn.aliases[resolved_qualifier]
             resolved_fn.aliases[resolved_qualifier] = dataclasses.replace(latest_alias)
@@ -1817,7 +1817,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         # Update revision id for alias or version
         # TODO: re-evaluate data model to prevent this dirty hack just for bumping the revision id
-        # TODO: does that need a `with function.lock`? => single .replace would facilitate this
+        # TODO: does that need a `with function.lock` for atomic updates of the policy + revision_id?
         if api_utils.qualifier_is_alias(resolved_qualifier):
             latest_alias = resolved_fn.aliases[resolved_qualifier]
             resolved_fn.aliases[resolved_qualifier] = dataclasses.replace(latest_alias)

--- a/localstack/utils/testutil.py
+++ b/localstack/utils/testutil.py
@@ -197,7 +197,8 @@ def create_lambda_function(
     region_name=None,
     **kwargs,
 ):
-    """Utility method to create a new function via the Lambda API"""
+    """Utility method to create a new function via the Lambda API
+    CAVEAT: Does NOT wait until the function is ready/active. The fixture create_lambda_function waits until ready."""
     if envvars is None:
         envvars = {}
     if tags is None:

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1322,7 +1322,7 @@ class TestLambdaRevisions:
         snapshot.match("create_function_response_rev1", create_function_response)
         rev1_create_function = create_function_response["CreateFunctionResponse"]["RevisionId"]
 
-        # rev2: created function becomes active
+        # rev2: created function becomes active (the fixture does the waiting)
         get_function_response_rev2 = lambda_client.get_function(FunctionName=function_name)
         snapshot.match("get_function_response_rev2", get_function_response_rev2)
         rev2_active_state = get_function_response_rev2["Configuration"]["RevisionId"]

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1298,7 +1298,14 @@ class TestLambdaAlias:
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
+@pytest.mark.skip_snapshot_verify(
+    paths=[
+        # new Lambda feature: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
+        "$..SnapStart"
+    ]
+)
 class TestLambdaRevisions:
+    @pytest.mark.aws_validated
     def test_function_revisions_basic(self, lambda_client, create_lambda_function, snapshot):
         """Tests basic revision id lifecycle for creating and updating functions"""
         function_name = f"fn-{short_uid()}"

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1441,6 +1441,7 @@ class TestLambdaRevisions:
         rev6a_update_alias = update_alias_response["RevisionId"]
         assert rev5a_create_alias != rev6a_update_alias
 
+    @pytest.mark.aws_validated
     def test_function_revisions_permissions(self, create_lambda_function, lambda_client, snapshot):
         """Tests revision id lifecycle for adding and removing permissions"""
         # rev1: create function
@@ -1457,7 +1458,7 @@ class TestLambdaRevisions:
 
         sid = "s3"
         with pytest.raises(lambda_client.exceptions.PreconditionFailedException) as e:
-            add_permission_response = lambda_client.add_permission(
+            lambda_client.add_permission(
                 FunctionName=function_name,
                 StatementId=sid,
                 Action="lambda:InvokeFunction",

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1376,6 +1376,7 @@ class TestLambdaRevisions:
         rev6_fn_config_update_done = get_function_response_rev6["Configuration"]["RevisionId"]
         assert rev5_fn_config_update != rev6_fn_config_update_done
 
+    @pytest.mark.aws_validated
     def test_function_revisions_version_and_alias(
         self, create_lambda_function, lambda_client, snapshot
     ):
@@ -1422,7 +1423,7 @@ class TestLambdaRevisions:
         assert rev4_publish_version_done != rev5a_create_alias
 
         with pytest.raises(lambda_client.exceptions.PreconditionFailedException) as e:
-            update_alias_response = lambda_client.update_alias(
+            lambda_client.update_alias(
                 FunctionName=function_name,
                 Name=alias_name,
                 RevisionId="wrong",

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -2629,6 +2629,10 @@ class TestLambdaPermissions:
         )
         snapshot.match("create_alias_response", create_alias_response)
 
+        get_alias_response = lambda_client.get_alias(FunctionName=function_name, Name=alias_name)
+        snapshot.match("get_alias", get_alias_response)
+        assert get_alias_response["RevisionId"] == create_alias_response["RevisionId"]
+
         sid = "s3"
         with pytest.raises(lambda_client.exceptions.PreconditionFailedException) as e:
             lambda_client.add_permission(

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -9496,7 +9496,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_lambda_permission_fn_versioning": {
-    "recorded-date": "23-12-2022, 13:23:23",
+    "recorded-date": "13-01-2023, 18:37:09",
     "recorded-content": {
       "add_permission": {
         "Statement": {
@@ -9506,10 +9506,10 @@
             "Service": "s3.amazonaws.com"
           },
           "Action": "lambda:InvokeFunction",
-          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
           "Condition": {
             "ArnLike": {
-              "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+              "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
             }
           }
         },
@@ -9530,16 +9530,98 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             }
           ]
         },
         "RevisionId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "publish_version_result": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:3>",
+        "Runtime": "python3.9",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_function_result_after_publishing": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:3>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -9557,16 +9639,16 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             }
           ]
         },
-        "RevisionId": "<uuid:2>",
+        "RevisionId": "<uuid:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -9596,16 +9678,16 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>:1",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             }
           ]
         },
-        "RevisionId": "<uuid:3>",
+        "RevisionId": "<uuid:4>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -9623,16 +9705,16 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>:permission-alias",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:permission-alias",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             }
           ]
         },
-        "RevisionId": "<uuid:4>",
+        "RevisionId": "<uuid:5>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -9650,16 +9732,16 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             }
           ]
         },
-        "RevisionId": "<uuid:2>",
+        "RevisionId": "<uuid:3>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -9677,10 +9759,10 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             },
@@ -9691,16 +9773,16 @@
                 "Service": "s3.amazonaws.com"
               },
               "Action": "lambda:InvokeFunction",
-              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:1>"
                 }
               }
             }
           ]
         },
-        "RevisionId": "<uuid:5>",
+        "RevisionId": "<uuid:6>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -10290,8 +10372,94 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version_and_alias": {
-    "recorded-date": "06-01-2023, 22:19:32",
+    "recorded-date": "13-01-2023, 18:36:42",
     "recorded-content": {
+      "create_function_response_rev1": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "get_function_active_rev2": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "publish_version_revision_exception": {
         "Error": {
           "Code": "PreconditionFailedException",
@@ -10304,7 +10472,7 @@
           "HTTPStatusCode": 412
         }
       },
-      "publish_version_response": {
+      "publish_version_response_rev_v1": {
         "Architectures": [
           "x86_64"
         ],
@@ -10324,8 +10492,8 @@
         "LastUpdateStatus": "Successful",
         "MemorySize": 128,
         "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:aws:iam::111111111111:role/<resource:2>",
+        "RevisionId": "<uuid:3>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
         "SnapStart": {
           "ApplyOn": "None",
@@ -10342,15 +10510,191 @@
           "HTTPStatusCode": 201
         }
       },
-      "create_alias_response_rev5a": {
+      "get_function_published_version_rev_v2": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_latest_rev3": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:4>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create_alias_response_rev_a1": {
         "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:revision_alias",
         "Description": "",
         "FunctionVersion": "1",
         "Name": "revision_alias",
-        "RevisionId": "<uuid:2>",
+        "RevisionId": "<uuid:5>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      },
+      "get_function_latest_rev4": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:4>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_published_version_rev_v3": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "handler.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "update_alias_revision_exception": {
@@ -10365,12 +10709,12 @@
           "HTTPStatusCode": 412
         }
       },
-      "update_alias_response_rev6a": {
+      "update_alias_response_rev_a2": {
         "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:revision_alias",
         "Description": "something changed",
         "FunctionVersion": "1",
         "Name": "revision_alias",
-        "RevisionId": "<uuid:3>",
+        "RevisionId": "<uuid:6>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -9496,7 +9496,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_lambda_permission_fn_versioning": {
-    "recorded-date": "16-01-2023, 12:31:25",
+    "recorded-date": "16-01-2023, 12:41:51",
     "recorded-content": {
       "add_permission": {
         "Statement": {
@@ -9702,6 +9702,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      },
+      "get_alias": {
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:permission-alias",
+        "Description": "",
+        "FunctionVersion": "1",
+        "Name": "permission-alias",
+        "RevisionId": "<uuid:5>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "add_permission_alias_revision_exception": {

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10005,5 +10005,288 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions": {
+    "recorded-date": "06-01-2023, 20:24:28",
+    "recorded-content": {
+      "create_function_response_rev1": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "index.handler",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "get_function_response_rev2": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "index.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_function_revision_id_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "update_function_code_response_rev3": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:3>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.9",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_rev4": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "index.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:4>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.9",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update_function_configuration_revision_id_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "update_function_configuration_response_rev5": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "index.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:5>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "python3.8",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_rev6": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "index.handler",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:6>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "python3.8",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -9496,7 +9496,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_lambda_permission_fn_versioning": {
-    "recorded-date": "13-01-2023, 18:37:09",
+    "recorded-date": "16-01-2023, 12:31:25",
     "recorded-content": {
       "add_permission": {
         "Statement": {
@@ -9693,6 +9693,29 @@
           "HTTPStatusCode": 200
         }
       },
+      "create_alias_response": {
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:permission-alias",
+        "Description": "",
+        "FunctionVersion": "1",
+        "Name": "permission-alias",
+        "RevisionId": "<uuid:5>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "add_permission_alias_revision_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
       "get_policy_alias": {
         "Policy": {
           "Version": "2012-10-17",
@@ -9714,7 +9737,7 @@
             }
           ]
         },
-        "RevisionId": "<uuid:5>",
+        "RevisionId": "<uuid:6>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -9782,7 +9805,7 @@
             }
           ]
         },
-        "RevisionId": "<uuid:6>",
+        "RevisionId": "<uuid:7>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10289,8 +10289,8 @@
       }
     }
   },
-  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version": {
-    "recorded-date": "06-01-2023, 21:16:06",
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version_and_alias": {
+    "recorded-date": "06-01-2023, 21:55:36",
     "recorded-content": {
       "publish_version_revision_id_exception": {
         "Error": {
@@ -10340,6 +10340,40 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
+        }
+      },
+      "create_alias_response_rev5a": {
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:revision_alias",
+        "Description": "",
+        "FunctionVersion": "1",
+        "Name": "revision_alias",
+        "RevisionId": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update_alias_revision_id_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "update_alias_response_rev6a": {
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:revision_alias",
+        "Description": "something changed",
+        "FunctionVersion": "1",
+        "Name": "revision_alias",
+        "RevisionId": "<uuid:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -7731,7 +7731,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_exceptions": {
-    "recorded-date": "18-11-2022, 08:32:32",
+    "recorded-date": "16-01-2023, 14:08:15",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -7801,6 +7801,18 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
+        }
+      },
+      "layer_permission_wrong_revision": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetLayerPolicy API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetLayerPolicy API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
         }
       },
       "layer_permission_layername_doesnotexist_add": {
@@ -7878,19 +7890,31 @@
       "layer_permission_statementid_doesnotexist_remove": {
         "Error": {
           "Code": "ResourceNotFoundException",
-          "Message": "Statement s2 is not found in resource policy."
+          "Message": "Statement doesnotexist is not found in resource policy."
         },
-        "Message": "Statement s2 is not found in resource policy.",
+        "Message": "Statement doesnotexist is not found in resource policy.",
         "Type": "User",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
         }
+      },
+      "layer_permission_wrong_revision_remove": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetLayerPolicy API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetLayerPolicy API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
       }
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_lifecycle": {
-    "recorded-date": "18-11-2022, 08:32:37",
+    "recorded-date": "16-01-2023, 14:12:10",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -7928,6 +7952,26 @@
           "HTTPStatusCode": 201
         }
       },
+      "get_layer_version_policy": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Id": "default",
+          "Statement": [
+            {
+              "Sid": "s1",
+              "Effect": "Allow",
+              "Principal": "*",
+              "Action": "lambda:GetLayerVersion",
+              "Resource": "arn:aws:lambda:<region>:111111111111:layer:<resource:1>:1"
+            }
+          ]
+        },
+        "RevisionId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "add_policy_s2": {
         "RevisionId": "<uuid:2>",
         "Statement": {
@@ -7942,7 +7986,7 @@
           "HTTPStatusCode": 201
         }
       },
-      "get_layer_version_policy": {
+      "get_layer_version_policy_postadd2": {
         "Policy": {
           "Version": "2012-10-17",
           "Id": "default",

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10007,7 +10007,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_basic": {
-    "recorded-date": "06-01-2023, 21:15:39",
+    "recorded-date": "06-01-2023, 22:19:13",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -10095,7 +10095,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "update_function_revision_id_exception": {
+      "update_function_revision_exception": {
         "Error": {
           "Code": "PreconditionFailedException",
           "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
@@ -10191,7 +10191,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "update_function_configuration_revision_id_exception": {
+      "update_function_configuration_revision_exception": {
         "Error": {
           "Code": "PreconditionFailedException",
           "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
@@ -10290,9 +10290,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version_and_alias": {
-    "recorded-date": "06-01-2023, 21:55:36",
+    "recorded-date": "06-01-2023, 22:19:32",
     "recorded-content": {
-      "publish_version_revision_id_exception": {
+      "publish_version_revision_exception": {
         "Error": {
           "Code": "PreconditionFailedException",
           "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
@@ -10353,7 +10353,7 @@
           "HTTPStatusCode": 201
         }
       },
-      "update_alias_revision_id_exception": {
+      "update_alias_revision_exception": {
         "Error": {
           "Code": "PreconditionFailedException",
           "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
@@ -10374,6 +10374,78 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_permissions": {
+    "recorded-date": "06-01-2023, 22:30:27",
+    "recorded-content": {
+      "add_permission_revision_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "add_permission_response": {
+        "Statement": {
+          "Sid": "s3",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "s3.amazonaws.com"
+          },
+          "Action": "lambda:InvokeFunction",
+          "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get_policy_response_rev3": {
+        "Policy": {
+          "Version": "2012-10-17",
+          "Id": "default",
+          "Statement": [
+            {
+              "Sid": "s3",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "s3.amazonaws.com"
+              },
+              "Action": "lambda:InvokeFunction",
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>"
+            }
+          ]
+        },
+        "RevisionId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove_permission_revision_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "remove_permission_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
         }
       }
     }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10006,8 +10006,8 @@
       }
     }
   },
-  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions": {
-    "recorded-date": "06-01-2023, 20:24:28",
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_basic": {
+    "recorded-date": "06-01-2023, 21:15:39",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -10285,6 +10285,61 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version": {
+    "recorded-date": "06-01-2023, 21:16:06",
+    "recorded-content": {
+      "publish_version_revision_id_exception": {
+        "Error": {
+          "Code": "PreconditionFailedException",
+          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
+        },
+        "Type": "User",
+        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 412
+        }
+      },
+      "publish_version_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+        "FunctionName": "<function-name:1>",
+        "Handler": "handler.handler",
+        "LastModified": "date",
+        "LastUpdateStatus": "Successful",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:2>",
+        "Runtime": "python3.9",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         }
       }
     }

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -298,7 +298,6 @@ def test_lambda_vpc(deploy_cfn_template, lambda_client):
         "$..Policy.PolicyName",
         "$..Policy.Statement..Resource",
         "$..Policy.Statement..Sid",
-        "$..RevisionId",
     ]
 )
 def test_update_lambda_permissions(deploy_cfn_template, lambda_client, sts_client):
@@ -338,6 +337,7 @@ class TestCfnLambdaIntegrations:
             "$..Configuration.EphemeralStorage",
             "$..Configuration.MemorySize",
             "$..Configuration.VpcConfig",
+            "$..RevisionId",  # seems the revision id of the policy actually corresponds to the one of the function version
         ],
         condition=is_old_provider,
     )
@@ -348,7 +348,6 @@ class TestCfnLambdaIntegrations:
             "$..Attributes.Policy",  # missing SNS:Receive
             "$..CodeSize",
             "$..Configuration.Layers",
-            "$..RevisionId",  # seems the revision id of the policy actually corresponds to the one of the function version
             "$..Tags",  # missing cloudformation automatic resource tags for the lambda function
         ]
     )


### PR DESCRIPTION
Test + implement revisions (i.e., RevisionId) for lambda in general (with versions, 
aliases, layers, etc). It seems that the revision id of permissions is 
the same as for qualified lambdas (i.e., VersionFunctionConfiguration).

## Motivation

- Follow-up from https://github.com/localstack/localstack/pull/7336
- Mentioned in skip_snapshot_verify and TODO comments at multiple places
    - CloudFormation tests also mentions: “seems the revision id of the policy actually corresponds to the one of the function version”

## Behavior

- [CreateFunction](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html): **[RevisionId](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#API_CreateFunction_ResponseSyntax)** The latest updated revision of the function or alias.
- Non-matching revision id raises a **`PreconditionFailedException`**

Overview of Actions / [API Operations](https://docs.aws.amazon.com/lambda/latest/dg/API_Operations.html) with RevisionId support:

| Request | Response | Both |
| --- | --- | --- |
| [AddPermission](https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html) ✔️ | [CreateAlias](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html) ✔️ | [AddLayerVersionPermission](https://docs.aws.amazon.com/lambda/latest/dg/API_AddLayerVersionPermission.html) ✔️ |
| [RemoveLayerVersionPermission](https://docs.aws.amazon.com/lambda/latest/dg/API_RemoveLayerVersionPermission.html) ✔️ | [CreateFunction](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html) ✔️ | [PublishVersion](https://docs.aws.amazon.com/lambda/latest/dg/API_PublishVersion.html) ✔️ |
| [RemovePermission](https://docs.aws.amazon.com/lambda/latest/dg/API_RemovePermission.html) ✔️ | [GetAlias](https://docs.aws.amazon.com/lambda/latest/dg/API_GetAlias.html) ✔️ | [UpdateAlias](https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateAlias.html) ✔️ |
|  | [GetFunction](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html) ✔️ | [UpdateFunctionCode](https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionCode.html) ✔️ |
|  | [GetFunctionConfiguration](https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunctionConfiguration.html) | [UpdateFunctionConfiguration](https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html) ✔️ |
|  | [GetLayerVersionPolicy](https://docs.aws.amazon.com/lambda/latest/dg/API_GetLayerVersionPolicy.html) ✔️ |  |
|  | [GetPolicy](https://docs.aws.amazon.com/lambda/latest/dg/API_GetPolicy.html) ✔️ |  |
|  | [ListAliases](https://docs.aws.amazon.com/lambda/latest/dg/API_ListAliases.html) |  |
|  | [ListFunctions](https://docs.aws.amazon.com/lambda/latest/dg/API_ListFunctions.html) |  |
|  | [ListVersionsByFunction](https://docs.aws.amazon.com/lambda/latest/dg/API_ListVersionsByFunction.html) |  |

- ✔️  refers to snapshot tested request/response
- The list* operations are not explicitly tested within the revisions lifecycle but are covered by other tests
- Note: This just shows which request/responses contain a revision_id but do NOT show which operations UPDATE it! For example, add_permission updates the revision_id despite not returning it.
- Q/A about behavior that prevents atomic updates: [https://repost.aws/questions/QU2NMlYyvYSaaoNY8xrPYcvQ/lambda-function-updating-cannot-be-made-atomic-with-revision-id](https://repost.aws/questions/QU2NMlYyvYSaaoNY8xrPYcvQ/lambda-function-updating-cannot-be-made-atomic-with-revision-id)

## Scope

* LayerVersionPolicy: have their own RevisionId independent of functions as they can exist without functions.
* RevisionId per function configuration. Aliases and versions have their own function configuration but lambda permissions don’t.
    - The fact that the permissions only require the RevisionId in the request but don’t contain it in the reply, could hint that it’s not part of their entity and only stored per function configuration
    - Also fits together with DeleteAlias not mentioning any RevisionId because it’s gone with the associated function configuration after deleting the alias


## Questions

* Do we need locking to ensure atomic updates across entities?

## Details

For more details: See [Revisions](https://www.notion.so/localstack/Revisions-5592ceef78fa421eaebfeb014d77daf6) in the Notion Lambda Board.

## Follow Up (out of scope)

- [ ] Consider updating the data model such that property updates automatically trigger a revision_id update within the right entity such that we a) don't need locks for ensuring atomic updates b) simplify code for retrieval and updates.
