### PR TITLE
apigw parity work resource method

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -488,9 +488,11 @@ def apply_json_patch_safe(subject, patch_operations, in_place=True, return_list=
                 target = subject.get(path.strip("/"))
                 target = target or common.extract_from_jsonpointer_path(subject, path)
                 if not isinstance(target, list):
-                    # for "add" operations, we should ensure that the path target is a list instance
-                    value = [] if target is None else [target]
-                    common.assign_to_path(subject, path, value=value, delimiter="/")
+                    # for `add` operation, if the target does not exist, set it to an empty dict (default behaviour)
+                    # previous behaviour was an empty list. Revisit this if issues arise.
+                    # TODO: we are assigning a value, even if not `in_place=True`
+                    common.assign_to_path(subject, path, value={}, delimiter="/")
+
                 target = common.extract_from_jsonpointer_path(subject, path)
                 if isinstance(target, list) and not path.endswith("/-"):
                     # if "path" is an attribute name pointing to an array in "subject", and we're running

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -11,7 +11,7 @@ from moto.apigateway.responses import APIGatewayResponse
 from moto.core.utils import camelcase_to_underscores
 
 from localstack.services.apigateway.helpers import TAG_KEY_CUSTOM_ID, apply_json_patch_safe
-from localstack.utils.common import str_to_bool, to_str
+from localstack.utils.common import str_to_bool
 from localstack.utils.patch import patch
 
 LOG = logging.getLogger(__name__)
@@ -40,16 +40,6 @@ def apply_patches():
     def apigateway_response_resource_methods(fn, self, request, *args, **kwargs):
         result = fn(self, request, *args, **kwargs)
 
-        if self.method == "PUT" and self._get_param("requestParameters"):
-            request_parameters = self._get_param("requestParameters")
-            url_path_parts = self.path.split("/")
-            function_id = url_path_parts[2]
-            resource_id = url_path_parts[4]
-            method_type = url_path_parts[6]
-            resource = self.backend.get_resource(function_id, resource_id)
-            resource.resource_methods[method_type].request_parameters = request_parameters
-            method = resource.resource_methods[method_type]
-            result = 201, {}, json.dumps(method.to_json())
         if len(result) != 3:
             return result
 
@@ -63,15 +53,6 @@ def apply_patches():
             method.apply_operations(patch_operations)
             return 200, {}, json.dumps(method.to_json())
 
-        authorization_type = self._get_param("authorizationType")
-        if authorization_type in ["CUSTOM", "COGNITO_USER_POOLS"]:
-            data = json.loads(result[2])
-            if not data.get("authorizerId"):
-                payload = json.loads(to_str(request.data))
-                if "authorizerId" in payload:
-                    data["authorizerId"] = payload["authorizerId"]
-                    result = result[0], result[1], json.dumps(data)
-                    return result
         return 201, {}, result[2]
 
     @patch(APIGatewayResponse.integrations)
@@ -177,41 +158,6 @@ def apply_patches():
         ) = backend_model_apply_operations
 
     # fix data types for some json-patch operation values
-
-    def method_apply_operations(self, patch_operations):
-        params = self.request_parameters or {}
-        bool_params_prefixes = ["method.request.querystring", "method.request.header"]
-
-        for param, value in params.items():
-            for param_prefix in bool_params_prefixes:
-                if param.startswith(param_prefix):
-                    params[param] = str_to_bool(value)
-
-        for op in patch_operations:
-            path = op["path"]
-            value = op["value"]
-            if op["op"] == "replace":
-                if "/httpMethod" in path:
-                    self.http_method = value
-                if "/authorizationType" in path:
-                    self.authorization_type = value
-                if "/authorizerId" in path:
-                    self.authorizer_id = value
-                if "/authorizationScopes" in path:
-                    self.authorization_scopes = value
-                if "/apiKeyRequired" in path:
-                    self.api_key_required = str_to_bool(value) or False
-                if "/requestParameters" in path:
-                    self.request_parameters = value
-                if "/requestModels" in path:
-                    self.request_models = value
-                if "/operationName" in path:
-                    self.operation_name = value
-                if "/requestValidatorId" in path:
-                    self.request_validator_id = value
-        return self
-
-    apigateway_models.Method.apply_operations = method_apply_operations
 
     def method_response_apply_operations(self, patch_operations):
         result = method_response_apply_operations_orig(self, patch_operations)

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -36,25 +36,6 @@ def apply_patches():
     apigateway_models_Stage_init_orig = apigateway_models.Stage.__init__
     apigateway_models.Stage.__init__ = apigateway_models_Stage_init
 
-    @patch(APIGatewayResponse.resource_methods)
-    def apigateway_response_resource_methods(fn, self, request, *args, **kwargs):
-        result = fn(self, request, *args, **kwargs)
-
-        if len(result) != 3:
-            return result
-
-        if self.method == "PATCH":
-            patch_operations = self._get_param("patchOperations")
-            url_path_parts = self.path.split("/")
-            function_id = url_path_parts[2]
-            resource_id = url_path_parts[4]
-            method_type = url_path_parts[6]
-            method = self.backend.get_method(function_id, resource_id, method_type)
-            method.apply_operations(patch_operations)
-            return 200, {}, json.dumps(method.to_json())
-
-        return 201, {}, result[2]
-
     @patch(APIGatewayResponse.integrations)
     def apigateway_response_integrations(fn, self, request, *args, **kwargs):
         result = fn(self, request, *args, **kwargs)

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -35,7 +35,9 @@ from localstack.aws.api.apigateway import (
     IntegrationType,
     ListOfPatchOperation,
     ListOfString,
+    MapOfStringToBoolean,
     MapOfStringToString,
+    Method,
     MethodResponse,
     NotFoundException,
     NullableBoolean,
@@ -370,6 +372,156 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         future_sibling_resources.append(resource_id)
 
         response = moto_resource.to_dict()
+        return response
+
+    # resource method
+
+    def get_method(
+        self, context: RequestContext, rest_api_id: String, resource_id: String, http_method: String
+    ) -> Method:
+        response: Method = call_moto(context)
+        remove_empty_attributes_from_method(response)
+        return response
+
+    def put_method(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        resource_id: String,
+        http_method: String,
+        authorization_type: String,
+        authorizer_id: String = None,
+        api_key_required: Boolean = None,
+        operation_name: String = None,
+        request_parameters: MapOfStringToBoolean = None,
+        request_models: MapOfStringToString = None,
+        request_validator_id: String = None,
+        authorization_scopes: ListOfString = None,
+    ) -> Method:
+        # TODO: add missing validation? check order of validation as well
+        moto_backend = apigw_models.apigateway_backends[context.account_id][context.region]
+        moto_rest_api: MotoRestAPI = moto_backend.apis.get(rest_api_id)
+        if not moto_rest_api or not moto_rest_api.resources.get(resource_id):
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        if http_method not in ("GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS", "HEAD", "ANY"):
+            raise BadRequestException(
+                "Invalid HttpMethod specified. "
+                "Valid options are GET,PUT,POST,DELETE,PATCH,OPTIONS,HEAD,ANY"
+            )
+
+        if request_parameters:
+            request_parameters_names = {
+                name.rsplit(".", maxsplit=1)[-1] for name in request_parameters.keys()
+            }
+            if len(request_parameters_names) != len(request_parameters):
+                raise BadRequestException(
+                    "Parameter names must be unique across querystring, header and path"
+                )
+        need_authorizer_id = authorization_type in ("CUSTOM", "COGNITO_USER_POOLS")
+
+        if need_authorizer_id and (
+            not authorizer_id
+            or not find_api_subentity_by_id(rest_api_id, authorizer_id, "authorizers")
+        ):
+            # TODO: will be cleaner with https://github.com/localstack/localstack/pull/7750
+            raise BadRequestException(
+                "Invalid authorizer ID specified. "
+                "Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
+            )
+
+        if request_validator_id and not find_api_subentity_by_id(
+            rest_api_id, request_validator_id, "validators"
+        ):
+            raise BadRequestException("Invalid Request Validator identifier specified")
+
+        if request_models:
+            for content_type, model_name in request_models.items():
+                # FIXME: add Empty model to rest api at creation
+                if model_name == "Empty":
+                    continue
+                if model_name not in moto_rest_api.models:
+                    raise BadRequestException(f"Invalid model identifier specified: {model_name}")
+
+        response: Method = call_moto(context)
+        remove_empty_attributes_from_method(response)
+
+        # this is straight from the moto patch, did not test it yet but has the same functionality
+        # FIXME: check if still necessary after testing Authorizers
+        if need_authorizer_id and "authorizerId" not in response:
+            response["authorizerId"] = authorizer_id
+
+        return response
+
+    def update_method(
+        self,
+        context: RequestContext,
+        rest_api_id: String,
+        resource_id: String,
+        http_method: String,
+        patch_operations: ListOfPatchOperation = None,
+    ) -> Method:
+        # see https://www.linkedin.com/pulse/updating-aws-cli-patch-operations-rest-api-yitzchak-meirovich/
+        # for path construction
+        moto_backend = apigw_models.apigateway_backends[context.account_id][context.region]
+        moto_rest_api: MotoRestAPI = moto_backend.apis.get(rest_api_id)
+        if not moto_rest_api or not (moto_resource := moto_rest_api.resources.get(resource_id)):
+            raise NotFoundException("Invalid Resource identifier specified")
+
+        if not (moto_method := moto_resource.resource_methods.get(http_method)):
+            raise NotFoundException("Invalid Method identifier specified")
+
+        applicable_patch_operations = []
+        for patch_operation in patch_operations:
+            op = patch_operation.get("op")
+            path = patch_operation.get("path")
+            # if the path is not supported at all, raise an Exception
+            if len(path.split("/")) > 3 or not any(
+                path.startswith(s_path) for s_path in UPDATE_METHOD_PATCH_PATHS["supported_paths"]
+            ):
+                raise BadRequestException(f"Invalid patch path {path}")
+
+            # if the path is not supported by the operation, ignore it and skip
+            op_supported_path = UPDATE_METHOD_PATCH_PATHS.get(op, [])
+            if not any(path.startswith(s_path) for s_path in op_supported_path):
+                continue
+
+            value = patch_operation.get("value")
+            if op not in ("add", "replace"):
+                # skip
+                applicable_patch_operations.append(patch_operation)
+                continue
+
+            if path == "/authorizationType" and value in ("CUSTOM", "COGNITO_USER_POOLS"):
+                # TODO: test with 2 operations adding this
+                raise BadRequestException(
+                    "Invalid authorizer ID specified. "
+                    "Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
+                )
+
+            if any(
+                path.startswith(s_path) for s_path in ("/apiKeyRequired", "/requestParameters/")
+            ):
+                patch_op = {"op": op, "path": path, "value": str_to_bool(value)}
+                applicable_patch_operations.append(patch_op)
+                continue
+
+            elif path == "/requestValidatorId" and not find_api_subentity_by_id(
+                rest_api_id, value, "validators"
+            ):
+                raise BadRequestException("Invalid Request Validator identifier specified")
+
+            elif path.startswith("/requestModels/"):
+                if value != "Empty" and value not in moto_rest_api.models:
+                    raise BadRequestException(f"Invalid model identifier specified: {value}")
+
+            applicable_patch_operations.append(patch_operation)
+
+        # TODO: test with multiple patch operations which would not be compatible between each other
+        _patch_api_gateway_entity(moto_method, applicable_patch_operations)
+
+        response = moto_method.to_json()
+        remove_empty_attributes_from_method(response)
         return response
 
     # method responses
@@ -1077,6 +1229,17 @@ def remove_empty_attributes_from_rest_api(rest_api: RestApi, remove_tags=True):
         rest_api.pop("description", None)
 
 
+def remove_empty_attributes_from_method(method: Method):
+    if not method.get("methodResponses"):
+        method.pop("methodResponses", None)
+
+    if not method.get("requestModels"):
+        method.pop("requestModels", None)
+
+    if not method.get("requestParameters"):
+        method.pop("requestParameters", None)
+
+
 def is_greedy_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("+}")
 
@@ -1188,3 +1351,37 @@ def to_response_json(model_type, data, api_id=None, self_link=None, id_attr=None
     }
     result["_links"]["%s:delete" % model_type] = {"href": self_link}
     return result
+
+
+# TODO: maybe extract this in its own files, or find a better generalizable way
+UPDATE_METHOD_PATCH_PATHS = {
+    "supported_paths": [
+        "/authorizationScopes",
+        "/authorizationType",
+        "/authorizerId",
+        "/apiKeyRequired",
+        "/operationName",
+        "/requestParameters/",
+        "/requestModels/",
+        "/requestValidatorId",
+    ],
+    "add": [
+        "/authorizationScopes",
+        "/requestParameters/",
+        "/requestModels/",
+    ],
+    "remove": [
+        "/authorizationScopes",
+        "/requestParameters/",
+        "/requestModels/",
+    ],
+    "replace": [
+        "/authorizationType",
+        "/authorizerId",
+        "/apiKeyRequired",
+        "/operationName",
+        "/requestParameters/",
+        "/requestModels/",
+        "/requestValidatorId",
+    ],
+}

--- a/localstack/utils/json.py
+++ b/localstack/utils/json.py
@@ -176,7 +176,7 @@ def assign_to_path(target, path: str, value, delimiter: str = "."):
             target,
         )
         return
-    path_end = int(parts[-1]) if is_number(parts[-1]) else parts[-1]
+    path_end = int(parts[-1]) if is_number(parts[-1]) else parts[-1].replace("~1", "/")
     parent[path_end] = value
     return target
 

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -684,3 +684,377 @@ class TestApiGatewayApi:
         with pytest.raises(ClientError) as e:
             apigateway_client.get_request_validators(restApiId="test-fake-rest-id")
         snapshot.match("wrong-rest-api-id-get-validators", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_method_lifecycle(
+        self,
+        apigateway_client,
+        apigw_create_rest_api,
+        apigw_create_rest_resource,
+        snapshot,
+    ):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource method lifecycle"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        put_base_method_response = apigateway_client.put_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            authorizationType="NONE",
+        )
+        snapshot.match("put-base-method-response", put_base_method_response)
+
+        get_base_method_response = apigateway_client.get_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="ANY"
+        )
+        snapshot.match("get-base-method-response", get_base_method_response)
+
+        del_base_method_response = apigateway_client.delete_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="ANY"
+        )
+        snapshot.match("del-base-method-response", del_base_method_response)
+
+    @pytest.mark.aws_validated
+    def test_method_request_parameters(
+        self,
+        apigateway_client,
+        apigw_create_rest_api,
+        apigw_create_rest_resource,
+        snapshot,
+    ):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource method request params"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        put_method_response = apigateway_client.put_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            authorizationType="NONE",
+            requestParameters={
+                "method.request.querystring.q_optional": False,
+                "method.request.querystring.q_required": True,
+                "method.request.header.h_optional": False,
+                "method.request.header.h_required": True,
+            },
+        )
+        snapshot.match("put-method-request-params-response", put_method_response)
+
+        get_method_response = apigateway_client.get_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="ANY"
+        )
+        snapshot.match("get-method-request-params-response", get_method_response)
+
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="GET",
+                authorizationType="NONE",
+                requestParameters={
+                    "method.request.querystring.optional": False,
+                    "method.request.header.optional": False,
+                },
+            )
+
+        snapshot.match("req-params-same-name", e.value.response)
+
+    @pytest.mark.aws_validated
+    def test_put_method_validation(
+        self,
+        apigateway_client,
+        apigw_create_rest_api,
+        apigw_create_rest_resource,
+        snapshot,
+    ):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource method request params"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        # wrong RestApiId
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId="fake-api",
+                resourceId=root_id,
+                httpMethod="WRONG",
+                authorizationType="NONE",
+            )
+        snapshot.match("wrong-api", e.value.response)
+
+        # wrong resourceId
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId="fake-resource-id",
+                httpMethod="WRONG",
+                authorizationType="NONE",
+            )
+        snapshot.match("wrong-resource", e.value.response)
+
+        # wrong httpMethod
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="WRONG",
+                authorizationType="NONE",
+            )
+        snapshot.match("wrong-method", e.value.response)
+
+        # missing AuthorizerId when setting authorizationType="CUSTOM"
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                authorizationType="CUSTOM",
+            )
+        snapshot.match("missing-authorizer-id", e.value.response)
+
+        # invalid RequestValidatorId
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                authorizationType="NONE",
+                requestValidatorId="fake-validator",
+            )
+        snapshot.match("invalid-request-validator", e.value.response)
+
+        # invalid Model id
+        with pytest.raises(ClientError) as e:
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                authorizationType="NONE",
+                requestModels={"application/json": "petModel"},
+            )
+        snapshot.match("invalid-model-name", e.value.response)
+
+        # TODO: validate authorizationScopes?
+        # TODO: add more validation on methods once its subresources are tested
+        # Authorizer, RequestValidator, Model
+
+    @pytest.mark.aws_validated
+    def test_update_method(
+        self,
+        apigateway_client,
+        apigw_create_rest_api,
+        apigw_create_rest_resource,
+        snapshot,
+    ):
+        # see https://www.linkedin.com/pulse/updating-aws-cli-patch-operations-rest-api-yitzchak-meirovich/
+        # for patch path
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing update method"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        put_method_response = apigateway_client.put_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            authorizationType="NONE",
+        )
+        snapshot.match("put-method-response", put_method_response)
+
+        patch_operations_add = [
+            {
+                "op": "add",
+                "path": "/requestParameters/method.request.querystring.optional",
+                "value": "true",
+            },
+            {"op": "add", "path": "/requestModels/application~1json", "value": "Empty"},
+        ]
+
+        update_method_response_add = apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            patchOperations=patch_operations_add,
+        )
+        snapshot.match("update-method-add", update_method_response_add)
+
+        patch_operations_replace = [
+            {"op": "replace", "path": "/operationName", "value": "ReplacedOperationName"},
+            {"op": "replace", "path": "/apiKeyRequired", "value": "true"},
+            {"op": "replace", "path": "/authorizationType", "value": "AWS_IAM"},
+            {
+                "op": "replace",
+                "path": "/requestParameters/method.request.querystring.optional",
+                "value": "false",
+            },
+        ]
+
+        update_method_response_replace = apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            patchOperations=patch_operations_replace,
+        )
+        snapshot.match("update-method-replace", update_method_response_replace)
+
+        patch_operations_remove = [
+            {
+                "op": "remove",
+                "path": "/requestParameters/method.request.querystring.optional",
+                "value": "true",
+            },
+            {"op": "remove", "path": "/requestModels/application~1json", "value": "Empty"},
+        ]
+
+        update_method_response_remove = apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            patchOperations=patch_operations_remove,
+        )
+        snapshot.match("update-method-remove", update_method_response_remove)
+
+    def test_update_method_validation(
+        self,
+        apigateway_client,
+        apigw_create_rest_api,
+        apigw_create_rest_resource,
+        snapshot,
+    ):
+        response = apigw_create_rest_api(
+            name=f"test-api-{short_uid()}", description="testing resource method request params"
+        )
+        api_id = response["id"]
+        root_rest_api_resource = apigateway_client.get_resources(restApiId=api_id)
+        root_id = root_rest_api_resource["items"][0]["id"]
+
+        with pytest.raises(ClientError) as e:
+            apigateway_client.update_method(
+                restApiId="fake-api",
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=[],
+            )
+        snapshot.match("wrong-rest-api", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId="fake-resource-id",
+                httpMethod="ANY",
+                patchOperations=[],
+            )
+        snapshot.match("wrong-resource-id", e.value.response)
+
+        # method is not set for the resource?
+        with pytest.raises(ClientError) as e:
+            patch_operations_add = [
+                {"op": "replace", "path": "/operationName", "value": "methodDoesNotExist"},
+            ]
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="GET",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("method-does-not-exist", e.value.response)
+
+        put_method_response = apigateway_client.put_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            authorizationType="NONE",
+            apiKeyRequired=True,
+        )
+        snapshot.match("put-method-response", put_method_response)
+
+        # unsupported operation ?
+        patch_operations_add = [
+            {"op": "add", "path": "/operationName", "value": "operationName"},
+        ]
+        unsupported_operation_resp = apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            patchOperations=patch_operations_add,
+        )
+        snapshot.match("unsupported-operation", unsupported_operation_resp)
+
+        # wrong path for requestParameters
+        with pytest.raises(ClientError) as e:
+            patch_operations_add = [
+                {
+                    "op": "replace",
+                    "path": "/requestParameters",
+                    "value": "method.request.querystring.optional=false",
+                },
+            ]
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("wrong-path-request-parameters", e.value.response)
+
+        # wrong path for requestModels
+        with pytest.raises(ClientError) as e:
+            patch_operations_add = [
+                {"op": "add", "path": "/requestModels/application/json", "value": "Empty"},
+            ]
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("wrong-path-request-models", e.value.response)
+
+        # wrong value type
+        patch_operations_add = [
+            {"op": "replace", "path": "/apiKeyRequired", "value": "whatever"},
+        ]
+        wrong_value_type_resp = apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="ANY",
+            patchOperations=patch_operations_add,
+        )
+        snapshot.match("wrong-value-type", wrong_value_type_resp)
+
+        # add auth type without authorizer?
+        with pytest.raises(ClientError) as e:
+            patch_operations_add = [
+                {"op": "replace", "path": "/authorizationType", "value": "CUSTOM"},
+            ]
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("wrong-auth-type", e.value.response)
+
+        # replace wrong validator id
+        with pytest.raises(ClientError) as e:
+            patch_operations_add = [
+                {"op": "replace", "path": "/requestValidatorId", "value": "fake-id"},
+            ]
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("wrong-req-validator-id", e.value.response)

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -690,7 +690,6 @@ class TestApiGatewayApi:
         self,
         apigateway_client,
         apigw_create_rest_api,
-        apigw_create_rest_resource,
         snapshot,
     ):
         response = apigw_create_rest_api(
@@ -723,7 +722,6 @@ class TestApiGatewayApi:
         self,
         apigateway_client,
         apigw_create_rest_api,
-        apigw_create_rest_resource,
         snapshot,
     ):
         response = apigw_create_rest_api(
@@ -771,7 +769,6 @@ class TestApiGatewayApi:
         self,
         apigateway_client,
         apigw_create_rest_api,
-        apigw_create_rest_resource,
         snapshot,
     ):
         response = apigw_create_rest_api(
@@ -852,7 +849,6 @@ class TestApiGatewayApi:
         self,
         apigateway_client,
         apigw_create_rest_api,
-        apigw_create_rest_resource,
         snapshot,
     ):
         # see https://www.linkedin.com/pulse/updating-aws-cli-patch-operations-rest-api-yitzchak-meirovich/
@@ -929,7 +925,6 @@ class TestApiGatewayApi:
         self,
         apigateway_client,
         apigw_create_rest_api,
-        apigw_create_rest_resource,
         snapshot,
     ):
         response = apigw_create_rest_api(
@@ -990,6 +985,19 @@ class TestApiGatewayApi:
             patchOperations=patch_operations_add,
         )
         snapshot.match("unsupported-operation", unsupported_operation_resp)
+
+        # unsupported path
+        with pytest.raises(ClientError) as e:
+            patch_operations_add = [
+                {"op": "add", "path": "/httpMethod", "value": "PUT"},
+            ]
+            apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=root_id,
+                httpMethod="ANY",
+                patchOperations=patch_operations_add,
+            )
+        snapshot.match("unsupported-path", e.value.response)
 
         # wrong path for requestParameters
         with pytest.raises(ClientError) as e:

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1037,5 +1037,315 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_lifecycle": {
+    "recorded-date": "24-02-2023, 19:17:18",
+    "recorded-content": {
+      "put-base-method-response": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-base-method-response": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "del-base-method-response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_request_parameters": {
+    "recorded-date": "24-02-2023, 19:25:22",
+    "recorded-content": {
+      "put-method-request-params-response": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestParameters": {
+          "method.request.header.h_optional": false,
+          "method.request.header.h_required": true,
+          "method.request.querystring.q_optional": false,
+          "method.request.querystring.q_required": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-method-request-params-response": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestParameters": {
+          "method.request.header.h_optional": false,
+          "method.request.header.h_required": true,
+          "method.request.querystring.q_optional": false,
+          "method.request.querystring.q_required": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "req-params-same-name": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Parameter names must be unique across querystring, header and path"
+        },
+        "message": "Parameter names must be unique across querystring, header and path",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_validation": {
+    "recorded-date": "25-02-2023, 17:49:08",
+    "recorded-content": {
+      "wrong-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "wrong-resource": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "wrong-method": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid HttpMethod specified. Valid options are GET,PUT,POST,DELETE,PATCH,OPTIONS,HEAD,ANY"
+        },
+        "message": "Invalid HttpMethod specified. Valid options are GET,PUT,POST,DELETE,PATCH,OPTIONS,HEAD,ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "missing-authorizer-id": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
+        },
+        "message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-request-validator": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid Request Validator identifier specified"
+        },
+        "message": "Invalid Request Validator identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-model-name": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid model identifier specified: petModel"
+        },
+        "message": "Invalid model identifier specified: petModel",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method": {
+    "recorded-date": "25-02-2023, 18:10:42",
+    "recorded-content": {
+      "put-method-response": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "update-method-add": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "Empty"
+        },
+        "requestParameters": {
+          "method.request.querystring.optional": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-method-replace": {
+        "apiKeyRequired": true,
+        "authorizationType": "AWS_IAM",
+        "httpMethod": "ANY",
+        "operationName": "ReplacedOperationName",
+        "requestModels": {
+          "application/json": "Empty"
+        },
+        "requestParameters": {
+          "method.request.querystring.optional": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "update-method-remove": {
+        "apiKeyRequired": true,
+        "authorizationType": "AWS_IAM",
+        "httpMethod": "ANY",
+        "operationName": "ReplacedOperationName",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method_validation": {
+    "recorded-date": "26-02-2023, 15:01:45",
+    "recorded-content": {
+      "wrong-rest-api": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "wrong-resource-id": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Resource identifier specified"
+        },
+        "message": "Invalid Resource identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "method-does-not-exist": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put-method-response": {
+        "apiKeyRequired": true,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "unsupported-operation": {
+        "apiKeyRequired": true,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "wrong-path-request-parameters": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /requestParameters"
+        },
+        "message": "Invalid patch path /requestParameters",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-path-request-models": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /requestModels/application/json"
+        },
+        "message": "Invalid patch path /requestModels/application/json",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-value-type": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "wrong-auth-type": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
+        },
+        "message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-req-validator-id": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid Request Validator identifier specified"
+        },
+        "message": "Invalid Request Validator identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1240,7 +1240,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method_validation": {
-    "recorded-date": "26-02-2023, 15:01:45",
+    "recorded-date": "02-03-2023, 16:58:33",
     "recorded-content": {
       "wrong-rest-api": {
         "Error": {
@@ -1291,6 +1291,17 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "unsupported-path": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid patch path /httpMethod"
+        },
+        "message": "Invalid patch path /httpMethod",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       },
       "wrong-path-request-parameters": {


### PR DESCRIPTION
This PR reimplements the `Method` resource CRUD API, removing the patches from moto to integrate them in our provider. 
There was quite some validations on the json patch area, I will focus my time on resources where `Update*` is more often called, as those can be huge rabbit holes. 

- [x] remove all moto patches related to the `Method` resource
- [x] implement validations on `UpdateMethod`, snapshot tested, see https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html#UpdateMethod-Patch
- [x] fixes in json patch logic, especially while adding new field in nested properties
- [x] add validations about "linked" resources to the created/updates resources (Authorizers, Validators, Models, etc)