### PR TITLE
validate StartingPosition during CreateEventSourceMapping operation

### DIFF
--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -181,6 +181,7 @@ from localstack.services.awslambda.urlrouter import FunctionUrlRouter
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import aws_stack
+from localstack.utils.aws.arns import extract_service_from_arn
 from localstack.utils.collections import PaginatedList
 from localstack.utils.files import load_file
 from localstack.utils.strings import get_random_hex, long_uid, short_uid, to_bytes, to_str
@@ -1345,6 +1346,13 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
     ) -> EventSourceMappingConfiguration:
         if "EventSourceArn" not in request:
             raise InvalidParameterValueException("Unrecognized event source.", Type="User")
+
+        service = extract_service_from_arn(request.get("EventSourceArn"))
+        if "StartingPosition" not in request and service in ["dynamodb", "kinesis", "kafka"]:
+            raise InvalidParameterValueException(
+                "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
+                Type="User",
+            )
 
         state = lambda_stores[context.account_id][context.region]
         function_name = request["FunctionName"]

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1348,7 +1348,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
             raise InvalidParameterValueException("Unrecognized event source.", Type="User")
 
         service = extract_service_from_arn(request.get("EventSourceArn"))
-        if "StartingPosition" not in request and service in ["dynamodb", "kinesis", "kafka"]:
+        if service in ["dynamodb", "kinesis", "kafka"] and "StartingPosition" not in request:
             raise InvalidParameterValueException(
                 "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
                 Type="User",

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -3834,6 +3834,40 @@ class TestLambdaEventSourceMappings:
         #
         # lambda_client.delete_event_source_mapping(UUID=uuid)
 
+    def test_create_event_source_validation(
+        self,
+        create_lambda_function,
+        lambda_su_role,
+        dynamodb_client,
+        dynamodb_create_table,
+        lambda_client,
+        snapshot,
+    ):
+        function_name = f"function-{short_uid()}"
+        create_lambda_function(
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            func_name=function_name,
+            runtime=Runtime.python3_9,
+            role=lambda_su_role,
+        )
+
+        table_name = f"table-{short_uid()}"
+        dynamodb_create_table(table_name=table_name, partition_key="id")
+        _await_dynamodb_table_active(dynamodb_client, table_name)
+        update_table_response = dynamodb_client.update_table(
+            TableName=table_name,
+            StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"},
+        )
+        stream_arn = update_table_response["TableDescription"]["LatestStreamArn"]
+
+        with pytest.raises(ClientError) as e:
+            lambda_client.create_event_source_mapping(
+                FunctionName=function_name, EventSourceArn=stream_arn
+            )
+
+        response = e.value.response
+        snapshot.match("error", response)
+
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not correctly supported")
 class TestLambdaTags:

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -3834,6 +3834,7 @@ class TestLambdaEventSourceMappings:
         #
         # lambda_client.delete_event_source_mapping(UUID=uuid)
 
+    @pytest.mark.skipif(is_old_provider(), reason="new provider only")
     def test_create_event_source_validation(
         self,
         create_lambda_function,

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10925,5 +10925,22 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_create_event_source_validation": {
+    "recorded-date": "15-02-2023, 11:03:02",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null."
+        },
+        "Type": "User",
+        "message": "1 validation error detected: Value null at 'startingPosition' failed to satisfy constraint: Member must not be null.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR makes the **CreateEventSourceMapping** operation validate the **StartingPosition** parameter. Addresses #7548

Changes:
- validation
- snapshoted test