### PR TITLE
Set download retries and log download exceptions for installer failures

### DIFF
--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -106,6 +106,7 @@ class ArchiveDownloadAndExtractInstaller(ExecutableInstaller):
         archive_name = os.path.basename(download_url)
         download_and_extract(
             download_url,
+            retries=3,
             tmp_archive=os.path.join(config.dirs.tmp, archive_name),
             target_dir=target_directory,
         )

--- a/localstack/utils/archives.py
+++ b/localstack/utils/archives.py
@@ -186,23 +186,20 @@ def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archiv
         # create temporary placeholder file, to avoid duplicate parallel downloads
         save_file(tmp_archive, "")
 
-        current_try = 1
-        while current_try <= retries + 1:
+        for i in range(retries + 1):
             try:
                 download(archive_url, tmp_archive)
                 break
             except Exception as e:
                 LOG.warning(
                     "Attempt %d. Failed to download archive from %s: %s",
-                    current_try,
+                    i + 1,
                     archive_url,
                     e,
                 )
                 # only sleep between retries, not after the last one
-                if current_try <= retries:
+                if i < retries:
                     time.sleep(sleep)
-            finally:
-                current_try += 1
 
     # if the temporary file we created above hasn't been replaced, we assume failure
     if os.path.getsize(tmp_archive) <= 0:

--- a/localstack/utils/archives.py
+++ b/localstack/utils/archives.py
@@ -185,12 +185,29 @@ def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archiv
     if not os.path.exists(tmp_archive) or os.path.getsize(tmp_archive) <= 0:
         # create temporary placeholder file, to avoid duplicate parallel downloads
         save_file(tmp_archive, "")
-        for i in range(retries + 1):
+
+        current_try = 1
+        while current_try <= retries + 1:
             try:
                 download(archive_url, tmp_archive)
                 break
-            except Exception:
-                time.sleep(sleep)
+            except Exception as e:
+                LOG.warning(
+                    "Attempt %d. Failed to download archive from %s: %s",
+                    current_try,
+                    archive_url,
+                    e,
+                )
+                # only sleep between retries, not after the last one
+                if current_try < retries:
+                    time.sleep(sleep)
+            finally:
+                current_try += 1
+
+    # if the temporary file we created above hasn't been replaced, we assume failure
+    if os.path.getsize(tmp_archive) <= 0:
+        raise Exception("Failed to download archive from %s: . Retries exhausted", archive_url)
+
     if ext == ".zip":
         unzip(tmp_archive, target_dir)
     elif ext in (

--- a/localstack/utils/archives.py
+++ b/localstack/utils/archives.py
@@ -199,7 +199,7 @@ def download_and_extract(archive_url, target_dir, retries=0, sleep=3, tmp_archiv
                     e,
                 )
                 # only sleep between retries, not after the last one
-                if current_try < retries:
+                if current_try <= retries:
                     time.sleep(sleep)
             finally:
                 current_try += 1


### PR DESCRIPTION
## Motivation
PR was motivated by failing downloads of ffmpeg where the Installer tries to extract the empty installer file instead of just re-trying to download the archive first. It also didn't log any meaningful exceptions in this case since it wasn't a `requests.exceptions.ReadTimeout`


## Changes

* Downloads are retried up to 3 times
* Exception + retry attempt number are logged in case of a failure
* Extraction is not attempted on an empty "archive" file.