### PR TITLE
Remove unused CFn resolving

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -733,10 +733,6 @@ LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 # TODO remove fallback to LAMBDA_DOCKER_NETWORK with next minor version
 MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER_NETWORK
 
-# EXPERIMENTAL/LEGACY. Use this flag to return to the legacy behavior of resolving references in the specific models
-CFN_ENABLE_RESOLVE_REFS_IN_MODELS = is_env_true("CFN_ENABLE_RESOLVE_REFS_IN_MODELS")
-
-
 # list of environment variable names used for configuration.
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately

--- a/localstack/services/cloudformation/models/certificatemanager.py
+++ b/localstack/services/cloudformation/models/certificatemanager.py
@@ -11,9 +11,7 @@ class CertificateManagerCertificate(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("acm")
         result = client.list_certificates().get("CertificateSummaryList", [])
-        domain_name = self.resolve_refs_recursively(
-            stack_name, self.props.get("DomainName"), resources
-        )
+        domain_name = self.props.get("DomainName")
         result = [c for c in result if c["DomainName"] == domain_name]
         return (result or [None])[0]
 

--- a/localstack/services/cloudformation/models/cloudformation.py
+++ b/localstack/services/cloudformation/models/cloudformation.py
@@ -18,7 +18,6 @@ class CloudFormationStack(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("cloudformation")
         child_stack_name = self.props["StackName"]
-        child_stack_name = self.resolve_refs_recursively(stack_name, child_stack_name, resources)
         result = client.describe_stacks(StackName=child_stack_name)
         # probably not the best way to wait in a blocking manner here but the current implementation requires it
         client.get_waiter("stack_create_complete").wait(StackName=child_stack_name)

--- a/localstack/services/cloudformation/models/cloudwatch.py
+++ b/localstack/services/cloudformation/models/cloudwatch.py
@@ -22,7 +22,7 @@ class CloudWatchAlarm(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("cloudwatch")
-        alarm_name = self.resolve_refs_recursively(stack_name, self.props["AlarmName"], resources)
+        alarm_name = self.props["AlarmName"]
         result = client.describe_alarms(AlarmNames=[alarm_name]).get(self._response_name(), [])
         return (result or [None])[0]
 

--- a/localstack/services/cloudformation/models/dynamodb.py
+++ b/localstack/services/cloudformation/models/dynamodb.py
@@ -74,7 +74,6 @@ class DynamoDBTable(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         table_name = self.props.get("TableName") or self.logical_resource_id
-        table_name = self.resolve_refs_recursively(stack_name, table_name, resources)
         return aws_stack.connect_to_service("dynamodb").describe_table(TableName=table_name)
 
     @staticmethod

--- a/localstack/services/cloudformation/models/ec2.py
+++ b/localstack/services/cloudformation/models/ec2.py
@@ -60,13 +60,9 @@ class EC2Route(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("ec2")
         props = self.props
-        dst_cidr = self.resolve_refs_recursively(
-            stack_name, props.get("DestinationCidrBlock"), resources
-        )
-        dst_cidr6 = self.resolve_refs_recursively(
-            stack_name, props.get("DestinationIpv6CidrBlock"), resources
-        )
-        table_id = self.resolve_refs_recursively(stack_name, props.get("RouteTableId"), resources)
+        dst_cidr = props.get("DestinationCidrBlock")
+        dst_cidr6 = props.get("DestinationIpv6CidrBlock")
+        table_id = props.get("RouteTableId")
         route_tables = client.describe_route_tables()["RouteTables"]
         route_table = ([t for t in route_tables if t["RouteTableId"] == table_id] or [None])[0]
         if route_table:
@@ -144,11 +140,11 @@ class EC2SubnetRouteTableAssociation(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("ec2")
         props = self.props
-        table_id = self.resolve_refs_recursively(stack_name, props.get("RouteTableId"), resources)
-        gw_id = self.resolve_refs_recursively(stack_name, props.get("GatewayId"), resources)
+        table_id = props.get("RouteTableId")
+        gw_id = props.get("GatewayId")
         route_tables = client.describe_route_tables()["RouteTables"]
         route_table = ([t for t in route_tables if t["RouteTableId"] == table_id] or [None])[0]
-        subnet_id = self.resolve_refs_recursively(stack_name, props.get("SubnetId"), resources)
+        subnet_id = props.get("SubnetId")
         if route_table:
             associations = route_table.get("Associations", [])
             association = [a for a in associations if a.get("GatewayId") == gw_id]
@@ -185,10 +181,8 @@ class EC2VPCGatewayAttachment(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("ec2")
         props = self.props
-        igw_id = self.resolve_refs_recursively(
-            stack_name, props.get("InternetGatewayId"), resources
-        )
-        vpngw_id = self.resolve_refs_recursively(stack_name, props.get("VpnGatewayId"), resources)
+        igw_id = props.get("InternetGatewayId")
+        vpngw_id = props.get("VpnGatewayId")
         gateways = []
         if igw_id:
             gateways = client.describe_internet_gateways()["InternetGateways"]
@@ -462,8 +456,8 @@ class EC2NatGateway(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("ec2")
         props = self.props
-        subnet_id = self.resolve_refs_recursively(stack_name, props.get("SubnetId"), resources)
-        assoc_id = self.resolve_refs_recursively(stack_name, props.get("AllocationId"), resources)
+        subnet_id = props.get("SubnetId")
+        assoc_id = props.get("AllocationId")
         result = client.describe_nat_gateways(
             Filters=[{"Name": "subnet-id", "Values": [subnet_id]}]
         )

--- a/localstack/services/cloudformation/models/elasticsearch.py
+++ b/localstack/services/cloudformation/models/elasticsearch.py
@@ -35,7 +35,6 @@ class ElasticsearchDomain(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         domain_name = self._domain_name()
-        domain_name = self.resolve_refs_recursively(stack_name, domain_name, resources)
         return aws_stack.connect_to_service("es").describe_elasticsearch_domain(
             DomainName=domain_name
         )

--- a/localstack/services/cloudformation/models/events.py
+++ b/localstack/services/cloudformation/models/events.py
@@ -21,7 +21,7 @@ class EventConnection(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("events")
-        conn_name = self.resolve_refs_recursively(stack_name, self.props.get("Name"), resources)
+        conn_name = self.props.get("Name")
         return client.describe_connection(Name=conn_name)
 
     def get_cfn_attribute(self, attribute_name):
@@ -47,9 +47,7 @@ class EventBus(GenericBaseModel):
         return "AWS::Events::EventBus"
 
     def fetch_state(self, stack_name, resources):
-        event_bus_name = self.resolve_refs_recursively(
-            stack_name, self.props.get("Name"), resources
-        )
+        event_bus_name = self.props.get("Name")
         client = aws_stack.connect_to_service("events")
         return client.describe_event_bus(Name=event_bus_name)
 
@@ -83,7 +81,7 @@ class EventsRule(GenericBaseModel):
         return self.props.get("Name")
 
     def fetch_state(self, stack_name, resources):
-        rule_name = self.resolve_refs_recursively(stack_name, self.props.get("Name"), resources)
+        rule_name = self.props.get("Name")
         result = aws_stack.connect_to_service("events").describe_rule(Name=rule_name) or {}
         return result if result.get("Name") else None
 

--- a/localstack/services/cloudformation/models/kinesis.py
+++ b/localstack/services/cloudformation/models/kinesis.py
@@ -13,7 +13,7 @@ class KinesisStreamConsumer(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         props = self.props
-        stream_arn = self.resolve_refs_recursively(stack_name, props["StreamARN"], resources)
+        stream_arn = props["StreamARN"]
         result = aws_stack.connect_to_service("kinesis").list_stream_consumers(StreamARN=stream_arn)
         result = [r for r in result["Consumers"] if r["ConsumerName"] == props["ConsumerName"]]
         return (result or [None])[0]
@@ -37,7 +37,7 @@ class KinesisStream(GenericBaseModel):
         return self.physical_resource_id
 
     def fetch_state(self, stack_name, resources):
-        stream_name = self.resolve_refs_recursively(stack_name, self.props["Name"], resources)
+        stream_name = self.props["Name"]
         result = aws_stack.connect_to_service("kinesis").describe_stream(StreamName=stream_name)
         return result
 

--- a/localstack/services/cloudformation/models/kinesisfirehose.py
+++ b/localstack/services/cloudformation/models/kinesisfirehose.py
@@ -10,7 +10,6 @@ class FirehoseDeliveryStream(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         stream_name = self.props.get("DeliveryStreamName") or self.logical_resource_id
-        stream_name = self.resolve_refs_recursively(stack_name, stream_name, resources)
         return aws_stack.connect_to_service("firehose").describe_delivery_stream(
             DeliveryStreamName=stream_name
         )

--- a/localstack/services/cloudformation/models/logs.py
+++ b/localstack/services/cloudformation/models/logs.py
@@ -21,7 +21,6 @@ class LogsLogGroup(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         group_name = self.props.get("LogGroupName")
-        group_name = self.resolve_refs_recursively(stack_name, group_name, resources)
         logs = aws_stack.connect_to_service("logs")
         groups = logs.describe_log_groups(logGroupNamePrefix=group_name)["logGroups"]
         return ([g for g in groups if g["logGroupName"] == group_name] or [None])[0]
@@ -62,7 +61,6 @@ class LogsLogStream(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         group_name = self.props.get("LogGroupName")
         stream_name = self.props.get("LogStreamName")
-        group_name = self.resolve_refs_recursively(stack_name, group_name, resources)
         logs = aws_stack.connect_to_service("logs")
         streams = logs.describe_log_streams(
             logGroupName=group_name, logStreamNamePrefix=stream_name
@@ -101,10 +99,8 @@ class LogsSubscriptionFilter(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         props = self.props
-        group_name = self.resolve_refs_recursively(stack_name, props.get("LogGroupName"), resources)
-        filter_pattern = self.resolve_refs_recursively(
-            stack_name, props.get("FilterPattern"), resources
-        )
+        group_name = props.get("LogGroupName")
+        filter_pattern = props.get("FilterPattern")
         logs = aws_stack.connect_to_service("logs")
         groups = logs.describe_subscription_filters(logGroupName=group_name)["subscriptionFilters"]
         groups = [g for g in groups if g.get("filterPattern") == filter_pattern]

--- a/localstack/services/cloudformation/models/opensearch.py
+++ b/localstack/services/cloudformation/models/opensearch.py
@@ -32,7 +32,6 @@ class OpenSearchDomain(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         domain_name = self._domain_name()
-        domain_name = self.resolve_refs_recursively(stack_name, domain_name, resources)
         return aws_stack.connect_to_service("opensearch").describe_domain(DomainName=domain_name)
 
     def _domain_name(self):

--- a/localstack/services/cloudformation/models/redshift.py
+++ b/localstack/services/cloudformation/models/redshift.py
@@ -13,9 +13,7 @@ class RedshiftCluster(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         client = aws_stack.connect_to_service("redshift")
-        cluster_id = self.resolve_refs_recursively(
-            stack_name, self.props.get("ClusterIdentifier"), resources
-        )
+        cluster_id = self.props.get("ClusterIdentifier")
         result = client.describe_clusters(ClusterIdentifier=cluster_id)["Clusters"]
         return (result or [None])[0]
 

--- a/localstack/services/cloudformation/models/s3.py
+++ b/localstack/services/cloudformation/models/s3.py
@@ -27,7 +27,6 @@ class S3BucketPolicy(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         bucket_name = self.props.get("Bucket") or self.logical_resource_id
-        bucket_name = self.resolve_refs_recursively(stack_name, bucket_name, resources)
         return aws_stack.connect_to_service("s3").get_bucket_policy(Bucket=bucket_name)
 
     @staticmethod
@@ -190,7 +189,6 @@ class S3Bucket(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         props = self.props
         bucket_name = self._get_bucket_name()
-        bucket_name = self.resolve_refs_recursively(stack_name, bucket_name, resources)
         bucket_name = self.normalize_bucket_name(bucket_name)
         s3_client = aws_stack.connect_to_service("s3")
         response = s3_client.get_bucket_location(Bucket=bucket_name)

--- a/localstack/services/cloudformation/models/secretsmanager.py
+++ b/localstack/services/cloudformation/models/secretsmanager.py
@@ -30,7 +30,6 @@ class SecretsManagerSecret(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         secret_name = self.props.get("Name") or self.logical_resource_id
-        secret_name = self.resolve_refs_recursively(stack_name, secret_name, resources)
         result = aws_stack.connect_to_service("secretsmanager").describe_secret(
             SecretId=secret_name
         )
@@ -159,7 +158,7 @@ class SecretsManagerResourcePolicy(GenericBaseModel):
         return arns.secretsmanager_secret_arn(self.props.get("SecretId"))
 
     def fetch_state(self, stack_name, resources):
-        secret_id = self.resolve_refs_recursively(stack_name, self.props.get("SecretId"), resources)
+        secret_id = self.props.get("SecretId")
         result = aws_stack.connect_to_service("secretsmanager").get_resource_policy(
             SecretId=secret_id
         )

--- a/localstack/services/cloudformation/models/sns.py
+++ b/localstack/services/cloudformation/models/sns.py
@@ -20,7 +20,7 @@ class SNSTopic(GenericBaseModel):
         return arns.sns_topic_arn(self.props["TopicName"])
 
     def fetch_state(self, stack_name, resources):
-        topic_name = self.resolve_refs_recursively(stack_name, self.props["TopicName"], resources)
+        topic_name = self.props["TopicName"]
         topics = aws_stack.connect_to_service("sns").list_topics()
         result = list(
             filter(
@@ -119,7 +119,6 @@ class SNSSubscription(GenericBaseModel):
     def fetch_state(self, stack_name, resources):
         props = self.props
         topic_arn = props.get("TopicArn")
-        topic_arn = self.resolve_refs_recursively(stack_name, topic_arn, resources)
         if topic_arn is None:
             return
         subs = aws_stack.connect_to_service("sns").list_subscriptions_by_topic(TopicArn=topic_arn)
@@ -177,7 +176,6 @@ class SNSTopicPolicy(GenericBaseModel):
         result = {}
         props = self.props
         for topic_arn in props["Topics"]:
-            topic_arn = self.resolve_refs_recursively(stack_name, topic_arn, resources)
             result[topic_arn] = None
             attrs = sns_client.get_topic_attributes(TopicArn=topic_arn)
             policy = attrs["Attributes"].get("Policy")

--- a/localstack/services/cloudformation/models/sqs.py
+++ b/localstack/services/cloudformation/models/sqs.py
@@ -85,7 +85,7 @@ class SQSQueue(GenericBaseModel):
         return queue_url
 
     def fetch_state(self, stack_name, resources):
-        queue_name = self.resolve_refs_recursively(stack_name, self.props["QueueName"], resources)
+        queue_name = self.props["QueueName"]
         sqs_client = aws_stack.connect_to_service("sqs")
         queues = sqs_client.list_queues()
         result = list(

--- a/localstack/services/cloudformation/models/ssm.py
+++ b/localstack/services/cloudformation/models/ssm.py
@@ -19,7 +19,6 @@ class SSMParameter(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         param_name = self.props.get("Name") or self.logical_resource_id
-        param_name = self.resolve_refs_recursively(stack_name, param_name, resources)
         return aws_stack.connect_to_service("ssm").get_parameter(Name=param_name)["Parameter"]
 
     @staticmethod
@@ -42,9 +41,6 @@ class SSMParameter(GenericBaseModel):
             "Value",
         ]
         update_config_props = select_attributes(props, parameters_to_select)
-        update_config_props = self.resolve_refs_recursively(
-            stack_name, update_config_props, resources
-        )
 
         if "Tags" in update_config_props:
             update_config_props["Tags"] = [

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -51,7 +51,6 @@ class SFNStateMachine(GenericBaseModel):
 
     def fetch_state(self, stack_name, resources):
         sm_name = self.props.get("StateMachineName") or self.logical_resource_id
-        sm_name = self.resolve_refs_recursively(stack_name, sm_name, resources)
         sfn_client = aws_stack.connect_to_service("stepfunctions")
         state_machines = sfn_client.list_state_machines()["stateMachines"]
         sm_arn = [m["stateMachineArn"] for m in state_machines if m["name"] == sm_name]

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -155,4 +155,4 @@ class GenericBaseModel:
     @property
     def resource_id(self) -> str:
         """Return the logical resource ID of this resource (i.e., the ref. name within the stack's resources)."""
-        return self.ource_json["LogicalResourceId"]
+        return self.resource_json["LogicalResourceId"]

--- a/localstack/services/cloudformation/service_models.py
+++ b/localstack/services/cloudformation/service_models.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional, TypedDict
 
-from localstack import config
 from localstack.utils.aws import aws_stack
 
 LOG = logging.getLogger(__name__)
@@ -156,18 +155,4 @@ class GenericBaseModel:
     @property
     def resource_id(self) -> str:
         """Return the logical resource ID of this resource (i.e., the ref. name within the stack's resources)."""
-        return self.resource_json["LogicalResourceId"]
-
-    @classmethod
-    def resolve_refs_recursively(cls, stack_name, value, resources):
-        if config.CFN_ENABLE_RESOLVE_REFS_IN_MODELS:
-            # TODO: restructure code to avoid circular import here
-            from localstack.services.cloudformation.engine.template_deployer import (
-                resolve_refs_recursively,
-            )
-            from localstack.services.cloudformation.provider import find_stack
-
-            stack = find_stack(stack_name)
-            return resolve_refs_recursively(stack, value)
-
-        return value
+        return self.ource_json["LogicalResourceId"]


### PR DESCRIPTION
In #7149 (nearly a month ago) this has been disabled by default, since we had the hypothesis that it is actually redundant. We haven't had to make use of the fallback flag since, so it is safe to assume that we can finally remove it.

This PR now cleans up all the resource models by removing the corresponding calls as well as the implementation itself.
