### PR TITLE
Refactor authorizer info in API Gateway invocation context

### DIFF
--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -30,7 +30,7 @@ class ApiInvocationContext:
     # invocation context
     context: Dict[str, Any]
     # authentication info for this invocation
-    auth_info: Dict[str, Any]
+    auth_context: Dict[str, Any]
 
     # target API/resource details extracted from the invocation
     apigw_version: ApiGatewayVersion
@@ -56,28 +56,29 @@ class ApiInvocationContext:
     # response object
     response: Response
 
-    stage_variables: Dict
+    # dict of stage variables (mapping names to values)
+    stage_variables: Dict[str, str]
 
     # websockets route selection
     ws_route: str
 
     def __init__(
         self,
-        method,
-        path,
-        data,
-        headers,
-        api_id=None,
-        stage=None,
-        context=None,
-        auth_info=None,
+        method: str,
+        path: str,
+        data: Union[str, bytes],
+        headers: Dict[str, str],
+        api_id: str = None,
+        stage: str = None,
+        context: Dict[str, Any] = None,
+        auth_context: Dict[str, Any] = None,
     ):
         self.method = method
         self.path = path
         self.data = data
         self.headers = headers
         self.context = {"requestId": short_uid()} if context is None else context
-        self.auth_info = {} if auth_info is None else auth_info
+        self.auth_context = {} if auth_context is None else auth_context
         self.apigw_version = None
         self.api_id = api_id
         self.stage = stage
@@ -113,7 +114,7 @@ class ApiInvocationContext:
         """Set a custom invocation path with query string (used to handle "../_user_request_/.." paths)."""
         self._path_with_query_string = new_path
 
-    def query_params(self) -> Dict:
+    def query_params(self) -> Dict[str, str]:
         """Extract the query parameters from the target URL or path in this request context."""
         query_string = self.path_with_query_string.partition("?")[2]
         return parse_query_string(query_string)
@@ -124,30 +125,22 @@ class ApiInvocationContext:
         return integration.get("uri") or integration.get("integrationUri")
 
     @property
-    def auth_context(self) -> Optional[Dict]:
-        if isinstance(self.auth_info, dict):
-            context = self.auth_info.setdefault("context", {})
-            if principal := self.auth_info.get("principalId"):
-                context["principalId"] = principal
-            return context
-
-    @property
     def auth_identity(self) -> Optional[Dict]:
-        if isinstance(self.auth_info, dict):
-            if self.auth_info.get("identity") is None:
-                self.auth_info["identity"] = {}
-            return self.auth_info["identity"]
+        if isinstance(self.auth_context, dict):
+            if self.auth_context.get("identity") is None:
+                self.auth_context["identity"] = {}
+            return self.auth_context["identity"]
 
     @property
     def authorizer_type(self) -> str:
-        if isinstance(self.auth_info, dict):
-            return self.auth_info.get("authorizer_type") if self.auth_info else None
+        if isinstance(self.auth_context, dict):
+            return self.auth_context.get("authorizer_type") if self.auth_context else None
 
-    def is_websocket_request(self):
+    def is_websocket_request(self) -> bool:
         upgrade_header = str(self.headers.get("upgrade") or "")
         return upgrade_header.lower() == "websocket"
 
-    def is_v1(self):
+    def is_v1(self) -> bool:
         """Whether this is an API Gateway v1 request"""
         return self.apigw_version == ApiGatewayVersion.V1
 
@@ -157,7 +150,7 @@ class ApiInvocationContext:
         return None
 
     @property
-    def is_data_base64_encoded(self):
+    def is_data_base64_encoded(self) -> bool:
         try:
             json.dumps(self.data) if isinstance(self.data, (dict, list)) else to_str(self.data)
             return False
@@ -173,15 +166,15 @@ class ApiInvocationContext:
             # we string encode our base64 as string as well
             return to_str(base64.b64encode(self.data))
 
-    def _extract_host_from_header(self):
+    def _extract_host_from_header(self) -> str:
         host = self.headers.get(HEADER_LOCALSTACK_EDGE_URL) or self.headers.get("host", "")
         return host.split("://")[-1].split("/")[0].split(":")[0]
 
     @property
-    def domain_name(self):
+    def domain_name(self) -> str:
         return self._extract_host_from_header()
 
     @property
-    def domain_prefix(self):
+    def domain_prefix(self) -> str:
         host = self._extract_host_from_header()
         return host.split(".")[0]

--- a/localstack/services/apigateway/context.py
+++ b/localstack/services/apigateway/context.py
@@ -136,6 +136,11 @@ class ApiInvocationContext:
         if isinstance(self.auth_context, dict):
             return self.auth_context.get("authorizer_type") if self.auth_context else None
 
+    @property
+    def authorizer_result(self) -> Dict[str, Any]:
+        if isinstance(self.auth_context, dict):
+            return self.auth_context.get("authorizer") if self.auth_context else {}
+
     def is_websocket_request(self) -> bool:
         upgrade_header = str(self.headers.get("upgrade") or "")
         return upgrade_header.lower() == "websocket"

--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -822,9 +822,9 @@ def get_event_request_context(invocation_context: ApiInvocationContext):
     }
 
     # set "authorizer" and "identity" event attributes from request context
-    auth_context = invocation_context.auth_context
-    if auth_context:
-        request_context["authorizer"] = auth_context
+    authorizer_result = invocation_context.authorizer_result
+    if authorizer_result:
+        request_context["authorizer"] = authorizer_result
     request_context["identity"].update(invocation_context.auth_identity or {})
 
     if not is_test_invoke_method(method, path):

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -268,7 +268,7 @@ class LambdaProxyIntegration(BackendIntegration):
             func_arn = uri.split(":lambda:path")[1].split("functions/")[1].split("/invocations")[0]
 
         if invocation_context.authorizer_type:
-            invocation_context.context["authorizer"] = invocation_context.auth_context
+            invocation_context.context["authorizer"] = invocation_context.authorizer_result
 
         payload = self.request_templates.render(invocation_context)
 
@@ -343,7 +343,7 @@ class LambdaIntegration(BackendIntegration):
         invocation_context.context = helpers.get_event_request_context(invocation_context)
         invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
         if invocation_context.authorizer_type:
-            invocation_context.context["authorizer"] = invocation_context.auth_context
+            invocation_context.context["authorizer"] = invocation_context.authorizer_result
 
         func_arn = self._lambda_integration_uri(invocation_context)
         request_templates = RequestTemplates()

--- a/localstack/utils/aws/aws_responses.py
+++ b/localstack/utils/aws/aws_responses.py
@@ -4,7 +4,7 @@ import json
 import re
 from binascii import crc32
 from struct import pack
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 from urllib.parse import parse_qs
 
 import xmltodict
@@ -234,11 +234,7 @@ def set_response_content(response, content, headers=None):
     response.headers["Content-Length"] = str(len(response._content))
 
 
-def make_requests_error(*args, **kwargs):
-    return flask_to_requests_response(flask_error_response_xml(*args, **kwargs))
-
-
-def create_sqs_system_attributes(headers):
+def create_sqs_system_attributes(headers: Dict[str, str]) -> Dict[str, Any]:
     system_attributes = {}
     if "X-Amzn-Trace-Id" in headers:
         system_attributes["AWSTraceHeader"] = {
@@ -248,7 +244,7 @@ def create_sqs_system_attributes(headers):
     return system_attributes
 
 
-def parse_query_string(url_or_qs: str, multi_values=False) -> Dict:
+def parse_query_string(url_or_qs: str, multi_values=False) -> Dict[str, str]:
     url_or_qs = str(url_or_qs or "").strip()
     if "://" in url_or_qs and "?" not in url_or_qs:
         url_or_qs = f"{url_or_qs}?"
@@ -259,7 +255,7 @@ def parse_query_string(url_or_qs: str, multi_values=False) -> Dict:
     return result
 
 
-def calculate_crc32(content):
+def calculate_crc32(content: Union[str, bytes]) -> int:
     return crc32(to_bytes(content)) & 0xFFFFFFFF
 
 


### PR DESCRIPTION
Refactor authorizer info in API Gateway invocation context. Companion to upstream PR.

The main changes in this PR is to rename the `auth_info` attribute and unify it with `auth_context` in the API GW invocation context

The PR also adds a few type hints across the codebase.