### PR TITLE
Fix docker runtime executor flags

### DIFF
--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -117,14 +117,12 @@ def _get_lambda_invocation_events(logs_client, function_name, expected_num_event
 
 
 def is_old_provider():
-    return (
-        os.environ.get("TEST_TARGET") != "AWS_CLOUD"
-        and os.environ.get("PROVIDER_OVERRIDE_LAMBDA") != "asf"
-    )
+    return os.environ.get("TEST_TARGET") != "AWS_CLOUD" and os.environ.get(
+        "PROVIDER_OVERRIDE_LAMBDA"
+    ) not in ["asf", "v2"]
 
 
 def is_new_provider():
-    return (
-        os.environ.get("TEST_TARGET") != "AWS_CLOUD"
-        and os.environ.get("PROVIDER_OVERRIDE_LAMBDA") == "asf"
-    )
+    return os.environ.get("TEST_TARGET") != "AWS_CLOUD" and os.environ.get(
+        "PROVIDER_OVERRIDE_LAMBDA"
+    ) in ["asf", "v2"]

--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 from typing import Literal
 
 from localstack.utils.common import to_str
@@ -126,3 +127,7 @@ def is_new_provider():
     return os.environ.get("TEST_TARGET") != "AWS_CLOUD" and os.environ.get(
         "PROVIDER_OVERRIDE_LAMBDA"
     ) in ["asf", "v2"]
+
+
+def is_arm_compatible():
+    return platform.machine() == "arm64"

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -506,7 +506,7 @@ class ContainerClient(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def pull_image(self, docker_image: str, platform: DockerPlatform | None = None) -> None:
+    def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
         """Pulls an image with a given name from a Docker registry"""
         pass
 

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -96,6 +96,13 @@ class CancellableStream(Protocol):
         raise NotImplementedError
 
 
+class DockerPlatform(str):
+    """Platform in the format ``os[/arch[/variant]]``"""
+
+    linux_amd64 = "linux/amd64"
+    linux_arm64 = "linux/arm64"
+
+
 # defines the type for port mappings (source->target port range)
 PortRange = Union[List, HashableList]
 
@@ -366,6 +373,7 @@ class ContainerConfiguration:
     network: Optional[str] = None
     dns: Optional[str] = None
     workdir: Optional[str] = None
+    platform: Optional[str] = None
 
 
 @dataclasses.dataclass
@@ -378,6 +386,8 @@ class DockerRunFlags:
     extra_hosts: Optional[Dict[str, str]]
     network: Optional[str]
     labels: Optional[Dict[str, str]]
+    user: Optional[str]
+    platform: Optional[DockerPlatform]
 
 
 class ContainerClient(metaclass=ABCMeta):
@@ -496,7 +506,7 @@ class ContainerClient(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def pull_image(self, docker_image: str) -> None:
+    def pull_image(self, docker_image: str, platform: DockerPlatform | None = None) -> None:
         """Pulls an image with a given name from a Docker registry"""
         pass
 
@@ -687,6 +697,7 @@ class ContainerClient(metaclass=ABCMeta):
             additional_flags=container_config.additional_flags,
             workdir=container_config.workdir,
             privileged=container_config.privileged,
+            platform=container_config.platform,
         )
 
     @abstractmethod
@@ -714,6 +725,7 @@ class ContainerClient(metaclass=ABCMeta):
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
         labels: Optional[Dict[str, str]] = None,
+        platform: Optional[DockerPlatform] = None,
     ) -> str:
         """Creates a container with the given image
 
@@ -888,6 +900,8 @@ class Util:
         ports: PortMappings = None,
         mounts: List[SimpleVolumeBind] = None,
         network: Optional[str] = None,
+        user: Optional[str] = None,
+        platform: Optional[DockerPlatform] = None,
     ) -> DockerRunFlags:
         """Parses environment, volume and port flags passed as string
         :param additional_flags: String which contains the flag definitions
@@ -895,6 +909,8 @@ class Util:
         :param ports: PortMapping object. Will be modified in place.
         :param mounts: List of mount tuples (host_path, container_path). Will be modified in place.
         :param network: Existing network name (optional). Warning will be printed if network is overwritten in flags.
+        :param user: User to run first process. Warning will be printed if user is overwritten in flags.
+        :param platform: Platform to execute container. Warning will be printed if platform is overwritten in flags.
         :return: A DockerRunFlags object containing the env_vars, ports, mount, extra_hosts, network, and labels.
                 The result will return new objects if respective parameters were None and additional flags contained
                 a flag for that object, the same which are passed otherwise.
@@ -917,6 +933,10 @@ class Util:
                     cur_state = "set-network"
                 elif flag == "--label":
                     cur_state = "add-label"
+                elif flag in ["-u", "--user"]:
+                    cur_state = "user"
+                elif flag == "--platform":
+                    cur_state = "platform"
                 else:
                     raise NotImplementedError(
                         f"Flag {flag} is currently not supported by this Docker client."
@@ -982,6 +1002,18 @@ class Util:
                         labels[key] = value
                     else:
                         LOG.warning("Invalid --label specified, unable to parse: '%s'", flag)
+                elif cur_state == "user":
+                    if user:
+                        LOG.warning(
+                            f"Overwriting Docker container user {user} with new value {flag}"
+                        )
+                    user = flag
+                elif cur_state == "platform":
+                    if platform:
+                        LOG.warning(
+                            f"Overwriting Docker container platform {platform} with new value {flag}"
+                        )
+                    platform = flag
 
                 cur_state = None
 
@@ -992,6 +1024,8 @@ class Util:
             extra_hosts=extra_hosts,
             network=network,
             labels=labels,
+            user=user,
+            platform=platform,
         )
 
     @staticmethod

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -264,7 +264,7 @@ class CmdDockerClient(ContainerClient):
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
             ) from e
 
-    def pull_image(self, docker_image: str, platform: DockerPlatform | None = None) -> None:
+    def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
         cmd = self._docker_cmd()
         cmd += ["pull", docker_image]
         if platform:

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -14,6 +14,7 @@ from localstack.utils.container_utils.container_client import (
     ContainerClient,
     ContainerException,
     DockerContainerStatus,
+    DockerPlatform,
     NoSuchContainer,
     NoSuchImage,
     NoSuchNetwork,
@@ -263,9 +264,11 @@ class CmdDockerClient(ContainerClient):
                 "Docker process returned with errorcode %s" % e.returncode, e.stdout, e.stderr
             ) from e
 
-    def pull_image(self, docker_image: str) -> None:
+    def pull_image(self, docker_image: str, platform: DockerPlatform | None = None) -> None:
         cmd = self._docker_cmd()
         cmd += ["pull", docker_image]
+        if platform:
+            cmd += ["--platform", platform]
         LOG.debug("Pulling image with cmd: %s", cmd)
         try:
             run(cmd)
@@ -616,6 +619,7 @@ class CmdDockerClient(ContainerClient):
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
         labels: Optional[Dict[str, str]] = None,
+        platform: Optional[DockerPlatform] = None,
     ) -> Tuple[List[str], str]:
         env_file = None
         cmd = self._docker_cmd() + [action]
@@ -663,6 +667,8 @@ class CmdDockerClient(ContainerClient):
         if labels:
             for key, value in labels.items():
                 cmd += ["--label", f"{key}={value}"]
+        if platform:
+            cmd += ["--platform", platform]
 
         if additional_flags:
             cmd += shlex.split(additional_flags)

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -17,6 +17,7 @@ from localstack.utils.container_utils.container_client import (
     ContainerClient,
     ContainerException,
     DockerContainerStatus,
+    DockerPlatform,
     NoSuchContainer,
     NoSuchImage,
     NoSuchNetwork,
@@ -213,11 +214,11 @@ class SdkDockerClient(ContainerClient):
         except APIError as e:
             raise ContainerException() from e
 
-    def pull_image(self, docker_image: str) -> None:
+    def pull_image(self, docker_image: str, platform: DockerPlatform | None = None) -> None:
         LOG.debug("Pulling Docker image: %s", docker_image)
         # some path in the docker image string indicates a custom repository
         try:
-            self.client().images.pull(docker_image)
+            self.client().images.pull(docker_image, platform=platform)
         except ImageNotFound:
             raise NoSuchImage(docker_image)
         except APIError as e:
@@ -507,12 +508,13 @@ class SdkDockerClient(ContainerClient):
         workdir: Optional[str] = None,
         privileged: Optional[bool] = None,
         labels: Optional[Dict[str, str]] = None,
+        platform: Optional[DockerPlatform] = None,
     ) -> str:
         LOG.debug("Creating container with attributes: %s", locals())
         extra_hosts = None
         if additional_flags:
             parsed_flags = Util.parse_additional_flags(
-                additional_flags, env_vars, ports, mount_volumes, network
+                additional_flags, env_vars, ports, mount_volumes, network, user, platform
             )
             env_vars = parsed_flags.env_vars
             ports = parsed_flags.ports
@@ -520,6 +522,8 @@ class SdkDockerClient(ContainerClient):
             extra_hosts = parsed_flags.extra_hosts
             network = parsed_flags.network
             labels = parsed_flags.labels
+            user = parsed_flags.user
+            platform = parsed_flags.platform
 
         try:
             kwargs = {}
@@ -558,13 +562,14 @@ class SdkDockerClient(ContainerClient):
                     network=network,
                     volumes=mounts,
                     extra_hosts=extra_hosts,
+                    platform=platform,
                     **kwargs,
                 )
 
             try:
                 container = create_container()
             except ImageNotFound:
-                self.pull_image(image_name)
+                self.pull_image(image_name, platform)
                 container = create_container()
             return container.id
         except ImageNotFound:

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -214,7 +214,7 @@ class SdkDockerClient(ContainerClient):
         except APIError as e:
             raise ContainerException() from e
 
-    def pull_image(self, docker_image: str, platform: DockerPlatform | None = None) -> None:
+    def pull_image(self, docker_image: str, platform: Optional[DockerPlatform] = None) -> None:
         LOG.debug("Pulling Docker image: %s", docker_image)
         # some path in the docker image string indicates a custom repository
         try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ runtime =
     cryptography
     dnslib>=0.9.10
     dnspython>=1.16.0
-    docker==5.0.0
+    docker==6.0.1
     flask==2.1.3
     flask-cors>=3.0.3,<3.1.0
     flask_swagger==0.2.12

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -180,8 +180,11 @@ class TestCliContainerLifecycle:
         output = container_client.exec_in_container(config.MAIN_CONTAINER_NAME, ["ps", "-u", user])
         assert "supervisord" in to_str(output[0])
 
+    @pytest.mark.skip(reason="skip temporarily until compatible localstack image is on DockerHub")
     def test_start_cli_within_container(self, runner, container_client):
         output = container_client.run_container(
+            # CAVEAT: Updates to the Docker image are not immediately reflected when using the latest image from
+            # DockerHub in the CI. Re-build the Docker image locally through `make docker-build` for local testing.
             "localstack/localstack",
             remove=True,
             entrypoint="",

--- a/tests/integration/awslambda/functions/lambda_introspect.py
+++ b/tests/integration/awslambda/functions/lambda_introspect.py
@@ -1,4 +1,8 @@
+import getpass
 import os
+import platform
+import stat
+import subprocess
 import time
 
 
@@ -8,6 +12,14 @@ def handler(event, context):
         time.sleep(event["wait"])
 
     return {
-        "env": {k: v for k, v in os.environ.items()},
+        # Tested in tests/integration/awslambda/test_lambda_common.py
+        # "environment": dict(os.environ),
         "event": event,
+        # user behavior: https://stackoverflow.com/a/25574419
+        "user_login_name": getpass.getuser(),
+        "user_whoami": subprocess.getoutput("whoami"),
+        "platform_system": platform.system(),
+        "platform_machine": platform.machine(),
+        "pwd_filemode": stat.filemode(os.stat(".").st_mode),
+        "opt_filemode": stat.filemode(os.stat("/opt").st_mode),
     }

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -315,6 +315,22 @@ class TestLambdaBehavior:
         # TODO: run lambdas as user `sbx_user1051`
         paths=["$..Payload.user_login_name", "$..Payload.user_whoami"]
     )
+    @pytest.mark.skip_snapshot_verify(
+        condition=is_old_provider,
+        paths=[
+            # empty dict is interpreted as string and fails upon event parsing
+            "$..FunctionError",
+            "$..LogResult",
+            "$..Payload.errorMessage",
+            "$..Payload.errorType",
+            "$..Payload.event",
+            "$..Payload.opt_filemode",
+            "$..Payload.platform_machine",
+            "$..Payload.platform_system",
+            "$..Payload.pwd_filemode",
+            "$..Payload.stackTrace",
+        ],
+    )
     def test_runtime_introspection_x86(self, lambda_client, create_lambda_function, snapshot):
         func_name = f"test_lambda_x86_{short_uid()}"
         create_lambda_function(

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -10,11 +10,12 @@ from typing import Dict, TypeVar
 import pytest
 from botocore.response import StreamingBody
 
-from localstack.aws.api.lambda_ import Runtime
+from localstack.aws.api.lambda_ import Architecture, Runtime
 from localstack.services.awslambda.lambda_api import use_docker
 from localstack.testing.aws.lambda_utils import (
     concurrency_update_done,
     get_invoke_init_type,
+    is_arm_compatible,
     is_old_provider,
     update_done,
 )
@@ -309,6 +310,45 @@ class TestLambdaBaseFeatures:
 
 
 class TestLambdaBehavior:
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        # TODO: run lambdas as user `sbx_user1051`
+        paths=["$..Payload.user_login_name", "$..Payload.user_whoami"]
+    )
+    def test_runtime_introspection_x86(self, lambda_client, create_lambda_function, snapshot):
+        func_name = f"test_lambda_x86_{short_uid()}"
+        create_lambda_function(
+            func_name=func_name,
+            handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
+            runtime=Runtime.python3_9,
+            Architectures=[Architecture.x86_64],
+        )
+
+        invoke_result = lambda_client.invoke(FunctionName=func_name)
+        snapshot.match("invoke_runtime_x86_introspection", invoke_result)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        # TODO: run lambdas as user `sbx_user1051`
+        paths=["$..Payload.user_login_name", "$..Payload.user_whoami"]
+    )
+    @pytest.mark.skipif(is_old_provider(), reason="unsupported in old provider")
+    @pytest.mark.skipif(
+        not is_arm_compatible() and not is_aws(),
+        reason="ARM architecture not supported on this host",
+    )
+    def test_runtime_introspection_arm(self, lambda_client, create_lambda_function, snapshot):
+        func_name = f"test_lambda_arm_{short_uid()}"
+        create_lambda_function(
+            func_name=func_name,
+            handler_file=TEST_LAMBDA_INTROSPECT_PYTHON,
+            runtime=Runtime.python3_9,
+            Architectures=[Architecture.arm64],
+        )
+
+        invoke_result = lambda_client.invoke(FunctionName=func_name)
+        snapshot.match("invoke_runtime_arm_introspection", invoke_result)
+
     @pytest.mark.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..Payload", "$..LogResult"]
     )

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -2465,5 +2465,49 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_arm": {
+    "recorded-date": "13-02-2023, 14:40:57",
+    "recorded-content": {
+      "invoke_runtime_arm_introspection": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "event": {},
+          "user_login_name": "sbx_user1051",
+          "user_whoami": "sbx_user1051",
+          "platform_system": "Linux",
+          "platform_machine": "aarch64",
+          "pwd_filemode": "drwxr-xr-x",
+          "opt_filemode": "drwxr-xr-x"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_x86": {
+    "recorded-date": "13-02-2023, 14:41:16",
+    "recorded-content": {
+      "invoke_runtime_x86_introspection": {
+        "ExecutedVersion": "$LATEST",
+        "Payload": {
+          "event": {},
+          "user_login_name": "sbx_user1051",
+          "user_whoami": "sbx_user1051",
+          "platform_system": "Linux",
+          "platform_machine": "x86_64",
+          "pwd_filemode": "drwxr-xr-x",
+          "opt_filemode": "drwxr-xr-x"
+        },
+        "StatusCode": 200,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -6835,7 +6835,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "06-10-2022, 14:07:27",
+    "recorded-date": "10-02-2023, 21:54:53",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -6850,10 +6850,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -6862,10 +6862,31 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "empty_architectures": "Parameter validation failed:\nInvalid length for parameter Architectures, value: 0, valid min length: 1",
+      "multiple_architectures": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[x86_64, arm64]' at 'architectures' failed to satisfy constraint: Member must have length less than or equal to 1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "uppercase_architecture": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value '[X86_64]' at 'architectures' failed to satisfy constraint: Member must satisfy constraint: [Member must satisfy enum value set: [x86_64, arm64], Member must not be null]"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -69,14 +69,37 @@ def test_argument_parsing():
     test_port_string_many_to_one = "-p 9230-9231:9230"
     test_env_string = "-e TEST_ENV_VAR=test_string=123"
     test_mount_string = "-v /var/test:/opt/test"
-    argument_string = f"{test_port_string} {test_env_string} {test_mount_string} {test_port_string_with_host} {test_port_string_many_to_one}"
+    test_network_string = "--network bridge"
+    test_user_string = "-u sbx_user1051"
+    test_platform_string = "--platform linux/arm64"
+    argument_string = " ".join(
+        [
+            test_port_string,
+            test_env_string,
+            test_mount_string,
+            test_port_string_with_host,
+            test_port_string_many_to_one,
+            test_network_string,
+            test_user_string,
+            test_platform_string,
+        ]
+    )
     env_vars = {}
     ports = PortMappings()
     mounts = []
-    Util.parse_additional_flags(argument_string, env_vars, ports, mounts)
+    network = "host"
+    user = "root"
+    platform = "linux/amd64"
+    flags = Util.parse_additional_flags(
+        argument_string, env_vars, ports, mounts, network, user, platform
+    )
     assert env_vars == {"TEST_ENV_VAR": "test_string=123"}
     assert ports.to_str() == "-p 80:8080/udp -p 6000:7000 -p 9230-9231:9230"
     assert mounts == [("/var/test", "/opt/test")]
+    assert flags.network == "bridge"
+    assert flags.user == "sbx_user1051"
+    assert flags.platform == "linux/arm64"
+
     argument_string = (
         "--add-host host.docker.internal:host-gateway --add-host arbitrary.host:127.0.0.1"
     )


### PR DESCRIPTION
This PR adds support for additional Docker flags and fixes ARM issues with lambda.

## Changes

* Bump docker dependency version (required for supporting platform flag)
* Add user and platform flags to docker clients (SdkDockerClient and CmdDockerClient). Set platform flag based on the architecture of the lambda function
* Test ARM create function exceptions and enable ARM functions
* Respect new provider override flags (`v2`) in lambda tests

## Addresses

* https://github.com/localstack/localstack/issues/7637
  * Resolves this issue by adding basic support for ARM Lambdas (more testing planned)
* https://github.com/localstack/localstack/pull/6724#issuecomment-1227314083
  * Enables workaround `LAMBDA_DOCKER_FLAGS=--user nobody`

## Related Issues

* https://github.com/localstack/localstack/issues/4921
* Shared ARM layers: https://github.com/localstack/localstack/issues/4932

## Follow Up

- [ ] Re-enable the skipped test `tests.bootstrap.test_cli.TestCliContainerLifecycle.test_start_cli_within_container` as soon as the new localstack image is on DockerHub (see [comment here](tests.bootstrap.test_cli.TestCliContainerLifecycle.test_start_cli_within_container))