### PR TITLE
Add idempotence to chmod utils to make startup as non-root more resilient

### DIFF
--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -10,6 +10,7 @@ from localstack.utils.common import (
     get_free_tcp_port,
     mkdir,
 )
+from localstack.utils.functions import run_safe
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 
@@ -99,7 +100,7 @@ class KinesisMockServer(Server):
         if self._bin_path.endswith(".jar"):
             cmd = ["java", "-XX:+UseG1GC", "-jar", self._bin_path]
         else:
-            chmod_r(self._bin_path, 0o777)
+            run_safe(lambda: chmod_r(self._bin_path, 0o777))
             cmd = [self._bin_path, "--gc=G1"]
         return cmd, env_vars
 

--- a/localstack/services/kinesis/kinesis_mock_server.py
+++ b/localstack/services/kinesis/kinesis_mock_server.py
@@ -10,7 +10,6 @@ from localstack.utils.common import (
     get_free_tcp_port,
     mkdir,
 )
-from localstack.utils.functions import run_safe
 from localstack.utils.run import FuncThread
 from localstack.utils.serving import Server
 
@@ -100,7 +99,7 @@ class KinesisMockServer(Server):
         if self._bin_path.endswith(".jar"):
             cmd = ["java", "-XX:+UseG1GC", "-jar", self._bin_path]
         else:
-            run_safe(lambda: chmod_r(self._bin_path, 0o777))
+            chmod_r(self._bin_path, 0o777)
             cmd = [self._bin_path, "--gc=G1"]
         return cmd, env_vars
 

--- a/localstack/testing/pytest/util.py
+++ b/localstack/testing/pytest/util.py
@@ -1,0 +1,24 @@
+import os
+import pwd
+from multiprocessing import Process, ProcessError
+from typing import Callable
+
+
+def run_as_os_user(target: Callable, uid: str | int, gid: str | int = None):
+    """
+    Run the given callable under a different OS user ID and (optionally) group ID, in a forked subprocess
+    """
+
+    def _wrapper():
+        if gid is not None:
+            _gid = pwd.getpwnam(gid).pw_gid if isinstance(gid, str) else gid
+            os.setgid(_gid)
+        _uid = pwd.getpwnam(uid).pw_uid if isinstance(uid, str) else uid
+        os.setuid(_uid)
+        return target()
+
+    proc = Process(target=_wrapper)
+    proc.start()
+    proc.join()
+    if proc.exitcode != 0:
+        raise ProcessError(f"Process exited with code {proc.exitcode}")

--- a/localstack/utils/files.py
+++ b/localstack/utils/files.py
@@ -139,15 +139,36 @@ def chown_r(path: str, user: str):
 
 
 def chmod_r(path: str, mode: int):
-    """Recursive chmod"""
+    """
+    Recursive chmod
+    :param path: path to file or directory
+    :param mode: permission mask as octal integer value
+    """
     if not os.path.exists(path):
         return
-    os.chmod(path, mode)
+    idempotent_chmod(path, mode)
     for root, dirnames, filenames in os.walk(path):
         for dirname in dirnames:
-            os.chmod(os.path.join(root, dirname), mode)
+            idempotent_chmod(os.path.join(root, dirname), mode)
         for filename in filenames:
-            os.chmod(os.path.join(root, filename), mode)
+            idempotent_chmod(os.path.join(root, filename), mode)
+
+
+def idempotent_chmod(path: str, mode: int):
+    """
+    Perform idempotent chmod on the given file path (non-recursively). The function attempts to call `os.chmod`, and
+    will catch and only re-raise exceptions (e.g., PermissionError) if the file does not have the given mode already.
+    :param path: path to file
+    :param mode: permission mask as octal integer value
+    """
+    try:
+        os.chmod(path, mode)
+    except Exception:
+        existing_mode = os.stat(path)
+        if mode in [existing_mode.st_mode, existing_mode.st_mode & 0o777]:
+            # file already has the desired permissions -> return
+            return
+        raise
 
 
 def rm_rf(path: str):

--- a/tests/unit/utils/generic/test_file_utils.py
+++ b/tests/unit/utils/generic/test_file_utils.py
@@ -1,7 +1,11 @@
+import os
+
 import pytest
 
+from localstack import config
+from localstack.testing.pytest.util import run_as_os_user
 from localstack.utils.common import new_tmp_file, save_file
-from localstack.utils.files import parse_config_file
+from localstack.utils.files import idempotent_chmod, new_tmp_dir, parse_config_file, rm_rf
 
 CONFIG_FILE_SECTION = """
 [section{section}]
@@ -44,3 +48,32 @@ def test_parse_config_file(input_type, sections):
         assert sections == len(result)
         for section in result.values():
             assert expected == section
+
+
+@pytest.mark.parametrize("file_type", ["file", "dir"])
+@pytest.mark.skipif(
+    condition=not config.is_in_docker, reason="running chmod with su user switch only in Docker"
+)
+def test_idempotent_chmod(file_type):
+    tmp_file = new_tmp_file() if file_type == "file" else new_tmp_dir()
+
+    # set up initial permissions
+    test_mode = 0o765
+    os.chmod(tmp_file, test_mode)
+    assert os.stat(tmp_file).st_mode & 0o777 == test_mode
+
+    def _test_chmod():
+        # assert that regular chmod fails with permission error
+        with pytest.raises(PermissionError):
+            os.chmod(tmp_file, test_mode)
+        # assert that idempotent chmod succeeds
+        idempotent_chmod(tmp_file, test_mode)
+        # assert that idempotent chmod with different mode fails
+        with pytest.raises(PermissionError):
+            idempotent_chmod(tmp_file, 0o733)
+
+    # run chmod tests in subprocess
+    run_as_os_user(_test_chmod, "localstack")
+
+    # clean up
+    rm_rf(tmp_file)


### PR DESCRIPTION
Add idempotence to `chmod` utils, to make startup as non-root users more resilient.

Addresses a customer issue where the Kinesis startup fails when running the container as a non-root user:
<img width="1226" alt="image" src="https://user-images.githubusercontent.com/2807888/215150446-e5eddcc6-19d4-4589-b866-ff7267c9683a.png">

We have several occurrences of chmod logic where this change can help increase the resiliency. This change will allow us to gracefully handle situations where the filesystem is not modifiable, but the correct permissions are already in place.