### PR TITLE
Add keepalive period for removing unused execution environments

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -649,6 +649,11 @@ LAMBDA_REMOVE_CONTAINERS = (
     os.environ.get("LAMBDA_REMOVE_CONTAINERS", "").lower().strip() not in FALSE_STRINGS
 )
 
+# time in milliseconds until lambda kills the execution environment after the last invocation has been processed
+# can be set to 0 to immediately kill the execution environments after an invocation
+# defaults to 600_000 ms => 10 minutes
+LAMBDA_KEEPALIVE_MS = int(os.environ.get("LAMBDA_KEEPALIVE_MS", "600000"))
+
 # DEV | Only for LS developers. Only applicable to new Lambda provider.
 # whether to explicitly expose port in lambda container when invoking functions in host mode for systems that cannot
 # reach the container via its IPv4 (e.g., macOS https://docs.docker.com/desktop/networking/#i-cannot-ping-my-containers)

--- a/localstack/services/awslambda/invocation/runtime_environment.py
+++ b/localstack/services/awslambda/invocation/runtime_environment.py
@@ -147,6 +147,7 @@ class RuntimeEnvironment:
                 raise InvalidStatusException("Runtime Handler cannot be shutdown before started")
             self.runtime_executor.stop()
             self.status = RuntimeStatus.STOPPED
+            self.keepalive_timer.cancel()
 
     # Status methods
     def set_ready(self) -> None:

--- a/localstack/services/awslambda/invocation/runtime_environment.py
+++ b/localstack/services/awslambda/invocation/runtime_environment.py
@@ -72,7 +72,7 @@ class RuntimeEnvironment:
         )
         self.last_returned = datetime.min
         self.startup_timer = None
-        self.keepalive_timer = None
+        self.keepalive_timer = Timer(0, lambda *args, **kwargs: None)
 
     def get_log_group_name(self) -> str:
         return f"/aws/lambda/{self.function_version.id.function_name}"
@@ -176,7 +176,6 @@ class RuntimeEnvironment:
             self.id,
             self.function_version.qualified_arn,
         )
-        self.keepalive_timer = None
         self.stop()
 
     def timed_out(self) -> None:

--- a/localstack/services/awslambda/invocation/runtime_environment.py
+++ b/localstack/services/awslambda/invocation/runtime_environment.py
@@ -46,6 +46,7 @@ def generate_runtime_id() -> str:
     return "".join(random.choices(string.hexdigits[:16], k=32)).lower()
 
 
+# TODO: add status callback
 class RuntimeEnvironment:
     runtime_executor: RuntimeExecutor
     status_lock: RLock
@@ -53,6 +54,7 @@ class RuntimeEnvironment:
     initialization_type: InitializationType
     last_returned: datetime
     startup_timer: Optional[Timer]
+    keepalive_timer: Optional[Timer]
 
     def __init__(
         self,
@@ -70,6 +72,7 @@ class RuntimeEnvironment:
         )
         self.last_returned = datetime.min
         self.startup_timer = None
+        self.keepalive_timer = None
 
     def get_log_group_name(self) -> str:
         return f"/aws/lambda/{self.function_version.id.function_name}"
@@ -164,6 +167,18 @@ class RuntimeEnvironment:
                 raise InvalidStatusException("Runtime Handler can only be set ready while running")
             self.status = RuntimeStatus.READY
 
+            self.keepalive_timer = Timer(config.LAMBDA_KEEPALIVE_MS / 1000, self.keepalive_passed)
+            self.keepalive_timer.start()
+
+    def keepalive_passed(self) -> None:
+        LOG.debug(
+            "Executor %s for function %s hasn't received any invocations in a while. Stopping.",
+            self.id,
+            self.function_version.qualified_arn,
+        )
+        self.keepalive_timer = None
+        self.stop()
+
     def timed_out(self) -> None:
         LOG.warning(
             "Executor %s for function %s timed out during startup",
@@ -190,6 +205,8 @@ class RuntimeEnvironment:
             if self.status != RuntimeStatus.READY:
                 raise InvalidStatusException("Invoke can only happen if status is ready")
             self.status = RuntimeStatus.RUNNING
+            self.keepalive_timer.cancel()
+
         invoke_payload = {
             "invoke-id": invocation_event.invocation_id,
             "invoked-function-arn": invocation_event.invocation.invoked_arn,

--- a/localstack/services/awslambda/invocation/version_manager.py
+++ b/localstack/services/awslambda/invocation/version_manager.py
@@ -265,6 +265,7 @@ class LambdaVersionManager(ServiceEndpoint):
                 if self.available_environments.empty() or self.active_environment_count() == 0:
                     self.start_environment()
                 environment = None
+                # TODO avoid infinite environment spawning retrying
                 while not environment:
                     try:
                         environment = self.available_environments.get(timeout=1)
@@ -295,6 +296,8 @@ class LambdaVersionManager(ServiceEndpoint):
                             environment.id,
                         )
                         self.running_invocations.pop(queued_invocation.invocation_id, None)
+                        # try next environment
+                        environment = None
             except Exception as e:
                 queued_invocation.result_future.set_exception(e)
 

--- a/localstack/services/awslambda/invocation/version_manager.py
+++ b/localstack/services/awslambda/invocation/version_manager.py
@@ -283,6 +283,9 @@ class LambdaVersionManager(ServiceEndpoint):
                         environment.invoke(invocation_event=queued_invocation)
                         LOG.debug("Invoke for request %s done", queued_invocation.invocation_id)
                     except queue.Empty:
+                        # TODO if one environment threw an invalid status exception, we will get here potentially with
+                        # another busy environment, and won't spawn a new one as there is one active here.
+                        # We will be stuck in the loop until another becomes active without scaling.
                         if self.active_environment_count() == 0:
                             LOG.debug(
                                 "Detected no active environments for version %s. Starting one...",


### PR DESCRIPTION
## Changes
- By default an execution environment will now wait 10 minutes after the last invocation has been processed and stop itself afterwards. Each new invocation it receives resets this timer.
- The timeout is configurable via `LAMBDA_KEEPALIVE_MS`.