### PR TITLE
Avoid installing amazon_kclpy>=2.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ localstack =
 runtime =
     airspeed==0.5.19
     # TODO: check amazon_kclpy pin once build failure in 2.1.0 has been fixed
-    amazon_kclpy>=2.0.6,!=2.1.0
+    amazon_kclpy>=2.0.6,<2.1.0
     antlr4-python3-runtime==4.11.1
     aws-sam-translator>=1.15.1
     awscli>=1.22.90


### PR DESCRIPTION
A new version was published recently ([2.1.1](https://pypi.org/project/amazon-kclpy/#history)).


The tests previously worked fine, but let's see if this will make it more stable again :thinking: 