### PR TITLE
randomly generate request-id for S3 notification events

### DIFF
--- a/localstack/services/s3/notifications.py
+++ b/localstack/services/s3/notifications.py
@@ -28,6 +28,7 @@ from localstack.aws.api.s3 import (
     TopicArn,
     TopicConfiguration,
 )
+from localstack.aws.protocol.serializer import gen_amzn_requestid_long
 from localstack.config import DEFAULT_REGION
 from localstack.services.s3.models import get_moto_s3_backend
 from localstack.services.s3.utils import (
@@ -456,7 +457,7 @@ class EventBridgeNotifier(BaseNotifier):
                 "etag": ctx.key_etag,
                 "sequencer": "0062E99A88DC407460",
             },
-            "request-id": "RKREYG1RN2X92YX6",
+            "request-id": gen_amzn_requestid_long(),
             "requester": "074255357339",
             "source-ip-address": "127.0.0.1",
             # TODO previously headers.get("X-Forwarded-For", "127.0.0.1").split(",")[0]

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -21,6 +21,7 @@ from requests.models import Request, Response
 
 from localstack import config, constants
 from localstack.aws.api import CommonServiceException
+from localstack.aws.protocol.serializer import gen_amzn_requestid_long
 from localstack.config import get_protocol as get_service_protocol
 from localstack.services.generic_proxy import ProxyListener
 from localstack.services.generic_proxy import append_cors_headers as _append_default_cors_headers
@@ -251,7 +252,7 @@ def get_event_message(
                 "userIdentity": {"principalId": "AIDAJDPLRKLG7UEXAMPLE"},
                 "requestParameters": {"sourceIPAddress": source_ip},
                 "responseElements": {
-                    "x-amz-request-id": short_uid(),
+                    "x-amz-request-id": gen_amzn_requestid_long(),
                     "x-amz-id-2": "eftixk72aD6Ap51TnqcoF8eFidJG9Z/2",  # Amazon S3 host that processed the request
                 },
                 "s3": {
@@ -419,7 +420,7 @@ def send_notification_for_subscriber(
                     "etag": object_data.get("ETag", ""),
                     "sequencer": "0062E99A88DC407460",
                 },
-                "request-id": "RKREYG1RN2X92YX6",
+                "request-id": gen_amzn_requestid_long(),
                 "requester": "074255357339",
                 "source-ip-address": source_ip,
             },

--- a/tests/integration/s3/test_s3_notifications_eventbridge.py
+++ b/tests/integration/s3/test_s3_notifications_eventbridge.py
@@ -121,9 +121,17 @@ class TestS3NotificationsToEventBridge:
 
         retries = 10 if is_aws_cloud() else 5
         retry(_receive_messages, retries=retries)
-
-        snapshot.match("object_deleted", messages.get("Object Deleted"))
-        snapshot.match("object_created", messages.get("Object Created"))
+        object_deleted_event = messages["Object Deleted"]
+        object_created_event = messages["Object Created"]
+        snapshot.match("object_deleted", object_deleted_event)
+        snapshot.match("object_created", object_created_event)
+        # assert that the request-id is randomly generated
+        # ideally, it should use the true request-id. However, the request-id is set in the serializer for now,
+        # and would need to be set before going through the skeleton
+        assert (
+            object_deleted_event["detail"]["request-id"]
+            != object_created_event["detail"]["request-id"]
+        )
 
     @pytest.mark.aws_validated
     @pytest.mark.skipif(condition=LEGACY_S3_PROVIDER, reason="not implemented")


### PR DESCRIPTION
This issue comes from a support ticket.
The `request-id` for an S3 notification to EventBridge would hard coded, which prevented them to check for duplicate events.
Adds a simple fix + small test. 
