### PR TITLE
Check original environment copy for deprecations

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1111,7 +1111,6 @@ def init_directories() -> Directories:
 
         # deprecation path
         DATA_DIR = dirs.data
-        os.environ["DATA_DIR"] = dirs.data  # still needed for external tools
 
     return dirs
 


### PR DESCRIPTION
This seemed to misbehave previously because we sometimes mutate/set environment variables during startup.

## Example
Setting `PERISTENCE=1` will still log the deprecation warning for `DATA_DIR` even though it hasn't been explicitly set.

## Changes
- Remove manual setting of `DATA_DIR` env variable when `PERSISTENCE=1`
- <s>Copy the environment directly after we finish loading any profiles. This copy is then used in when determining deprecations instead of using the current environment.</s> Talked with @alexrashed about this and we decided against this for now. Instead removed the line that was causing the specifically observed issue with the environment variable `DATA_DIR` being set manually as a fallback.

@thrau & @giograno  Do you remember why this was added? What are the potential regressions we'd be creating by  removing this?

