### PR TITLE
fix S3 ASF storage class validation PutObject/CompleteMultipart

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -747,6 +747,13 @@ class InvalidPartOrder(ServiceException):
     UploadId: Optional[MultipartUploadId]
 
 
+class InvalidStorageClass(ServiceException):
+    code: str = "InvalidStorageClass"
+    sender_fault: bool = False
+    status_code: int = 400
+    StorageClassRequested: Optional[StorageClass]
+
+
 AbortDate = datetime
 
 

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -754,6 +754,23 @@
         "documentation": "<p>The list of parts was not in ascending order. Parts must be ordered by part number.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/InvalidStorageClass",
+      "value": {
+        "type": "structure",
+        "members": {
+          "StorageClassRequested": {
+            "shape": "StorageClass"
+          }
+        },
+        "error": {
+          "httpStatusCode": 400
+        },
+        "documentation": "<p>The storage class you specified is not valid</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -482,11 +482,11 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         # we need to check before sending it to moto
         moto_backend = get_moto_s3_backend(context)
         bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
-        if multipart := bucket.multipart.get(request["UploadId"]):
-            if multipart.storage_class and multipart.storage_class not in VALID_STORAGE_CLASSES:
+        if multipart := bucket.multiparts.get(request["UploadId"]):
+            if multipart.storage and multipart.storage not in VALID_STORAGE_CLASSES:
                 raise InvalidStorageClass(
                     "The storage class you specified is not valid",
-                    StorageClassRequested=multipart.storage_class,
+                    StorageClassRequested=multipart.storage,
                 )
 
         response: CompleteMultipartUploadOutput = call_moto(context)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -54,6 +54,7 @@ from localstack.aws.api.s3 import (
     HeadObjectRequest,
     InvalidBucketName,
     InvalidPartOrder,
+    InvalidStorageClass,
     ListObjectsOutput,
     ListObjectsRequest,
     ListObjectsV2Output,
@@ -109,6 +110,7 @@ from localstack.services.s3.utils import (
     ALLOWED_HEADER_OVERRIDES,
     VALID_ACL_PREDEFINED_GROUPS,
     VALID_GRANTEE_PERMISSIONS,
+    VALID_STORAGE_CLASSES,
     _create_invalid_argument_exc,
     capitalize_header_name_from_snake_case,
     get_bucket_from_moto,
@@ -357,7 +359,16 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             validate_kms_key_id(sse_kms_key_id, bucket)
 
-        response: PutObjectOutput = call_moto(context)
+        try:
+            response: PutObjectOutput = call_moto(context)
+        except CommonServiceException as e:
+            # missing attributes in exception
+            if e.code == "InvalidStorageClass":
+                raise InvalidStorageClass(
+                    "The storage class you specified is not valid",
+                    StorageClassRequested=request.get("StorageClass"),
+                )
+            raise
 
         # moto interprets the Expires in query string for presigned URL as an Expires header and use it for the object
         # we set it to the correctly parsed value in Request, else we remove it from moto metadata
@@ -467,7 +478,19 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 UploadId=request["UploadId"],
             )
 
+        # if moto raises an InvalidStorageClass, it would delete the multipart before validating
+        # we need to check before sending it to moto
+        moto_backend = get_moto_s3_backend(context)
+        bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
+        if multipart := bucket.multipart.get(request["UploadId"]):
+            if multipart.storage_class and multipart.storage_class not in VALID_STORAGE_CLASSES:
+                raise InvalidStorageClass(
+                    "The storage class you specified is not valid",
+                    StorageClassRequested=multipart.storage_class,
+                )
+
         response: CompleteMultipartUploadOutput = call_moto(context)
+
         # moto return the Location in AWS `http://{bucket}.s3.amazonaws.com/{key}`
         response[
             "Location"
@@ -1170,9 +1193,14 @@ def _create_redirect_for_post_request(
 def apply_moto_patches():
     # importing here in case we need InvalidObjectState from `localstack.aws.api.s3`
     from moto.s3.exceptions import InvalidObjectState
+    from moto.s3.models import STORAGE_CLASS
 
     if not os.environ.get("MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"):
         os.environ["MOTO_S3_DEFAULT_KEY_BUFFER_SIZE"] = str(S3_MAX_FILE_SIZE_BYTES)
+
+    # TODO: fix upstream
+    STORAGE_CLASS.clear()
+    STORAGE_CLASS.extend(VALID_STORAGE_CLASSES)
 
     @patch(moto_s3_responses.S3Response.key_response)
     def _fix_key_response(fn, self, *args, **kwargs):

--- a/localstack/services/s3/utils.py
+++ b/localstack/services/s3/utils.py
@@ -19,6 +19,7 @@ from localstack.aws.api.s3 import (
     ObjectCannedACL,
     ObjectKey,
     Permission,
+    StorageClass,
 )
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import parse_arn
@@ -75,6 +76,17 @@ VALID_GRANTEE_PERMISSIONS = {
     Permission.WRITE,
     Permission.WRITE_ACP,
 }
+
+VALID_STORAGE_CLASSES = [
+    StorageClass.STANDARD,
+    StorageClass.STANDARD_IA,
+    StorageClass.GLACIER,
+    StorageClass.GLACIER_IR,
+    StorageClass.REDUCED_REDUNDANCY,
+    StorageClass.ONEZONE_IA,
+    StorageClass.INTELLIGENT_TIERING,
+    StorageClass.DEEP_ARCHIVE,
+]
 
 # response header overrides the client may request
 ALLOWED_HEADER_OVERRIDES = {

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2937,13 +2937,12 @@ class TestS3:
 
         key_name = "test-multipart-storage-class"
         with pytest.raises(ClientError) as e:
-            s3_multipart_upload(
-                bucket=s3_bucket,
-                key=key_name,
-                data="upload-part-1" * 5,
+            s3_client.create_multipart_upload(
+                Bucket=s3_bucket,
+                Key=key_name,
                 StorageClass=StorageClass.OUTPOSTS,
             )
-        snapshot.match("multipart-outposts", e.value.response)
+        snapshot.match("create-multipart-outposts-exc", e.value.response)
 
 
 class TestS3TerraformRawRequests:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2915,12 +2915,8 @@ class TestS3:
         snapshot.match("put-object-storage-class", response)
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        condition=is_old_provider,
-        paths=[
-            "$..Error.StorageClassRequested",
-            "$..Error.RequestID",
-        ],
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER, reason="Validation not implemented in legacy provider"
     )
     def test_put_object_storage_class_outposts(
         self, s3_client, s3_bucket, s3_multipart_upload, snapshot

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4242,7 +4242,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class_outposts": {
-    "recorded-date": "16-01-2023, 21:51:03",
+    "recorded-date": "17-01-2023, 14:34:16",
     "recorded-content": {
       "put-object-outposts": {
         "Error": {
@@ -4255,7 +4255,7 @@
           "HTTPStatusCode": 400
         }
       },
-      "multipart-outposts": {
+      "create-multipart-outposts-exc": {
         "Error": {
           "Code": "InvalidStorageClass",
           "Message": "The storage class you specified is not valid",

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4136,5 +4136,125 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD]": {
+    "recorded-date": "16-01-2023, 18:02:54",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA]": {
+    "recorded-date": "16-01-2023, 18:01:59",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "STANDARD_IA",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER]": {
+    "recorded-date": "16-01-2023, 18:02:01",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "GLACIER",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR]": {
+    "recorded-date": "16-01-2023, 18:02:04",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "GLACIER_IR",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY]": {
+    "recorded-date": "16-01-2023, 18:02:06",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "REDUCED_REDUNDANCY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA]": {
+    "recorded-date": "16-01-2023, 18:02:09",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "ONEZONE_IA",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING]": {
+    "recorded-date": "16-01-2023, 18:02:11",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "INTELLIGENT_TIERING",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE]": {
+    "recorded-date": "16-01-2023, 18:02:13",
+    "recorded-content": {
+      "put-object-storage-class": {
+        "LastModified": "datetime",
+        "StorageClass": "DEEP_ARCHIVE",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class_outposts": {
+    "recorded-date": "16-01-2023, 18:04:54",
+    "recorded-content": {
+      "put-object-outposts": {
+        "Error": {
+          "Code": "InvalidStorageClass",
+          "Message": "The storage class you specified is not valid",
+          "StorageClassRequested": "OUTPOSTS"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4242,9 +4242,20 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class_outposts": {
-    "recorded-date": "16-01-2023, 18:04:54",
+    "recorded-date": "16-01-2023, 21:51:03",
     "recorded-content": {
       "put-object-outposts": {
+        "Error": {
+          "Code": "InvalidStorageClass",
+          "Message": "The storage class you specified is not valid",
+          "StorageClassRequested": "OUTPOSTS"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "multipart-outposts": {
         "Error": {
           "Code": "InvalidStorageClass",
           "Message": "The storage class you specified is not valid",


### PR DESCRIPTION
This PR fixes an issue reported here #7493

It seems moto validation is outdated, and we can make use of the specs for validation. Added snapshot tests and missing field to an exception.

I tested on `PutObject` because that's what moto uses under the hood after completing a multi part upload. However, there's an issue there as the validation occurs after completing the upload, meaning that the data would be lost if an exception is raised when trying to complete. 

__fixes #7505__