### PR TITLE
fix S3 ASF pre-signed port permutation logic

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -557,7 +557,7 @@ class S3SigV4SignatureContext:
         :param original_host_port:
         :return:
         """
-        if new_host_port:
+        if original_host_port:
             updated_netloc = self._original_host.replace(original_host_port, new_host_port)
         else:
             updated_netloc = f"{self._original_host}{new_host_port}"

--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -498,10 +498,10 @@ def _find_valid_signature_through_ports(context: RequestContext) -> FindSigV4Res
             # the request has already been tested before the loop, skip
             if request_port == port:
                 continue
-            sigv4_context.update_host_port(port, request_port)
+            sigv4_context.update_host_port(new_host_port=port, original_host_port=request_port)
 
         else:
-            sigv4_context.update_host_port(port)
+            sigv4_context.update_host_port(new_host_port=port)
 
         # we ignore the additional data because we want the exception raised to match the original request
         signature, _, _ = sigv4_context.get_signature_data()
@@ -538,6 +538,7 @@ class S3SigV4SignatureContext:
             netloc = self._headers.get(S3_VIRTUAL_HOST_FORWARDED_HEADER)
             self.host = netloc
             self._original_host = netloc
+            self.signed_headers["host"] = netloc
             # the request comes from the Virtual Host router, we need to remove the bucket from the path
             splitted_path = self.request.path.split("/", maxsplit=2)
             self.path = f"/{splitted_path[-1]}"

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3063,9 +3063,11 @@ class TestS3PresignedUrl:
         response = requests.get(presign_url, headers={"host": host_443})
         assert b"test-value" == response._content
 
-        host_no_port = host.replace(":443", "")
-        response = requests.get(presign_url, headers={"host": host_no_port})
-        assert b"test-value" == response._content
+        if is_asf_provider():
+            # this does not work with old legacy provider, the signature does not match
+            host_no_port = host_443.replace(":443", "")
+            response = requests.get(presign_url, headers={"host": host_no_port})
+            assert b"test-value" == response._content
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3047,7 +3047,7 @@ class TestS3PresignedUrl:
         host = f"{S3_VIRTUAL_HOSTNAME}:{config.EDGE_PORT}"
         s3_presign = _s3_client_custom_config(
             Config(signature_version="s3v4"),
-            endpoint_url=_endpoint_url(),
+            endpoint_url=f"http://{host}",
         )
 
         s3_client.put_object(Body="test-value", Bucket=s3_bucket, Key="test")

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3041,21 +3041,13 @@ class TestS3PresignedUrl:
             s3_presigned_client.meta.events.unregister("before-sign.s3.GetObject", add_query_param)
 
     @pytest.mark.only_localstack
-    @pytest.mark.xfail(
-        condition=not LEGACY_S3_PROVIDER,
-        reason="failing for ASF provider, will be fixed in separate PR",
-    )
     def test_presign_check_signature_validation_for_port_permutation(
         self, s3_client, s3_bucket, patch_s3_skip_signature_validation_false
     ):
-        port1 = 443
-        port2 = config.EDGE_PORT
-        endpoint = (
-            f"http://{config.LOCALSTACK_HOSTNAME}:{port1}"  # .replace(f":{port2}", f":{port1}")
-        )
+        host = f"{S3_VIRTUAL_HOSTNAME}:{config.EDGE_PORT}"
         s3_presign = _s3_client_custom_config(
             Config(signature_version="s3v4"),
-            endpoint_url=endpoint,
+            endpoint_url=_endpoint_url(),
         )
 
         s3_client.put_object(Body="test-value", Bucket=s3_bucket, Key="test")
@@ -3065,10 +3057,14 @@ class TestS3PresignedUrl:
             Params={"Bucket": s3_bucket, "Key": "test"},
             ExpiresIn=86400,
         )
-        assert f":{port1}" in presign_url
-        presign_url = presign_url.replace(f":{port1}", f":{port2}")
+        assert f":{config.EDGE_PORT}" in presign_url
 
-        response = requests.get(presign_url)
+        host_443 = host.replace(f":{config.EDGE_PORT}", ":443")
+        response = requests.get(presign_url, headers={"host": host_443})
+        assert b"test-value" == response._content
+
+        host_no_port = host.replace(":443", "")
+        response = requests.get(presign_url, headers={"host": host_no_port})
         assert b"test-value" == response._content
 
     @pytest.mark.aws_validated


### PR DESCRIPTION
While working on a support case, I've seen an Exception raises while trying to check a pre-signed URL with the new S3 ASF provider. The logic was inverted and we trying to replace a string with `None` parameter, which failed. 

This PR fixes the issue and removes an old xfail for this specific case that was fixed a while ago. I've added a new case for when we don't have the port (which was actually failing for the new provider). 

Also added a fix for the CI failure ([see here the run](https://app.circleci.com/pipelines/github/localstack/localstack/12466/workflows/18f7ea07-662a-4d7c-8862-9e5d3491a3c2/jobs/89244)), it seems the host header was wrong for the signature calculation, weird that nothing picked it up before. 