### PR TITLE
refactor community ext imports

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -2,6 +2,7 @@ from localstack.aws import handlers
 from localstack.aws.handlers.metric_handler import MetricHandler
 from localstack.aws.handlers.service_plugin import ServiceLoader
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceManager, ServicePluginManager
+from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
 
 from .gateway import Gateway
 from .handlers.fallback import EmptyResponseHandler
@@ -86,13 +87,8 @@ def main():
     setup_logging()
 
     if use_ssl:
-        from localstack.services.generic_proxy import (
-            GenericProxy,
-            install_predefined_cert_if_available,
-        )
-
         install_predefined_cert_if_available()
-        _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert(serial_number=port)
+        _, cert_file_name, key_file_name = create_ssl_cert(serial_number=port)
         ssl_creds = (cert_file_name, key_file_name)
     else:
         ssl_creds = None

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -256,11 +256,16 @@ def cmd_config_validate(file):
 @publish_invocation
 def cmd_config_show(format):
     # TODO: parse values from potential docker-compose file?
-
-    from localstack_ext import config as ext_config
-
     assert config
-    assert ext_config
+
+    try:
+        # only load the ext config if it's available
+        from localstack_ext import config as ext_config
+
+        assert ext_config
+    except ImportError:
+        # the ext package is not available
+        return None
 
     if format == "table":
         print_config_table()

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -36,6 +36,10 @@ MAVEN_REPO_URL = "https://repo1.maven.org/maven2"
 # URL of localstack's artifacts repository on GitHub
 ARTIFACTS_REPO = "https://github.com/localstack/localstack-artifacts"
 
+# Download URLs
+SSL_CERT_URL = f"{ARTIFACTS_REPO}/raw/master/local-certs/server.key"
+SSL_CERT_URL_FALLBACK = "{api_endpoint}/proxy/localstack.cert.key"
+
 # map of default service APIs and ports to be spun up (fetch map from localstack_client)
 DEFAULT_SERVICE_PORTS = localstack_client.config.get_service_ports()
 

--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -10,9 +10,9 @@ from localstack.aws.gateway import Gateway
 from localstack.aws.handlers.proxy import ProxyHandler
 from localstack.aws.serving.asgi import AsgiGateway
 from localstack.logging.setup import setup_hypercorn_logger
-from localstack.services.generic_proxy import GenericProxy, install_predefined_cert_if_available
 from localstack.utils.collections import ensure_list
 from localstack.utils.serving import Server
+from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
 
 
 class HypercornServer(Server):
@@ -98,7 +98,7 @@ class GatewayServer(HypercornServer):
 
         if use_ssl:
             install_predefined_cert_if_available()
-            _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert(serial_number=port)
+            _, cert_file_name, key_file_name = create_ssl_cert(serial_number=port)
             config.certfile = cert_file_name
             config.keyfile = key_file_name
 

--- a/localstack/services/opensearch/packages.py
+++ b/localstack/services/opensearch/packages.py
@@ -22,6 +22,7 @@ from localstack.services.opensearch import versions
 from localstack.utils.archives import download_and_extract_with_retry
 from localstack.utils.files import chmod_r, load_file, mkdir, rm_rf, save_file
 from localstack.utils.run import run
+from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
 from localstack.utils.sync import SynchronizedDefaultDict, retry
 
 LOG = logging.getLogger(__name__)
@@ -113,15 +114,10 @@ class OpensearchPackageInstaller(PackageInstaller):
         :param install_dir: root installation directory for OpenSearch which should be configured
         :param parsed_version: parsed semantic version of the OpenSearch installation which should be configured
         """
-        from localstack.services.generic_proxy import (
-            GenericProxy,
-            install_predefined_cert_if_available,
-        )
-
         # create & copy SSL certs to opensearch config dir
         install_predefined_cert_if_available()
         config_path = os.path.join(install_dir, "config")
-        _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert()
+        _, cert_file_name, key_file_name = create_ssl_cert()
         shutil.copyfile(cert_file_name, os.path.join(config_path, "cert.crt"))
         shutil.copyfile(key_file_name, os.path.join(config_path, "cert.key"))
 

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -83,22 +83,6 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 
 
-def is_pro_enabled() -> bool:
-    """Return whether the Pro extensions are enabled, i.e., restricted modules can be imported"""
-    try:
-        import localstack_ext.utils.common  # noqa
-
-        return True
-    except Exception:
-        return False
-
-
-# marker to indicate that a test should be skipped if the Pro extensions are enabled
-skip_if_pro_enabled = pytest.mark.skipif(
-    condition=is_pro_enabled(), reason="skipping, as Pro extensions are enabled"
-)
-
-
 def _client(service, region_name=None, aws_access_key_id=None, *, additional_config=None):
     config = botocore.config.Config()
 

--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -119,10 +119,12 @@ def _generate_machine_id() -> str:
 
 def read_api_key_safe():
     try:
+        # FIXME this info (maybe along with other info) should be plugged in by ext instead of importing it here
         from localstack_ext.bootstrap.licensing import read_api_key
 
         return read_api_key(raise_if_missing=False)
-    except Exception:
+    except ImportError:
+        # the ext package is not available, API key cannot be read (or used)
         return None
 
 

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -9,6 +9,7 @@ from localstack.utils.asyncio import ensure_event_loop
 from localstack.utils.files import new_tmp_file, save_file
 from localstack.utils.functions import run_safe
 from localstack.utils.numbers import is_number
+from localstack.utils.ssl import create_ssl_cert
 from localstack.utils.threads import TMP_THREADS, FuncThread, start_worker_thread
 
 LOG = logging.getLogger(__name__)
@@ -136,8 +137,6 @@ def _do_start_ssl_proxy(
     """
     import pproxy
 
-    from localstack.services.generic_proxy import GenericProxy
-
     if ":" not in str(target):
         target = f"127.0.0.1:{target}"
     LOG.debug("Starting SSL proxy server %s -> %s", port, target)
@@ -154,7 +153,7 @@ def _do_start_ssl_proxy(
     args = dict(rserver=[remote])
 
     # set SSL contexts
-    _, cert_file_name, key_file_name = GenericProxy.create_ssl_cert()
+    _, cert_file_name, key_file_name = create_ssl_cert()
     for context in pproxy.server.sslcontexts:
         context.load_cert_chain(cert_file_name, key_file_name)
 

--- a/localstack/utils/ssl.py
+++ b/localstack/utils/ssl.py
@@ -1,0 +1,67 @@
+import logging
+import os
+
+from localstack import config
+from localstack.constants import API_ENDPOINT, SSL_CERT_URL, SSL_CERT_URL_FALLBACK
+from localstack.utils.crypto import generate_ssl_cert
+from localstack.utils.http import download, download_github_artifact
+from localstack.utils.time import now
+
+LOG = logging.getLogger(__name__)
+
+
+# path for test certificate
+_SERVER_CERT_PEM_FILE = "server.test.pem"
+
+
+def install_predefined_cert_if_available():
+    try:
+        if config.SKIP_SSL_CERT_DOWNLOAD:
+            LOG.debug("Skipping download of local SSL cert, as SKIP_SSL_CERT_DOWNLOAD=1")
+            return
+        setup_ssl_cert()
+    except Exception:
+        pass
+
+
+def setup_ssl_cert():
+    target_file = get_cert_pem_file_path()
+
+    # cache file for 6 hours (non-enterprise) or forever (enterprise)
+    if os.path.exists(target_file):
+        cache_duration_secs = 6 * 60 * 60
+        mod_time = os.path.getmtime(target_file)
+        if mod_time > (now() - cache_duration_secs):
+            LOG.debug("Using cached SSL certificate (less than 6hrs since last update).")
+            return
+
+    # download certificate from GitHub artifacts
+    LOG.debug("Attempting to download local SSL certificate file")
+
+    # apply timeout (and fall back to using self-signed certs)
+    timeout_gh = 3  # short timeout for GitHub (default download)
+    timeout_proxy = 5  # slightly higher timeout for our proxy
+    try:
+        return download_github_artifact(SSL_CERT_URL, target_file, timeout=timeout_gh)
+    except Exception:
+        # try fallback URL, directly from our API proxy
+        url = SSL_CERT_URL_FALLBACK.format(api_endpoint=API_ENDPOINT)
+        try:
+            return download(url, target_file, timeout=timeout_proxy)
+        except Exception as e:
+            LOG.info(
+                "Unable to download local test SSL certificate from %s to %s (using self-signed cert as fallback): %s",
+                url,
+                target_file,
+                e,
+            )
+            raise
+
+
+def get_cert_pem_file_path():
+    return config.CUSTOM_SSL_CERT_PATH or os.path.join(config.dirs.cache, _SERVER_CERT_PEM_FILE)
+
+
+def create_ssl_cert(serial_number=None):
+    cert_pem_file = get_cert_pem_file_path()
+    return generate_ssl_cert(cert_pem_file, serial_number=serial_number)

--- a/tests/integration/awslambda/test_lambda_legacy.py
+++ b/tests/integration/awslambda/test_lambda_legacy.py
@@ -15,7 +15,6 @@ from localstack.services.awslambda.lambda_api import (
 from localstack.services.awslambda.lambda_utils import LAMBDA_DEFAULT_HANDLER
 from localstack.services.awslambda.packages import awslambda_go_runtime_package
 from localstack.testing.aws.lambda_utils import is_new_provider, is_old_provider
-from localstack.testing.pytest.fixtures import skip_if_pro_enabled
 from localstack.utils import testutil
 from localstack.utils.archives import download_and_extract
 from localstack.utils.aws import arns, aws_stack
@@ -32,6 +31,22 @@ from tests.integration.awslambda.test_lambda import (
 
 pytestmark = pytest.mark.skipif(
     condition=is_new_provider(), reason="only relevant for old provider"
+)
+
+
+def is_pro_enabled() -> bool:
+    """Return whether the Pro extensions are enabled, i.e., restricted modules can be imported"""
+    try:
+        import localstack_ext.utils.common  # noqa
+
+        return True
+    except Exception:
+        return False
+
+
+# marker to indicate that a test should be skipped if the Pro extensions are enabled
+skip_if_pro_enabled = pytest.mark.skipif(
+    condition=is_pro_enabled(), reason="skipping, as Pro extensions are enabled"
 )
 
 

--- a/tests/unit/utils/test_ssl.py
+++ b/tests/unit/utils/test_ssl.py
@@ -1,7 +1,7 @@
 import pytest
 
 from localstack import config
-from localstack.services.generic_proxy import get_cert_pem_file_path
+from localstack.utils.ssl import get_cert_pem_file_path
 
 
 def test_custom_ssl_cert_path_is_used(monkeypatch):


### PR DESCRIPTION
This PR tries to decrease the coupling to our LocalStack Pro extensions.
It can only merged together with its companion PR.

The changes are separated in different commits:
- _remove DNS startup from community:_
  - This commit removes the DNS startup from the `edge.py`. It will be started as a Pro plugin (infra start hook) instead.
    /cc @dfangl 
- _refactor SSL cert handling:_
  - Moves the SSL cert handling to community, since it is used and supported by community since the HTTP/HTTPS multiplexing is used (https://github.com/localstack/localstack/pull/1823).
    /cc @whummer 
- _unify, move, document ext imports:_
  - Documents, moves, and unifies remaining (for now tolerated) ext imports.
- _migrate serve_flask_app to only remaining using module:_
  - A somewhat unrelated refactoring, moving a legacy function from the generic proxy to its only using module (a legacy service provider).
    /cc @dominikschubert 