### PR TITLE
Allow configuration of docker image used for port checks

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -16,6 +16,7 @@ from localstack.constants import (
     DEFAULT_PORT_EDGE,
     DEFAULT_SERVICE_PORTS,
     DEFAULT_VOLUME_DIR,
+    DOCKER_IMAGE_NAME,
     ENV_INTERNAL_TEST_COLLECT_METRIC,
     ENV_INTERNAL_TEST_RUN,
     FALSE_STRINGS,
@@ -433,6 +434,11 @@ DOCKER_CMD = os.environ.get("DOCKER_CMD", "").strip() or "docker"
 # use the command line docker client instead of the new sdk version, might get removed in the future
 LEGACY_DOCKER_CLIENT = is_env_true("LEGACY_DOCKER_CLIENT")
 
+# Docker image to use when starting up containers for port checks
+PORTS_CHECK_DOCKER_IMAGE = (
+    os.environ.get("PORTS_CHECK_DOCKER_IMAGE", "").strip() or DOCKER_IMAGE_NAME
+)
+
 # whether to forward edge requests in-memory (instead of via proxy servers listening on backend ports)
 # TODO: this will likely become the default and may get removed in the future
 FORWARD_EDGE_INMEM = True
@@ -825,6 +831,7 @@ CONFIG_ENV_VARS = [
     "OUTBOUND_HTTP_PROXY",
     "OUTBOUND_HTTPS_PROXY",
     "PERSISTENCE",
+    "PORTS_CHECK_DOCKER_IMAGE",
     "REQUESTS_CA_BUNDLE",
     "S3_SKIP_SIGNATURE_VALIDATION",
     "S3_SKIP_KMS_KEY_VALIDATION",

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -6,7 +6,7 @@ import re
 from typing import List, Optional
 
 from localstack import config
-from localstack.constants import DEFAULT_VOLUME_DIR, DOCKER_IMAGE_NAME
+from localstack.constants import DEFAULT_VOLUME_DIR
 from localstack.utils.container_utils.container_client import (
     ContainerClient,
     PortMappings,
@@ -17,8 +17,6 @@ from localstack.utils.strings import to_str
 
 LOG = logging.getLogger(__name__)
 
-# Docker image to use when starting up containers for port checks
-PORTS_CHECK_DOCKER_IMAGE = DOCKER_IMAGE_NAME
 
 # port range instance used to reserve Docker container ports
 PORT_START = 1024
@@ -146,7 +144,7 @@ def container_port_can_be_bound(port: int) -> bool:
     ports.add(port, port)
     try:
         result = DOCKER_CLIENT.run_container(
-            PORTS_CHECK_DOCKER_IMAGE,
+            config.PORTS_CHECK_DOCKER_IMAGE,
             entrypoint="",
             command=["echo", "test123"],
             ports=ports,

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -11,7 +11,6 @@ import pytest
 
 from localstack import config
 from localstack.config import in_docker
-from localstack.utils import docker_utils
 from localstack.utils.common import is_ipv4_address, safe_run, save_file, short_uid, to_str
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
@@ -1378,7 +1377,7 @@ class TestDockerPorts:
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")
 
-        monkeypatch.setattr(docker_utils, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
+        monkeypatch.setattr(config, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)
@@ -1402,7 +1401,7 @@ class TestDockerPorts:
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")
 
-        monkeypatch.setattr(docker_utils, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
+        monkeypatch.setattr(config, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)


### PR DESCRIPTION
Closes #7681

## Changes

Now allows overriding the default image that is used internally in ECS to verify we can open ports with a docker container. Previously this was statically set to `localstack/localstack` and some users might not have access to that image in their environment.



## Discussion

I've noticed we are also using the DOCKER_IMAGE_NAME (`localstack/localstack`) in other places as well.
Should we maybe make these constants configurable as well? :thinking: 