### PR TITLE
Ignore dangling images in localstack update

### DIFF
--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -359,7 +359,12 @@ def cmd_update_docker_images():
     console.rule("Updating docker images")
 
     all_images = DOCKER_CLIENT.get_docker_image_names(strip_latest=False)
-    image_prefixes = ["localstack/", "lambci/lambda:", "mlupin/docker-lambda:"]
+    image_prefixes = [
+        "localstack/",
+        "lambci/lambda:",
+        "mlupin/docker-lambda:",
+        "public.ecr.aws/lambda",
+    ]
     localstack_images = [
         image
         for image in all_images
@@ -367,6 +372,7 @@ def cmd_update_docker_images():
             image.startswith(image_prefix) or image.startswith(f"docker.io/{image_prefix}")
             for image_prefix in image_prefixes
         )
+        and not image.endswith(":<none>")  # ignore dangling images
     ]
     update_images(localstack_images)
 


### PR DESCRIPTION
Previously we generated a list of all images which also included images such as `localstack/localstack:<none>`, i.e. dangling images without tags assigned.

## Changes

- Filter list of all images and removes any image names ending with `:<none>` before trying to update them.
- Add new new image prefix to check for updates in images used by the lambda v2 provider (`public.ecr.aws/lambda`)


Closes #7156