### PR TITLE
Enable generic actions and enhance parity for DynamoDB API GW integration

### DIFF
--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -492,7 +492,7 @@ class S3Integration(BackendIntegration):
         try:
             object = s3.get_object(Bucket=bucket, Key=object_key)
         except s3.exceptions.NoSuchKey:
-            msg = "Object %s not found" % object_key
+            msg = f"Object {object_key} not found"
             LOG.debug(msg)
             return make_error_response(msg, 404)
 

--- a/localstack/services/apigateway/integration.py
+++ b/localstack/services/apigateway/integration.py
@@ -1,15 +1,19 @@
 import base64
 import json
 import logging
+import re
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from http import HTTPStatus
 from typing import Any, Dict, List, Union
+from urllib.parse import urljoin
 
+import requests
 from moto.apigatewayv2.exceptions import BadRequestException
 from requests import Response
 
 from localstack import config
+from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON, HEADER_CONTENT_TYPE
 from localstack.services.apigateway import helpers
 from localstack.services.apigateway.context import ApiInvocationContext
@@ -30,11 +34,15 @@ from localstack.services.stepfunctions.stepfunctions_utils import await_sfn_exec
 from localstack.utils import common
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_region_from_arn
-from localstack.utils.aws.aws_responses import LambdaResponse, requests_response
+from localstack.utils.aws.aws_responses import (
+    LambdaResponse,
+    request_response_stream,
+    requests_response,
+)
 from localstack.utils.aws.templating import VtlTemplate
 from localstack.utils.collections import remove_attributes
 from localstack.utils.common import make_http_request, to_str
-from localstack.utils.http import canonicalize_headers, parse_request_data
+from localstack.utils.http import add_query_params_to_url, canonicalize_headers, parse_request_data
 from localstack.utils.json import json_safe
 from localstack.utils.strings import camel_to_snake_case, to_bytes
 
@@ -90,26 +98,6 @@ class BackendIntegration(ABC):
                 header_name = key[len("method.response.header.") :]
                 response.headers[header_name] = value.strip("'")
         return response
-
-
-class SnsIntegration(BackendIntegration):
-    def invoke(self, invocation_context: ApiInvocationContext) -> Response:
-        invocation_context.context = get_event_request_context(invocation_context)
-        try:
-            payload = self.request_templates.render(invocation_context)
-        except Exception as e:
-            LOG.warning("Failed to apply template for SNS integration", e)
-            raise
-        uri = (
-            invocation_context.integration.get("uri")
-            or invocation_context.integration.get("integrationUri")
-            or ""
-        )
-        region_name = uri.split(":")[3]
-        headers = aws_stack.mock_aws_request_headers(service="sns", region_name=region_name)
-        return make_http_request(
-            config.service_url("sns"), method="POST", headers=headers, data=payload
-        )
 
 
 def call_lambda(function_arn: str, event: bytes, asynchronous: bool) -> str:
@@ -439,134 +427,170 @@ class KinesisIntegration(BackendIntegration):
 
 class DynamoDBIntegration(BackendIntegration):
     def invoke(self, invocation_context: ApiInvocationContext):
-        method = invocation_context.method
-        data = invocation_context.data
         integration = invocation_context.integration
-        integration_response = integration.get("integrationResponses", {})
-        response_templates = integration_response.get("200", {}).get("responseTemplates", {})
         uri = integration.get("uri") or integration.get("integrationUri") or ""
 
         # example: arn:aws:apigateway:us-east-1:dynamodb:action/PutItem&Table=MusicCollection
         action = uri.split(":dynamodb:action/")[1].split("&")[0]
 
-        if "PutItem" in action and method == "PUT":
-            table_name = uri.split(":dynamodb:action")[1].split("&Table=")[1]
-            response_template = response_templates.get("application/json")
+        # render request template
+        payload = self.request_templates.render(invocation_context)
+        payload = json.loads(payload)
 
-            if response_template is None:
-                msg = "Invalid response template defined in integration response."
-                LOG.info("%s Existing: %s", msg, response_templates)
-                return make_error_response(msg, 404)
+        # determine target method via reflection
+        dynamo_client = aws_stack.connect_to_service("dynamodb")
+        method_name = camel_to_snake_case(action)
+        client_method = getattr(dynamo_client, method_name, None)
+        if not client_method:
+            raise Exception(f"Unsupported action {action} in API Gateway integration URI {uri}")
 
-            response_template = json.loads(response_template)
-            if response_template["TableName"] != table_name:
-                # TODO: check if this error is valid (AWS parity)
-                msg = "Invalid table name specified in integration response template."
-                return make_error_response(msg, 404)
+        # run request against DynamoDB backend
+        response = client_method(**payload)
 
-            dynamo_client = aws_stack.connect_to_resource("dynamodb")
-            table = dynamo_client.Table(table_name)
+        # apply response templates
+        response_content = json.dumps(remove_attributes(response, ["ResponseMetadata"]))
+        response_obj = requests_response(content=response_content)
+        response = self.response_templates.render(invocation_context, response=response_obj)
 
-            event_data = {}
-            data_dict = json.loads(data)
-            for key, _ in response_template["Item"].items():
-                event_data[key] = data_dict[key]
-
-            table.put_item(Item=event_data)
-            response = requests_response(event_data)
-            return response
-
-        if "Query" in action:
-            template = integration["requestTemplates"].get(APPLICATION_JSON)
-
-            if template is None:
-                msg = "No request template is defined in the integration."
-                LOG.info("%s Existing: %s", msg, response_templates)
-                return make_error_response(msg, 404)
-
-            response_template = response_templates.get(APPLICATION_JSON)
-
-            if response_template is None:
-                msg = "Invalid response template defined in integration response."
-                LOG.info("%s Existing: %s", msg, response_templates)
-                return make_error_response(msg, 404)
-
-            # render request template
-            payload = self.request_templates.render(invocation_context)
-            payload = json.loads(payload)
-
-            # query data from DynamoDB
-            dynamo_client = aws_stack.connect_to_service("dynamodb")
-            response = dynamo_client.query(**payload)
-
-            if "Items" not in response:
-                msg = "Items not found in DynamoDB"
-                LOG.info("%s - existing: %s", msg, response_template)
-                return make_error_response(msg, 404)
-
-            # apply response templates
-            response_content = json.dumps(remove_attributes(response, ["ResponseMetadata"]))
-            response_obj = requests_response(content=response_content)
-            response = self.response_templates.render(invocation_context, response=response_obj)
-
-            # construct final response
-            response = requests_response(response)
-            invocation_context.response = response
-            return response
-
-        raise Exception(f"Unsupported action {action} in API Gateway integration URI {uri}")
-
-
-class MockIntegration(BackendIntegration):
-    @classmethod
-    def check_passthrough_behavior(cls, passthrough_behavior: str, request_template: str):
-        return MappingTemplates(passthrough_behavior).check_passthrough_behavior(request_template)
-
-    def invoke(self, invocation_context: ApiInvocationContext) -> Response:
-        passthrough_behavior = invocation_context.integration.get("passthroughBehavior") or ""
-        request_template = invocation_context.integration.get("requestTemplates", {}).get(
-            invocation_context.headers.get(HEADER_CONTENT_TYPE, APPLICATION_JSON)
-        )
-
-        # based on the configured passthrough behavior and the existence of template or not,
-        # we proceed calling the integration or raise an exception.
-        try:
-            self.check_passthrough_behavior(passthrough_behavior, request_template)
-        except MappingTemplates.UnsupportedMediaType:
-            return MockIntegration._create_response(
-                HTTPStatus.UNSUPPORTED_MEDIA_TYPE.value,
-                headers={"Content-Type": APPLICATION_JSON},
-                data=json.dumps({"message": f"{HTTPStatus.UNSUPPORTED_MEDIA_TYPE.phrase}"}),
-            )
-
-        # request template rendering
-        request_payload = self.request_templates.render(invocation_context)
-
-        # mapping is done based on "statusCode" field, we default to 200
-        status_code = 200
-        if invocation_context.headers.get(HEADER_CONTENT_TYPE) == APPLICATION_JSON:
-            try:
-                mock_response = json.loads(request_payload)
-                status_code = mock_response.get("statusCode", status_code)
-            except Exception as e:
-                LOG.warning("failed to deserialize request payload after transformation: %s", e)
-                http_status = HTTPStatus(500)
-                return MockIntegration._create_response(
-                    http_status.value,
-                    headers={"Content-Type": APPLICATION_JSON},
-                    data=json.dumps({"message": f"{http_status.phrase}"}),
-                )
-
-        # response template
-        response = MockIntegration._create_response(
-            status_code, invocation_context.headers, data=request_payload
-        )
-        response._content = self.response_templates.render(invocation_context, response=response)
-        # apply response parameters
-        response = self.apply_response_parameters(invocation_context, response)
-        if not invocation_context.headers.get(HEADER_CONTENT_TYPE):
-            invocation_context.headers.update({HEADER_CONTENT_TYPE: APPLICATION_JSON})
+        # construct final response
+        response = requests_response(response)
+        invocation_context.response = response
         return response
+
+
+class S3Integration(BackendIntegration):
+    # target ARN patterns
+    TARGET_REGEX_PATH_S3_URI = (
+        r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
+    )
+    TARGET_REGEX_ACTION_S3_URI = r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
+
+    def invoke(self, invocation_context: ApiInvocationContext):
+        invocation_path = invocation_context.path_with_query_string
+        integration = invocation_context.integration
+        path_params = invocation_context.path_params
+        relative_path, query_string_params = extract_query_string_params(path=invocation_path)
+        uri = integration.get("uri") or integration.get("integrationUri") or ""
+
+        s3 = aws_stack.connect_to_service("s3")
+        uri = apply_request_parameters(
+            uri,
+            integration=integration,
+            path_params=path_params,
+            query_params=query_string_params,
+        )
+        uri_match = re.match(self.TARGET_REGEX_PATH_S3_URI, uri) or re.match(
+            self.TARGET_REGEX_ACTION_S3_URI, uri
+        )
+        if not uri_match:
+            msg = "Request URI does not match s3 specifications"
+            LOG.warning(msg)
+            return make_error_response(msg, 400)
+
+        bucket, object_key = uri_match.group("bucket", "object")
+        LOG.debug("Getting request for bucket %s object %s", bucket, object_key)
+        try:
+            object = s3.get_object(Bucket=bucket, Key=object_key)
+        except s3.exceptions.NoSuchKey:
+            msg = "Object %s not found" % object_key
+            LOG.debug(msg)
+            return make_error_response(msg, 404)
+
+        headers = aws_stack.mock_aws_request_headers(service="s3")
+
+        if object.get("ContentType"):
+            headers["Content-Type"] = object["ContentType"]
+
+        # stream used so large files do not fill memory
+        response = request_response_stream(stream=object["Body"], headers=headers)
+        return response
+
+
+class HTTPIntegration(BackendIntegration):
+    def invoke(self, invocation_context: ApiInvocationContext):
+        invocation_path = invocation_context.path_with_query_string
+        integration = invocation_context.integration
+        path_params = invocation_context.path_params
+        method = invocation_context.method
+        headers = invocation_context.headers
+        relative_path, query_string_params = extract_query_string_params(path=invocation_path)
+        uri = integration.get("uri") or integration.get("integrationUri") or ""
+
+        if ":servicediscovery:" in uri:
+            # check if this is a servicediscovery integration URI
+            client = aws_stack.connect_to_service("servicediscovery")
+            service_id = uri.split("/")[-1]
+            instances = client.list_instances(ServiceId=service_id)["Instances"]
+            instance = (instances or [None])[0]
+            if instance and instance.get("Id"):
+                uri = "http://%s/%s" % (instance["Id"], invocation_path.lstrip("/"))
+
+        # apply custom request template
+        invocation_context.context = helpers.get_event_request_context(invocation_context)
+        invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
+        request_templates = RequestTemplates()
+        payload = request_templates.render(invocation_context)
+
+        if isinstance(payload, dict):
+            payload = json.dumps(payload)
+
+        uri = apply_request_parameters(
+            uri,
+            integration=integration,
+            path_params=path_params,
+            query_params=query_string_params,
+        )
+        result = requests.request(method=method, url=uri, data=payload, headers=headers)
+        # apply custom response template
+        invocation_context.response = result
+        response_templates = ResponseTemplates()
+        response_templates.render(invocation_context)
+        return invocation_context.response
+
+
+class SQSIntegration(BackendIntegration):
+    def invoke(self, invocation_context: ApiInvocationContext):
+        integration = invocation_context.integration
+        uri = integration.get("uri") or integration.get("integrationUri") or ""
+
+        template = integration["requestTemplates"].get(APPLICATION_JSON)
+        account_id, queue = uri.split("/")[-2:]
+        region_name = uri.split(":")[3]
+        if "GetQueueUrl" in template or "CreateQueue" in template:
+            request_templates = RequestTemplates()
+            payload = request_templates.render(invocation_context)
+            new_request = f"{payload}&QueueName={queue}"
+        else:
+            request_templates = RequestTemplates()
+            payload = request_templates.render(invocation_context)
+            queue_url = f"{config.get_edge_url()}/{account_id}/{queue}"
+            new_request = f"{payload}&QueueUrl={queue_url}"
+        headers = aws_stack.mock_aws_request_headers(service="sqs", region_name=region_name)
+
+        url = urljoin(config.service_url("sqs"), f"{get_aws_account_id()}/{queue}")
+        result = common.make_http_request(url, method="POST", headers=headers, data=new_request)
+        return result
+
+
+class SNSIntegration(BackendIntegration):
+    def invoke(self, invocation_context: ApiInvocationContext) -> Response:
+        # TODO: check if the logic below is accurate - cover with snapshot tests!
+        invocation_context.context = get_event_request_context(invocation_context)
+        invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
+        integration = invocation_context.integration
+        uri = integration.get("uri") or integration.get("integrationUri") or ""
+
+        try:
+            payload = self.request_templates.render(invocation_context)
+        except Exception as e:
+            LOG.warning("Failed to apply template for SNS integration", e)
+            raise
+        region_name = uri.split(":")[3]
+        headers = aws_stack.mock_aws_request_headers(service="sns", region_name=region_name)
+        result = make_http_request(
+            config.service_url("sns"), method="POST", headers=headers, data=payload
+        )
+        return self.apply_response_parameters(invocation_context, result)
 
 
 class StepFunctionIntegration(BackendIntegration):
@@ -622,7 +646,7 @@ class StepFunctionIntegration(BackendIntegration):
             )
 
         result = method(**payload)
-        result = json_safe(remove_attributes(result, "ResponseMetadata"))
+        result = json_safe(remove_attributes(result, ["ResponseMetadata"]))
         response = StepFunctionIntegration._create_response(
             HTTPStatus.OK.value, aws_stack.mock_aws_request_headers(), data=result
         )
@@ -668,3 +692,79 @@ class StepFunctionIntegration(BackendIntegration):
             "stateMachineArn": request_parameters.get("StateMachineArn"),
             "input": rendered_input,
         }
+
+
+class MockIntegration(BackendIntegration):
+    @classmethod
+    def check_passthrough_behavior(cls, passthrough_behavior: str, request_template: str):
+        return MappingTemplates(passthrough_behavior).check_passthrough_behavior(request_template)
+
+    def invoke(self, invocation_context: ApiInvocationContext) -> Response:
+        passthrough_behavior = invocation_context.integration.get("passthroughBehavior") or ""
+        request_template = invocation_context.integration.get("requestTemplates", {}).get(
+            invocation_context.headers.get(HEADER_CONTENT_TYPE, APPLICATION_JSON)
+        )
+
+        # based on the configured passthrough behavior and the existence of template or not,
+        # we proceed calling the integration or raise an exception.
+        try:
+            self.check_passthrough_behavior(passthrough_behavior, request_template)
+        except MappingTemplates.UnsupportedMediaType:
+            return MockIntegration._create_response(
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE.value,
+                headers={"Content-Type": APPLICATION_JSON},
+                data=json.dumps({"message": f"{HTTPStatus.UNSUPPORTED_MEDIA_TYPE.phrase}"}),
+            )
+
+        # request template rendering
+        request_payload = self.request_templates.render(invocation_context)
+
+        # mapping is done based on "statusCode" field, we default to 200
+        status_code = 200
+        if invocation_context.headers.get(HEADER_CONTENT_TYPE) == APPLICATION_JSON:
+            try:
+                mock_response = json.loads(request_payload)
+                status_code = mock_response.get("statusCode", status_code)
+            except Exception as e:
+                LOG.warning("failed to deserialize request payload after transformation: %s", e)
+                http_status = HTTPStatus(500)
+                return MockIntegration._create_response(
+                    http_status.value,
+                    headers={"Content-Type": APPLICATION_JSON},
+                    data=json.dumps({"message": f"{http_status.phrase}"}),
+                )
+
+        # response template
+        response = MockIntegration._create_response(
+            status_code, invocation_context.headers, data=request_payload
+        )
+        response._content = self.response_templates.render(invocation_context, response=response)
+        # apply response parameters
+        response = self.apply_response_parameters(invocation_context, response)
+        if not invocation_context.headers.get(HEADER_CONTENT_TYPE):
+            invocation_context.headers.update({HEADER_CONTENT_TYPE: APPLICATION_JSON})
+        return response
+
+
+# TODO: remove once we migrate all usages to `apply_request_parameters` on BackendIntegration
+def apply_request_parameters(
+    uri: str, integration: Dict[str, Any], path_params: Dict[str, str], query_params: Dict[str, str]
+):
+    request_parameters = integration.get("requestParameters")
+    uri = uri or integration.get("uri") or integration.get("integrationUri") or ""
+    if request_parameters:
+        for key in path_params:
+            # check if path_params is present in the integration request parameters
+            request_param_key = f"integration.request.path.{key}"
+            request_param_value = f"method.request.path.{key}"
+            if request_parameters.get(request_param_key) == request_param_value:
+                uri = uri.replace(f"{{{key}}}", path_params[key])
+
+    if integration.get("type") != "HTTP_PROXY" and request_parameters:
+        for key in query_params.copy():
+            request_query_key = f"integration.request.querystring.{key}"
+            request_param_val = f"method.request.querystring.{key}"
+            if request_parameters.get(request_query_key, None) != request_param_val:
+                query_params.pop(key)
+
+    return add_query_params_to_url(uri, query_params)

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -258,6 +258,8 @@ def invoke_rest_api_integration(invocation_context: ApiInvocationContext):
         return make_error_response(msg, 400)
 
 
+# This function is patched downstream for backend integrations that are only available
+# in Pro (potentially to be replaced with a runtime hook in the future).
 def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext):
     # define local aliases from invocation context
     invocation_path = invocation_context.path_with_query_string

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -1,15 +1,10 @@
 import json
 import logging
-import re
-from typing import Any, Dict, Union
-from urllib.parse import urljoin
+from typing import Dict
 
-import requests
 from jsonschema import ValidationError, validate
 from requests.models import Response
 
-from localstack import config
-from localstack.aws.accounts import get_aws_account_id
 from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway import helpers
 from localstack.services.apigateway.context import ApiInvocationContext
@@ -21,32 +16,19 @@ from localstack.services.apigateway.helpers import (
 )
 from localstack.services.apigateway.integration import (
     DynamoDBIntegration,
+    HTTPIntegration,
     KinesisIntegration,
     LambdaIntegration,
     LambdaProxyIntegration,
     MockIntegration,
-    SnsIntegration,
+    S3Integration,
+    SNSIntegration,
+    SQSIntegration,
     StepFunctionIntegration,
 )
-from localstack.services.apigateway.templates import (
-    RequestTemplates,
-    ResponseTemplates,
-    VtlTemplate,
-)
-from localstack.utils import common
 from localstack.utils.aws import aws_stack
-from localstack.utils.aws.aws_responses import request_response_stream
-from localstack.utils.http import add_query_params_to_url
 
 LOG = logging.getLogger(__name__)
-
-# target ARN patterns
-TARGET_REGEX_PATH_S3_URI = (
-    r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:path/(?P<bucket>[^/]+)/(?P<object>.+)$"
-)
-TARGET_REGEX_ACTION_S3_URI = r"^arn:aws:apigateway:[a-zA-Z0-9\-]+:s3:action/(?:GetObject&Bucket\=(?P<bucket>[^&]+)&Key\=(?P<object>.+))$"
-
-# TODO: refactor / split up this file into suitable submodules
 
 
 class AuthorizationError(Exception):
@@ -183,30 +165,6 @@ def update_content_length(response: Response):
         response.headers["Content-Length"] = str(len(response.content))
 
 
-# TODO: remove once we migrate all usages to `apply_request_parameters` on BackendIntegration
-def apply_request_parameters(
-    uri: str, integration: Dict[str, Any], path_params: Dict[str, str], query_params: Dict[str, str]
-):
-    request_parameters = integration.get("requestParameters")
-    uri = uri or integration.get("uri") or integration.get("integrationUri") or ""
-    if request_parameters:
-        for key in path_params:
-            # check if path_params is present in the integration request parameters
-            request_param_key = f"integration.request.path.{key}"
-            request_param_value = f"method.request.path.{key}"
-            if request_parameters.get(request_param_key) == request_param_value:
-                uri = uri.replace(f"{{{key}}}", path_params[key])
-
-    if integration.get("type") != "HTTP_PROXY" and request_parameters:
-        for key in query_params.copy():
-            request_query_key = f"integration.request.querystring.{key}"
-            request_param_val = f"method.request.querystring.{key}"
-            if request_parameters.get(request_query_key, None) != request_param_val:
-                query_params.pop(key)
-
-    return add_query_params_to_url(uri, query_params)
-
-
 def apply_response_parameters(invocation_context: ApiInvocationContext):
     response = invocation_context.response
     integration = invocation_context.integration
@@ -300,11 +258,6 @@ def invoke_rest_api_integration(invocation_context: ApiInvocationContext):
         return make_error_response(msg, 400)
 
 
-# TODO: refactor this to have a class per integration type to make it easy to
-# test the encapsulated logic
-
-# this call is patched downstream for backend integrations that are only available
-# in the PRO version
 def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext):
     # define local aliases from invocation context
     invocation_path = invocation_context.path_with_query_string
@@ -312,8 +265,6 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
     headers = invocation_context.headers
     resource_path = invocation_context.resource_path
     integration = invocation_context.integration
-    integration_response = integration.get("integrationResponses", {})
-    response_templates = integration_response.get("200", {}).get("responseTemplates", {})
     # extract integration type and path parameters
     relative_path, query_string_params = extract_query_string_params(path=invocation_path)
     integration_type_orig = integration.get("type") or integration.get("integrationType") or ""
@@ -321,10 +272,11 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
     uri = integration.get("uri") or integration.get("integrationUri") or ""
 
     try:
-        path_params = extract_path_params(path=relative_path, extracted_path=resource_path)
-        invocation_context.path_params = path_params
+        invocation_context.path_params = extract_path_params(
+            path=relative_path, extracted_path=resource_path
+        )
     except Exception:
-        path_params = {}
+        invocation_context.path_params = {}
 
     if (uri.startswith("arn:aws:apigateway:") and ":lambda:path" in uri) or uri.startswith(
         "arn:aws:lambda"
@@ -333,10 +285,6 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
             return LambdaProxyIntegration().invoke(invocation_context)
         elif integration_type == "AWS":
             return LambdaIntegration().invoke(invocation_context)
-
-        raise Exception(
-            f'Unsupported API Gateway integration type "{integration_type}", action "{uri}", method "{method}"'
-        )
 
     elif integration_type == "AWS":
         if "kinesis:action/" in uri:
@@ -348,109 +296,20 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
         if ":dynamodb:action" in uri:
             return DynamoDBIntegration().invoke(invocation_context)
 
-        # https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/
-        if ("s3:path/" in uri or "s3:action/" in uri) and method == "GET":
-            s3 = aws_stack.connect_to_service("s3")
-            uri = apply_request_parameters(
-                uri,
-                integration=integration,
-                path_params=path_params,
-                query_params=query_string_params,
-            )
-            uri_match = re.match(TARGET_REGEX_PATH_S3_URI, uri) or re.match(
-                TARGET_REGEX_ACTION_S3_URI, uri
-            )
-            if uri_match:
-                bucket, object_key = uri_match.group("bucket", "object")
-                LOG.debug("Getting request for bucket %s object %s", bucket, object_key)
-                try:
-                    object = s3.get_object(Bucket=bucket, Key=object_key)
-                except s3.exceptions.NoSuchKey:
-                    msg = "Object %s not found" % object_key
-                    LOG.debug(msg)
-                    return make_error_response(msg, 404)
-
-                headers = aws_stack.mock_aws_request_headers(service="s3")
-
-                if object.get("ContentType"):
-                    headers["Content-Type"] = object["ContentType"]
-
-                # stream used so large files do not fill memory
-                response = request_response_stream(stream=object["Body"], headers=headers)
-                return response
-            else:
-                msg = "Request URI does not match s3 specifications"
-                LOG.warning(msg)
-                return make_error_response(msg, 400)
+        if "s3:path/" in uri or "s3:action/" in uri:
+            return S3Integration().invoke(invocation_context)
 
         if method == "POST" and ":sqs:path" in uri:
-            template = integration["requestTemplates"].get(APPLICATION_JSON)
-            account_id, queue = uri.split("/")[-2:]
-            region_name = uri.split(":")[3]
-            if "GetQueueUrl" in template or "CreateQueue" in template:
-                request_templates = RequestTemplates()
-                payload = request_templates.render(invocation_context)
-                new_request = f"{payload}&QueueName={queue}"
-            else:
-                request_templates = RequestTemplates()
-                payload = request_templates.render(invocation_context)
-                queue_url = f"{config.get_edge_url()}/{account_id}/{queue}"
-                new_request = f"{payload}&QueueUrl={queue_url}"
-            headers = aws_stack.mock_aws_request_headers(service="sqs", region_name=region_name)
-
-            url = urljoin(config.service_url("sqs"), f"{get_aws_account_id()}/{queue}")
-            result = common.make_http_request(url, method="POST", headers=headers, data=new_request)
-            return result
+            return SQSIntegration().invoke(invocation_context)
 
         if method == "POST" and ":sns:path" in uri:
-            invocation_context.context = helpers.get_event_request_context(invocation_context)
-            invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
-
-            integration_response = SnsIntegration().invoke(invocation_context)
-            return apply_request_response_templates(
-                integration_response, response_templates, content_type=APPLICATION_JSON
-            )
-
-        raise Exception(
-            f'API Gateway action uri "{uri}", integration type {integration_type} not yet implemented'
-        )
+            return SNSIntegration().invoke(invocation_context)
 
     elif integration_type in ["HTTP_PROXY", "HTTP"]:
-
-        if ":servicediscovery:" in uri:
-            # check if this is a servicediscovery integration URI
-            client = aws_stack.connect_to_service("servicediscovery")
-            service_id = uri.split("/")[-1]
-            instances = client.list_instances(ServiceId=service_id)["Instances"]
-            instance = (instances or [None])[0]
-            if instance and instance.get("Id"):
-                uri = "http://%s/%s" % (instance["Id"], invocation_path.lstrip("/"))
-
-        # apply custom request template
-        invocation_context.context = helpers.get_event_request_context(invocation_context)
-        invocation_context.stage_variables = helpers.get_stage_variables(invocation_context)
-        request_templates = RequestTemplates()
-        payload = request_templates.render(invocation_context)
-
-        if isinstance(payload, dict):
-            payload = json.dumps(payload)
-
-        uri = apply_request_parameters(
-            uri,
-            integration=integration,
-            path_params=path_params,
-            query_params=query_string_params,
-        )
-        result = requests.request(method=method, url=uri, data=payload, headers=headers)
-        # apply custom response template
-        invocation_context.response = result
-        response_templates = ResponseTemplates()
-        response_templates.render(invocation_context)
-        return invocation_context.response
+        return HTTPIntegration().invoke(invocation_context)
 
     elif integration_type == "MOCK":
-        mock_integration = MockIntegration()
-        return mock_integration.invoke(invocation_context)
+        return MockIntegration().invoke(invocation_context)
 
     if method == "OPTIONS":
         # fall back to returning CORS headers if this is an OPTIONS request
@@ -459,26 +318,3 @@ def invoke_rest_api_integration_backend(invocation_context: ApiInvocationContext
     raise Exception(
         f'API Gateway integration type "{integration_type}", method "{method}", URI "{uri}" not yet implemented'
     )
-
-
-def apply_request_response_templates(
-    data: Union[Response, bytes],
-    templates: Dict[str, str],
-    content_type: str = None,
-    as_json: bool = False,
-):
-    """Apply the matching request/response template (if it exists) to the payload data and return the result"""
-
-    content_type = content_type or APPLICATION_JSON
-    is_response = isinstance(data, Response)
-    templates = templates or {}
-    template = templates.get(content_type)
-    if not template:
-        return data
-    content = (data.content if is_response else data) or ""
-    result = VtlTemplate().render_vtl(template, content, as_json=as_json)
-    if is_response:
-        data._content = result
-        update_content_length(data)
-        return data
-    return result

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -10,7 +10,6 @@ from localstack import config
 from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
-from localstack.utils.functions import run_safe
 from localstack.utils.json import extract_jsonpath, json_safe
 from localstack.utils.strings import to_str
 
@@ -178,13 +177,6 @@ class Templates:
 
     @staticmethod
     def build_variables_mapping(api_context: ApiInvocationContext):
-        # prepare request body
-        request_body = api_context.data
-        if isinstance(request_body, bytes):
-            request_body = to_str(request_body)
-        if isinstance(request_body, str):
-            request_body = run_safe(lambda: json.loads(request_body), _default=request_body)
-
         # TODO: make this (dict) an object so usages of "render_vtl" variables are defined
         return {
             "context": api_context.context or {},
@@ -199,12 +191,6 @@ class Templates:
                     # the template.
                     "header": dict(api_context.headers),
                 },
-            },
-            "request": {
-                "header": dict(api_context.headers),
-                "querystring": api_context.query_params(),
-                "path": api_context.invocation_path,
-                "body": request_body,
             },
         }
 

--- a/localstack/services/apigateway/templates.py
+++ b/localstack/services/apigateway/templates.py
@@ -10,6 +10,7 @@ from localstack import config
 from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.utils.aws.templating import VelocityUtil, VtlTemplate
+from localstack.utils.functions import run_safe
 from localstack.utils.json import extract_jsonpath, json_safe
 from localstack.utils.strings import to_str
 
@@ -177,6 +178,13 @@ class Templates:
 
     @staticmethod
     def build_variables_mapping(api_context: ApiInvocationContext):
+        # prepare request body
+        request_body = api_context.data
+        if isinstance(request_body, bytes):
+            request_body = to_str(request_body)
+        if isinstance(request_body, str):
+            request_body = run_safe(lambda: json.loads(request_body), _default=request_body)
+
         # TODO: make this (dict) an object so usages of "render_vtl" variables are defined
         return {
             "context": api_context.context or {},
@@ -191,6 +199,12 @@ class Templates:
                     # the template.
                     "header": dict(api_context.headers),
                 },
+            },
+            "request": {
+                "header": dict(api_context.headers),
+                "querystring": api_context.query_params(),
+                "path": api_context.invocation_path,
+                "body": request_body,
             },
         }
 

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -297,7 +297,8 @@ def remove_attributes(obj: Dict, attributes: List[str], recursive: bool = False)
             return o
 
         return recurse_object(obj, _remove)
-    attributes = attributes if is_list_or_tuple(attributes) else [attributes]
+
+    attributes = ensure_list(attributes)
     for attr in attributes:
         obj.pop(attr, None)
     return obj

--- a/tests/integration/apigateway/test_apigateway_dynamodb.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_dynamodb.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "tests/integration/apigateway/test_apigateway_dynamodb.py::test_rest_api_to_dynamodb_integration": {
-    "recorded-date": "25-02-2023, 19:14:23",
+  "tests/integration/apigateway/test_apigateway_dynamodb.py::test_error_aws_proxy_not_supported": {
+    "recorded-date": "26-02-2023, 12:45:17",
     "recorded-content": {
       "create-integration-error": {
         "Error": {
@@ -12,7 +12,40 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
         }
-      },
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_dynamodb.py::test_rest_api_to_dynamodb_integration[PutItem]": {
+    "recorded-date": "26-02-2023, 13:03:53",
+    "recorded-content": {
+      "result-put-item": {},
+      "result-scan": {
+        "Count": 4,
+        "Items": [
+          {
+            "id": "test"
+          },
+          {
+            "id": "test 3"
+          },
+          {
+            "id": "test-new"
+          },
+          {
+            "id": "test2"
+          }
+        ],
+        "ScannedCount": 4,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_dynamodb.py::test_rest_api_to_dynamodb_integration[Query]": {
+    "recorded-date": "26-02-2023, 13:04:46",
+    "recorded-content": {
       "result-test": {
         "Count": 1,
         "Items": [
@@ -50,6 +83,32 @@
         "Count": 0,
         "Items": [],
         "ScannedCount": 0
+      }
+    }
+  },
+  "tests/integration/apigateway/test_apigateway_dynamodb.py::test_rest_api_to_dynamodb_integration[Scan]": {
+    "recorded-date": "26-02-2023, 12:49:50",
+    "recorded-content": {
+      "result-scan": {
+        "Count": 3,
+        "Items": [
+          {
+            "id": {
+              "S": "test"
+            }
+          },
+          {
+            "id": {
+              "S": "test 3"
+            }
+          },
+          {
+            "id": {
+              "S": "test2"
+            }
+          }
+        ],
+        "ScannedCount": 3
       }
     }
   }

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -103,6 +103,12 @@ APIGATEWAY_DYNAMODB_POLICY = {
     "Statement": [{"Effect": "Allow", "Action": "dynamodb:*", "Resource": "*"}],
 }
 
+APIGATEWAY_LAMBDA_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Allow", "Action": "lambda:*", "Resource": "*"}],
+}
+
+
 APIGATEWAY_ASSUME_ROLE_POLICY = {
     "Statement": {
         "Sid": "",
@@ -110,10 +116,6 @@ APIGATEWAY_ASSUME_ROLE_POLICY = {
         "Principal": {"Service": "apigateway.amazonaws.com"},
         "Action": "sts:AssumeRole",
     }
-}
-APIGATEWAY_LAMBDA_POLICY = {
-    "Version": "2012-10-17",
-    "Statement": [{"Effect": "Allow", "Action": "lambda:*", "Resource": "*"}],
 }
 
 THIS_FOLDER = os.path.dirname(os.path.realpath(__file__))

--- a/tests/integration/test_apigateway.py
+++ b/tests/integration/test_apigateway.py
@@ -1325,7 +1325,10 @@ class TestAPIGateway:
             "application/json": json.dumps(
                 {
                     "TableName": "MusicCollection",
-                    "Item": {"id": {"S": "$request.body.id"}, "data": {"S": "$request.body.data"}},
+                    "Item": {
+                        "id": {"S": "$input.path('id')"},
+                        "data": {"S": "$input.path('data')"},
+                    },
                 }
             )
         }
@@ -1349,7 +1352,10 @@ class TestAPIGateway:
             "application/json": json.dumps(
                 {
                     "TableName": "MusicCollection",
-                    "Item": {"id": {"S": "$request.body.id"}, "data": {"S": "$request.body.data"}},
+                    "Item": {
+                        "id": {"S": "$input.path('id')"},
+                        "data": {"S": "$input.path('data')"},
+                    },
                 }
             )
         }
@@ -1402,7 +1408,10 @@ class TestAPIGateway:
             "application/json": json.dumps(
                 {
                     "TableName": "MusicCollection",
-                    "Item": {"id": {"S": "$request.body.id"}, "data": {"S": "$request.body.data"}},
+                    "Item": {
+                        "id": {"S": "$input.path('id')"},
+                        "data": {"S": "$input.path('data')"},
+                    },
                 }
             )
         }

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -18,12 +18,11 @@ from localstack.services.apigateway.helpers import (
     extract_query_string_params,
     get_resource_for_path,
 )
-from localstack.services.apigateway.integration import LambdaProxyIntegration
-from localstack.services.apigateway.invocations import (
-    ApiInvocationContext,
-    RequestValidator,
+from localstack.services.apigateway.integration import (
+    LambdaProxyIntegration,
     apply_request_parameters,
 )
+from localstack.services.apigateway.invocations import ApiInvocationContext, RequestValidator
 from localstack.services.apigateway.templates import (
     RequestTemplates,
     ResponseTemplates,


### PR DESCRIPTION
Enable generic actions and further enhance parity for DynamoDB API GW integration. Follow-up from #7753 

So far, we had support for `dynamodb:action/PutItem` and `dynamodb:action/Query` DynamoDB integrations. While working on deploying a more complex [AWS sample app](https://github.com/aws-samples/serverless-coffee-workshop) against LocalStack, the requirements for further integration operations came up (incl. `dynamodb:action/Scan`, among others). 

Summary of changes:
* make the DynamoDB integration generic - accepting any type of valid `dynamodb:action/*` integration action that can be executed against DynamoDB
* add snapshot test for additional DynamoDB integrations (incl. `PutItem`, `Scan`)
* refactor additional `invocations.py` into separate backend classes in `integrations.py`

/cc @calvernaz @bentsku @joe4dev 