### PR TITLE
improve parity for APIGW Resource

### DIFF
--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -23,6 +23,9 @@ class ApiGatewayStore(BaseStore):
     # maps (API id) -> [gateway_responses]
     gateway_responses: Dict[str, List[Dict]] = LocalAttribute(default=dict)
 
+    # maps (API id) -> Resource id -> its children Resource id
+    resources_children: Dict[str, Dict[str, List[str]]] = LocalAttribute(default=dict)
+
     # account details
     account: Dict[str, Any] = LocalAttribute(default=dict)
 

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -283,6 +283,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         _delete_children(resource_id)
 
+        # remove the resource as a child from its parent
+        parent_id = moto_resource.parent_id
+        api_resources[parent_id].remove(resource_id)
+
     def update_resource(
         self,
         context: RequestContext,

--- a/localstack/testing/snapshots/transformer_utility.py
+++ b/localstack/testing/snapshots/transformer_utility.py
@@ -130,6 +130,7 @@ class TransformerUtility:
         return [
             TransformerUtility.key_value("id"),
             TransformerUtility.key_value("name"),
+            TransformerUtility.key_value("parentId"),
         ]
 
     @staticmethod

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -520,7 +520,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_resource_behaviour": {
-    "recorded-date": "23-02-2023, 22:36:17",
+    "recorded-date": "24-02-2023, 11:37:12",
     "recorded-content": {
       "nonexistent-resource": {
         "Error": {
@@ -578,7 +578,7 @@
       },
       "update-parent-id-to-root-id": {
         "id": "<id:1>",
-        "parentId": "<parent-id:2>",
+        "parentId": "<id:2>",
         "path": "/subpets",
         "pathPart": "subpets",
         "ResponseMetadata": {
@@ -595,6 +595,24 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
+        }
+      },
+      "resources-after-deletion": {
+        "items": [
+          {
+            "id": "<id:2>",
+            "path": "/"
+          },
+          {
+            "id": "<id:1>",
+            "parentId": "<id:2>",
+            "path": "/subpets",
+            "pathPart": "subpets"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "remove-unsupported": {

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -520,7 +520,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_resource_behaviour": {
-    "recorded-date": "24-02-2023, 11:37:12",
+    "recorded-date": "24-02-2023, 17:56:07",
     "recorded-content": {
       "nonexistent-resource": {
         "Error": {
@@ -565,6 +565,27 @@
           "HTTPStatusCode": 201
         }
       },
+      "create-subresource-child": {
+        "id": "<id:2>",
+        "parentId": "<id:1>",
+        "path": "/pets/subpets/pets",
+        "pathPart": "pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "existing-future-sibling-path": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Another resource with the same parent already has this name: pets"
+        },
+        "message": "Another resource with the same parent already has this name: pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
       "update-parent-id-to-subresource-id": {
         "Error": {
           "Code": "BadRequestException",
@@ -578,7 +599,7 @@
       },
       "update-parent-id-to-root-id": {
         "id": "<id:1>",
-        "parentId": "<id:2>",
+        "parentId": "<id:3>",
         "path": "/subpets",
         "pathPart": "subpets",
         "ResponseMetadata": {
@@ -600,12 +621,12 @@
       "resources-after-deletion": {
         "items": [
           {
-            "id": "<id:2>",
+            "id": "<id:3>",
             "path": "/"
           },
           {
             "id": "<id:1>",
-            "parentId": "<id:2>",
+            "parentId": "<id:3>",
             "path": "/subpets",
             "pathPart": "subpets"
           }

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -403,7 +403,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_resource_lifecycle": {
-    "recorded-date": "23-02-2023, 14:46:09",
+    "recorded-date": "23-02-2023, 22:08:31",
     "recorded-content": {
       "rest-api-root-resource": {
         "items": [
@@ -438,6 +438,40 @@
             "parentId": "<id:1>",
             "path": "/pets",
             "pathPart": "pets"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-subresource": {
+        "id": "<id:3>",
+        "parentId": "<id:2>",
+        "path": "/pets/subpets",
+        "pathPart": "subpets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "rest-api-resources-after-create-sub": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<id:2>",
+            "parentId": "<id:1>",
+            "path": "/pets",
+            "pathPart": "pets"
+          },
+          {
+            "id": "<id:3>",
+            "parentId": "<id:2>",
+            "path": "/pets/subpets",
+            "pathPart": "subpets"
           }
         ],
         "ResponseMetadata": {
@@ -486,7 +520,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_resource_behaviour": {
-    "recorded-date": "23-02-2023, 15:29:44",
+    "recorded-date": "23-02-2023, 22:36:17",
     "recorded-content": {
       "nonexistent-resource": {
         "Error": {
@@ -523,7 +557,7 @@
       },
       "create-subresource": {
         "id": "<id:1>",
-        "parentId": "fshq0l",
+        "parentId": "<parent-id:1>",
         "path": "/pets/subpets",
         "pathPart": "subpets",
         "ResponseMetadata": {
@@ -544,7 +578,7 @@
       },
       "update-parent-id-to-root-id": {
         "id": "<id:1>",
-        "parentId": "psq39vw338",
+        "parentId": "<parent-id:2>",
         "path": "/subpets",
         "pathPart": "subpets",
         "ResponseMetadata": {
@@ -583,6 +617,40 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_delete_resource": {
+    "recorded-date": "23-02-2023, 20:41:28",
+    "recorded-content": {
+      "delete-resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "get-resources": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-subresource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -401,5 +401,190 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_resource_lifecycle": {
+    "recorded-date": "23-02-2023, 14:46:09",
+    "recorded-content": {
+      "rest-api-root-resource": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-resource": {
+        "id": "<id:2>",
+        "parentId": "<id:1>",
+        "path": "/pets",
+        "pathPart": "pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "rest-api-resources-after-create": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          },
+          {
+            "id": "<id:2>",
+            "parentId": "<id:1>",
+            "path": "/pets",
+            "pathPart": "pets"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-path-part": {
+        "id": "<id:2>",
+        "parentId": "<id:1>",
+        "path": "/dogs",
+        "pathPart": "dogs",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get-resp-after-update-path-part": {
+        "id": "<id:2>",
+        "parentId": "<id:1>",
+        "path": "/dogs",
+        "pathPart": "dogs",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-resource": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "rest-api-resources-after-delete": {
+        "items": [
+          {
+            "id": "<id:1>",
+            "path": "/"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_resource_behaviour": {
+    "recorded-date": "23-02-2023, 15:29:44",
+    "recorded-content": {
+      "nonexistent-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "invalid-path-part": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path  '/invalid' specified for op 'replace'. Must be one of: [/parentId, /pathPart]"
+        },
+        "message": "Invalid patch path  '/invalid' specified for op 'replace'. Must be one of: [/parentId, /pathPart]",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-parent-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "create-subresource": {
+        "id": "<id:1>",
+        "parentId": "fshq0l",
+        "path": "/pets/subpets",
+        "pathPart": "subpets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-parent-id-to-subresource-id": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Resources cannot be cyclical."
+        },
+        "message": "Resources cannot be cyclical.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "update-parent-id-to-root-id": {
+        "id": "<id:1>",
+        "parentId": "psq39vw338",
+        "path": "/subpets",
+        "pathPart": "subpets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-path-already-exists": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Another resource with the same parent already has this name: pets"
+        },
+        "message": "Another resource with the same parent already has this name: pets",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "remove-unsupported": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path  '/pathPart' specified for op 'remove'. Please choose supported operations"
+        },
+        "message": "Invalid patch path  '/pathPart' specified for op 'remove'. Please choose supported operations",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "add-unsupported": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path  '/pathPart' specified for op 'add'. Please choose supported operations"
+        },
+        "message": "Invalid patch path  '/pathPart' specified for op 'add'. Please choose supported operations",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Work on APIGW Resource parity, improve UpdateResource parity (patch operations validation), remove moto patches to move them into provider directly (we still manipulates moto entities directly as its tightly integrated, but extend moto with our own store), and fix deleting child resources when deleting a resource that was used as a parent.

Example:
`/` -> `/pets` -> `/pets/dogs` 
We delete `/pets`, `/pets/dogs` should be deleted as well because it declared `/pets` to be its parent.
We do this by mapping children IDs when they are created with a parent ID. When deleting a resource, we check if it is in the parent list, and then recursively delete resources. 

- [x] remove patches on Resource entity
- [x] create AWS validated tests with snapshots for resource manipulation
- [x] fix parity for `UpdateResource` (validation)
- [x] fix recursively deleting all child `Resource` when deleting a parent `Resource` with `DeleteResource`

note: I might delete the fixture for creating resource in a following PR, as we clean up all related resources when deleting the RestAPI.
note2: more tests are coming for deleting the resource with more children in a following PR. (#7746)
note3: I'd like to do a store refactor to allow easier validation of resources, see #7750 

\cc @whummer 