### PR TITLE
guard process information pytest_unconfigure hook from exceptions

### DIFF
--- a/localstack/testing/pytest/detect_thread_leakage.py
+++ b/localstack/testing/pytest/detect_thread_leakage.py
@@ -32,8 +32,15 @@ def pytest_unconfigure(config):
     print(f"Thread actions: {json.dumps(info_tuples, indent=None)}")
     current_process = psutil.Process()
     children = current_process.children(recursive=True)
-    process_information_list = [
-        {"cmdline": child.cmdline(), "pid": child.pid, "status": child.status()}
-        for child in children
-    ]
+
+    process_information_list = []
+
+    for child in children:
+        try:
+            process_information_list.append(
+                {"cmdline": child.cmdline(), "pid": child.pid, "status": child.status()}
+            )
+        except Exception as e:
+            print(f"Error while collecting process information of {child.pid}: {e}")
+
     print(f"Subprocesses: {json.dumps(process_information_list, indent=None)}")


### PR DESCRIPTION
We've seen github actions executions fail (especially in pro), although all tests pass. This seems to be because pytest exits the interpreter with 1, because exceptions are raised in the `pytest_unconfigure` hook. This PR is just a pragmatic fix to avoid this.

here's the relevant github actions log from one of the runs. Note the  `2023-02-15T20:22:40.1435412Z ##[error]Process completed with exit code 1.` which i traced back to be the pytest runner.

```
2023-02-15T20:21:39.5009797Z Traceback (most recent call last):
2023-02-15T20:21:39.5259267Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/psutil/_pslinux.py", line 1645, in wrapper
2023-02-15T20:21:39.5265044Z     return fun(self, *args, **kwargs)
2023-02-15T20:21:39.5266101Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/psutil/_pslinux.py", line 1763, in cmdline
2023-02-15T20:21:39.5266649Z     with open_text("%s/%s/cmdline" % (self._procfs_path, self.pid)) as f:
2023-02-15T20:21:39.5267474Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/psutil/_common.py", line 742, in open_text
2023-02-15T20:21:39.5268533Z     fobj = open(fname, "rt", buffering=FILE_READ_BUFFER_SIZE,
2023-02-15T20:21:39.5269070Z FileNotFoundError: [Errno 2] No such file or directory: '/proc/78288/cmdline'
2023-02-15T20:21:39.5269328Z 
2023-02-15T20:21:39.5269542Z During handling of the above exception, another exception occurred:
2023-02-15T20:21:39.5269793Z 
2023-02-15T20:21:39.5269950Z Traceback (most recent call last):
2023-02-15T20:21:39.5270554Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pytest/__main__.py", line 5, in <module>
2023-02-15T20:21:39.5271027Z     raise SystemExit(pytest.console_main())
2023-02-15T20:21:39.5271663Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 185, in console_main
2023-02-15T20:21:39.5272073Z     code = main()
2023-02-15T20:21:39.5272640Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 162, in main
2023-02-15T20:21:39.5273124Z     ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
2023-02-15T20:21:39.5273748Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
2023-02-15T20:21:39.5274218Z     return self._hookexec(self, self.get_hookimpls(), kwargs)
2023-02-15T20:21:39.5274855Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
2023-02-15T20:21:39.5275319Z     return self._inner_hookexec(hook, methods, kwargs)
2023-02-15T20:21:39.5275925Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
2023-02-15T20:21:39.5276635Z     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
2023-02-15T20:21:39.5277328Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/callers.py", line 208, in _multicall
2023-02-15T20:21:39.5277784Z     return outcome.get_result()
2023-02-15T20:21:39.5278411Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
2023-02-15T20:21:39.5278902Z     raise ex[1].with_traceback(ex[2])
2023-02-15T20:21:39.5282239Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
2023-02-15T20:21:39.5291504Z     res = hook_impl.function(*args)
2023-02-15T20:21:39.5296086Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/_pytest/main.py", line 316, in pytest_cmdline_main
2023-02-15T20:21:39.5301613Z     return wrap_session(config, _main)
2023-02-15T20:21:39.5302393Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/_pytest/main.py", line 311, in wrap_session
2023-02-15T20:21:39.5306308Z     config._ensure_unconfigure()
2023-02-15T20:21:39.5307116Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/_pytest/config/__init__.py", line 987, in _ensure_unconfigure
2023-02-15T20:21:39.5310362Z     self.hook.pytest_unconfigure(config=self)
2023-02-15T20:21:39.5314294Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/hooks.py", line 286, in __call__
2023-02-15T20:21:39.5315153Z     return self._hookexec(self, self.get_hookimpls(), kwargs)
2023-02-15T20:21:39.5331921Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/manager.py", line 93, in _hookexec
2023-02-15T20:21:39.5338128Z     return self._inner_hookexec(hook, methods, kwargs)
2023-02-15T20:21:39.5342312Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/manager.py", line 84, in <lambda>
2023-02-15T20:21:39.5342943Z     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
2023-02-15T20:21:39.5351813Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/callers.py", line 208, in _multicall
2023-02-15T20:21:39.5352422Z     return outcome.get_result()
2023-02-15T20:21:39.5357469Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/callers.py", line 80, in get_result
2023-02-15T20:21:39.5359775Z     raise ex[1].with_traceback(ex[2])
2023-02-15T20:21:39.5363306Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/pluggy/callers.py", line 187, in _multicall
2023-02-15T20:21:39.5363843Z     res = hook_impl.function(*args)
2023-02-15T20:21:39.5378384Z   File "/opt/code/localstack/localstack/testing/pytest/detect_thread_leakage.py", line 35, in pytest_unconfigure
2023-02-15T20:21:39.5379078Z     process_information_list = [
2023-02-15T20:21:39.5385382Z   File "/opt/code/localstack/localstack/testing/pytest/detect_thread_leakage.py", line 36, in <listcomp>
2023-02-15T20:21:39.5391226Z     {"cmdline": child.cmdline(), "pid": child.pid, "status": child.status()}
2023-02-15T20:21:39.5392436Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/psutil/__init__.py", line 681, in cmdline
2023-02-15T20:21:39.5406447Z     return self._proc.cmdline()
2023-02-15T20:21:39.5409440Z   File "/opt/code/localstack/.venv/lib/python3.10/site-packages/psutil/_pslinux.py", line 1652, in wrapper
2023-02-15T20:21:39.5413196Z     raise NoSuchProcess(self.pid, self._name)
2023-02-15T20:21:39.5413797Z psutil.NoSuchProcess: process no longer exists (pid=78288)
2023-02-15T20:22:25.7141345Z Event loop is closed
2023-02-15T20:22:25.7299983Z Event loop is closed
2023-02-15T20:22:25.7304994Z Event loop is closed
2023-02-15T20:22:25.7305678Z Event loop is closed
2023-02-15T20:22:25.7310258Z Event loop is closed
2023-02-15T20:22:25.7310742Z Event loop is closed
2023-02-15T20:22:33.8816835Z ERROR: testing.common.database: failed to shutdown the server automatically.
2023-02-15T20:22:33.8829296Z Any server processes and files might have been leaked. Please remove them and call the stop() certainly
2023-02-15T20:22:34.3577094Z ERROR: testing.common.database: failed to shutdown the server automatically.
2023-02-15T20:22:34.3586853Z Any server processes and files might have been leaked. Please remove them and call the stop() certainly
2023-02-15T20:22:34.3595039Z ERROR: testing.common.database: failed to shutdown the server automatically.
2023-02-15T20:22:34.3642825Z Any server processes and files might have been leaked. Please remove them and call the stop() certainly
2023-02-15T20:22:34.3650022Z ERROR: testing.common.database: failed to shutdown the server automatically.
2023-02-15T20:22:34.3654320Z Any server processes and files might have been leaked. Please remove them and call the stop() certainly
2023-02-15T20:22:40.1435412Z ##[error]Process completed with exit code 1.
```