### PR TITLE
refactor router to enable resource class pattern via rules

### DIFF
--- a/localstack/http/__init__.py
+++ b/localstack/http/__init__.py
@@ -1,5 +1,6 @@
 from .request import Request
+from .resource import Resource, resource
 from .response import Response
 from .router import Router, route
 
-__all__ = ["route", "Router", "Response", "Request"]
+__all__ = ["route", "resource", "Resource", "Router", "Response", "Request"]

--- a/localstack/http/dispatcher.py
+++ b/localstack/http/dispatcher.py
@@ -2,7 +2,6 @@ import json
 from typing import Any, Dict, Protocol, Union
 
 from werkzeug import Response as WerkzeugResponse
-from werkzeug.exceptions import MethodNotAllowed
 
 from localstack.utils.json import CustomEncoder
 
@@ -31,58 +30,6 @@ def _populate_response(response: WerkzeugResponse, result: ResultValue):
         raise ValueError("unhandled result type %s", type(result))
 
     return response
-
-
-def resource_dispatcher(pass_response: bool = False) -> Dispatcher:
-    """
-    A ``Dispatcher`` treats a Router endpoint like a REST resource, which dispatches the request further to the
-    respective ``on_<http_verb>`` method. The following shows an example of how the pattern is used::
-
-        class Foo:
-            def on_get(self, request: Request):
-                return {"ok": "GET it"}
-
-            def on_post(self, request: Request):
-                return {"ok": "it was POSTed"}
-
-        router = Router(dispatcher=resource_dispatcher())
-        router.add("/foo", Foo())
-
-    Alternatively, if you create a dispatcher with pass_response=True then the dispatcher ignores the return value,
-    but instead passes the response object. An implementation can look like this::
-
-        class Foo:
-            def on_get(self, request: Request, response: Response):
-                response.set_json({"ok": "GET it"})
-
-        router = Router(dispatcher=resource_dispatcher(pass_response=True))
-        router.add("/foo", Foo())
-
-    :param pass_response: whether to pass the response object to the resource
-    :returns: a new Dispatcher
-    """
-
-    def _dispatch(request: Request, endpoint: object, args: RequestArguments) -> Response:
-        fn_name = f"on_{request.method.lower()}"
-
-        fn = getattr(endpoint, fn_name, None)
-
-        if fn:
-            if pass_response:
-                response = Response()
-                fn(request, response, **args)
-            else:
-                result = fn(request, **args)
-                if isinstance(result, WerkzeugResponse):
-                    return result
-                response = Response()
-                _populate_response(response, result)
-
-            return response
-        else:
-            raise MethodNotAllowed()
-
-    return _dispatch
 
 
 class Handler(Protocol):

--- a/localstack/http/resource.py
+++ b/localstack/http/resource.py
@@ -1,0 +1,100 @@
+"""
+This module enables the resource class pattern, where each respective ``on_<http_method>`` method of a class is
+treated like an endpoint for the respective HTTP method. The following shows an example of how the pattern is used::
+
+    class Foo:
+        def on_get(self, request: Request):
+            return {"ok": "GET it"}
+
+        def on_post(self, request: Request):
+            return {"ok": "it was POSTed"}
+
+
+    router = Router(dispatcher=resource_dispatcher())
+    router.add(Resource("/foo", Foo())
+"""
+from typing import Any, Iterable, Optional, Type
+
+from werkzeug.routing import Map, Rule, RuleFactory
+
+from .router import HTTP_METHODS, route
+
+
+def resource(path: str, host: Optional[str] = None, **kwargs):
+    """
+    Class decorator that turns every method that follows the pattern ``on_<http-method>`` into a route,
+    where the allowed method for that route is automatically set to the method specified in the function name. Example
+    when using a Router with the ``handler_dispatcher``::
+
+        @resource("/myresource/<resource_id>")
+        class MyResource:
+            def on_get(request: Request, resource_id: str) -> Response:
+                return Response(f"GET called on {resource_id}")
+
+            def on_post(request: Request, resource_id: str) -> Response:
+                return Response(f"POST called on {resource_id}")
+
+    This class can then be added to a router via ``router.add_route_endpoints(MyResource())``.
+
+    Note that HEAD requests are automatically routed to ``on_get``. There is currently no way of specifying ``on_head``
+    methods because of how werkzeug works. See https://werkzeug.palletsprojects.com/en/2.2.x/routing/
+
+    :param path: the path pattern to match
+    :param host: an optional host matching pattern. if not pattern is given, the rule matches any host
+    :param kwargs: any other argument that can be passed to ``werkzeug.routing.Rule``
+    :return: a class where each matching function is wrapped as a ``_RouteEndpoint``
+    """
+    allowed_names = [f"on_{method.lower()}" for method in HTTP_METHODS if method != "HEAD"]
+    kwargs.pop("methods", None)
+
+    def _wrapper(cls: Type):
+        for name in allowed_names:
+            member = getattr(cls, name, None)
+            if member is None:
+                continue
+
+            http_method = name[3:].upper()
+            setattr(cls, name, route(path, host, methods=[http_method], **kwargs)(member))
+
+        return cls
+
+    return _wrapper
+
+
+class Resource(RuleFactory):
+    """
+    Exposes a given object that follows the "Resource" class pattern as a ``RuleFactory` that can then be added to a
+    Router. Example use when using a Router with the ``handler_dispatcher``::
+
+        class MyResource:
+            def on_get(request: Request, resource_id: str) -> Response:
+                return Response(f"GET called on {resource_id}")
+
+            def on_post(request: Request, resource_id: str) -> Response:
+                return Response(f"POST called on {resource_id}")
+
+        router.add(Resource("/myresource/<resource_id>", MyResource()))
+    """
+
+    def __init__(self, path: str, obj: Any, host: Optional[str] = None, **kwargs):
+        self.path = path
+        self.obj = obj
+        self.host = host
+        self.kwargs = kwargs
+
+    def get_rules(self, map: "Map") -> Iterable["Rule"]:
+        allowed_names = [f"on_{method.lower()}" for method in HTTP_METHODS if method != "HEAD"]
+
+        rules = []
+        for name in allowed_names:
+            member = getattr(self.obj, name, None)
+            if member is None:
+                continue
+
+            http_method = name[3:].upper()
+            rules.append(
+                Rule(
+                    self.path, endpoint=member, methods=[http_method], host=self.host, **self.kwargs
+                )
+            )
+        return rules

--- a/localstack/http/response.py
+++ b/localstack/http/response.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Iterable, Union
+from typing import Any, Dict, Iterable, Union
 
 from werkzeug.wrappers import Response as WerkzeugResponse
 
@@ -23,7 +23,7 @@ class Response(WerkzeugResponse):
         self.response = other.response
         self.headers.update(other.headers)
 
-    def set_json(self, doc: Dict):
+    def set_json(self, doc: Any):
         """
         Serializes the given dictionary using localstack's ``CustomEncoder`` into a json response, and sets the
         mimetype automatically to ``application/json``.
@@ -51,6 +51,8 @@ class Response(WerkzeugResponse):
         else:
             self.response = response
 
+        return self
+
     def to_readonly_response_dict(self) -> Dict:
         """
         Returns a read-only version of a response dictionary as it is often expected by other libraries like boto.
@@ -60,3 +62,17 @@ class Response(WerkzeugResponse):
             "status_code": self.status_code,
             "headers": dict(self.headers),
         }
+
+    @classmethod
+    def for_json(cls, doc: Any, *args, **kwargs) -> "Response":
+        """
+        Creates a new JSON response from the given document. It automatically sets the mimetype to ``application/json``.
+
+        :param doc: the document to serialize into JSON
+        :param args: arguments passed to the ``Response`` constructor
+        :param kwargs: keyword arguments passed to the ``Response`` constructor
+        :return: a new Response object
+        """
+        response = cls(*args, **kwargs)
+        response.set_json(doc)
+        return response

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -14,14 +14,14 @@ from typing import (
     Protocol,
     Type,
     TypeVar,
+    Union,
+    overload,
 )
 
+from werkzeug import Request, Response
 from werkzeug.routing import BaseConverter, Map, Rule, RuleFactory
 
-from localstack.utils.common import to_str
-
-from .request import Request
-from .response import Response
+HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE")
 
 E = TypeVar("E")
 RequestArguments = Mapping[str, Any]
@@ -96,7 +96,7 @@ def route(
 
     :param path: the path pattern to match
     :param host: an optional host matching pattern. if not pattern is given, the rule matches any host
-    :param methods: the allowed HTTP verbs for this rule
+    :param methods: the allowed HTTP methods for this rule
     :param kwargs: any other argument that can be passed to ``werkzeug.routing.Rule``
     :return: the function endpoint wrapped as a ``_RouteEndpoint``
     """
@@ -167,7 +167,74 @@ class Router(Generic[E]):
         self.dispatcher = dispatcher or call_endpoint
         self._mutex = threading.RLock()
 
+    @overload
     def add(
+        self,
+        path: str,
+        endpoint: E,
+        host: Optional[str] = None,
+        methods: Optional[Iterable[str]] = None,
+        **kwargs,
+    ) -> Rule:
+        """
+        Creates a new Rule from the given parameters and adds it to the URL Map.
+
+        :param path: the path pattern to match
+        :param endpoint: the endpoint to invoke
+        :param host: an optional host matching pattern. if not pattern is given, the rule matches any host
+        :param methods: the allowed HTTP verbs for this rule
+        :param kwargs: any other argument that can be passed to ``werkzeug.routing.Rule``
+        :return:
+        """
+        ...
+
+    @overload
+    def add(self, fn: _RouteEndpoint) -> Rule:
+        """
+        Adds a RouteEndpoint (typically a function decorated with ``@route``) as a rule to the router.
+
+        :param fn: the RouteEndpoint function
+        :return: the rule that was added
+        """
+        ...
+
+    @overload
+    def add(self, rule_factory: RuleFactory) -> List[Rule]:
+        """
+        Adds a ``Rule`` or the rules created by a ``RuleFactory`` to the given router. It passes the rules down to
+        the underlying Werkzeug ``Map``, but also returns the created Rules.
+
+        :param rule_factory: a `Rule` or ``RuleFactory`
+        :return: the rules that were added
+        """
+        ...
+
+    @overload
+    def add(self, obj: Any) -> List[Rule]:
+        """
+        Scans the given object for members that can be used as a `RouteEndpoint` and adds them to the router.
+
+        :param obj: the object to scan
+        :return: the rules that were added
+        """
+        ...
+
+    def add(self, *args, **kwargs) -> Union[Rule, List[Rule]]:
+        """
+        Dispatcher for overloaded ``add`` methods.
+        """
+        if "path" in kwargs or type(args[0]) == str:
+            return self._add_endpoint(*args, **kwargs)
+
+        if "fn" in kwargs or callable(args[0]):
+            return self._add_route(*args, **kwargs)
+
+        if "rule_factory" in kwargs or isinstance(args[0], RuleFactory):
+            return self._add_rules(*args, **kwargs)
+
+        return self._add_routes(*args, **kwargs)
+
+    def _add_endpoint(
         self,
         path: str,
         endpoint: E,
@@ -196,18 +263,18 @@ class Router(Generic[E]):
         self.add_rule(rule)
         return rule
 
-    def add_route_endpoint(self, fn: _RouteEndpoint) -> Rule:
+    def _add_route(self, fn: _RouteEndpoint) -> Rule:
         """
         Adds a RouteEndpoint (typically a function decorated with ``@route``) as a rule to the router.
         :param fn: the RouteEndpoint function
         :return: the rule that was added
         """
         attr: _RuleAttributes = fn.rule_attributes
-        return self.add(
+        return self._add_endpoint(
             path=attr.path, endpoint=fn, host=attr.host, methods=attr.methods, **attr.kwargs
         )
 
-    def add_route_endpoints(self, obj: object) -> List[Rule]:
+    def _add_routes(self, obj: object) -> List[Rule]:
         """
         Scans the given object for members that can be used as a `RouteEndpoint` and adds them to the router.
         :param obj: the object to scan
@@ -218,17 +285,44 @@ class Router(Generic[E]):
         members = inspect.getmembers(obj)
         for _, member in members:
             if hasattr(member, "rule_attributes"):
-                rules.append(self.add_route_endpoint(member))
+                rules.append(self._add_route(member))
 
         return rules
 
+    def _add_rules(self, rule_factory: RuleFactory) -> List[Rule]:
+        """
+        Thread safe version of Werkzeug's ``Map.add``.
+
+        :param rule_factory: the rule to add
+        """
+        with self._mutex:
+            rules = []
+            for rule in rule_factory.get_rules(self.url_map):
+                rules.append(rule)
+
+                if rule.host is None and self.url_map.host_matching:
+                    # this creates a "match any" rule, and will put the value of the host
+                    # into the variable "__host__"
+                    rule.host = "<__host__>"
+
+                self.url_map.add(rule)
+
+            return rules
+
     def add_rule(self, rule: RuleFactory):
+        """
+        Thread safe version of Werkzeug's ``Map.add``. This can be used as low-level method to pass a rule directly to
+        the Werkzeug URL map without any manipulation or manual creation of the rule, which ``add`` does.
+
+        :param rule: the rule to add
+        """
         with self._mutex:
             self.url_map.add(rule)
 
-    def remove_rule(self, rule: Rule):
+    @overload
+    def remove(self, rule: Rule):
         """
-        Removes a Rule from the Router.
+        Removes a single Rule from the Router.
 
         **Caveat**: This is an expensive operation. Removing rules from a URL Map is intentionally not supported by
         werkzeug due to issues with thread safety, see https://github.com/pallets/werkzeug/issues/796, and because
@@ -239,18 +333,51 @@ class Router(Generic[E]):
 
         :param rule: the Rule to remove that was previously returned by ``add``.
         """
+        ...
+
+    @overload
+    def remove(self, rules: Iterable[Rule]):
+        """
+        Removes a set of Rules from the Router.
+
+        :param rules: the list of Rule objects to remove that were previously returned by ``add``.
+        """
+        ...
+
+    def remove(self, rules: Union[Rule, Iterable[Rule]]):
+        if isinstance(rules, Rule):
+            self._remove_rules([rules])
+        else:
+            self._remove_rules(rules)
+
+    def _remove_rules(self, rules: Iterable[Rule]):
+        """
+        Removes a set of Rules from the Router.
+
+        **Caveat**: This is an expensive operation. Removing rules from a URL Map is intentionally not supported by
+        werkzeug due to issues with thread safety, see https://github.com/pallets/werkzeug/issues/796, and because
+        using a lock in ``match`` would be too expensive. However, some services that use Routers for routing
+        internal resources need to be able to remove rules when those resources are removed. So to remove rules we
+        create a new Map without that rule. This will not prevent the rules from dispatching until the Map has been
+        completely constructed.
+
+        :param rules: the list of Rule objects to remove that were previously returned by ``add``.
+        """
         with self._mutex:
             old = self.url_map
-            if rule not in old._rules:
-                raise KeyError("no such rule")
+            for r in rules:
+                if r not in old._rules:
+                    raise KeyError("no such rule")
 
+            # collect all old rules that are not in the set of rules to remove
             new = _clone_map_without_rules(old)
 
-            for r in old.iter_rules():
-                if r == rule:
+            for old_rule in old.iter_rules():
+                if old_rule in rules:
                     # this works even with copied rules because of the __eq__ implementation of Rule
                     continue
-                new.add(r.empty())
+
+                new.add(old_rule.empty())
             self.url_map = new
 
     def dispatch(self, request: Request) -> Response:
@@ -263,9 +390,7 @@ class Router(Generic[E]):
         :return: the HTTP response
         """
         matcher = self.url_map.bind(server_name=request.host)
-        handler, args = matcher.match(
-            request.path, method=request.method, query_args=to_str(request.query_string)
-        )
+        handler, args = matcher.match(request.path, method=request.method)
         args.pop("__host__", None)
         return self.dispatcher(request, handler, args)
 
@@ -290,7 +415,23 @@ class Router(Generic[E]):
         def wrapper(fn):
             r = route(path, host, methods, **kwargs)
             fn = r(fn)
-            self.add_route_endpoint(fn)
+            self._add_route(fn)
             return fn
 
         return wrapper
+
+    def add_route_endpoint(self, fn: _RouteEndpoint) -> Rule:
+        """
+        DEPRECATED: use ``add`` instead.
+        """
+        return self._add_route(fn)
+
+    def add_route_endpoints(self, obj: object) -> List[Rule]:
+        """
+        DEPRECATED: use ``add`` instead.
+        """
+        return self._add_routes(obj)
+
+    def remove_rule(self, rule: Rule):
+        """DEPRECATED: use ``remove`` instead."""
+        self._remove_rules([rule])

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -299,7 +299,7 @@ class LocalstackResources(Router):
         self.add(Resource("/_localstack/cloudformation/deploy", CloudFormationUi()))
 
         if config.ENABLE_CONFIG_UPDATES:
-            self.add(Resource("/_localstack/diagnose", ConfigResource()))
+            self.add(Resource("/_localstack/config", ConfigResource()))
 
         if config.DEBUG:
             LOG.warning(

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -4,22 +4,23 @@ import logging
 import os
 import re
 from collections import defaultdict
-from typing import List, Optional
+from typing import List
 
 import requests
 from werkzeug.exceptions import NotFound
 
 from localstack import config, constants
 from localstack.deprecations import deprecated_endpoint
-from localstack.http import Request, Response, Router
+from localstack.http import Request, Resource, Response, Router
 from localstack.http.adapters import RouterListener
-from localstack.http.dispatcher import resource_dispatcher
+from localstack.http.dispatcher import handler_dispatcher
 from localstack.services.infra import SHUTDOWN_INFRA, terminate_all_processes_in_docker
 from localstack.utils.collections import merge_recursive
 from localstack.utils.config_listener import update_config_variable
 from localstack.utils.files import load_file
 from localstack.utils.functions import call_safe
 from localstack.utils.json import parse_json_or_yaml
+from localstack.utils.objects import singleton_factory
 from localstack.utils.server.http2_server import HTTP_METHODS
 
 LOG = logging.getLogger(__name__)
@@ -70,6 +71,9 @@ class HealthResource:
         return Response("ok", 200)
 
     def on_get(self, request: Request):
+        if request.method == "HEAD":
+            return Response("ok", 200)
+
         path = request.path
 
         reload = "reload" in path
@@ -86,9 +90,6 @@ class HealthResource:
         result = merge_recursive({"services": services}, result)
         result["version"] = constants.VERSION
         return result
-
-    def on_head(self, _request: Request):
-        return Response("ok", 200)
 
     def on_put(self, request: Request):
         data = request.get_json(True, True) or {}
@@ -270,7 +271,7 @@ class LocalstackResources(Router):
     """
 
     def __init__(self):
-        super().__init__(dispatcher=resource_dispatcher(pass_response=False))
+        super().__init__(dispatcher=handler_dispatcher())
         self.add_default_routes()
         # TODO: load routes as plugins
 
@@ -278,37 +279,34 @@ class LocalstackResources(Router):
         from localstack.services.plugins import SERVICE_PLUGINS
 
         health_resource = HealthResource(SERVICE_PLUGINS)
-        plugins_resource = PluginsResource()
-
         # special route for legacy support (before `/_localstack` was introduced)
-        super().add(
-            "/health",
-            DeprecatedResource(
-                health_resource,
-                previous_path="/health",
-                deprecation_version="1.3.0",
-                new_path="/_localstack/health",
+        self.add(
+            Resource(
+                "/health",
+                DeprecatedResource(
+                    health_resource,
+                    previous_path="/health",
+                    deprecation_version="1.3.0",
+                    new_path="/_localstack/health",
+                ),
             ),
         )
+        self.add(Resource("/_localstack/health", health_resource))
 
-        self.add("/health", health_resource)
-        self.add("/plugins", plugins_resource)
-        self.add("/init", InitScriptsResource())
-        self.add("/init/<stage>", InitScriptsStageResource())
-        self.add("/cloudformation/deploy", CloudFormationUi())
+        self.add(Resource("/_localstack/plugins", PluginsResource()))
+        self.add(Resource("/_localstack/init", InitScriptsResource()))
+        self.add(Resource("/_localstack/init/<stage>", InitScriptsStageResource()))
+        self.add(Resource("/_localstack/cloudformation/deploy", CloudFormationUi()))
 
         if config.ENABLE_CONFIG_UPDATES:
-            self.add("/config", ConfigResource())
+            self.add(Resource("/_localstack/diagnose", ConfigResource()))
 
         if config.DEBUG:
             LOG.warning(
                 "Enabling diagnose endpoint, "
                 "please be aware that this can expose sensitive information via your network."
             )
-            self.add("/diagnose", DiagnoseResource())
-
-    def add(self, path, *args, **kwargs):
-        return super().add(f"{constants.INTERNAL_RESOURCE_PATH}{path}", *args, **kwargs)
+            self.add(Resource("/_localstack/diagnose", DiagnoseResource()))
 
 
 class LocalstackResourceHandler(RouterListener):
@@ -333,14 +331,9 @@ class LocalstackResourceHandler(RouterListener):
                 return 404
 
 
-INTERNAL_APIS: Optional[LocalstackResources] = None
-
-
+@singleton_factory
 def get_internal_apis() -> LocalstackResources:
     """
     Get the LocalstackResources singleton.
     """
-    global INTERNAL_APIS
-    if not INTERNAL_APIS:
-        INTERNAL_APIS = LocalstackResources()
-    return INTERNAL_APIS
+    return LocalstackResources()

--- a/localstack/services/internal.py
+++ b/localstack/services/internal.py
@@ -71,9 +71,6 @@ class HealthResource:
         return Response("ok", 200)
 
     def on_get(self, request: Request):
-        if request.method == "HEAD":
-            return Response("ok", 200)
-
         path = request.path
 
         reload = "reload" in path
@@ -90,6 +87,9 @@ class HealthResource:
         result = merge_recursive({"services": services}, result)
         result["version"] = constants.VERSION
         return result
+
+    def on_head(self, request: Request):
+        return Response("ok", 200)
 
     def on_put(self, request: Request):
         data = request.get_json(True, True) or {}

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -51,6 +51,7 @@ from localstack.aws.api.ses import (
     VerificationStatus,
 )
 from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
+from localstack.http import resource
 from localstack.services.internal import get_internal_apis
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
@@ -118,6 +119,7 @@ def get_ses_backend(context: RequestContext) -> SESBackend:
     return ses_backends[context.account_id][context.region]
 
 
+@resource(f"/_localstack{EMAILS_ENDPOINT}")
 class SesServiceApiResource:
     """Provides a REST API for retrospective access to emails sent via SES.
 
@@ -147,7 +149,7 @@ def register_ses_api_resource():
     global _EMAILS_ENDPOINT_REGISTERED
 
     if not _EMAILS_ENDPOINT_REGISTERED:
-        get_internal_apis().add(EMAILS_ENDPOINT, SesServiceApiResource())
+        get_internal_apis().add(SesServiceApiResource())
         _EMAILS_ENDPOINT_REGISTERED = True
 
 

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -942,7 +942,7 @@ def extract_tags(topic_arn, tags, is_create_topic_request, store):
 
 def register_sns_api_resource(router: Router):
     """Register the platform endpointmessages retrospection endpoint as an internal LocalStack endpoint."""
-    router.add_route_endpoints(SNSServicePlatformEndpointMessagesApiResource())
+    router.add(SNSServicePlatformEndpointMessagesApiResource())
 
 
 def _format_platform_endpoint_messages(sent_messages: List[Dict[str, str]]):

--- a/localstack/services/sqs/provider.py
+++ b/localstack/services/sqs/provider.py
@@ -556,7 +556,7 @@ class SqsProvider(SqsApi, ServiceLifecycleHook):
         return sqs_stores[account_id or get_aws_account_id()][region or aws_stack.get_region()]
 
     def on_before_start(self):
-        self._router_rules = ROUTER.add_route_endpoints(SqsDeveloperEndpoints())
+        self._router_rules = ROUTER.add(SqsDeveloperEndpoints())
         self._queue_update_worker.start()
         self._cloudwatch_publish_worker.start()
 

--- a/localstack/services/sqs/query_api.py
+++ b/localstack/services/sqs/query_api.py
@@ -81,9 +81,9 @@ def register(router: Router[Handler]):
 
     :param router: the router to add the handlers into.
     """
-    router.add_route_endpoint(path_strategy_handler)
-    router.add_route_endpoint(domain_strategy_handler)
-    router.add_route_endpoint(legacy_handler)
+    router.add(path_strategy_handler)
+    router.add(domain_strategy_handler)
+    router.add(legacy_handler)
 
 
 class UnknownOperationException(Exception):

--- a/localstack/utils/config_listener.py
+++ b/localstack/utils/config_listener.py
@@ -52,7 +52,7 @@ class ConfigUpdateProxyListener(ProxyListener):
             endpoint=_update_config_variable_handler,
             previous_path=constants.CONFIG_UPDATE_PATH,
             deprecation_version="1.4.0",
-            new_path="/_localstack/config-update",
+            new_path="/_localstack/config",
         )
 
     def forward_request(self, method, path, data, headers):

--- a/tests/integration/services/test_internal.py
+++ b/tests/integration/services/test_internal.py
@@ -29,3 +29,15 @@ class TestInitScriptsResource:
         response = requests.get(get_edge_url() + f"/_localstack/init/{stage}")
         assert response.status_code == 200
         assert response.json()["completed"] == completed
+
+
+class TestHealthResource:
+    def test_get(self):
+        response = requests.get(get_edge_url() + "/_localstack/health")
+        assert response.ok
+        assert "services" in response.json()
+
+    def test_head(self):
+        response = requests.head(get_edge_url() + "/_localstack/health")
+        assert response.ok
+        assert not response.text

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -17,10 +17,10 @@ def config_endpoint(monkeypatch):
     # will listen on /?_config_
     config_listener.start_listener()
     # will listen on /_localstack/config-update
-    rule = router.add("/config", ConfigResource())
+    rules = router.add(ConfigResource())
     yield
     config_listener.remove_listener()
-    router.remove_rule(rule)
+    router.remove(rules)
 
 
 def test_config_endpoint(config_endpoint):

--- a/tests/integration/test_config_endpoint.py
+++ b/tests/integration/test_config_endpoint.py
@@ -3,6 +3,7 @@ import requests
 
 from localstack import config
 from localstack.constants import CONFIG_UPDATE_PATH
+from localstack.http import Resource
 from localstack.services.internal import ConfigResource, get_internal_apis
 from localstack.utils import config_listener
 
@@ -16,8 +17,8 @@ def config_endpoint(monkeypatch):
     monkeypatch.setattr(config, "ENABLE_CONFIG_UPDATES", True)
     # will listen on /?_config_
     config_listener.start_listener()
-    # will listen on /_localstack/config-update
-    rules = router.add(ConfigResource())
+    # will listen on /_localstack/config
+    rules = router.add(Resource("/_localstack/config", ConfigResource()))
     yield
     config_listener.remove_listener()
     router.remove(rules)

--- a/tests/unit/http_/test_dispatcher.py
+++ b/tests/unit/http_/test_dispatcher.py
@@ -1,72 +1,10 @@
 from typing import Any, Dict
 
 import pytest
-from werkzeug.exceptions import MethodNotAllowed, NotFound
+from werkzeug.exceptions import NotFound
 
 from localstack.http import Request, Response, Router
-from localstack.http.dispatcher import handler_dispatcher, resource_dispatcher
-
-
-class TestResourceDispatcher:
-    def test_dispatch_to_correct_function(self):
-        router = Router(dispatcher=resource_dispatcher(pass_response=False))
-
-        requests = []
-
-        class TestResource:
-            def on_get(self, req):
-                requests.append(req)
-                return "GET/OK"
-
-            def on_post(self, req):
-                requests.append(req)
-                return {"ok": "POST"}
-
-            def on_head(self, req):
-                requests.append(req)
-                return "HEAD/OK"
-
-        router.add("/_localstack/health", TestResource())
-
-        request1 = Request("GET", "/_localstack/health")
-        request2 = Request("POST", "/_localstack/health")
-        request3 = Request("HEAD", "/_localstack/health")
-        assert router.dispatch(request1).get_data(True) == "GET/OK"
-        assert router.dispatch(request1).get_data(True) == "GET/OK"
-        assert router.dispatch(request2).json == {"ok": "POST"}
-        assert router.dispatch(request3).get_data(True) == "HEAD/OK"
-        assert len(requests) == 4
-        assert requests[0] is request1
-        assert requests[1] is request1
-        assert requests[2] is request2
-        assert requests[3] is request3
-
-    def test_dispatch_to_non_existing_method_raises_exception(self):
-        router = Router(dispatcher=resource_dispatcher(pass_response=False))
-
-        class TestResource:
-            def on_post(self, request):
-                return "POST/OK"
-
-        router.add("/_localstack/health", TestResource())
-
-        with pytest.raises(MethodNotAllowed):
-            assert router.dispatch(Request("GET", "/_localstack/health"))
-        assert router.dispatch(Request("POST", "/_localstack/health")).get_data(True) == "POST/OK"
-
-    def test_dispatcher_with_pass_response(self):
-        router = Router(dispatcher=resource_dispatcher(pass_response=True))
-
-        class TestResource:
-            def on_get(self, req, resp: Response):
-                resp.set_json({"message": "GET/OK"})
-
-            def on_post(self, req, resp):
-                resp.set_data("POST/OK")
-
-        router.add("/_localstack/health", TestResource())
-        assert router.dispatch(Request("GET", "/_localstack/health")).json == {"message": "GET/OK"}
-        assert router.dispatch(Request("POST", "/_localstack/health")).get_data(True) == "POST/OK"
+from localstack.http.dispatcher import handler_dispatcher
 
 
 class TestHandlerDispatcher:

--- a/tests/unit/http_/test_resource.py
+++ b/tests/unit/http_/test_resource.py
@@ -34,7 +34,7 @@ class TestResource:
         assert router.dispatch(request1).get_data(True) == "GET/OK"
         assert router.dispatch(request1).get_data(True) == "GET/OK"
         assert router.dispatch(request2).json == {"ok": "POST"}
-        assert router.dispatch(request3).get_data(True) == "GET/OK"
+        assert router.dispatch(request3).get_data(True) == "HEAD/OK"
         assert len(requests) == 4
         assert requests[0] is request1
         assert requests[1] is request1
@@ -51,12 +51,17 @@ class TestResource:
             def on_post(self, req):
                 return "POST/OK"
 
+            def on_head(self, req):
+                return "HEAD/OK"
+
         router.add(Resource("/_localstack/health", TestResource()))
 
         request1 = Request("GET", "/_localstack/health")
         request2 = Request("POST", "/_localstack/health")
+        request3 = Request("HEAD", "/_localstack/health")
         assert router.dispatch(request1).get_data(True) == "GET/OK"
         assert router.dispatch(request2).get_data(True) == "POST/OK"
+        assert router.dispatch(request3).get_data(True) == "HEAD/OK"
 
     def test_dispatch_to_non_existing_method_raises_exception(self):
         router = Router(dispatcher=handler_dispatcher())

--- a/tests/unit/http_/test_resource.py
+++ b/tests/unit/http_/test_resource.py
@@ -1,0 +1,127 @@
+import pytest
+from werkzeug.exceptions import MethodNotAllowed
+
+from localstack.http import Request, Resource, Response, Router, resource
+from localstack.http.dispatcher import handler_dispatcher
+
+
+class TestResource:
+    def test_resource_decorator_dispatches_correctly(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        requests = []
+
+        @resource("/_localstack/health")
+        class TestResource:
+            def on_get(self, req):
+                requests.append(req)
+                return "GET/OK"
+
+            def on_post(self, req):
+                requests.append(req)
+                return {"ok": "POST"}
+
+            def on_head(self, req):
+                # this is ignored
+                requests.append(req)
+                return "HEAD/OK"
+
+        router.add(TestResource())
+
+        request1 = Request("GET", "/_localstack/health")
+        request2 = Request("POST", "/_localstack/health")
+        request3 = Request("HEAD", "/_localstack/health")
+        assert router.dispatch(request1).get_data(True) == "GET/OK"
+        assert router.dispatch(request1).get_data(True) == "GET/OK"
+        assert router.dispatch(request2).json == {"ok": "POST"}
+        assert router.dispatch(request3).get_data(True) == "GET/OK"
+        assert len(requests) == 4
+        assert requests[0] is request1
+        assert requests[1] is request1
+        assert requests[2] is request2
+        assert requests[3] is request3
+
+    def test_resource_dispatches_correctly(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        class TestResource:
+            def on_get(self, req):
+                return "GET/OK"
+
+            def on_post(self, req):
+                return "POST/OK"
+
+        router.add(Resource("/_localstack/health", TestResource()))
+
+        request1 = Request("GET", "/_localstack/health")
+        request2 = Request("POST", "/_localstack/health")
+        assert router.dispatch(request1).get_data(True) == "GET/OK"
+        assert router.dispatch(request2).get_data(True) == "POST/OK"
+
+    def test_dispatch_to_non_existing_method_raises_exception(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        @resource("/_localstack/health")
+        class TestResource:
+            def on_post(self, request):
+                return "POST/OK"
+
+        router.add(TestResource())
+
+        with pytest.raises(MethodNotAllowed):
+            assert router.dispatch(Request("GET", "/_localstack/health"))
+        assert router.dispatch(Request("POST", "/_localstack/health")).get_data(True) == "POST/OK"
+
+    def test_resource_with_default_dispatcher(self):
+        router = Router()
+
+        @resource("/_localstack/<path>")
+        class TestResource:
+            def on_get(self, req, args):
+                return Response.for_json({"message": "GET/OK", "path": args["path"]})
+
+            def on_post(self, req, args):
+                return Response.for_json({"message": "POST/OK", "path": args["path"]})
+
+        router.add(TestResource())
+        assert router.dispatch(Request("GET", "/_localstack/health")).json == {
+            "message": "GET/OK",
+            "path": "health",
+        }
+        assert router.dispatch(Request("POST", "/_localstack/foobar")).json == {
+            "message": "POST/OK",
+            "path": "foobar",
+        }
+
+    def test_resource_overwrite_with_resource_wrapper(self):
+        router = Router(dispatcher=handler_dispatcher())
+
+        @resource("/_localstack/health")
+        class TestResourceHealth:
+            def on_get(self, req):
+                return Response.for_json({"message": "GET/OK", "path": req.path})
+
+            def on_post(self, req):
+                return Response.for_json({"message": "POST/OK", "path": req.path})
+
+        endpoints = TestResourceHealth()
+        router.add(endpoints)
+        router.add(Resource("/health", endpoints))
+
+        assert router.dispatch(Request("GET", "/_localstack/health")).json == {
+            "message": "GET/OK",
+            "path": "/_localstack/health",
+        }
+        assert router.dispatch(Request("POST", "/_localstack/health")).json == {
+            "message": "POST/OK",
+            "path": "/_localstack/health",
+        }
+
+        assert router.dispatch(Request("GET", "/health")).json == {
+            "message": "GET/OK",
+            "path": "/health",
+        }
+        assert router.dispatch(Request("POST", "/health")).json == {
+            "message": "POST/OK",
+            "path": "/health",
+        }

--- a/tests/unit/http_/test_router.py
+++ b/tests/unit/http_/test_router.py
@@ -203,6 +203,31 @@ class TestRouter:
         with pytest.raises(NotFound):
             assert router.dispatch(Request("GET", "/users/12"))
 
+    def test_remove_rules(self):
+        router = Router()
+
+        class MyRoutes:
+            @route("/a")
+            def route_a(self, request, args):
+                return Response(b"a")
+
+            @route("/b")
+            def route_b(self, request, args):
+                return Response(b"b")
+
+        rules = router.add(MyRoutes())
+
+        assert router.dispatch(Request("GET", "/a")).data == b"a"
+        assert router.dispatch(Request("GET", "/b")).data == b"b"
+
+        router.remove(rules)
+
+        with pytest.raises(NotFound):
+            assert router.dispatch(Request("GET", "/a"))
+
+        with pytest.raises(NotFound):
+            assert router.dispatch(Request("GET", "/b"))
+
     def test_remove_non_existing_rule(self):
         router = Router()
 
@@ -252,7 +277,7 @@ class TestRouter:
 
         api = MyApi()
         router = Router()
-        rules = router.add_route_endpoints(api)
+        rules = router.add(api)
         assert len(rules) == 2
 
         assert router.dispatch(Request("GET", "/users")).data == b"user"
@@ -273,7 +298,7 @@ class TestRouter:
 
         api = MyApi()
         router = Router()
-        rules = router.add_route_endpoints(api)
+        rules = router.add(api)
         assert len(rules) == 2
 
         assert router.dispatch(Request("GET", "/my_api")).data == b"/my_api/do-get"


### PR DESCRIPTION
The main goal of this PR is to enable the migration of `/_pods` endpoints into the `/_localstack` namespace, without having to refactor the current pods endpoints into what I'll call the "resource class pattern" (classes with `on_<http-method>` functions).

Previously, a Router needed the special `resource_dispatcher` to make the resource class pattern work, meaning it was not possible to mix the use of `@route` endpoints with the resoure class pattern. The changes in this PR get rid of the special `resource_dispatcher` all together. The way we should think about this is that, dispatchers are responsible for *how* functions are called (i.e., how the request parameters are unpacked into the method call), and rules are responsible for *which* functions are called. So instead of having the dispatcher find the methods, we now generate rules that tell the router where the methods are, which is IMO also much cleaner design (even though I found that the previous solution nicely demonstrated how flexible the dispatchers are).

Here are examples of achieving the same thing in different ways:

```python
class MyResource:
    def on_get(request: Request, resource_id: str) -> Response:
        return Response(f"GET called on {resource_id}")

    def on_post(request: Request, resource_id: str) -> Response:
        return Response(f"POST called on {resource_id}")


@resource("/myresource/<resource_id>")
class MyDecoratedResource:
    def on_get(request: Request, resource_id: str) -> Response:
        return Response(...)
    ...

class MyResource:
    @route("/myresource/<resource_id>", methods=["GET"])
    def on_get(request: Request, resource_id: str) -> Response:
        return Response(...)

    ...


def on_get(request: Request, resource_id: str) -> Response:
    return Response(...)


def on_post(request: Request, resource_id: str) -> Response:
    return Response(...)


router = Router(dispatcher=handler_dispatcher())

# wrapping a resource class with the Resource rule factory to specify the path
router.add(Resource("/myresource/<resource_id>", MyResource()))

# adding a class decorated with @resource
router.add(MyDecoratedResource())

# using classes the have @route decorated methods
router.add(MyRoutes())

# functions decorated with route
router.add(MyRoutes().on_get)
router.add(MyRoutes().on_post)

# using manual rules
router.add("/myresource/<resource_id>", on_get, methods=["GET"])
router.add("/myresource/<resource_id>", on_post, methods=["POST"])
```

To enable this in a clean way, I made several changes to the `Router`.

* `add` can now be used universally to add things to the router, making the interface more user-friendly
* consequently, `add` now returns either a rule or multiple rules. to make life easier, `remove` was introduced, that can now take both a list of rules, or a single rule. that way there's a coherent api (`router.remove(router.add(...))` will always work, regardless of what you pass to `add`.
* `add` now also takes `RuleFactory` instances. by default, the werkzeug `Map` does not return the `Rule` objects created by passing the `RuleFactory`. this is however needed for the `add` contract. so the method to add a `RuleFactory` to the router works a bit differently: it adds the rules individually, and also conveniently adds the catch-all host matching.
* to make those things work, i re-organized some of the internal methods and deprecated the confusing `add_route_endpoint`, `add_route_endpoints`

Finally, I refactored the `LocalstackResourceRouter` to use the new pattern. Also added a little decorator that can be used analogous to `@route` for resource classes.
I'm deliberately not using this decorator for the default resources, since the HealthResource cannot use it (needs to be added to two different paths), and it is more consistent in the code this way. Everywhere else I added the decorator.
