### PR TITLE
fix coveralls integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -115,7 +115,7 @@ test =
 dev =
     autoflake
     black==22.3.0
-    coveralls==3.1.0
+    coveralls>=3.3.1
     Cython
     flake8-black>=0.3.6
     flake8-isort>=6.0.0


### PR DESCRIPTION
The integration with coveralls.io is broken for a while.
After [CircleCI's incident in January](https://circleci.com/blog/jan-4-2023-incident-report/) we rotated all secrets (including the coveralls token).
The token has been updated. With this PR we also upgrade to the latest version to keep up to date.