### PR TITLE
Update kinesis-mock to 0.3.3

### DIFF
--- a/localstack/services/kinesis/packages.py
+++ b/localstack/services/kinesis/packages.py
@@ -6,7 +6,7 @@ from localstack import config
 from localstack.packages import GitHubReleaseInstaller, Package, PackageInstaller
 from localstack.utils.platform import get_arch, get_os
 
-_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.3.2"
+_KINESIS_MOCK_VERSION = os.environ.get("KINESIS_MOCK_VERSION") or "0.3.3"
 
 
 class KinesisMockPackage(Package):


### PR DESCRIPTION
See https://github.com/etspaceman/kinesis-mock/releases/tag/0.3.3

Specifically, see https://github.com/etspaceman/kinesis-mock/pull/412

This release fixes several issues with regards to how scaling operations worked, and most notably provides the capability to scale the Kinesis streams while consuming them. This also provides StreamARN support to all API calls that added it.
