### PR TITLE
Fix resolving CFn SSM stack parameters in !Sub references

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -410,7 +410,7 @@ class StackChangeSet(Stack):
         return self.stack.stack_parameters(defaults=defaults)
 
 
-def resolve_ssm_parameter_value(parameter_type: str, parameter_value: str) -> Any:
+def resolve_ssm_parameter_value(parameter_type: str, parameter_value: str) -> str:
     """
     Resolve the SSM stack parameter with the name specified via the given `parameter_value`.
 

--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -239,6 +239,7 @@ class Stack:
 
         return result
 
+    # TODO: check duplication with stack_parameters(..) property method
     def _resolve_stack_parameters(
         self, defaults=True, existing: Dict[str, Dict] = None
     ) -> Dict[str, Dict]:
@@ -248,14 +249,25 @@ class Stack:
         for param in self.stack_parameters(defaults=defaults):
             param_key = param["ParameterKey"]
             if param_key not in existing:
+                template_parameter = self.template_parameters.get(param_key, {})
+                param_type = template_parameter.get("Type")
                 resolved_value = param.get("ResolvedValue")
+                # TODO: check if we should fall back to template_parameter.get("Default") in case prop_value is None
                 prop_value = (
                     resolved_value if resolved_value is not None else param.get("ParameterValue")
                 )
-                result[param["ParameterKey"]] = {
+                # TODO: consider replacing "Value" with "ResolvedValue", to have a clearer distinction
+                properties = {
+                    "Value": prop_value,
+                    "ParameterType": param_type,
+                    "ParameterValue": param.get("ParameterValue"),
+                }
+                if resolved_value is not None:
+                    properties["ResolvedValue"] = resolved_value
+                result[param_key] = {
                     "Type": "Parameter",
                     "LogicalResourceId": param_key,
-                    "Properties": {"Value": prop_value},
+                    "Properties": properties,
                 }
         return result
 
@@ -296,11 +308,9 @@ class Stack:
                 param_type = value.get("Type", "")
                 if not param_type:
                     if param_type == "AWS::SSM::Parameter::Value<String>":
-                        ssm_client = aws_stack.connect_to_service("ssm")
-                        resolved_value = ssm_client.get_parameter(Name=param_value)["Parameter"][
-                            "Value"
-                        ]
-                        result[key]["ResolvedValue"] = resolved_value
+                        result[key]["ResolvedValue"] = resolve_ssm_parameter_value(
+                            param_type, param_value
+                        )
                     elif param_type.startswith("AWS::"):
                         LOG.info(
                             f"Parameter Type '{param_type}' is currently not supported. Coming soon, stay tuned!"
@@ -398,3 +408,18 @@ class StackChangeSet(Stack):
 
     def stack_parameters(self, defaults=True) -> List[Dict[str, Any]]:
         return self.stack.stack_parameters(defaults=defaults)
+
+
+def resolve_ssm_parameter_value(parameter_type: str, parameter_value: str) -> Any:
+    """
+    Resolve the SSM stack parameter with the name specified via the given `parameter_value`.
+
+    Given a stack template with parameter {"param1": {"Type": "AWS::SSM::Parameter::Value<String>"}} and
+    a stack instance with stack parameter {"ParameterKey": "param1", "ParameterValue": "test-param"}, this
+    function will resolve the SSM parameter with name `test-param` and return the SSM parameter's value.
+    """
+    # TODO: support different parameter value types
+    if parameter_type == "AWS::SSM::Parameter::Value<String>":
+        ssm_client = aws_stack.connect_to_service("ssm")
+        return ssm_client.get_parameter(Name=parameter_value)["Parameter"]["Value"]
+    raise Exception(f"Unsupported parameter value type {parameter_type}")

--- a/tests/integration/cloudformation/test_template_engine.py
+++ b/tests/integration/cloudformation/test_template_engine.py
@@ -267,13 +267,17 @@ class TestImports:
 
 
 class TestSsmParameters:
+    @pytest.mark.aws_validated
     def test_create_stack_with_ssm_parameters(
-        self, cfn_client, ssm_client, sns_client, deploy_cfn_template
+        self, cfn_client, create_parameter, sns_client, deploy_cfn_template, snapshot
     ):
+        snapshot.add_transformer(snapshot.transform.cloudformation_api())
+        snapshot.add_transformer(snapshot.transform.key_value("ParameterValue"))
+        snapshot.add_transformer(snapshot.transform.key_value("ResolvedValue"))
+
         parameter_name = f"ls-param-{short_uid()}"
         parameter_value = f"ls-param-value-{short_uid()}"
-        parameter_logical_id = "parameter123"
-        ssm_client.put_parameter(Name=parameter_name, Value=parameter_value, Type="String")
+        create_parameter(Name=parameter_name, Value=parameter_value, Type="String")
         stack = deploy_cfn_template(
             template_path=os.path.join(
                 os.path.dirname(__file__), "../templates/dynamicparameter_ssm_string.yaml"
@@ -282,14 +286,16 @@ class TestSsmParameters:
         )
 
         stack_description = cfn_client.describe_stacks(StackName=stack.stack_name)["Stacks"][0]
-        assert stack_description is not None
-        assert stack_description["Parameters"][0]["ParameterKey"] == parameter_logical_id
-        assert stack_description["Parameters"][0]["ParameterValue"] == parameter_name
-        assert stack_description["Parameters"][0]["ResolvedValue"] == parameter_value
+        snapshot.match("stack-details", stack_description)
 
         topics = sns_client.list_topics()
         topic_arns = [t["TopicArn"] for t in topics["Topics"]]
-        assert any(parameter_value in t for t in topic_arns)
+
+        matching = [arn for arn in topic_arns if parameter_value in arn]
+        assert len(matching) == 1
+
+        tags = sns_client.list_tags_for_resource(ResourceArn=matching[0])
+        snapshot.match("topic-tags", tags)
 
     def test_resolve_ssm(
         self,

--- a/tests/integration/cloudformation/test_template_engine.snapshot.json
+++ b/tests/integration/cloudformation/test_template_engine.snapshot.json
@@ -474,5 +474,50 @@
         "Timestamp": "timestamp"
       }
     }
+  },
+  "tests/integration/cloudformation/test_template_engine.py::TestSsmParameters::test_create_stack_with_ssm_parameters": {
+    "recorded-date": "15-01-2023, 17:54:23",
+    "recorded-content": {
+      "stack-details": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
+        "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:1>",
+        "CreationTime": "datetime",
+        "DisableRollback": false,
+        "DriftInformation": {
+          "StackDriftStatus": "NOT_CHECKED"
+        },
+        "EnableTerminationProtection": false,
+        "LastUpdatedTime": "datetime",
+        "NotificationARNs": [],
+        "Parameters": [
+          {
+            "ParameterKey": "parameter123",
+            "ParameterValue": "<parameter-value:1>",
+            "ResolvedValue": "<resolved-value:1>"
+          }
+        ],
+        "RollbackConfiguration": {},
+        "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
+        "StackName": "<stack-name:1>",
+        "StackStatus": "CREATE_COMPLETE",
+        "Tags": []
+      },
+      "topic-tags": {
+        "Tags": [
+          {
+            "Key": "param-value",
+            "Value": "param <resolved-value:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/dynamicparameter_ssm_string.yaml
+++ b/tests/integration/templates/dynamicparameter_ssm_string.yaml
@@ -9,5 +9,8 @@ Resources:
     Properties:
       TopicName:
         Ref: parameter123
+      Tags:
+        - Key: param-value
+          Value: !Sub "param ${parameter123}"
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete


### PR DESCRIPTION
Fix resolving SSM stack parameters in CloudFormation `!Sub` references. This issue has surfaced in a user SAM template that used a `AWS::SSM::Parameter::Value<String>` stack reference in an ARN reference that was constructed via a `!Sub` (`Fn::Sub`) intrinsic function.

Summary of changes:
* update template deployer logic to allow resolving `AWS::SSM::Parameter::Value<String>` references in `!Sub` CloudFormation intrinsic functions
* encapsulate the resolution of `AWS::SSM::Parameter::Value<String>` stack parameters in a single `resolve_ssm_parameter_value(..)` utility function
* add a snapshot test to ensure parity with AWS
* a few minor refactorings, f-strings, etc


Overall, working on this PR has highlighted again that stack parameters are in a pretty bad state, unfortunately :/ (as we already previously discussed @dominikschubert ). A more general overhaul of stack/template parameters will be very helpful to make the logic more maintainable, going forward. Happy to take a stab at it, to help out with a first round of basic refactoring - unless you already have plans for this on your own roadmap/backlog @dominikschubert 👍 