### PR TITLE
migrate internal SES endpoint

### DIFF
--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -51,8 +51,8 @@ from localstack.aws.api.ses import (
     VerificationStatus,
 )
 from localstack.constants import TEST_AWS_SECRET_ACCESS_KEY
-from localstack.http import resource
-from localstack.services.internal import get_internal_apis
+from localstack.http import Resource
+from localstack.services.internal import DeprecatedResource, get_internal_apis
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.ses.models import SentEmail, SentEmailBody
@@ -72,7 +72,7 @@ EMAILS: Dict[MessageId, Dict[str, Any]] = {}
 
 # Endpoint to access all the sent emails
 # (relative to LocalStack internal HTTP resources base endpoint)
-EMAILS_ENDPOINT = "/ses"
+EMAILS_ENDPOINT = "/_aws/ses"
 
 _EMAILS_ENDPOINT_REGISTERED = False
 
@@ -119,7 +119,6 @@ def get_ses_backend(context: RequestContext) -> SESBackend:
     return ses_backends[context.account_id][context.region]
 
 
-@resource(f"/_localstack{EMAILS_ENDPOINT}")
 class SesServiceApiResource:
     """Provides a REST API for retrospective access to emails sent via SES.
 
@@ -149,7 +148,23 @@ def register_ses_api_resource():
     global _EMAILS_ENDPOINT_REGISTERED
 
     if not _EMAILS_ENDPOINT_REGISTERED:
-        get_internal_apis().add(SesServiceApiResource())
+        ses_service_api_resource = SesServiceApiResource()
+        get_internal_apis().add(
+            Resource(
+                "/_localstack/ses",
+                DeprecatedResource(
+                    ses_service_api_resource,
+                    previous_path="/_localstack/ses",
+                    deprecation_version="1.4.0",
+                    new_path="/_aws/ses/",
+                ),
+            )
+        )
+
+        from localstack.services.edge import ROUTER
+
+        ROUTER.add(Resource("/_aws/ses/", ses_service_api_resource))
+
         _EMAILS_ENDPOINT_REGISTERED = True
 
 

--- a/localstack/services/ses/provider.py
+++ b/localstack/services/ses/provider.py
@@ -163,7 +163,7 @@ def register_ses_api_resource():
 
         from localstack.services.edge import ROUTER
 
-        ROUTER.add(Resource("/_aws/ses/", ses_service_api_resource))
+        ROUTER.add(Resource(EMAILS_ENDPOINT, ses_service_api_resource))
 
         _EMAILS_ENDPOINT_REGISTERED = True
 

--- a/tests/integration/test_ses.py
+++ b/tests/integration/test_ses.py
@@ -8,7 +8,6 @@ import requests
 from botocore.exceptions import ClientError
 
 import localstack.config as config
-from localstack.constants import INTERNAL_RESOURCE_PATH
 from localstack.services.ses.provider import EMAILS_ENDPOINT
 from localstack.utils.strings import short_uid
 
@@ -182,7 +181,7 @@ class TestSES:
         assert "Body" not in contents2
 
         # Ensure all sent messages can be retrieved using the API endpoint
-        emails_url = config.get_edge_url() + INTERNAL_RESOURCE_PATH + EMAILS_ENDPOINT
+        emails_url = config.get_edge_url() + EMAILS_ENDPOINT
         api_contents = requests.get(emails_url).json()
         api_contents = {msg["Id"]: msg for msg in api_contents["messages"]}
         assert len(api_contents) >= 1
@@ -192,16 +191,9 @@ class TestSES:
         assert api_contents[message2_id] == contents2
 
         # Ensure messages can be filtered by email source via the REST endpoint
-        emails_url = (
-            config.get_edge_url()
-            + INTERNAL_RESOURCE_PATH
-            + EMAILS_ENDPOINT
-            + "?email=none@example.com"
-        )
+        emails_url = config.get_edge_url() + EMAILS_ENDPOINT + "?email=none@example.com"
         assert len(requests.get(emails_url).json()["messages"]) == 0
-        emails_url = (
-            config.get_edge_url() + INTERNAL_RESOURCE_PATH + EMAILS_ENDPOINT + f"?email={email}"
-        )
+        emails_url = config.get_edge_url() + EMAILS_ENDPOINT + f"?email={email}"
         assert len(requests.get(emails_url).json()["messages"]) == 2
 
     def test_send_templated_email_can_retrospect(self, ses_client, create_template):


### PR DESCRIPTION
This PR migrates the internal endpoint to retrieve emails sent by SES from `/_localstack/ses` to `/_aws/ses`.
The old endpoint is still routed, but on each invocation a deprecation warning is logged.

This PR is based on https://github.com/localstack/localstack/pull/7614 (since it refactors the resource routing quite a lot).