### PR TITLE
Update Kinesis Mock to 0.3.2

### DIFF
--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -6,7 +6,7 @@ from localstack import config
 from localstack.packages import GitHubReleaseInstaller, Package, PackageInstaller
 from localstack.utils.platform import get_arch, get_os
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.3.1"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.3.2"
 
 
 class KinesisMockPackage(Package):


### PR DESCRIPTION
See https://github.com/etspaceman/kinesis-mock/releases

Specifically adds StreamARN parameter support for putRecord and putRecords. Needed for the KPL 0.15.x releases.
