### PR TITLE
fix encoding issues in router, proxy, partition rewriting

### DIFF
--- a/localstack/aws/handlers/partition_rewriter.py
+++ b/localstack/aws/handlers/partition_rewriter.py
@@ -2,7 +2,7 @@ import logging
 import re
 from re import Match
 from typing import Optional
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 from localstack import config
 from localstack.aws.api import RequestContext
@@ -79,7 +79,7 @@ class ArnPartitionRewriteHandler(Handler):
         result_response = forward(
             request=forward_request,
             forward_base_url=config.get_edge_url(),
-            forward_path=get_raw_path(request),
+            forward_path=get_raw_path(forward_request),
             headers=forward_request.headers,
         )
         self.modify_response(result_response, request_region=request_region)
@@ -158,7 +158,7 @@ class ArnPartitionRewriteHandler(Handler):
             return result
         elif isinstance(source, bytes):
             try:
-                decoded = unquote(to_str(source))
+                decoded = to_str(source)
                 adjusted = self._adjust_partition(
                     decoded, static_partition, request_region, encoded=encoded
                 )

--- a/localstack/http/client.py
+++ b/localstack/http/client.py
@@ -4,9 +4,13 @@ from urllib.parse import urlparse
 import requests
 from werkzeug import Request, Response
 from werkzeug.datastructures import Headers
-from werkzeug.sansio.utils import get_current_url
 
-from localstack.http.request import get_raw_base_url, get_raw_path, restore_payload
+from localstack.http.request import (
+    get_raw_base_url,
+    get_raw_current_url,
+    get_raw_path,
+    restore_payload,
+)
 
 
 class HttpClient(abc.ABC):
@@ -64,7 +68,7 @@ class SimpleRequestsClient(HttpClient):
                 scheme, server = parts.scheme, parts.netloc
             else:
                 scheme = request.scheme
-            url = get_current_url(scheme, server, request.root_path, get_raw_path(request))
+            url = get_raw_current_url(scheme, server, request.root_path, get_raw_path(request))
         else:
             url = get_raw_base_url(request)
 

--- a/localstack/http/proxy.py
+++ b/localstack/http/proxy.py
@@ -7,7 +7,7 @@ from werkzeug.datastructures import Headers
 from werkzeug.test import EnvironBuilder
 
 from .client import HttpClient, SimpleRequestsClient
-from .request import restore_payload, set_environment_headers
+from .request import get_raw_path, restore_payload, set_environment_headers
 
 
 def forward(
@@ -77,7 +77,7 @@ class Proxy(HttpClient):
                 headers["X-Forwarded-For"] = f"{client_ip}"
 
         if forward_path is None:
-            forward_path = request.path
+            forward_path = get_raw_path(request)
         if forward_path:
             forward_path = "/" + forward_path.lstrip("/")
 

--- a/localstack/http/router.py
+++ b/localstack/http/router.py
@@ -21,6 +21,8 @@ from typing import (
 from werkzeug import Request, Response
 from werkzeug.routing import BaseConverter, Map, Rule, RuleFactory
 
+from localstack.http.request import get_raw_path
+
 HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS", "TRACE")
 
 E = TypeVar("E")
@@ -427,7 +429,7 @@ class Router(Generic[E]):
         :return: the HTTP response
         """
         matcher = self.url_map.bind(server_name=request.host)
-        handler, args = matcher.match(request.path, method=request.method)
+        handler, args = matcher.match(get_raw_path(request), method=request.method)
         args.pop("__host__", None)
         return self.dispatcher(request, handler, args)
 

--- a/tests/unit/test_partition_rewriter.py
+++ b/tests/unit/test_partition_rewriter.py
@@ -96,19 +96,20 @@ def test_arn_partition_rewriting_in_request(internal_call, encoding, origin_part
 def test_arn_partition_rewriting_url_encoding(httpserver, monkeypatch):
     path = "/query%3Aencoded%2Fpath/"
 
-    def echo_path(request: WerkzeugRequest) -> Response:
+    def echo_path(_request: WerkzeugRequest) -> Response:
         response = Response()
         response.set_json(
             {
-                "method": request.method,
-                "raw_path": get_raw_path(request),
-                "url": request.url,
-                "headers": dict(request.headers),
+                "method": _request.method,
+                "raw_path": get_raw_path(_request),
+                "url": _request.url,
+                "headers": dict(_request.headers),
             }
         )
         return response
 
-    httpserver.expect_request(path).respond_with_handler(echo_path)
+    # httpserver matches on the URL-decoded path
+    httpserver.expect_request("/query:encoded/path/").respond_with_handler(echo_path)
 
     def mock_get_edge_url() -> str:
         # Set the forwarding URL to the mock HTTP server
@@ -287,4 +288,103 @@ def test_arn_partition_rewriting_in_response_without_region_and_with_default_reg
         )
         assert response.data == to_bytes(
             json.dumps({"some-data-with-arn": "arn:aws-us-gov:iam::123456789012:ArnInData"})
+        )
+
+
+@pytest.mark.parametrize("internal_call", [True, False])
+@pytest.mark.parametrize("encoding", [byte_encoding, string_encoding])
+@pytest.mark.parametrize("origin_partition", ["aws", "aws-us-gov"])
+def test_arn_partition_rewriting_in_request_and_response(
+    internal_call, encoding, origin_partition, httpserver, monkeypatch
+):
+    handler_data = {}
+
+    def echo(_request: WerkzeugRequest) -> Response:
+        handler_data["received_request"] = _request
+        response = Response()
+        response.set_data(_request.data)
+        response.headers = request.headers
+        handler_data["sent_request"] = response
+        return response
+
+    httpserver.expect_request("").respond_with_handler(echo)
+
+    def mock_get_edge_url() -> str:
+        # Set the forwarding URL to the mock HTTP server
+        return httpserver.url_for("/")
+
+    monkeypatch.setattr(config, "get_edge_url", mock_get_edge_url)
+    data = encoding(
+        json.dumps(
+            {
+                "some-data-with-arn": f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-body/*"
+            }
+        )
+    )
+
+    # if this test is parameterized to be an internal call, set the internal auth
+    # incoming requests should be rewritten for both, internal and external requests (in contrast to the responses!)
+    if internal_call:
+        headers = mock_aws_request_headers(
+            region_name=origin_partition,
+            access_key=INTERNAL_AWS_ACCESS_KEY_ID,
+            internal=True,
+        )
+    else:
+        headers = {"Host": f"{httpserver.host}:{httpserver.port}"}
+
+    headers[
+        "Arn-Header"
+    ] = f"arn:{origin_partition}:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+
+    request = Request(
+        method="POST",
+        path=f"/arn%3A{origin_partition}%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path%2F%2A",
+        query_string=f"arn=arn%3A{origin_partition}%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-query%2F%2A&"
+        f"arn2=arn%3A{origin_partition}%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-query2%2F%2A",
+        body=data,
+        headers=headers,
+    )
+    rewrite_handler = ArnPartitionRewriteHandler()
+    chain = HandlerChain()
+    chain.request_handlers.append(rewrite_handler)
+    context = RequestContext()
+    context.request = request
+    chain.handle(context, Response())
+    if internal_call:
+        assert not chain.terminated
+        assert chain.response.data == b""
+    else:
+        # ensure that the backend system received the "internal" path, query, header, and data (partition is always "AWS")
+        assert (
+            get_raw_path(handler_data["received_request"])
+            == "/arn%3Aaws%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-path%2F%2A"
+        )
+        assert (
+            handler_data["received_request"].query_string
+            == b"arn=arn%3Aaws%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-query%2F%2A&arn2=arn%3Aaws%3Aapigateway%3Aus-gov-west-1%3A%3A%2Frestapis%2Farn-in-query2%2F%2A"
+        )
+        assert (
+            handler_data["received_request"].headers["Arn-Header"]
+            == "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+        )
+        assert handler_data["received_request"].data == to_bytes(
+            json.dumps(
+                {"some-data-with-arn": "arn:aws:apigateway:us-gov-west-1::/restapis/arn-in-body/*"}
+            )
+        )
+
+        # ensure the client receives the "external" header, and data (partition is always the one which was sent)
+        received_response = chain.response
+        response_headers = received_response.headers
+        assert (
+            response_headers["Arn-Header"]
+            == "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-header/*"
+        )
+        assert received_response.data == to_bytes(
+            json.dumps(
+                {
+                    "some-data-with-arn": "arn:aws-us-gov:apigateway:us-gov-west-1::/restapis/arn-in-body/*"
+                }
+            )
         )


### PR DESCRIPTION
This PR addresses several encoding issues:
- `get_raw_base_url` now avoids multi-encoding by avoiding the usage of `werkzeug.sansio.utils.get_current_url`.
- `SimpleRequestsClient` now avoids multi-encoding by avoiding the usage of `werkzeug.sansio.utils.get_current_url`.
- `Proxy` uses the encoded path of the given request (instead of the decoded one) if no `forward_path` is given.
- `Router` now matches on the encoded path (instead of the decoded one).
  - This is a quite fundamental change, but it is necessary, because otherwise the encoding information is lost for parsed path parameters (f.e. when using `/<path:path>`).
- `ArnPartitionRewriteHandler` now uses the correct forward path (the modified one, instead of the original one).
- `ArnPartitionRewriteHandler` does not decode string values anymore. It uses the encoding-specific regex if necessary anyways.

/cc @whummer 