### PR TITLE
Add support for route.destination-cidr-block filter in DescribeRouteTables

### DIFF
--- a/localstack/services/ec2/provider.py
+++ b/localstack/services/ec2/provider.py
@@ -7,6 +7,7 @@ from moto.core.utils import camelcase_to_underscores, underscores_to_camelcase
 from moto.ec2.exceptions import InvalidVpcEndPointIdError
 from moto.ec2.models import SubnetBackend, TransitGatewayAttachmentBackend
 from moto.ec2.models.launch_templates import LaunchTemplate as MotoLaunchTemplate
+from moto.ec2.models.route_tables import RouteTable
 from moto.ec2.models.subnets import Subnet
 
 from localstack.aws.api import RequestContext, handler
@@ -402,6 +403,18 @@ def get_filter_value(fn, self, filter_name):
         "ipv6-cidr-block-association.association-id",
     ):
         return self.ipv6_cidr_block_associations
+    return fn(self, filter_name)
+
+
+# TODO: can be removed once https://github.com/getmoto/moto/pull/5932 is merged
+@patch(RouteTable.get_filter_value)
+def route_table_get_filter_value(fn, self, filter_name):
+    if filter_name == "route.destination-cidr-block":
+        return [
+            route.destination_cidr_block
+            for route in self.routes.values()
+            if route.destination_cidr_block is not None
+        ]
     return fn(self, filter_name)
 
 

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -402,3 +402,46 @@ def test_pickle_ec2_backend(ec2_client, pickle_backends):
     _ = ec2_client.describe_account_attributes()
     pickle_backends(ec2_backends)
     assert pickle_backends(ec2_backends)
+
+
+@pytest.mark.aws_validated
+def test_route_table_filter(ec2_client, cleanups):
+    """
+    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html
+
+    Tests two filters:
+    - "route.destination-cidr-block"
+    - "route-table-id"
+
+    """
+    vpc = ec2_client.create_vpc(CidrBlock="10.0.99.0/24")
+    vpc_id = vpc["Vpc"]["VpcId"]
+    cleanups.append(lambda: ec2_client.delete_vpc(VpcId=vpc_id))
+
+    gateway_id = ec2_client.create_internet_gateway()["InternetGateway"]["InternetGatewayId"]
+    cleanups.append(lambda: ec2_client.delete_internet_gateway(InternetGatewayId=gateway_id))
+
+    ec2_client.attach_internet_gateway(InternetGatewayId=gateway_id, VpcId=vpc_id)
+    cleanups.append(
+        lambda: ec2_client.detach_internet_gateway(InternetGatewayId=gateway_id, VpcId=vpc_id)
+    )
+
+    create_route_table_response = ec2_client.create_route_table(VpcId=vpc_id)
+    route_table_id = create_route_table_response["RouteTable"]["RouteTableId"]
+    cleanups.append(lambda: ec2_client.delete_route_table(RouteTableId=route_table_id))
+
+    ec2_client.create_route(
+        RouteTableId=route_table_id, DestinationCidrBlock="0.0.0.0/0", GatewayId=gateway_id
+    )
+
+    result = ec2_client.describe_route_tables(
+        Filters=[
+            {"Name": "route.destination-cidr-block", "Values": ["0.0.0.0/0"]},
+            {"Name": "route-table-id", "Values": [route_table_id]},
+        ]
+    )
+    tables = result["RouteTables"]
+    assert len(tables) == 1
+    table = tables[0]
+    assert table["VpcId"] == vpc_id
+    assert table["RouteTableId"] == route_table_id


### PR DESCRIPTION
Adds support for the `route.destination-cidr-block` filter in `EC2.DescribeRouteTables`

See: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html

Can be removed once https://github.com/getmoto/moto/pull/5932/files is merged upstream and we have updated our fork.