### PR TITLE
Fix apigateway authorizer path suffix

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -394,7 +394,7 @@ class MockIntegration(BackendIntegration):
     def invoke(self, invocation_context: ApiInvocationContext) -> Response:
         passthrough_behavior = invocation_context.integration.get("passthroughBehavior") or ""
         request_template = invocation_context.integration.get("requestTemplates", {}).get(
-            invocation_context.headers.get(HEADER_CONTENT_TYPE)
+            invocation_context.headers.get(HEADER_CONTENT_TYPE, APPLICATION_JSON)
         )
 
         # based on the configured passthrough behavior and the existence of template or not,
@@ -411,7 +411,7 @@ class MockIntegration(BackendIntegration):
         # request template rendering
         request_payload = self.request_templates.render(invocation_context)
 
-        # mapping is done based on "statusCode" field
+        # mapping is done based on "statusCode" field, we default to 200
         status_code = 200
         if invocation_context.headers.get(HEADER_CONTENT_TYPE) == APPLICATION_JSON:
             try:

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -103,17 +103,20 @@ class ApigatewayRouter:
             host="<api_id>.execute-api.<regex('.*'):server>",
             endpoint=self.invoke_rest_api,
             defaults={"path": "", "stage": None},
+            strict_slashes=True,
         )
         self.router.add(
             "/<stage>/",
             host="<api_id>.execute-api.<regex('.*'):server>",
             endpoint=self.invoke_rest_api,
             defaults={"path": ""},
+            strict_slashes=False,
         )
         self.router.add(
             "/<stage>/<path:path>",
             host="<api_id>.execute-api.<regex('.*'):server>",
             endpoint=self.invoke_rest_api,
+            strict_slashes=True,
         )
 
         # add the localstack-specific _user_request_ routes
@@ -125,6 +128,7 @@ class ApigatewayRouter:
         self.router.add(
             "/restapis/<api_id>/<stage>/_user_request_/<path:path>",
             endpoint=self.invoke_rest_api,
+            strict_slashes=True,
         )
 
     def invoke_rest_api(self, request: Request, **url_params: Dict[str, Any]) -> Response:

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import json
 import logging
@@ -269,6 +270,9 @@ class ResponseTemplates(Templates):
 
         # we render the template with the context data and the response content
         variables = self.build_variables_mapping(api_context)
-        response._content = self.render_vtl(template, variables=variables)
+        rendered_tpl = self.render_vtl(template, variables=variables)
+
+        # TODO: we need to do a parity test for templates that generate invalid JSON
+        response._content = json.dumps(ast.literal_eval(rendered_tpl.strip()))
         LOG.info("Endpoint response body after transformations:\n%s", response._content)
         return response._content

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -614,7 +614,9 @@ class TestAPIGateway:
             }
         ]
         api_id = self.create_api_gateway_and_deploy(
-            integration_type="MOCK", integration_responses=responses
+            integration_type="MOCK",
+            integration_responses=responses,
+            stage_name=self.TEST_STAGE_NAME,
         )
 
         # invoke endpoint with Origin header
@@ -2026,6 +2028,7 @@ class TestAPIGateway:
         is_api_key_required=False,
         integration_type=None,
         integration_responses=None,
+        stage_name="staging",
     ):
         response_templates = response_templates or {}
         integration_type = integration_type or "AWS_PROXY"
@@ -2079,7 +2082,7 @@ class TestAPIGateway:
                 **resp_details,
             )
 
-        apigw_client.create_deployment(restApiId=api_id, stageName="staging")
+        apigw_client.create_deployment(restApiId=api_id, stageName=stage_name)
         return api_id
 
     @pytest.mark.parametrize("base_path_type", ["ignore", "prepend", "split"])

--- a/tests/unit/test_templating.py
+++ b/tests/unit/test_templating.py
@@ -139,7 +139,7 @@ class TestMessageTransformationBasic:
         #end
         #return('end')
         """
-        result = render_velocity_template(template, {"context": dict()})
+        result = render_velocity_template(template, {"context": {}})
         result = re.sub(r"\s+", " ", result).strip()
         assert result == "loop1 loop3 end"
 
@@ -250,3 +250,20 @@ class TestMessageTransformationApiGateway:
         variables = {"method": {"request": {"header": {"X-My-Header": "my-header-value"}}}}
         result = ApiGatewayVtlTemplate().render_vtl(template, variables).strip()
         assert result == "my-header-value"
+
+    def test_boolean_in_variable(self):
+        # Inspired by authorizer context from Lambda authorizer:
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html
+        # The returned values are all stringified. Notice that you cannot set a JSON
+        # object or array as a valid value of any key in the context map.
+        template = '{"booleanKeyTrue": $booleanKeyTrue, "booleanKeyFalse": $booleanKeyFalse}'
+        variables = {
+            "booleanKeyTrue": "true",
+            "booleanKeyFalse": "false",
+        }
+        result = ApiGatewayVtlTemplate().render_vtl(template, variables)
+        assert "true" in result
+        assert "false" in result
+        assert result == '{"booleanKeyTrue": true, "booleanKeyFalse": false}'
+        # test is valid json
+        json.loads(result)


### PR DESCRIPTION
This PR accomplishes two things:

1) making sure literal booleans are correctly parsed on our VTL templates. Why `ast.literal_eval` and not `json.loads`? Imagine the following case:

```
# valid rendered template (well, given airspeed implementation)
tpl = '{"key": True}' 

# fails because the string above is not valid json, True is not a valid json literal
json.loads(tpl)
# works and returns the following dict {"key": True}
ast.literal_eval(tpl)
```
2) routes with trailing slashes are correctly handled inside APIGW router, it uses the `strict_slashes` where it's needed.

There is a comprehensive test upstream for the templating and routing issue.