### PR TITLE
add pattern for predicting moto-backend location

### DIFF
--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -156,6 +156,13 @@ class ReflectionStateLocator:
                 attribute_name = f"{service_name}_backends"
                 attribute = _load_attribute_from_module(module_name, attribute_name)
 
+                if attribute is None and "_" in attribute_name:
+                    # some services like application_autoscaling do have a backend without the underscore
+                    service_name_tmp = service_name.replace("_", "")
+                    module_name = f"moto.{service_name_tmp}.models"
+                    attribute_name = f"{service_name_tmp}_backends"
+                    attribute = _load_attribute_from_module(module_name, attribute_name)
+
                 if attribute is not None:
                     LOG.debug("Visiting attribute %s in module %s", attribute_name, module_name)
                     visitor.visit(attribute)

--- a/localstack/services/visitors.py
+++ b/localstack/services/visitors.py
@@ -136,6 +136,12 @@ class ReflectionStateLocator:
                     ("moto.cloudformation.models", "cloudformation_backends"),
                 ]
                 _visit_modules(modules)
+            case "ce":
+                modules = [
+                    ("localstack_ext.services.costexplorer.models", "ce_stores"),
+                    ("moto.ce.models", "ce_backends"),
+                ]
+                _visit_modules(modules)
             case _:
                 # try to load AccountRegionBundle from predictable location
                 attribute_name = f"{service_name}_stores"


### PR DESCRIPTION
This PR adds tests an additional location for moto-backends that is used in `visitors.py` to determine cleanup locations.
Some services that have a name with an underscore, like `application_autoscaling` have a related moto-backend that does exclude the underscore.

Additionally, the service `ce` has a special location for the model, I also added it with this PR.
