### PR TITLE
fix: rename list bucket/object reponse class

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2334,6 +2334,17 @@ class ListObjectVersionsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
+class ListObjectsRequest(ServiceRequest):
+    Bucket: BucketName
+    Delimiter: Optional[Delimiter]
+    EncodingType: Optional[EncodingType]
+    Marker: Optional[Marker]
+    MaxKeys: Optional[MaxKeys]
+    Prefix: Optional[Prefix]
+    RequestPayer: Optional[RequestPayer]
+    ExpectedBucketOwner: Optional[AccountId]
+
+
 class Object(TypedDict, total=False):
     Key: Optional[ObjectKey]
     LastModified: Optional[LastModified]
@@ -2345,31 +2356,6 @@ class Object(TypedDict, total=False):
 
 
 ObjectList = List[Object]
-
-
-class ListObjectsOutput(TypedDict, total=False):
-    IsTruncated: Optional[IsTruncated]
-    Marker: Optional[Marker]
-    NextMarker: Optional[NextMarker]
-    Contents: Optional[ObjectList]
-    Name: Optional[BucketName]
-    Prefix: Optional[Prefix]
-    Delimiter: Optional[Delimiter]
-    MaxKeys: Optional[MaxKeys]
-    CommonPrefixes: Optional[CommonPrefixList]
-    EncodingType: Optional[EncodingType]
-    BucketRegion: Optional[BucketRegion]
-
-
-class ListObjectsRequest(ServiceRequest):
-    Bucket: BucketName
-    Delimiter: Optional[Delimiter]
-    EncodingType: Optional[EncodingType]
-    Marker: Optional[Marker]
-    MaxKeys: Optional[MaxKeys]
-    Prefix: Optional[Prefix]
-    RequestPayer: Optional[RequestPayer]
-    ExpectedBucketOwner: Optional[AccountId]
 
 
 class ListObjectsV2Output(TypedDict, total=False):
@@ -3097,6 +3083,20 @@ class ListAllMyBucketsResult(TypedDict, total=False):
     Owner: Optional[Owner]
 
 
+class ListBucketResult(TypedDict, total=False):
+    IsTruncated: Optional[IsTruncated]
+    Marker: Optional[Marker]
+    NextMarker: Optional[NextMarker]
+    Contents: Optional[ObjectList]
+    Name: Optional[BucketName]
+    Prefix: Optional[Prefix]
+    Delimiter: Optional[Delimiter]
+    MaxKeys: Optional[MaxKeys]
+    CommonPrefixes: Optional[CommonPrefixList]
+    EncodingType: Optional[EncodingType]
+    BucketRegion: Optional[BucketRegion]
+
+
 class S3Api:
 
     service = "s3"
@@ -3745,7 +3745,7 @@ class S3Api:
         prefix: Prefix = None,
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
-    ) -> ListObjectsOutput:
+    ) -> ListBucketResult:
         raise NotImplementedError
 
     @handler("ListObjectsV2")

--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2253,11 +2253,6 @@ class ListBucketMetricsConfigurationsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
-class ListBucketsOutput(TypedDict, total=False):
-    Buckets: Optional[Buckets]
-    Owner: Optional[Owner]
-
-
 class MultipartUpload(TypedDict, total=False):
     UploadId: Optional[MultipartUploadId]
     Key: Optional[ObjectKey]
@@ -3097,6 +3092,11 @@ class PostResponse(TypedDict, total=False):
     RequestCharged: Optional[RequestCharged]
 
 
+class ListAllMyBucketsResult(TypedDict, total=False):
+    Buckets: Optional[Buckets]
+    Owner: Optional[Owner]
+
+
 class S3Api:
 
     service = "s3"
@@ -3700,7 +3700,7 @@ class S3Api:
     def list_buckets(
         self,
         context: RequestContext,
-    ) -> ListBucketsOutput:
+    ) -> ListAllMyBucketsResult:
         raise NotImplementedError
 
     @handler("ListMultipartUploads")

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -773,30 +773,24 @@
       }
     },
     {
-        "op": "remove",
-        "path": "/shapes/ListBucketsOutput"
-    },
-    {
-        "op": "add",
-        "path": "/shapes/ListAllMyBucketsResult",
-        "value": {
-            "type": "structure",
-            "members": {
-                "Buckets": {
-                    "shape": "Buckets",
-                    "documentation": "<p>The list of buckets owned by the requester.</p>"
-                },
-                "Owner": {
-                    "shape": "Owner",
-                    "documentation": "<p>The owner of the buckets listed.</p>"
-                }
-            }
-        }
+      "op": "move",
+      "from": "/shapes/ListBucketsOutput",
+      "path": "/shapes/ListAllMyBucketsResult"
     },
     {
         "op": "replace",
         "path": "/operations/ListBuckets/output/shape",
         "value": "ListAllMyBucketsResult"
+    },
+    {
+      "op": "replace",
+      "path": "/operations/ListObjects/output/shape",
+      "value": "ListBucketResult"
+    },
+    {
+      "op": "move",
+      "from": "/shapes/ListObjectsOutput",
+      "path": "/shapes/ListBucketResult"
     }
   ]
 }

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -771,6 +771,32 @@
         "documentation": "<p>The storage class you specified is not valid</p>",
         "exception": true
       }
+    },
+    {
+        "op": "remove",
+        "path": "/shapes/ListBucketsOutput"
+    },
+    {
+        "op": "add",
+        "path": "/shapes/ListAllMyBucketsResult",
+        "value": {
+            "type": "structure",
+            "members": {
+                "Buckets": {
+                    "shape": "Buckets",
+                    "documentation": "<p>The list of buckets owned by the requester.</p>"
+                },
+                "Owner": {
+                    "shape": "Owner",
+                    "documentation": "<p>The owner of the buckets listed.</p>"
+                }
+            }
+        }
+    },
+    {
+        "op": "replace",
+        "path": "/operations/ListBuckets/output/shape",
+        "value": "ListAllMyBucketsResult"
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -55,7 +55,7 @@ from localstack.aws.api.s3 import (
     InvalidBucketName,
     InvalidPartOrder,
     InvalidStorageClass,
-    ListObjectsOutput,
+    ListBucketResult,
     ListObjectsRequest,
     ListObjectsV2Output,
     ListObjectsV2Request,
@@ -262,8 +262,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self,
         context: RequestContext,
         request: ListObjectsRequest,
-    ) -> ListObjectsOutput:
-        response: ListObjectsOutput = call_moto(context)
+    ) -> ListBucketResult:
+        response: ListBucketResult = call_moto(context)
 
         if "Marker" not in response:
             response["Marker"] = request.get("Marker") or ""
@@ -283,7 +283,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
             response["BucketRegion"] = bucket.region_name
 
-        return ListObjectsOutput(**response)
+        return ListBucketResult(**response)
 
     @handler("ListObjectsV2", expand=False)
     def list_objects_v2(

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -2940,6 +2940,27 @@ class TestS3:
             )
         snapshot.match("create-multipart-outposts-exc", e.value.response)
 
+    @pytest.mark.aws_validated
+    def test_response_structure(self, aws_http_client_factory, s3_bucket):
+        """
+        Test that the response structure is correct for the S3 API
+        """
+        headers = {"x-amz-content-sha256": "UNSIGNED-PAYLOAD"}
+
+        s3_http_client = aws_http_client_factory("s3", signer_factory=SigV4Auth)
+
+        # Lists all buckets
+        endpoint_url = _endpoint_url()
+        resp = s3_http_client.get(endpoint_url, headers=headers)
+        resp_dict = xmltodict.parse(resp.content)
+        assert "ListAllMyBucketsResult" in resp_dict
+
+        # Lists all objects in a bucket
+        bucket_url = _bucket_url(s3_bucket)
+        resp = s3_http_client.get(bucket_url, headers=headers)
+        resp_dict = xmltodict.parse(resp.content)
+        assert "ListBucketResult" in resp_dict
+
 
 class TestS3TerraformRawRequests:
     @pytest.mark.only_localstack


### PR DESCRIPTION
# Issue
- #7541 

# Fix
- Patched `ListBucketsOutput` to `ListAllMyBucketsResult`.
  - In boto spec definition of output from `ListBuckets` is `ListBucketsOutput` whereas AWS is returning  `ListAllMyBucketsResult`.
- `list_objects` contains `ListBucketResult` object whereas we are returning `ListObjectsOutput` 

# Commands to Reproduce

```
Start localstack instance with env `PROVIDER_OVERRIDE_S3: "asf"`
```

Comparing the response from this commands will po
`list_bucket`
```
awslocal s3api list-buckets --profile ls --debug
```
```
aws s3api list-buckets --profile ls --debug
```

`list-objects`
```
awslocal s3 mb s3://test-bucket --profile ls --region us-east-1 --debug
awslocal s3api list-objects --bucket test-bucket --profile ls --region us-east-1 --debug
```
```
aws s3 mb s3://test-bucket --profile ls --region us-east-1 --debug
aws s3api list-objects --bucket test-bucket --profile ls --region us-east-1 --debug
```


# Tested Also with
https://github.com/Dowwie/localstack_s3_xml_issue