### PR TITLE
use lifecycle hook for registering lambda function URL routes

### DIFF
--- a/localstack/services/awslambda/lambda_starter.py
+++ b/localstack/services/awslambda/lambda_starter.py
@@ -6,6 +6,7 @@ from localstack import config
 from localstack.services.awslambda.lambda_api import handle_lambda_url_invocation
 from localstack.services.awslambda.lambda_utils import get_default_executor_mode
 from localstack.services.edge import ROUTER
+from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.analytics import log
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.request_context import AWS_REGION_REGEX
@@ -15,26 +16,28 @@ from localstack.utils.strings import to_bytes
 
 LOG = logging.getLogger(__name__)
 
-
 # Key for tracking patch applience
 PATCHES_APPLIED = "LAMBDA_PATCHED"
+
+
+class LambdaLifecycleHook(ServiceLifecycleHook):
+    def on_after_init(self):
+        ROUTER.add(
+            "/",
+            host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",
+            endpoint=handle_lambda_url_invocation,
+            defaults={"path": ""},
+        )
+        ROUTER.add(
+            "/<path:path>",
+            host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",
+            endpoint=handle_lambda_url_invocation,
+        )
 
 
 def start_lambda(port=None, asynchronous=False):
     from localstack.services.awslambda import lambda_api, lambda_utils
     from localstack.services.infra import start_local_api
-
-    ROUTER.add(
-        "/",
-        host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",
-        endpoint=handle_lambda_url_invocation,
-        defaults={"path": ""},
-    )
-    ROUTER.add(
-        "/<path:path>",
-        host=f"<api_id>.lambda-url.<regex('{AWS_REGION_REGEX}'):region>.<regex('.*'):server>",
-        endpoint=handle_lambda_url_invocation,
-    )
 
     log.event(
         "lambda:config",

--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -148,6 +148,7 @@ def awslambda():
         start=lambda_starter.start_lambda,
         stop=lambda_starter.stop_lambda,
         check=lambda_starter.check_lambda,
+        lifecycle_hook=lambda_starter.LambdaLifecycleHook(),
     )
 
 


### PR DESCRIPTION
This PR adds a `ServiceLifecycleHook` for the legacy lambda provider. This is to properly register lambda function URLs when persistence restores the service state, and will help in pro to unify persistence behavior into lifecycle hooks.

For community this has to significant effects other than the routes being registered a bit earlier now. 