### PR TITLE
CFN - special case for store location

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -310,6 +310,8 @@ class CloudformationProvider(CloudformationApi):
             for key, values in id_summaries.items()
         ]
         result["Version"] = stack.template.get("AWSTemplateFormatVersion", "2010-09-09")
+        # these do not appear in the output
+        result.pop("Capabilities", None)
 
         return select_from_typed_dict(GetTemplateSummaryOutput, result)
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -80,7 +80,11 @@ from localstack.services.cloudformation.stores import (
     get_cloudformation_store,
 )
 from localstack.utils.aws import aws_stack
-from localstack.utils.collections import remove_attributes, select_attributes
+from localstack.utils.collections import (
+    remove_attributes,
+    select_attributes,
+    select_from_typed_dict,
+)
 from localstack.utils.json import clone
 from localstack.utils.strings import short_uid
 
@@ -306,9 +310,8 @@ class CloudformationProvider(CloudformationApi):
             for key, values in id_summaries.items()
         ]
         result["Version"] = stack.template.get("AWSTemplateFormatVersion", "2010-09-09")
-        # these do not appear in the output
-        result.pop("Capabilities", None)
-        return result
+
+        return select_from_typed_dict(GetTemplateSummaryOutput, result)
 
     def update_termination_protection(
         self,

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -130,6 +130,12 @@ class ReflectionStateLocator:
                     ("moto.apigatewayv2.models", "apigatewayv2_backends"),
                 ]
                 _visit_modules(modules)
+            case "cloudformation":
+                modules = [
+                    ("localstack.services.cloudformation.stores", "cloudformation_stores"),
+                    ("moto.cloudformation.models", "cloudformation_backends"),
+                ]
+                _visit_modules(modules)
             case _:
                 # try to load AccountRegionBundle from predictable location
                 attribute_name = f"{service_name}_stores"


### PR DESCRIPTION
Fixes https://github.com/localstack/localstack-ext/issues/1278.

CFN deviates from the standard pattern when it comes to the `AccountRegionBundle` module (normally, `localstack.services.<service>.models`; `localstack.services.cloudformation.stores` instead).

In addition, `GetTemplateSummaryOutput` was containing unspecified members. I filtered the result with the `select_from_typed_dict` utility function.