### PR TITLE
fix APIGW UpdateMethodResponse error response code

### DIFF
--- a/localstack/aws/forwarder.py
+++ b/localstack/aws/forwarder.py
@@ -46,6 +46,10 @@ def ForwardingFallbackDispatcher(
     return table
 
 
+class NotImplementedAvoidFallbackError(NotImplementedError):
+    pass
+
+
 def _wrap_with_fallthrough(
     handler: ServiceRequestHandler, fallthrough_handler: ServiceRequestHandler
 ) -> ServiceRequestHandler:
@@ -54,6 +58,9 @@ def _wrap_with_fallthrough(
             # handler will typically be an ASF provider method, and in case it hasn't been
             # implemented, we try to fall back to forwarding the request to the backend
             return handler(context, req)
+        except NotImplementedAvoidFallbackError as e:
+            # if the fallback has been explicitly disabled, don't pass on to the fallback
+            raise e
         except NotImplementedError:
             pass
 

--- a/tests/integration/test_forwarder.py
+++ b/tests/integration/test_forwarder.py
@@ -1,0 +1,47 @@
+import pytest
+
+from localstack.aws.api import (
+    RequestContext,
+    ServiceException,
+    ServiceRequest,
+    ServiceResponse,
+    handler,
+)
+from localstack.aws.forwarder import ForwardingFallbackDispatcher, NotImplementedAvoidFallbackError
+
+
+def test_forwarding_fallback_dispatcher():
+    # create a dummy provider which raises a NotImplementedError (triggering the fallthrough)
+    class TestProvider:
+        @handler(operation="TestOperation")
+        def test_method(self, context):
+            raise NotImplementedError
+
+    test_provider = TestProvider()
+
+    # create a dummy fallback function
+    def test_request_forwarder(_, __) -> ServiceResponse:
+        return "fallback-result"
+
+    # invoke the function and expect the result from the fallback function
+    dispatcher = ForwardingFallbackDispatcher(test_provider, test_request_forwarder)
+    assert dispatcher["TestOperation"](RequestContext(), ServiceRequest()) == "fallback-result"
+
+
+def test_forwarding_fallback_dispatcher_avoid_fallback():
+    # create a dummy provider which raises a NotImplementedAvoidFallbackError (avoiding the fallthrough)
+    class TestProvider:
+        @handler(operation="TestOperation")
+        def test_method(self, context):
+            raise NotImplementedAvoidFallbackError
+
+    test_provider = TestProvider()
+
+    # create a dummy forwarding function which raises a ServiceException
+    def test_request_forwarder(_, __) -> ServiceResponse:
+        raise ServiceException
+
+    # expect a NotImplementedError exception (and not the ServiceException from the fallthrough)
+    dispatcher = ForwardingFallbackDispatcher(test_provider, test_request_forwarder)
+    with pytest.raises(NotImplementedError):
+        dispatcher["TestOperation"](RequestContext(), ServiceRequest())


### PR DESCRIPTION
moto currently does not implement API Gatway's "UpdateMethodResponse" operation (which is invoked with an HTTP PATCH request):
https://github.com/getmoto/moto/blob/173e1549c06e3bdea110bd5222ed09307867a923/moto/apigateway/responses.py#L222-L254
The raised exception in moto translates to a status code `500` ("Internal Server Error") in the HTTP response in the client, even though it should raise a `501` ("Not Implemented"). This slight difference can cause issues, f.e. with IaC tools like Terraform.

This PR introduces a new feature in the fallback dispatching logic (and therefore to the `MotoFallbackDispatcher`) which allows the primary provider to avoid a fallback, but actually raise the 501 to the client.
This is used in the API Gateway provider to define the `update_method_response` operation to fix the status code.
/cc @macnev2013 