### PR TITLE
Re-enable cli container lifecycle test

### DIFF
--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -180,7 +180,6 @@ class TestCliContainerLifecycle:
         output = container_client.exec_in_container(config.MAIN_CONTAINER_NAME, ["ps", "-u", user])
         assert "supervisord" in to_str(output[0])
 
-    @pytest.mark.skip(reason="skip temporarily until compatible localstack image is on DockerHub")
     def test_start_cli_within_container(self, runner, container_client):
         output = container_client.run_container(
             # CAVEAT: Updates to the Docker image are not immediately reflected when using the latest image from


### PR DESCRIPTION
Re-enables a Docker CLI test that depends on the not-immediately-updated `localstack/localstack` image from Dockerhub.

Follow up from https://github.com/localstack/localstack/pull/7675

## Background

`tests.bootstrap.test_cli.TestCliContainerLifecycle.test_start_cli_within_container` depends on the latest [localstack/localstack](https://github.com/localstack/localstack/blob/ce0f939c228448eb0b4aedcd7ea6110c132243e2/tests/bootstrap/test_cli.py#L185) image from DockerHub. The test could not pass because bumping the PyPi `docker` version added an incompatibility. Specifically, a `platform` flag required for fixing ARM compatibility in lambda.

See internal [demo](https://www.notion.so/localstack/Releasing-a-change-with-conflicting-circular-dependency-8ca299173c5140bdb766b0a0512bd2d3?pvs=4)
