### PR TITLE
Fix cloudwatch reset

### DIFF
--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -3,7 +3,7 @@ import logging
 import math
 import threading
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from localstack.aws.api.cloudwatch import MetricAlarm, MetricDataQuery, StateValue
 from localstack.utils.aws import arns, aws_stack
@@ -53,6 +53,9 @@ class AlarmScheduler:
         starting a new one"""
         alarm_details = get_metric_alarm_details_for_alarm_arn(alarm_arn)
         self.delete_scheduler_for_alarm(alarm_arn)
+        if not alarm_details:
+            LOG.warning("Scheduling alarm failed: could not find alarm %s", alarm_arn)
+            return
 
         if not self._is_alarm_supported(alarm_details):
             LOG.warning(
@@ -115,10 +118,13 @@ class AlarmScheduler:
         return True
 
 
-def get_metric_alarm_details_for_alarm_arn(alarm_arn: str) -> MetricAlarm:
+def get_metric_alarm_details_for_alarm_arn(alarm_arn: str) -> Optional[MetricAlarm]:
     alarm_name = arns.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
     client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
-    return client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"][0]
+    response = client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"]
+    if len(response) == 1:
+        return response[0]
+    return None
 
 
 def get_cloudwatch_client_for_region_of_alarm(alarm_arn: str) -> "CloudWatchClient":
@@ -279,6 +285,10 @@ def calculate_alarm_state(alarm_arn: str) -> None:
     :param alarm_arn: the arn of the alarm to be evaluated
     """
     alarm_details = get_metric_alarm_details_for_alarm_arn(alarm_arn)
+    if not alarm_details:
+        LOG.warning("Could not find alarm %s", alarm_arn)
+        return
+
     client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
 
     query_date = datetime.utcnow().strftime(format="%Y-%m-%dT%H:%M:%S+0000")

--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -121,10 +121,8 @@ class AlarmScheduler:
 def get_metric_alarm_details_for_alarm_arn(alarm_arn: str) -> Optional[MetricAlarm]:
     alarm_name = arns.extract_resource_from_arn(alarm_arn).split(":", 1)[1]
     client = get_cloudwatch_client_for_region_of_alarm(alarm_arn)
-    response = client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"]
-    if len(response) == 1:
-        return response[0]
-    return None
+    metric_alarms = client.describe_alarms(AlarmNames=[alarm_name])["MetricAlarms"]
+    return metric_alarms[0] if metric_alarms else None
 
 
 def get_cloudwatch_client_for_region_of_alarm(alarm_arn: str) -> "CloudWatchClient":


### PR DESCRIPTION
When doing a reset of resources, the schedule cloudwatch alarms still assume that the alarms can be found.
Included a check which will ensure that the alarm exists.

This happens only if the backend is deleted, e.g. when running a cleanup process. I.e. when the api `delete_alarm` is used, the scheduler will be removed anyhow.

@giograno: I realized there is another `persistence` pattern for the Pro version, where we can do additional resets. 
However, the alarm-scheduler is part of the `CloudwatchProvider` and it seems tricky to do reset and I have a feeling this is a rare edge case anyhow.

Do you think it's fine to just keep the scheduler running, given that in normal setup, just deleting the backends (without restarting LocalStack) should not happen?
