### PR TITLE
add validation for multipart upload order

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -740,6 +740,13 @@ class MissingSecurityHeader(ServiceException):
     MissingHeaderName: Optional[MissingHeaderName]
 
 
+class InvalidPartOrder(ServiceException):
+    code: str = "InvalidPartOrder"
+    sender_fault: bool = False
+    status_code: int = 400
+    UploadId: Optional[MultipartUploadId]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -737,6 +737,23 @@
       "value": {
         "type": "string"
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidPartOrder",
+      "value": {
+        "type": "structure",
+        "members": {
+          "UploadId": {
+            "shape": "MultipartUploadId"
+          }
+        },
+        "error": {
+          "httpStatusCode": 400
+        },
+        "documentation": "<p>The list of parts was not in ascending order. Parts must be ordered by part number.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -52,6 +52,7 @@ from localstack.aws.api.s3 import (
     HeadObjectOutput,
     HeadObjectRequest,
     InvalidBucketName,
+    InvalidPartOrder,
     ListObjectsOutput,
     ListObjectsRequest,
     ListObjectsV2Output,
@@ -453,6 +454,15 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def complete_multipart_upload(
         self, context: RequestContext, request: CompleteMultipartUploadRequest
     ) -> CompleteMultipartUploadOutput:
+        parts = request.get("MultipartUpload", {}).get("Parts", [])
+        parts_numbers = [part.get("PartNumber") for part in parts]
+        # sorted is very fast (fastest) if the list is already sorted, which should be the case
+        if sorted(parts_numbers) != parts_numbers:
+            raise InvalidPartOrder(
+                "The list of parts was not in ascending order. Parts must be ordered by part number.",
+                UploadId=request["UploadId"],
+            )
+
         response: CompleteMultipartUploadOutput = call_moto(context)
         # moto return the Location in AWS `http://{bucket}.s3.amazonaws.com/{key}`
         response[

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -689,7 +689,7 @@ class TestS3:
     @pytest.mark.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..Error.RequestID"]
     )
-    def test_multipart_and_list_parts(self, s3_client, s3_bucket, s3_multipart_upload, snapshot):
+    def test_multipart_and_list_parts(self, s3_client, s3_bucket, snapshot):
         snapshot.add_transformer(
             [
                 snapshot.transform.key_value("Bucket", reference_replacement=False),
@@ -2795,6 +2795,84 @@ class TestS3:
                 SSEKMSKeyId="fake-key-id",
             )
         snapshot.match("copy-obj-wrong-kms-key", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_complete_multipart_parts_order(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(
+            [
+                snapshot.transform.key_value("Bucket", reference_replacement=False),
+                snapshot.transform.key_value("Location"),
+                snapshot.transform.key_value("UploadId"),
+            ]
+        )
+
+        key_name = "test-order-parts"
+        response = s3_client.create_multipart_upload(Bucket=s3_bucket, Key=key_name)
+        upload_id = response["UploadId"]
+
+        # data must be at least 5MiB
+        part_data = "a" * (5_242_880 + 1)
+        part_data = to_bytes(part_data)
+
+        parts = 3
+        multipart_upload_parts = []
+        for part in range(parts):
+            # Write contents to memory rather than a file.
+            part_number = part + 1
+            upload_file_object = BytesIO(part_data)
+            response = s3_client.upload_part(
+                Bucket=s3_bucket,
+                Key=key_name,
+                Body=upload_file_object,
+                PartNumber=part_number,
+                UploadId=upload_id,
+            )
+            multipart_upload_parts.append({"ETag": response["ETag"], "PartNumber": part_number})
+
+        # testing completing the multipart with an unordered sequence of parts
+        with pytest.raises(ClientError) as e:
+            s3_client.complete_multipart_upload(
+                Bucket=s3_bucket,
+                Key=key_name,
+                MultipartUpload={"Parts": list(reversed(multipart_upload_parts))},
+                UploadId=upload_id,
+            )
+        snapshot.match("complete-multipart-unordered", e.value.response)
+
+        response = s3_client.complete_multipart_upload(
+            Bucket=s3_bucket,
+            Key=key_name,
+            MultipartUpload={"Parts": multipart_upload_parts},
+            UploadId=upload_id,
+        )
+        snapshot.match("complete-multipart-ordered", response)
+
+        # testing completing the multipart with a sequence of parts number going from 2, 4, and 6 (missing numbers)
+        key_name_2 = "key-sequence-with-step-2"
+        response = s3_client.create_multipart_upload(Bucket=s3_bucket, Key=key_name_2)
+        upload_id = response["UploadId"]
+
+        multipart_upload_parts = []
+        for part in range(parts):
+            # Write contents to memory rather than a file.
+            part_number = part + 2
+            upload_file_object = BytesIO(part_data)
+            response = s3_client.upload_part(
+                Bucket=s3_bucket,
+                Key=key_name_2,
+                Body=upload_file_object,
+                PartNumber=part_number,
+                UploadId=upload_id,
+            )
+            multipart_upload_parts.append({"ETag": response["ETag"], "PartNumber": part_number})
+
+        response = s3_client.complete_multipart_upload(
+            Bucket=s3_bucket,
+            Key=key_name_2,
+            MultipartUpload={"Parts": multipart_upload_parts},
+            UploadId=upload_id,
+        )
+        snapshot.match("complete-multipart-with-step-2", response)
 
 
 class TestS3TerraformRawRequests:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2797,6 +2797,9 @@ class TestS3:
         snapshot.match("copy-obj-wrong-kms-key", e.value.response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER, reason="Validation not implemented in legacy provider"
+    )
     def test_complete_multipart_parts_order(self, s3_client, s3_bucket, snapshot):
         snapshot.add_transformer(
             [

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4100,5 +4100,41 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_complete_multipart_parts_order": {
+    "recorded-date": "14-01-2023, 13:07:10",
+    "recorded-content": {
+      "complete-multipart-unordered": {
+        "Error": {
+          "Code": "InvalidPartOrder",
+          "Message": "The list of parts was not in ascending order. Parts must be ordered by part number.",
+          "UploadId": "<upload-id:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "complete-multipart-ordered": {
+        "Bucket": "bucket",
+        "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
+        "Key": "test-order-parts",
+        "Location": "<location:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "complete-multipart-with-step-2": {
+        "Bucket": "bucket",
+        "ETag": "\"c7cb0938a47e31f70cf07028d22e6913-3\"",
+        "Key": "key-sequence-with-step-2",
+        "Location": "<location:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This issue was brought up in #7492 

`CompleteMultipartUpload` would not raise an exception when the parts were not ordered in the `MultipartUpload.Parts` parameter. 

Added snapshotted test cases against AWS + the validation in the provider operation. 

_fixes #7492_
