### PR TITLE
create a new ConfigResource and deprecate /?_config_

### DIFF
--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import re
 from collections import defaultdict
 from typing import List, Optional
 
@@ -15,6 +16,7 @@ from localstack.http.adapters import RouterListener
 from localstack.http.dispatcher import resource_dispatcher
 from localstack.services.infra import SHUTDOWN_INFRA, terminate_all_processes_in_docker
 from localstack.utils.collections import merge_recursive
+from localstack.utils.config_listener import update_config_variable
 from localstack.utils.files import load_file
 from localstack.utils.functions import call_safe
 from localstack.utils.json import parse_json_or_yaml
@@ -247,6 +249,21 @@ class InitScriptsStageResource:
         }
 
 
+class ConfigUpdateResource:
+    def on_post(self, request: Request):
+        data = request.get_json(force=True)
+        variable = data.get("variable", "")
+        if not re.match(r"^[_a-zA-Z0-9]+$", variable):
+            return Response("{}", mimetype="application/json", status=400)
+        new_value = data.get("value")
+        update_config_variable(variable, new_value)
+        value = getattr(config, variable, None)
+        return {
+            "variable": variable,
+            "value": value,
+        }
+
+
 class LocalstackResources(Router):
     """
     Router for localstack-internal HTTP resources.
@@ -280,6 +297,9 @@ class LocalstackResources(Router):
         self.add("/init/<stage>", InitScriptsStageResource())
         self.add("/cloudformation/deploy", CloudFormationUi())
 
+        if config.ENABLE_CONFIG_UPDATES:
+            self.add("/config-update", ConfigUpdateResource())
+
         if config.DEBUG:
             LOG.warning(
                 "Enabling diagnose endpoint, "
@@ -288,7 +308,7 @@ class LocalstackResources(Router):
             self.add("/diagnose", DiagnoseResource())
 
     def add(self, path, *args, **kwargs):
-        super().add(f"{constants.INTERNAL_RESOURCE_PATH}{path}", *args, **kwargs)
+        return super().add(f"{constants.INTERNAL_RESOURCE_PATH}{path}", *args, **kwargs)
 
 
 class LocalstackResourceHandler(RouterListener):

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -249,7 +249,7 @@ class InitScriptsStageResource:
         }
 
 
-class ConfigUpdateResource:
+class ConfigResource:
     def on_post(self, request: Request):
         data = request.get_json(force=True)
         variable = data.get("variable", "")
@@ -298,7 +298,7 @@ class LocalstackResources(Router):
         self.add("/cloudformation/deploy", CloudFormationUi())
 
         if config.ENABLE_CONFIG_UPDATES:
-            self.add("/config-update", ConfigUpdateResource())
+            self.add("/config", ConfigResource())
 
         if config.DEBUG:
             LOG.warning(

--- a/localstack/utils/config_listener.py
+++ b/localstack/utils/config_listener.py
@@ -6,6 +6,7 @@ from typing import Callable, List
 from requests.models import Response
 
 from localstack import config, constants
+from localstack.deprecations import deprecated_endpoint
 from localstack.services.generic_proxy import ProxyListener
 
 LOG = logging.getLogger(__name__)
@@ -26,26 +27,39 @@ def update_config_variable(variable, new_value):
         trigger_config_listeners(variable, new_value)
 
 
+def _update_config_variable_handler(data):
+    response = Response()
+    data = json.loads(data)
+    variable = data.get("variable", "")
+    response._content = "{}"
+    response.status_code = 200
+    if not re.match(r"^[_a-zA-Z0-9]+$", variable):
+        response.status_code = 400
+        return response
+    new_value = data.get("value")
+    update_config_variable(variable, new_value)
+    value = getattr(config, variable, None)
+    result = {"variable": variable, "value": value}
+    response._content = json.dumps(result)
+    return response
+
+
 class ConfigUpdateProxyListener(ProxyListener):
     """Default proxy listener that intercepts requests to retrieve or update config variables."""
+
+    def __init__(self):
+        self._handler = deprecated_endpoint(
+            endpoint=_update_config_variable_handler,
+            previous_path=constants.CONFIG_UPDATE_PATH,
+            deprecation_version="1.4.0",
+            new_path="/_localstack/config-update",
+        )
 
     def forward_request(self, method, path, data, headers):
         if path != constants.CONFIG_UPDATE_PATH or method != "POST":
             return True
-        response = Response()
-        data = json.loads(data)
-        variable = data.get("variable", "")
-        response._content = "{}"
-        response.status_code = 200
-        if not re.match(r"^[_a-zA-Z0-9]+$", variable):
-            response.status_code = 400
-            return response
-        new_value = data.get("value")
-        update_config_variable(variable, new_value)
-        value = getattr(config, variable, None)
-        result = {"variable": variable, "value": value}
-        response._content = json.dumps(result)
-        return response
+
+        return self._handler(data)
 
 
 CONFIG_UPDATE_LISTENER = ConfigUpdateProxyListener()

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -2,17 +2,25 @@ import pytest
 import requests
 
 from localstack import config
+from localstack.constants import CONFIG_UPDATE_PATH
+from localstack.services.internal import ConfigUpdateResource, get_internal_apis
 from localstack.utils import config_listener
 
 
 @pytest.fixture
-def config_endpoint():
-    cur_value = config.ENABLE_CONFIG_UPDATES
-    config.ENABLE_CONFIG_UPDATES = True
+def config_endpoint(monkeypatch):
+    if config.ENABLE_CONFIG_UPDATES:
+        return
+
+    router = get_internal_apis()
+    monkeypatch.setattr(config, "ENABLE_CONFIG_UPDATES", True)
+    # will listen on /?_config_
     config_listener.start_listener()
+    # will listen on /_localstack/config-update
+    rule = router.add("/config-update", ConfigUpdateResource())
     yield
-    config.ENABLE_CONFIG_UPDATES = cur_value
     config_listener.remove_listener()
+    router.remove_rule(rule)
 
 
 def test_config_endpoint(config_endpoint):
@@ -24,10 +32,11 @@ def test_config_endpoint(config_endpoint):
         value = config_value
 
     config.FOO = None
-    body = {"variable": "FOO", "value": "BAR"}
     config_listener.CONFIG_LISTENERS.append(custom_listener)
-    url = f"{config.get_edge_url()}/?_config_"
-    print(url)
+
+    # test the ProxyListener
+    body = {"variable": "FOO", "value": "BAR"}
+    url = f"{config.get_edge_url()}{CONFIG_UPDATE_PATH}"
     response = requests.post(url, json=body)
     assert 200 == response.status_code
     response_body = response.json()
@@ -35,3 +44,18 @@ def test_config_endpoint(config_endpoint):
     assert body["value"] == config.FOO
     assert body["variable"] == key
     assert body["value"] == value
+
+    # test the Route
+    body = {"variable": "FOO", "value": "BAZ"}
+    config_listener.CONFIG_LISTENERS.append(custom_listener)
+    # test the ProxyListener
+    url = f"{config.get_edge_url()}/_localstack/config-update"
+    response = requests.post(url, json=body)
+    assert 200 == response.status_code
+    response_body = response.json()
+    assert body == response_body
+    assert body["value"] == config.FOO
+    assert body["variable"] == key
+    assert body["value"] == value
+
+    del config.FOO

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -3,7 +3,7 @@ import requests
 
 from localstack import config
 from localstack.constants import CONFIG_UPDATE_PATH
-from localstack.services.internal import ConfigUpdateResource, get_internal_apis
+from localstack.services.internal import ConfigResource, get_internal_apis
 from localstack.utils import config_listener
 
 
@@ -17,7 +17,7 @@ def config_endpoint(monkeypatch):
     # will listen on /?_config_
     config_listener.start_listener()
     # will listen on /_localstack/config-update
-    rule = router.add("/config-update", ConfigUpdateResource())
+    rule = router.add("/config", ConfigResource())
     yield
     config_listener.remove_listener()
     router.remove_rule(rule)
@@ -49,7 +49,7 @@ def test_config_endpoint(config_endpoint):
     body = {"variable": "FOO", "value": "BAZ"}
     config_listener.CONFIG_LISTENERS.append(custom_listener)
     # test the ProxyListener
-    url = f"{config.get_edge_url()}/_localstack/config-update"
+    url = f"{config.get_edge_url()}/_localstack/config"
     response = requests.post(url, json=body)
     assert 200 == response.status_code
     response_body = response.json()


### PR DESCRIPTION
Relates to #7465

We're adding a migration path to `ConfigUpdateProxyListener(ProxyListener)`

It currently allows to update the config with a POST on `/?_config_`, and some services can set up listeners to react to the changes. 

This endpoint will be deprecated.

We can't remove the current ProxyListener and will log a deprecation message.
It currently match on `/?_config_`, a query string, which we cannot use the router to match. The new route is at `/_localstack/config-update` and make uses of `LocalstackResources`. 

\cc @thrau for the change in `LocalstackResources`