### PR TITLE
work on APIGW parity for RestAPI resource, remove patches

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -521,7 +521,7 @@ def apply_json_patch_safe(subject, patch_operations, in_place=True, return_list=
                 if isinstance(target, list) and not path.endswith("/-"):
                     # if "path" is an attribute name pointing to an array in "subject", and we're running
                     # an "add" operation, then we should use the standard-compliant notation "/path/-"
-                    operation["path"] = "%s/-" % path
+                    operation["path"] = f"{path}/-"
 
             result = apply_patch(subject, [operation], in_place=in_place)
             if not in_place:

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -339,10 +339,9 @@ def apply_patches():
     if not hasattr(apigateway_models.APIGatewayBackend, "update_deployment"):
         apigateway_models.APIGatewayBackend.update_deployment = backend_update_deployment
 
-    apigateway_models_RestAPI_to_dict_orig = apigateway_models.RestAPI.to_dict
-
-    def apigateway_models_RestAPI_to_dict(self):
-        resp = apigateway_models_RestAPI_to_dict_orig(self)
+    @patch(apigateway_models.RestAPI.to_dict)
+    def apigateway_models_rest_api_to_dict(fn, self):
+        resp = fn(self)
         resp["policy"] = None
         if self.policy:
             # Strip whitespaces for TF compatibility (not entirely sure why we need double-dumps,
@@ -404,4 +403,3 @@ def apply_patches():
 
     apigateway_response_usage_plan_individual_orig = APIGatewayResponse.usage_plan_individual
     APIGatewayResponse.usage_plan_individual = apigateway_response_usage_plan_individual
-    apigateway_models.RestAPI.to_dict = apigateway_models_RestAPI_to_dict

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -11,22 +11,12 @@ from moto.apigateway.exceptions import (
 from moto.apigateway.responses import APIGatewayResponse
 from moto.core.utils import camelcase_to_underscores
 
-from localstack.aws.accounts import get_aws_account_id
-from localstack.aws.api.apigateway import NotFoundException
 from localstack.services.apigateway.helpers import TAG_KEY_CUSTOM_ID, apply_json_patch_safe
 from localstack.utils.collections import ensure_list
 from localstack.utils.common import DelSafeDict, str_to_bool, to_str
-from localstack.utils.json import parse_json_or_yaml
+from localstack.utils.patch import patch
 
 LOG = logging.getLogger(__name__)
-
-# additional REST API attributes
-REST_API_ATTRIBUTES = [
-    "apiKeySource",
-    "binaryMediaTypes",
-    "disableExecuteApiEndpoint",
-    "minimumCompressionSize",
-]
 
 
 def apply_patches():
@@ -55,8 +45,6 @@ def apply_patches():
 
         model_attributes = list(entity.keys())
         for operation in patch_operations:
-            if operation["path"].strip("/") in REST_API_ATTRIBUTES:
-                operation["path"] = camelcase_to_underscores(operation["path"])
             path_start = operation["path"].strip("/").split("/")[0]
             path_start_usc = camelcase_to_underscores(path_start)
             if path_start not in model_attributes and path_start_usc in model_attributes:
@@ -71,42 +59,6 @@ def apply_patches():
             entity["disableExecuteApiEndpoint"] = bool(entity.pop("disable_execute_api_endpoint"))
         if "binary_media_types" in entity:
             entity["binaryMediaTypes"] = ensure_list(entity.pop("binary_media_types"))
-
-    def apigateway_response_restapis_individual(self, request, full_url, headers):
-        if request.method in ["GET", "DELETE"]:
-            return apigateway_response_restapis_individual_orig(self, request, full_url, headers)
-
-        self.setup_class(request, full_url, headers)
-        function_id = self.path.replace("/restapis/", "", 1).split("/")[0]
-
-        if self.method == "PATCH":
-            rest_api = self.backend.apis.get(function_id)
-            if not rest_api:
-                msg = f"Invalid API identifier specified {get_aws_account_id()}:{function_id}"
-                raise NotFoundException(msg)
-
-            if not isinstance(rest_api.__dict__, DelSafeDict):
-                rest_api.__dict__ = DelSafeDict(rest_api.__dict__)
-
-            result = _patch_api_gateway_entity(self, rest_api.__dict__)
-            if result is not None:
-                return result
-
-            # fix data types after patches have been applied
-            rest_api.minimum_compression_size = int(rest_api.minimum_compression_size or -1)
-            endpoint_configs = rest_api.endpoint_configuration or {}
-            if isinstance(endpoint_configs.get("vpcEndpointIds"), str):
-                endpoint_configs["vpcEndpointIds"] = [endpoint_configs["vpcEndpointIds"]]
-
-            return 200, {}, json.dumps(self.backend.get_rest_api(function_id).to_dict())
-
-        # handle import rest_api via swagger file
-        if self.method == "PUT":
-            body = parse_json_or_yaml(to_str(self.body))
-            rest_api = self.backend.put_rest_api(function_id, body, self.querystring)
-            return 200, {}, json.dumps(rest_api.to_dict())
-
-        return 400, {}, ""
 
     def apigateway_response_resource_individual(self, request, full_url, headers):
         if request.method in ["GET", "DELETE"]:
@@ -381,9 +333,6 @@ def apply_patches():
             raise NoIntegrationDefined()
         return resource_method.method_integration
 
-    # TODO: put_rest_api now available upstream - see if we can leverage some synergies
-    apigateway_response_restapis_individual_orig = APIGatewayResponse.restapis_individual
-    APIGatewayResponse.restapis_individual = apigateway_response_restapis_individual
     apigateway_response_resource_individual_orig = APIGatewayResponse.resource_individual
     APIGatewayResponse.resource_individual = apigateway_response_resource_individual
 
@@ -405,9 +354,6 @@ def apply_patches():
         if not self.tags:
             resp["tags"] = None
 
-        for attr in REST_API_ATTRIBUTES:
-            if attr not in resp:
-                resp[attr] = getattr(self, camelcase_to_underscores(attr), None)
         resp["disableExecuteApiEndpoint"] = (
             str(resp.get("disableExecuteApiEndpoint")).lower() == "true"
         )
@@ -427,28 +373,26 @@ def apply_patches():
             return 201, {}, json.dumps(deployment)
         return result
 
-    def create_rest_api(self, *args, tags={}, **kwargs):
+    @patch(apigateway_models.APIGatewayBackend.create_rest_api)
+    def create_rest_api(fn, self, *args, tags=None, **kwargs):
         """
         https://github.com/localstack/localstack/pull/4413/files
         Add ability to specify custom IDs for API GW REST APIs via tags
         """
-        result = create_rest_api_orig(self, *args, tags=tags, **kwargs)
         tags = tags or {}
+        result = fn(self, *args, tags=tags, **kwargs)
         if custom_id := tags.get(TAG_KEY_CUSTOM_ID):
             self.apis.pop(result.id)
             result.id = custom_id
             self.apis[custom_id] = result
         return result
 
+    @patch(apigateway_models.APIGatewayBackend.get_rest_api, pass_target=False)
     def get_rest_api(self, function_id):
         for key in self.apis.keys():
             if key.lower() == function_id.lower():
                 return self.apis[key]
         raise RestAPINotFound()
-
-    create_rest_api_orig = apigateway_models.APIGatewayBackend.create_rest_api
-    apigateway_models.APIGatewayBackend.create_rest_api = create_rest_api
-    apigateway_models.APIGatewayBackend.get_rest_api = get_rest_api
 
     apigateway_models.Resource.get_integration = apigateway_models_resource_get_integration
     apigateway_response_resource_methods_orig = APIGatewayResponse.resource_methods

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -157,7 +157,11 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         patch_operations: ListOfPatchOperation = None,
     ) -> RestApi:
         moto_backend = get_moto_backend(context)
-        rest_api = moto_backend.get_rest_api(rest_api_id)
+        rest_api = moto_backend.apis.get(rest_api_id)
+        if not rest_api:
+            raise NotFoundException(
+                f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
+            )
 
         fixed_patch_ops = []
         binary_media_types_path = "/binaryMediaTypes"

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -2,9 +2,10 @@ import io
 import json
 import logging
 from copy import deepcopy
-from typing import IO
+from typing import IO, Dict
 
 from moto.apigateway import models as apigw_models
+from moto.core.utils import camelcase_to_underscores
 
 from localstack.aws.api import RequestContext, ServiceRequest, handler
 from localstack.aws.api.apigateway import (
@@ -13,6 +14,7 @@ from localstack.aws.api.apigateway import (
     ApiKeys,
     Authorizer,
     Authorizers,
+    BadRequestException,
     BasePathMapping,
     BasePathMappings,
     Blob,
@@ -37,6 +39,7 @@ from localstack.aws.api.apigateway import (
     RequestValidator,
     RequestValidators,
     RestApi,
+    RestApis,
     String,
     Tags,
     TestInvokeMethodRequest,
@@ -59,12 +62,35 @@ from localstack.services.apigateway.router_asf import ApigatewayRouter, to_invoc
 from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
-from localstack.utils.collections import PaginatedList, ensure_list, select_from_typed_dict
+from localstack.utils.collections import (
+    DelSafeDict,
+    PaginatedList,
+    ensure_list,
+    select_from_typed_dict,
+)
 from localstack.utils.json import parse_json_or_yaml
 from localstack.utils.strings import short_uid, str_to_bool, to_str
 from localstack.utils.time import now_utc
 
 LOG = logging.getLogger(__name__)
+
+
+def get_moto_backend(context: RequestContext) -> apigw_models.APIGatewayBackend:
+    return apigw_models.apigateway_backends[context.account_id][context.region]
+
+
+def remove_empty_attributes_from_rest_api(rest_api: RestApi, remove_tags=True):
+    if not rest_api.get("binaryMediaTypes"):
+        rest_api.pop("binaryMediaTypes", None)
+    if remove_tags:
+        if not rest_api.get("tags"):
+            rest_api.pop("tags", None)
+    else:
+        rest_api["tags"] = {}
+    if rest_api.get("version") == "V1":
+        rest_api.pop("version", None)
+    if not rest_api.get("description"):
+        rest_api.pop("description", None)
 
 
 class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
@@ -107,22 +133,84 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
     @handler("CreateRestApi", expand=False)
     def create_rest_api(self, context: RequestContext, request: CreateRestApiRequest) -> RestApi:
+        # binaryMediaTypes: Optional[ListOfString]
+        #     minimumCompressionSize: Optional[NullableInteger]
+        #     apiKeySource: Optional[ApiKeySourceType]
+        #     endpointConfiguration: Optional[EndpointConfiguration]
+        #     policy: Optional[String]
+        #     tags: Optional[MapOfStringToString]
+        #     disableExecuteApiEndpoint: Optional[Boolean]
         result = call_moto(context)
-        if not result.get("binaryMediaTypes"):
-            result.pop("binaryMediaTypes", None)
-        if not result.get("tags"):
-            result.pop("tags", None)
-        if result.get("version") == "V1":
-            result.pop("version", None)
+        remove_empty_attributes_from_rest_api(result)
+
         return result
+
+    def get_rest_api(self, context: RequestContext, rest_api_id: String) -> RestApi:
+        rest_api: RestApi = call_moto(context)
+        remove_empty_attributes_from_rest_api(rest_api)
+        return rest_api
+
+    def update_rest_api(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        patch_operations: ListOfPatchOperation = None,
+    ) -> RestApi:
+        moto_backend = get_moto_backend(context)
+        rest_api = moto_backend.get_rest_api(rest_api_id)
+
+        fixed_patch_ops = []
+        binary_media_types_path = "/binaryMediaTypes"
+        for patch_op in patch_operations:
+            patch_op_path = patch_op.get("path", "")
+            # binaryMediaTypes has a specific way of being set
+            # see https://docs.aws.amazon.com/apigateway/latest/api/API_PatchOperation.html
+            # TODO: maybe implement a more generalized way if this happens anywhere else
+            if patch_op_path.startswith(binary_media_types_path):
+                if patch_op_path == binary_media_types_path:
+                    raise BadRequestException(f"Invalid patch path {patch_op_path}")
+                value = patch_op_path.rsplit("/", maxsplit=1)[-1]
+                path_value = value.replace("~1", "/")
+                patch_op["path"] = "/binaryMediaTypes"
+
+                if patch_op["op"] == "add":
+                    patch_op["value"] = path_value
+
+                elif patch_op["op"] == "remove":
+                    remove_index = rest_api.binaryMediaTypes.index(path_value)
+                    patch_op["path"] = f"/binaryMediaTypes/{remove_index}"
+
+                elif patch_op["op"] == "replace":
+                    # AWS is behaving weirdly, and will actually remove/add instead of replacing in place
+                    # it will put the replaced value last in the array
+                    replace_index = rest_api.binaryMediaTypes.index(path_value)
+                    fixed_patch_ops.append(
+                        {"op": "remove", "path": f"/binaryMediaTypes/{replace_index}"}
+                    )
+                    patch_op["op"] = "add"
+
+            fixed_patch_ops.append(patch_op)
+
+        if not isinstance(rest_api.__dict__, DelSafeDict):
+            rest_api.__dict__ = DelSafeDict(rest_api.__dict__)
+
+        _patch_api_gateway_entity(rest_api.__dict__, fixed_patch_ops)
+
+        # fix data types after patches have been applied
+        if rest_api.minimum_compression_size:
+            rest_api.minimum_compression_size = int(rest_api.minimum_compression_size or -1)
+        endpoint_configs = rest_api.endpoint_configuration or {}
+        if isinstance(endpoint_configs.get("vpcEndpointIds"), str):
+            endpoint_configs["vpcEndpointIds"] = [endpoint_configs["vpcEndpointIds"]]
+
+        response = rest_api.to_dict()
+        remove_empty_attributes_from_rest_api(response, remove_tags=False)
+        return response
 
     @handler("PutRestApi", expand=False)
     def put_rest_api(self, context: RequestContext, request: PutRestApiRequest) -> RestApi:
-        account_id = context.account_id
-        region_name = context.region
-        rest_api = apigw_models.apigateway_backends[account_id][region_name].apis.get(
-            request["restApiId"]
-        )
+        moto_backend = get_moto_backend(context)
+        rest_api = moto_backend.get_rest_api(request["restApiId"])
         body_data = request["body"].read()
 
         openapi_spec = parse_json_or_yaml(to_str(body_data))
@@ -130,7 +218,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             rest_api, openapi_spec, context.request.values.to_dict()
         )
 
-        return to_rest_api_response_json(rest_api.to_dict())
+        response = rest_api.to_dict()
+        remove_empty_attributes_from_rest_api(response)
+        # TODO: verify this
+        return to_rest_api_response_json(response)
 
     def delete_rest_api(self, context: RequestContext, rest_api_id: String) -> None:
         try:
@@ -140,6 +231,14 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             raise NotFoundException(
                 f"Invalid API identifier specified {context.account_id}:{rest_api_id}"
             ) from e
+
+    def get_rest_apis(
+        self, context: RequestContext, position: String = None, limit: NullableInteger = None
+    ) -> RestApis:
+        response: RestApis = call_moto(context)
+        for rest_api in response["items"]:
+            remove_empty_attributes_from_rest_api(rest_api)
+        return response
 
     # method responses
 
@@ -779,6 +878,21 @@ def normalize_authorizer(data):
         entry["authorizerResultTtlInSeconds"] = int(entry.get("authorizerResultTtlInSeconds", 300))
         entries[i] = entry
     return entries if is_list else entries[0]
+
+
+def _patch_api_gateway_entity(entity: Dict, patch_operations: ListOfPatchOperation):
+    not_supported_attributes = {"/id", "/region_name", "/create_date"}
+
+    model_attributes = list(entity.keys())
+    for operation in patch_operations:
+        path_start = operation["path"].strip("/").split("/")[0]
+        path_start_usc = camelcase_to_underscores(path_start)
+        if path_start not in model_attributes and path_start_usc in model_attributes:
+            operation["path"] = operation["path"].replace(path_start, path_start_usc)
+        if operation["path"] in not_supported_attributes:
+            raise BadRequestException(f"Invalid patch path {operation['path']}")
+
+    apply_json_patch_safe(entity, patch_operations, in_place=True)
 
 
 def to_authorizer_response_json(api_id, data):

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -115,6 +115,41 @@ class TestApiGatewayApi:
         assert len(items) == 1
 
     @pytest.mark.aws_validated
+    def test_create_rest_api_with_optional_params(
+        self,
+        apigateway_client,
+        apigw_create_rest_api,
+        snapshot,
+    ):
+        # create only with mandatory name
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}",
+        )
+        snapshot.match("create-only-name", response)
+
+        # create with empty description
+        with pytest.raises(ClientError) as e:
+            apigw_create_rest_api(
+                name=f"test-api-{short_uid()}",
+                description="",
+            )
+        snapshot.match("create-empty-desc", e.value.response)
+
+        # create with random version
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}",
+            version="v1",
+        )
+        snapshot.match("create-with-version", response)
+
+        # create with empty binaryMediaTypes
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}",
+            binaryMediaTypes=[],
+        )
+        snapshot.match("create-with-empty-binary-media", response)
+
+    @pytest.mark.aws_validated
     def test_create_rest_api_with_tags(self, apigateway_client, apigw_create_rest_api, snapshot):
         response = apigw_create_rest_api(
             name=f"test-api-{short_uid()}",

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -235,3 +235,11 @@ class TestApiGatewayApi:
             ]
             apigateway_client.update_rest_api(restApiId=api_id, patchOperations=patch_operations)
         snapshot.match("update-rest-api-remove-base-path", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_update_rest_api_invalid_api_id(self, apigateway_client, snapshot):
+        patch_operations = [{"op": "replace", "path": "/apiKeySource", "value": "AUTHORIZER"}]
+        with pytest.raises(ClientError) as ex:
+            apigateway_client.update_rest_api(restApiId="api_id", patchOperations=patch_operations)
+        snapshot.match("not-found-update-rest-api", ex.value.response)
+        assert ex.value.response["Error"]["Code"] == "NotFoundException"

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -85,8 +85,8 @@ def test_import_rest_api(import_apigw, snapshot):
 class TestApiGatewayApi:
     @pytest.mark.aws_validated
     def test_list_and_delete_apis(self, apigateway_client, apigw_create_rest_api, snapshot):
-        api_name1 = "test-list-and-delete-apis-1"
-        api_name2 = "test-list-and-delete-apis-2"
+        api_name1 = f"test-list-and-delete-apis-{short_uid()}"
+        api_name2 = f"test-list-and-delete-apis-{short_uid()}"
 
         response = apigw_create_rest_api(name=api_name1, description="this is my api")
         snapshot.match("create-rest-api-1", response)
@@ -100,19 +100,11 @@ class TestApiGatewayApi:
         response["items"].sort(key=itemgetter("createdDate"))
         snapshot.match("get-rest-api-before-delete", response)
 
-        # TODO: remove this once we know we have proper cleanup of resources
-        items = [item for item in response["items"] if item["name"] in [api_name1, api_name2]]
-        assert len(items) == 2
-
         response = apigateway_client.delete_rest_api(restApiId=api_id)
         snapshot.match("delete-rest-api", response)
 
         response = apigateway_client.get_rest_apis()
         snapshot.match("get-rest-api-after-delete", response)
-
-        # TODO: remove this once we know we have proper cleanup of resources
-        items = [item for item in response["items"] if item["name"] in [api_name1, api_name2]]
-        assert len(items) == 1
 
     @pytest.mark.aws_validated
     def test_create_rest_api_with_optional_params(

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1,4 +1,301 @@
 {
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_list_and_delete_apis": {
+    "recorded-date": "01-02-2023, 20:16:52",
+    "recorded-content": {
+      "create-rest-api-1": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-rest-api-2": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api2",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:2>",
+        "name": "<name:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-rest-api-before-delete": {
+        "items": [
+          {
+            "apiKeySource": "HEADER",
+            "createdDate": "datetime",
+            "description": "this is my api",
+            "disableExecuteApiEndpoint": false,
+            "endpointConfiguration": {
+              "types": [
+                "EDGE"
+              ]
+            },
+            "id": "<id:1>",
+            "name": "<name:1>"
+          },
+          {
+            "apiKeySource": "HEADER",
+            "createdDate": "datetime",
+            "description": "this is my api2",
+            "disableExecuteApiEndpoint": false,
+            "endpointConfiguration": {
+              "types": [
+                "EDGE"
+              ]
+            },
+            "id": "<id:2>",
+            "name": "<name:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-rest-api": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "get-rest-api-after-delete": {
+        "items": [
+          {
+            "apiKeySource": "HEADER",
+            "createdDate": "datetime",
+            "description": "this is my api2",
+            "disableExecuteApiEndpoint": false,
+            "endpointConfiguration": {
+              "types": [
+                "EDGE"
+              ]
+            },
+            "id": "<id:2>",
+            "name": "<name:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_tags": {
+    "recorded-date": "01-02-2023, 20:11:19",
+    "recorded-content": {
+      "create-rest-api-w-tags": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {
+          "MY_TAG1": "MY_VALUE1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-rest-api-w-tags": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {
+          "MY_TAG1": "MY_VALUE1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-rest-apis-w-tags": {
+        "items": [
+          {
+            "apiKeySource": "HEADER",
+            "createdDate": "datetime",
+            "description": "this is my api",
+            "disableExecuteApiEndpoint": false,
+            "endpointConfiguration": {
+              "types": [
+                "EDGE"
+              ]
+            },
+            "id": "<id:1>",
+            "name": "<name:1>",
+            "tags": {
+              "MY_TAG1": "MY_VALUE1"
+            }
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_operation_add_remove": {
+    "recorded-date": "01-02-2023, 20:11:40",
+    "recorded-content": {
+      "update-rest-api-add": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/png",
+          "image/jpeg"
+        ],
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-rest-api-replace": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/jpeg",
+          "image/gif"
+        ],
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-rest-api-remove": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "image/jpeg"
+        ],
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_behaviour": {
+    "recorded-date": "01-02-2023, 20:27:17",
+    "recorded-content": {
+      "update-rest-api-array": {
+        "apiKeySource": "HEADER",
+        "binaryMediaTypes": [
+          "-"
+        ],
+        "createdDate": "datetime",
+        "description": "this is my api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {},
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-rest-api-add-base-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /binaryMediaTypes"
+        },
+        "message": "Invalid patch path /binaryMediaTypes",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-rest-api-replace-base-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /binaryMediaTypes"
+        },
+        "message": "Invalid patch path /binaryMediaTypes",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-rest-api-remove-base-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /binaryMediaTypes"
+        },
+        "message": "Invalid patch path /binaryMediaTypes",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
   "tests/integration/apigateway/test_apigateway_api.py::test_import_rest_api": {
     "recorded-date": "10-01-2023, 20:08:25",
     "recorded-content": {

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -320,5 +320,21 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_rest_api_invalid_api_id": {
+    "recorded-date": "01-02-2023, 22:26:45",
+    "recorded-content": {
+      "not-found-update-rest-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:api_id"
+        },
+        "message": "Invalid API identifier specified 111111111111:api_id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -336,5 +336,70 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_rest_api_with_optional_params": {
+    "recorded-date": "01-02-2023, 23:48:05",
+    "recorded-content": {
+      "create-only-name": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-empty-desc": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Description cannot be an empty string"
+        },
+        "message": "Description cannot be an empty string",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-with-version": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:2>",
+        "name": "<name:2>",
+        "version": "v1",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-with-empty-binary-media": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:3>",
+        "name": "<name:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -2244,7 +2244,7 @@ def test_import_swagger_api(apigateway_client):
     api_spec_dict = json.loads(api_spec)
 
     backend = apigateway_backends[TEST_AWS_ACCOUNT_ID][TEST_AWS_REGION_NAME]
-    api_model = backend.create_rest_api(name="")
+    api_model = backend.create_rest_api(name="api_name", description="description-1")
 
     imported_api = import_api_from_openapi_spec(api_model, api_spec_dict, {})
 

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -873,7 +873,7 @@ class TestAPIGateway:
         target_uri = arns.apigateway_invocations_arn(lambda_uri)
 
         # create REST API
-        api_id, _, _ = create_rest_apigw(name="test-api", description="")
+        api_id, _, _ = create_rest_apigw(name="test-api")
         root_res_id = apigateway_client.get_resources(restApiId=api_id)["items"][0]["id"]
         api_resource = apigateway_client.create_resource(
             restApiId=api_id, parentId=root_res_id, pathPart="test"
@@ -1032,7 +1032,7 @@ class TestAPIGateway:
         lambda_uri = arns.lambda_function_arn(lambda_name)
 
         # create REST API
-        api_id, _, _ = create_rest_apigw(name="test-api", description="")
+        api_id, _, _ = create_rest_apigw(name="test-api")
         root_res_id = apigateway_client.get_resources(restApiId=api_id)["items"][0]["id"]
 
         # create authorizer at root resource
@@ -1796,7 +1796,7 @@ class TestAPIGateway:
         assert "POST,OPTIONS" == result.headers.get("Access-Control-Allow-Methods")
 
     def test_api_gateway_update_resource_path_part(self, apigateway_client, create_rest_apigw):
-        api_id, _, _ = create_rest_apigw(name="test-api", description="")
+        api_id, _, _ = create_rest_apigw(name="test-api")
         root_res_id = apigateway_client.get_resources(restApiId=api_id)["items"][0]["id"]
         api_resource = apigateway_client.create_resource(
             restApiId=api_id, parentId=root_res_id, pathPart="test"
@@ -2244,7 +2244,7 @@ def test_import_swagger_api(apigateway_client):
     api_spec_dict = json.loads(api_spec)
 
     backend = apigateway_backends[TEST_AWS_ACCOUNT_ID][TEST_AWS_REGION_NAME]
-    api_model = backend.create_rest_api(name="", description="")
+    api_model = backend.create_rest_api(name="")
 
     imported_api = import_api_from_openapi_spec(api_model, api_spec_dict, {})
 

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 import pytest
 import requests
@@ -10,64 +11,14 @@ from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
 from tests.integration.test_apigateway import TEST_IMPORT_PETSTORE_SWAGGER
 
+LOG = logging.getLogger(__name__)
+
 
 def test_update_rest_api_invalid_api_id(apigateway_client):
     patchOperations = [{"op": "replace", "path": "/apiKeySource", "value": "AUTHORIZER"}]
     with pytest.raises(ClientError) as ex:
         apigateway_client.update_rest_api(restApiId="api_id", patchOperations=patchOperations)
     assert ex.value.response["Error"]["Code"] == "NotFoundException"
-
-
-# TODO enable/fix test!
-@pytest.mark.skip
-def test_update_rest_api_operation_add_remove(apigateway_client):
-    response = apigateway_client.create_rest_api(name="my_api", description="this is my api")
-    api_id = response["id"]
-    patchOperations = [
-        {"op": "add", "path": "/binaryMediaTypes", "value": "image/png"},
-        {"op": "add", "path": "/binaryMediaTypes", "value": "image/jpeg"},
-    ]
-    response = apigateway_client.update_rest_api(restApiId=api_id, patchOperations=patchOperations)
-    assert response["binaryMediaTypes"] == ["image/png", "image/jpeg"]
-    assert response["description"] == "this is my api"
-    patchOperations = [
-        {"op": "remove", "path": "/binaryMediaTypes", "value": "image/png"},
-        {"op": "remove", "path": "/description"},
-    ]
-    response = apigateway_client.update_rest_api(restApiId=api_id, patchOperations=patchOperations)
-    assert response["binaryMediaTypes"] == ["image/jpeg"]
-    assert response["description"] == ""
-
-
-def test_list_and_delete_apis(apigateway_client):
-    api_name1 = short_uid()
-    api_name2 = short_uid()
-
-    response = apigateway_client.create_rest_api(name=api_name1, description="this is my api")
-    api_id = response["id"]
-    apigateway_client.create_rest_api(name=api_name2, description="this is my api2")
-
-    response = apigateway_client.get_rest_apis()
-    items = [item for item in response["items"] if item["name"] in [api_name1, api_name2]]
-    assert len(items) == (2)
-
-    apigateway_client.delete_rest_api(restApiId=api_id)
-
-    response = apigateway_client.get_rest_apis()
-    items = [item for item in response["items"] if item["name"] in [api_name1, api_name2]]
-    assert len(items) == 1
-
-
-def test_create_rest_api_with_tags(apigateway_client):
-    response = apigateway_client.create_rest_api(
-        name="my_api", description="this is my api", tags={"MY_TAG1": "MY_VALUE1"}
-    )
-    api_id = response["id"]
-
-    response = apigateway_client.get_rest_api(restApiId=api_id)
-
-    assert "tags" in response
-    assert response["tags"] == {"MY_TAG1": "MY_VALUE1"}
 
 
 @pytest.mark.skip

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -14,13 +14,6 @@ from tests.integration.test_apigateway import TEST_IMPORT_PETSTORE_SWAGGER
 LOG = logging.getLogger(__name__)
 
 
-def test_update_rest_api_invalid_api_id(apigateway_client):
-    patchOperations = [{"op": "replace", "path": "/apiKeySource", "value": "AUTHORIZER"}]
-    with pytest.raises(ClientError) as ex:
-        apigateway_client.update_rest_api(restApiId="api_id", patchOperations=patchOperations)
-    assert ex.value.response["Error"]["Code"] == "NotFoundException"
-
-
 @pytest.mark.skip
 def test_create_authorizer(apigateway_client, cognito_idp_client):
     authorizer_name = "my_authorizer"


### PR DESCRIPTION
This PR introduces and migrates some current API Gateway tests to a new file structure, and those are AWS validated. The focus of this PR is the `RestAPI` resource. 

The end goal is to remove most of the moto patches contained in `localstack/services/apigateway/patches.py` if those can be part of the ASF provider (some makes sense to stay, as they directly interact with the moto backend and would be harder to implement, those will be migrate to use `@patch`), and to improve parity on basic CRUD operations of the provider. 
