### PR TITLE
fix: rename list buckets reponse

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2253,11 +2253,6 @@ class ListBucketMetricsConfigurationsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
-class ListBucketsOutput(TypedDict, total=False):
-    Buckets: Optional[Buckets]
-    Owner: Optional[Owner]
-
-
 class MultipartUpload(TypedDict, total=False):
     UploadId: Optional[MultipartUploadId]
     Key: Optional[ObjectKey]
@@ -3097,6 +3092,11 @@ class PostResponse(TypedDict, total=False):
     RequestCharged: Optional[RequestCharged]
 
 
+class ListAllMyBucketsResult(TypedDict, total=False):
+    Buckets: Optional[Buckets]
+    Owner: Optional[Owner]
+
+
 class S3Api:
 
     service = "s3"
@@ -3700,7 +3700,7 @@ class S3Api:
     def list_buckets(
         self,
         context: RequestContext,
-    ) -> ListBucketsOutput:
+    ) -> ListAllMyBucketsResult:
         raise NotImplementedError
 
     @handler("ListMultipartUploads")

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -771,6 +771,32 @@
         "documentation": "<p>The storage class you specified is not valid</p>",
         "exception": true
       }
+    },
+    {
+        "op": "remove",
+        "path": "/shapes/ListBucketsOutput"
+    },
+    {
+        "op": "add",
+        "path": "/shapes/ListAllMyBucketsResult",
+        "value": {
+            "type": "structure",
+            "members": {
+                "Buckets": {
+                    "shape": "Buckets",
+                    "documentation": "<p>The list of buckets owned by the requester.</p>"
+                },
+                "Owner": {
+                    "shape": "Owner",
+                    "documentation": "<p>The owner of the buckets listed.</p>"
+                }
+            }
+        }
+    },
+    {
+        "op": "replace",
+        "path": "/operations/ListBuckets/output/shape",
+        "value": "ListAllMyBucketsResult"
     }
   ]
 }


### PR DESCRIPTION
# Issue
- #7541 

# Fix
- Patched `ListBucketsOutput` to `ListAllMyBucketsResult`.
  - In boto spec definition of output from `ListBuckets` is `ListBucketsOutput` whereas AWS is returning  `ListAllMyBucketsResult`.

# Commands to Reproduce

```
Start localstack instance with env `PROVIDER_OVERRIDE_S3: "asf"`
```

Comparing the response from this commands will po
```
awslocal s3api list-buckets --profile ls --debug
```
```
aws s3api list-buckets --profile ls --debug
```

# Tested Also with
https://github.com/Dowwie/localstack_s3_xml_issue