### PR TITLE
fix SNS PublishBatch modifying batch context for all subscribers after filtering

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -495,6 +495,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         removed_attrs = ["sqs_queue_url"]
         if "FilterPolicyScope" in sub and "FilterPolicy" not in sub:
             removed_attrs.append("FilterPolicyScope")
+        elif "FilterPolicy" in sub and "FilterPolicyScope" not in sub:
+            sub["FilterPolicyScope"] = "MessageAttributes"
 
         attributes = {k: v for k, v in sub.items() if k not in removed_attrs}
         return GetSubscriptionAttributesResponse(Attributes=attributes)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -241,6 +241,7 @@ class TestSNSProvider:
         snapshot.match("messages-response", response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
     def test_filter_policy(
         self,
         sns_client,
@@ -308,6 +309,7 @@ class TestSNSProvider:
         assert num_msgs_2 == num_msgs_1
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
     def test_exists_filter_policy(
         self,
         sns_client,
@@ -432,6 +434,7 @@ class TestSNSProvider:
         assert num_msgs_4 == num_msgs_3
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
     def test_subscribe_sqs_queue(
         self,
         sns_client,

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -3263,3 +3263,114 @@ class TestSNSProvider:
             MessageGroupId="123",
         )
         assert "MessageId" in response
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(paths=["$..Attributes.SubscriptionPrincipal"])
+    def test_filter_policy_for_batch(
+        self,
+        sns_client,
+        sqs_client,
+        sqs_create_queue,
+        sns_create_topic,
+        sns_create_sqs_subscription,
+        snapshot,
+    ):
+
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url_with_filter = sqs_create_queue()
+        subscription_with_filter = sns_create_sqs_subscription(
+            topic_arn=topic_arn, queue_url=queue_url_with_filter
+        )
+        subscription_with_filter_arn = subscription_with_filter["SubscriptionArn"]
+
+        queue_url_no_filter = sqs_create_queue()
+        subscription_no_filter = sns_create_sqs_subscription(
+            topic_arn=topic_arn, queue_url=queue_url_no_filter
+        )
+        subscription_no_filter_arn = subscription_no_filter["SubscriptionArn"]
+
+        filter_policy = {"attr1": [{"numeric": [">", 0, "<=", 100]}]}
+        sns_client.set_subscription_attributes(
+            SubscriptionArn=subscription_with_filter_arn,
+            AttributeName="FilterPolicy",
+            AttributeValue=json.dumps(filter_policy),
+        )
+
+        response_attributes = sns_client.get_subscription_attributes(
+            SubscriptionArn=subscription_with_filter_arn
+        )
+        snapshot.match("subscription-attributes-with-filter", response_attributes)
+
+        response_attributes = sns_client.get_subscription_attributes(
+            SubscriptionArn=subscription_no_filter_arn
+        )
+        snapshot.match("subscription-attributes-no-filter", response_attributes)
+
+        sqs_wait_time = 4 if is_aws_cloud() else 1
+
+        response_before_publish_no_filter = sqs_client.receive_message(
+            QueueUrl=queue_url_with_filter, VisibilityTimeout=0, WaitTimeSeconds=sqs_wait_time
+        )
+        snapshot.match("messages-no-filter-before-publish", response_before_publish_no_filter)
+
+        response_before_publish_filter = sqs_client.receive_message(
+            QueueUrl=queue_url_with_filter, VisibilityTimeout=0, WaitTimeSeconds=sqs_wait_time
+        )
+        snapshot.match("messages-with-filter-before-publish", response_before_publish_filter)
+
+        # publish message that satisfies the filter policy, assert that message is received
+        message = "This is a test message"
+        message_attributes = {"attr1": {"DataType": "Number", "StringValue": "99"}}
+        sns_client.publish_batch(
+            TopicArn=topic_arn,
+            PublishBatchRequestEntries=[
+                {
+                    "Id": "1",
+                    "Message": message,
+                    "MessageAttributes": message_attributes,
+                }
+            ],
+        )
+
+        response_after_publish_no_filter = sqs_client.receive_message(
+            QueueUrl=queue_url_no_filter, VisibilityTimeout=0, WaitTimeSeconds=sqs_wait_time
+        )
+        snapshot.match("messages-no-filter-after-publish-ok", response_after_publish_no_filter)
+        sqs_client.delete_message(
+            QueueUrl=queue_url_no_filter,
+            ReceiptHandle=response_after_publish_no_filter["Messages"][0]["ReceiptHandle"],
+        )
+
+        response_after_publish_filter = sqs_client.receive_message(
+            QueueUrl=queue_url_with_filter, VisibilityTimeout=0, WaitTimeSeconds=sqs_wait_time
+        )
+        snapshot.match("messages-with-filter-after-publish-ok", response_after_publish_filter)
+        sqs_client.delete_message(
+            QueueUrl=queue_url_with_filter,
+            ReceiptHandle=response_after_publish_filter["Messages"][0]["ReceiptHandle"],
+        )
+
+        # publish message that does not satisfy the filter policy, assert that message is not received by the
+        # subscription with the filter and received by the other
+        sns_client.publish_batch(
+            TopicArn=topic_arn,
+            PublishBatchRequestEntries=[
+                {
+                    "Id": "1",
+                    "Message": "This is another test message",
+                    "MessageAttributes": {"attr1": {"DataType": "Number", "StringValue": "111"}},
+                }
+            ],
+        )
+
+        response_after_publish_no_filter = sqs_client.receive_message(
+            QueueUrl=queue_url_no_filter, VisibilityTimeout=0, WaitTimeSeconds=sqs_wait_time
+        )
+        # there should be 1 message in the queue, latest sent
+        snapshot.match("messages-no-filter-after-publish-ok-1", response_after_publish_no_filter)
+
+        response_after_publish_filter = sqs_client.receive_message(
+            QueueUrl=queue_url_with_filter, VisibilityTimeout=0, WaitTimeSeconds=sqs_wait_time
+        )
+        # there should be no messages in this queue
+        snapshot.match("messages-with-filter-after-publish-filtered", response_after_publish_filter)

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3040,5 +3040,165 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_for_batch": {
+    "recorded-date": "13-02-2023, 13:40:06",
+    "recorded-content": {
+      "subscription-attributes-with-filter": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+          "FilterPolicy": {
+            "attr1": [
+              {
+                "numeric": [
+                  ">",
+                  0,
+                  "<=",
+                  100
+                ]
+              }
+            ]
+          },
+          "FilterPolicyScope": "MessageAttributes",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscription-attributes-no-filter": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "arn:aws:sqs:<region>:111111111111:<resource:4>",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sqs",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:5>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-no-filter-before-publish": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-with-filter-before-publish": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-no-filter-after-publish-ok": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "Message": "This is a test message",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:5>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-with-filter-after-publish-ok": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:1>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "Message": "This is a test message",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "99"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:3>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-no-filter-after-publish-ok-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:4>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>",
+              "Message": "This is another test message",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:3>:<resource:5>",
+              "MessageAttributes": {
+                "attr1": {
+                  "Type": "Number",
+                  "Value": "111"
+                }
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:5>",
+            "ReceiptHandle": "<receipt-handle:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "messages-with-filter-after-publish-filtered": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -242,7 +242,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy": {
-    "recorded-date": "09-08-2022, 11:30:09",
+    "recorded-date": "13-02-2023, 16:48:57",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -260,11 +260,13 @@
               }
             ]
           },
+          "FilterPolicyScope": "MessageAttributes",
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
         },
         "ResponseMetadata": {
@@ -341,7 +343,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_exists_filter_policy": {
-    "recorded-date": "09-08-2022, 11:30:12",
+    "recorded-date": "13-02-2023, 16:49:47",
     "recorded-content": {
       "subscription-attributes-policy-1": {
         "Attributes": {
@@ -354,11 +356,13 @@
               }
             ]
           },
+          "FilterPolicyScope": "MessageAttributes",
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
         },
         "ResponseMetadata": {
@@ -451,11 +455,13 @@
               }
             ]
           },
+          "FilterPolicyScope": "MessageAttributes",
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
         },
         "ResponseMetadata": {
@@ -526,7 +532,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_subscribe_sqs_queue": {
-    "recorded-date": "09-08-2022, 11:30:15",
+    "recorded-date": "13-02-2023, 16:50:28",
     "recorded-content": {
       "subscription-attributes": {
         "Attributes": {
@@ -544,11 +550,13 @@
               }
             ]
           },
+          "FilterPolicyScope": "MessageAttributes",
           "Owner": "111111111111",
           "PendingConfirmation": "false",
           "Protocol": "sqs",
           "RawMessageDelivery": "false",
           "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:3>:<resource:2>",
+          "SubscriptionPrincipal": "<sub-principal>",
           "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:3>"
         },
         "ResponseMetadata": {


### PR DESCRIPTION
### Problem
After reading the report from #7662, I could not understand how this could happen when we were filtering the messages before passing the context to worker to send the message. If after filtering there were no messages to send, we would not pass the task to the executor, so no empty message entries could be passed to SQS.

However, after reading the publishing code again for `PublishBatch`, it showed that I was setting the filtered messages (messages are filtered on a subscriber basis) on the global context (used by all subscribers). It created 2 issues:
- First, if in the order of subscription, we have a subscription with a filter then one without filter, we would filter the message and set them in the global context, so the next subscription in line would not have any messages in its context, even if it had no filter.
- Second, if the order is reversed. A subscription with no filter, then one with a filter. We would in this order:
  - Iterate over subscribers
  - During iteration, send the context to the first worker with for example 1 message
  - Continuing iteration, filter the messages depending on the subscriber and set them in the global context
  - Sending it to the second worker
  - During that time, the first worker would start its job, and might have an empty `messages` attributes while using the given context, which lead to the exception in the issue report.

### Solution

If some messages are filtered, we will create a copy of the context, set the filtered messages only on the copy and pass the copy to the worker, instead of always passing a global context. If no filter is set, we can safely pass the global one (allows us to not always copy the context if there are no reasons for it, workers do not manipulate the context, it is used read-only). 

I've added a test case for the first issue, the second one will mostly happen as a race condition and is not always reproducible. But if one is fixed, so is there other.


_fixes #7662_