### PR TITLE
Extend allowed CORS origins to include EDGE_PORT_HTTP endpoint

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -16,16 +16,18 @@ from flask_cors.core import (
 from werkzeug.datastructures import Headers
 
 from localstack import config
-from localstack.config import (
-    EXTRA_CORS_ALLOWED_HEADERS,
-    EXTRA_CORS_ALLOWED_ORIGINS,
-    EXTRA_CORS_EXPOSE_HEADERS,
-)
+from localstack.config import EXTRA_CORS_ALLOWED_HEADERS, EXTRA_CORS_EXPOSE_HEADERS
 from localstack.http import Response
 
 from ...constants import PATH_USER_REQUEST
 from ..api import RequestContext
 from ..chain import Handler, HandlerChain
+
+LOG = logging.getLogger(__name__)
+
+# header name constants
+ACL_REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network"
+ACL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network"
 
 # CORS constants below
 CORS_ALLOWED_HEADERS = [
@@ -72,25 +74,34 @@ ALLOWED_CORS_RESPONSE_HEADERS = [
     "Access-Control-Expose-Headers",
 ]
 
-ALLOWED_CORS_ORIGINS = [
-    "https://app.localstack.cloud",
-    "http://app.localstack.cloud",
-    f"https://localhost:{config.EDGE_PORT}",
-    f"http://localhost:{config.EDGE_PORT}",
-    f"https://localhost.localstack.cloud:{config.EDGE_PORT}",
-    f"http://localhost.localstack.cloud:{config.EDGE_PORT}",
-    "https://localhost",
-    "https://localhost.localstack.cloud",
-    # for requests from Electron apps, e.g., DynamoDB NoSQL Workbench
-    "file://",
-]
-if EXTRA_CORS_ALLOWED_ORIGINS:
-    ALLOWED_CORS_ORIGINS += EXTRA_CORS_ALLOWED_ORIGINS.split(",")
 
-ACL_REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network"
-ACL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network"
+def _get_allowed_cors_origins() -> List[str]:
+    """Construct the list of allowed origins for CORS enforcement purposes"""
+    result = [
+        # allow access from Web app and localhost domains
+        "https://app.localstack.cloud",
+        "http://app.localstack.cloud",
+        "https://localhost",
+        "https://localhost.localstack.cloud",
+        # for requests from Electron apps, e.g., DynamoDB NoSQL Workbench
+        "file://",
+    ]
+    # Add allowed origins for localhost domains, using different protocol/port combinations.
+    # If a different port is configured for EDGE_PORT_HTTP, add it to allowed origins as well
+    _ports = set([config.EDGE_PORT] + ([config.EDGE_PORT_HTTP] if config.EDGE_PORT_HTTP else []))
+    for protocol in {"http", "https"}:
+        for port in _ports:
+            result.append(f"{protocol}://localhost:{port}")
+            result.append(f"{protocol}://localhost.localstack.cloud:{port}")
 
-LOG = logging.getLogger(__name__)
+    if config.EXTRA_CORS_ALLOWED_ORIGINS:
+        result += config.EXTRA_CORS_ALLOWED_ORIGINS.split(",")
+
+    return result
+
+
+# allowed origins used for CORS / CSRF checks
+ALLOWED_CORS_ORIGINS = _get_allowed_cors_origins()
 
 
 def should_enforce_self_managed_service(context: RequestContext) -> bool:

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -169,6 +169,9 @@ class CorsEnforcer(Handler):
     def _is_in_allowed_origins(allowed_origins: List[str], origin: str) -> bool:
         """Returns true if the `origin` is in the `allowed_origins`."""
         for allowed_origin in allowed_origins:
+            if origin and origin.startswith("https://test-"):
+                # TODO CI debugging - remove
+                print("!!!origin cmp", origin, allowed_origin, origin == allowed_origin)
             if allowed_origin == "*" or origin == allowed_origin:
                 return True
         return False

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -19,7 +19,7 @@ from localstack import config
 from localstack.config import EXTRA_CORS_ALLOWED_HEADERS, EXTRA_CORS_EXPOSE_HEADERS
 from localstack.http import Response
 
-from ...constants import PATH_USER_REQUEST
+from ...constants import LOCALHOST, LOCALHOST_HOSTNAME, PATH_USER_REQUEST
 from ..api import RequestContext
 from ..chain import Handler, HandlerChain
 
@@ -91,8 +91,8 @@ def _get_allowed_cors_origins() -> List[str]:
     _ports = set([config.EDGE_PORT] + ([config.EDGE_PORT_HTTP] if config.EDGE_PORT_HTTP else []))
     for protocol in {"http", "https"}:
         for port in _ports:
-            result.append(f"{protocol}://localhost:{port}")
-            result.append(f"{protocol}://localhost.localstack.cloud:{port}")
+            result.append(f"{protocol}://{LOCALHOST}:{port}")
+            result.append(f"{protocol}://{LOCALHOST_HOSTNAME}:{port}")
 
     if config.EXTRA_CORS_ALLOWED_ORIGINS:
         result += config.EXTRA_CORS_ALLOWED_ORIGINS.split(",")
@@ -169,9 +169,6 @@ class CorsEnforcer(Handler):
     def _is_in_allowed_origins(allowed_origins: List[str], origin: str) -> bool:
         """Returns true if the `origin` is in the `allowed_origins`."""
         for allowed_origin in allowed_origins:
-            if origin and origin.startswith("https://test-"):
-                # TODO CI debugging - remove
-                print("!!!origin cmp", origin, allowed_origin, origin == allowed_origin)
             if allowed_origin == "*" or origin == allowed_origin:
                 return True
         return False

--- a/localstack/services/generic_proxy.py
+++ b/localstack/services/generic_proxy.py
@@ -1,3 +1,6 @@
+# TODO majority of this file is deprecated and will be removed in the near future.
+#  Beware of duplications between this file and localstack.aws.handlers.cors, among other modules.
+
 from __future__ import annotations
 
 import functools
@@ -25,11 +28,7 @@ from requests.models import Request, Response
 from werkzeug.exceptions import HTTPException
 
 from localstack import config
-from localstack.config import (
-    EXTRA_CORS_ALLOWED_HEADERS,
-    EXTRA_CORS_ALLOWED_ORIGINS,
-    EXTRA_CORS_EXPOSE_HEADERS,
-)
+from localstack.config import EXTRA_CORS_ALLOWED_HEADERS, EXTRA_CORS_EXPOSE_HEADERS
 from localstack.constants import APPLICATION_JSON, BIND_HOST, HEADER_LOCALSTACK_REQUEST_URL
 from localstack.http.request import get_full_raw_path
 from localstack.services.messages import Headers, MessagePayload
@@ -97,20 +96,13 @@ ALLOWED_CORS_RESPONSE_HEADERS = [
     "Access-Control-Expose-Headers",
 ]
 
-ALLOWED_CORS_ORIGINS = [
-    "https://app.localstack.cloud",
-    "http://app.localstack.cloud",
-    f"https://localhost:{config.EDGE_PORT}",
-    f"http://localhost:{config.EDGE_PORT}",
-    f"https://localhost.localstack.cloud:{config.EDGE_PORT}",
-    f"http://localhost.localstack.cloud:{config.EDGE_PORT}",
-    "https://localhost",
-    "https://localhost.localstack.cloud",
-    # for requests from Electron apps, e.g., DynamoDB NoSQL Workbench
-    "file://",
-]
-if EXTRA_CORS_ALLOWED_ORIGINS:
-    ALLOWED_CORS_ORIGINS += EXTRA_CORS_ALLOWED_ORIGINS.split(",")
+
+def get_allowed_cors_origins() -> List[str]:
+    """Return the list of allowed CORS origins."""
+    # Note: importing from localstack.aws.handlers.cors, to keep the logic in a single place for now
+    from localstack.aws.handlers.cors import _get_allowed_cors_origins
+
+    return _get_allowed_cors_origins()
 
 
 class ProxyListener:
@@ -263,7 +255,7 @@ def _is_in_allowed_origins(allowed_origins, origin):
 
 def is_cors_origin_allowed(headers, allowed_origins=None):
     """Returns true if origin is allowed to perform cors requests, false otherwise"""
-    allowed_origins = ALLOWED_CORS_ORIGINS if allowed_origins is None else allowed_origins
+    allowed_origins = get_allowed_cors_origins() if allowed_origins is None else allowed_origins
     origin = headers.get("origin")
     referer = headers.get("referer")
     if origin:

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -122,6 +122,9 @@ class TestCSRF:
         test_domain = f"test-{short_uid()}.com"
         monkeypatch.setattr(config, "EXTRA_CORS_ALLOWED_ORIGINS", f"https://{test_domain}")
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
+        # TODO: CI debugging - remove!
+        print("!!_get_allowed_cors_origins", _get_allowed_cors_origins())
+        print("!!ALLOWED_CORS_ORIGINS", cors_handler.ALLOWED_CORS_ORIGINS)
 
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers("sns")

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -122,9 +122,6 @@ class TestCSRF:
         test_domain = f"test-{short_uid()}.com"
         monkeypatch.setattr(config, "EXTRA_CORS_ALLOWED_ORIGINS", f"https://{test_domain}")
         monkeypatch.setattr(cors_handler, "ALLOWED_CORS_ORIGINS", _get_allowed_cors_origins())
-        # TODO: CI debugging - remove!
-        print("!!_get_allowed_cors_origins", _get_allowed_cors_origins())
-        print("!!ALLOWED_CORS_ORIGINS", cors_handler.ALLOWED_CORS_ORIGINS)
 
         url = config.get_edge_url()
         headers = aws_stack.mock_aws_request_headers("sns")

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,0 +1,20 @@
+from localstack import config
+from localstack.aws.handlers.cors import _get_allowed_cors_origins
+
+
+def test_allowed_cors_headers_different_ports_and_protocols(monkeypatch):
+    # test allowed origins for default config (edge port 4566)
+    monkeypatch.setattr(config, "EDGE_PORT", 4566)
+    monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)
+    origins = _get_allowed_cors_origins()
+    assert "http://localhost:4566" in origins
+    assert "http://localhost.localstack.cloud:4566" in origins
+    assert "https://localhost.localstack.cloud:443" not in origins
+
+    # test allowed origins for extended config (HTTPS edge port 443, HTTP edge port 4566)
+    monkeypatch.setattr(config, "EDGE_PORT", 443)
+    monkeypatch.setattr(config, "EDGE_PORT_HTTP", 4566)
+    origins = _get_allowed_cors_origins()
+    assert "http://localhost:4566" in origins
+    assert "http://localhost.localstack.cloud:4566" in origins
+    assert "https://localhost.localstack.cloud:443" in origins

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -2,7 +2,7 @@ from localstack import config
 from localstack.aws.handlers.cors import _get_allowed_cors_origins
 
 
-def test_allowed_cors_headers_different_ports_and_protocols(monkeypatch):
+def test_allowed_cors_origins_different_ports_and_protocols(monkeypatch):
     # test allowed origins for default config (edge port 4566)
     monkeypatch.setattr(config, "EDGE_PORT", 4566)
     monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)


### PR DESCRIPTION
Extend allowed CORS origins to include `EDGE_PORT_HTTP` endpoint. This change ensures that the `http://localhost:4566` endpoint is in the `ALLOWED_CORS_ORIGINS` list (for Community + Pro users). 

The issue surfaced when deploying our [demo sample app](https://github.com/localstack/localstack-demo/pull/47) Web UI (HTML file) as an S3 website, and testing against LocalStack Pro: In the default Pro setup, we have `EDGE_PORT=443` and `EDGE_PORT_HTTP=4566`, and since we were previously configuring the allowed origins only via `config.EDGE_PORT`, it was not possible to access the LocalStack APIs from a website running under `http://localhost:4566` (only when using port 443).

Touching the CORS setup is always a bit finicky, but this change (1) should have no negative security side effects (we're only allowing the additional localhost port 4566, in addition to localhost port 443), and (2) ensures that we can offer S3 websites (e.g., `http://localhost:4566/mybucket/index.html`) that can connect directly to the LocalStack APIs, working for both Community and Pro.

The PR adds a small integration test to cover the logic around `EXTRA_CORS_EXPOSE_HEADERS` (existing logic, currently not yet covered), as well as a unit test to cover the new functionality around allowed localhost origins with different ports (incl. `EDGE_PORT_HTTP`).