### PR TITLE
fix list_firewall_domain_lists

### DIFF
--- a/localstack/services/route53resolver/provider.py
+++ b/localstack/services/route53resolver/provider.py
@@ -221,7 +221,7 @@ class Route53ResolverProvider(Route53ResolverApi):
         store = self.get_store(context.account_id, context.region)
         firewall_domain_lists = []
         for firewall_domain_list in store.firewall_domain_lists.values():
-            firewall_domain_list.append(
+            firewall_domain_lists.append(
                 select_from_typed_dict(FirewallDomainListMetadata, firewall_domain_list)
             )
         return ListFirewallDomainListsResponse(FirewallDomainLists=firewall_domain_lists)

--- a/tests/integration/test_route53resolver.snapshot.json
+++ b/tests/integration/test_route53resolver.snapshot.json
@@ -533,5 +533,47 @@
       "resource_not_found_ex_error_code": "ResourceNotFoundException",
       "resource_not_found_ex_http_status_code": 400
     }
+  },
+  "tests/integration/test_route53resolver.py::TestRoute53Resolver::test_list_firewall_domain_lists": {
+    "recorded-date": "13-01-2023, 18:47:03",
+    "recorded-content": {
+      "create-firewall-domain-list": {
+        "FirewallDomainList": {
+          "Arn": "arn:aws:route53resolver:<region>:111111111111:firewall-domain-list/<id:1>",
+          "CreationTime": "date",
+          "CreatorRequestId": "<creator-request-id:1>",
+          "DomainCount": 0,
+          "Id": "<id:1>",
+          "ModificationTime": "date",
+          "Name": "my_firewall_domain",
+          "Status": "COMPLETE",
+          "StatusMessage": "status-message"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-firewall-domain-list-filtered": [
+        {
+          "Id": "<id:1>",
+          "Arn": "arn:aws:route53resolver:<region>:111111111111:firewall-domain-list/<id:1>",
+          "Name": "my_firewall_domain",
+          "CreatorRequestId": "<creator-request-id:1>"
+        }
+      ],
+      "list-tags-for-resource": {
+        "Tags": [
+          {
+            "Key": "hello",
+            "Value": "world"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
While checking the non-implemented coverage responses, I found a weird error for `list_firewall_domain_lists`:

```
exception while calling route53resolver.ListFirewallDomainLists: Traceback (most recent call last):
  File "/opt/code/localstack/localstack/aws/chain.py", line 90, in handle
    handler(self, self.context, response)
  File "/opt/code/localstack/localstack/aws/handlers/service.py", line 122, in __call__
    handler(chain, context, response)
  File "/opt/code/localstack/localstack/aws/handlers/service.py", line 92, in __call__
    skeleton_response = self.skeleton.invoke(context)
  File "/opt/code/localstack/localstack/aws/skeleton.py", line 153, in invoke
    return self.dispatch_request(context, instance)
  File "/opt/code/localstack/localstack/aws/skeleton.py", line 165, in dispatch_request
    result = handler(context, instance) or {}
  File "/opt/code/localstack/localstack/aws/forwarder.py", line 56, in _call
    return handler(context, req)
  File "/opt/code/localstack/localstack/aws/skeleton.py", line 117, in __call__
    return self.fn(*args, **kwargs)
  File "/opt/code/localstack/localstack/services/route53resolver/provider.py", line 224, in list_firewall_domain_lists
    firewall_domain_list.append(
AttributeError: 'dict' object has no attribute 'append'
```

It seems like a little typo in the implementation - the PR contains a fix, and I also added a snapshot test to verify the behavior.
