### PR TITLE
Allow container port binding for privileged ports

### DIFF
--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -23,7 +23,6 @@ PORT_START = 0
 PORT_END = 65536
 RANDOM_PORT_START = 1024
 RANDOM_PORT_END = 65536
-reserved_docker_ports = PortRange(PORT_START, PORT_END)
 
 
 def is_docker_sdk_installed() -> bool:
@@ -135,11 +134,6 @@ def get_host_path_for_path_in_docker(path):
     return path
 
 
-def is_port_available_for_containers(port: int) -> bool:
-    """Check whether the given port can be bound by containers and is not currently reserved"""
-    return not is_container_port_reserved(port) and container_port_can_be_bound(port)
-
-
 def container_port_can_be_bound(port: int) -> bool:
     """Determine whether a port can be bound by Docker containers"""
     ports = PortMappings()
@@ -163,6 +157,31 @@ def container_port_can_be_bound(port: int) -> bool:
             "Unexpected output when attempting to determine container port status: %s", result[0]
         )
     return True
+
+
+class _DockerPortRange(PortRange):
+    """
+    PortRange which checks whether the port can be bound on the host instead of inside the container.
+    """
+
+    def _try_reserve_port(self, port: int, duration: int) -> int:
+        """Checks if the given port is currently not reserved."""
+        if not self.is_port_reserved(port) and container_port_can_be_bound(port):
+            # reserve the port for a short period of time
+            self._ports_cache[port] = "__reserved__"
+            if duration:
+                self._ports_cache.set_expiry(port, duration)
+            return port
+        else:
+            raise PortNotAvailableException(f"The given port ({port}) is already reserved.")
+
+
+reserved_docker_ports = _DockerPortRange(PORT_START, PORT_END)
+
+
+def is_port_available_for_containers(port: int) -> bool:
+    """Check whether the given port can be bound by containers and is not currently reserved"""
+    return not is_container_port_reserved(port) and container_port_can_be_bound(port)
 
 
 def reserve_container_port(port: int, duration: int = None):
@@ -192,9 +211,11 @@ def reserve_available_container_port(
     retries = 10
     for i in range(retries):
         port = _random_port()
-        if container_port_can_be_bound(port):
+        try:
             reserve_container_port(port, duration=duration)
             return port
+        except PortNotAvailableException as e:
+            LOG.debug("Could not bind port %s, trying the next one: %s", port, e)
 
     raise PortNotAvailableException(
         f"Unable to determine available Docker container port after {retries} retries"

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -19,8 +19,10 @@ LOG = logging.getLogger(__name__)
 
 
 # port range instance used to reserve Docker container ports
-PORT_START = 1024
+PORT_START = 0
 PORT_END = 65536
+RANDOM_PORT_START = 1024
+RANDOM_PORT_END = 65536
 reserved_docker_ports = PortRange(PORT_START, PORT_END)
 
 
@@ -173,13 +175,18 @@ def is_container_port_reserved(port: int) -> bool:
     return reserved_docker_ports.is_port_reserved(port)
 
 
-def reserve_available_container_port(duration: int = None) -> int:
+def reserve_available_container_port(
+    duration: int = None, port_start: int = None, port_end: int = None
+) -> int:
     """Determine and reserve a port that can then be bound by a Docker container"""
 
     def _random_port():
         port = None
         while not port or reserved_docker_ports.is_port_reserved(port):
-            port = random.randint(PORT_START, PORT_END)
+            port = random.randint(
+                RANDOM_PORT_START if port_start is None else port_start,
+                RANDOM_PORT_END if port_end is None else port_end,
+            )
         return port
 
     retries = 10

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1397,6 +1397,12 @@ class TestDockerPorts:
         assert is_container_port_reserved(port)
         assert container_port_can_be_bound(port)
 
+        # reservation should work on privileged port
+        port = reserve_available_container_port(duration=1, port_start=1, port_end=1024)
+        assert is_container_port_reserved(port)
+        assert container_port_can_be_bound(port)
+        assert not is_port_available_for_containers(port)
+
     def test_container_port_can_be_bound(self, docker_client, monkeypatch):
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")


### PR DESCRIPTION
## Motivation
Currently, we do not allow checking privileged ports to be bound by LS. This leads to a problem with a hostport configuration in ECS for privileged ports - even if they are free.

Also, we are checking for each port we check on the host, if the port is free in the container as well. We should not do this, as we might want to use ports bound inside LS on the host as well.

## Changes
* Introduce separate port ranges for ports returned by `reserve_available_container_port` and ports which can be reserved on request. Per default, the former only returns non-privileged ports, while the whole port range can be reserved on explicit request for a port
* Add additional option to override the port range for reserving available ports. This can be used to further limit the random port range, for example for ECS: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PortMapping.html (The default ephemeral port range for Docker version 1.6.0 and later is listed on the instance under /proc/sys/net/ipv4/ip_local_port_range. If this kernel parameter is unavailable, the default ephemeral port range from 49153 through 65535 is used.)

## Remaining Problems
If checking is_port_available_for_containers before reserving the port, with the new changes, the port check will be done twice, which can lead to reduced performance.
Where possible, we should try reserving and catching the exception, instead of checking if it is possible first.