### PR TITLE
add OpenSearch SecurityPlugin configuration

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -745,9 +745,6 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER") or is_en
     "ES_MULTI_CLUSTER"
 )
 
-# Whether the OpenSearch Security Plugin should be enabled or not
-OPENSEARCH_SECURITY = is_env_true("OPENSEARCH_SECURITY")
-
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -745,6 +745,9 @@ OPENSEARCH_MULTI_CLUSTER = is_env_not_false("OPENSEARCH_MULTI_CLUSTER") or is_en
     "ES_MULTI_CLUSTER"
 )
 
+# Whether the OpenSearch Security Plugin should be enabled or not
+OPENSEARCH_SECURITY = is_env_true("OPENSEARCH_SECURITY")
+
 # Whether to really publish to GCM while using SNS Platform Application (needs credentials)
 LEGACY_SNS_GCM_PUBLISHING = is_env_true("LEGACY_SNS_GCM_PUBLISHING")
 

--- a/localstack/http/proxy.py
+++ b/localstack/http/proxy.py
@@ -112,13 +112,14 @@ class ProxyHandler:
         }
     """
 
-    def __init__(self, forward_base_url: str):
+    def __init__(self, forward_base_url: str, client: HttpClient = None):
         """
         Creates a new Proxy with the given ``forward_base_url`` (see ``Proxy``).
 
         :param forward_base_url: the base url (backend) to forward the requests to.
+        :param client: the HTTP Client used to make the requests
         """
-        self.proxy = Proxy(forward_base_url=forward_base_url)
+        self.proxy = Proxy(forward_base_url=forward_base_url, client=client)
 
     def __call__(self, request: Request, **kwargs) -> Response:
         return self.proxy.forward(request, forward_path=kwargs.get("path", ""))

--- a/localstack/services/es/provider.py
+++ b/localstack/services/es/provider.py
@@ -141,11 +141,12 @@ def _clusterconfig_to_opensearch(
 ) -> Optional[ClusterConfig]:
     if elasticsearch_cluster_config is not None:
         result = cast(ClusterConfig, elasticsearch_cluster_config)
-        result["InstanceType"] = _instancetype_to_opensearch(result.get("InstanceType"))
-        result["DedicatedMasterType"] = _instancetype_to_opensearch(
-            result.get("DedicatedMasterType")
-        )
-        result["WarmType"] = _instancetype_to_opensearch(result.get("WarmType"))
+        if instance_type := result.get("InstanceType"):
+            result["InstanceType"] = _instancetype_to_opensearch(instance_type)
+        if dedicated_master_type := result.get("DedicatedMasterType"):
+            result["DedicatedMasterType"] = _instancetype_to_opensearch(dedicated_master_type)
+        if warm_type := result.get("WarmType"):
+            result["WarmType"] = _instancetype_to_opensearch(warm_type)
         return result
 
 

--- a/localstack/services/opensearch/cluster.py
+++ b/localstack/services/opensearch/cluster.py
@@ -6,7 +6,6 @@ from typing import Dict, List, NamedTuple, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
-import semver
 from werkzeug.routing import Rule
 
 from localstack import config, constants
@@ -287,20 +286,12 @@ class OpensearchCluster(Server):
         self._version = version or self.default_version
         self.arn = arn
         self.auth = None
-
-        parsed_version = semver.VersionInfo.parse(self.install_version)
-        if parsed_version < "2.3.0" and security_options and security_options.enabled:
-            LOG.warning(
-                "Advanced security options are enabled, but are not supported for OpenSearch < 2.3.0."
+        self.security_options = security_options
+        if self.security_options:
+            self.auth = (
+                self.security_options.master_username,
+                self.security_options.master_password,
             )
-            self.security_options = None
-        else:
-            self.security_options = security_options
-            if self.security_options:
-                self.auth = (
-                    self.security_options.master_username,
-                    self.security_options.master_password,
-                )
 
     @property
     def default_version(self) -> str:

--- a/localstack/services/opensearch/packages.py
+++ b/localstack/services/opensearch/packages.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import shutil
+import textwrap
 import threading
 from typing import List
 
@@ -75,9 +76,10 @@ class OpensearchPackageInstaller(PackageInstaller):
                     mkdir(dir_path)
                     chmod_r(dir_path, 0o777)
 
-                # install default plugins for opensearch 1.1+
+                # install and configure default plugins for opensearch 1.1+
                 # https://forum.opensearch.org/t/ingest-attachment-cannot-be-installed/6494/12
                 parsed_version = semver.VersionInfo.parse(version)
+                self._setup_security(install_dir)
                 if parsed_version >= "1.1.0":
                     for plugin in OPENSEARCH_PLUGIN_LIST:
                         plugin_binary = os.path.join(install_dir, "bin", "opensearch-plugin")
@@ -101,6 +103,89 @@ class OpensearchPackageInstaller(PackageInstaller):
                                 )
                                 if not os.environ.get("IGNORE_OS_DOWNLOAD_ERRORS"):
                                     raise
+
+    def _setup_security(self, install_dir: str):
+        from localstack.services.generic_proxy import (
+            GenericProxy,
+            install_predefined_cert_if_available,
+        )
+
+        # create & copy SSL certs to opensearch config dir
+        install_predefined_cert_if_available()
+        config_path = os.path.join(install_dir, "config")
+        _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert()
+        shutil.copyfile(cert_file_name, os.path.join(config_path, "cert.crt"))
+        shutil.copyfile(key_file_name, os.path.join(config_path, "cert.key"))
+
+        # configure the default roles, roles_mappings, and internal_users
+        security_config_folder = os.path.join(install_dir, "config", "opensearch-security")
+
+        roles_path = os.path.join(security_config_folder, "roles.yml")
+        save_file(
+            file=roles_path,
+            permissions=0o666,
+            content=textwrap.dedent(
+                """\
+                _meta:
+                  type: "roles"
+                  config_version: 2
+                """
+            ),
+        )
+
+        roles_mapping_path = os.path.join(security_config_folder, "roles_mapping.yml")
+        save_file(
+            file=roles_mapping_path,
+            permissions=0o666,
+            content=textwrap.dedent(
+                """\
+                _meta:
+                  type: "rolesmapping"
+                  config_version: 2
+
+                security_manager:
+                  hosts: []
+                  users:
+                    - localstack-internal
+                  reserved: false
+                  hidden: false
+                  backend_roles: []
+                  and_backend_roles: []
+
+                all_access:
+                  hosts: []
+                  users:
+                    - localstack-internal
+                  reserved: false
+                  hidden: false
+                  backend_roles: []
+                  and_backend_roles: []
+                """
+            ),
+        )
+
+        internal_users_path = os.path.join(security_config_folder, "internal_users.yml")
+        save_file(
+            file=internal_users_path,
+            permissions=0o666,
+            content=textwrap.dedent(
+                """\
+                _meta:
+                  type: "internalusers"
+                  config_version: 2
+
+                # Define your internal users here
+                localstack-internal:
+                  hash: "$2y$12$ZvpKLI2nsdGj1ResAmlLne7ki5o45XpBppyg9nXF2RLNfmwjbFY22"
+                  reserved: true
+                  hidden: true
+                  backend_roles: []
+                  attributes: {}
+                  opendistro_security_roles: []
+                  static: false
+                """
+            ),
+        )
 
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "bin", "opensearch")

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -81,7 +81,7 @@ from localstack.aws.api.opensearch import (
 from localstack.config import LOCALSTACK_HOSTNAME
 from localstack.constants import OPENSEARCH_DEFAULT_VERSION
 from localstack.services.opensearch import versions
-from localstack.services.opensearch.cluster import OpensearchCluster, SecurityOptions
+from localstack.services.opensearch.cluster import SecurityOptions
 from localstack.services.opensearch.cluster_manager import (
     ClusterManager,
     DomainKey,
@@ -90,6 +90,7 @@ from localstack.services.opensearch.cluster_manager import (
 from localstack.services.opensearch.models import OpenSearchStore, opensearch_stores
 from localstack.utils.aws.request_context import get_region_from_request_context
 from localstack.utils.collections import PaginatedList, remove_none_values_from_dict
+from localstack.utils.serving import Server
 
 LOG = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ def cluster_manager() -> ClusterManager:
     return __CLUSTER_MANAGER
 
 
-def _run_cluster_startup_monitor(cluster: OpensearchCluster, domain_name: str, region: str):
+def _run_cluster_startup_monitor(cluster: Server, domain_name: str, region: str):
     LOG.debug("running cluster startup monitor for cluster %s", cluster)
 
     # wait until the cluster is started

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -81,7 +81,7 @@ from localstack.aws.api.opensearch import (
 from localstack.config import LOCALSTACK_HOSTNAME
 from localstack.constants import OPENSEARCH_DEFAULT_VERSION
 from localstack.services.opensearch import versions
-from localstack.services.opensearch.cluster import SecurityOptions
+from localstack.services.opensearch.cluster import OpensearchCluster, SecurityOptions
 from localstack.services.opensearch.cluster_manager import (
     ClusterManager,
     DomainKey,
@@ -90,7 +90,6 @@ from localstack.services.opensearch.cluster_manager import (
 from localstack.services.opensearch.models import OpenSearchStore, opensearch_stores
 from localstack.utils.aws.request_context import get_region_from_request_context
 from localstack.utils.collections import PaginatedList, remove_none_values_from_dict
-from localstack.utils.serving import Server
 
 LOG = logging.getLogger(__name__)
 
@@ -118,7 +117,7 @@ def cluster_manager() -> ClusterManager:
     return __CLUSTER_MANAGER
 
 
-def _run_cluster_startup_monitor(cluster: Server, domain_name: str, region: str):
+def _run_cluster_startup_monitor(cluster: OpensearchCluster, domain_name: str, region: str):
     LOG.debug("running cluster startup monitor for cluster %s", cluster)
 
     # wait until the cluster is started

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -5,6 +5,8 @@ import threading
 
 import botocore.exceptions
 import pytest
+from opensearchpy import OpenSearch
+from opensearchpy.exceptions import AuthorizationException
 
 from localstack import config
 from localstack.aws.accounts import get_aws_account_id
@@ -324,6 +326,83 @@ class TestOpensearchProvider:
             assert requested_plugins.issubset(installed_plugins)
         finally:
             opensearch_client.delete_domain(DomainName=domain_name)
+
+    def test_security_plugin(self, monkeypatch, opensearch_create_domain, opensearch_client):
+        # enable the security plugin for this test
+        monkeypatch.setattr(config, "OPENSEARCH_SECURITY", True)
+        domain_name = opensearch_create_domain()
+        endpoint = opensearch_client.describe_domain(DomainName=domain_name)["DomainStatus"][
+            "Endpoint"
+        ]
+
+        # make sure the plugins are installed
+        plugins_url = f"https://{endpoint}/_cat/plugins?s=component&h=component"
+
+        # request without credentials fails
+        unauthorized_response = requests.get(plugins_url, headers={"Accept": "application/json"})
+        assert unauthorized_response.status_code == 401
+
+        # request with default admin credentials is successful
+        plugins_response = requests.get(
+            plugins_url, headers={"Accept": "application/json"}, auth=("admin", "admin")
+        )
+        assert plugins_response.status_code == 200
+        installed_plugins = set(plugin["component"] for plugin in plugins_response.json())
+        requested_plugins = set(OPENSEARCH_PLUGIN_LIST)
+        assert requested_plugins.issubset(installed_plugins)
+        assert "opensearch-security" in installed_plugins
+
+        # create a new index with the admin user
+        test_index_name = "new-index"
+        test_index_id = "new-index-id"
+        test_document = {"test-key": "test-value"}
+        admin_auth = ("admin", "admin")  # For testing only. Don't store credentials in code.
+        admin_client = OpenSearch(hosts=endpoint, http_auth=admin_auth)
+        admin_client.create(test_index_name, id=test_index_id, body={})
+        admin_client.index(test_index_name, body=test_document)
+
+        # create a new user which is only mapped to the readall role
+        test_user = {"password": "test_password", "backend_roles": ["readall"]}
+        response = requests.put(
+            f"https://{endpoint}/_plugins/_security/api/internalusers/test_user",
+            json=test_user,
+            auth=admin_auth,
+        )
+        assert response.status_code == 201
+
+        # ensure the user can only read but cannot write
+        test_user_auth = ("test_user", "test_password")
+        test_user_client = OpenSearch(hosts=endpoint, http_auth=test_user_auth)
+
+        def _search():
+            search_result = test_user_client.search(
+                index=test_index_name, body={"query": {"match": {"test-key": "value"}}}
+            )
+            assert "hits" in search_result
+            assert search_result["hits"]["hits"][0]["_source"] == test_document
+
+        # it might take a bit for the document to be indexed
+        retry(_search, sleep=0.5, retries=3)
+
+        with pytest.raises(AuthorizationException):
+            test_user_client.create("new-index2", id="new-index-id2", body={})
+
+        with pytest.raises(AuthorizationException):
+            test_user_client.index(test_index_name, body={"test-key1": "test-value1"})
+
+        # add the user to the all_access role
+        user_patch = [{"op": "replace", "path": "/backend_roles", "value": ["admin"]}]
+        response = requests.patch(
+            f"https://{endpoint}/_plugins/_security/api/internalusers/test_user",
+            json=user_patch,
+            auth=admin_auth,
+        )
+        assert response.status_code == 200
+
+        # ensure the user can now write and create a new index
+        test_user_client = OpenSearch(hosts=endpoint, http_auth=test_user_auth)
+        test_user_client.create("new-index2", id="new-index-id2", body={})
+        test_user_client.index(test_index_name, body={"test-key1": "test-value1"})
 
     @pytest.mark.aws_validated
     def test_create_domain_with_invalid_name(self, opensearch_client):

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -332,9 +332,7 @@ class TestOpensearchProvider:
     @pytest.mark.parametrize("engine_version", ["OpenSearch_2.3"])
     def test_security_plugin(self, opensearch_create_domain, opensearch_client, engine_version):
         # TODO try to support OpenSearch < 2.3 too
-        # TODO create the master user after the startup
-        # admin_auth = ("master-user", "12345678Aa!")
-        admin_auth = ("localstack-internal", "localstack-internal")
+        admin_auth = ("master-user", "12345678Aa!")
 
         # enable the security plugin for this test
         advanced_security_options = AdvancedSecurityOptionsInput(

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -334,16 +334,15 @@ class TestOpensearchProvider:
         ["OpenSearch_1.0", "OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3", "OpenSearch_2.3"],
     )
     def test_security_plugin(self, opensearch_create_domain, opensearch_client, engine_version):
-        # TODO try to support OpenSearch < 2.3 too
-        admin_auth = ("master-user", "12345678Aa!")
+        master_user_auth = ("master-user", "12345678Aa!")
 
         # enable the security plugin for this test
         advanced_security_options = AdvancedSecurityOptionsInput(
             Enabled=True,
             InternalUserDatabaseEnabled=True,
             MasterUserOptions=MasterUserOptions(
-                MasterUserName=admin_auth[0],
-                MasterUserPassword=admin_auth[1],
+                MasterUserName=master_user_auth[0],
+                MasterUserPassword=master_user_auth[1],
             ),
         )
         domain_name = opensearch_create_domain(
@@ -362,7 +361,7 @@ class TestOpensearchProvider:
 
         # request with default admin credentials is successful
         plugins_response = requests.get(
-            plugins_url, headers={"Accept": "application/json"}, auth=admin_auth
+            plugins_url, headers={"Accept": "application/json"}, auth=master_user_auth
         )
         assert plugins_response.status_code == 200
         installed_plugins = set(plugin["component"] for plugin in plugins_response.json())
@@ -372,7 +371,7 @@ class TestOpensearchProvider:
         test_index_name = "new-index"
         test_index_id = "new-index-id"
         test_document = {"test-key": "test-value"}
-        admin_client = OpenSearch(hosts=endpoint, http_auth=admin_auth)
+        admin_client = OpenSearch(hosts=endpoint, http_auth=master_user_auth)
         admin_client.create(test_index_name, id=test_index_id, body={})
         admin_client.index(test_index_name, body=test_document)
 
@@ -381,7 +380,7 @@ class TestOpensearchProvider:
         response = requests.put(
             f"https://{endpoint}/_plugins/_security/api/rolesmapping/readall",
             json=test_rolemapping,
-            auth=admin_auth,
+            auth=master_user_auth,
         )
         assert response.status_code == 201
 
@@ -390,7 +389,7 @@ class TestOpensearchProvider:
         response = requests.put(
             f"https://{endpoint}/_plugins/_security/api/internalusers/test_user",
             json=test_user,
-            auth=admin_auth,
+            auth=master_user_auth,
         )
         assert response.status_code == 201
 
@@ -419,7 +418,7 @@ class TestOpensearchProvider:
         response = requests.patch(
             f"https://{endpoint}/_plugins/_security/api/rolesmapping/all_access",
             json=rolemappins_patch,
-            auth=admin_auth,
+            auth=master_user_auth,
         )
         assert response.status_code == 200
 

--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -329,7 +329,10 @@ class TestOpensearchProvider:
             opensearch_client.delete_domain(DomainName=domain_name)
 
     @pytest.mark.only_localstack
-    @pytest.mark.parametrize("engine_version", ["OpenSearch_2.3"])
+    @pytest.mark.parametrize(
+        "engine_version",
+        ["OpenSearch_1.0", "OpenSearch_1.1", "OpenSearch_1.2", "OpenSearch_1.3", "OpenSearch_2.3"],
+    )
     def test_security_plugin(self, opensearch_create_domain, opensearch_client, engine_version):
         # TODO try to support OpenSearch < 2.3 too
         admin_auth = ("master-user", "12345678Aa!")
@@ -363,8 +366,6 @@ class TestOpensearchProvider:
         )
         assert plugins_response.status_code == 200
         installed_plugins = set(plugin["component"] for plugin in plugins_response.json())
-        requested_plugins = set(OPENSEARCH_PLUGIN_LIST)
-        assert requested_plugins.issubset(installed_plugins)
         assert "opensearch-security" in installed_plugins
 
         # create a new index with the admin user


### PR DESCRIPTION
This PR extends the OpenSearch and ElasticSearch service such that it supports enabling the security plugin for OpenSearch domains.

This first iteration supports the internal user database, there is no integration with IAM yet (might be implemented in later iterations, based on user feedback). Currently, only OpenSearch domains are supported. ElasticSearch domains are currently not supported (neither via the OpenSearch nor the ElasticSearch service).

A secured OpenSearch domain can be spawned with this example CLI input:
```json
{
    "DomainName": "secure-domain",
    "ClusterConfig": {
        "InstanceType": "r5.large.search",
        "InstanceCount": 1,
            "DedicatedMasterEnabled": false,
            "ZoneAwarenessEnabled": false,
            "WarmEnabled": false
        },
    "EBSOptions": {
        "EBSEnabled": true,
        "VolumeType": "gp2",
        "VolumeSize": 10
    },
    "EncryptionAtRestOptions": {
        "Enabled": true
    },
    "NodeToNodeEncryptionOptions": {
        "Enabled": true
    },
    "DomainEndpointOptions": {
        "EnforceHTTPS": true
    },
    "AdvancedSecurityOptions": {
        "Enabled": true,
        "InternalUserDatabaseEnabled": true,
        "MasterUserOptions": {
            "MasterUserName": "admin",
            "MasterUserPassword": "really-secure-passwordAa!1"
        }
    }
}
```
It can be provisioned with the following aws(local) cli command:
```bash
$ awslocal opensearch create-domain --cli-input-json file://./opensearch_domain.json
```
Once the domain is set up (`Processing: false`), the cluster can only be accessed with the given master user credentials (via HTTP basic auth):
```
$ curl -u "admin:really-secure-passwordAa!1" http://secure-domain.us-east-1.opensearch.localhost.localstack.cloud:4566/_cluster/health
{"cluster_name":"opensearch","status":"green",...}
```
Any unauthorized requests will result in an HTTP response status code 401 (Unauthorized).

This feature is implemented by:
- Setting up the TLS certificates in the config folder of the OpenSearch installations.
- Setting up initial roles, roles mappings, and internal users in the config folder of the OpenSearch installstions.
  - It defines a hidden, reserved user called `localstack-internal` which is used to manipulate the OpenSearch instance at runtime.
  - This user is used to create the initial master user once the cluster is up.
  - This is necessary because the initial user cannot be defined in the startup configuration and the user config would otherwise be shared among multiple instances (since they share an installation directory containing the config files).
- Modifying the configuration on startup to enable the security plugin.

Once this PR is merged, and the feature becomes available in the latest image, the docs will be extended accordingly.