### PR TITLE
Copy runtime init to container including parent folders

### DIFF
--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -138,7 +138,7 @@ resolver = RuntimeImageResolver()
 def get_runtime_client_path() -> Path:
     installer = awslambda_runtime_package.get_installer()
     installer.install()
-    return Path(installer.get_executable_path())
+    return Path(installer.get_installed_dir())
 
 
 def prepare_image(target_path: Path, function_version: FunctionVersion) -> None:
@@ -264,7 +264,7 @@ class DockerRuntimeExecutor(RuntimeExecutor):
             or self.function_version.config.package_type != PackageType.Zip
         ):
             CONTAINER_CLIENT.copy_into_container(
-                self.id, str(get_runtime_client_path()), RAPID_ENTRYPOINT
+                self.id, f"{str(get_runtime_client_path())}/.", "/"
             )
         if not config.LAMBDA_PREBUILD_IMAGES:
             # copy_folders should be empty here if package type is not zip

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -36,10 +36,21 @@ class AWSLambdaRuntimePackage(Package):
 
 
 class AWSLambdaRuntimePackageInstaller(DownloadInstaller):
-    def _get_download_url(self) -> str:
+    def _get_arch(self):
         arch = get_arch()
-        arch = "x86_64" if arch == "amd64" else arch
+        return "x86_64" if arch == "amd64" else arch
+
+    def _get_download_url(self) -> str:
+        arch = self._get_arch()
         return LAMBDA_RUNTIME_INIT_URL.format(version=self.version, arch=arch)
+
+    def _get_install_dir(self, target: InstallTarget) -> str:
+        install_dir = super()._get_install_dir(target)
+        arch = self._get_arch()
+        return os.path.join(install_dir, arch)
+
+    def _get_install_marker_path(self, install_dir: str) -> str:
+        return os.path.join(install_dir, "var", "rapid", "init")
 
     def _install(self, target: InstallTarget) -> None:
         super()._install(target)


### PR DESCRIPTION
## Motivation
The copying of the lambda runtime init binary into the container fails, if `/var/rapid` does not exist beforehand. This does not appear in AWS provided lambda images, as the folder is already present there, but for custom images without this folder.

## Changes
* Adapt the installer slightly, so the binary is stored under `<version>/<arch>/var/rapid/init`. With this, we can just copy the contents of `<version>/<arch>` to `/`, and it will create / copy all the necessary parent directories with it, circumventing that problem.

@alexrashed @baermat might be a unusual usage of the installers, tagging for reference