### PR TITLE
fix npm ownership issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,7 @@ RUN source .venv/bin/activate && \
       timescaledb && \
     rm -rf /tmp/localstack/* && \
     rm -rf /var/lib/localstack/cache/* && \
-    chown localstack:localstack /usr/lib/localstack && \
+    chown -R localstack:localstack /usr/lib/localstack && \
     chmod -R 777 /usr/lib/localstack
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,8 @@ RUN source .venv/bin/activate && \
       timescaledb && \
     rm -rf /tmp/localstack/* && \
     rm -rf /var/lib/localstack/cache/* && \
-    chmod -R 777 /var/lib/localstack
+    chown localstack:localstack /usr/lib/localstack && \
+    chmod -R 777 /usr/lib/localstack
 
 
 # Add the build date and git hash at last (changes everytime)


### PR DESCRIPTION
This PR addresses issues with the latest version of npm:
- [node 18.14.0 has been released on 2023-02-02.](https://nodejs.org/fr/blog/release/v18.14.0/)
- This minor release of node upgrades the shipped npm version from version 8.19.3 to 9.3.1.
- npm v9 contains a breaking change: It will no longer attempt to modify the ownership of files it creates.
  - https://github.com/npm/cli/pull/5704

This PR ensures that all files created in the LPM step of the Docker build are in fact owned by the `localstack` user / group.

Fixes #7620