### PR TITLE
fixed: ssm maintenance_window get/delete with exception

### DIFF
--- a/localstack/services/ssm/provider.py
+++ b/localstack/services/ssm/provider.py
@@ -4,6 +4,8 @@ import time
 from abc import ABC
 from typing import Dict, Optional
 
+from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
+
 from localstack.aws.api import CommonServiceException, RequestContext
 from localstack.aws.api.ssm import (
     Boolean,
@@ -25,7 +27,6 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.collections import remove_attributes
 from localstack.utils.objects import keys_to_lower
 from localstack.utils.patch import patch
-from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
 
 PARAM_PREFIX_SECRETSMANAGER = "/aws/reference/secretsmanager"
 
@@ -48,8 +49,9 @@ class InvalidParameterNameException(ValidationException):
 class DoesNotExistException(CommonServiceException):
     def __init__(self, window_id):
         super().__init__(
-            "DoesNotExistException", message=f"Maintenance window {window_id} does not exist",
-            sender_fault=True
+            "DoesNotExistException",
+            message=f"Maintenance window {window_id} does not exist",
+            sender_fault=True,
         )
 
 
@@ -239,4 +241,3 @@ def delete_maintenance_window(fn, self, window_id):
     if not store.windows.get(window_id):
         raise DoesNotExistException(window_id)
     return fn(self, window_id)
-

--- a/localstack/services/ssm/provider.py
+++ b/localstack/services/ssm/provider.py
@@ -24,6 +24,8 @@ from localstack.services.moto import call_moto, call_moto_with_request
 from localstack.utils.aws import aws_stack
 from localstack.utils.collections import remove_attributes
 from localstack.utils.objects import keys_to_lower
+from localstack.utils.patch import patch
+from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
 
 PARAM_PREFIX_SECRETSMANAGER = "/aws/reference/secretsmanager"
 
@@ -41,6 +43,14 @@ class InvalidParameterNameException(ValidationException):
             "each sub-path can be formed as a mix of letters, numbers and the following 3 symbols .-_"
         )
         super().__init__(msg)
+
+
+class DoesNotExistException(CommonServiceException):
+    def __init__(self, window_id):
+        super().__init__(
+            "DoesNotExistException", message=f"Maintenance window {window_id} does not exist",
+            sender_fault=True
+        )
 
 
 # TODO: check if _normalize_name(..) calls are still required here
@@ -211,3 +221,22 @@ class SsmProvider(SsmApi, ABC):
             "DetailType": "Parameter Store Change",
         }
         events.put_events(Entries=[event])
+
+
+@patch(SimpleSystemManagerBackend.get_maintenance_window)
+def get_maintenance_window(fn, self, window_id):
+    """Get a maintenance window by ID."""
+    store = ssm_backends[aws_stack.get_aws_account_id()][aws_stack.get_region()]
+    if not store.windows.get(window_id):
+        raise DoesNotExistException(window_id)
+    return fn(self, window_id)
+
+
+@patch(SimpleSystemManagerBackend.delete_maintenance_window)
+def delete_maintenance_window(fn, self, window_id):
+    """Delete a maintenance window by ID."""
+    store = ssm_backends[aws_stack.get_aws_account_id()][aws_stack.get_region()]
+    if not store.windows.get(window_id):
+        raise DoesNotExistException(window_id)
+    return fn(self, window_id)
+

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -145,6 +145,7 @@ class TestSSM:
         assert found_param["Type"] == "String"
         assert found_param["Value"] == "value"
 
+    @pytest.mark.aws_validated
     def test_get_inexistent_maintenance_window(self, ssm_client):
         invalid_name = "mw-00000000000000000"
         with pytest.raises(ssm_client.exceptions.DoesNotExistException) as exc:

--- a/tests/integration/test_ssm.py
+++ b/tests/integration/test_ssm.py
@@ -144,3 +144,10 @@ class TestSSM:
         assert found_param["ARN"]
         assert found_param["Type"] == "String"
         assert found_param["Value"] == "value"
+
+    def test_get_inexistent_maintenance_window(self, ssm_client):
+        invalid_name = "mw-00000000000000000"
+        with pytest.raises(ssm_client.exceptions.DoesNotExistException) as exc:
+            ssm_client.get_maintenance_window(WindowId=invalid_name)
+        exc.match("DoesNotExistException")
+        exc.match(f"Maintenance window {invalid_name} does not exist")


### PR DESCRIPTION
# Summary
- Patched get and delete operations for `maintenance_window` from moto to handle `DoesNotExistException`.

- Tests inside `terraform-provider-aws/internal/service/ssm/maintenance_window_test.go` file were timing because of unhandled retrieval from dict exception in moto - which caused overall terraform test suite pipeline to timeout for SSM service.

# Steps to reproduce the issue
- `awslocal ssm get-maintenance-window --window-id mw-00000000000000000`