### PR TITLE
[Bugfix] fixed populating unprocessed item

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -857,7 +857,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                 unprocessed[table_name] = []
             for key in ["PutRequest", "DeleteRequest"]:
                 if any(unprocessed_items[key]):
-                    unprocessed_items[table_name].append({key: unprocessed_items[key]})
+                    unprocessed[table_name].append({key: unprocessed_items[key]})
             for key in list(unprocessed.keys()):
                 if not unprocessed.get(key):
                     del unprocessed[key]


### PR DESCRIPTION
Issue:

https://github.com/localstack/localstack/issues/7597

The fix is simple. unprocessed items should be appended to `unprocessed[table_name]` not `unprocessed_items[table_name]`

Tested the fix in my docker container. 