### PR TITLE
refactor state visitor code and lifecycle hooks

### DIFF
--- a/localstack/state/__init__.py
+++ b/localstack/state/__init__.py
@@ -1,0 +1,9 @@
+from .core import AssetDirectory, StateContainer, StateLifecycleHook, StateVisitable, StateVisitor
+
+__all__ = [
+    "StateVisitable",
+    "StateVisitor",
+    "StateLifecycleHook",
+    "AssetDirectory",
+    "StateContainer",
+]

--- a/localstack/state/core.py
+++ b/localstack/state/core.py
@@ -1,0 +1,78 @@
+"""Core concepts of the persistence API."""
+from typing import Any, Protocol, runtime_checkable
+
+StateContainer = Any
+"""While a StateContainer can in principle be anything, localstack currently supports by default the following
+containers:
+
+- BackendDict (moto backend state)
+- AccountRegionBundle (localstack stores)
+- AssetDirectory (folders on disk)
+"""
+
+
+class StateLifecycleHook:
+    """
+    There are three well-known state manipulation operations for a service provider:
+
+    - reset: the state within the service provider is reset, stores cleared, directories removed
+    - save: the state of the service provider is extracted and stored into some format (on disk, pods, ...)
+    - load: the state is injected into the service, or state directories on disk are restored
+    """
+
+    def on_before_state_reset(self):
+        """Hook triggered before the provider's state containers are reset/cleared."""
+        pass
+
+    def on_after_state_reset(self):
+        """Hook triggered after the provider's state containers have been reset/cleared."""
+        pass
+
+    def on_before_state_save(self):
+        """Hook triggered before the provider's state containers are saved."""
+        pass
+
+    def on_after_state_save(self):
+        """Hook triggered after the provider's state containers have been saved."""
+        pass
+
+    def on_before_state_load(self):
+        """Hook triggered before a previously serialized state is loaded into the provider's state containers."""
+        pass
+
+    def on_after_state_load(self):
+        """Hook triggered after a previously serialized state has been loaded into the provider's state containers."""
+        pass
+
+
+class StateVisitor:
+    def visit(self, state_container: StateContainer):
+        """
+        Visit (=do something with) a given state container. A state container can be anything that holds service state.
+        An AccountRegionBundle, a moto BackendDict, or a directory containing assets.
+        """
+        raise NotImplementedError
+
+
+@runtime_checkable
+class StateVisitable(Protocol):
+    def accept_state_visitor(self, visitor: StateVisitor):
+        """
+        Accept a StateVisitor. The implementing method should call visit not necessarily on itself, but can also call
+        the visit method on the state container it holds. The common case is calling visit on the stores of a provider.
+        :param visitor: the StateVisitor
+        """
+
+
+class AssetDirectory:
+    """
+    A state container manifested as a directory on the file system.
+    """
+
+    path: str
+
+    def __init__(self, path: str):
+        if not path:
+            raise ValueError("path must be set")
+
+        self.path = path

--- a/tests/unit/persistence/test_inspect.py
+++ b/tests/unit/persistence/test_inspect.py
@@ -1,10 +1,10 @@
 from moto.sns import models as sns_models
 
 from localstack.services.sqs import models as sqs_models
-from localstack.services.visitors import ReflectionStateLocator, ServiceBackendCollectorVisitor
+from localstack.state.inspect import ReflectionStateLocator, ServiceBackendCollectorVisitor
 
 
-class TestVisitors:
+class TestReflectionStateLocator:
     def test_collect_store(self, sample_stores, monkeypatch):
         """Ensures that the visitor can effectively collect store backend"""
         account = "696969696969"
@@ -15,7 +15,7 @@ class TestVisitors:
 
         visitor = ServiceBackendCollectorVisitor()
         state_manager = ReflectionStateLocator(service="sqs")
-        state_manager.accept(visitor=visitor)
+        state_manager.accept_state_visitor(visitor=visitor)
         backends = visitor.collect()
 
         store_backend = backends.get("localstack")
@@ -37,7 +37,7 @@ class TestVisitors:
 
         visitor = ServiceBackendCollectorVisitor()
         state_manager = ReflectionStateLocator(service="sns")
-        state_manager.accept(visitor=visitor)
+        state_manager.accept_state_visitor(visitor=visitor)
         backends = visitor.collect()
 
         store_backend = backends.get("moto")


### PR DESCRIPTION
This PR includes some minor refactoring (mostly moving and renaming) of code related to persistence, state, and the visitors.

* Introduce `localstack.state` for the state API (which are the base abstractions for disk-based persistence and pods)
* Extracted a comprehensive `StateLifecyleHook` that will be used in the future
* Made `ServiceLifecycleHook` extend from that
* let `Service` implement the `accept_state_visitor` (pre-requisite for follow-up code)
* Removed unused `BackendStateLifecycle` (now `StateLifecycleHook` as originally intended)