### PR TITLE
add factory for ASF service providers

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -5,13 +5,14 @@ import threading
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Protocol, Tuple
 
 from plugin import Plugin, PluginLifecycleListener, PluginManager, PluginSpec
 from readerwriterlock import rwlock
 from werkzeug import Request
 
 from localstack import config
+from localstack.aws.skeleton import DispatchTable
 from localstack.config import ServiceProviderConfig
 from localstack.utils.bootstrap import get_enabled_apis, log_duration
 from localstack.utils.functions import call_safe
@@ -160,7 +161,19 @@ class BackendStateLifecycle(abc.ABC):
         pass
 
 
+class ServiceProvider(Protocol):
+    service: str
+
+
 class Service:
+    """
+    FIXME: this has become frankenstein's monster, and it has to go. once we've rid ourselves of the legacy edge
+     proxy, we can get rid of the ``listener`` concept. we should then do one iteration over all the
+     ``start_dynamodb``, ``start_<whatever>``, ``check_<whatever>``, etc. methods, to make all of those integral part
+     of the service provider. the assumption that every service provider starts a backend server is outdated, and then
+     we can get rid of ``start``, and ``check``.
+    """
+
     def __init__(
         self,
         name,
@@ -180,6 +193,7 @@ class Service:
         self.stop_function = stop
         self.lifecycle_hook = lifecycle_hook or ServiceLifecycleHook()
         self.backend_state_lifecycle = backend_state_lifecycle
+        self._provider = None
         call_safe(self.lifecycle_hook.on_after_init)
 
     def start(self, asynchronous):
@@ -219,6 +233,44 @@ class Service:
 
     def is_enabled(self):
         return True
+
+    @staticmethod
+    def for_provider(
+        provider: ServiceProvider,
+        dispatch_table_factory: Callable[[ServiceProvider], DispatchTable] = None,
+        service_lifecycle_hook=_default,
+    ) -> "Service":
+        """
+        Factory method for creating services for providers. This method hides a bunch of legacy code and
+        band-aids/adapters to make persistence visitors work, while providing compatibility with the legacy edge proxy.
+
+        :param provider: the service provider, i.e., the implementation of the generated ASF service API.
+        :param dispatch_table_factory: a `MotoFallbackDispatcher` or something similar that uses the provider to
+            create a dispatch table. this one's a bit clumsy.
+        :param service_lifecycle_hook: if left empty, then it checks whether the provider is a ServiceLifecycleHook.
+            if set to None, it will disable the lifecyle hook alltogether
+        :return: a service instance
+        """
+        from localstack.aws.proxy import AwsApiListener
+
+        # determine the service_lifecycle_hook
+        if service_lifecycle_hook is _default:
+            if isinstance(provider, ServiceLifecycleHook):
+                service_lifecycle_hook = provider
+            else:
+                service_lifecycle_hook = None
+
+        # determine the delegate for injecting into the AwsApiListener
+        delegate = dispatch_table_factory(provider) if dispatch_table_factory else provider
+
+        service = Service(
+            name=provider.service,
+            listener=AwsApiListener(provider.service, delegate=delegate),
+            lifecycle_hook=service_lifecycle_hook,
+        )
+        service._provider = provider
+
+        return service
 
 
 class ServiceState(Enum):

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -238,7 +238,7 @@ class Service:
     def for_provider(
         provider: ServiceProvider,
         dispatch_table_factory: Callable[[ServiceProvider], DispatchTable] = None,
-        service_lifecycle_hook=_default,
+        service_lifecycle_hook=None,
     ) -> "Service":
         """
         Factory method for creating services for providers. This method hides a bunch of legacy code and
@@ -247,18 +247,15 @@ class Service:
         :param provider: the service provider, i.e., the implementation of the generated ASF service API.
         :param dispatch_table_factory: a `MotoFallbackDispatcher` or something similar that uses the provider to
             create a dispatch table. this one's a bit clumsy.
-        :param service_lifecycle_hook: if left empty, then it checks whether the provider is a ServiceLifecycleHook.
-            if set to None, it will disable the lifecyle hook alltogether
+        :param service_lifecycle_hook: if left empty, the factory checks whether the provider is a ServiceLifecycleHook.
         :return: a service instance
         """
         from localstack.aws.proxy import AwsApiListener
 
         # determine the service_lifecycle_hook
-        if service_lifecycle_hook is _default:
+        if service_lifecycle_hook is None:
             if isinstance(provider, ServiceLifecycleHook):
                 service_lifecycle_hook = provider
-            else:
-                service_lifecycle_hook = None
 
         # determine the delegate for injecting into the AwsApiListener
         delegate = dispatch_table_factory(provider) if dispatch_table_factory else provider

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -238,7 +238,7 @@ class Service:
     def for_provider(
         provider: ServiceProvider,
         dispatch_table_factory: Callable[[ServiceProvider], DispatchTable] = None,
-        service_lifecycle_hook=None,
+        service_lifecycle_hook: ServiceLifecycleHook = None,
     ) -> "Service":
         """
         Factory method for creating services for providers. This method hides a bunch of legacy code and

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -1,6 +1,5 @@
 from localstack import config
 from localstack.aws.forwarder import HttpFallbackDispatcher
-from localstack.aws.proxy import AwsApiListener
 from localstack.services.moto import MotoFallbackDispatcher
 from localstack.services.plugins import Service, aws_provider
 
@@ -11,8 +10,7 @@ def acm():
     from localstack.services.moto import MotoFallbackDispatcher
 
     provider = AcmProvider()
-
-    return Service("acm", listener=AwsApiListener("acm", MotoFallbackDispatcher(provider)))
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider(api="apigateway")
@@ -20,9 +18,7 @@ def apigateway():
     from localstack.services.apigateway.provider import ApigatewayProvider
 
     provider = ApigatewayProvider()
-    listener = AwsApiListener("apigateway", MotoFallbackDispatcher(provider))
-
-    return Service("apigateway", listener=listener, lifecycle_hook=provider)
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -30,92 +26,68 @@ def cloudformation():
     from localstack.services.cloudformation.provider import CloudformationProvider
 
     provider = CloudformationProvider()
-
-    return Service("cloudformation", listener=AwsApiListener("cloudformation", provider))
+    return Service.for_provider(provider)
 
 
 @aws_provider(api="config")
 def awsconfig():
     from localstack.services.configservice.provider import ConfigProvider
-    from localstack.services.moto import MotoFallbackDispatcher
 
     provider = ConfigProvider()
-    return Service("config", listener=AwsApiListener("config", MotoFallbackDispatcher(provider)))
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def cloudwatch():
     from localstack.services.cloudwatch.provider import CloudwatchProvider
-    from localstack.services.moto import MotoFallbackDispatcher
 
     provider = CloudwatchProvider()
-    listener = AwsApiListener("cloudwatch", MotoFallbackDispatcher(provider))
-
-    return Service(
-        "cloudwatch",
-        listener=listener,
-        lifecycle_hook=provider,
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def dynamodb():
-    from localstack.aws.forwarder import HttpFallbackDispatcher
     from localstack.services.dynamodb.provider import DynamoDBProvider
 
     provider = DynamoDBProvider()
-    listener = AwsApiListener(
-        "dynamodb", HttpFallbackDispatcher(provider, provider.get_forward_url)
-    )
-
-    return Service(
-        "dynamodb",
-        listener=listener,
-        lifecycle_hook=provider,
+    return Service.for_provider(
+        provider,
+        dispatch_table_factory=lambda _provider: HttpFallbackDispatcher(
+            _provider, _provider.get_forward_url
+        ),
     )
 
 
 @aws_provider()
 def dynamodbstreams():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services.dynamodbstreams.provider import DynamoDBStreamsProvider
 
     provider = DynamoDBStreamsProvider()
-    return Service(
-        "dynamodbstreams",
-        listener=AwsApiListener("dynamodbstreams", provider),
-        lifecycle_hook=provider,
-    )
+    return Service.for_provider(provider)
 
 
 @aws_provider()
 def ec2():
     from localstack.services.ec2.provider import Ec2Provider
-    from localstack.services.moto import MotoFallbackDispatcher
 
     provider = Ec2Provider()
-    return Service(
-        "ec2",
-        listener=AwsApiListener("ec2", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def es():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services.es.provider import EsProvider
 
     provider = EsProvider()
-    return Service("es", listener=AwsApiListener("es", provider))
+    return Service.for_provider(provider)
 
 
 @aws_provider()
 def firehose():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services.firehose.provider import FirehoseProvider
 
     provider = FirehoseProvider()
-    return Service("firehose", listener=AwsApiListener("firehose", provider))
+    return Service.for_provider(provider)
 
 
 @aws_provider()
@@ -124,10 +96,7 @@ def iam():
     from localstack.services.moto import MotoFallbackDispatcher
 
     provider = IamProvider()
-    return Service(
-        "iam",
-        listener=AwsApiListener("iam", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -135,7 +104,7 @@ def sts():
     from localstack.services.sts.provider import StsProvider
 
     provider = StsProvider()
-    return Service("sts", listener=AwsApiListener("sts", MotoFallbackDispatcher(provider)))
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -143,11 +112,11 @@ def kinesis():
     from localstack.services.kinesis.provider import KinesisProvider
 
     provider = KinesisProvider()
-    listener = AwsApiListener("kinesis", HttpFallbackDispatcher(provider, provider.get_forward_url))
-    return Service(
-        "kinesis",
-        listener=listener,
-        lifecycle_hook=provider,
+    return Service.for_provider(
+        provider,
+        dispatch_table_factory=lambda _provider: HttpFallbackDispatcher(
+            _provider, _provider.get_forward_url
+        ),
     )
 
 
@@ -157,17 +126,17 @@ def kms():
         from localstack.services.kms.local_kms_provider import LocalKmsProvider
 
         provider = LocalKmsProvider()
-        # something like HttpFallbackDispatcher but without the base provider might be handy here
-        listener = AwsApiListener(
-            "kms", HttpFallbackDispatcher(provider, provider.start_and_get_backend)
+        return Service.for_provider(
+            provider,
+            dispatch_table_factory=lambda _provider: HttpFallbackDispatcher(
+                _provider, _provider.start_and_get_backend
+            ),
         )
-
-        return Service("kms", listener=listener)
 
     from localstack.services.kms.provider import KmsProvider
 
     provider = KmsProvider()
-    return Service("kms", listener=AwsApiListener("kms", provider))
+    return Service.for_provider(provider)
 
 
 @aws_provider(api="lambda")
@@ -184,12 +153,10 @@ def awslambda():
 
 @aws_provider(api="lambda", name="asf")
 def awslambda_asf():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services.awslambda.provider import LambdaProvider
 
     provider = LambdaProvider()
-
-    return Service("lambda", listener=AwsApiListener("lambda", provider), lifecycle_hook=provider)
+    return Service.for_provider(provider)
 
 
 @aws_provider()
@@ -197,17 +164,15 @@ def logs():
     from localstack.services.logs.provider import LogsProvider
 
     provider = LogsProvider()
-    listener = AwsApiListener("logs", MotoFallbackDispatcher(provider))
-    return Service("logs", listener=listener)
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def opensearch():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services.opensearch.provider import OpensearchProvider
 
     provider = OpensearchProvider()
-    return Service("opensearch", listener=AwsApiListener("opensearch", provider))
+    return Service.for_provider(provider)
 
 
 @aws_provider()
@@ -215,9 +180,7 @@ def redshift():
     from localstack.services.redshift.provider import RedshiftProvider
 
     provider = RedshiftProvider()
-    listener = AwsApiListener("redshift", MotoFallbackDispatcher(provider))
-
-    return Service("redshift", listener=listener)
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -225,8 +188,7 @@ def route53():
     from localstack.services.route53.provider import Route53Provider
 
     provider = Route53Provider()
-
-    return Service("route53", listener=AwsApiListener("route53", MotoFallbackDispatcher(provider)))
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -234,11 +196,7 @@ def route53resolver():
     from localstack.services.route53resolver.provider import Route53ResolverProvider
 
     provider = Route53ResolverProvider()
-
-    return Service(
-        "route53resolver",
-        listener=AwsApiListener("route53resolver", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider(api="s3", name="default")
@@ -255,63 +213,43 @@ def s3_asf():
     from localstack.services.s3.provider import S3Provider
 
     provider = S3Provider()
-
-    return Service(
-        "s3",
-        listener=AwsApiListener("s3", MotoFallbackDispatcher(provider)),
-        lifecycle_hook=provider,
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def s3control():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.s3control.provider import S3ControlProvider
 
     provider = S3ControlProvider()
-    return Service(
-        "s3control", listener=AwsApiListener("s3control", MotoFallbackDispatcher(provider))
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def secretsmanager():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.secretsmanager.provider import SecretsmanagerProvider
 
     provider = SecretsmanagerProvider()
-    return Service(
-        "secretsmanager",
-        listener=AwsApiListener("secretsmanager", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def ses():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.ses.provider import SesProvider
 
     provider = SesProvider()
-    return Service(
-        "ses",
-        listener=AwsApiListener("ses", MotoFallbackDispatcher(provider)),
-        lifecycle_hook=provider,
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def sns():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services.sns.provider import SnsProvider
 
     provider = SnsProvider()
-
-    return Service("sns", listener=AwsApiListener("sns", provider), lifecycle_hook=provider)
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def sqs():
-    from localstack.aws.proxy import AwsApiListener
     from localstack.services import edge
     from localstack.services.sqs import query_api
     from localstack.services.sqs.provider import SqsProvider
@@ -319,8 +257,7 @@ def sqs():
     query_api.register(edge.ROUTER)
 
     provider = SqsProvider()
-
-    return Service("sqs", listener=AwsApiListener("sqs", provider), lifecycle_hook=provider)
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -329,10 +266,7 @@ def ssm():
     from localstack.services.ssm.provider import SsmProvider
 
     provider = SsmProvider()
-    return Service(
-        "ssm",
-        listener=AwsApiListener("ssm", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -341,11 +275,7 @@ def events():
     from localstack.services.moto import MotoFallbackDispatcher
 
     provider = EventsProvider()
-    return Service(
-        "events",
-        listener=AwsApiListener("events", MotoFallbackDispatcher(provider)),
-        lifecycle_hook=provider,
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
@@ -353,13 +283,11 @@ def stepfunctions():
     from localstack.services.stepfunctions.provider import StepFunctionsProvider
 
     provider = StepFunctionsProvider()
-    listener = AwsApiListener(
-        "stepfunctions", HttpFallbackDispatcher(provider, provider.get_forward_url)
-    )
-    return Service(
-        "stepfunctions",
-        listener=listener,
-        lifecycle_hook=provider,
+    return Service.for_provider(
+        provider,
+        dispatch_table_factory=lambda _provider: HttpFallbackDispatcher(
+            _provider, _provider.get_forward_url
+        ),
     )
 
 
@@ -369,58 +297,38 @@ def swf():
     from localstack.services.swf.provider import SWFProvider
 
     provider = SWFProvider()
-    return Service(
-        "swf",
-        listener=AwsApiListener("swf", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def resourcegroupstaggingapi():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.resourcegroupstaggingapi.provider import (
         ResourcegroupstaggingapiProvider,
     )
 
     provider = ResourcegroupstaggingapiProvider()
-    return Service(
-        "resourcegroupstaggingapi",
-        listener=AwsApiListener("resourcegroupstaggingapi", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider(api="resource-groups")
 def resource_groups():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.resourcegroups.provider import ResourceGroupsProvider
 
     provider = ResourceGroupsProvider()
-    return Service(
-        "resource-groups",
-        listener=AwsApiListener("resource-groups", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def support():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.support.provider import SupportProvider
 
     provider = SupportProvider()
-    return Service(
-        "support",
-        listener=AwsApiListener("support", MotoFallbackDispatcher(provider)),
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)
 
 
 @aws_provider()
 def transcribe():
-    from localstack.services.moto import MotoFallbackDispatcher
     from localstack.services.transcribe.provider import TranscribeProvider
 
     provider = TranscribeProvider()
-    return Service(
-        "transcribe",
-        listener=AwsApiListener("transcribe", MotoFallbackDispatcher(provider)),
-        lifecycle_hook=provider,
-    )
+    return Service.for_provider(provider, dispatch_table_factory=MotoFallbackDispatcher)


### PR DESCRIPTION
This PR adds a factory for creating `Service` instances for ASF providers.

Through the `MotoFallbackDispatcher` we lost the reference the original provider instance. Basically there was no way to use the `ServicePluginManager` to iterate over the provider instances. This is however necessary for the state visitor pattern to work correctly. Providers need to be able to implement the `accept_state_visitor` method, and some higher-order mechanism needs to collect all provider instances and call the method on them. Now this can be the `Service` instance, since the `Service` can delegate the call to the `_provider` attribute it now holds.
So basically what this will enable down the road is

```python
for service in SERVICE_PLUGINS:
     service.accept_state_visitor(visitor)
```

It also creates a nice way of phasing out the `AwsApiListener` which will go away soon :partying_face:  it isolates the use into the factory method.

Plus it makes the `providers.py` a bit cleaner :-)
