### PR TITLE
Add support for LAMBDA_SYNCHRONOUS_CREATE flag

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -702,6 +702,10 @@ LAMBDA_TRUNCATE_STDOUT = int(os.getenv("LAMBDA_TRUNCATE_STDOUT") or 2000)
 #   The delay between the first retry and the second retry will be 60s
 LAMBDA_RETRY_BASE_DELAY_SECONDS = int(os.getenv("LAMBDA_RETRY_BASE_DELAY") or 60)
 
+# whether Lambda.CreateFunction will block until the function is in a terminal state (active or failed)
+# this technically breaks behavior parity but is provided as a simplification over the default AWS behavior
+LAMBDA_SYNCHRONOUS_CREATE = is_env_true("LAMBDA_SYNCHRONOUS_CREATE")
+
 # A comma-delimited string of stream names and its corresponding shard count to
 # initialize during startup (DEPRECATED).
 # For example: "my-first-stream:1,my-other-stream:2,my-last-stream:1"
@@ -798,6 +802,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_STAY_OPEN_MODE",
     "LAMBDA_TRUNCATE_STDOUT",
     "LAMBDA_RETRY_BASE_DELAY_SECONDS",
+    "LAMBDA_SYNCHRONOUS_CREATE",
     "LEGACY_DIRECTORIES",
     "LEGACY_DOCKER_CLIENT",
     "LEGACY_EDGE_PROXY",

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -180,6 +180,7 @@ from localstack.utils.aws import aws_stack
 from localstack.utils.collections import PaginatedList
 from localstack.utils.files import load_file
 from localstack.utils.strings import get_random_hex, long_uid, short_uid, to_bytes, to_str
+from localstack.utils.sync import poll_condition
 
 LOG = logging.getLogger(__name__)
 
@@ -627,6 +628,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             version = self._publish_version_with_changes(
                 function_name=function_name, region=context.region, account_id=context.account_id
             )
+
+        if config.LAMBDA_SYNCHRONOUS_CREATE:
+            # block via retrying until "terminal" condition reached before returning
+            if not poll_condition(lambda: self._get_function_version(function_name, version.id.qualifier, version.id.account, version.id.region).config.state.state in [State.Active, State.Failed], timeout=10):
+                LOG.warning("LAMBDA_SYNCHRONOUS_CREATE is active, but waiting for %s reached timeout.", function_name)
 
         return api_utils.map_config_out(
             version, return_qualified_arn=False, return_update_status=False

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -631,8 +631,17 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
         if config.LAMBDA_SYNCHRONOUS_CREATE:
             # block via retrying until "terminal" condition reached before returning
-            if not poll_condition(lambda: self._get_function_version(function_name, version.id.qualifier, version.id.account, version.id.region).config.state.state in [State.Active, State.Failed], timeout=10):
-                LOG.warning("LAMBDA_SYNCHRONOUS_CREATE is active, but waiting for %s reached timeout.", function_name)
+            if not poll_condition(
+                lambda: self._get_function_version(
+                    function_name, version.id.qualifier, version.id.account, version.id.region
+                ).config.state.state
+                in [State.Active, State.Failed],
+                timeout=10,
+            ):
+                LOG.warning(
+                    "LAMBDA_SYNCHRONOUS_CREATE is active, but waiting for %s reached timeout.",
+                    function_name,
+                )
 
         return api_utils.map_config_out(
             version, return_qualified_arn=False, return_update_status=False


### PR DESCRIPTION
Introduces the option to mirror the previous "simplified" behavior where the `Lambda.CreateFunction` API call now blocks until the created function/version is in a non-transitional state (e.g. it will be either `Active` or `Failed`).

This feature is only available via an optional feature flag, since it technically breaks behavior parity with AWS.

Intended primarily for people getting started when only using CLI/SDKs and for easier friction-less migration paths from the old to the new provider.