### PR TITLE
add Gateway server abstraction

### DIFF
--- a/localstack/aws/handlers/proxy.py
+++ b/localstack/aws/handlers/proxy.py
@@ -1,0 +1,20 @@
+from ...http import Response
+from ...http.proxy import Proxy
+from ..api import RequestContext
+from ..chain import Handler, HandlerChain
+
+
+class ProxyHandler(Handler):
+    """
+    Directly serves a localstack.http.proxy.Proxy as a HandlerChain Handler.
+    This handler does not command the handler chain to stop or terminate.
+    """
+
+    proxy: Proxy
+
+    def __init__(self, forward_base_url: str) -> None:
+        self.proxy = Proxy(forward_base_url)
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        proxy_response = self.proxy.forward(context.request)
+        response.update_from(proxy_response)

--- a/localstack/aws/serving/edge.py
+++ b/localstack/aws/serving/edge.py
@@ -1,5 +1,4 @@
-import asyncio
-
+from localstack.http.hypercorn import GatewayServer
 from localstack.services.plugins import SERVICE_PLUGINS
 
 
@@ -8,34 +7,12 @@ def serve_gateway(bind_address, port, use_ssl, asynchronous=False):
     Implementation of the edge.do_start_edge_proxy interface to start a Hypercorn server instance serving the
     LocalstackAwsGateway.
     """
-    from hypercorn import Config
-
     from localstack.aws.app import LocalstackAwsGateway
-    from localstack.aws.serving.asgi import AsgiGateway
-    from localstack.http.hypercorn import HypercornServer
-    from localstack.logging.setup import setup_hypercorn_logger
-    from localstack.services.generic_proxy import GenericProxy, install_predefined_cert_if_available
 
-    # build server config
-    config = Config()
-    setup_hypercorn_logger(config)
-
-    if isinstance(bind_address, str):
-        bind_address = [bind_address]
-    config.bind = [f"{addr}:{port}" for addr in bind_address]
-
-    if use_ssl:
-        install_predefined_cert_if_available()
-        _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert(serial_number=port)
-        config.certfile = cert_file_name
-        config.keyfile = key_file_name
-
-    # build gateway
-    loop = asyncio.new_event_loop()
-    app = AsgiGateway(LocalstackAwsGateway(SERVICE_PLUGINS), event_loop=loop)
+    gateway = LocalstackAwsGateway(SERVICE_PLUGINS)
 
     # start serving gateway
-    server = HypercornServer(app, config, loop)
+    server = GatewayServer(gateway, port, bind_address, use_ssl)
     server.start()
 
     if not asynchronous:

--- a/tests/unit/http_/test_hypercorn.py
+++ b/tests/unit/http_/test_hypercorn.py
@@ -1,0 +1,51 @@
+from contextlib import contextmanager
+
+import requests
+
+from localstack.aws.api import RequestContext
+from localstack.aws.chain import HandlerChain
+from localstack.aws.gateway import Gateway
+from localstack.http import Response
+from localstack.http.hypercorn import GatewayServer, ProxyServer
+from localstack.utils.net import get_free_tcp_port
+from localstack.utils.serving import Server
+
+
+@contextmanager
+def server_context(server: Server):
+    server.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+def test_gateway_server():
+    def echo_request_handler(_: HandlerChain, context: RequestContext, response: Response):
+        response.set_response(context.request.data)
+        response.status_code = 200
+        response.headers = context.request.headers
+
+    gateway = Gateway()
+    gateway.request_handlers.append(echo_request_handler)
+    port = get_free_tcp_port()
+    server = GatewayServer(gateway, port, "127.0.0.1", use_ssl=True)
+    with server_context(server):
+        get_response = requests.get(
+            f"https://localhost.localstack.cloud:{port}", data="Let's see if this works..."
+        )
+        assert get_response.text == "Let's see if this works..."
+
+
+def test_proxy_server(httpserver):
+    httpserver.expect_request("/base-path/relative-path").respond_with_data("Reached Mock Server.")
+    port = get_free_tcp_port()
+    proxy_server = ProxyServer(
+        f"{httpserver.url_for('/base-path')}", port, "127.0.0.1", use_ssl=True
+    )
+    with server_context(proxy_server):
+        # Test that only the base path is added by the proxy
+        response = requests.get(
+            f"https://localhost.localstack.cloud:{port}/relative-path", data="data"
+        )
+        assert response.text == "Reached Mock Server."


### PR DESCRIPTION
This PR adds two new utility specializations of the `HypercornServer`:
- `GatewayServer` which simplifies serving a `localstack.aws.gatway.Gateway` as a `Server`.
- `ProxyServer` which serves a `Gateway` with only a `ProxyHandler`.
  - The `ProxyHandler` is just a handler which forwards requests to an external system.
  - This effectively means serving a HTTP/HTTPS mulitplexing proxy server.

Relates to: #7465