### PR TITLE
Add patch for pickling acm certificate

### DIFF
--- a/localstack/services/acm/provider.py
+++ b/localstack/services/acm/provider.py
@@ -3,6 +3,7 @@ from moto.acm import models as acm_models
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.acm import AcmApi, RequestCertificateRequest, RequestCertificateResponse
 from localstack.services import moto
+from localstack.utils.objects import singleton_factory
 from localstack.utils.patch import patch
 
 
@@ -53,6 +54,32 @@ def describe(describe_orig, self):
             cert[key] = value
     cert["Serial"] = str(cert.get("Serial") or "")
     return result
+
+
+@singleton_factory
+def patch_cert_bundle_pickling():
+    """Apply patches to pickle CertBundle base models. It prevents the "cannot pickle 'builtins.Certificate'" errors"""
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.x509 import load_pem_x509_certificate
+    from moto.acm.models import CertBundle
+
+    def cert_set_state(self, state, *args, **kwargs):
+        certificate = state.get("cert")
+        state["_cert"] = load_pem_x509_certificate(certificate, default_backend())
+        self.__dict__.update(state)
+
+    CertBundle.__setstate__ = cert_set_state
+
+    def cert_get_state(self, *args, **kwargs):
+        state = self.__dict__.copy()
+        # pop builtins.Certificate
+        state.pop("_cert", None)
+        return state
+
+    CertBundle.__getstate__ = cert_get_state
+
+
+patch_cert_bundle_pickling()
 
 
 class AcmProvider(AcmApi):


### PR DESCRIPTION
This PR adds a patch to pickle the `CertBundle` models. 