### PR TITLE
fix cfn stack events resource types

### DIFF
--- a/localstack/services/cloudformation/engine/entities.py
+++ b/localstack/services/cloudformation/engine/entities.py
@@ -143,8 +143,20 @@ class Stack:
         self.metadata[attribute] = new_time or timestamp_millis()
 
     def add_stack_event(
-        self, resource_id: str, physical_res_id: str, status: str, status_reason: str = None
+        self,
+        resource_id: str = None,
+        physical_res_id: str = None,
+        status: str = "",
+        status_reason: str = "",
     ):
+        resource_id = resource_id or self.stack_name
+        physical_res_id = physical_res_id or self.stack_id
+        resource_type = (
+            self.template.get("Resources", {})
+            .get(resource_id, {})
+            .get("Type", "AWS::CloudFormation::Stack")
+        )
+
         event = {
             "EventId": long_uid(),
             "Timestamp": timestamp_millis(),
@@ -153,7 +165,7 @@ class Stack:
             "LogicalResourceId": resource_id,
             "PhysicalResourceId": physical_res_id,
             "ResourceStatus": status,
-            "ResourceType": "AWS::CloudFormation::Stack",
+            "ResourceType": resource_type,
         }
 
         if status_reason:

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -538,5 +538,6 @@ def test_events_resource_types(deploy_cfn_template, cfn_client, snapshot):
     stack = deploy_cfn_template(template_path=template_path, max_wait=500)
     events = cfn_client.describe_stack_events(StackName=stack.stack_name)["StackEvents"]
 
-    resource_types = set([event["ResourceType"] for event in events])
-    snapshot.match("resource_types", dict.fromkeys(resource_types, 0))
+    resource_types = list(set([event["ResourceType"] for event in events]))
+    resource_types.sort()
+    snapshot.match("resource_types", resource_types)

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -528,3 +528,13 @@ def test_update_termination_protection(deploy_cfn_template, cfn_client, sns_clie
     )
     res = cfn_client.describe_stacks(StackName=stack.stack_name)
     snapshot.match("describe-stack-2", res)
+
+
+@pytest.mark.aws_validated
+def test_events_types(deploy_cfn_template, cfn_client, snapshot):
+    template_path = os.path.join(os.path.dirname(__file__), "../../templates/sfn_apigateway.yaml")
+    stack = deploy_cfn_template(template_path=template_path)
+    events = cfn_client.describe_stack_events(StackName=stack.stack_name)["StackEvents"]
+
+    resource_types = set([event["ResourceType"] for event in events])
+    assert resource_types

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -531,10 +531,12 @@ def test_update_termination_protection(deploy_cfn_template, cfn_client, sns_clie
 
 
 @pytest.mark.aws_validated
-def test_events_types(deploy_cfn_template, cfn_client, snapshot):
-    template_path = os.path.join(os.path.dirname(__file__), "../../templates/sfn_apigateway.yaml")
-    stack = deploy_cfn_template(template_path=template_path)
+def test_events_resource_types(deploy_cfn_template, cfn_client, snapshot):
+    template_path = os.path.join(
+        os.path.dirname(__file__), "../../templates/cfn_cdk_sample_app.yaml"
+    )
+    stack = deploy_cfn_template(template_path=template_path, max_wait=500)
     events = cfn_client.describe_stack_events(StackName=stack.stack_name)["StackEvents"]
 
     resource_types = set([event["ResourceType"] for event in events])
-    assert resource_types
+    snapshot.match("resource_types", dict.fromkeys(resource_types, 0))

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -563,5 +563,17 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/api/test_stacks.py::test_events_resource_types": {
+    "recorded-date": "02-02-2023, 14:34:00",
+    "recorded-content": {
+      "resource_types": {
+        "AWS::CloudFormation::Stack": 0,
+        "AWS::SNS::Subscription": 0,
+        "AWS::SNS::Topic": 0,
+        "AWS::SQS::Queue": 0,
+        "AWS::SQS::QueuePolicy": 0
+      }
+    }
   }
 }

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -565,15 +565,15 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_events_resource_types": {
-    "recorded-date": "02-02-2023, 14:34:00",
+    "recorded-date": "15-02-2023, 10:46:53",
     "recorded-content": {
-      "resource_types": {
-        "AWS::CloudFormation::Stack": 0,
-        "AWS::SNS::Subscription": 0,
-        "AWS::SNS::Topic": 0,
-        "AWS::SQS::Queue": 0,
-        "AWS::SQS::QueuePolicy": 0
-      }
+      "resource_types": [
+        "AWS::CloudFormation::Stack",
+        "AWS::SNS::Subscription",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SQS::QueuePolicy"
+      ]
     }
   }
 }


### PR DESCRIPTION
With this change the CFn Api returns the correct resource type in the stack events. Important for cli tools that rely in the stack events for progress indicators.