### PR TITLE
fix validation when publishing to FIFO topic with TargetArn

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -3241,3 +3241,25 @@ class TestSNSProvider:
             AttributeNames=["All"],
         )
         snapshot.match("messages", response)
+
+    @pytest.mark.aws_validated
+    def test_publish_to_fifo_with_target_arn(self, sns_client, sns_create_topic):
+        topic_name = f"topic-{short_uid()}.fifo"
+        topic_attributes = {
+            "FifoTopic": "true",
+            "ContentBasedDeduplication": "true",
+        }
+
+        topic_arn = sns_create_topic(
+            Name=topic_name,
+            Attributes=topic_attributes,
+        )["TopicArn"]
+
+        message = {"foo": "bar"}
+        response = sns_client.publish(
+            TargetArn=topic_arn,
+            Message=json.dumps({"default": json.dumps(message)}),
+            MessageStructure="json",
+            MessageGroupId="123",
+        )
+        assert "MessageId" in response


### PR DESCRIPTION
An issue (#7562) has been reported when publishing to SNS FIFO topics with `TargetArn`: our validation was only for when `TopicArn` was set. For compatibility reasons, AWS allows users to use either `TargetArn` or `TopicArn` while publishing to an SNS topic. This moves the logic that used a bit later in the method to validate topics with either `TargetArn` or `TopicArn`.

_fixes #7562_