### PR TITLE
Enhance parity for API Gateway DynamoDB integrations

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -19,6 +19,7 @@ from localstack.services.apigateway.helpers import (
     extract_path_params,
     extract_query_string_params,
     get_event_request_context,
+    make_error_response,
 )
 from localstack.services.apigateway.templates import (
     MappingTemplates,
@@ -392,6 +393,133 @@ class LambdaIntegration(BackendIntegration):
         response_templates.render(invocation_context)
         invocation_context.response.headers["Content-Length"] = str(len(response.content or ""))
         return invocation_context.response
+
+
+class KinesisIntegration(BackendIntegration):
+    def invoke(self, invocation_context: ApiInvocationContext):
+        integration = invocation_context.integration
+        integration_type_orig = integration.get("type") or integration.get("integrationType") or ""
+        integration_type = integration_type_orig.upper()
+        uri = integration.get("uri") or integration.get("integrationUri") or ""
+
+        if uri.endswith("kinesis:action/PutRecord"):
+            target = "Kinesis_20131202.PutRecord"
+        elif uri.endswith("kinesis:action/PutRecords"):
+            target = "Kinesis_20131202.PutRecords"
+        elif uri.endswith("kinesis:action/ListStreams"):
+            target = "Kinesis_20131202.ListStreams"
+        else:
+            LOG.info(
+                f"Unexpected API Gateway integration URI '{uri}' for integration type {integration_type}",
+            )
+            target = ""
+
+        try:
+            invocation_context.context = helpers.get_event_request_context(invocation_context)
+            invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
+            request_templates = RequestTemplates()
+            payload = request_templates.render(invocation_context)
+
+        except Exception as e:
+            LOG.warning("Unable to convert API Gateway payload to str", e)
+            raise
+
+        # forward records to target kinesis stream
+        headers = aws_stack.mock_aws_request_headers(
+            service="kinesis", region_name=invocation_context.region_name
+        )
+        headers["X-Amz-Target"] = target
+
+        result = common.make_http_request(
+            url=config.service_url("kinesis"), data=payload, headers=headers, method="POST"
+        )
+
+        # apply response template
+        invocation_context.response = result
+        response_templates = ResponseTemplates()
+        response_templates.render(invocation_context)
+        return invocation_context.response
+
+
+class DynamoDBIntegration(BackendIntegration):
+    def invoke(self, invocation_context: ApiInvocationContext):
+        method = invocation_context.method
+        data = invocation_context.data
+        integration = invocation_context.integration
+        integration_response = integration.get("integrationResponses", {})
+        response_templates = integration_response.get("200", {}).get("responseTemplates", {})
+        uri = integration.get("uri") or integration.get("integrationUri") or ""
+
+        # example: arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection
+        action = uri.split(":dynamodb:action/")[1].split("&")[0]
+
+        if "PutItem" in action and method == "PUT":
+            table_name = uri.split(":dynamodb:action")[1].split("&Table=")[1]
+            response_template = response_templates.get("application/json")
+
+            if response_template is None:
+                msg = "Invalid response template defined in integration response."
+                LOG.info("%s Existing: %s", msg, response_templates)
+                return make_error_response(msg, 404)
+
+            response_template = json.loads(response_template)
+            if response_template["TableName"] != table_name:
+                # TODO: check if this error is valid (AWS parity)
+                msg = "Invalid table name specified in integration response template."
+                return make_error_response(msg, 404)
+
+            dynamo_client = aws_stack.connect_to_resource("dynamodb")
+            table = dynamo_client.Table(table_name)
+
+            event_data = {}
+            data_dict = json.loads(data)
+            for key, _ in response_template["Item"].items():
+                event_data[key] = data_dict[key]
+
+            table.put_item(Item=event_data)
+            response = requests_response(event_data)
+            return response
+
+        if "Query" in action:
+            template = integration["requestTemplates"].get(APPLICATION_JSON)
+
+            if template is None:
+                msg = "No request template is defined in the integration."
+                LOG.info("%s Existing: %s", msg, response_templates)
+                return make_error_response(msg, 404)
+
+            response_template = response_templates.get(APPLICATION_JSON)
+
+            if response_template is None:
+                msg = "Invalid response template defined in integration response."
+                LOG.info("%s Existing: %s", msg, response_templates)
+                return make_error_response(msg, 404)
+
+            request_templates = RequestTemplates()
+            payload = request_templates.render(invocation_context)
+            payload = json.loads(payload)
+
+            # query data from DynamoDB
+            dynamo_client = aws_stack.connect_to_service("dynamodb")
+            response = dynamo_client.query(**payload)
+
+            if "Items" not in response:
+                msg = "Items not found in DynamoDB"
+                LOG.info("%s - existing: %s", msg, response_template)
+                return make_error_response(msg, 404)
+
+            # apply response templates
+            response_templates = ResponseTemplates()
+            response_content = json.dumps(remove_attributes(response, ["ResponseMetadata"]))
+            response_obj = requests_response(content=response_content)
+            response = response_templates.render(invocation_context, response=response_obj)
+
+            # construct final response
+            response = requests_response(response)
+            invocation_context.response = response
+            return response
+
+        raise Exception(f"Unsupported action {action} in API Gateway integration URI {uri}")
 
 
 class MockIntegration(BackendIntegration):

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -28,6 +28,8 @@ from localstack.aws.api.apigateway import (
     DocumentationParts,
     ExportResponse,
     GetDocumentationPartsRequest,
+    Integration,
+    IntegrationType,
     ListOfPatchOperation,
     ListOfString,
     MapOfStringToString,
@@ -35,6 +37,7 @@ from localstack.aws.api.apigateway import (
     NotFoundException,
     NullableBoolean,
     NullableInteger,
+    PutIntegrationRequest,
     PutRestApiRequest,
     RequestValidator,
     RequestValidators,
@@ -780,6 +783,18 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
             put_api_request,
         )
         return self.put_rest_api(put_api_context, put_api_request)
+
+    def put_integration(
+        self, context: RequestContext, request: PutIntegrationRequest
+    ) -> Integration:
+        if request.get("type") == IntegrationType.AWS_PROXY:
+            integration_uri = request.get("uri") or ""
+            if ":lambda:" not in integration_uri and ":firehose:" not in integration_uri:
+                raise BadRequestException(
+                    "Integrations of type 'AWS_PROXY' currently only supports "
+                    "Lambda function and Firehose stream invocations."
+                )
+        return call_moto(context)
 
     def delete_integration(
         self, context: RequestContext, rest_api_id: String, resource_id: String, http_method: String

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -439,7 +439,7 @@ def dynamodb_create_table(dynamodb_client, dynamodb_wait_for_table_active):
     def factory(**kwargs):
         kwargs["client"] = dynamodb_client
         if "table_name" not in kwargs:
-            kwargs["table_name"] = "test-table-%s" % short_uid()
+            kwargs["table_name"] = f"test-table-{short_uid()}"
         if "partition_key" not in kwargs:
             kwargs["partition_key"] = "id"
 
@@ -1935,7 +1935,7 @@ def sample_backend_dict() -> BackendDict:
 
 @pytest.fixture
 def create_rest_apigw():
-    rest_api_ids = []
+    rest_apis = []
 
     def _create_apigateway_function(**kwargs):
         region_name = kwargs.pop("region_name", None)
@@ -1943,7 +1943,7 @@ def create_rest_apigw():
 
         response = apigateway_client.create_rest_api(**kwargs)
         api_id = response.get("id")
-        rest_api_ids.append(api_id)
+        rest_apis.append((api_id, region_name))
         resources = apigateway_client.get_resources(restApiId=api_id)
         root_id = next(item for item in resources["items"] if item["path"] == "/")["id"]
 
@@ -1951,8 +1951,9 @@ def create_rest_apigw():
 
     yield _create_apigateway_function
 
-    for rest_api_id in rest_api_ids:
+    for rest_api_id, region_name in rest_apis:
         with contextlib.suppress(Exception):
+            apigateway_client = _client("apigateway", region_name)
             apigateway_client.delete_rest_api(restApiId=rest_api_id)
 
 

--- a/tests/integration/apigateway/conftest.py
+++ b/tests/integration/apigateway/conftest.py
@@ -29,7 +29,11 @@ def create_rest_api_with_integration(
     create_iam_role_with_policy,
 ):
     def _factory(
-        integration_uri, req_templates=None, res_templates=None, stage=None, integration_type=None
+        integration_uri,
+        req_templates=None,
+        res_templates=None,
+        integration_type=None,
+        stage=DEFAULT_STAGE_NAME,
     ):
         name = f"test-apigw-{short_uid()}"
         api_id, name, root_id = create_rest_apigw(
@@ -93,7 +97,6 @@ def create_rest_api_with_integration(
         )
 
         deployment_id, _ = create_rest_api_deployment(apigateway_client, restApiId=api_id)
-        stage = stage or DEFAULT_STAGE_NAME
         create_rest_api_stage(
             apigateway_client, restApiId=api_id, stageName=stage, deploymentId=deployment_id
         )

--- a/tests/integration/apigateway/conftest.py
+++ b/tests/integration/apigateway/conftest.py
@@ -1,0 +1,103 @@
+import pytest
+
+from localstack.constants import APPLICATION_JSON
+from localstack.utils.strings import short_uid
+from tests.integration.apigateway_fixtures import (
+    create_rest_api_deployment,
+    create_rest_api_integration,
+    create_rest_api_integration_response,
+    create_rest_api_method_response,
+    create_rest_api_stage,
+    create_rest_resource,
+    create_rest_resource_method,
+)
+from tests.integration.test_apigateway import (
+    APIGATEWAY_ASSUME_ROLE_POLICY,
+    APIGATEWAY_DYNAMODB_POLICY,
+    APIGATEWAY_KINESIS_POLICY,
+)
+
+# default name used for created REST API stages
+DEFAULT_STAGE_NAME = "dev"
+
+
+@pytest.fixture
+def create_rest_api_with_integration(
+    create_rest_apigw,
+    apigateway_client,
+    wait_for_stream_ready,
+    create_iam_role_with_policy,
+):
+    def _factory(
+        integration_uri, req_templates=None, res_templates=None, stage=None, integration_type=None
+    ):
+        name = f"test-apigw-{short_uid()}"
+        api_id, name, root_id = create_rest_apigw(
+            name=name, endpointConfiguration={"types": ["REGIONAL"]}
+        )
+
+        resource_id, _ = create_rest_resource(
+            apigateway_client, restApiId=api_id, parentId=root_id, pathPart="test"
+        )
+
+        method, _ = create_rest_resource_method(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+        )
+
+        # set AWS policy to give API GW access to backend resources
+        if ":dynamodb:" in integration_uri:
+            policy = APIGATEWAY_DYNAMODB_POLICY
+        elif ":kinesis:" in integration_uri:
+            policy = APIGATEWAY_KINESIS_POLICY
+        else:
+            raise Exception(f"Unexpected integration URI: {integration_uri}")
+        assume_role_arn = create_iam_role_with_policy(
+            RoleName=f"role-apigw-{short_uid()}",
+            PolicyName=f"policy-apigw-{short_uid()}",
+            RoleDefinition=APIGATEWAY_ASSUME_ROLE_POLICY,
+            PolicyDefinition=policy,
+        )
+
+        create_rest_api_integration(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod=method,
+            integrationHttpMethod="POST",
+            type=integration_type or "AWS",
+            credentials=assume_role_arn,
+            uri=integration_uri,
+            requestTemplates=req_templates or {},
+        )
+
+        create_rest_api_method_response(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
+
+        res_templates = res_templates or {APPLICATION_JSON: "$input.json('$')"}
+        create_rest_api_integration_response(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+            responseTemplates=res_templates,
+        )
+
+        deployment_id, _ = create_rest_api_deployment(apigateway_client, restApiId=api_id)
+        stage = stage or DEFAULT_STAGE_NAME
+        create_rest_api_stage(
+            apigateway_client, restApiId=api_id, stageName=stage, deploymentId=deployment_id
+        )
+
+        return api_id
+
+    yield _factory

--- a/tests/integration/apigateway/test_apigateway_dynamodb.py
+++ b/tests/integration/apigateway/test_apigateway_dynamodb.py
@@ -1,0 +1,75 @@
+import json
+
+import pytest
+from botocore.exceptions import ClientError
+
+from localstack.constants import APPLICATION_JSON
+from localstack.utils.http import safe_requests as requests
+from localstack.utils.sync import retry
+from tests.integration.apigateway.conftest import DEFAULT_STAGE_NAME
+from tests.integration.apigateway_fixtures import api_invoke_url, create_rest_api_integration
+
+
+def test_rest_api_to_dynamodb_integration(
+    apigateway_client,
+    dynamodb_create_table,
+    dynamodb_resource,
+    create_rest_api_with_integration,
+    snapshot,
+):
+    # create table
+    table = dynamodb_create_table()["TableDescription"]
+    table_name = table["TableName"]
+
+    # insert items
+    dynamodb_table = dynamodb_resource.Table(table_name)
+    item_ids = ("test", "test2", "test 3")
+    for item_id in item_ids:
+        dynamodb_table.put_item(Item={"id": item_id})
+
+    region_name = apigateway_client.meta.region_name
+    integration_uri = f"arn:aws:apigateway:{region_name}:dynamodb:action/Query"
+    request_templates = {
+        APPLICATION_JSON: json.dumps(
+            {
+                "TableName": table_name,
+                "KeyConditionExpression": "id = :id",
+                "ExpressionAttributeValues": {":id": {"S": "$input.params('id')"}},
+            }
+        )
+    }
+    api_id = create_rest_api_with_integration(
+        integration_uri=integration_uri,
+        req_templates=request_templates,
+        integration_type="AWS",
+    )
+
+    # assert error - AWS_PROXY not supported for DDB integrations (AWS parity)
+    resources = apigateway_client.get_resources(restApiId=api_id)["items"]
+    child_resource = [res for res in resources if res.get("parentId")][0]
+    with pytest.raises(ClientError) as exc:
+        create_rest_api_integration(
+            apigateway_client,
+            restApiId=api_id,
+            resourceId=child_resource["id"],
+            httpMethod="POST",
+            integrationHttpMethod="POST",
+            type="AWS_PROXY",
+            uri=integration_uri,
+        )
+    snapshot.match("create-integration-error", exc.value.response)
+
+    def _invoke_endpoint(id_param):
+        url = api_invoke_url(api_id, stage=DEFAULT_STAGE_NAME, path=f"/test?id={id_param}")
+        response = requests.post(url)
+        assert response.status_code == 200
+        return response.json()
+
+    # retrieve valid item IDs
+    for item_id in item_ids:
+        result = retry(lambda: _invoke_endpoint(item_id), retries=15, sleep=1)
+        snapshot.match(f"result-{item_id}", result)
+
+    # retrieve invalid item ID
+    result = retry(lambda: _invoke_endpoint("test-invalid"), retries=15, sleep=1)
+    snapshot.match("result-invalid", result)

--- a/tests/integration/apigateway/test_apigateway_dynamodb.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_dynamodb.snapshot.json
@@ -1,0 +1,56 @@
+{
+  "tests/integration/apigateway/test_apigateway_dynamodb.py::test_rest_api_to_dynamodb_integration": {
+    "recorded-date": "25-02-2023, 19:14:23",
+    "recorded-content": {
+      "create-integration-error": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations."
+        },
+        "message": "Integrations of type 'AWS_PROXY' currently only supports Lambda function and Firehose stream invocations.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "result-test": {
+        "Count": 1,
+        "Items": [
+          {
+            "id": {
+              "S": "test"
+            }
+          }
+        ],
+        "ScannedCount": 1
+      },
+      "result-test2": {
+        "Count": 1,
+        "Items": [
+          {
+            "id": {
+              "S": "test2"
+            }
+          }
+        ],
+        "ScannedCount": 1
+      },
+      "result-test 3": {
+        "Count": 1,
+        "Items": [
+          {
+            "id": {
+              "S": "test 3"
+            }
+          }
+        ],
+        "ScannedCount": 1
+      },
+      "result-invalid": {
+        "Count": 0,
+        "Items": [],
+        "ScannedCount": 0
+      }
+    }
+  }
+}

--- a/tests/integration/apigateway/test_apigateway_kinesis.py
+++ b/tests/integration/apigateway/test_apigateway_kinesis.py
@@ -5,111 +5,26 @@ import pytest
 from localstack.utils.http import safe_requests as requests
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import retry
-from tests.integration.apigateway_fixtures import (
-    api_invoke_url,
-    create_rest_api_deployment,
-    create_rest_api_integration,
-    create_rest_api_integration_response,
-    create_rest_api_method_response,
-    create_rest_api_stage,
-    create_rest_resource,
-    create_rest_resource_method,
-)
-from tests.integration.test_apigateway import (
-    APIGATEWAY_ASSUME_ROLE_POLICY,
-    APIGATEWAY_KINESIS_POLICY,
-)
+from tests.integration.apigateway.conftest import DEFAULT_STAGE_NAME
+from tests.integration.apigateway_fixtures import api_invoke_url
 
 
 # PutRecord does not return EncryptionType, but it's documented as such.
 # xxx requires further investigation
 @pytest.mark.skip_snapshot_verify(paths=["$..EncryptionType", "$..ChildShards"])
 def test_apigateway_to_kinesis(
-    create_rest_apigw,
     apigateway_client,
-    sts_client,
     kinesis_create_stream,
-    kinesis_client,
-    create_lambda_function,
-    lambda_client,
-    lambda_su_role,
-    cleanups,
     wait_for_stream_ready,
-    create_iam_role_with_policy,
+    create_rest_api_with_integration,
+    kinesis_client,
     snapshot,
 ):
     snapshot.add_transformer(snapshot.transform.apigateway_api())
     snapshot.add_transformer(snapshot.transform.kinesis_api())
 
+    # create stream
     stream_name = f"kinesis-stream-{short_uid()}"
-    region_name = apigateway_client.meta.region_name
-
-    api_id, name, root_id = create_rest_apigw(
-        name="test-apigateway-to-kinesis",
-        description="test apigateway to kinesis",
-        endpointConfiguration={"types": ["REGIONAL"]},
-    )
-
-    resource_id, _ = create_rest_resource(
-        apigateway_client, restApiId=api_id, parentId=root_id, pathPart="test"
-    )
-
-    method, _ = create_rest_resource_method(
-        apigateway_client,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod="POST",
-        authorizationType="NONE",
-    )
-
-    assume_role_arn = create_iam_role_with_policy(
-        RoleName=f"role-apigw-{short_uid()}",
-        PolicyName=f"policy-apigw-{short_uid()}",
-        RoleDefinition=APIGATEWAY_ASSUME_ROLE_POLICY,
-        PolicyDefinition=APIGATEWAY_KINESIS_POLICY,
-    )
-
-    create_rest_api_integration(
-        apigateway_client,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod=method,
-        integrationHttpMethod="POST",
-        type="AWS",
-        credentials=assume_role_arn,
-        uri=f"arn:aws:apigateway:{region_name}:kinesis:action/PutRecord",
-        requestTemplates={
-            "application/json": json.dumps(
-                {
-                    "StreamName": stream_name,
-                    "Data": "$util.base64Encode($input.body)",
-                    "PartitionKey": "test",
-                }
-            )
-        },
-    )
-
-    create_rest_api_method_response(
-        apigateway_client,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod="POST",
-        statusCode="200",
-    )
-
-    create_rest_api_integration_response(
-        apigateway_client,
-        restApiId=api_id,
-        resourceId=resource_id,
-        httpMethod="POST",
-        statusCode="200",
-    )
-
-    deployment_id, _ = create_rest_api_deployment(apigateway_client, restApiId=api_id)
-    stage = create_rest_api_stage(
-        apigateway_client, restApiId=api_id, stageName="dev", deploymentId=deployment_id
-    )
-
     kinesis_create_stream(StreamName=stream_name, ShardCount=1)
     wait_for_stream_ready(stream_name=stream_name)
     stream_summary = kinesis_client.describe_stream_summary(StreamName=stream_name)
@@ -119,18 +34,36 @@ def test_apigateway_to_kinesis(
     ]["Shards"][0]
     shard_id = first_stream_shard_data["ShardId"]
 
-    shard_iterator = kinesis_client.get_shard_iterator(
-        StreamName=stream_name, ShardIteratorType="LATEST", ShardId=shard_id
-    )["ShardIterator"]
+    # create REST API with Kinesis integration
+    region_name = apigateway_client.meta.region_name
+    integration_uri = f"arn:aws:apigateway:{region_name}:kinesis:action/PutRecord"
+    request_templates = {
+        "application/json": json.dumps(
+            {
+                "StreamName": stream_name,
+                "Data": "$util.base64Encode($input.body)",
+                "PartitionKey": "test",
+            }
+        )
+    }
+    api_id = create_rest_api_with_integration(
+        integration_uri=integration_uri,
+        req_templates=request_templates,
+        integration_type="AWS",
+    )
 
-    # asserts
     def _invoke_apigw_to_kinesis():
-        url = api_invoke_url(api_id, stage=stage, path="/test")
+        url = api_invoke_url(api_id, stage=DEFAULT_STAGE_NAME, path="/test")
         response = requests.post(url, json={"kinesis": "snapshot"})
         assert response.status_code == 200
         snapshot.match("apigateway_response", response.json())
 
+    # push events to Kinesis via API
+    shard_iterator = kinesis_client.get_shard_iterator(
+        StreamName=stream_name, ShardIteratorType="LATEST", ShardId=shard_id
+    )["ShardIterator"]
     retry(_invoke_apigw_to_kinesis, retries=15, sleep=1)
 
+    # get records from stream
     get_records_response = kinesis_client.get_records(ShardIterator=shard_iterator)
     snapshot.match("kinesis_records", get_records_response)

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -98,6 +98,11 @@ APIGATEWAY_KINESIS_POLICY = {
     "Statement": [{"Effect": "Allow", "Action": "kinesis:*", "Resource": "*"}],
 }
 
+APIGATEWAY_DYNAMODB_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Allow", "Action": "dynamodb:*", "Resource": "*"}],
+}
+
 APIGATEWAY_ASSUME_ROLE_POLICY = {
     "Statement": {
         "Sid": "",

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -2036,7 +2036,7 @@ class TestAPIGateway:
         stage_name="staging",
     ):
         response_templates = response_templates or {}
-        integration_type = integration_type or "AWS_PROXY"
+        integration_type = integration_type or "AWS"
         apigw_client = aws_stack.create_external_boto_client("apigateway")
         response = apigw_client.create_rest_api(name="my_api", description="this is my api")
         api_id = response["id"]
@@ -2045,7 +2045,7 @@ class TestAPIGateway:
         root_id = root_resources[0]["id"]
 
         kwargs = {}
-        if integration_type == "AWS_PROXY":
+        if integration_type == "AWS":
             resource_util.create_dynamodb_table("MusicCollection", partition_key="id")
             kwargs[
                 "uri"

--- a/tests/integration/test_apigateway_api.py
+++ b/tests/integration/test_apigateway_api.py
@@ -294,6 +294,7 @@ def test_put_integration_response_with_response_template(apigateway_client):
     }
 
 
+# TODO: add snapshot test!
 def test_put_integration_validation(apigateway_client):
     response = apigateway_client.create_rest_api(name="my_api", description="this is my api")
     api_id = response["id"]
@@ -309,7 +310,7 @@ def test_put_integration_validation(apigateway_client):
 
     http_types = ["HTTP", "HTTP_PROXY"]
     aws_types = ["AWS", "AWS_PROXY"]
-    types_requiring_integration_method = http_types + aws_types
+    types_requiring_integration_method = http_types + ["AWS"]
     types_not_requiring_integration_method = ["MOCK"]
 
     for _type in types_requiring_integration_method:
@@ -404,35 +405,35 @@ def test_put_integration_validation(apigateway_client):
             )
         assert ex.value.response["Error"]["Code"] == "BadRequestException"
         assert ex.value.response["Error"]["Message"] == "Invalid HTTP endpoint specified for URI"
-    for _type in aws_types:
-        # Ensure that the URI is an ARN
-        with pytest.raises(ClientError) as ex:
-            apigateway_client.put_integration(
-                restApiId=api_id,
-                resourceId=root_id,
-                httpMethod="GET",
-                type=_type,
-                uri="non-valid-arn",
-                integrationHttpMethod="POST",
-            )
-        assert ex.value.response["Error"]["Code"] == "BadRequestException"
-        assert ex.value.response["Error"]["Message"] == "Invalid ARN specified in the request"
-    for _type in aws_types:
-        # Ensure that the URI is a valid ARN
-        with pytest.raises(ClientError) as ex:
-            apigateway_client.put_integration(
-                restApiId=api_id,
-                resourceId=root_id,
-                httpMethod="GET",
-                type=_type,
-                uri="arn:aws:iam::0000000000:role/service-role/asdf",
-                integrationHttpMethod="POST",
-            )
-        assert ex.value.response["Error"]["Code"] == "BadRequestException"
-        assert (
-            ex.value.response["Error"]["Message"] == "AWS ARN for integration must contain path or "
-            "action"
+
+    # Ensure that the URI is an ARN
+    with pytest.raises(ClientError) as ex:
+        apigateway_client.put_integration(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="GET",
+            type="AWS",
+            uri="non-valid-arn",
+            integrationHttpMethod="POST",
         )
+    assert ex.value.response["Error"]["Code"] == "BadRequestException"
+    assert ex.value.response["Error"]["Message"] == "Invalid ARN specified in the request"
+
+    # Ensure that the URI is a valid ARN
+    with pytest.raises(ClientError) as ex:
+        apigateway_client.put_integration(
+            restApiId=api_id,
+            resourceId=root_id,
+            httpMethod="GET",
+            type="AWS",
+            uri="arn:aws:iam::0000000000:role/service-role/asdf",
+            integrationHttpMethod="POST",
+        )
+    assert ex.value.response["Error"]["Code"] == "BadRequestException"
+    assert (
+        ex.value.response["Error"]["Message"] == "AWS ARN for integration must contain path or "
+        "action"
+    )
 
 
 def test_create_domain_names(apigateway_client):


### PR DESCRIPTION
Enhance parity for API Gateway DynamoDB integrations. Follow-up from https://github.com/localstack/localstack/pull/7572

The PR also contains a few refactorings, starting to pull more of the service-specific integrations as classes into `integrations.py`

Summary of changes:
* pull out logic for Kinesis/DDB integrations into separate `KinesisIntegration` and `DynamoDBIntegration`
* add snapshot test for DDB integration
* introduce a couple more `@patch` decorators for API GW patches
* add `BadRequestException` for incorrect use of `AWS_PROXY` integration (AWS parity)
* extract generic `create_rest_api_with_integration` fixture that can used for DDB&Kinesis integration tests (and other integrations in the future)