### PR TITLE
apigateway - refactor store

### DIFF
--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -1,5 +1,15 @@
 from typing import Any, Dict, List
 
+from requests.structures import CaseInsensitiveDict
+
+from localstack.aws.api.apigateway import (
+    Authorizer,
+    DocumentationPart,
+    GatewayResponse,
+    Model,
+    RequestValidator,
+    RestApi,
+)
 from localstack.services.stores import (
     AccountRegionBundle,
     BaseStore,
@@ -9,22 +19,36 @@ from localstack.services.stores import (
 from localstack.utils.aws import arns
 
 
+class RestApiContainer:
+    # contains the RestApi dictionary. We're not making use of it yet, still using moto data.
+    rest_api: RestApi
+    # maps AuthorizerId -> Authorizer
+    authorizers: Dict[str, Authorizer]
+    # maps RequestValidatorId -> RequestValidator
+    validators: Dict[str, RequestValidator]
+    # map DocumentationPartId -> DocumentationPart
+    documentation_parts: Dict[str, DocumentationPart]
+    # not used yet, still in moto
+    gateway_responses: Dict[str, GatewayResponse]
+    # not used yet, still in moto
+    models: Dict[str, Model]
+    # maps ResourceId of a Resource to its children ResourceIds
+    resource_children: Dict[str, List[str]]
+
+    def __init__(self, rest_api: RestApi):
+        self.rest_api = rest_api
+        self.authorizers = {}
+        self.validators = {}
+        self.documentation_parts = {}
+        self.gateway_responses = {}
+        self.models = {}
+        self.resource_children = {}
+
+
 class ApiGatewayStore(BaseStore):
-    # TODO: introduce a RestAPI class to encapsulate the variables below
-    # maps (API id) -> [authorizers]
-    authorizers: Dict[str, List[Dict]] = LocalAttribute(default=dict)
-
-    # maps (API id) -> [validators]
-    validators: Dict[str, List[Dict]] = LocalAttribute(default=dict)
-
-    # maps (API id) -> [documentation_parts]
-    documentation_parts: Dict[str, List[Dict]] = LocalAttribute(default=dict)
-
-    # maps (API id) -> [gateway_responses]
-    gateway_responses: Dict[str, List[Dict]] = LocalAttribute(default=dict)
-
-    # maps (API id) -> Resource id -> its children Resource id
-    resources_children: Dict[str, Dict[str, List[str]]] = LocalAttribute(default=dict)
+    # maps (API id) -> RestApiContainer
+    # TODO: remove CaseInsensitiveDict, and lower the value of the ID when getting it from the tags
+    rest_apis: Dict[str, RestApiContainer] = LocalAttribute(default=CaseInsensitiveDict)
 
     # account details
     account: Dict[str, Any] = LocalAttribute(default=dict)

--- a/localstack/services/apigateway/patches.py
+++ b/localstack/services/apigateway/patches.py
@@ -332,6 +332,7 @@ def apply_patches():
         """
         tags = tags or {}
         result = fn(self, *args, tags=tags, **kwargs)
+        # TODO: lower the custom_id when getting it from the tags, as AWS is case insensitive
         if custom_id := tags.get(TAG_KEY_CUSTOM_ID):
             self.apis.pop(result.id)
             result.id = custom_id

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -923,5 +923,119 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_authorizer_crud_no_api": {
+    "recorded-date": "28-02-2023, 20:06:16",
+    "recorded-content": {
+      "wrong-rest-api-id-create-authorizer": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Unable to complete operation due to concurrent modification. Please try again later."
+        },
+        "message": "Unable to complete operation due to concurrent modification. Please try again later.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "wrong-rest-api-id-get-authorizers": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_doc_arts_crud_no_api": {
+    "recorded-date": "28-02-2023, 20:11:32",
+    "recorded-content": {
+      "wrong-rest-api-id-create-doc-part": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "wrong-rest-api-id-get-doc-parts": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_validators_crud_no_api": {
+    "recorded-date": "28-02-2023, 20:18:59",
+    "recorded-content": {
+      "wrong-rest-api-id-create-validator": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid REST API identifier specified"
+        },
+        "message": "Invalid REST API identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "wrong-rest-api-id-get-validators": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:test-fake-rest-id"
+        },
+        "message": "Invalid API identifier specified 111111111111:test-fake-rest-id",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_get_api_case_insensitive": {
+    "recorded-date": "01-03-2023, 16:26:45",
+    "recorded-content": {
+      "create-rest-api": {
+        "apiKeySource": "HEADER",
+        "createdDate": "datetime",
+        "description": "lower case api",
+        "disableExecuteApiEndpoint": false,
+        "endpointConfiguration": {
+          "types": [
+            "EDGE"
+          ]
+        },
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "get-api-upper-case": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid API identifier specified 111111111111:<upper-id>"
+        },
+        "message": "Invalid API identifier specified 111111111111:<upper-id>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR refactors the store of API Gateway to make use of dictionary for an easier look up of RestAPI sub-entities.
~~I've added utilities to support the use of both old restored stores and new, fresh stores, but it makes it a bit verbose.~~

This refactor will also help in the recent parity work, to move more data into our stores and add more validations.

I'm not sure how much breakage we can do with persistence, but if we can break, I'll remove the utils and just use the new store attributes directly, which will be much cleaner. If we can't break it yet, we can keep those utils to support restored state, and remove them before `v2`. I will be working on API Gateway until then, so I can undertake that effort then. 

Also cleaned up some methods that were not used anymore anywhere. 

\cc @whummer @thrau about how this should tackled, should I break the store, or use these utils until then? 

note: green lighted the breakage of persistence, so now this PR just uses the new store format 😄 