### PR TITLE
fix 'unexpected keyword argument' error

### DIFF
--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -30,8 +30,10 @@ from localstack.aws.api.ec2 import (
     DescribeSubnetsResult,
     DescribeTransitGatewaysRequest,
     DescribeTransitGatewaysResult,
+    DnsOptionsSpecification,
     Ec2Api,
     InstanceType,
+    IpAddressType,
     ModifyLaunchTemplateRequest,
     ModifyLaunchTemplateResult,
     ModifySubnetAttributeRequest,
@@ -185,6 +187,8 @@ class Ec2Provider(Ec2Api, ABC):
         remove_subnet_ids: VpcEndpointSubnetIdList = None,
         add_security_group_ids: VpcEndpointSecurityGroupIdList = None,
         remove_security_group_ids: VpcEndpointSecurityGroupIdList = None,
+        ip_address_type: IpAddressType = None,
+        dns_options: DnsOptionsSpecification = None,
         private_dns_enabled: Boolean = None,
     ) -> ModifyVpcEndpointResult:
         backend = get_ec2_backend(context.account_id, context.region)

--- a/localstack/services/kinesis/provider.py
+++ b/localstack/services/kinesis/provider.py
@@ -19,6 +19,7 @@ from localstack.aws.api.kinesis import (
     SequenceNumber,
     ShardId,
     StartingPosition,
+    StreamARN,
     StreamName,
     SubscribeToShardEvent,
     SubscribeToShardEventStream,
@@ -116,11 +117,12 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
     def put_record(
         self,
         context: RequestContext,
-        stream_name: StreamName,
         data: Data,
         partition_key: PartitionKey,
+        stream_name: StreamName = None,
         explicit_hash_key: HashKey = None,
         sequence_number_for_ordering: SequenceNumber = None,
+        stream_arn: StreamARN = None,
     ):
         if random() < config.KINESIS_ERROR_PROBABILITY:
             raise ProvisionedThroughputExceededException(
@@ -131,7 +133,11 @@ class KinesisProvider(KinesisApi, ServiceLifecycleHook):
         raise NotImplementedError
 
     def put_records(
-        self, context: RequestContext, records: PutRecordsRequestEntryList, stream_name: StreamName
+        self,
+        context: RequestContext,
+        records: PutRecordsRequestEntryList,
+        stream_name: StreamName = None,
+        stream_arn: StreamARN = None,
     ) -> PutRecordsOutput:
         if random() < config.KINESIS_ERROR_PROBABILITY:
             records_count = len(records) if records is not None else 0


### PR DESCRIPTION
The API for some services changed over time. Currently, we do not have linting/checks that verify that the arguments of overriden functions differ.

This PR changes the definition of the implemented functions in the corresponding `provider.py`. As source, I used the CircleCI output for the script `capture_notimplemented_responses.py`, which logs the "unexpected keyword argument" errors. 

TODO: some moto tests are failing because of `unexpected keyword argument` but the functionality must also be implemented. 
