### PR TITLE
Fix CFn Route53 Record Set TTL

### DIFF
--- a/localstack/services/cloudformation/models/route53.py
+++ b/localstack/services/cloudformation/models/route53.py
@@ -38,6 +38,10 @@ class Route53RecordSet(GenericBaseModel):
                 "HealthCheckId",
             ]
             attrs = select_attributes(params, attr_names)
+
+            if isinstance(attrs["TTL"], str):
+                attrs["TTL"] = int(attrs["TTL"])
+
             alias_target = attrs.get("AliasTarget", {})
             alias_target["EvaluateTargetHealth"] = alias_target.get("EvaluateTargetHealth", False)
             if "ResourceRecords" in attrs:

--- a/tests/integration/cloudformation/resources/test_route53.py
+++ b/tests/integration/cloudformation/resources/test_route53.py
@@ -1,6 +1,9 @@
 import os
 
+import pytest
 
+
+@pytest.mark.aws_validated
 def test_create_record_set_via_id(route53_hosted_zone, deploy_cfn_template):
     create_zone_response = route53_hosted_zone()
     hosted_zone_id = create_zone_response["HostedZone"]["Id"]
@@ -11,6 +14,7 @@ def test_create_record_set_via_id(route53_hosted_zone, deploy_cfn_template):
             os.path.dirname(__file__), "../../templates/route53_hostedzoneid_template.yaml"
         ),
         parameters=parameters,
+        max_wait=300,
     )
 
 

--- a/tests/integration/templates/route53_hostedzoneid_template.yaml
+++ b/tests/integration/templates/route53_hostedzoneid_template.yaml
@@ -12,5 +12,5 @@ Resources:
       Name: !Ref Name
       ResourceRecords:
         - 192.0.2.99
-      TTL: 900
+      TTL: "900"
       Type: A


### PR DESCRIPTION
The TTL should be accepted either as a string or int.

Changes:
- Convert attribute to integer if it's a string
- Altered one test to validate the behavior
- mark the test as AWS validated