### PR TITLE
Add timeout when finding out if docker is installed

### DIFF
--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -478,9 +478,9 @@ class CmdDockerClient(ContainerClient):
 
     def has_docker(self) -> bool:
         try:
-            run(self._docker_cmd() + ["ps"])
+            run(self._docker_cmd() + ["ps"], timeout=5)
             return True
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except (subprocess.CalledProcessError, FileNotFoundError, TimeoutError):
             return False
 
     def create_container(self, image_name: str, **kwargs) -> str:

--- a/localstack/utils/run.py
+++ b/localstack/utils/run.py
@@ -35,6 +35,7 @@ def run(
     tty=False,
     shell=True,
     cwd: str = None,
+    timeout: Optional[float] = None,
 ) -> Union[str, subprocess.Popen]:
     LOG.debug("Executing command: %s", cmd)
     env_dict = os.environ.copy() if inherit_env else {}
@@ -64,9 +65,9 @@ def run(
         if not asynchronous:
             if stdin:
                 return subprocess.check_output(
-                    cmd, shell=shell, stderr=stderr, env=env_dict, stdin=subprocess.PIPE, cwd=cwd
+                    cmd, shell=shell, stderr=stderr, env=env_dict, stdin=subprocess.PIPE, cwd=cwd, timeout=timeout,
                 )
-            output = subprocess.check_output(cmd, shell=shell, stderr=stderr, env=env_dict, cwd=cwd)
+            output = subprocess.check_output(cmd, shell=shell, stderr=stderr, env=env_dict, cwd=cwd, timeout=timeout)
             return output.decode(config.DEFAULT_ENCODING)
 
         stdin_arg = subprocess.PIPE if stdin else None


### PR DESCRIPTION
If docker is not running, then `docker ps` hangs indefinitely. I discovered this when running `make entrypoints` on a mac which was not running docker.
