### PR TITLE
Fix !GetAtt with Outputs from Nested Stacks

### DIFF
--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -3,38 +3,24 @@ import logging
 import os
 
 import boto3
-import yaml
-from moto.cloudformation.utils import yaml_tag_constructor
 from samtranslator.translator.transform import transform as transform_sam
 
+from localstack.services.cloudformation.engine import yaml_parser
 from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
 from localstack.utils.aws import aws_stack
-from localstack.utils.json import clone_safe
 
 LOG = logging.getLogger(__name__)
-
-# create safe yaml loader that parses date strings as string, not date objects
-NoDatesSafeLoader = yaml.SafeLoader
-NoDatesSafeLoader.yaml_implicit_resolvers = {
-    k: [r for r in v if r[0] != "tag:yaml.org,2002:timestamp"]
-    for k, v in NoDatesSafeLoader.yaml_implicit_resolvers.items()
-}
 
 
 def parse_template(template: str) -> dict:
     try:
         return json.loads(template)
     except Exception:
-        # FIXME: removing this still breaks all short-hand intrinsic functions :|
-        yaml.add_multi_constructor("", yaml_tag_constructor, Loader=NoDatesSafeLoader)
         try:
-            return clone_safe(yaml.safe_load(template))
+            return yaml_parser.parse_yaml(template)
         except Exception:
-            try:
-                return clone_safe(yaml.load(template, Loader=NoDatesSafeLoader))
-            except Exception as e:
-                LOG.debug("Unable to parse CloudFormation template (%s): %s", e, template)
-                raise
+            # TODO
+            raise
 
 
 def template_to_json(template: str) -> str:

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -8,6 +8,7 @@ from samtranslator.translator.transform import transform as transform_sam
 from localstack.services.cloudformation.engine import yaml_parser
 from localstack.services.cloudformation.engine.policy_loader import create_policy_loader
 from localstack.utils.aws import aws_stack
+from localstack.utils.json import clone_safe
 
 LOG = logging.getLogger(__name__)
 
@@ -17,9 +18,9 @@ def parse_template(template: str) -> dict:
         return json.loads(template)
     except Exception:
         try:
-            return yaml_parser.parse_yaml(template)
-        except Exception:
-            # TODO
+            return clone_safe(yaml_parser.parse_yaml(template))
+        except Exception as e:
+            LOG.debug("Unable to parse CloudFormation template (%s): %s", e, template)
             raise
 
 

--- a/localstack/services/cloudformation/engine/yaml_parser.py
+++ b/localstack/services/cloudformation/engine/yaml_parser.py
@@ -43,6 +43,8 @@ def shorthand_constructor(loader: yaml.Loader, tag_suffix: str, node: yaml.Node)
         return {fn_name: node.value}
     elif isinstance(node, yaml.SequenceNode):
         return {fn_name: loader.construct_sequence(node)}
+    elif isinstance(node, yaml.MappingNode):
+        return {fn_name: loader.construct_mapping(node)}
     else:
         raise ValueError(f"Unexpected yaml Node type: {type(node)}")
 

--- a/localstack/services/cloudformation/engine/yaml_parser.py
+++ b/localstack/services/cloudformation/engine/yaml_parser.py
@@ -37,7 +37,7 @@ def shorthand_constructor(loader: yaml.Loader, tag_suffix: str, node: yaml.Node)
         parts = node.value.partition(".")
         if len(parts) != 3:
             raise ValueError(f"Node value contains unexpected format for !GetAtt: {parts}")
-        return {fn_name: [parts[0], *parts[2:]]}
+        return {fn_name: [parts[0], parts[2]]}
 
     if isinstance(node, yaml.ScalarNode):
         return {fn_name: node.value}

--- a/localstack/services/cloudformation/engine/yaml_parser.py
+++ b/localstack/services/cloudformation/engine/yaml_parser.py
@@ -13,7 +13,7 @@ class NoDatesSafeLoader(yaml.SafeLoader):
         """
         # needed to make sure we're not changing the constructors of the base class
         # otherwise usage across the code base is affected as well
-        if not "yaml_constructors" in cls.__dict__:
+        if "yaml_constructors" not in cls.__dict__:
             cls.yaml_constructors = cls.yaml_constructors.copy()
 
         cls.yaml_constructors[tag] = construct_raw
@@ -44,7 +44,7 @@ def shorthand_constructor(loader: yaml.Loader, tag_suffix: str, node: yaml.Node)
     elif isinstance(node, yaml.SequenceNode):
         return {fn_name: loader.construct_sequence(node)}
     else:
-        raise ValueError(f"Unexpected yaml Node type")
+        raise ValueError(f"Unexpected yaml Node type: {type(node)}")
 
 
 customloader = NoDatesSafeLoader

--- a/localstack/services/cloudformation/engine/yaml_parser.py
+++ b/localstack/services/cloudformation/engine/yaml_parser.py
@@ -1,0 +1,56 @@
+import yaml
+
+
+def construct_raw(_, node):
+    return node.value
+
+
+class NoDatesSafeLoader(yaml.SafeLoader):
+    @classmethod
+    def remove_tag_constructor(cls, tag):
+        """
+        Remove the YAML constructor for a given tag and replace it with a raw constructor
+        """
+        # needed to make sure we're not changing the constructors of the base class
+        # otherwise usage across the code base is affected as well
+        if not "yaml_constructors" in cls.__dict__:
+            cls.yaml_constructors = cls.yaml_constructors.copy()
+
+        cls.yaml_constructors[tag] = construct_raw
+
+
+NoDatesSafeLoader.remove_tag_constructor("tag:yaml.org,2002:timestamp")
+
+
+def shorthand_constructor(loader: yaml.Loader, tag_suffix: str, node: yaml.Node):
+    """
+    TODO: proper exceptions (introduce this when fixing the provider)
+    TODO: fix select & split (is this even necessary?)
+    { "Fn::Select" : [ "2", { "Fn::Split": [",", {"Fn::ImportValue": "AccountSubnetIDs"}]}] }
+    !Select [2, !Split [",", !ImportValue AccountSubnetIDs]]
+    shorthand: 2 => canonical "2"
+    """
+    fn_name = "Ref" if tag_suffix == "Ref" else f"Fn::{tag_suffix}"
+
+    if tag_suffix == "GetAtt" and isinstance(node, yaml.ScalarNode):
+        # !GetAtt A.B.C => {"Fn::GetAtt": ["A", "B.C"]}
+        parts = node.value.partition(".")
+        if len(parts) != 3:
+            raise ValueError(f"Node value contains unexpected format for !GetAtt")
+        return {fn_name: [parts[0], *parts[2:]]}
+
+    if isinstance(node, yaml.ScalarNode):
+        return {fn_name: node.value}
+    elif isinstance(node, yaml.SequenceNode):
+        return {fn_name: loader.construct_sequence(node)}
+    else:
+        raise ValueError(f"Unexpected yaml Node type")
+
+
+customloader = NoDatesSafeLoader
+
+yaml.add_multi_constructor("!", shorthand_constructor, customloader)
+
+
+def parse_yaml(input_data: str):
+    return yaml.load(input_data, customloader)

--- a/localstack/services/cloudformation/engine/yaml_parser.py
+++ b/localstack/services/cloudformation/engine/yaml_parser.py
@@ -36,7 +36,7 @@ def shorthand_constructor(loader: yaml.Loader, tag_suffix: str, node: yaml.Node)
         # !GetAtt A.B.C => {"Fn::GetAtt": ["A", "B.C"]}
         parts = node.value.partition(".")
         if len(parts) != 3:
-            raise ValueError(f"Node value contains unexpected format for !GetAtt")
+            raise ValueError(f"Node value contains unexpected format for !GetAtt: {parts}")
         return {fn_name: [parts[0], *parts[2:]]}
 
     if isinstance(node, yaml.ScalarNode):

--- a/tests/integration/cloudformation/api/test_nested_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_nested_stacks.snapshot.json
@@ -1,0 +1,67 @@
+{
+  "tests/integration/cloudformation/api/test_nested_stacks.py::test_nested_output_in_params": {
+    "recorded-date": "07-02-2023, 10:57:47",
+    "recorded-content": {
+      "get_role_response": {
+        "Role": {
+          "Arn": "arn:aws:iam::111111111111:role/<role-name>",
+          "AssumeRolePolicyDocument": {
+            "Statement": [
+              {
+                "Action": "sts:AssumeRole",
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "lambda.amazonaws.com"
+                }
+              }
+            ],
+            "Version": "2012-10-17"
+          },
+          "CreateDate": "datetime",
+          "Description": "",
+          "MaxSessionDuration": 3600,
+          "Path": "/",
+          "RoleId": "<role-id:1>",
+          "RoleLastUsed": {},
+          "RoleName": "<role-name>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role_policies": {
+        "IsTruncated": false,
+        "PolicyNames": [
+          "PolicyA"
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "actual_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sns:Publish"
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:sns:<region>:111111111111:<topic>"
+              ]
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "PolicyA",
+        "RoleName": "<role-name>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -6,7 +6,6 @@ import pytest
 import yaml
 
 from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
-from localstack.testing.aws.cloudformation_utils import load_template_file
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
@@ -110,10 +109,10 @@ class TestStacksApi:
 
         # create stack
         deployed = deploy_cfn_template(
-            template_path=os.path.join(os.path.dirname(__file__), "../../templates/simple_api.yaml"),
-            parameters={
-                "ApiName": api_name
-            }
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/simple_api.yaml"
+            ),
+            parameters={"ApiName": api_name},
         )
         stack_name = deployed.stack_name
         stack_id = deployed.stack_id
@@ -126,7 +125,9 @@ class TestStacksApi:
         deploy_cfn_template(
             is_update=True,
             stack_name=deployed.stack_name,
-            template_path=os.path.join(os.path.dirname(__file__), "../../templates/simple_api.update.yaml"),
+            template_path=os.path.join(
+                os.path.dirname(__file__), "../../templates/simple_api.update.yaml"
+            ),
             parameters={"ApiName": api_name},
         )
 

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -5,6 +5,7 @@ import botocore.exceptions
 import pytest
 import yaml
 
+from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
 from localstack.testing.aws.cloudformation_utils import load_template_file
 from localstack.testing.snapshots.transformer import SortingTransformer
 from localstack.utils.files import load_file
@@ -106,11 +107,13 @@ class TestStacksApi:
         snapshot.add_transformer(snapshot.transform.key_value("PhysicalResourceId"))
 
         api_name = f"test_{short_uid()}"
-        template_path = os.path.join(os.path.dirname(__file__), "../../templates/simple_api.yaml")
 
         # create stack
         deployed = deploy_cfn_template(
-            template_path=template_path, parameters={"ApiName": api_name}
+            template_path=os.path.join(os.path.dirname(__file__), "../../templates/simple_api.yaml"),
+            parameters={
+                "ApiName": api_name
+            }
         )
         stack_name = deployed.stack_name
         stack_id = deployed.stack_id
@@ -120,12 +123,10 @@ class TestStacksApi:
 
         # update stack, with one additional resource
         api_name = f"test_{short_uid()}"
-        template_body = yaml.safe_load(load_template_file(template_path))
-        template_body["Resources"]["Bucket"] = {"Type": "AWS::S3::Bucket"}
         deploy_cfn_template(
             is_update=True,
             stack_name=deployed.stack_name,
-            template=json.dumps(template_body),
+            template_path=os.path.join(os.path.dirname(__file__), "../../templates/simple_api.update.yaml"),
             parameters={"ApiName": api_name},
         )
 
@@ -155,7 +156,7 @@ class TestStacksApi:
         assert statuses == {"CREATE_COMPLETE"}
 
         # remove one resource from the template, then update stack (via change set)
-        template_dict = yaml.safe_load(open(template_path))
+        template_dict = parse_yaml(load_file(template_path))
         template_dict["Resources"].pop("eventPolicy2")
         template2 = yaml.dump(template_dict)
 

--- a/tests/integration/cloudformation/api/test_update_stack.py
+++ b/tests/integration/cloudformation/api/test_update_stack.py
@@ -4,7 +4,6 @@ import os
 import botocore.errorfactory
 import botocore.exceptions
 import pytest
-import yaml
 
 from localstack.utils.files import load_file
 from localstack.utils.strings import short_uid
@@ -254,13 +253,19 @@ def test_no_parameters_update(deploy_cfn_template, cfn_client):
 @pytest.mark.aws_validated
 def test_update_with_previous_parameter_value(deploy_cfn_template, cfn_client, snapshot):
     stack = deploy_cfn_template(
-        template_path=os.path.join(os.path.dirname(__file__), "../../templates/sns_topic_parameter.yml"),
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/sns_topic_parameter.yml"
+        ),
         parameters={"TopicName": f"topic-{short_uid()}"},
     )
 
     cfn_client.update_stack(
         StackName=stack.stack_name,
-        TemplateBody=load_file(os.path.join(os.path.dirname(__file__), "../../templates/sns_topic_parameter.update.yml")),
+        TemplateBody=load_file(
+            os.path.join(
+                os.path.dirname(__file__), "../../templates/sns_topic_parameter.update.yml"
+            )
+        ),
         Parameters=[{"ParameterKey": "TopicName", "UsePreviousValue": True}],
     )
 

--- a/tests/integration/cloudformation/api/test_update_stack.py
+++ b/tests/integration/cloudformation/api/test_update_stack.py
@@ -253,22 +253,14 @@ def test_no_parameters_update(deploy_cfn_template, cfn_client):
 
 @pytest.mark.aws_validated
 def test_update_with_previous_parameter_value(deploy_cfn_template, cfn_client, snapshot):
-    template = load_file(
-        os.path.join(os.path.dirname(__file__), "../../templates/sns_topic_parameter.yml")
-    )
-
     stack = deploy_cfn_template(
-        template=template,
+        template_path=os.path.join(os.path.dirname(__file__), "../../templates/sns_topic_parameter.yml"),
         parameters={"TopicName": f"topic-{short_uid()}"},
     )
 
-    template_dict = yaml.safe_load(template)
-    del template_dict["Resources"]["topic123"]["UpdateReplacePolicy"]
-    template = yaml.safe_dump(template_dict)
-
     cfn_client.update_stack(
         StackName=stack.stack_name,
-        TemplateBody=template,
+        TemplateBody=load_file(os.path.join(os.path.dirname(__file__), "../../templates/sns_topic_parameter.update.yml")),
         Parameters=[{"ParameterKey": "TopicName", "UsePreviousValue": True}],
     )
 

--- a/tests/integration/cloudformation/test_template_engine.py
+++ b/tests/integration/cloudformation/test_template_engine.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from localstack.aws.api.lambda_ import Runtime
+from localstack.services.cloudformation.engine.yaml_parser import parse_yaml
 from localstack.testing.aws.cloudformation_utils import load_template_raw
 from localstack.utils.aws import arns
 from localstack.utils.common import short_uid
@@ -709,7 +710,7 @@ class TestMacros:
             lambda_client,
         )
 
-        template_dict = yaml.safe_load(
+        template_dict = parse_yaml(
             load_file(
                 os.path.join(
                     os.path.dirname(__file__), "../templates/transformation_global_parameter.yml"
@@ -721,7 +722,7 @@ class TestMacros:
                 template_dict["Resources"]["Parameter"]
             )
 
-        template = yaml.safe_dump(template_dict)
+        template = yaml.dump(template_dict)
 
         with pytest.raises(botocore.exceptions.ClientError) as ex:
             deploy_cfn_template(template=template)

--- a/tests/integration/templates/nested-stack-outputref/root.yaml
+++ b/tests/integration/templates/nested-stack-outputref/root.yaml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  Sub1TemplateUrl:
+    Type: String
+  Sub2TemplateUrl:
+    Type: String
+  TopicName:
+    Type: String
+  RoleName:
+    Type: String
+
+Resources:
+  Sub1:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Ref Sub1TemplateUrl
+      Parameters:
+        TopicName: !Ref TopicName
+
+  Sub2:
+    Type: AWS::CloudFormation::Stack
+    DependsOn:
+      - Sub1
+    Properties:
+      TemplateURL: !Ref Sub2TemplateUrl
+      Parameters:
+        TopicArn: !GetAtt Sub1.Outputs.OutputA
+        RoleName: !Ref RoleName

--- a/tests/integration/templates/nested-stack-outputref/sub1.yaml
+++ b/tests/integration/templates/nested-stack-outputref/sub1.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  TopicName:
+    Type: String
+
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Ref TopicName
+
+Outputs:
+  OutputA:
+    Value: !Ref MyTopic

--- a/tests/integration/templates/nested-stack-outputref/sub2.yaml
+++ b/tests/integration/templates/nested-stack-outputref/sub2.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  TopicArn:
+    Type: String
+  RoleName:
+    Type: String
+
+Resources:
+  MyPolicy:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: PolicyA
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Ref TopicArn

--- a/tests/integration/templates/simple_api.update.yaml
+++ b/tests/integration/templates/simple_api.update.yaml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Parameters:
+  ApiName:
+    Type: String
+
+Resources:
+  Api:
+    Type: 'AWS::ApiGateway::RestApi'
+    Properties:
+      Name:
+        Ref: ApiName
+  Bucket:
+    Type: AWS::S3::Bucket

--- a/tests/integration/templates/sns_topic_parameter.update.yml
+++ b/tests/integration/templates/sns_topic_parameter.update.yml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  TopicName:
+    Type: String
+    Default: sns-topic-simple
+Resources:
+  topic123:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName:
+        Ref: TopicName
+    DeletionPolicy: Delete
+
+Outputs:
+  TopicArn:
+    Value:
+      Fn::GetAtt:
+        - topic123
+        - TopicArn

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -44,7 +44,7 @@ class TestMisc(unittest.TestCase):
         if isinstance(obj["Version"], datetime.date):
             obj = json_safe(obj)
             self.assertEqual(str, type(obj["Version"]))
-            self.assertEqual("2012-10-17", obj["Version"])
+            self.assertEqual("2012-10-17T00:00:00.000Z", obj["Version"])
 
     def test_timstamp_millis(self):
         t1 = now_utc()


### PR DESCRIPTION
The previous YAML parsing had an issue with parsing this: `!GetAtt Sub1.Outputs.OutputA` which led to the parameter being passed empty.

This also touched code that I recently refactored and I continued there to refactor the yaml parsing a bit to be cleaner & more robust. This also only uses the yaml module now without other external libs.


## Changes
- Rewrote YAML parsing of cloudformation templates which also now includes a fix for !GetAtt short hand parsing
- Added validated parity test for a simple reproduction sample with snapshots
- Fixed a unit test that had an invalid assertion. (This was already broken on master but didn't evaluate to false because yaml loader was globally patched when the cloudformation module was loaded in other tests)