### PR TITLE
Update flake8 and isort dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -19,7 +19,7 @@ repos:
         types: [pyi]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
       - id: flake8
         entry: pflake8

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1546,10 +1546,23 @@ def create_user(iam_client):
                     attached_policy["PolicyArn"],
                     username,
                 )
+        access_keys = iam_client.list_access_keys(UserName=username)["AccessKeyMetadata"]
+        for access_key in access_keys:
+            try:
+                iam_client.delete_access_key(
+                    UserName=username, AccessKeyId=access_key["AccessKeyId"]
+                )
+            except Exception:
+                LOG.debug(
+                    "Error deleting access key '%s' from user '%s'",
+                    access_key["AccessKeyId"],
+                    username,
+                )
+
         try:
             iam_client.delete_user(UserName=username)
-        except Exception:
-            LOG.debug("Error deleting user '%s' during test cleanup", username)
+        except Exception as e:
+            LOG.debug("Error deleting user '%s' during test cleanup: %s", username, e)
 
 
 @pytest.fixture

--- a/setup.cfg
+++ b/setup.cfg
@@ -115,15 +115,15 @@ dev =
     black==22.3.0
     coveralls==3.1.0
     Cython
-    flake8==3.9.2
-    flake8-black==0.3.2
-    flake8-isort==5.0.0
-    flake8-quotes>=0.11.0
+    flake8-black>=0.3.6
+    flake8-isort>=6.0.0
+    flake8-quotes>=3.3.2
+    flake8>=6.0.0.post1
     isort==5.9.1
     networkx>=2.8.4
     pandoc
     pre-commit==2.13.0
     pypandoc
     # enables flake8 configuration through pyproject.toml
-    pyproject-flake8==3.9.2
+    pyproject-flake8>=6.0.0.post1
     rstr>=3.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -118,8 +118,8 @@ dev =
     flake8-black>=0.3.6
     flake8-isort>=6.0.0
     flake8-quotes>=3.3.2
-    flake8>=6.0.0.post1
-    isort==5.9.1
+    flake8>=6.0.0
+    isort==5.12.0
     networkx>=2.8.4
     pandoc
     pre-commit==2.13.0


### PR DESCRIPTION
## Motivation
Our current flake8 version seemed to have problems with python 3.10 dict structural decomposition. In -ext, the following code:
```
    match something:
        case {"AWS": a_variable}:
              print(a_variable)
```
Raised a name not found error to a_variable, as it could not detect the assignment.

## Changes
* Update flake8 to 6.0.0
* Update isort to 5.12.0
* Update all flake8 dependencies to their current version
* Update flake8 + isort in the precommit hooks (this is the reason why isort has to be updated, the older version could not be installed anymore with poetry, issue: https://github.com/PyCQA/isort/issues/2077

## Discussion
Not sure if we want to leave the version ranges that open for now. Any opinions? A breaking change should at least be a quick fix and instantly detectable.

superseding #7208