### PR TITLE
Add initial support for CFn Fn:Transform intrinsic functions

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1462,6 +1462,8 @@ class TemplateDeployer:
             res_change["_deployed"] = is_deployed
             if not is_deployed:
                 return True
+            if action == "Add":
+                return False
             if action == "Modify" and not self.is_updateable(resource):
                 LOG.debug(
                     'Action "update" not yet implemented for CF resource type %s',

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -44,6 +44,10 @@ def template_to_json(template: str) -> str:
 def transform_template(template: dict, parameters: list) -> Dict:
     result = dict(template)
 
+    # apply 'Fn::Transform' intrinsic functions (note: needs to be applied before global
+    #  transforms below, as some utils - incl samtransformer - expect them to be resolved already)
+    result = apply_transform_intrinsic_functions(result)
+
     # apply global transforms
     transformations = format_transforms(result.get("Transform", []))
     for transformation in transformations:
@@ -65,9 +69,6 @@ def transform_template(template: dict, parameters: list) -> Dict:
                 macro=transformation,
                 stack_parameters=parameters,
             )
-
-    # apply 'Fn::Transform' intrinsic functions
-    result = apply_transform_intrinsic_functions(result)
 
     return result
 

--- a/localstack/services/cloudformation/engine/template_preparer.py
+++ b/localstack/services/cloudformation/engine/template_preparer.py
@@ -41,12 +41,12 @@ def template_to_json(template: str) -> str:
 
 
 # TODO: consider moving to transformers.py as well
-def transform_template(template: dict, parameters: list) -> Dict:
+def transform_template(template: dict, parameters: list, stack=None) -> Dict:
     result = dict(template)
 
     # apply 'Fn::Transform' intrinsic functions (note: needs to be applied before global
     #  transforms below, as some utils - incl samtransformer - expect them to be resolved already)
-    result = apply_transform_intrinsic_functions(result)
+    result = apply_transform_intrinsic_functions(result, stack=stack)
 
     # apply global transforms
     transformations = format_transforms(result.get("Transform", []))

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -49,8 +49,8 @@ def apply_transform_intrinsic_functions(template: dict) -> dict:
             transformer_class = transformers.get(transform_name)
             if transformer_class:
                 transformer = transformer_class()
-                properties = transform.get("Parameters") or {}
-                return transformer.transform(properties)
+                parameters = transform.get("Parameters") or {}
+                return transformer.transform(parameters)
         return obj
 
     return recurse_object(template, _visit)

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -1,0 +1,54 @@
+import logging
+from typing import Dict, Type
+
+from localstack.utils import testutil
+from localstack.utils.aws import aws_stack
+from localstack.utils.objects import recurse_object
+
+LOG = logging.getLogger(__name__)
+
+
+class Transformer:
+    """Abstract class for Fn::Transform intrinsic functions"""
+
+    def transform(self, parameters: dict) -> dict | str:
+        """Apply the transformer to the given parameters and return the modified construct"""
+
+
+class AwsIncludeTransformer(Transformer):
+    """Implements the 'AWS::Include' transform intrinsic function"""
+
+    def transform(self, parameters: dict) -> dict | str:
+        from localstack.services.cloudformation.engine.template_preparer import parse_template
+
+        location = parameters.get("Location")
+        if location and location.startswith("s3://"):
+            s3_client = aws_stack.connect_to_resource("s3")
+            bucket, _, path = location.removeprefix("s3://").partition("/")
+            content = testutil.download_s3_object(s3_client, bucket, path)
+            content = parse_template(content)
+            return content
+        else:
+            LOG.warning("Unexpected ")
+        return parameters
+
+
+# maps transformer names to implementing classes
+transformers: Dict[str, Type] = {"AWS::Include": AwsIncludeTransformer}
+
+
+def apply_transform_intrinsic_functions(template: dict) -> dict:
+    """Resolve constructs using the 'Fn::Transform' intrinsic function."""
+
+    def _visit(obj, **_):
+        if isinstance(obj, dict) and obj.keys() == {"Fn::Transform"}:
+            transform = obj["Fn::Transform"]
+            transform_name = transform.get("Name")
+            transformer_class = transformers.get(transform_name)
+            if transformer_class:
+                transformer = transformer_class()
+                properties = transform.get("Parameters") or {}
+                return transformer.transform(properties)
+        return obj
+
+    return recurse_object(template, _visit)

--- a/localstack/services/cloudformation/engine/transformers.py
+++ b/localstack/services/cloudformation/engine/transformers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Type
+from typing import Dict, Type, Union
 
 from localstack.utils import testutil
 from localstack.utils.aws import aws_stack
@@ -7,18 +7,20 @@ from localstack.utils.objects import recurse_object
 
 LOG = logging.getLogger(__name__)
 
+TransformResult = Union[dict, str]
+
 
 class Transformer:
     """Abstract class for Fn::Transform intrinsic functions"""
 
-    def transform(self, parameters: dict) -> dict | str:
+    def transform(self, parameters: dict) -> TransformResult:
         """Apply the transformer to the given parameters and return the modified construct"""
 
 
 class AwsIncludeTransformer(Transformer):
     """Implements the 'AWS::Include' transform intrinsic function"""
 
-    def transform(self, parameters: dict) -> dict | str:
+    def transform(self, parameters: dict) -> TransformResult:
         from localstack.services.cloudformation.engine.template_preparer import parse_template
 
         location = parameters.get("Location")

--- a/localstack/services/cloudformation/models/apigateway.py
+++ b/localstack/services/cloudformation/models/apigateway.py
@@ -801,6 +801,8 @@ class GatewayAccount(GenericBaseModel):
         return "AWS::ApiGateway::Account"
 
     def fetch_state(self, stack_name, resources):
+        if not self.physical_resource_id:
+            return None
         client = aws_stack.connect_to_service("apigateway")
         return client.get_account()
 
@@ -823,4 +825,8 @@ class GatewayAccount(GenericBaseModel):
                 args[2], resource["LogicalResourceId"]
             )
 
-        return {"create": {"function": _create}}
+        def _delete(*_, **__):
+            # note: deletion of accounts is currently a no-op
+            pass
+
+        return {"create": {"function": _create}, "delete": {"function": _delete}}

--- a/localstack/services/cloudformation/models/stepfunctions.py
+++ b/localstack/services/cloudformation/models/stepfunctions.py
@@ -84,6 +84,7 @@ class SFNStateMachine(GenericBaseModel):
     def get_deploy_templates(cls):
         def _create_params(params, **kwargs):
             def _get_definition(params):
+                # TODO: support "Definition" parameter
                 definition_str = params.get("DefinitionString")
                 s3_location = params.get("DefinitionS3Location")
                 if not definition_str and s3_location:

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -421,14 +421,6 @@ class CloudformationProvider(CloudformationApi):
             ]  # should then have been set by prepare_template_body
         template = template_preparer.parse_template(req_params["TemplateBody"])
 
-        if (
-            "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
-            and "Transform" in template
-        ):
-            raise InsufficientCapabilitiesException(
-                "Requires capabilities : [CAPABILITY_AUTO_EXPAND]"
-            )
-
         del req_params["TemplateBody"]  # TODO: stop mutating req_params
         template["StackName"] = stack_name
         # TODO: validate with AWS what this is actually doing?

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -173,13 +173,10 @@ class CloudformationProvider(CloudformationApi):
             template.get("Parameters", {}), request.get("Parameters", [])
         )
 
+        stack = Stack(request, template)
         try:
-            template = template_preparer.transform_template(
-                template,
-                parameters,
-            )
+            template = template_preparer.transform_template(template, parameters, stack=stack)
         except FailedTransformationException as e:
-            stack = Stack(request, template)
             stack.add_stack_event(
                 stack.stack_name,
                 stack.stack_id,
@@ -249,7 +246,7 @@ class CloudformationProvider(CloudformationApi):
         )
 
         try:
-            template = template_preparer.transform_template(template, parameters)
+            template = template_preparer.transform_template(template, parameters, stack=stack)
         except FailedTransformationException as e:
             stack.add_stack_event(
                 stack.stack_name,
@@ -424,17 +421,19 @@ class CloudformationProvider(CloudformationApi):
             ]  # should then have been set by prepare_template_body
         template = template_preparer.parse_template(req_params["TemplateBody"])
 
-        parameters = template_preparer.resolve_parameters(
-            template.get("Parameters", {}), request.get("Parameters", [])
-        )
-        template = template_preparer.transform_template(template, parameters)
+        if (
+            "CAPABILITY_AUTO_EXPAND" not in request.get("Capabilities", [])
+            and "Transform" in template
+        ):
+            raise InsufficientCapabilitiesException(
+                "Requires capabilities : [CAPABILITY_AUTO_EXPAND]"
+            )
 
         del req_params["TemplateBody"]  # TODO: stop mutating req_params
         template["StackName"] = stack_name
         # TODO: validate with AWS what this is actually doing?
         template["ChangeSetName"] = change_set_name
         state = get_cloudformation_store()
-        #
 
         if change_set_type == "UPDATE":
             # add changeset to existing stack
@@ -467,6 +466,13 @@ class CloudformationProvider(CloudformationApi):
             )
             raise ValidationError(msg)
 
+        # apply template transformations
+        parameters = template_preparer.resolve_parameters(
+            template.get("Parameters", {}), request.get("Parameters", [])
+        )
+        template = template_preparer.transform_template(template, parameters, stack=stack)
+
+        # create change set for the stack and apply changes
         change_set = StackChangeSet(stack, req_params, template)
         deployer = template_deployer.TemplateDeployer(change_set)
         changes = deployer.construct_changes(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1196,7 +1196,7 @@ def deploy_cfn_template(
 
         outputs = cfn_client.describe_stacks(StackName=stack_id)["Stacks"][0].get("Outputs", [])
 
-        mapped_outputs = {o["OutputKey"]: o["OutputValue"] for o in outputs}
+        mapped_outputs = {o["OutputKey"]: o.get("OutputValue") for o in outputs}
 
         def _destroy_stack():
             cfn_client.delete_stack(StackName=stack_id)

--- a/tests/integration/cloudformation/api/test_transformers.py
+++ b/tests/integration/cloudformation/api/test_transformers.py
@@ -1,0 +1,45 @@
+import pytest
+
+from localstack.utils.strings import short_uid, to_bytes
+
+
+@pytest.mark.aws_validated
+@pytest.mark.skip_snapshot_verify(paths=["$..tags"])
+def test_duplicate_resources(
+    deploy_cfn_template, s3_bucket, s3_client, apigateway_client, cfn_client, snapshot
+):
+    snapshot.add_transformer(snapshot.transform.key_value("id"))
+    snapshot.add_transformer(snapshot.transform.key_value("name"))
+
+    api_name = f"api-{short_uid()}"
+
+    # put API spec to S3
+    api_spec = """
+    swagger: 2.0
+    info:
+      version: "1.2.3"
+      title: "Test API"
+    basePath: /base
+    """
+    s3_client.put_object(Bucket=s3_bucket, Key="api.yaml", Body=to_bytes(api_spec))
+
+    # deploy template
+    template = f"""
+    Resources:
+      RestApi:
+        Type: AWS::ApiGateway::RestApi
+        Properties:
+          Name: {api_name}
+          Body:
+            'Fn::Transform':
+              Name: 'AWS::Include'
+              Parameters:
+                Location: s3://{s3_bucket}/api.yaml
+    """
+    deploy_cfn_template(template=template)
+
+    # assert REST API is created properly
+    result = apigateway_client.get_rest_apis()
+    matching = [api for api in result["items"] if api["name"] == api_name]
+    assert matching
+    snapshot.match("api-details", matching)

--- a/tests/integration/cloudformation/api/test_transformers.snapshot.json
+++ b/tests/integration/cloudformation/api/test_transformers.snapshot.json
@@ -1,27 +1,29 @@
 {
   "tests/integration/cloudformation/api/test_transformers.py::test_duplicate_resources": {
-    "recorded-date": "17-02-2023, 14:24:10",
+    "recorded-date": "21-02-2023, 09:45:29",
     "recorded-content": {
-      "api-details": [
-        {
-          "id": "<id:1>",
-          "name": "<name:1>",
-          "createdDate": "datetime",
-          "version": "1.2.3",
-          "apiKeySource": "HEADER",
-          "endpointConfiguration": {
-            "types": [
-              "EDGE"
-            ]
-          },
-          "tags": {
-            "aws:cloudformation:logical-id": "RestApi",
-            "aws:cloudformation:stack-id": "arn:aws:cloudformation:<region>:111111111111:stack/stack-8a6438b2/51efa190-aec6-11ed-a8ce-0a8057042631",
-            "aws:cloudformation:stack-name": "stack-8a6438b2"
-          },
-          "disableExecuteApiEndpoint": false
+      "api-details": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "tags": {
+          "aws:cloudformation:logical-id": "RestApi",
+          "aws:cloudformation:stack-id": "<aws:cloudformation:stack-id:1>",
+          "aws:cloudformation:stack-name": "<aws:cloudformation:stack-name:1>"
+        },
+        "version": "1.2.3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
-      ]
+      }
     }
   }
 }

--- a/tests/integration/cloudformation/api/test_transformers.snapshot.json
+++ b/tests/integration/cloudformation/api/test_transformers.snapshot.json
@@ -1,0 +1,27 @@
+{
+  "tests/integration/cloudformation/api/test_transformers.py::test_duplicate_resources": {
+    "recorded-date": "17-02-2023, 14:24:10",
+    "recorded-content": {
+      "api-details": [
+        {
+          "id": "<id:1>",
+          "name": "<name:1>",
+          "createdDate": "datetime",
+          "version": "1.2.3",
+          "apiKeySource": "HEADER",
+          "endpointConfiguration": {
+            "types": [
+              "EDGE"
+            ]
+          },
+          "tags": {
+            "aws:cloudformation:logical-id": "RestApi",
+            "aws:cloudformation:stack-id": "arn:aws:cloudformation:<region>:111111111111:stack/stack-8a6438b2/51efa190-aec6-11ed-a8ce-0a8057042631",
+            "aws:cloudformation:stack-name": "stack-8a6438b2"
+          },
+          "disableExecuteApiEndpoint": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/integration/cloudformation/resources/test_ec2.py
+++ b/tests/integration/cloudformation/resources/test_ec2.py
@@ -35,6 +35,7 @@ def test_cfn_with_multiple_route_tables(ec2_client, deploy_cfn_template):
     vpc_id = result.outputs["VPC"]
 
     resp = ec2_client.describe_route_tables(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
+
     # 4 route tables being created (validated against AWS): 3 in template + 1 default = 4
     assert len(resp["RouteTables"]) == 4
 


### PR DESCRIPTION
Add initial support for CFn `Fn:Transform` intrinsic functions. This requirement came up while playing around with a more complex AWS sample app using a SAM / CloudFormation template: https://workshop.serverlesscoffee.com

For reference - part of the SAM template in the sample is a construct like this:
```
  RESTApConfigService:
    Type: AWS::Serverless::Api
    Properties:
      StageName: Prod
      DefinitionBody:
        'Fn::Transform':
          Name: 'AWS::Include'
          Parameters:
            Location: '../backends/2-config-service/RestAPIs/api.yaml'
```
(the `Location` parameter is replaced with an `s3://...` URL by SAM upon deployment)