### PR TITLE
fix opensearch store access in create_cluster method

### DIFF
--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -139,8 +139,8 @@ def create_cluster(
     preferred_port: Optional[int] = None,
 ):
     """
-    Uses the ClusterManager to create a new cluster for the given domain_name in the region of the current request
-    context. NOT thread safe, needs to be called around _domain_mutex.
+    Uses the ClusterManager to create a new cluster for the given domain key. NOT thread safe, needs to be called
+    around _domain_mutex.
     If the preferred_port is given, this port will be preferred (if OPENSEARCH_ENDPOINT_STRATEGY == "port").
     """
     store = opensearch_stores[domain_key.account][domain_key.region]

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -143,7 +143,7 @@ def create_cluster(
     context. NOT thread safe, needs to be called around _domain_mutex.
     If the preferred_port is given, this port will be preferred (if OPENSEARCH_ENDPOINT_STRATEGY == "port").
     """
-    store = OpensearchProvider.get_store()
+    store = opensearch_stores[domain_key.account][domain_key.region]
 
     manager = cluster_manager()
     engine_version = engine_version or OPENSEARCH_DEFAULT_VERSION


### PR DESCRIPTION
This PR fixes an issue that would prevent opensearch persistence to restore clusters properly under certain conditions.

`OpensearchProvider.get_store()` relies on having a request context, but when we're restoring the cluster through `restore_backend_state`, we don't have that.
Conveniently, we have the account and the region information in the `DomainKey`, so we just use that.