### PR TITLE
Minor: Pass providerARNs to API GW authorizer on OpenAPI import

### DIFF
--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1466,7 +1466,7 @@ class TestAPIGateway:
         resources = apigateway_client.get_resources(restApiId=rest_api_id)
         for rv in resources.get("items"):
             for method in rv.get("resourceMethods", {}).values():
-                assert method.get("authorizationType") == "request"
+                assert method.get("authorizationType") == "REQUEST"
                 assert method.get("authorizerId") is not None
 
         spec_file = load_file(TEST_SWAGGER_FILE_YAML)
@@ -2099,7 +2099,7 @@ class TestAPIGateway:
         resources = get_rest_api_resources(apigateway_client, restApiId=rest_api_id)
         for rv in resources:
             for method in rv.get("resourceMethods", {}).values():
-                assert method.get("authorizationType") == "request"
+                assert method.get("authorizationType") == "REQUEST"
                 assert method.get("authorizerId") is not None
 
         spec_file = load_file(TEST_SWAGGER_FILE_YAML)


### PR DESCRIPTION
Minor: Pass `providerARNs` to API Gateway authorizer entity on OpenAPI import.

This resolves a customer issue where an API endpoint with Cognito authorizer - imported from OpenAPI/Swagger spec - could not be invoked because no user pools are associated with the API:
```
    pool, user = self._lookup_user(invocation_context)
  File "localstack-ext/localstack_ext/services/apigateway/authorizers.py", line 96, in _lookup_user
    raise Exception(f"Unable to find user {username} in configured user pools: {providers}")
Exception: Unable to find user test in configured user pools: []
```

TODO: Probably still going to add a test for this functionality (upstream in -ext) - would make sense, given our current focus to increase the level of testing/parity. 👍 