### PR TITLE
Minimal implementation for continuous backup

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -29,12 +29,15 @@ from localstack.aws.api.dynamodb import (
     BatchWriteItemInput,
     BatchWriteItemOutput,
     BillingMode,
+    ContinuousBackupsDescription,
+    ContinuousBackupsStatus,
     CreateGlobalTableOutput,
     CreateTableInput,
     CreateTableOutput,
     DeleteItemInput,
     DeleteItemOutput,
     DeleteTableOutput,
+    DescribeContinuousBackupsOutput,
     DescribeGlobalTableOutput,
     DescribeKinesisStreamingDestinationOutput,
     DescribeTableOutput,
@@ -55,6 +58,9 @@ from localstack.aws.api.dynamodb import (
     ListTagsOfResourceOutput,
     NextTokenString,
     PartiQLBatchRequest,
+    PointInTimeRecoveryDescription,
+    PointInTimeRecoverySpecification,
+    PointInTimeRecoveryStatus,
     PositiveIntegerObject,
     ProvisionedThroughputExceededException,
     PutItemInput,
@@ -73,6 +79,7 @@ from localstack.aws.api.dynamodb import (
     ScanInput,
     ScanOutput,
     StreamArn,
+    TableDescription,
     TableName,
     TagKeyList,
     TagList,
@@ -81,6 +88,7 @@ from localstack.aws.api.dynamodb import (
     TransactGetItemsOutput,
     TransactWriteItemsInput,
     TransactWriteItemsOutput,
+    UpdateContinuousBackupsOutput,
     UpdateGlobalTableOutput,
     UpdateItemInput,
     UpdateItemOutput,
@@ -109,7 +117,7 @@ from localstack.services.plugins import ServiceLifecycleHook
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.aws.aws_stack import get_valid_regions_for_service
-from localstack.utils.collections import select_attributes
+from localstack.utils.collections import select_attributes, select_from_typed_dict
 from localstack.utils.common import short_uid, to_bytes
 from localstack.utils.json import BytesEncoder, canonical_json
 from localstack.utils.strings import long_uid, to_str
@@ -545,7 +553,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
                     "TableClass": table_definitions["TableClass"]
                 }
 
-        return result
+        return DescribeTableOutput(Table=select_from_typed_dict(TableDescription, result["Table"]))
 
     @handler("UpdateTable", expand=False)
     def update_table(
@@ -1198,6 +1206,56 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
         )
 
     #
+    # Continuous Backups
+    #
+
+    def describe_continuous_backups(
+        self, context: RequestContext, table_name: TableName
+    ) -> DescribeContinuousBackupsOutput:
+        self.get_global_table_region(context, table_name)
+        store = get_store(context.account_id, context.region)
+        continuous_backup_description = (
+            store.table_properties.get(table_name, {}).get("ContinuousBackupsDescription")
+        ) or ContinuousBackupsDescription(
+            ContinuousBackupsStatus=ContinuousBackupsStatus.ENABLED,
+            PointInTimeRecoveryDescription=PointInTimeRecoveryDescription(
+                PointInTimeRecoveryStatus=PointInTimeRecoveryStatus.DISABLED
+            ),
+        )
+
+        return DescribeContinuousBackupsOutput(
+            ContinuousBackupsDescription=continuous_backup_description
+        )
+
+    def update_continuous_backups(
+        self,
+        context: RequestContext,
+        table_name: TableName,
+        point_in_time_recovery_specification: PointInTimeRecoverySpecification,
+    ) -> UpdateContinuousBackupsOutput:
+        self.get_global_table_region(context, table_name)
+
+        store = get_store(context.account_id, context.region)
+        pit_recovery_status = (
+            PointInTimeRecoveryStatus.ENABLED
+            if point_in_time_recovery_specification["PointInTimeRecoveryEnabled"]
+            else PointInTimeRecoveryStatus.DISABLED
+        )
+        continuous_backup_description = ContinuousBackupsDescription(
+            ContinuousBackupsStatus=ContinuousBackupsStatus.ENABLED,
+            PointInTimeRecoveryDescription=PointInTimeRecoveryDescription(
+                PointInTimeRecoveryStatus=pit_recovery_status
+            ),
+        )
+        store.table_properties[table_name] = {
+            "ContinuousBackupsDescription": continuous_backup_description
+        }
+
+        return UpdateContinuousBackupsOutput(
+            ContinuousBackupsDescription=continuous_backup_description
+        )
+
+    #
     # Helpers
     #
 
@@ -1271,7 +1329,7 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
         # DynamoDBLocal namespaces based on the value of Credentials
         # Since we want to namespace by both account ID and region, use an aggregate key
-        # We also replace the region to keep compatibilty with NoSQL Workbench
+        # We also replace the region to keep compatibility with NoSQL Workbench
         headers["Authorization"] = re.sub(
             AUTH_CREDENTIAL_REGEX,
             rf"Credential={key}/\2/{region_name}/\4/",

--- a/tests/integration/test_dynamodb.snapshot.json
+++ b/tests/integration/test_dynamodb.snapshot.json
@@ -376,5 +376,38 @@
         }
       }
     }
+  },
+  "tests/integration/test_dynamodb.py::TestDynamoDB::test_continuous_backup_update": {
+    "recorded-date": "22-02-2023, 21:13:32",
+    "recorded-content": {
+      "update-continuous-backup": {
+        "ContinuousBackupsDescription": {
+          "ContinuousBackupsStatus": "ENABLED",
+          "PointInTimeRecoveryDescription": {
+            "EarliestRestorableDateTime": "datetime",
+            "LatestRestorableDateTime": "datetime",
+            "PointInTimeRecoveryStatus": "ENABLED"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "describe-continuous-backup": {
+        "ContinuousBackupsDescription": {
+          "ContinuousBackupsStatus": "ENABLED",
+          "PointInTimeRecoveryDescription": {
+            "EarliestRestorableDateTime": "datetime",
+            "LatestRestorableDateTime": "datetime",
+            "PointInTimeRecoveryStatus": "ENABLED"
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR enables a minimal implementation for the `UpdateContinuousBackups` and `DescribeContinuousBackups` actions.

The feature of continuous backup is actually not implemented. We only return the minimum needed to achieve Terraform parity for https://github.com/localstack/localstack/issues/7569.