### PR TITLE
fixed too many arguments for local lambda executor

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1325,11 +1325,14 @@ class LambdaExecutorLocal(LambdaExecutor):
 
         env_vars = lambda_function and lambda_function.envvars
         input = env_vars.pop("AWS_LAMBDA_EVENT_BODY", None)
+        args = {}
+        if input:
+            args["input"] = input.encode("utf-8")
         env_vars["DOCKER_LAMBDA_USE_STDIN"] = "1"
         kwargs = {"stdin": True, "inherit_env": True, "asynchronous": True, "env_vars": env_vars}
 
         process = run(cmd, stderr=subprocess.PIPE, outfile=subprocess.PIPE, **kwargs)
-        result, log_output = process.communicate(input=input.encode("utf-8"))
+        result, log_output = process.communicate(**args)
 
         try:
             result = to_str(result).strip()

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1324,10 +1324,12 @@ class LambdaExecutorLocal(LambdaExecutor):
         """
 
         env_vars = lambda_function and lambda_function.envvars
+        input = env_vars.pop("AWS_LAMBDA_EVENT_BODY")
+        env_vars["DOCKER_LAMBDA_USE_STDIN"] = "1"
         kwargs = {"stdin": True, "inherit_env": True, "asynchronous": True, "env_vars": env_vars}
 
         process = run(cmd, stderr=subprocess.PIPE, outfile=subprocess.PIPE, **kwargs)
-        result, log_output = process.communicate()
+        result, log_output = process.communicate(input=input.encode("utf-8"))
 
         try:
             result = to_str(result).strip()

--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -1324,7 +1324,7 @@ class LambdaExecutorLocal(LambdaExecutor):
         """
 
         env_vars = lambda_function and lambda_function.envvars
-        input = env_vars.pop("AWS_LAMBDA_EVENT_BODY")
+        input = env_vars.pop("AWS_LAMBDA_EVENT_BODY", None)
         env_vars["DOCKER_LAMBDA_USE_STDIN"] = "1"
         kwargs = {"stdin": True, "inherit_env": True, "asynchronous": True, "env_vars": env_vars}
 


### PR DESCRIPTION
Fixed issue, which is the same as in #1081 but for `LAMBDA_EXECUTOR: local`. Using local executor to avoid using DIND in Gitlab CI