### PR TITLE
fix: Unable to forward SNS message to SQS: An error occurred (AWS.SimpleQueueService.EmptyBatchRequest) when calling the SendMessageBatch

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -356,6 +356,10 @@ class SqsBatchTopicPublisher(SqsTopicPublisher):
 
             entries.append(entry)
 
+        if len(entries) == 0:
+            LOG.info("Unable to forward SNS message to SQS with empty entries")
+            return
+
         try:
             queue_url = sqs_queue_url_for_arn(subscriber["Endpoint"])
             parsed_arn = parse_arn(subscriber["Endpoint"])


### PR DESCRIPTION
fix for #7662 