### PR TITLE
add newline after XML preamble for S3 (fix serverless issue)

### DIFF
--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1582,7 +1582,3 @@ def aws_response_serializer(service: str, operation: str):
         return _proxy
 
     return _decorate
-
-
-# b'<?xml version="1.0" encoding="UTF-8"?>\n<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2</LocationConstraint>'
-# b'<?xml version="1.0" encoding="UTF-8"?><LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2</LocationConstraint>'

--- a/localstack/aws/protocol/serializer.py
+++ b/localstack/aws/protocol/serializer.py
@@ -1438,6 +1438,11 @@ class S3ResponseSerializer(RestXMLResponseSerializer):
     def _create_empty_node(xmlnode: ETree.Element, name: str) -> None:
         ETree.SubElement(xmlnode, name)
 
+    def _prepare_additional_traits_in_xml(self, root: Optional[ETree.Element]):
+        # some tools (Serverless) require a newline after the "<?xml ...>\n" preamble line, e.g., for LocationConstraint
+        if root and not root.tail:
+            root.tail = "\n"
+
 
 class SqsResponseSerializer(QueryResponseSerializer):
     """
@@ -1577,3 +1582,7 @@ def aws_response_serializer(service: str, operation: str):
         return _proxy
 
     return _decorate
+
+
+# b'<?xml version="1.0" encoding="UTF-8"?>\n<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2</LocationConstraint>'
+# b'<?xml version="1.0" encoding="UTF-8"?><LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2</LocationConstraint>'

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -254,11 +254,18 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_bucket_location(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
     ) -> GetBucketLocationOutput:
+        """
+        When implementing the ASF provider, this operation is implemented because:
+        - The spec defines a root element GetBucketLocationOutput containing a LocationConstraint member, where
+          S3 actually just returns the LocationConstraint on the root level (only operation so far that we know of).
+        - We circumvent the root level element here by patching the spec such that this operation returns a
+          single "payload" (the XML body response), which causes the serializer to directly take the payload element.
+        - The above "hack" causes the fix in the serializer to not be picked up here as we're passing the XML body as
+          the payload, which is why we need to manually do this here by manipulating the string.
+        Botocore implements this hack for parsing the response in `botocore.handlers.py#parse_get_bucket_location`
+        """
         response = call_moto(context)
-        # LocationConstraint is a bit of weird response, we return directly XML from moto because it does not have
-        # a GetBucketLocationOutput XML tag.
-        # some tools (Serverless) require a newline after the "<?xml ...>\n" preamble line, e.g., for LocationConstraint
-        # this is required because upstream moto is generally collapsing all S3 XML responses
+
         location_constraint_xml = response["LocationConstraint"]
         xml_root_end = location_constraint_xml.find(">") + 1
         location_constraint_xml = (

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -1381,6 +1381,11 @@ class TestS3:
         response = client_2.get_bucket_location(Bucket=bucket_3_name)
         snapshot.match("get_bucket_location_bucket_3", response)
 
+        with pytest.raises(ClientError) as exc:
+            s3_client.get_bucket_location(Bucket=f"random-bucket-test-{short_uid()}")
+
+        snapshot.match("get_bucket_location_non_existent_bucket", exc.value.response)
+
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         condition=is_old_provider,

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -943,7 +943,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_different_location_constraint": {
-    "recorded-date": "21-09-2022, 13:35:57",
+    "recorded-date": "08-02-2023, 12:03:07",
     "recorded-content": {
       "get_bucket_location_bucket_1": {
         "LocationConstraint": null,
@@ -981,6 +981,18 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "get_bucket_location_non_existent_bucket": {
+        "Error": {
+          "BucketName": "<bucket-name:1>",
+          "Code": "NoSuchBucket",
+          "Message": "The specified bucket does not exist"
+        },
+        "LocationConstraint": null,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }


### PR DESCRIPTION
While working on different support tickets, it appeared Serverless had an issue saying that the deployment bucket would not be in the same region as the lambda, while it was. By debugging Serverless adding `console.log` statement around, I've realized we were missing a newline return after the XML preamble, which was added in the old S3 provider for some responses (especially `LocationConstraint`). 

I've added it to the serializer, and in the `GetBucketLocation` as well, as it's a bit specific: it does not have the usual root tag, so I've declared it as a `payload` as a workaround. Problem is, we don't parse the response from moto, we pass its response "as-is", so we need to add the newline manually. It's a bit of an odd case, so I suppose we should not modify the serializer for something like that, a very specific case, but I'd like to hear @alexrashed opinion!

Anyway, this fix allows us to use Serverless with the new S3 ASF provider. I've added some checks in an existing test case checking XML response structure. 

Before the change, the response returned was:
```xml
<?xml version="1.0" encoding="UTF-8"?><LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2</LocationConstraint>
```

And after (note the `\n` after the XML preamble):
```xml
<?xml version="1.0" encoding="UTF-8"?>\n<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2</LocationConstraint>
```

Serverless would parse the response without newline this way:
```js
{
  LocationConstraint: '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-west-2'
}
```
When it should have been:
```js
{
  LocationConstraint: 'eu-west-2'
}
```