### PR TITLE
EC2: Fix attribute not initialised in Subnet instance during unpickling

### DIFF
--- a/localstack/services/ec2/models.py
+++ b/localstack/services/ec2/models.py
@@ -13,7 +13,7 @@ def get_ec2_backend(account_id: str, region: str) -> EC2Backend:
 
 
 def set_state(self, state):
-    state["_subnet_ip_generator"] = self.cidr.hosts()
+    state["_subnet_ip_generator"] = state["cidr"].hosts()
     self.__dict__.update(state)
 
 


### PR DESCRIPTION
Changes introduced in https://github.com/localstack/localstack/pull/7629/ caused failures in the persistence test suite:
```
2023-02-08T18:11:42.280 DEBUG --- [   asgi_gw_0] l.utils.persistence        : Unable to read pickled persistence file /home/viren/repo/localstack/.filesystem/var/lib/localstack/state/api_states/ec2/backend.state: 'Subnet' object has no attribute 'cidr'
```
During unpickling, the `__init__()` is not called which meant that `self.cidr` did not exist. This prevented the persisted state from being restored.

This PR fixes this so that `cidr` from the state is used to create `_subnet_ip_generator`.