### PR TITLE
Ignore stack trace in lambda exception tests

### DIFF
--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -165,7 +165,7 @@ class TestLambdaRuntimesCommon:
             "$..CodeSha256",  # works locally but unfortunately still produces a different hash in CI
         ]
     )
-    @pytest.mark.multiruntime(scenario="uncaughtexception", runtimes=["python"])
+    @pytest.mark.multiruntime(scenario="uncaughtexception")
     def test_uncaught_exception_invoke(self, lambda_client, multiruntime_lambda, snapshot):
         # unfortunately the stack trace is quite unreliable and changes when AWS updates the runtime transparently
         # since the stack trace contains references to internal runtime code.

--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -172,6 +172,10 @@ class TestLambdaRuntimesCommon:
         snapshot.add_transformer(
             snapshot.transform.key_value("stackTrace", "<stack-trace>", reference_replacement=False)
         )
+        # for nodejs
+        snapshot.add_transformer(
+            snapshot.transform.key_value("trace", "<stack-trace>", reference_replacement=False)
+        )
         create_function_result = multiruntime_lambda.create_function(MemorySize=1024)
         snapshot.match("create_function_result", create_function_result)
 

--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -165,8 +165,13 @@ class TestLambdaRuntimesCommon:
             "$..CodeSha256",  # works locally but unfortunately still produces a different hash in CI
         ]
     )
-    @pytest.mark.multiruntime(scenario="uncaughtexception")
+    @pytest.mark.multiruntime(scenario="uncaughtexception", runtimes=["python"])
     def test_uncaught_exception_invoke(self, lambda_client, multiruntime_lambda, snapshot):
+        # unfortunately the stack trace is quite unreliable and changes when AWS updates the runtime transparently
+        # since the stack trace contains references to internal runtime code.
+        snapshot.add_transformer(
+            snapshot.transform.key_value("stackTrace", "<stack-trace>", reference_replacement=False)
+        )
         create_function_result = multiruntime_lambda.create_function(MemorySize=1024)
         snapshot.match("create_function_result", create_function_result)
 

--- a/tests/integration/awslambda/test_lambda_common.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_common.snapshot.json
@@ -2124,11 +2124,7 @@
         "Payload": {
           "errorType": "Error",
           "errorMessage": "Error: some_error_msg",
-          "trace": [
-            "Error: Error: some_error_msg",
-            "    at Runtime.exports.handler (/var/task/index.js:2:11)",
-            "    at Runtime.handleOnce (/var/runtime/Runtime.js:66:25)"
-          ]
+          "trace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2179,11 +2175,7 @@
         "Payload": {
           "errorType": "Error",
           "errorMessage": "Error: some_error_msg",
-          "trace": [
-            "Error: Error: some_error_msg",
-            "    at Runtime.exports.handler (/var/task/index.js:2:11)",
-            "    at Runtime.handleOnceNonStreaming (/var/runtime/Runtime.js:74:25)"
-          ]
+          "trace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2234,11 +2226,7 @@
         "Payload": {
           "errorType": "Error",
           "errorMessage": "Error: some_error_msg",
-          "trace": [
-            "Error: Error: some_error_msg",
-            "    at Runtime.exports.handler (/var/task/index.js:2:11)",
-            "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1089:29)"
-          ]
+          "trace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2939,11 +2927,7 @@
         "Payload": {
           "errorType": "Error",
           "errorMessage": "Error: some_error_msg",
-          "trace": [
-            "Error: Error: some_error_msg",
-            "    at exports.handler (/var/task/index.js:2:11)",
-            "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1089:29)"
-          ]
+          "trace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {

--- a/tests/integration/awslambda/test_lambda_common.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_common.snapshot.json
@@ -1970,9 +1970,7 @@
         "Payload": {
           "errorMessage": "Failed: some_error_msg",
           "errorType": "Exception",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 15, in handler\n    raise Exception(f\"Failed: {event.get('error_msg')}\")\n"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2023,9 +2021,7 @@
         "Payload": {
           "errorMessage": "Failed: some_error_msg",
           "errorType": "Exception",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 15, in handler\n    raise Exception(f\"Failed: {event.get('error_msg')}\")\n"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2077,9 +2073,7 @@
           "errorMessage": "Failed: some_error_msg",
           "errorType": "Exception",
           "requestId": "<uuid:2>",
-          "stackTrace": [
-            "  File \"/var/task/handler.py\", line 15, in handler\n    raise Exception(f\"Failed: {event.get('error_msg')}\")\n"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2295,10 +2289,7 @@
         "Payload": {
           "errorMessage": "Error: some_error_msg",
           "errorType": "java.lang.RuntimeException",
-          "stackTrace": [
-            "echo.Handler.handleRequest(Handler.java:11)",
-            "echo.Handler.handleRequest(Handler.java:8)"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2349,10 +2340,7 @@
         "Payload": {
           "errorMessage": "Error: some_error_msg",
           "errorType": "java.lang.RuntimeException",
-          "stackTrace": [
-            "echo.Handler.handleRequest(Handler.java:11)",
-            "echo.Handler.handleRequest(Handler.java:8)"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2403,10 +2391,7 @@
         "Payload": {
           "errorMessage": "Error: some_error_msg",
           "errorType": "java.lang.RuntimeException",
-          "stackTrace": [
-            "echo.Handler.handleRequest(Handler.java:11)",
-            "echo.Handler.handleRequest(Handler.java:8)"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2457,9 +2442,7 @@
         "Payload": {
           "errorMessage": "Error: some_error_msg",
           "errorType": "Function<RuntimeError>",
-          "stackTrace": [
-            "/var/task/function.rb:2:in `handler'"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2660,13 +2643,7 @@
         "Payload": {
           "errorType": "Exception",
           "errorMessage": "Error: some_error_msg",
-          "stackTrace": [
-            "at dotnet6.Function.FunctionHandler(IDictionary`2 input, ILambdaContext context) in /app2/Function.cs:line 15",
-            "at lambda_method1(Closure , Stream , ILambdaContext , Stream )",
-            "at Amazon.Lambda.RuntimeSupport.Bootstrap.UserCodeLoader.Invoke(Stream lambdaData, ILambdaContext lambdaContext, Stream outStream) in /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/UserCodeLoader.cs:line 145",
-            "at Amazon.Lambda.RuntimeSupport.HandlerWrapper.<>c__DisplayClass8_0.<GetHandlerWrapper>b__0(InvocationRequest invocation) in /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/HandlerWrapper.cs:line 56",
-            "at Amazon.Lambda.RuntimeSupport.LambdaBootstrap.InvokeOnceAsync(CancellationToken cancellationToken) in /src/Repo/Libraries/src/Amazon.Lambda.RuntimeSupport/Bootstrap/LambdaBootstrap.cs:line 176"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -2717,10 +2694,7 @@
         "Payload": {
           "errorType": "Exception",
           "errorMessage": "Error: some_error_msg",
-          "stackTrace": [
-            "at dotnetcore31.Function.FunctionHandler(IDictionary`2 input, ILambdaContext context) in /app2/Function.cs:line 15",
-            "at lambda_method(Closure , Stream , Stream , LambdaContextInternal )"
-          ]
+          "stackTrace": "<stack-trace>"
         },
         "StatusCode": 200,
         "ResponseMetadata": {


### PR DESCRIPTION
Fixes current CI failures caused by updates to the latest runtime images provided by AWS.

We could still work with some form of pinning but I feel like the stack trace is inherently too brittle for a full snapshot comparison.