### PR TITLE
workaround: fix amazon_kclpy build failure by pinning previous version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,8 @@ localstack =
 # required to actually run localstack on the host
 runtime =
     airspeed==0.5.19
-    amazon_kclpy>=2.0.6
+    # TODO: remove amazon_kclpy pin once build failure in 2.1.0 has been fixed
+    amazon_kclpy==2.0.6
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
     awscrt>=0.13.14

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,8 +62,8 @@ localstack =
 # required to actually run localstack on the host
 runtime =
     airspeed==0.5.19
-    # TODO: remove amazon_kclpy pin once build failure in 2.1.0 has been fixed
-    amazon_kclpy==2.0.6
+    # TODO: check amazon_kclpy pin once build failure in 2.1.0 has been fixed
+    amazon_kclpy>=2.0.6,!=2.1.0
     aws-sam-translator>=1.15.1
     awscli>=1.22.90
     awscrt>=0.13.14


### PR DESCRIPTION
Seems we're encountering errors in CI because a 3rd party release is broken at the moment: `amazon-kclpy`.
https://github.com/awslabs/amazon-kinesis-client-python/commit/2642ae73edd72cb2c0c70ca448294577a3702995
https://github.com/awslabs/amazon-kinesis-client-python/compare/v2.0.6...v2.1.0

Pinning the version to the previous release until it is fixed. 

Two failed build:
https://app.circleci.com/pipelines/github/localstack/localstack/11871/workflows/4346b802-95f8-4e54-a9c9-2cba836635fe/jobs/83637
https://app.circleci.com/pipelines/github/localstack/localstack/11869/workflows/f24b9c21-d3e1-41bc-823a-edd4ac4b88b7/jobs/83635

I could reproduce locally the issue as well.

```python
Failed to build amazon-kclpy
Installing collected packages: [...redacted, too long of a list]
  Running setup.py install for amazon-kclpy ... - error
  error: subprocess-exited-with-error
  
  × Running setup.py install for amazon-kclpy did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      /tmp/workspace/repo/.venv/lib/python3.10/site-packages/setuptools/dist.py:770: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
        warnings.warn(
      /tmp/workspace/repo/.venv/lib/python3.10/site-packages/setuptools/installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        warnings.warn(
      running install
      /tmp/workspace/repo/.venv/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      error: [Errno 2] No such file or directory: 'pom.xml'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> amazon-kclpy
```

edit: not sure why it fails for `integrations-against-pro`, I must be missing something

cc\ @alexrashed 