### PR TITLE
fix streaming and header handling for proxies

### DIFF
--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -3,9 +3,8 @@ import abc
 import requests
 from werkzeug import Request, Response
 from werkzeug.datastructures import Headers
-from werkzeug.sansio.utils import get_current_url
 
-from localstack.http.request import get_raw_base_url, get_raw_path, restore_payload
+from localstack.http.request import get_raw_base_url, restore_payload
 
 
 class HttpClient(abc.ABC):
@@ -38,14 +37,7 @@ class HttpClient(abc.ABC):
 class SimpleRequestsClient(HttpClient):
     session: requests.Session
 
-    def __init__(self, session: requests.Session = None, prefer_server: bool = False):
-        """
-        :param session: to reuse (if given)
-        :param prefer_server: True if the WSGI environment's SERVER_NAME and SERVER_PORT should have precedence over the
-                                Request's "Host" header when determining the target URL. This allows setting a different
-                                target without modifying the Host header.
-        """
-        self.prefer_server = prefer_server
+    def __init__(self, session: requests.Session = None):
         self.session = session or requests.Session()
 
     def request(self, request: Request) -> Response:
@@ -60,10 +52,10 @@ class SimpleRequestsClient(HttpClient):
         :param request: the request to perform
         :return: the response.
         """
-        url = self._get_url(request)
         response = self.session.request(
             method=request.method,
-            url=url,
+            # use raw base url to preserve path url encoding
+            url=get_raw_base_url(request),
             # request.args are only the url parameters
             params=[(k, v) for k, v in request.args.items(multi=True)],
             headers=dict(request.headers.items()),
@@ -80,26 +72,6 @@ class SimpleRequestsClient(HttpClient):
             # the final_response object
             final_response.content_length = response.headers.get("Content-Length", 0)
         return final_response
-
-    def _get_url(self, request: Request):
-        """
-        Determines the target URL of the given request depending on the configuration of this client.
-
-        :param request: to construct the URL for
-        :return: URL string which can be used as the target URL by an HTTP client library
-        """
-        if self.prefer_server:
-            # Prefer the WSGI `SERVER_*` fields instead of the `Host` header field
-            server_tuple = request.server
-            if server_tuple is not None and server_tuple[0] is not None:
-                host_part = server_tuple[0]
-                port_part = server_tuple[1]
-                host = host_part if port_part is None else f"{host_part}:{port_part}"
-                scheme = request.environ.get("SERVER_PROTOCOL", None) or request.scheme
-                # make sure to use the raw path to avoid encoding issues
-                return get_current_url(scheme, host, request.root_path, get_raw_path(request))
-        # make sure to use the raw base URL to avoid encoding issues
-        return get_raw_base_url(request)
 
     def close(self):
         self.session.close()

--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -3,8 +3,9 @@ import abc
 import requests
 from werkzeug import Request, Response
 from werkzeug.datastructures import Headers
+from werkzeug.sansio.utils import get_current_url
 
-from localstack.http.request import get_raw_base_url, restore_payload
+from localstack.http.request import get_raw_base_url, get_raw_path, restore_payload
 
 
 class HttpClient(abc.ABC):
@@ -37,7 +38,14 @@ class HttpClient(abc.ABC):
 class SimpleRequestsClient(HttpClient):
     session: requests.Session
 
-    def __init__(self, session: requests.Session = None):
+    def __init__(self, session: requests.Session = None, prefer_server: bool = False):
+        """
+        :param session: to reuse (if given)
+        :param prefer_server: True if the WSGI environment's SERVER_NAME and SERVER_PORT should have precedence over the
+                                Request's "Host" header when determining the target URL. This allows setting a different
+                                target without modifying the Host header.
+        """
+        self.prefer_server = prefer_server
         self.session = session or requests.Session()
 
     def request(self, request: Request) -> Response:
@@ -52,10 +60,10 @@ class SimpleRequestsClient(HttpClient):
         :param request: the request to perform
         :return: the response.
         """
+        url = self._get_url(request)
         response = self.session.request(
             method=request.method,
-            # use raw base url to preserve path url encoding
-            url=get_raw_base_url(request),
+            url=url,
             # request.args are only the url parameters
             params=[(k, v) for k, v in request.args.items(multi=True)],
             headers=dict(request.headers.items()),
@@ -72,6 +80,26 @@ class SimpleRequestsClient(HttpClient):
             # the final_response object
             final_response.content_length = response.headers.get("Content-Length", 0)
         return final_response
+
+    def _get_url(self, request: Request):
+        """
+        Determines the target URL of the given request depending on the configuration of this client.
+
+        :param request: to construct the URL for
+        :return: URL string which can be used as the target URL by an HTTP client library
+        """
+        if self.prefer_server:
+            # Prefer the WSGI `SERVER_*` fields instead of the `Host` header field
+            server_tuple = request.server
+            if server_tuple is not None and server_tuple[0] is not None:
+                host_part = server_tuple[0]
+                port_part = server_tuple[1]
+                host = host_part if port_part is None else f"{host_part}:{port_part}"
+                scheme = request.environ.get("SERVER_PROTOCOL", None) or request.scheme
+                # make sure to use the raw path to avoid encoding issues
+                return get_current_url(scheme, host, request.root_path, get_raw_path(request))
+        # make sure to use the raw base URL to avoid encoding issues
+        return get_raw_base_url(request)
 
     def close(self):
         self.session.close()

--- a/localstack/http/proxy.py
+++ b/localstack/http/proxy.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from typing import Mapping, Union
+from urllib.parse import urlparse
 
 from werkzeug import Request, Response
 from werkzeug.datastructures import Headers
@@ -24,6 +25,9 @@ def forward(
 
 
 class Proxy(HttpClient):
+
+    preserve_host: bool
+
     def __init__(self, forward_base_url: str, client: HttpClient = None):
         """
         Creates a new HTTP Proxy which can be used to forward incoming requests according to the configuration.
@@ -33,12 +37,14 @@ class Proxy(HttpClient):
         """
         self.forward_base_url = forward_base_url
         self.client = client or SimpleRequestsClient()
+        self.preserve_host = True
 
-    def request(self, request: Request) -> Response:
+    def request(self, request: Request, server: str | None = None) -> Response:
         """
         Compatibility with HttpClient interface. A call is equivalent to ``Proxy.forward(request, None, None)``.
 
         :param request: the request to proxy
+        :param server: ignored for a proxy, since the server is already set by `forward_base_url`.
         :return: the proxied response
         """
         return self.forward(request)
@@ -72,7 +78,12 @@ class Proxy(HttpClient):
             forward_path = "/" + forward_path.lstrip("/")
 
         proxy_request = _copy_request(request, self.forward_base_url, forward_path, headers)
-        return self.client.request(proxy_request)
+
+        if self.preserve_host:
+            proxy_request.headers["Host"] = request.host
+
+        target = urlparse(self.forward_base_url)
+        return self.client.request(proxy_request, server=f"{target.scheme}://{target.netloc}")
 
     def close(self):
         self.client.close()
@@ -152,5 +163,8 @@ def _copy_request(
     # explicitly set the path in the environment and in the newly created request
     if path is not None:
         new_request.environ["RAW_URI"] = path or "/"
+
+    # copy headers s.t. they are no longer immutable (by default, EnvironHeaders are used)
+    new_request.headers = Headers(new_request.headers)
 
     return new_request

--- a/localstack/http/proxy.py
+++ b/localstack/http/proxy.py
@@ -28,16 +28,20 @@ class Proxy(HttpClient):
 
     preserve_host: bool
 
-    def __init__(self, forward_base_url: str, client: HttpClient = None):
+    def __init__(
+        self, forward_base_url: str, client: HttpClient = None, preserve_host: bool = True
+    ):
         """
         Creates a new HTTP Proxy which can be used to forward incoming requests according to the configuration.
 
         :param forward_base_url: the base url (backend) to forward the requests to.
         :param client: the HTTP Client used to make the requests
+        :param preserve_host: True to ensure that the Host header of the incoming request is preserved.
+                              If False, then the Host header will be set to the Host from the perspective of the Proxy.
         """
         self.forward_base_url = forward_base_url
         self.client = client or SimpleRequestsClient()
-        self.preserve_host = True
+        self.preserve_host = preserve_host
 
     def request(self, request: Request, server: str | None = None) -> Response:
         """

--- a/tests/unit/http_/conftest.py
+++ b/tests/unit/http_/conftest.py
@@ -5,7 +5,10 @@ from asyncio import AbstractEventLoop
 import pytest
 from hypercorn import Config
 from hypercorn.typing import ASGIFramework
+from werkzeug.datastructures import Headers
+from werkzeug.wrappers import Request as WerkzeugRequest
 
+from localstack.http import Response
 from localstack.http.asgi import ASGIAdapter
 from localstack.http.hypercorn import HypercornServer
 from localstack.utils import net
@@ -53,3 +56,26 @@ def serve_asgi_adapter(serve_asgi_app):
         )
 
     yield _create
+
+
+@pytest.fixture()
+def httpserver_echo_request_metadata():
+    def httpserver_handler(request: WerkzeugRequest) -> Response:
+        """
+        Simple request handler that returns the incoming request metadata (method, path, url, headers).
+
+        :param request: the incoming HTTP request
+        :return: an HTTP response
+        """
+        response = Response()
+        response.set_json(
+            {
+                "method": request.method,
+                "path": request.path,
+                "url": request.url,
+                "headers": Headers(request.headers),
+            }
+        )
+        return response
+
+    return httpserver_handler

--- a/tests/unit/http_/conftest.py
+++ b/tests/unit/http_/conftest.py
@@ -73,7 +73,7 @@ def httpserver_echo_request_metadata():
                 "method": request.method,
                 "path": request.path,
                 "url": request.url,
-                "headers": Headers(request.headers),
+                "headers": dict(Headers(request.headers)),
             }
         )
         return response

--- a/tests/unit/http_/test_hypercorn.py
+++ b/tests/unit/http_/test_hypercorn.py
@@ -1,13 +1,16 @@
+import re
 from contextlib import contextmanager
 
 import requests
+from werkzeug.datastructures import Headers
+from werkzeug.wrappers import Request as WerkzeugRequest
 
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.aws.gateway import Gateway
 from localstack.http import Response
 from localstack.http.hypercorn import GatewayServer, ProxyServer
-from localstack.utils.net import get_free_tcp_port
+from localstack.utils.net import IP_REGEX, get_free_tcp_port
 from localstack.utils.serving import Server
 
 
@@ -40,12 +43,97 @@ def test_gateway_server():
 def test_proxy_server(httpserver):
     httpserver.expect_request("/base-path/relative-path").respond_with_data("Reached Mock Server.")
     port = get_free_tcp_port()
-    proxy_server = ProxyServer(
-        f"{httpserver.url_for('/base-path')}", port, "127.0.0.1", use_ssl=True
-    )
+    proxy_server = ProxyServer(httpserver.url_for("/base-path"), port, "127.0.0.1", use_ssl=True)
     with server_context(proxy_server):
         # Test that only the base path is added by the proxy
         response = requests.get(
             f"https://localhost.localstack.cloud:{port}/relative-path", data="data"
         )
         assert response.text == "Reached Mock Server."
+
+
+def test_proxy_server_properly_handles_headers(httpserver):
+    def header_echo_handler(request: WerkzeugRequest) -> Response:
+        # The proxy needs to preserve multi-value headers in the request to the backend
+        headers = Headers(request.headers)
+        assert "Multi-Value-Header" in headers
+        assert headers["Multi-Value-Header"] == "Value-1,Value-2"
+
+        # The proxy needs to preserve the Host header (some backend systems use the host header to construct Location URLs)
+        assert headers["Host"] == f"localhost.localstack.cloud:{port}"
+
+        # The proxy needs to correctly set the "X-Forwarded-For" header
+        # It contains the previous XFF header, as well as the IP of the machine which sent the request to the proxy
+        assert len(request.access_route) == 2
+        assert request.access_route[0] == "127.0.0.3"
+        assert re.match(IP_REGEX, request.access_route[1])
+
+        # return the headers
+        return Response(headers=headers)
+
+    httpserver.expect_request("").respond_with_handler(header_echo_handler)
+    port = get_free_tcp_port()
+    proxy_server = ProxyServer(httpserver.url_for("/"), port, "127.0.0.1", use_ssl=True)
+
+    with server_context(proxy_server):
+        response = requests.request(
+            "GET",
+            f"https://localhost.localstack.cloud:{port}/",
+            headers={"Multi-Value-Header": "Value-1,Value-2", "X-Forwarded-For": "127.0.0.3"},
+        )
+
+        # The proxy needs to preserve multi-value headers in the response from the backend
+        assert "Multi-Value-Header" in response.headers
+        assert response.headers["Multi-Value-Header"] == "Value-1,Value-2"
+
+
+def test_proxy_server_with_chunked_request(httpserver, httpserver_echo_request_metadata):
+    chunks = [bytes(f"{n:2}", "utf-8") for n in range(0, 100)]
+
+    def handler(request: WerkzeugRequest) -> Response:
+        # TODO Change this assertion to check for each sent chunk (once the proxy supports that).
+        #   Currently, the proxy does not support streaming the individual chunks directly to the backend.
+        #   Instead, the proxy receives the whole payload from the client and then forwards it
+        #   (maybe in chunks of different size) to the backend.
+        assert b"".join(chunks) == request.get_data(parse_form_data=False)
+        return Response()
+
+    httpserver.expect_request("/").respond_with_handler(handler)
+    port = get_free_tcp_port()
+    proxy_server = ProxyServer(httpserver.url_for("/"), port, "127.0.0.1", use_ssl=True)
+
+    def chunk_generator():
+        for chunk in chunks:
+            yield chunk
+
+    with server_context(proxy_server):
+        response = requests.get(
+            f"https://localhost.localstack.cloud:{port}/", data=chunk_generator()
+        )
+        assert response
+
+
+def test_proxy_server_with_streamed_response(httpserver):
+    chunks = [bytes(f"{n:2}", "utf-8") for n in range(0, 100)]
+
+    def chunk_generator():
+        for chunk in chunks:
+            yield chunk
+
+    def stream_response_handler(_: WerkzeugRequest) -> Response:
+        return Response(response=chunk_generator())
+
+    httpserver.expect_request("").respond_with_handler(stream_response_handler)
+    port = get_free_tcp_port()
+    proxy_server = ProxyServer(httpserver.url_for("/"), port, "127.0.0.1", use_ssl=True)
+
+    with server_context(proxy_server):
+        with requests.get(f"https://localhost.localstack.cloud:{port}/", stream=True) as r:
+            r.raise_for_status()
+            chunk_iterator = r.iter_content(chunk_size=None)
+            # TODO Change this assertion to check for each chunk (once the proxy supports that).
+            #   Currently, the proxy does not support streaming the individual chunks directly to the client.
+            #   Instead, the proxy receives the whole payload from the backend and then forwards it
+            #   (maybe in chunks of different size) to the client.
+            received_chunks = list(chunk_iterator)
+            assert b"".join(chunks) == b"".join(received_chunks)

--- a/tests/unit/logging_/__init__.py
+++ b/tests/unit/logging_/__init__.py
@@ -1,0 +1,3 @@
+# This module cannot be named logging, since pycharm cannot run in tests in the module above anymore in debug mode
+# - https://youtrack.jetbrains.com/issue/PY-54265
+# - https://youtrack.jetbrains.com/issue/PY-35220


### PR DESCRIPTION
This PR fixes several issues with our proxy framework, namely:
- **Forwarding of streamed requests (HTTP 1.1 streaming using `Transfer-Encoding: chunked`):**
  - Incoming streamed requests have the header `Transfer-Encoding: chunked` and no `Content-Length` header.
  - The forwarding currently does not support forwarding the stream itself, therefore it loads the data in memory and sends the request (just as the legacy gateway did), but it did not reset the `Transfer-Encoding` header or set the `Content-Length`.
- **Preserving the `Host` header of the origin client:**
  - The `SimpleRequestsClient` solely used the `Host` header to determine the host part of the target URL.
  - The proxy has to preserve the `Host` header because it might be used by backend services to build URLs which should be reachable by the original client.
  - The `SimpleRequestsClient` now allows being configured to use the WSGI `SERVER_` settings instead of the `Host` header.
  - This allows setting the target on the request object, without modifying the `HttpClient` interface, and without modifying the `Host` header of the request which should be sent.
  - This has the consequence that the `Proxy` cannot use an arbitrary `HttpClient` anymore. However, this feature has not been used yet, and the described use-case (setting header on all requests) could still easily be added again.

Relates to: #7465, #7563