### PR TITLE
add internal pods endpoint to legacy cors check

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -181,7 +181,7 @@ def legacy_rules(request: Request) -> Optional[str]:
 
     # TODO Remove once fallback to S3 is disabled (after S3 ASF and Cors rework)
     # necessary for correct handling of cors for internal endpoints
-    if path == "/health" or path.startswith("/_localstack"):
+    if path == "/health" or path.startswith("/_localstack") or path.startswith("/_pods"):
         return None
 
     # TODO The remaining rules here are special S3 rules - needs to be discussed how these should be handled.


### PR DESCRIPTION
This PR adds the internal `_pods` endpoint to our legacy cors checks, which essentially applies typical cors handling onto those routes.

Necessitated by the Pods Launchpad


