### PR TITLE
improve apigw parity work for Resource proxy path

### DIFF
--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -443,6 +443,7 @@ class TestApiGatewayApi:
             )
         snapshot.match("add-unsupported", e.value.response)
 
+    @pytest.mark.aws_validated
     def test_delete_resource(self, apigateway_client, apigw_create_rest_api, snapshot):
         response = apigw_create_rest_api(
             name=f"test-api-{short_uid()}", description="testing resource behaviour"
@@ -475,3 +476,147 @@ class TestApiGatewayApi:
         with pytest.raises(ClientError) as e:
             apigateway_client.delete_resource(restApiId=api_id, resourceId=subresource_id)
         snapshot.match("delete-subresource", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_create_resource_parent_invalid(
+        self, apigateway_client, apigw_create_rest_api, apigw_create_rest_resource, snapshot
+    ):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource parent"
+        )
+        api_id = response["id"]
+
+        # create subresource with wrong parent
+        with pytest.raises(ClientError) as e:
+            apigw_create_rest_resource(
+                rest_api_id=api_id, parent_id="fake-resource-id", path_part="subpets"
+            )
+        snapshot.match("wrong-resource-parent-id", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_create_proxy_resource(
+        self, apigateway_client, apigw_create_rest_api, apigw_create_rest_resource, snapshot
+    ):
+        # test following docs
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-request.html#api-gateway-proxy-resource
+        snapshot.add_transformer(SortingTransformer("items", lambda x: x["path"]))
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource proxy"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        # creating `/{proxy+}` resource
+        base_proxy_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=root_id, path_part="{proxy+}"
+        )
+        snapshot.match("create-base-proxy-resource", base_proxy_response)
+
+        # creating `/parent` resource, sibling to `/{proxy+}`
+        proxy_sibling_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=root_id, path_part="parent"
+        )
+        proxy_sibling_id = proxy_sibling_response["id"]
+        snapshot.match("create-proxy-sibling-resource", proxy_sibling_id)
+
+        # creating `/parent/{proxy+}` resource
+        proxy_sibling_proxy_child_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=proxy_sibling_id, path_part="{proxy+}"
+        )
+        proxy_child_id = proxy_sibling_proxy_child_response["id"]
+        snapshot.match(
+            "create-proxy-sibling-proxy-child-resource", proxy_sibling_proxy_child_response
+        )
+
+        # creating `/parent/child` resource, sibling to `/parent/{proxy+}`
+        proxy_sibling_static_child_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=proxy_sibling_id, path_part="child"
+        )
+        dynamic_child_id = proxy_sibling_static_child_response["id"]
+        snapshot.match(
+            "create-proxy-sibling-static-child-resource", proxy_sibling_static_child_response
+        )
+
+        # creating `/parent/child/{proxy+}` resource
+        dynamic_child_proxy_child_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=dynamic_child_id, path_part="{proxy+}"
+        )
+        snapshot.match("create-static-child-proxy-resource", dynamic_child_proxy_child_response)
+
+        # list all resources
+        result_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        snapshot.match("all-resources", result_api_resource)
+
+        # to allow nested route testing, we will delete `/parent/{proxy+}` to allow creation of a dynamic {child}
+        apigateway_client.delete_resource(restApiId=api_id, resourceId=proxy_child_id)
+
+        # creating `/parent/{child}` resource, as its sibling `/parent/{proxy+}` is now deleted
+        proxy_sibling_dynamic_child_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=proxy_sibling_id, path_part="{child}"
+        )
+        dynamic_child_id = proxy_sibling_dynamic_child_response["id"]
+        snapshot.match(
+            "create-proxy-sibling-dynamic-child-resource", proxy_sibling_dynamic_child_response
+        )
+
+        # creating `/parent/{child}/{proxy+}` resource
+        dynamic_child_proxy_child_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=dynamic_child_id, path_part="{proxy+}"
+        )
+        snapshot.match("create-dynamic-child-proxy-resource", dynamic_child_proxy_child_response)
+
+        result_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        snapshot.match("all-resources-2", result_api_resource)
+
+    @pytest.mark.aws_validated
+    def test_create_proxy_resource_validation(
+        self, apigateway_client, apigw_create_rest_api, apigw_create_rest_resource, snapshot
+    ):
+        # test following docs
+        # https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-request.html#api-gateway-proxy-resource
+        snapshot.add_transformer(SortingTransformer("items", lambda x: x["path"]))
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource proxy"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        # creating `/{proxy+}` resource
+        base_proxy_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=root_id, path_part="{proxy+}"
+        )
+        base_proxy_id = base_proxy_response["id"]
+        snapshot.match("create-base-proxy-resource", base_proxy_response)
+
+        # try creating `/{dynamic}` resource, sibling to `/{proxy+}`
+        with pytest.raises(ClientError) as e:
+            apigw_create_rest_resource(rest_api_id=api_id, parent_id=root_id, path_part="{dynamic}")
+        snapshot.match("create-proxy-dynamic-sibling-resource", e.value.response)
+
+        # try creating `/{proxy+}/child` resource, child to `/{proxy+}`
+        with pytest.raises(ClientError) as e:
+            apigw_create_rest_resource(
+                rest_api_id=api_id, parent_id=base_proxy_id, path_part="child"
+            )
+        snapshot.match("create-proxy-static-child-resource", e.value.response)
+
+        # try creating `/{proxy+}/{child}` resource, dynamic child to `/{proxy+}`
+        with pytest.raises(ClientError) as e:
+            apigw_create_rest_resource(
+                rest_api_id=api_id, parent_id=base_proxy_id, path_part="{child}"
+            )
+        snapshot.match("create-proxy-dynamic-child-resource", e.value.response)
+
+        # creating `/parent` static resource
+        parent_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=root_id, path_part="parent"
+        )
+        parent_id = parent_response["id"]
+
+        # create `/parent/{child+}` resource, dynamic greedy child to `/parent`
+        greedy_child_response = apigw_create_rest_resource(
+            rest_api_id=api_id, parent_id=parent_id, path_part="{child+}"
+        )
+        snapshot.match("create-greedy-child-resource", greedy_child_response)

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -693,5 +693,235 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_proxy_resource": {
+    "recorded-date": "24-02-2023, 15:56:43",
+    "recorded-content": {
+      "create-base-proxy-resource": {
+        "id": "<id:1>",
+        "parentId": "<id:5>",
+        "path": "/{proxy+}",
+        "pathPart": "{proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-proxy-sibling-resource": "<id:6>",
+      "create-proxy-sibling-proxy-child-resource": {
+        "id": "<id:2>",
+        "parentId": "<id:6>",
+        "path": "/parent/{proxy+}",
+        "pathPart": "{proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-proxy-sibling-static-child-resource": {
+        "id": "<id:3>",
+        "parentId": "<id:6>",
+        "path": "/parent/child",
+        "pathPart": "child",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-static-child-proxy-resource": {
+        "id": "<id:4>",
+        "parentId": "<id:3>",
+        "path": "/parent/child/{proxy+}",
+        "pathPart": "{proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "all-resources": {
+        "items": [
+          {
+            "id": "<id:5>",
+            "path": "/"
+          },
+          {
+            "id": "<id:6>",
+            "parentId": "<id:5>",
+            "path": "/parent",
+            "pathPart": "parent"
+          },
+          {
+            "id": "<id:3>",
+            "parentId": "<id:6>",
+            "path": "/parent/child",
+            "pathPart": "child"
+          },
+          {
+            "id": "<id:4>",
+            "parentId": "<id:3>",
+            "path": "/parent/child/{proxy+}",
+            "pathPart": "{proxy+}"
+          },
+          {
+            "id": "<id:2>",
+            "parentId": "<id:6>",
+            "path": "/parent/{proxy+}",
+            "pathPart": "{proxy+}"
+          },
+          {
+            "id": "<id:1>",
+            "parentId": "<id:5>",
+            "path": "/{proxy+}",
+            "pathPart": "{proxy+}"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "create-proxy-sibling-dynamic-child-resource": {
+        "id": "<id:7>",
+        "parentId": "<id:6>",
+        "path": "/parent/{child}",
+        "pathPart": "{child}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-dynamic-child-proxy-resource": {
+        "id": "<id:8>",
+        "parentId": "<id:7>",
+        "path": "/parent/{child}/{proxy+}",
+        "pathPart": "{proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "all-resources-2": {
+        "items": [
+          {
+            "id": "<id:5>",
+            "path": "/"
+          },
+          {
+            "id": "<id:6>",
+            "parentId": "<id:5>",
+            "path": "/parent",
+            "pathPart": "parent"
+          },
+          {
+            "id": "<id:3>",
+            "parentId": "<id:6>",
+            "path": "/parent/child",
+            "pathPart": "child"
+          },
+          {
+            "id": "<id:4>",
+            "parentId": "<id:3>",
+            "path": "/parent/child/{proxy+}",
+            "pathPart": "{proxy+}"
+          },
+          {
+            "id": "<id:7>",
+            "parentId": "<id:6>",
+            "path": "/parent/{child}",
+            "pathPart": "{child}"
+          },
+          {
+            "id": "<id:8>",
+            "parentId": "<id:7>",
+            "path": "/parent/{child}/{proxy+}",
+            "pathPart": "{proxy+}"
+          },
+          {
+            "id": "<id:1>",
+            "parentId": "<id:5>",
+            "path": "/{proxy+}",
+            "pathPart": "{proxy+}"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_proxy_resource_validation": {
+    "recorded-date": "24-02-2023, 16:17:00",
+    "recorded-content": {
+      "create-base-proxy-resource": {
+        "id": "<id:1>",
+        "parentId": "<parent-id:1>",
+        "path": "/{proxy+}",
+        "pathPart": "{proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-proxy-dynamic-sibling-resource": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "A sibling ({proxy+}) of this resource already has a variable path part -- only one is allowed"
+        },
+        "message": "A sibling ({proxy+}) of this resource already has a variable path part -- only one is allowed",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-proxy-static-child-resource": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Cannot create a child of a resource with a greedy path variable: {proxy+}"
+        },
+        "message": "Cannot create a child of a resource with a greedy path variable: {proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-proxy-dynamic-child-resource": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Cannot create a child of a resource with a greedy path variable: {proxy+}"
+        },
+        "message": "Cannot create a child of a resource with a greedy path variable: {proxy+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create-greedy-child-resource": {
+        "id": "<id:2>",
+        "parentId": "<parent-id:2>",
+        "path": "/parent/{child+}",
+        "pathPart": "{child+}",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_create_resource_parent_invalid": {
+    "recorded-date": "24-02-2023, 16:39:00",
+    "recorded-content": {
+      "wrong-resource-parent-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
When moving on to implement resource methods validation/removing patches, I've seen this page of the docs:
https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-settings-method-request.html#api-gateway-proxy-resource
So I followed it to implement more validations on the previous PR #7738

Stumbled unto an interesting issue in the docs:
> An API can have more than one proxy resource. For example, the following proxy resources are allowed within an API.
```
/{proxy+}
/parent/{proxy+}
/parent/{child}/{proxy+}
```
But it's not actually allowed, as the 2 last paths have a variable part, which will throw an exception. Implemented all the validations around this example in the docs. 

Based on #7738

\cc @whummer 