### PR TITLE
Extend Docker client to accept --label flag

### DIFF
--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -370,7 +370,7 @@ class ContainerConfiguration:
 
 @dataclasses.dataclass
 class DockerRunFlags:
-    """Class to capture Docker run flags that can be specified by the user"""
+    """Class to capture Docker run flags for a container"""
 
     env_vars: Optional[Dict[str, str]]
     ports: Optional[PortMappings]

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -368,6 +368,18 @@ class ContainerConfiguration:
     workdir: Optional[str] = None
 
 
+@dataclasses.dataclass
+class DockerRunFlags:
+    """Class to capture Docker run flags that can be specified by the user"""
+
+    env_vars: Optional[Dict[str, str]]
+    ports: Optional[PortMappings]
+    mounts: Optional[List[SimpleVolumeBind]]
+    extra_hosts: Optional[Dict[str, str]]
+    network: Optional[str]
+    labels: Optional[Dict[str, str]]
+
+
 class ContainerClient(metaclass=ABCMeta):
     STOP_TIMEOUT = 0
 
@@ -701,6 +713,7 @@ class ContainerClient(metaclass=ABCMeta):
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
+        labels: Optional[Dict[str, str]] = None,
     ) -> str:
         """Creates a container with the given image
 
@@ -875,25 +888,20 @@ class Util:
         ports: PortMappings = None,
         mounts: List[SimpleVolumeBind] = None,
         network: Optional[str] = None,
-    ) -> Tuple[
-        Dict[str, str],
-        PortMappings,
-        List[SimpleVolumeBind],
-        Optional[Dict[str, str]],
-        Optional[str],
-    ]:
+    ) -> DockerRunFlags:
         """Parses environment, volume and port flags passed as string
         :param additional_flags: String which contains the flag definitions
         :param env_vars: Dict with env vars. Will be modified in place.
         :param ports: PortMapping object. Will be modified in place.
         :param mounts: List of mount tuples (host_path, container_path). Will be modified in place.
         :param network: Existing network name (optional). Warning will be printed if network is overwritten in flags.
-        :return: A tuple containing the env_vars, ports, mount, extra_hosts and network objects. Will return new objects
-                if respective parameters were None and additional flags contained a flag for that object, the same which
-                are passed otherwise.
+        :return: A DockerRunFlags object containing the env_vars, ports, mount, extra_hosts, network, and labels.
+                The result will return new objects if respective parameters were None and additional flags contained
+                a flag for that object, the same which are passed otherwise.
         """
         cur_state = None
         extra_hosts = None
+        labels = {}
         # TODO Use argparse to simplify this logic
         for flag in shlex.split(additional_flags):
             if not cur_state:
@@ -907,6 +915,8 @@ class Util:
                     cur_state = "add-host"
                 elif flag == "--network":
                     cur_state = "set-network"
+                elif flag == "--label":
+                    cur_state = "add-label"
                 else:
                     raise NotImplementedError(
                         f"Flag {flag} is currently not supported by this Docker client."
@@ -966,9 +976,23 @@ class Util:
                             flag,
                         )
                     network = flag
+                elif cur_state == "add-label":
+                    key, _, value = flag.partition("=")
+                    if key:
+                        labels[key] = value
+                    else:
+                        LOG.warning("Invalid --label specified, unable to parse: '%s'", flag)
 
                 cur_state = None
-        return env_vars, ports, mounts, extra_hosts, network
+
+        return DockerRunFlags(
+            env_vars=env_vars,
+            ports=ports,
+            mounts=mounts,
+            extra_hosts=extra_hosts,
+            network=network,
+            labels=labels,
+        )
 
     @staticmethod
     def convert_mount_list_to_dict(

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -615,6 +615,7 @@ class CmdDockerClient(ContainerClient):
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
+        labels: Optional[Dict[str, str]] = None,
     ) -> Tuple[List[str], str]:
         env_file = None
         cmd = self._docker_cmd() + [action]
@@ -659,6 +660,10 @@ class CmdDockerClient(ContainerClient):
             cmd += ["--dns", dns]
         if workdir:
             cmd += ["--workdir", workdir]
+        if labels:
+            for key, value in labels.items():
+                cmd += ["--label", f"{key}={value}"]
+
         if additional_flags:
             cmd += shlex.split(additional_flags)
         cmd.append(image_name)

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -506,13 +506,21 @@ class SdkDockerClient(ContainerClient):
         additional_flags: Optional[str] = None,
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
+        labels: Optional[Dict[str, str]] = None,
     ) -> str:
         LOG.debug("Creating container with attributes: %s", locals())
         extra_hosts = None
         if additional_flags:
-            env_vars, ports, mount_volumes, extra_hosts, network = Util.parse_additional_flags(
+            parsed_flags = Util.parse_additional_flags(
                 additional_flags, env_vars, ports, mount_volumes, network
             )
+            env_vars = parsed_flags.env_vars
+            ports = parsed_flags.ports
+            mount_volumes = parsed_flags.mounts
+            extra_hosts = parsed_flags.extra_hosts
+            network = parsed_flags.network
+            labels = parsed_flags.labels
+
         try:
             kwargs = {}
             if cap_add:
@@ -529,6 +537,8 @@ class SdkDockerClient(ContainerClient):
                 kwargs["working_dir"] = workdir
             if privileged:
                 kwargs["privileged"] = True
+            if labels:
+                kwargs["labels"] = labels
             mounts = None
             if mount_volumes:
                 mounts = Util.convert_mount_list_to_dict(mount_volumes)

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1186,6 +1186,8 @@ class TestDockerClient:
         assert is_ipv4_address(ip)
         assert "127.0.0.1" != ip
 
+
+class TestDockerImages:
     def test_commit_creates_image_from_running_container(self, docker_client: ContainerClient):
         image_name = "lorem"
         image_tag = "ipsum"
@@ -1217,6 +1219,8 @@ class TestDockerClient:
         with pytest.raises(NoSuchImage):
             docker_client.remove_image(image, force=False)
 
+
+class TestDockerNetworking:
     def test_get_container_ip_with_network(
         self, docker_client: ContainerClient, create_container, create_network
     ):
@@ -1313,6 +1317,8 @@ class TestDockerClient:
                 container_name_or_id=container_2.container_id, attach=True
             )
 
+
+class TestDockerPermissions:
     def test_container_with_cap_add(self, docker_client: ContainerClient, create_container):
         container = create_container(
             "alpine",
@@ -1426,3 +1432,12 @@ class TestDockerPorts:
         if delta <= 1:
             time.sleep(1.01 - delta)
         assert is_port_available_for_containers(port)
+
+
+class TestDockerLabels:
+    def test_create_container_with_labels(self, docker_client, create_container):
+        labels = {"foo": "bar", short_uid(): short_uid()}
+        container = create_container("alpine", command=["dummy"], labels=labels)
+        result = docker_client.inspect_container(container.container_id)
+        result_labels = result.get("Config", {}).get("Labels")
+        assert result_labels == labels

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -130,6 +130,9 @@ def test_argument_parsing():
     argument_string = r'--label foo1="bar" --label foo2="baz"'  # test with multiple labels
     flags = Util.parse_additional_flags(argument_string)
     assert flags.labels == {"foo1": "bar", "foo2": "baz"}
+    argument_string = r"--label foo=bar=baz"  # assert label values that contain equal signs
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.labels == {"foo": "bar=baz"}
     argument_string = r'--label ""'  # assert that we gracefully handle invalid labels
     flags = Util.parse_additional_flags(argument_string)
     assert flags.labels == {}

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -80,8 +80,11 @@ def test_argument_parsing():
     argument_string = (
         "--add-host host.docker.internal:host-gateway --add-host arbitrary.host:127.0.0.1"
     )
-    _, _, _, extra_hosts, _ = Util.parse_additional_flags(argument_string, env_vars, ports, mounts)
-    assert {"host.docker.internal": "host-gateway", "arbitrary.host": "127.0.0.1"} == extra_hosts
+    flags = Util.parse_additional_flags(argument_string, env_vars, ports, mounts)
+    assert {
+        "host.docker.internal": "host-gateway",
+        "arbitrary.host": "127.0.0.1",
+    } == flags.extra_hosts
 
     with pytest.raises(NotImplementedError):
         argument_string = "--somerandomargument"
@@ -92,30 +95,41 @@ def test_argument_parsing():
 
     # Test windows paths
     argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task"'
-    _, _, mounts, _, _ = Util.parse_additional_flags(argument_string)
-    assert mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
     argument_string = r'-v "C:\Users\SomeUser\SomePath:/var/task:ro"'
-    _, _, mounts, _, _ = Util.parse_additional_flags(argument_string)
-    assert mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.mounts == [(r"C:\Users\SomeUser\SomePath", "/var/task")]
     argument_string = r'-v "C:\Users\Some User\Some Path:/var/task:ro"'
-    _, _, mounts, _, _ = Util.parse_additional_flags(argument_string)
-    assert mounts == [(r"C:\Users\Some User\Some Path", "/var/task")]
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.mounts == [(r"C:\Users\Some User\Some Path", "/var/task")]
     argument_string = r'-v "/var/test:/var/task:ro"'
-    _, _, mounts, _, _ = Util.parse_additional_flags(argument_string)
-    assert mounts == [("/var/test", "/var/task")]
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.mounts == [("/var/test", "/var/task")]
 
     # Test file paths
     argument_string = r'-v "/tmp/test.jar:/tmp/foo bar/test.jar"'
-    _, _, mounts, _, _ = Util.parse_additional_flags(argument_string)
-    assert mounts == [(r"/tmp/test.jar", "/tmp/foo bar/test.jar")]
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.mounts == [(r"/tmp/test.jar", "/tmp/foo bar/test.jar")]
     argument_string = r'-v "/tmp/test-foo_bar.jar:/tmp/test-foo_bar2.jar"'
-    _, _, mounts, _, _ = Util.parse_additional_flags(argument_string)
-    assert mounts == [(r"/tmp/test-foo_bar.jar", "/tmp/test-foo_bar2.jar")]
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.mounts == [(r"/tmp/test-foo_bar.jar", "/tmp/test-foo_bar2.jar")]
 
     # Test file paths
     argument_string = r'-v "/tmp/test.jar:/tmp/foo bar/test.jar" --network mynet123'
-    _, _, _, _, network = Util.parse_additional_flags(argument_string)
-    assert network == "mynet123"
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.network == "mynet123"
+
+    # Test labels
+    argument_string = r"--label foo=bar.123"
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.labels == {"foo": "bar.123"}
+    argument_string = r'--label foo="bar 123"'
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.labels == {"foo": "bar 123"}
+    argument_string = r'--label ""'  # assert that we gracefully handle invalid labels
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.labels == {}
 
 
 def list_in(a, b):

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -124,9 +124,12 @@ def test_argument_parsing():
     argument_string = r"--label foo=bar.123"
     flags = Util.parse_additional_flags(argument_string)
     assert flags.labels == {"foo": "bar.123"}
-    argument_string = r'--label foo="bar 123"'
+    argument_string = r'--label foo="bar 123"'  # test with whitespaces
     flags = Util.parse_additional_flags(argument_string)
     assert flags.labels == {"foo": "bar 123"}
+    argument_string = r'--label foo1="bar" --label foo2="baz"'  # test with multiple labels
+    flags = Util.parse_additional_flags(argument_string)
+    assert flags.labels == {"foo1": "bar", "foo2": "baz"}
     argument_string = r'--label ""'  # assert that we gracefully handle invalid labels
     flags = Util.parse_additional_flags(argument_string)
     assert flags.labels == {}


### PR DESCRIPTION
Extend Docker client utilities (SDK-based as well as CLI-based Docker client) to accept `--label` flags in the additional flags. This is a requirement that recently came up for the [LocalStack Docker Desktop extension](https://github.com/localstack/localstack-docker-extension). /cc @HarshCasper @Pive01

The PR also contains slight refactoring of the `parse_additional_flags(..)` util function - returning a `DockerRunFlags` object, instead of a tuple with the result entries.

Tests have been extended to cover the new functionality.