### PR TITLE
Gather outdated snapshots

### DIFF
--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -1,0 +1,38 @@
+import datetime
+import json
+import os
+
+integration_test_path = "../tests/integration/"
+
+
+def get_outdated_snapshots(date_limit: str) -> list[str]:
+    """
+    Fetches all snapshots that were recorded before the given date_limit.
+    :param date_limit: All snapshots whose recorded-date is older than date-limit are considered outdated.
+            Format of the date-string must be "DD-MM-YYYY".
+    :return: List of test names whose snapshots (if any) are outdated.
+    """
+    # FIXME: this might have side effects
+    os.chdir(integration_test_path)
+    date_limit = datetime.datetime.strptime(date_limit, "%d-%m-%Y")
+    outdated_snapshots = []
+
+    for file in os.listdir():
+        if not file.endswith(".snapshot.json"):
+            continue
+        with open(file) as f:
+            json_content: dict = json.load(f)
+            for name, snapshot in json_content.items():
+                date = snapshot.get("recorded-date")
+                date = datetime.datetime.strptime(date, "%d-%m-%Y, %H:%M:%S")
+                if date < date_limit:
+                    outdated_snapshots.append(name)
+    return outdated_snapshots
+
+
+if __name__ == "__main__":
+    snapshots = get_outdated_snapshots("14-09-2022")
+    print(f"Number of outdated snapshots: {len(snapshots)}\n")
+    print(f"Names of outdated snapshots: {snapshots}")
+    join = " ".join(snapshots)
+    pass

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -18,8 +18,8 @@ def get_outdated_snapshots_for_directory(
     :return: List of test names whose snapshots (if any) are outdated.
     """
 
-    date_limit = datetime.datetime.strptime(date_limit, "%d-%m-%Y")
     result = {"date": date_limit}
+    date_limit = datetime.datetime.strptime(date_limit, "%d-%m-%Y")
     outdated_snapshots = []
 
     def do_get_outdated_snapshots(path: str):
@@ -70,13 +70,18 @@ def get_snapshots(path: str, date_limit: str, check_sub_dirs, combine_parametriz
     Fetches all snapshots in PATH that were recorded before the given DATE_LIMIT.
     Format of the DATE_LIMIT-string must be "DD-MM-YYYY".
 
-    Example usage: python gather_outdated_snapshots.py ../tests/integration 24-12-2022
-
     Returns a JSON with the relevant information
+
+    \b
+    Example usage:
+    python gather_outdated_snapshots.py ../tests/integration 24-12-2022 | jq .
     """
     snapshots = get_outdated_snapshots_for_directory(
         path, date_limit, check_sub_dirs, combine_parametrized
     )
+    # sorted lists are prettier to read in the console
+    snapshots["outdated_snapshots"] = sorted(snapshots["outdated_snapshots"])
+
     # turn the list of snapshots into a whitespace separated string usable by pytest
     join = " ".join(snapshots["outdated_snapshots"])
     snapshots["pytest_executable_list"] = join

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -14,7 +14,8 @@ def get_outdated_snapshots_for_directory(
     :param date_limit: All snapshots whose recorded-date is older than date-limit are considered outdated.
             Format of the date-string must be "DD-MM-YYYY".
     :param check_sub_directories: Whether to look for snapshots in subdirectories
-    :param differentiate_parametrized: Whether to treat parametrized versions of the same test as different snapshots
+    :param differentiate_parametrized: Whether to treat parametrized versions of the same test as multiple snapshots or
+    not (meaning they are treated as the same one snapshot)
     :return: List of test names whose snapshots (if any) are outdated.
     """
 
@@ -36,9 +37,14 @@ def get_outdated_snapshots_for_directory(
                         date = snapshot.get("recorded-date")
                         date = datetime.datetime.strptime(date, "%d-%m-%Y, %H:%M:%S")
                         if date < date_limit:
+                            if not differentiate_parametrized:
+
+                                name = name.split("[")[0]
                             outdated_snapshots.append(name)
 
     do_get_outdated_snapshots(path)
+    # if differentiate_parametrized was True, we end up with duplicates that need to be removed
+    outdated_snapshots = set(outdated_snapshots)
     result["count"] = len(outdated_snapshots)
     result["outdated_snapshots"] = outdated_snapshots
     return result
@@ -54,21 +60,29 @@ def get_outdated_snapshots_for_directory(
     default=True,
     help="Whether to check sub directories of PATH too",
 )
-def get_snapshots(path: str, date_limit: str, check_sub_dirs):
+@click.option(
+    "--differentiate-parametrized",
+    type=bool,
+    required=False,
+    default=False,
+    help="Whether to treat parametrized versions of the same test as multiple snapshots or not, and therefore as single one",
+)
+def get_snapshots(path: str, date_limit: str, check_sub_dirs, differentiate_parametrized):
     """
     Fetches all snapshots in PATH that were recorded before the given DATE_LIMIT.
     Format of the DATE_LIMIT-string must be "DD-MM-YYYY".
 
-    Example usage: python get_snapshots.py ../tests/integration 24-12-2022
+    Example usage: python gather_outdated_snapthos.py ../tests/integration 24-12-2022
 
     Returns a JSON with the relevant information
     """
-    snapshots = get_outdated_snapshots_for_directory(path, date_limit, check_sub_dirs)
+    snapshots = get_outdated_snapshots_for_directory(
+        path, date_limit, check_sub_dirs, differentiate_parametrized
+    )
     # turn the list of snapshots into a whitespace separated string usable by pytest
     join = " ".join(snapshots["outdated_snapshots"])
     snapshots["pytest_executable_list"] = join
     print(json.dumps(snapshots, default=str))
-    print(len(snapshots["outdated_snapshots"]) == len(set(snapshots["outdated_snapshots"])))
 
 
 if __name__ == "__main__":

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -37,6 +37,7 @@ def get_outdated_snapshots_for_directory(
                         date = datetime.datetime.strptime(date, "%d-%m-%Y, %H:%M:%S")
                         if date < date_limit:
                             if combine_parametrized:
+                                # change parametrized tests of the form <mytest[param_value]> to just <mytest>
                                 name = name.split("[")[0]
                             outdated_snapshots.append(name)
 

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -1,7 +1,8 @@
 import datetime
 import json
 import os
-import sys
+
+import click
 
 
 def get_outdated_snapshots_for_directory(path: str, date_limit: str) -> dict:
@@ -33,9 +34,21 @@ def get_outdated_snapshots_for_directory(path: str, date_limit: str) -> dict:
     return result
 
 
-if __name__ == "__main__":
-    snapshots = get_outdated_snapshots_for_directory(sys.argv[1], sys.argv[2])
+@click.command()
+@click.argument("path", required=True)
+@click.argument("date_limit", required=True)
+def get_snapshots(path: str, date_limit: str):
+    """
+    Fetches all snapshots in PATH that were recorded before the given DATE_LIMIT
+
+    Returns a JSON with the relevant information
+    """
+    snapshots = get_outdated_snapshots_for_directory(path, date_limit)
     # turn the list of snapshots into a whitespace separated string usable by pytest
     join = " ".join(snapshots["outdated_snapshots"])
     snapshots["pytest_executable_list"] = join
     print(json.dumps(snapshots, default=str))
+
+
+if __name__ == "__main__":
+    get_snapshots()

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -5,39 +5,66 @@ import os
 import click
 
 
-def get_outdated_snapshots_for_directory(path: str, date_limit: str) -> dict:
+def get_outdated_snapshots_for_directory(
+    path: str, date_limit: str, check_sub_directories: bool = True
+) -> dict:
     """
     Fetches all snapshots that were recorded before the given date_limit
     :param path: The directory where to look for snapshot files.
     :param date_limit: All snapshots whose recorded-date is older than date-limit are considered outdated.
             Format of the date-string must be "DD-MM-YYYY".
+    :param check_sub_directories: Whether to look for snapshots in subdirectories
+    :param outdated_snapshots: The list of names of outdated snapshots. Used in combination with check_sub_directories
+    to recurse through the directory tree
     :return: List of test names whose snapshots (if any) are outdated.
     """
 
     date_limit = datetime.datetime.strptime(date_limit, "%d-%m-%Y")
     result = {"date": date_limit}
     outdated_snapshots = []
-    if not path.endswith("/"):
-        path = f"{path}/"
-    for file in os.listdir(path):
-        if not file.endswith(".snapshot.json"):
-            continue
-        with open(f"{path}{file}") as f:
-            json_content: dict = json.load(f)
-            for name, snapshot in json_content.items():
-                date = snapshot.get("recorded-date")
-                date = datetime.datetime.strptime(date, "%d-%m-%Y, %H:%M:%S")
-                if date < date_limit:
-                    outdated_snapshots.append(name)
+
+    def do_get_outdated_snapshots(
+        path: str, date_limit: datetime, check_sub_directories: bool = True
+    ):
+
+        if not path.endswith("/"):
+            path = f"{path}/"
+        for _, sub_dirs, files in os.walk(path):
+            for file in files:
+                if not file.endswith(".snapshot.json"):
+                    continue
+                try:
+                    with open(f"{path}{file}") as f:
+                        json_content: dict = json.load(f)
+                        for name, snapshot in json_content.items():
+                            date = snapshot.get("recorded-date")
+                            date = datetime.datetime.strptime(date, "%d-%m-%Y, %H:%M:%S")
+                            if date < date_limit:
+                                outdated_snapshots.append(name)
+                except FileNotFoundError as e:
+                    print(e)
+                    pass
+            if check_sub_directories:
+                for sub_dir in sub_dirs:
+                    do_get_outdated_snapshots(f"{path}{sub_dir}", date_limit, check_sub_directories)
+
+    do_get_outdated_snapshots(path, date_limit, check_sub_directories)
     result["count"] = len(outdated_snapshots)
     result["outdated_snapshots"] = outdated_snapshots
     return result
 
 
 @click.command()
-@click.argument("path", required=True)
-@click.argument("date_limit", required=True)
-def get_snapshots(path: str, date_limit: str):
+@click.argument("path", type=str, required=True)
+@click.argument("date_limit", type=str, required=True)
+@click.option(
+    "--check-sub-dirs",
+    type=bool,
+    required=False,
+    default=True,
+    help="Whether to check sub directories of PATH too",
+)
+def get_snapshots(path: str, date_limit: str, check_sub_dirs):
     """
     Fetches all snapshots in PATH that were recorded before the given DATE_LIMIT.
     Format of the DATE_LIMIT-string must be "DD-MM-YYYY".
@@ -46,7 +73,7 @@ def get_snapshots(path: str, date_limit: str):
 
     Returns a JSON with the relevant information
     """
-    snapshots = get_outdated_snapshots_for_directory(path, date_limit)
+    snapshots = get_outdated_snapshots_for_directory(path, date_limit, check_sub_dirs)
     # turn the list of snapshots into a whitespace separated string usable by pytest
     join = " ".join(snapshots["outdated_snapshots"])
     snapshots["pytest_executable_list"] = join

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -1,38 +1,41 @@
 import datetime
 import json
 import os
+import sys
 
-integration_test_path = "../tests/integration/"
 
-
-def get_outdated_snapshots(date_limit: str) -> list[str]:
+def get_outdated_snapshots_for_directory(path: str, date_limit: str) -> dict:
     """
-    Fetches all snapshots that were recorded before the given date_limit.
+    Fetches all snapshots that were recorded before the given date_limit
+    :param path: The directory where to look for snapshot files.
     :param date_limit: All snapshots whose recorded-date is older than date-limit are considered outdated.
             Format of the date-string must be "DD-MM-YYYY".
     :return: List of test names whose snapshots (if any) are outdated.
     """
-    # FIXME: this might have side effects
-    os.chdir(integration_test_path)
-    date_limit = datetime.datetime.strptime(date_limit, "%d-%m-%Y")
-    outdated_snapshots = []
 
-    for file in os.listdir():
+    date_limit = datetime.datetime.strptime(date_limit, "%d-%m-%Y")
+    result = {"date": date_limit}
+    outdated_snapshots = []
+    if not path.endswith("/"):
+        path = f"{path}/"
+    for file in os.listdir(path):
         if not file.endswith(".snapshot.json"):
             continue
-        with open(file) as f:
+        with open(f"{path}{file}") as f:
             json_content: dict = json.load(f)
             for name, snapshot in json_content.items():
                 date = snapshot.get("recorded-date")
                 date = datetime.datetime.strptime(date, "%d-%m-%Y, %H:%M:%S")
                 if date < date_limit:
                     outdated_snapshots.append(name)
-    return outdated_snapshots
+    result["count"] = len(outdated_snapshots)
+    result["outdated_snapshots"] = outdated_snapshots
+    return result
 
 
 if __name__ == "__main__":
-    snapshots = get_outdated_snapshots("14-09-2022")
-    print(f"Number of outdated snapshots: {len(snapshots)}\n")
-    print(f"Names of outdated snapshots: {snapshots}")
-    join = " ".join(snapshots)
-    pass
+    snapshots = get_outdated_snapshots_for_directory(sys.argv[1], sys.argv[2])
+    # turn the list of snapshots into a whitespace separated string usable by pytest
+    join = " ".join(snapshots["outdated_snapshots"])
+    snapshots["pytest_executable_list"] = join
+    print(json.dumps(snapshots, default=str))

--- a/scripts/gather_outdated_snapshots.py
+++ b/scripts/gather_outdated_snapshots.py
@@ -39,7 +39,10 @@ def get_outdated_snapshots_for_directory(path: str, date_limit: str) -> dict:
 @click.argument("date_limit", required=True)
 def get_snapshots(path: str, date_limit: str):
     """
-    Fetches all snapshots in PATH that were recorded before the given DATE_LIMIT
+    Fetches all snapshots in PATH that were recorded before the given DATE_LIMIT.
+    Format of the DATE_LIMIT-string must be "DD-MM-YYYY".
+
+    Example usage: python get_snapshots.py ../tests/integration 24-12-2022
 
     Returns a JSON with the relevant information
     """


### PR DESCRIPTION
This adds a scripts that enables to gather which snapshots are older than a given date. The data is gathered within a JSON object

The data includes at the moment:
- The provided date to check the snapshot date against
- The number of outdated snapshots
- The name/node-ids of the outdated snapshots as list
- If invoked via cli, the names in a whitespace-separated string instead of a list, to make automated execution via pytest possible if wanted