### PR TITLE
fix issues with redhat example build for 1.3+

### DIFF
--- a/.github/workflows/rh-support.yml
+++ b/.github/workflows/rh-support.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Open Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.10
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Build RH Docker Image
         run: |

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -43,7 +43,7 @@ RUN python3 -m venv .venv
 # Install python packages
 RUN source .venv/bin/activate && python3 -m pip install supervisor awscli awscli-local --upgrade --no-cache-dir
 # Install localstack dev packages
-RUN source .venv/bin/activate && python3 -m pip install 'localstack[full]>=1.3.0' 'localstack-ext[full]>=1.3.0' --pre --upgrade --no-cache-dir
+RUN source .venv/bin/activate && python3 -m pip install 'localstack[runtime]>=1.3.0' 'localstack-ext[runtime]>=1.3.0' --pre --upgrade --no-cache-dir
 
 # Set default settings
 ENV USER=localstack

--- a/Dockerfile.rh
+++ b/Dockerfile.rh
@@ -43,9 +43,7 @@ RUN python3 -m venv .venv
 # Install python packages
 RUN source .venv/bin/activate && python3 -m pip install supervisor awscli awscli-local --upgrade --no-cache-dir
 # Install localstack dev packages
-RUN source .venv/bin/activate && python3 -m pip install 'localstack[full]>=1.2.0' 'localstack-ext[full]>=1.2.0' --pre --upgrade --no-cache-dir
-# Install the basic libraries
-RUN source .venv/bin/activate && python3 -m localstack.services.install libs
+RUN source .venv/bin/activate && python3 -m pip install 'localstack[full]>=1.3.0' 'localstack-ext[full]>=1.3.0' --pre --upgrade --no-cache-dir
 
 # Set default settings
 ENV USER=localstack


### PR DESCRIPTION
This PR fixes the RedHat image build after the removal of the "init" make target with https://github.com/localstack/localstack/pull/7129.
The RedHat smoke test workflow is executed once a week on a fixed schedule.