### PR TITLE
Fix apigateway path encoding

### DIFF
--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -31,7 +31,13 @@ def to_invocation_context(
         url_params = {}
 
     method = request.method
-    path = request.full_path if request.query_string else request.path
+    url_params_stage = url_params.get("stage", "dev")
+    url_params_path = url_params.get("path", request.path)
+    # Base path is not URL-decoded. Example: test%2Balias@gmail.com => test%2Balias@gmail.com
+    path = f"{url_params_stage}/{url_params_path}"
+    if request.query_string:
+        # Parameters are URL-decoded. Example: test%2Balias@gmail.com => test+alias@gmail.com
+        path += f"?{request.query_string.decode()}"
     data = restore_payload(request)
     headers = Headers(request.headers)
 

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -17,6 +17,9 @@ from localstack.utils.aws.aws_responses import LambdaResponse
 LOG = logging.getLogger(__name__)
 
 
+# TODO: with the latest snapshot tests, we might start moving away from the
+# invocation context property decorators and use the url_params directly,
+# something ask for a long time.
 def to_invocation_context(
     request: Request, url_params: Dict[str, Any] = None
 ) -> ApiInvocationContext:
@@ -31,13 +34,16 @@ def to_invocation_context(
         url_params = {}
 
     method = request.method
-    url_params_stage = url_params.get("stage", "dev")
+    url_params_stage = url_params.get("stage")
     url_params_path = url_params.get("path", request.path)
-    # Base path is not URL-decoded. Example: test%2Balias@gmail.com => test%2Balias@gmail.com
-    path = f"{url_params_stage}/{url_params_path}"
+    # Base path is not URL-decoded.
+    # Example: test%2Balias@gmail.com => test%2Balias@gmail.com
+    path = f"/{url_params_stage}/{url_params_path}"
     if request.query_string:
-        # Parameters are URL-decoded. Example: test%2Balias@gmail.com => test+alias@gmail.com
+        # Parameters are URL-decoded.
+        # Example: test%2Balias@gmail.com => test+alias@gmail.com
         path += f"?{request.query_string.decode()}"
+
     data = restore_payload(request)
     headers = Headers(request.headers)
 

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -34,16 +34,9 @@ def to_invocation_context(
         url_params = {}
 
     method = request.method
-    url_params_stage = url_params.get("stage")
-    url_params_path = url_params.get("path", request.path)
     # Base path is not URL-decoded.
     # Example: test%2Balias@gmail.com => test%2Balias@gmail.com
-    path = f"/{url_params_stage}/{url_params_path}"
-    if request.query_string:
-        # Parameters are URL-decoded.
-        # Example: test%2Balias@gmail.com => test+alias@gmail.com
-        path += f"?{request.query_string.decode()}"
-
+    path = request.environ.get("RAW_URI")
     data = restore_payload(request)
     headers = Headers(request.headers)
 

--- a/localstack/services/apigateway/router_asf.py
+++ b/localstack/services/apigateway/router_asf.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 
 # TODO: with the latest snapshot tests, we might start moving away from the
 # invocation context property decorators and use the url_params directly,
-# something ask for a long time.
+# something asked for a long time.
 def to_invocation_context(
     request: Request, url_params: Dict[str, Any] = None
 ) -> ApiInvocationContext:

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -306,7 +306,6 @@ def test_lambda_proxy_integration(
         "invocation-payload-with-params-encoding",
         response_params_encoding.json(),
     )
-    # TODO: ensure that pathParameters follow the same encoding rules when using non {proxy+} matching
 
 
 #

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -254,30 +254,59 @@ def test_lambda_proxy_integration(
     # invoke rest api with trailing slash
     response_trailing_slash = retry(invoke_api, sleep=2, retries=10, url=f"{invocation_url}/")
     snapshot.match("invocation-payload-with-trailing-slash", response_trailing_slash.json())
-    response_trailing_slash = retry(
-        invoke_api, sleep=2, retries=10, url=f"{invocation_url}?urlparam=test@gmail.com"
+
+    response_no_trailing_slash = retry(
+        invoke_api, sleep=2, retries=10, url=f"{invocation_url}?urlparam=test"
     )
     snapshot.match(
         "invocation-payload-without-trailing-slash-and-query-params",
-        response_trailing_slash.json(),
+        response_no_trailing_slash.json(),
     )
-    response_trailing_slash = retry(
-        invoke_api, sleep=2, retries=10, url=f"{invocation_url}/?urlparam=test+alias@gmail.com"
+
+    response_trailing_slash_param = retry(
+        invoke_api, sleep=2, retries=10, url=f"{invocation_url}/?urlparam=test"
     )
     snapshot.match(
         "invocation-payload-with-trailing-slash-and-query-params",
-        response_trailing_slash.json(),
+        response_trailing_slash_param.json(),
     )
+
+    # invoke rest api with encoded information in URL path
+    path_encoded_emails = "user/test%2Balias@gmail.com/plus/test+alias@gmail.com"
     response_path_encoding = retry(
         invoke_api,
         sleep=2,
         retries=10,
-        url=f"{invocation_url}/api/v1/user/test%2Balias@gmail.com",
+        url=f"{invocation_url}/api/{path_encoded_emails}",
     )
     snapshot.match(
         "invocation-payload-with-path-encoded-email",
         response_path_encoding.json(),
     )
+
+    # invoke rest api with encoded information in URL params
+    url_params = "&".join(
+        [
+            "dateTimeOffset=2023-06-12T18:05:10.123456+00:00",
+            "email=test%2Balias@gmail.com",
+            "plus=test+alias@gmail.com",
+            "url=https://www.google.com/",
+            "whitespace=foo bar",
+            "zhash=abort/#",
+            "ignored=this-does-not-appear-after-the-hash",
+        ]
+    )
+    response_params_encoding = retry(
+        invoke_api,
+        sleep=2,
+        retries=10,
+        url=f"{invocation_url}/api?{url_params}",
+    )
+    snapshot.match(
+        "invocation-payload-with-params-encoding",
+        response_params_encoding.json(),
+    )
+    # TODO: ensure that pathParameters follow the same encoding rules when using non {proxy+} matching
 
 
 #

--- a/tests/integration/test_apigateway_integrations.py
+++ b/tests/integration/test_apigateway_integrations.py
@@ -211,7 +211,7 @@ def test_lambda_proxy_integration(
     rest_api_id = rest_api_creation_response["id"]
     root_resource_id = apigateway_client.get_resources(restApiId=rest_api_id)["items"][0]["id"]
     resource_id = apigateway_client.create_resource(
-        restApiId=rest_api_id, parentId=root_resource_id, pathPart="test-path"
+        restApiId=rest_api_id, parentId=root_resource_id, pathPart="{proxy+}"
     )["id"]
     apigateway_client.put_method(
         restApiId=rest_api_id,
@@ -255,18 +255,28 @@ def test_lambda_proxy_integration(
     response_trailing_slash = retry(invoke_api, sleep=2, retries=10, url=f"{invocation_url}/")
     snapshot.match("invocation-payload-with-trailing-slash", response_trailing_slash.json())
     response_trailing_slash = retry(
-        invoke_api, sleep=2, retries=10, url=f"{invocation_url}?urlparam=test"
+        invoke_api, sleep=2, retries=10, url=f"{invocation_url}?urlparam=test@gmail.com"
     )
     snapshot.match(
         "invocation-payload-without-trailing-slash-and-query-params",
         response_trailing_slash.json(),
     )
     response_trailing_slash = retry(
-        invoke_api, sleep=2, retries=10, url=f"{invocation_url}/?urlparam=test"
+        invoke_api, sleep=2, retries=10, url=f"{invocation_url}/?urlparam=test+alias@gmail.com"
     )
     snapshot.match(
         "invocation-payload-with-trailing-slash-and-query-params",
         response_trailing_slash.json(),
+    )
+    response_path_encoding = retry(
+        invoke_api,
+        sleep=2,
+        retries=10,
+        url=f"{invocation_url}/api/v1/user/test%2Balias@gmail.com",
+    )
+    snapshot.match(
+        "invocation-payload-with-path-encoded-email",
+        response_path_encoding.json(),
     )
 
 

--- a/tests/integration/test_apigateway_integrations.snapshot.json
+++ b/tests/integration/test_apigateway_integrations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/test_apigateway_integrations.py::test_lambda_proxy_integration": {
-    "recorded-date": "21-02-2023, 17:32:43",
+    "recorded-date": "22-02-2023, 11:19:13",
     "recorded-content": {
       "rest-api-creation": {
         "apiKeySource": "HEADER",
@@ -339,7 +339,7 @@
         },
         "multiValueQueryStringParameters": {
           "urlparam": [
-            "test@gmail.com"
+            "test"
           ]
         },
         "path": "/test-path",
@@ -347,7 +347,7 @@
           "proxy": "test-path"
         },
         "queryStringParameters": {
-          "urlparam": "test@gmail.com"
+          "urlparam": "test"
         },
         "requestContext": {
           "accountId": "111111111111",
@@ -464,7 +464,7 @@
         },
         "multiValueQueryStringParameters": {
           "urlparam": [
-            "test alias@gmail.com"
+            "test"
           ]
         },
         "path": "/test-path/",
@@ -472,7 +472,7 @@
           "proxy": "test-path"
         },
         "queryStringParameters": {
-          "urlparam": "test alias@gmail.com"
+          "urlparam": "test"
         },
         "requestContext": {
           "accountId": "111111111111",
@@ -588,9 +588,9 @@
           ]
         },
         "multiValueQueryStringParameters": null,
-        "path": "/test-path/api/v1/user/test%2Balias@gmail.com",
+        "path": "/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
         "pathParameters": {
-          "proxy": "test-path/api/v1/user/test%2Balias@gmail.com"
+          "proxy": "test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com"
         },
         "queryStringParameters": null,
         "requestContext": {
@@ -614,9 +614,154 @@
             "userAgent": "python-requests/testing",
             "userArn": null
           },
-          "path": "/test/test-path/api/v1/user/test%2Balias@gmail.com",
+          "path": "/test/test-path/api/user/test%2Balias@gmail.com/plus/test+alias@gmail.com",
           "protocol": "HTTP/1.1",
           "requestId": "<uuid:5>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/{proxy+}",
+          "stage": "test"
+        },
+        "resource": "/{proxy+}",
+        "stageVariables": null
+      },
+      "invocation-payload-with-params-encoding": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<id:1>.execute-api.<region>.amazonaws.com",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:6>",
+          "X-Amz-Cf-Id": "<cf-id:6>",
+          "X-Amzn-Trace-Id": "<trace-id:6>",
+          "X-Forwarded-For": "<source-ip:1>, <ip>",
+          "X-Forwarded-Port": "443",
+          "X-Forwarded-Proto": "https",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<id:1>.execute-api.<region>.amazonaws.com"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:6>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:6>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:6>"
+          ],
+          "X-Forwarded-For": [
+            "<source-ip:1>, <ip>"
+          ],
+          "X-Forwarded-Port": [
+            "443"
+          ],
+          "X-Forwarded-Proto": [
+            "https"
+          ],
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": {
+          "dateTimeOffset": [
+            "2023-06-12T18:05:10.123456 00:00"
+          ],
+          "email": [
+            "test+alias@gmail.com"
+          ],
+          "plus": [
+            "test alias@gmail.com"
+          ],
+          "url": [
+            "https://www.google.com/"
+          ],
+          "whitespace": [
+            "foo bar"
+          ],
+          "zhash": [
+            "abort/"
+          ]
+        },
+        "path": "/test-path/api",
+        "pathParameters": {
+          "proxy": "test-path/api"
+        },
+        "queryStringParameters": {
+          "dateTimeOffset": "2023-06-12T18:05:10.123456 00:00",
+          "email": "test+alias@gmail.com",
+          "plus": "test alias@gmail.com",
+          "url": "https://www.google.com/",
+          "whitespace": "foo bar",
+          "zhash": "abort/"
+        },
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<id:1>",
+          "domainName": "<id:1>.execute-api.<region>.amazonaws.com",
+          "domainPrefix": "<id:1>",
+          "extendedRequestId": "<extended-request-id:6>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path/api",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:6>",
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",

--- a/tests/integration/test_apigateway_integrations.snapshot.json
+++ b/tests/integration/test_apigateway_integrations.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/test_apigateway_integrations.py::test_lambda_proxy_integration": {
-    "recorded-date": "09-01-2023, 20:50:16",
+    "recorded-date": "21-02-2023, 17:32:43",
     "recorded-content": {
       "rest-api-creation": {
         "apiKeySource": "HEADER",
@@ -101,7 +101,9 @@
         },
         "multiValueQueryStringParameters": null,
         "path": "/test-path",
-        "pathParameters": null,
+        "pathParameters": {
+          "proxy": "test-path"
+        },
         "queryStringParameters": null,
         "requestContext": {
           "accountId": "111111111111",
@@ -130,10 +132,10 @@
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
-          "resourcePath": "/test-path",
+          "resourcePath": "/{proxy+}",
           "stage": "test"
         },
-        "resource": "/test-path",
+        "resource": "/{proxy+}",
         "stageVariables": null
       },
       "invocation-payload-with-trailing-slash": {
@@ -218,7 +220,9 @@
         },
         "multiValueQueryStringParameters": null,
         "path": "/test-path/",
-        "pathParameters": null,
+        "pathParameters": {
+          "proxy": "test-path"
+        },
         "queryStringParameters": null,
         "requestContext": {
           "accountId": "111111111111",
@@ -247,10 +251,10 @@
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
-          "resourcePath": "/test-path",
+          "resourcePath": "/{proxy+}",
           "stage": "test"
         },
-        "resource": "/test-path",
+        "resource": "/{proxy+}",
         "stageVariables": null
       },
       "invocation-payload-without-trailing-slash-and-query-params": {
@@ -335,13 +339,15 @@
         },
         "multiValueQueryStringParameters": {
           "urlparam": [
-            "test"
+            "test@gmail.com"
           ]
         },
         "path": "/test-path",
-        "pathParameters": null,
+        "pathParameters": {
+          "proxy": "test-path"
+        },
         "queryStringParameters": {
-          "urlparam": "test"
+          "urlparam": "test@gmail.com"
         },
         "requestContext": {
           "accountId": "111111111111",
@@ -370,10 +376,10 @@
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
-          "resourcePath": "/test-path",
+          "resourcePath": "/{proxy+}",
           "stage": "test"
         },
-        "resource": "/test-path",
+        "resource": "/{proxy+}",
         "stageVariables": null
       },
       "invocation-payload-with-trailing-slash-and-query-params": {
@@ -458,13 +464,15 @@
         },
         "multiValueQueryStringParameters": {
           "urlparam": [
-            "test"
+            "test alias@gmail.com"
           ]
         },
         "path": "/test-path/",
-        "pathParameters": null,
+        "pathParameters": {
+          "proxy": "test-path"
+        },
         "queryStringParameters": {
-          "urlparam": "test"
+          "urlparam": "test alias@gmail.com"
         },
         "requestContext": {
           "accountId": "111111111111",
@@ -493,10 +501,129 @@
           "requestTime": "<request-time>",
           "requestTimeEpoch": "<request-time-epoch>",
           "resourceId": "<resource-id:1>",
-          "resourcePath": "/test-path",
+          "resourcePath": "/{proxy+}",
           "stage": "test"
         },
-        "resource": "/test-path",
+        "resource": "/{proxy+}",
+        "stageVariables": null
+      },
+      "invocation-payload-with-path-encoded-email": {
+        "body": null,
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "CloudFront-Forwarded-Proto": "https",
+          "CloudFront-Is-Desktop-Viewer": "true",
+          "CloudFront-Is-Mobile-Viewer": "false",
+          "CloudFront-Is-SmartTV-Viewer": "false",
+          "CloudFront-Is-Tablet-Viewer": "false",
+          "CloudFront-Viewer-ASN": "<cloudfront-asn:1>",
+          "CloudFront-Viewer-Country": "<cloudfront-country:1>",
+          "Host": "<id:1>.execute-api.<region>.amazonaws.com",
+          "User-Agent": "python-requests/testing",
+          "Via": "<via:5>",
+          "X-Amz-Cf-Id": "<cf-id:5>",
+          "X-Amzn-Trace-Id": "<trace-id:5>",
+          "X-Forwarded-For": "<source-ip:1>, <ip>",
+          "X-Forwarded-Port": "443",
+          "X-Forwarded-Proto": "https",
+          "tEsT-HEADeR": "aValUE"
+        },
+        "httpMethod": "GET",
+        "isBase64Encoded": false,
+        "multiValueHeaders": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "CloudFront-Forwarded-Proto": [
+            "https"
+          ],
+          "CloudFront-Is-Desktop-Viewer": [
+            "true"
+          ],
+          "CloudFront-Is-Mobile-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-SmartTV-Viewer": [
+            "false"
+          ],
+          "CloudFront-Is-Tablet-Viewer": [
+            "false"
+          ],
+          "CloudFront-Viewer-ASN": [
+            "<cloudfront-asn:1>"
+          ],
+          "CloudFront-Viewer-Country": [
+            "<cloudfront-country:1>"
+          ],
+          "Host": [
+            "<id:1>.execute-api.<region>.amazonaws.com"
+          ],
+          "User-Agent": [
+            "python-requests/testing"
+          ],
+          "Via": [
+            "<via:5>"
+          ],
+          "X-Amz-Cf-Id": [
+            "<cf-id:5>"
+          ],
+          "X-Amzn-Trace-Id": [
+            "<trace-id:5>"
+          ],
+          "X-Forwarded-For": [
+            "<source-ip:1>, <ip>"
+          ],
+          "X-Forwarded-Port": [
+            "443"
+          ],
+          "X-Forwarded-Proto": [
+            "https"
+          ],
+          "tEsT-HEADeR": [
+            "aValUE"
+          ]
+        },
+        "multiValueQueryStringParameters": null,
+        "path": "/test-path/api/v1/user/test%2Balias@gmail.com",
+        "pathParameters": {
+          "proxy": "test-path/api/v1/user/test%2Balias@gmail.com"
+        },
+        "queryStringParameters": null,
+        "requestContext": {
+          "accountId": "111111111111",
+          "apiId": "<id:1>",
+          "domainName": "<id:1>.execute-api.<region>.amazonaws.com",
+          "domainPrefix": "<id:1>",
+          "extendedRequestId": "<extended-request-id:5>",
+          "httpMethod": "GET",
+          "identity": {
+            "accessKey": null,
+            "accountId": null,
+            "caller": null,
+            "cognitoAuthenticationProvider": null,
+            "cognitoAuthenticationType": null,
+            "cognitoIdentityId": null,
+            "cognitoIdentityPoolId": null,
+            "principalOrgId": null,
+            "sourceIp": "<source-ip:1>",
+            "user": null,
+            "userAgent": "python-requests/testing",
+            "userArn": null
+          },
+          "path": "/test/test-path/api/v1/user/test%2Balias@gmail.com",
+          "protocol": "HTTP/1.1",
+          "requestId": "<uuid:5>",
+          "requestTime": "<request-time>",
+          "requestTimeEpoch": "<request-time-epoch>",
+          "resourceId": "<resource-id:1>",
+          "resourcePath": "/{proxy+}",
+          "stage": "test"
+        },
+        "resource": "/{proxy+}",
         "stageVariables": null
       }
     }


### PR DESCRIPTION
This PR fixes an rest api parity issue related to encoding paths in URL.

## Actual behavior

Given the following invocation URL against a rest api (e.g., with `{proxy+}` integration and a lambda function as backend):

`GET https://{restapi_id}.execute-api.{region}.amazonaws.com/{stage_name}/user/test%2Balias@gmail.com/plus/test+alias@gmail.com?email=test%2Balias@gmail.com`

* `path`: `"/{stage_name}/user/test+alias@gmail.com/plus/test+alias@gmail.com?email=test%2Balias@gmail.com"`
* `queryStringParameters.email`: `test+alias@gmail.com`


## Expected behavior

The base `path` should not decode URL encoded characters such as `%2B => +` and looks like this in AWS: `/user/test%2Balias@gmail.com/plus/test+alias@gmail.com`

## Implementation

Instead of relying on decoded `request.path` or `request.full_path` from Werkzeug, we need to compose the invocation `path` manually consisting of a non-decoded base part and a decode params part.

## Questions

* When can `url_params` be None?
* Can we assume defaults for non-present stage and path variables or should we fail fast?
* Does the current solution work with custom domain names where the `stage_name` is omitted?
* Any other special cases to consider?
