### PR TITLE
Use token in GitHubReleaseInstaller for increased rate-limits

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -47,6 +47,8 @@ jobs:
       run:
         working-directory: localstack-ext
     environment: localstack-ext-tests
+    env:
+      GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # used for increased rate-limits when installing packages
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository  # skip job if fork PR
     steps:
       - name: Determine companion-ref

--- a/localstack/packages/core.py
+++ b/localstack/packages/core.py
@@ -142,7 +142,12 @@ class GitHubReleaseInstaller(PermissionDownloadInstaller):
     @lru_cache()
     def _get_download_url(self) -> str:
         asset_name = self._get_github_asset_name()
-        response = requests.get(self.github_tag_url)
+        # try to use a token when calling the GH API for increased API rate limits
+        headers = None
+        gh_token = os.environ.get("GITHUB_API_TOKEN")
+        if gh_token:
+            headers = {"authorization": f"Bearer {gh_token}"}
+        response = requests.get(self.github_tag_url, headers=headers)
         if not response.ok:
             raise PackageException(
                 f"Could not get list of releases from {self.github_tag_url}: {response.text}"


### PR DESCRIPTION
We're often running into rate-limits in the `GitHubReleaseInstaller` which calls the GitHub Rest API to get a list of artifacts for a given release. This is by default capped at **60 calls per hour** (per IP) for **unauthenticated** calls and any further calls currently lead to pipeline failures.

In CircleCI we're now using a custom secret (`GITHUB_API_TOKEN` which is a personal access token from @localstack-bot without any permissions). This increases the rate-limit to **5_000 calls per hour** (independent of IP)

In GitHub we're now using the intrinsic `GITHUB_TOKEN` secret. This increases the rate-limit to **1_000 calls per hour** 
 (independent of IP). If we ever need a higher limit in GitHub we can also use the token, but as long as it's not necessary I feel using `GITHUB_TOKEN` is more reliable.


Follow-up TODO:
- [x] check for more GitHub API calls in LocalStack and add token
- [ ] Use token in -ext repo