### PR TITLE
Add lambda model and api updates

### DIFF
--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -80,6 +80,8 @@ VERSION_REGEX = re.compile(r"^[0-9]+$")
 # Rules: https://docs.aws.amazon.com/lambda/latest/dg/API_CreateAlias.html#SSS-CreateAlias-request-Name
 # The original regex from AWS misses ^ and $ in the second regex, which allowed for partial substring matches
 ALIAS_REGEX = re.compile(r"(?!^[0-9]+)(^[a-zA-Z0-9-_]+$)")
+# Permission statement id
+STATEMENT_ID_REGEX = re.compile(r"^[a-zA-Z0-9-_]+$")
 
 
 URL_CHAR_SET = string.ascii_lowercase + string.digits

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -468,6 +468,8 @@ def map_config_out(
         PackageType=version.config.package_type,
         TracingConfig=TracingConfig(Mode=version.config.tracing_config_mode),
         EphemeralStorage=EphemeralStorage(Size=version.config.ephemeral_storage.size),
+        # TODO: Do we return the model or build the SnapStart object?
+        SnapStart=version.config.snap_start,
         **optional_kwargs,
     )
     return func_conf

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -573,10 +573,11 @@ def parse_layer_arn(layer_version_arn: str):
     )
 
 
-# TODO: save list of valid runtimes somewhere
+# TODO: use list of valid runtimes from botocore through validators. See:
+#  https://github.com/localstack/localstack/pull/7675#discussion_r1107777058
 def validate_layer_runtime(compatible_runtime: str) -> str | None:
     if compatible_runtime is not None and compatible_runtime not in RUNTIMES:
-        return f"Value '{compatible_runtime}' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, java17, nodejs, nodejs4.3, java8.al2, go1.x, go1.9, byol, nodejs10.x, python3.10, java8, nodejs12.x, nodejs8.x, nodejs14.x, nodejs8.9, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, python3.4, ruby2.5, python3.6, python2.7]"
+        return f"Value '{compatible_runtime}' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, python3.10, java8, nodejs12.x, nodejs8.x, nodejs14.x, nodejs8.9, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby2.5, python3.6, python2.7]"
     return None
 
 

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -468,8 +468,8 @@ def map_config_out(
         PackageType=version.config.package_type,
         TracingConfig=TracingConfig(Mode=version.config.tracing_config_mode),
         EphemeralStorage=EphemeralStorage(Size=version.config.ephemeral_storage.size),
-        # TODO: Do we return the model or build the SnapStart object?
         SnapStart=version.config.snap_start,
+        RuntimeVersionConfig=version.config.runtime_version_config,
         **optional_kwargs,
     )
     return func_conf

--- a/localstack/services/awslambda/api_utils.py
+++ b/localstack/services/awslambda/api_utils.py
@@ -485,6 +485,7 @@ def map_to_list_response(config: FunctionConfiguration) -> FunctionConfiguration
         "LastUpdateStatus",
         "LastUpdateStatusReason",
         "LastUpdateStatusReasonCode",
+        "RuntimeVersionConfig",
     ]:
         shallow_copy.pop(k, None)
     return shallow_copy

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -78,6 +78,7 @@ IMAGE_MAPPING = {
     "provided": "provided:alami",
     "provided.al2": "provided:al2",
 }
+SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -24,6 +24,7 @@ from localstack.aws.api.lambda_ import (
     PackageType,
     ProvisionedConcurrencyStatusEnum,
     Runtime,
+    SnapStartResponse,
     State,
     StateReasonCode,
     TracingMode,
@@ -592,6 +593,7 @@ class VersionFunctionConfiguration:
     # internal revision is updated when runtime restart is necessary
     internal_revision: str
     ephemeral_storage: LambdaEphemeralStorage
+    snap_start: SnapStartResponse
 
     tracing_config_mode: TracingMode
     code: ArchiveCode

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -24,6 +24,7 @@ from localstack.aws.api.lambda_ import (
     PackageType,
     ProvisionedConcurrencyStatusEnum,
     Runtime,
+    RuntimeVersionConfig,
     SnapStartResponse,
     State,
     StateReasonCode,
@@ -595,6 +596,7 @@ class VersionFunctionConfiguration:
     internal_revision: str
     ephemeral_storage: LambdaEphemeralStorage
     snap_start: SnapStartResponse
+    runtime_version_config: RuntimeVersionConfig
 
     tracing_config_mode: TracingMode
     code: ArchiveCode

--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -596,7 +596,6 @@ class VersionFunctionConfiguration:
     internal_revision: str
     ephemeral_storage: LambdaEphemeralStorage
     snap_start: SnapStartResponse
-    runtime_version_config: RuntimeVersionConfig
 
     tracing_config_mode: TracingMode
     code: ArchiveCode
@@ -605,6 +604,7 @@ class VersionFunctionConfiguration:
 
     image: Optional[ImageCode] = None
     image_config: Optional[ImageConfig] = None
+    runtime_version_config: Optional[RuntimeVersionConfig] = None
     last_update: Optional[UpdateStatus] = None
     revision_id: str = dataclasses.field(init=False, default_factory=long_uid)
     layers: list[LayerVersion] = dataclasses.field(default_factory=list)

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -114,6 +114,7 @@ from localstack.aws.api.lambda_ import (
     ResourceConflictException,
     ResourceNotFoundException,
     Runtime,
+    RuntimeVersionConfig,
     ServiceException,
     SnapStart,
     SnapStartApplyOn,
@@ -693,6 +694,10 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     snap_start=SnapStartResponse(
                         ApplyOn=request.get("SnapStart", {}).get("ApplyOn", SnapStartApplyOn.None_),
                         OptimizationStatus=SnapStartOptimizationStatus.Off,
+                    ),
+                    runtime_version_config=RuntimeVersionConfig(
+                        # Limitation: the runtime id (presumably sha256 of image) is currently hardcoded
+                        RuntimeVersionArn=f"arn:aws:lambda:{context.region}::runtime:8eeff65f6809a3ce81507fe733fe09b835899b99481ba22fd75b5a7338290ec1"
                     ),
                     dead_letter_arn=request.get("DeadLetterConfig", {}).get("TargetArn"),
                     state=VersionState(

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -144,6 +144,7 @@ from localstack.services.awslambda.invocation.lambda_models import (
     LAMBDA_LIMITS_CREATE_FUNCTION_REQUEST_SIZE,
     LAMBDA_LIMITS_MAX_FUNCTION_ENVVAR_SIZE_BYTES,
     LAMBDA_MINIMUM_UNRESERVED_CONCURRENCY,
+    SNAP_START_SUPPORTED_RUNTIMES,
     AliasRoutingConfig,
     CodeSigningConfig,
     EventInvokeConfig,
@@ -580,11 +581,17 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 + " at 'role' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+"
             )
         package_type = request.get("PackageType", PackageType.Zip)
-        if package_type == PackageType.Zip and request.get("Runtime") not in IMAGE_MAPPING:
+        runtime = request.get("Runtime")
+        if package_type == PackageType.Zip and runtime not in IMAGE_MAPPING:
             raise InvalidParameterValueException(
                 f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
                 Type="User",
             )
+        if request.get("SnapStart"):
+            if runtime not in SNAP_START_SUPPORTED_RUNTIMES:
+                raise InvalidParameterValueException(
+                    f"{runtime} is not supported for SnapStart enabled functions.", Type="User"
+                )
         state = lambda_stores[context.account_id][context.region]
 
         function_name = request["FunctionName"]

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -115,6 +115,9 @@ from localstack.aws.api.lambda_ import (
     ResourceNotFoundException,
     Runtime,
     ServiceException,
+    SnapStartApplyOn,
+    SnapStartOptimizationStatus,
+    SnapStartResponse,
     State,
     StatementId,
     StateReasonCode,
@@ -657,6 +660,10 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                     internal_revision=short_uid(),
                     ephemeral_storage=LambdaEphemeralStorage(
                         size=request.get("EphemeralStorage", {}).get("Size", 512)
+                    ),
+                    snap_start=SnapStartResponse(
+                        ApplyOn=SnapStartApplyOn.None_,
+                        OptimizationStatus=SnapStartOptimizationStatus.Off,
                     ),
                     dead_letter_arn=request.get("DeadLetterConfig", {}).get("TargetArn"),
                     state=VersionState(

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -1222,7 +1222,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         for key, value in routing_config_dict.items():
             if value < 0.0 or value >= 1.0:
                 raise ValidationException(
-                    f"1 validation error detected: Value '{{{key}={value}}}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map value must satisfy constraint: [Member must have value less than or equal to 1.0, Member must have value greater than or equal to 0.0]"
+                    f"1 validation error detected: Value '{{{key}={value}}}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map value must satisfy constraint: [Member must have value less than or equal to 1.0, Member must have value greater than or equal to 0.0, Member must not be null]"
                 )
             if key == function_version.id.qualifier:
                 raise InvalidParameterValueException(
@@ -1236,7 +1236,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 )
             if not api_utils.qualifier_is_version(key):
                 raise ValidationException(
-                    f"1 validation error detected: Value '{{{key}={value}}}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map keys must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: [0-9]+]"
+                    f"1 validation error detected: Value '{{{key}={value}}}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map keys must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: [0-9]+, Member must not be null]"
                 )
 
             # checking if the version in the config exists

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -597,11 +597,18 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 Type="User",
             )
         if request.get("SnapStart"):
+            apply_on = request.get("SnapStart").get("ApplyOn")
+            if apply_on not in [
+                SnapStartApplyOn.PublishedVersions,
+                SnapStartApplyOn.None_,
+            ]:
+                raise ValidationException(
+                    f"1 validation error detected: Value '{apply_on}' at 'snapStart.applyOn' failed to satisfy constraint: Member must satisfy enum value set: [PublishedVersions, None]"
+                )
             if runtime not in SNAP_START_SUPPORTED_RUNTIMES:
                 raise InvalidParameterValueException(
                     f"{runtime} is not supported for SnapStart enabled functions.", Type="User"
                 )
-        #     TODO: ApplyOn valid values check
         state = lambda_stores[context.account_id][context.region]
 
         function_name = request["FunctionName"]

--- a/localstack/utils/container_utils/container_client.py
+++ b/localstack/utils/container_utils/container_client.py
@@ -516,12 +516,19 @@ class ContainerClient(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def build_image(self, dockerfile_path: str, image_name: str, context_path: str = None) -> None:
+    def build_image(
+        self,
+        dockerfile_path: str,
+        image_name: str,
+        context_path: str = None,
+        platform: Optional[DockerPlatform] = None,
+    ) -> None:
         """Builds an image from the given Dockerfile
 
         :param dockerfile_path: Path to Dockerfile, or a directory that contains a Dockerfile
         :param image_name: Name of the image to be built
         :param context_path: Path for build context (defaults to dirname of Dockerfile)
+        :param platform: Target platform for build (defaults to platform of Docker host)
         """
         pass
 

--- a/localstack/utils/container_utils/docker_cmd_client.py
+++ b/localstack/utils/container_utils/docker_cmd_client.py
@@ -296,11 +296,20 @@ class CmdDockerClient(ContainerClient):
                 f"Docker process returned with errorcode {e.returncode}", e.stdout, e.stderr
             ) from e
 
-    def build_image(self, dockerfile_path: str, image_name: str, context_path: str = None):
+    def build_image(
+        self,
+        dockerfile_path: str,
+        image_name: str,
+        context_path: str = None,
+        platform: Optional[DockerPlatform] = None,
+    ):
         cmd = self._docker_cmd()
         dockerfile_path = Util.resolve_dockerfile_path(dockerfile_path)
         context_path = context_path or os.path.dirname(dockerfile_path)
-        cmd += ["build", "-t", image_name, "-f", dockerfile_path, context_path]
+        cmd += ["build", "-t", image_name, "-f", dockerfile_path]
+        if platform:
+            cmd += ["--platform", platform]
+        cmd += [context_path]
         LOG.debug("Building Docker image: %s", cmd)
         try:
             run(cmd)

--- a/localstack/utils/container_utils/docker_sdk_client.py
+++ b/localstack/utils/container_utils/docker_sdk_client.py
@@ -242,7 +242,13 @@ class SdkDockerClient(ContainerClient):
         except APIError as e:
             raise ContainerException() from e
 
-    def build_image(self, dockerfile_path: str, image_name: str, context_path: str = None):
+    def build_image(
+        self,
+        dockerfile_path: str,
+        image_name: str,
+        context_path: str = None,
+        platform: Optional[DockerPlatform] = None,
+    ):
         try:
             dockerfile_path = Util.resolve_dockerfile_path(dockerfile_path)
             context_path = context_path or os.path.dirname(dockerfile_path)
@@ -252,6 +258,7 @@ class SdkDockerClient(ContainerClient):
                 dockerfile=dockerfile_path,
                 tag=image_name,
                 rm=True,
+                platform=platform,
             )
         except APIError as e:
             raise ContainerException("Unable to build Docker image") from e

--- a/tests/integration/awslambda/functions/common/echo/go/Makefile
+++ b/tests/integration/awslambda/functions/common/echo/go/Makefile
@@ -1,7 +1,15 @@
+# go1.x does not support arm64 architecture: https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html
+DOCKER_PLATFORM ?= linux/amd64
+# Golang EOL overview: https://endoflife.date/go
+DOCKER_GOLANG_IMAGE ?= golang:1.19.6
 
 build:
 	mkdir -p build
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out golang:latest@sha256:b850621230956a6d960d6d7cfaba6a8a2e8e245b230a928ef66aa0cfd065e229 /bin/bash -c "cd /app && GOOS=linux CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
+	docker run --rm --platform $(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out $(DOCKER_GOLANG_IMAGE) /bin/bash -c "cd /app && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
 	find ./build -exec touch -t 200001010100.00 {} \;
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/echo/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/echo/provided/Makefile
@@ -4,4 +4,8 @@ build:
 	cp -r ./src/* build/; \
 	find ./build -exec touch -t 200001010100.00 {} \;
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/endpointinjection/go/Makefile
+++ b/tests/integration/awslambda/functions/common/endpointinjection/go/Makefile
@@ -1,7 +1,15 @@
+# go1.x does not support arm64 architecture: https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html
+DOCKER_PLATFORM ?= linux/amd64
+# Golang EOL overview: https://endoflife.date/go
+DOCKER_GOLANG_IMAGE ?= golang:1.19.6
 
 build:
 	mkdir -p build
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out golang:latest@sha256:b850621230956a6d960d6d7cfaba6a8a2e8e245b230a928ef66aa0cfd065e229 /bin/bash -c "cd /app && GOOS=linux CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
+	docker run --rm --platform $(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out $(DOCKER_GOLANG_IMAGE) /bin/bash -c "cd /app && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
 	find ./build -exec touch -t 200001010100.00 {} \;
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/endpointinjection/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/endpointinjection/provided/Makefile
@@ -1,8 +1,33 @@
+DOCKER_PLATFORM ?= linux/amd64
+# Using a sha256 hash breaks on multi-platform hosts (e.g., ARM Macs): https://github.com/moby/moby/issues/43188
+DOCKER_RUST_IMAGE ?= rust:1.67.1
+
+# x86 cross-build on ARM hosts are killed due to memory issues: https://github.com/rust-lang/cargo/issues/10781#issuecomment-1351670409
+# Slow workaround takes ~5 to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
+ARM_CROSS_BUILD_WORKAROUND ?= --config net.git-fetch-with-cli=true
+
+# Overview: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+# Targets: x86_64-unknown-linux-musl or x86_64-unknown-linux-gnu or add aarch64-unknown-linux-gnu
+# ARM cross-compile requires some more config and dependencies because cargo does not find cross-build tools itself:
+# https://stackoverflow.com/questions/69360099/apple-m1-to-linux-x86-64-unrecognized-command-line-option-m64
+# --env RUSTFLAGS='-C linker=x86_64-linux-gnu-gcc' yields: error: linker `x86_64-linux-gnu-gcc` not found
+# Alternative cross compilation tool: https://github.com/cross-rs/cross
+# cargo install cross --git https://github.com/cross-rs/cross
+# --env CROSS_CONTAINER_IN_CONTAINER=true -v /var/run/docker.sock:/var/run/docker.sock
+# cross build --target x86_64-unknown-linux-musl
+# "no container engine found" => requires installing Docker
+# ARM support for aarch64-unknown-linux-gnu pending: https://github.com/rust-lang/rust/issues/77071
+RUST_TARGET ?= x86_64-unknown-linux-musl
+
 build:
 	mkdir -p build && \
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out rust:1.64.0@sha256:922d814994d77f8e3ab8a7db45a277e9cebe41a557046eeef91a2e34b28b4962 bash -c "rustup target add x86_64-unknown-linux-musl && mkdir -p /app2 && cp -r /app/* /app2 && cd /app2 && cargo build --release --target x86_64-unknown-linux-musl && cp ./target/x86_64-unknown-linux-musl/release/bootstrap /out && chown $$(id -u):$$(id -g) /out/bootstrap"
+	docker run --rm --platform=$(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out:cached $(DOCKER_RUST_IMAGE) bash -c "rustup target add $(RUST_TARGET) && mkdir -p /app2 && cp -r /app/* /app2 && cd /app2 && cargo build $(ARM_CROSS_BUILD_WORKAROUND) --release --target $(RUST_TARGET) && cp ./target/$(RUST_TARGET)/release/bootstrap /out && chown $$(id -u):$$(id -g) /out/bootstrap"
 	find ./build -exec touch -t 200001010100.00 {} \;
 	cd ./build && zip -r handler.zip .
 	mv ./build/handler.zip .
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/endpointinjection/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/endpointinjection/provided/Makefile
@@ -3,7 +3,7 @@ DOCKER_PLATFORM ?= linux/amd64
 DOCKER_RUST_IMAGE ?= rust:1.67.1
 
 # x86 cross-build on ARM hosts are killed due to memory issues: https://github.com/rust-lang/cargo/issues/10781#issuecomment-1351670409
-# Slow workaround takes ~5 to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
+# Slow workaround takes ~5min to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
 ARM_CROSS_BUILD_WORKAROUND ?= --config net.git-fetch-with-cli=true
 
 # Overview: https://doc.rust-lang.org/nightly/rustc/platform-support.html

--- a/tests/integration/awslambda/functions/common/introspection/go/Makefile
+++ b/tests/integration/awslambda/functions/common/introspection/go/Makefile
@@ -1,7 +1,15 @@
+# go1.x does not support arm64 architecture: https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html
+DOCKER_PLATFORM ?= linux/amd64
+# Golang EOL overview: https://endoflife.date/go
+DOCKER_GOLANG_IMAGE ?= golang:1.19.6
 
 build:
 	mkdir -p build
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out golang:latest@sha256:b850621230956a6d960d6d7cfaba6a8a2e8e245b230a928ef66aa0cfd065e229 /bin/bash -c "cd /app && GOOS=linux CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
+	docker run --rm --platform $(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out $(DOCKER_GOLANG_IMAGE) /bin/bash -c "cd /app && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
 	find ./build -exec touch -t 200001010100.00 {} \;
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/introspection/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/introspection/provided/Makefile
@@ -1,8 +1,33 @@
+DOCKER_PLATFORM ?= linux/amd64
+# Using a sha256 hash breaks on multi-platform hosts (e.g., ARM Macs): https://github.com/moby/moby/issues/43188
+DOCKER_RUST_IMAGE ?= rust:1.67.1
+
+# x86 cross-build on ARM hosts are killed due to memory issues: https://github.com/rust-lang/cargo/issues/10781#issuecomment-1351670409
+# Slow workaround takes ~5 to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
+ARM_CROSS_BUILD_WORKAROUND ?= --config net.git-fetch-with-cli=true
+
+# Overview: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+# Targets: x86_64-unknown-linux-musl or x86_64-unknown-linux-gnu or add aarch64-unknown-linux-gnu
+# ARM cross-compile requires some more config and dependencies because cargo does not find cross-build tools itself:
+# https://stackoverflow.com/questions/69360099/apple-m1-to-linux-x86-64-unrecognized-command-line-option-m64
+# --env RUSTFLAGS='-C linker=x86_64-linux-gnu-gcc' yields: error: linker `x86_64-linux-gnu-gcc` not found
+# Alternative cross compilation tool: https://github.com/cross-rs/cross
+# cargo install cross --git https://github.com/cross-rs/cross
+# --env CROSS_CONTAINER_IN_CONTAINER=true -v /var/run/docker.sock:/var/run/docker.sock
+# cross build --target x86_64-unknown-linux-musl
+# "no container engine found" => requires installing Docker
+# ARM support for aarch64-unknown-linux-gnu pending: https://github.com/rust-lang/rust/issues/77071
+RUST_TARGET ?= x86_64-unknown-linux-musl
+
 build:
 	mkdir -p build && \
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out rust:1.64.0@sha256:922d814994d77f8e3ab8a7db45a277e9cebe41a557046eeef91a2e34b28b4962 bash -c "rustup target add x86_64-unknown-linux-musl && mkdir -p /app2 && cp -r /app/* /app2 && cd /app2 && cargo build --release --target x86_64-unknown-linux-musl && cp ./target/x86_64-unknown-linux-musl/release/bootstrap /out && chown $$(id -u):$$(id -g) /out/bootstrap"
+	docker run --rm --platform=$(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out:cached $(DOCKER_RUST_IMAGE) bash -c "rustup target add $(RUST_TARGET) && mkdir -p /app2 && cp -r /app/* /app2 && cd /app2 && cargo build $(ARM_CROSS_BUILD_WORKAROUND) --release --target $(RUST_TARGET) && cp ./target/$(RUST_TARGET)/release/bootstrap /out && chown $$(id -u):$$(id -g) /out/bootstrap"
 	find ./build -exec touch -t 200001010100.00 {} \;
 	cd ./build && zip -r handler.zip .
 	mv ./build/handler.zip .
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/introspection/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/introspection/provided/Makefile
@@ -3,7 +3,7 @@ DOCKER_PLATFORM ?= linux/amd64
 DOCKER_RUST_IMAGE ?= rust:1.67.1
 
 # x86 cross-build on ARM hosts are killed due to memory issues: https://github.com/rust-lang/cargo/issues/10781#issuecomment-1351670409
-# Slow workaround takes ~5 to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
+# Slow workaround takes ~5min to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
 ARM_CROSS_BUILD_WORKAROUND ?= --config net.git-fetch-with-cli=true
 
 # Overview: https://doc.rust-lang.org/nightly/rustc/platform-support.html

--- a/tests/integration/awslambda/functions/common/uncaughtexception/go/Makefile
+++ b/tests/integration/awslambda/functions/common/uncaughtexception/go/Makefile
@@ -1,7 +1,15 @@
+# go1.x does not support arm64 architecture: https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html
+DOCKER_PLATFORM ?= linux/amd64
+# Golang EOL overview: https://endoflife.date/go
+DOCKER_GOLANG_IMAGE ?= golang:1.19.6
 
 build:
 	mkdir -p build
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out golang:latest@sha256:b850621230956a6d960d6d7cfaba6a8a2e8e245b230a928ef66aa0cfd065e229 /bin/bash -c "cd /app && GOOS=linux CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
+	docker run --rm --platform $(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out $(DOCKER_GOLANG_IMAGE) /bin/bash -c "cd /app && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags=-buildid= -o /out/main main.go && chown $$(id -u):$$(id -g) /out/main"
 	find ./build -exec touch -t 200001010100.00 {} \;
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/uncaughtexception/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/uncaughtexception/provided/Makefile
@@ -1,8 +1,33 @@
+DOCKER_PLATFORM ?= linux/amd64
+# Using a sha256 hash breaks on multi-platform hosts (e.g., ARM Macs): https://github.com/moby/moby/issues/43188
+DOCKER_RUST_IMAGE ?= rust:1.67.1
+
+# x86 cross-build on ARM hosts are killed due to memory issues: https://github.com/rust-lang/cargo/issues/10781#issuecomment-1351670409
+# Slow workaround takes ~5 to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
+ARM_CROSS_BUILD_WORKAROUND ?= --config net.git-fetch-with-cli=true
+
+# Overview: https://doc.rust-lang.org/nightly/rustc/platform-support.html
+# Targets: x86_64-unknown-linux-musl or x86_64-unknown-linux-gnu or add aarch64-unknown-linux-gnu
+# ARM cross-compile requires some more config and dependencies because cargo does not find cross-build tools itself:
+# https://stackoverflow.com/questions/69360099/apple-m1-to-linux-x86-64-unrecognized-command-line-option-m64
+# --env RUSTFLAGS='-C linker=x86_64-linux-gnu-gcc' yields: error: linker `x86_64-linux-gnu-gcc` not found
+# Alternative cross compilation tool: https://github.com/cross-rs/cross
+# cargo install cross --git https://github.com/cross-rs/cross
+# --env CROSS_CONTAINER_IN_CONTAINER=true -v /var/run/docker.sock:/var/run/docker.sock
+# cross build --target x86_64-unknown-linux-musl
+# "no container engine found" => requires installing Docker
+# ARM support for aarch64-unknown-linux-gnu pending: https://github.com/rust-lang/rust/issues/77071
+RUST_TARGET ?= x86_64-unknown-linux-musl
+
 build:
 	mkdir -p build && \
-	docker run --rm -v $$(pwd)/src:/app -v $$(pwd)/build:/out rust:1.64.0@sha256:922d814994d77f8e3ab8a7db45a277e9cebe41a557046eeef91a2e34b28b4962 bash -c "rustup target add x86_64-unknown-linux-musl && mkdir -p /app2 && cp -r /app/* /app2 && cd /app2 && cargo build --release --target x86_64-unknown-linux-musl && cp ./target/x86_64-unknown-linux-musl/release/bootstrap /out && chown $$(id -u):$$(id -g) /out/bootstrap"
+	docker run --rm --platform=$(DOCKER_PLATFORM) -v $$(pwd)/src:/app -v $$(pwd)/build:/out:cached $(DOCKER_RUST_IMAGE) bash -c "rustup target add $(RUST_TARGET) && mkdir -p /app2 && cp -r /app/* /app2 && cd /app2 && cargo build $(ARM_CROSS_BUILD_WORKAROUND) --release --target $(RUST_TARGET) && cp ./target/$(RUST_TARGET)/release/bootstrap /out && chown $$(id -u):$$(id -g) /out/bootstrap"
 	find ./build -exec touch -t 200001010100.00 {} \;
 	cd ./build && zip -r handler.zip .
 	mv ./build/handler.zip .
 
-.PHONY: build
+clean:
+	$(RM) -r build
+	$(RM) handler.zip
+
+.PHONY: build clean

--- a/tests/integration/awslambda/functions/common/uncaughtexception/provided/Makefile
+++ b/tests/integration/awslambda/functions/common/uncaughtexception/provided/Makefile
@@ -3,7 +3,7 @@ DOCKER_PLATFORM ?= linux/amd64
 DOCKER_RUST_IMAGE ?= rust:1.67.1
 
 # x86 cross-build on ARM hosts are killed due to memory issues: https://github.com/rust-lang/cargo/issues/10781#issuecomment-1351670409
-# Slow workaround takes ~5 to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
+# Slow workaround takes ~5min to build on an M1 MacBook Pro: --config net.git-fetch-with-cli=true
 ARM_CROSS_BUILD_WORKAROUND ?= --config net.git-fetch-with-cli=true
 
 # Overview: https://doc.rust-lang.org/nightly/rustc/platform-support.html

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -171,12 +171,12 @@ if is_old_provider():
             "$..Environment",  # missing
             "$..HTTPStatusCode",  # 201 vs 200
             "$..Layers",
-            "$..SnapStart",  # FIXME
+            "$..SnapStart",
         ],
     )
 else:
     pytestmark = pytest.mark.skip_snapshot_verify(
-        paths=["$..CodeSize", "$..SnapStart"],  # FIXME
+        paths=["$..CodeSize"],  # FIXME
     )
 
 
@@ -405,6 +405,7 @@ class TestLambdaBehavior:
         logs_client,
         snapshot,
     ):
+        # Snapshot generation could be flaky against AWS with a small timeout margin (e.g., 1.02 instead of 1.00)
         regex = re.compile(r".*\s(?P<uuid>[-a-z0-9]+) Task timed out after \d.\d+ seconds")
         snapshot.add_transformer(
             KeyValueBasedTransformer(

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -210,6 +210,7 @@ class TestLambdaBaseFeatures:
             "$..Code.RepositoryType",
             "$..CodeSize",  # CI reports different code size here,
             "$..Layers",  # PRO
+            "$..RuntimeVersionConfig",
         ],
     )
     @pytest.mark.aws_validated
@@ -451,7 +452,13 @@ class TestLambdaBehavior:
         retry(assert_events, retries=15)
 
     @pytest.mark.skip_snapshot_verify(
-        condition=is_old_provider, paths=["$..Payload", "$..LogResult", "$..Layers"]
+        condition=is_old_provider,
+        paths=[
+            "$..Payload",
+            "$..LogResult",
+            "$..Layers",
+            "$..CreateFunctionResponse.RuntimeVersionConfig",
+        ],
     )
     @pytest.mark.aws_validated
     def test_lambda_invoke_no_timeout(

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -156,28 +156,24 @@ def fixture_snapshot(snapshot):
 
 
 # some more common ones that usually don't work in the old provider
-if is_old_provider():
-    pytestmark = pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Architectures",
-            "$..EphemeralStorage",
-            "$..LastUpdateStatus",
-            "$..MemorySize",
-            "$..State",
-            "$..StateReason",
-            "$..StateReasonCode",
-            "$..VpcConfig",
-            "$..CodeSigningConfig",
-            "$..Environment",  # missing
-            "$..HTTPStatusCode",  # 201 vs 200
-            "$..Layers",
-            "$..SnapStart",
-        ],
-    )
-else:
-    pytestmark = pytest.mark.skip_snapshot_verify(
-        paths=["$..CodeSize"],  # FIXME
-    )
+pytestmark = pytest.mark.skip_snapshot_verify(
+    condition=is_old_provider,
+    paths=[
+        "$..Architectures",
+        "$..EphemeralStorage",
+        "$..LastUpdateStatus",
+        "$..MemorySize",
+        "$..State",
+        "$..StateReason",
+        "$..StateReasonCode",
+        "$..VpcConfig",
+        "$..CodeSigningConfig",
+        "$..Environment",  # missing
+        "$..HTTPStatusCode",  # 201 vs 200
+        "$..Layers",
+        "$..SnapStart",
+    ],
+)
 
 
 class TestLambdaBaseFeatures:
@@ -208,7 +204,6 @@ class TestLambdaBaseFeatures:
             "$..Tags",
             "$..Configuration.RevisionId",
             "$..Code.RepositoryType",
-            "$..CodeSize",  # CI reports different code size here,
             "$..Layers",  # PRO
             "$..RuntimeVersionConfig",
         ],

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -152,61 +152,61 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[nodejs]": {
-    "recorded-date": "01-09-2022, 07:36:39",
+    "recorded-date": "17-02-2023, 14:00:08",
     "recorded-content": {
       "first_invoke_result": {
         "ExecutedVersion": "$LATEST",
         "Payload": {
           "counter": 0
         },
+        "StatusCode": 200,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StatusCode": 200
+        }
       },
       "second_invoke_result": {
         "ExecutedVersion": "$LATEST",
         "Payload": {
           "counter": 1
         },
+        "StatusCode": 200,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StatusCode": 200
+        }
       }
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_cache_local[python]": {
-    "recorded-date": "01-09-2022, 07:36:55",
+    "recorded-date": "17-02-2023, 14:00:12",
     "recorded-content": {
       "first_invoke_result": {
         "ExecutedVersion": "$LATEST",
         "Payload": {
           "counter": 0
         },
+        "StatusCode": 200,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StatusCode": 200
+        }
       },
       "second_invoke_result": {
         "ExecutedVersion": "$LATEST",
         "Payload": {
           "counter": 1
         },
+        "StatusCode": 200,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StatusCode": 200
+        }
       }
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_with_timeout": {
-    "recorded-date": "14-11-2022, 16:13:13",
+    "recorded-date": "17-02-2023, 14:00:17",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -232,6 +232,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -250,7 +257,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorMessage": "date <timeout_error_msg> Task timed out after 1.00 seconds"
+          "errorMessage": "date <timeout_error_msg> Task timed out after 1.02 seconds"
         },
         "StatusCode": 200,
         "ResponseMetadata": {
@@ -261,7 +268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_no_timeout": {
-    "recorded-date": "09-09-2022, 20:59:55",
+    "recorded-date": "17-02-2023, 14:00:29",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -287,6 +294,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -313,7 +327,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_function_state": {
-    "recorded-date": "09-09-2022, 20:57:58",
+    "recorded-date": "17-02-2023, 13:59:50",
     "recorded-content": {
       "create-fn-response": {
         "Architectures": [
@@ -334,6 +348,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -372,6 +393,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -387,23 +415,23 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_large_payloads": {
-    "recorded-date": "01-09-2022, 08:12:32",
+    "recorded-date": "17-02-2023, 13:59:47",
     "recorded-content": {
       "invocation_response": {
         "ExecutedVersion": "$LATEST",
         "Payload": {
           "test": "<large-value>"
         },
+        "StatusCode": 200,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StatusCode": 200
+        }
       }
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[python3.9]": {
-    "recorded-date": "09-09-2022, 19:13:50",
+    "recorded-date": "17-02-2023, 14:01:27",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -421,7 +449,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_logs[nodejs16.x]": {
-    "recorded-date": "09-09-2022, 19:14:05",
+    "recorded-date": "17-02-2023, 14:01:30",
     "recorded-content": {
       "invoke": {
         "ExecutedVersion": "$LATEST",
@@ -439,7 +467,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[python3.9]": {
-    "recorded-date": "09-09-2022, 19:14:21",
+    "recorded-date": "17-02-2023, 14:01:34",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -453,7 +481,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_request_response[nodejs16.x]": {
-    "recorded-date": "09-09-2022, 19:14:37",
+    "recorded-date": "17-02-2023, 14:01:37",
     "recorded-content": {
       "invoke-result": {
         "ExecutedVersion": "$LATEST",
@@ -467,7 +495,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[python3.9]": {
-    "recorded-date": "09-09-2022, 19:14:52",
+    "recorded-date": "17-02-2023, 14:01:40",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",
@@ -480,7 +508,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_type_event[nodejs16.x]": {
-    "recorded-date": "09-09-2022, 19:15:07",
+    "recorded-date": "17-02-2023, 14:01:43",
     "recorded-content": {
       "invoke-result": {
         "Payload": "",
@@ -611,7 +639,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_invocation_with_qualifier": {
-    "recorded-date": "09-09-2022, 20:40:51",
+    "recorded-date": "17-02-2023, 14:02:08",
     "recorded-content": {
       "creation-response": {
         "Architectures": [
@@ -632,6 +660,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -680,7 +715,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaFeatures::test_upload_lambda_from_s3": {
-    "recorded-date": "09-09-2022, 20:24:37",
+    "recorded-date": "17-02-2023, 14:02:21",
     "recorded-content": {
       "creation-response": {
         "Architectures": [
@@ -701,6 +736,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -919,7 +961,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaVersions::test_lambda_versions_with_code_changes": {
-    "recorded-date": "12-10-2022, 17:48:20",
+    "recorded-date": "17-02-2023, 14:02:41",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -940,6 +982,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -973,6 +1022,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1006,6 +1062,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1063,6 +1126,13 @@
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1106,6 +1176,13 @@
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1174,7 +1251,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaAliases::test_lambda_alias_moving": {
-    "recorded-date": "29-09-2022, 19:42:57",
+    "recorded-date": "17-02-2023, 14:02:51",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1195,6 +1272,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1267,6 +1351,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1311,6 +1402,13 @@
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1374,7 +1472,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaAliases::test_alias_routingconfig": {
-    "recorded-date": "28-09-2022, 10:21:24",
+    "recorded-date": "17-02-2023, 14:03:03",
     "recorded-content": {
       "create_alias_response": {
         "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
@@ -1395,7 +1493,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBaseFeatures::test_lambda_different_iam_keys_environment": {
-    "recorded-date": "28-09-2022, 21:03:48",
+    "recorded-date": "17-02-2023, 13:59:57",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -1421,6 +1519,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -1869,7 +1974,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_timed_out_environment_reuse": {
-    "recorded-date": "10-11-2022, 18:59:18",
+    "recorded-date": "17-02-2023, 14:00:37",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -1895,6 +2000,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -1986,7 +2098,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation_exception": {
-    "recorded-date": "12-01-2023, 09:22:41",
+    "recorded-date": "17-02-2023, 14:01:22",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -2016,6 +2128,9 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -2063,7 +2178,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaConcurrency::test_lambda_concurrency_crud": {
-    "recorded-date": "13-12-2022, 19:16:23",
+    "recorded-date": "17-02-2023, 14:02:25",
     "recorded-content": {
       "get_function_concurrency_default": {
         "ResponseMetadata": {
@@ -2102,7 +2217,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[dict]": {
-    "recorded-date": "12-01-2023, 09:16:21",
+    "recorded-date": "17-02-2023, 14:00:42",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2145,7 +2260,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[http-response]": {
-    "recorded-date": "12-01-2023, 09:16:25",
+    "recorded-date": "17-02-2023, 14:00:47",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2186,7 +2301,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[http-response-json]": {
-    "recorded-date": "12-01-2023, 09:16:29",
+    "recorded-date": "17-02-2023, 14:00:51",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2229,7 +2344,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[list-mixed]": {
-    "recorded-date": "12-01-2023, 09:16:33",
+    "recorded-date": "17-02-2023, 14:00:56",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2270,7 +2385,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[string]": {
-    "recorded-date": "12-01-2023, 09:16:37",
+    "recorded-date": "17-02-2023, 14:01:00",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2311,7 +2426,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[integer]": {
-    "recorded-date": "12-01-2023, 09:16:41",
+    "recorded-date": "17-02-2023, 14:01:04",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2352,7 +2467,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[float]": {
-    "recorded-date": "12-01-2023, 09:16:44",
+    "recorded-date": "17-02-2023, 14:01:09",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2393,7 +2508,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_invocation[boolean]": {
-    "recorded-date": "12-01-2023, 09:16:48",
+    "recorded-date": "17-02-2023, 14:01:13",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2434,7 +2549,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaURL::test_lambda_url_echo_invoke": {
-    "recorded-date": "12-01-2023, 09:11:03",
+    "recorded-date": "17-02-2023, 14:01:18",
     "recorded-content": {
       "create_lambda_url_config": {
         "AuthType": "NONE",
@@ -2467,7 +2582,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_arm": {
-    "recorded-date": "13-02-2023, 14:40:57",
+    "recorded-date": "17-02-2023, 14:00:04",
     "recorded-content": {
       "invoke_runtime_arm_introspection": {
         "ExecutedVersion": "$LATEST",
@@ -2489,7 +2604,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_runtime_introspection_x86": {
-    "recorded-date": "13-02-2023, 14:41:16",
+    "recorded-date": "17-02-2023, 14:00:01",
     "recorded-content": {
       "invoke_runtime_x86_introspection": {
         "ExecutedVersion": "$LATEST",

--- a/tests/integration/awslambda/test_lambda.snapshot.json
+++ b/tests/integration/awslambda/test_lambda.snapshot.json
@@ -206,7 +206,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda.py::TestLambdaBehavior::test_lambda_invoke_with_timeout": {
-    "recorded-date": "17-02-2023, 14:00:17",
+    "recorded-date": "17-02-2023, 14:20:09",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -257,7 +257,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorMessage": "date <timeout_error_msg> Task timed out after 1.02 seconds"
+          "errorMessage": "date <timeout_error_msg> Task timed out after 1.00 seconds"
         },
         "StatusCode": 200,
         "ResponseMetadata": {

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1301,12 +1301,12 @@ class TestLambdaAlias:
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
-@pytest.mark.skip_snapshot_verify(
-    paths=[
-        # new Lambda feature: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
-        "$..SnapStart"
-    ]
-)
+# @pytest.mark.skip_snapshot_verify(
+#     paths=[
+#         # new Lambda feature: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
+#         "$..SnapStart"
+#     ]
+# )
 class TestLambdaRevisions:
     @pytest.mark.aws_validated
     def test_function_revisions_basic(self, lambda_client, create_lambda_function, snapshot):

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -2458,6 +2458,16 @@ class TestLambdaPermissions:
             runtime=Runtime.python3_9,
         )
 
+        # invalid statement id
+        with pytest.raises(lambda_client.exceptions.ClientError) as e:
+            lambda_client.add_permission(
+                FunctionName=function_name,
+                Action="lambda:InvokeFunction",
+                StatementId="example.com",
+                Principal="s3.amazonaws.com",
+            )
+        snapshot.match("add_permission_invalid_statement_id", e.value.response)
+
         # qualifier mismatch between specified Qualifier and derived ARN from FunctionName
         with pytest.raises(lambda_client.exceptions.InvalidParameterValueException) as e:
             lambda_client.add_permission(

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -959,6 +959,7 @@ class TestLambdaVersions:
         )
         snapshot.match("publish_result", publish_result)
 
+    @pytest.mark.aws_validated
     def test_publish_with_update(
         self, lambda_client, create_lambda_function_aws, lambda_su_role, snapshot
     ):
@@ -1142,6 +1143,7 @@ class TestLambdaAlias:
         )  # 3 aliases
         snapshot.match("list_aliases_for_fnname_afterdelete", list_aliases_for_fnname_afterdelete)
 
+    @pytest.mark.aws_validated
     def test_notfound_and_invalid_routingconfigs(
         self, create_boto_client, create_lambda_function_aws, snapshot, lambda_su_role
     ):
@@ -3939,6 +3941,7 @@ class TestLambdaTags:
         assert "a_key" not in lambda_client.list_tags(Resource=function_arn)["Tags"]
         assert "b_key" in lambda_client.list_tags(Resource=function_arn)["Tags"]
 
+    @pytest.mark.aws_validated
     def test_tag_limits(self, lambda_client, create_lambda_function, snapshot):
         """test the limit of 50 tags per resource"""
         function_name = f"fn-tag-{short_uid()}"
@@ -4010,6 +4013,7 @@ class TestLambdaTags:
             )
         snapshot.match("tag_resource_latest_exception", e.value.response)
 
+    @pytest.mark.aws_validated
     def test_tag_lifecycle(self, lambda_client, create_lambda_function, snapshot):
         function_name = f"fn-tag-{short_uid()}"
 
@@ -4190,6 +4194,7 @@ class TestLambdaLayer:
             )
         snapshot.match("publish_layer_version_exc_partially_invalid_values", e.value.response)
 
+    @pytest.mark.aws_validated
     def test_layer_function_exceptions(
         self, lambda_client, create_lambda_function, snapshot, dummylayer, cleanups
     ):

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -4694,14 +4694,6 @@ class TestLambdaLayer:
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
-@pytest.mark.skip_snapshot_verify(
-    paths=[
-        # TODO: new lambda feature: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html
-        "$..CreateFunctionResponse.RuntimeVersionConfig",
-        "$..Configuration.RuntimeVersionConfig",
-        "$..RuntimeVersionConfig",
-    ]
-)
 class TestLambdaSnapStart:
     @pytest.mark.aws_validated
     def test_snapstart_lifecycle(self, lambda_client, create_lambda_function, snapshot):

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -2615,12 +2615,6 @@ class TestLambdaPermissions:
         snapshot.match("get_policy", get_policy_result)
 
     @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            # new Lambda feature: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
-            "$..SnapStart"
-        ]
-    )
     @pytest.mark.aws_validated
     def test_lambda_permission_fn_versioning(
         self, lambda_client, iam_client, create_lambda_function, account_id, snapshot
@@ -4196,7 +4190,6 @@ class TestLambdaLayer:
             )
         snapshot.match("publish_layer_version_exc_partially_invalid_values", e.value.response)
 
-    @pytest.mark.skip_snapshot_verify(paths=["$..SnapStart"])  # FIXME: new lambda feature
     def test_layer_function_exceptions(
         self, lambda_client, create_lambda_function, snapshot, dummylayer, cleanups
     ):
@@ -4328,7 +4321,6 @@ class TestLambdaLayer:
             )
         snapshot.match("create_function_with_layer_in_different_region", e.value.response)
 
-    @pytest.mark.skip_snapshot_verify(paths=["$..SnapStart"])  # FIXME: new lambda feature
     def test_layer_function_quota_exception(
         self, lambda_client, create_lambda_function, snapshot, dummylayer, cleanups
     ):

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -4702,10 +4702,11 @@ class TestLambdaSnapStart:
             "$..Configuration.RuntimeVersionConfig",
         ]
     )
-    # TODO: validate
     @pytest.mark.aws_validated
     def test_snapstart_lifecycle(self, lambda_client, create_lambda_function, snapshot):
-        """Test the API of the SnapStart feature. The optimization behavior is not supported in LocalStack."""
+        """Test the API of the SnapStart feature. The optimization behavior is not supported in LocalStack.
+        Slow (~1-2min) against AWS.
+        """
         function_name = f"fn-{short_uid()}"
         java_jar_with_lib = load_file(TEST_LAMBDA_JAVA_WITH_LIB, mode="rb")
         create_response = create_lambda_function(
@@ -4713,8 +4714,7 @@ class TestLambdaSnapStart:
             zip_file=java_jar_with_lib,
             runtime=Runtime.java11,
             handler="cloud.localstack.sample.LambdaHandlerWithLib",
-            # TODO: enable SnapStart
-            # SnapStart={"ApplyOn": "PublishedVersions"},
+            SnapStart={"ApplyOn": "PublishedVersions"},
         )
         snapshot.match("create_function_response", create_response)
         lambda_client.get_waiter("function_active_v2").wait(FunctionName=function_name)

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1667,6 +1667,8 @@ pytestmark = pytest.mark.skip_snapshot_verify(
         "$..Environment",  # missing
         "$..HTTPStatusCode",  # 201 vs 200
         "$..Layers",
+        "$..CreateFunctionResponse.RuntimeVersionConfig",
+        "$..CreateFunctionResponse.SnapStart",
     ],
 )
 
@@ -2439,7 +2441,7 @@ class TestLambdaProvisionedConcurrency:
         "$..PolicyArn",
         "$..Layers",
         # mismatching resource index due to SnapStart
-        "$..Statement.Condition.ArnLike.AWS:SourceArn",
+        "$..Statement.Condition.ArnLike.'AWS:SourceArn'",
     ],
 )
 class TestLambdaPermissions:
@@ -3349,8 +3351,6 @@ class TestLambdaSizeLimits:
             "$..StateReason",
             "$..StateReasonCode",
             "$..VpcConfig",
-            "$..CreateFunctionResponse.RuntimeVersionConfig",
-            "$..CreateFunctionResponse.SnapStart",
         ],
     )
     def test_lambda_envvars_near_limit_succeeds(

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -2432,7 +2432,15 @@ class TestLambdaProvisionedConcurrency:
 
 @pytest.mark.skip_snapshot_verify(
     condition=is_old_provider,
-    paths=["$..RevisionId", "$..Policy.Statement", "$..PolicyName", "$..PolicyArn", "$..Layers"],
+    paths=[
+        "$..RevisionId",
+        "$..Policy.Statement",
+        "$..PolicyName",
+        "$..PolicyArn",
+        "$..Layers",
+        # mismatching resource index due to SnapStart
+        "$..Statement.Condition.ArnLike.AWS:SourceArn",
+    ],
 )
 class TestLambdaPermissions:
     @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
@@ -3341,6 +3349,8 @@ class TestLambdaSizeLimits:
             "$..StateReason",
             "$..StateReasonCode",
             "$..VpcConfig",
+            "$..CreateFunctionResponse.RuntimeVersionConfig",
+            "$..CreateFunctionResponse.SnapStart",
         ],
     )
     def test_lambda_envvars_near_limit_succeeds(

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -4752,3 +4752,15 @@ class TestLambdaSnapStart:
                 SnapStart={"ApplyOn": "PublishedVersions"},
             )
         snapshot.match("create_function_unsupported_snapstart_runtime", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            lambda_client.create_function(
+                FunctionName=function_name,
+                Handler="cloud.localstack.sample.LambdaHandlerWithLib",
+                Code={"ZipFile": zip_file_bytes},
+                PackageType="Zip",
+                Role=lambda_su_role,
+                Runtime=Runtime.java11,
+                SnapStart={"ApplyOn": "invalidOption"},
+            )
+        snapshot.match("create_function_invalid_snapstart_apply", e.value.response)

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -64,6 +64,11 @@ def environment_length_bytes(e: dict) -> int:
 
 @pytest.mark.skipif(is_old_provider(), reason="focusing on new provider")
 class TestLambdaFunction:
+    @pytest.mark.skip_snapshot_verify(
+        # The RuntimeVersionArn is currently a hardcoded id and therefore does not reflect the ARN resource update
+        # from python3.9 to python3.8 in update_func_conf_response.
+        paths=["$..RuntimeVersionConfig.RuntimeVersionArn"]
+    )
     @pytest.mark.aws_validated
     def test_function_lifecycle(
         self, lambda_client, snapshot, create_lambda_function, lambda_su_role
@@ -1302,13 +1307,15 @@ class TestLambdaAlias:
 
 
 @pytest.mark.skipif(condition=is_old_provider(), reason="not supported")
-# @pytest.mark.skip_snapshot_verify(
-#     paths=[
-#         # new Lambda feature: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html
-#         "$..SnapStart"
-#     ]
-# )
 class TestLambdaRevisions:
+    @pytest.mark.skip_snapshot_verify(
+        # The RuntimeVersionArn is currently a hardcoded id and therefore does not reflect the ARN resource update
+        # from python3.9 to python3.8 in update_function_configuration_response_rev5.
+        paths=[
+            "update_function_configuration_response_rev5..RuntimeVersionConfig.RuntimeVersionArn",
+            "get_function_response_rev6..RuntimeVersionConfig.RuntimeVersionArn",
+        ]
+    )
     @pytest.mark.aws_validated
     def test_function_revisions_basic(self, lambda_client, create_lambda_function, snapshot):
         """Tests basic revision id lifecycle for creating and updating functions"""

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -11113,5 +11113,98 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration": {
+    "recorded-date": "15-02-2023, 18:18:14",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "update_function_response": {
+        "Architectures": [
+          "x86_64"
+        ],
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
+        "Description": "",
+        "Environment": {
+          "Variables": {}
+        },
+        "EphemeralStorage": {
+          "Size": 512
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+        "FunctionName": "<function-name:1>",
+        "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+        "LastModified": "date",
+        "LastUpdateStatus": "InProgress",
+        "LastUpdateStatusReason": "The function is being created.",
+        "LastUpdateStatusReasonCode": "Creating",
+        "MemorySize": 128,
+        "PackageType": "Zip",
+        "RevisionId": "<uuid:2>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "Runtime": "java11",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "PublishedVersions",
+          "OptimizationStatus": "Off"
+        },
+        "State": "Active",
+        "Timeout": 30,
+        "TracingConfig": {
+          "Mode": "PassThrough"
+        },
+        "Version": "$LATEST",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10942,5 +10942,166 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
+    "recorded-date": "15-02-2023, 15:59:01",
+    "recorded-content": {
+      "create_function_unsupported_snapstart_runtime": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "python3.9 is not supported for SnapStart enabled functions."
+        },
+        "Type": "User",
+        "message": "python3.9 is not supported for SnapStart enabled functions.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle": {
+    "recorded-date": "15-02-2023, 17:02:48",
+    "recorded-content": {
+      "create_function_response": {
+        "CreateEventSourceMappingResponse": null,
+        "CreateFunctionResponse": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:1>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Pending",
+          "StateReason": "The function is being created.",
+          "StateReasonCode": "Creating",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST",
+          "ResponseMetadata": {
+            "HTTPHeaders": {},
+            "HTTPStatusCode": 201
+          }
+        }
+      },
+      "get_function_response_latest": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:2>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "$LATEST"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_response_version_1": {
+        "Code": {
+          "Location": "<location>",
+          "RepositoryType": "S3"
+        },
+        "Configuration": {
+          "Architectures": [
+            "x86_64"
+          ],
+          "CodeSha256": "<code-sha256:1>",
+          "CodeSize": "<code-size>",
+          "Description": "version1",
+          "Environment": {
+            "Variables": {}
+          },
+          "EphemeralStorage": {
+            "Size": 512
+          },
+          "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+          "FunctionName": "<function-name:1>",
+          "Handler": "cloud.localstack.sample.LambdaHandlerWithLib",
+          "LastModified": "date",
+          "LastUpdateStatus": "Successful",
+          "MemorySize": 128,
+          "PackageType": "Zip",
+          "RevisionId": "<uuid:3>",
+          "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
+          "State": "Active",
+          "Timeout": 30,
+          "TracingConfig": {
+            "Mode": "PassThrough"
+          },
+          "Version": "1"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -1344,7 +1344,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_version_on_create": {
-    "recorded-date": "17-02-2023, 11:38:37",
+    "recorded-date": "27-02-2023, 21:39:19",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1690,7 +1690,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_version_lifecycle": {
-    "recorded-date": "17-02-2023, 11:38:45",
+    "recorded-date": "27-02-2023, 21:39:27",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2391,7 +2391,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_wrong_sha256": {
-    "recorded-date": "17-02-2023, 11:38:47",
+    "recorded-date": "27-02-2023, 21:39:29",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2529,7 +2529,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_update": {
-    "recorded-date": "30-09-2022, 15:31:48",
+    "recorded-date": "27-02-2023, 21:41:30",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2550,6 +2550,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2588,6 +2595,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -2619,6 +2633,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2656,6 +2677,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -2697,6 +2725,13 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -3162,7 +3197,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAlias::test_notfound_and_invalid_routingconfigs": {
-    "recorded-date": "05-10-2022, 17:03:46",
+    "recorded-date": "27-02-2023, 21:42:10",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -3188,6 +3223,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -3226,6 +3268,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -3262,6 +3311,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -3288,7 +3344,7 @@
       "routing_config_exc_toohigh": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value '{2=2.0}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map value must satisfy constraint: [Member must have value less than or equal to 1.0, Member must have value greater than or equal to 0.0]"
+          "Message": "1 validation error detected: Value '{2=2.0}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map value must satisfy constraint: [Member must have value less than or equal to 1.0, Member must have value greater than or equal to 0.0, Member must not be null]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3298,7 +3354,7 @@
       "routing_config_exc_subzero": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value '{2=-1.0}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map value must satisfy constraint: [Member must have value less than or equal to 1.0, Member must have value greater than or equal to 0.0]"
+          "Message": "1 validation error detected: Value '{2=-1.0}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map value must satisfy constraint: [Member must have value less than or equal to 1.0, Member must have value greater than or equal to 0.0, Member must not be null]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -3355,7 +3411,7 @@
       "routing_config_exc_version_latest": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value '{$LATEST=0.5}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map keys must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: [0-9]+]"
+          "Message": "1 validation error detected: Value '{$LATEST=0.5}' at 'routingConfig.additionalVersionWeights' failed to satisfy constraint: Map keys must satisfy constraint: [Member must have length less than or equal to 1024, Member must have length greater than or equal to 1, Member must satisfy regular expression pattern: [0-9]+, Member must not be null]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -5561,7 +5617,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_limits": {
-    "recorded-date": "30-09-2022, 15:36:23",
+    "recorded-date": "27-02-2023, 21:42:31",
     "recorded-content": {
       "tag_lambda_too_many_tags": {
         "Error": {
@@ -5667,6 +5723,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -5746,7 +5809,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTags::test_tag_lifecycle": {
-    "recorded-date": "04-10-2022, 15:18:34",
+    "recorded-date": "27-02-2023, 21:42:57",
     "recorded-content": {
       "list_tags_response_postfncreate": {
         "Tags": {
@@ -5785,6 +5848,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -5847,6 +5917,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -5913,6 +5990,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -5971,6 +6055,13 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -6023,6 +6114,13 @@
           "RevisionId": "<uuid:5>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -8537,7 +8635,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_function_exceptions": {
-    "recorded-date": "26-01-2023, 22:16:37",
+    "recorded-date": "27-02-2023, 21:43:54",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8627,6 +8725,9 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:2>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -7129,8 +7129,18 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_permission_exceptions": {
-    "recorded-date": "17-02-2023, 11:40:14",
+    "recorded-date": "28-02-2023, 11:08:16",
     "recorded-content": {
+      "add_permission_invalid_statement_id": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'example.com' at 'statementId' failed to satisfy constraint: Member must satisfy regular expression pattern: ([a-zA-Z0-9-_]+)"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
       "add_permission_fn_qualifier_mismatch": {
         "Error": {
           "Code": "InvalidParameterValueException",

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -4363,12 +4363,95 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency_exceptions": {
-    "recorded-date": "17-02-2023, 11:39:57",
-    "recorded-content": {}
+    "recorded-date": "17-02-2023, 12:35:56",
+    "recorded-content": {
+      "put_concurrency_unknown_fn": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST"
+        },
+        "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put_concurrency_unknown_fn_invalid_concurrency": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST"
+        },
+        "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put_concurrency_known_fn_concurrency_limit_exceeded": {
+        "Error": {
+          "Code": "InvalidParameterValueException",
+          "Message": "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [100]."
+        },
+        "message": "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [100].",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "put_0_response": {
+        "ReservedConcurrentExecutions": 0,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put_1_response": {
+        "ReservedConcurrentExecutions": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_response": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      }
+    }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency": {
-    "recorded-date": "17-02-2023, 11:39:57",
-    "recorded-content": {}
+    "recorded-date": "17-02-2023, 12:38:26",
+    "recorded-content": {
+      "put_function_concurrency": {
+        "ReservedConcurrentExecutions": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_function_concurrency": {
+        "ReservedConcurrentExecutions": 1,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete_function_concurrency": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get_function_concurrency_postdelete": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_aws": {
     "recorded-date": "17-02-2023, 11:40:18",
@@ -4756,7 +4839,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_lambda": {
-    "recorded-date": "30-09-2022, 15:34:46",
+    "recorded-date": "17-02-2023, 12:42:06",
     "recorded-content": {
       "create_function_large_zip": {
         "Architectures": [
@@ -4777,6 +4860,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -6199,14 +6289,14 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_lambda_provisioned_lifecycle": {
-    "recorded-date": "17-02-2023, 11:40:09",
+    "recorded-date": "17-02-2023, 12:32:55",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "FpPXBDUwLt1SFHQdKkNXDJPy3+MYxnXuK7BVufrmzlk=",
-        "CodeSize": 264,
+        "CodeSha256": "<code-sha256:1>",
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {}
@@ -6214,18 +6304,18 @@
         "EphemeralStorage": {
           "Size": 512
         },
-        "FunctionArn": "arn:aws:lambda:us-east-1:644798471398:function:lambda_func-f012a158:1",
-        "FunctionName": "lambda_func-f012a158",
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+        "FunctionName": "<function-name:1>",
         "Handler": "handler.handler",
-        "LastModified": "2023-02-17T10:40:04.850+0000",
+        "LastModified": "date",
         "LastUpdateStatus": "Successful",
         "MemorySize": 128,
         "PackageType": "Zip",
-        "RevisionId": "66e16a1d-24fa-4e32-940b-65b4969df09c",
-        "Role": "arn:aws:iam::644798471398:role/lambda-autogenerated-5689708c",
+        "RevisionId": "<uuid:1>",
+        "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "python3.9",
         "RuntimeVersionConfig": {
-          "RuntimeVersionArn": "arn:aws:lambda:us-east-1::runtime:07a48df201798d627f2b950f03bb227aab4a655a1d019c3296406f95937e2525"
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
         },
         "SnapStart": {
           "ApplyOn": "None",
@@ -6238,35 +6328,108 @@
         },
         "Version": "1",
         "ResponseMetadata": {
-          "HTTPHeaders": {
-            "connection": "keep-alive",
-            "content-length": "1207",
-            "content-type": "application/json",
-            "date": "Fri, 17 Feb 2023 10:40:06 GMT",
-            "x-amzn-requestid": "6120238a-bd4e-4c5e-b9c1-8bfe64b1d396"
-          },
-          "HTTPStatusCode": 201,
-          "RequestId": "6120238a-bd4e-4c5e-b9c1-8bfe64b1d396",
-          "RetryAttempts": 0
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
         }
       },
       "create_alias_result": {
-        "AliasArn": "arn:aws:lambda:us-east-1:644798471398:function:lambda_func-f012a158:alias-ff4bbe5c",
+        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:<alias-name>",
         "Description": "",
         "FunctionVersion": "1",
-        "Name": "alias-ff4bbe5c",
-        "RevisionId": "a4000072-c18e-49fb-aca4-bd4f0aab0056",
+        "Name": "<alias-name>",
+        "RevisionId": "<uuid:2>",
         "ResponseMetadata": {
-          "HTTPHeaders": {
-            "connection": "keep-alive",
-            "content-length": "233",
-            "content-type": "application/json",
-            "date": "Fri, 17 Feb 2023 10:40:07 GMT",
-            "x-amzn-requestid": "71379a0d-f93c-4863-9461-08e06654c528"
-          },
-          "HTTPStatusCode": 201,
-          "RequestId": "71379a0d-f93c-4863-9461-08e06654c528",
-          "RetryAttempts": 0
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put_provisioned_on_version": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "IN_PROGRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "put_provisioned_on_alias_versionconflict": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "Alias can't be used for Provisioned Concurrency configuration on an already Provisioned version"
+        },
+        "Type": "User",
+        "message": "Alias can't be used for Provisioned Concurrency configuration on an already Provisioned version",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "delete_provisioned_version": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get_provisioned_version_postdelete": {
+        "Error": {
+          "Code": "ProvisionedConcurrencyConfigNotFoundException",
+          "Message": "No Provisioned Concurrency Config found for this function"
+        },
+        "Type": "User",
+        "message": "No Provisioned Concurrency Config found for this function",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "put_provisioned_on_alias": {
+        "AllocatedProvisionedConcurrentExecutions": 0,
+        "AvailableProvisionedConcurrentExecutions": 0,
+        "LastModified": "date",
+        "RequestedProvisionedConcurrentExecutions": 1,
+        "Status": "IN_PROGRESS",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "put_provisioned_on_version_conflict": {
+        "Error": {
+          "Code": "ResourceConflictException",
+          "Message": "Version is pointed by a Provisioned Concurrency alias"
+        },
+        "Type": "User",
+        "message": "Version is pointed by a Provisioned Concurrency alias",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "delete_alias_result": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "get_provisioned_alias_postaliasdelete": {
+        "Error": {
+          "Code": "ResourceNotFoundException",
+          "Message": "Cannot find alias arn: arn:aws:lambda:<region>:111111111111:function:<function-name:1>:<alias-name>"
+        },
+        "Message": "Cannot find alias arn: arn:aws:lambda:<region>:111111111111:function:<function-name:1>:<alias-name>",
+        "Type": "User",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "list_response_postdeletes": {
+        "ProvisionedConcurrencyConfigs": [],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10961,7 +10961,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle": {
-    "recorded-date": "15-02-2023, 17:02:48",
+    "recorded-date": "15-02-2023, 17:37:32",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,
@@ -10991,7 +10991,7 @@
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "None",
+            "ApplyOn": "PublishedVersions",
             "OptimizationStatus": "Off"
           },
           "State": "Pending",
@@ -11040,7 +11040,7 @@
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "None",
+            "ApplyOn": "PublishedVersions",
             "OptimizationStatus": "Off"
           },
           "State": "Active",
@@ -11087,8 +11087,8 @@
             "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
           },
           "SnapStart": {
-            "ApplyOn": "None",
-            "OptimizationStatus": "Off"
+            "ApplyOn": "PublishedVersions",
+            "OptimizationStatus": "On"
           },
           "State": "Active",
           "Timeout": 30,

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -10944,7 +10944,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
-    "recorded-date": "15-02-2023, 15:59:01",
+    "recorded-date": "15-02-2023, 18:01:40",
     "recorded-content": {
       "create_function_unsupported_snapstart_runtime": {
         "Error": {
@@ -10953,6 +10953,16 @@
         },
         "Type": "User",
         "message": "python3.9 is not supported for SnapStart enabled functions.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "create_function_invalid_snapstart_apply": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "1 validation error detected: Value 'invalidOption' at 'snapStart.applyOn' failed to satisfy constraint: Member must satisfy enum value set: [PublishedVersions, None]"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_function_lifecycle": {
-    "recorded-date": "30-09-2022, 15:30:31",
+    "recorded-date": "17-02-2023, 11:33:32",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -26,6 +26,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -68,6 +75,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 5,
           "TracingConfig": {
@@ -107,6 +121,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 10,
         "TracingConfig": {
@@ -148,6 +169,13 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 10,
           "TracingConfig": {
@@ -187,6 +215,13 @@
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 10,
         "TracingConfig": {
@@ -228,6 +263,13 @@
           "RevisionId": "<uuid:6>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 10,
           "TracingConfig": {
@@ -261,7 +303,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_redundant_updates": {
-    "recorded-date": "30-09-2022, 15:30:37",
+    "recorded-date": "17-02-2023, 11:33:39",
     "recorded-content": {
       "create_response": {
         "CreateEventSourceMappingResponse": null,
@@ -287,6 +329,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -326,6 +375,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -360,6 +416,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -399,6 +462,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -436,6 +506,13 @@
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -475,6 +552,13 @@
           "RevisionId": "<uuid:5>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -490,7 +574,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[delete_function]": {
-    "recorded-date": "30-09-2022, 15:30:37",
+    "recorded-date": "17-02-2023, 11:33:39",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -519,7 +603,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function]": {
-    "recorded-date": "30-09-2022, 15:30:38",
+    "recorded-date": "17-02-2023, 11:33:40",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -548,7 +632,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_with_arn_qualifier_mismatch[get_function_configuration]": {
-    "recorded-date": "30-09-2022, 15:30:38",
+    "recorded-date": "17-02-2023, 11:33:40",
     "recorded-content": {
       "not_match_exception": {
         "Error": {
@@ -577,7 +661,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function]": {
-    "recorded-date": "30-09-2022, 15:30:41",
+    "recorded-date": "17-02-2023, 11:33:43",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -594,7 +678,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_configuration]": {
-    "recorded-date": "30-09-2022, 15:30:43",
+    "recorded-date": "17-02-2023, 11:33:46",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -611,7 +695,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_version[get_function_event_invoke_config]": {
-    "recorded-date": "30-09-2022, 15:30:46",
+    "recorded-date": "17-02-2023, 11:33:49",
     "recorded-content": {
       "version_not_found_exception": {
         "Error": {
@@ -628,7 +712,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_delete_on_nonexisting_version": {
-    "recorded-date": "30-09-2022, 15:30:50",
+    "recorded-date": "17-02-2023, 11:33:53",
     "recorded-content": {
       "delete_function_response_non_existent": {
         "Error": {
@@ -657,7 +741,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[delete_function]": {
-    "recorded-date": "30-09-2022, 15:30:50",
+    "recorded-date": "17-02-2023, 11:33:53",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -674,7 +758,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function]": {
-    "recorded-date": "30-09-2022, 15:30:50",
+    "recorded-date": "17-02-2023, 11:33:54",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -691,7 +775,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_configuration]": {
-    "recorded-date": "30-09-2022, 15:30:50",
+    "recorded-date": "17-02-2023, 11:33:54",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -708,7 +792,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_url_config]": {
-    "recorded-date": "30-09-2022, 15:30:51",
+    "recorded-date": "17-02-2023, 11:33:54",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -725,7 +809,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_code_signing_config]": {
-    "recorded-date": "30-09-2022, 15:30:51",
+    "recorded-date": "17-02-2023, 11:33:54",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -742,7 +826,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_event_invoke_config]": {
-    "recorded-date": "30-09-2022, 15:30:51",
+    "recorded-date": "17-02-2023, 11:33:55",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -759,7 +843,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_ops_on_nonexisting_fn[get_function_concurrency]": {
-    "recorded-date": "30-09-2022, 15:30:51",
+    "recorded-date": "17-02-2023, 11:33:55",
     "recorded-content": {
       "not_found_exception": {
         "Error": {
@@ -776,7 +860,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function]": {
-    "recorded-date": "30-09-2022, 15:30:54",
+    "recorded-date": "17-02-2023, 11:33:58",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -793,7 +877,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_configuration]": {
-    "recorded-date": "30-09-2022, 15:30:57",
+    "recorded-date": "17-02-2023, 11:34:01",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -810,7 +894,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_url_config]": {
-    "recorded-date": "30-09-2022, 15:30:59",
+    "recorded-date": "17-02-2023, 11:34:04",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -827,7 +911,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_code_signing_config]": {
-    "recorded-date": "30-09-2022, 15:31:02",
+    "recorded-date": "17-02-2023, 11:34:07",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -844,7 +928,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_event_invoke_config]": {
-    "recorded-date": "30-09-2022, 15:31:05",
+    "recorded-date": "17-02-2023, 11:34:10",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -861,7 +945,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[get_function_concurrency]": {
-    "recorded-date": "30-09-2022, 15:31:08",
+    "recorded-date": "17-02-2023, 11:34:13",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -878,7 +962,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[delete_function]": {
-    "recorded-date": "30-09-2022, 15:31:10",
+    "recorded-date": "17-02-2023, 11:34:16",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -895,7 +979,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_get_function_wrong_region[invoke]": {
-    "recorded-date": "30-09-2022, 15:31:13",
+    "recorded-date": "17-02-2023, 11:34:19",
     "recorded-content": {
       "wrong_region_exception": {
         "Error": {
@@ -912,7 +996,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_zipfile": {
-    "recorded-date": "30-09-2022, 15:31:17",
+    "recorded-date": "15-02-2023, 19:51:39",
     "recorded-content": {
       "create-response-zip-file": {
         "Architectures": [
@@ -933,6 +1017,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -971,6 +1062,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1005,6 +1103,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1043,6 +1148,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1058,7 +1170,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_lambda_code_location_s3": {
-    "recorded-date": "30-09-2022, 15:31:23",
+    "recorded-date": "15-02-2023, 19:51:47",
     "recorded-content": {
       "create_response_s3": {
         "Architectures": [
@@ -1079,6 +1191,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1117,6 +1236,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1151,6 +1277,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1189,6 +1322,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1204,7 +1344,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_version_on_create": {
-    "recorded-date": "30-09-2022, 15:31:33",
+    "recorded-date": "17-02-2023, 11:38:37",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1225,6 +1365,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1263,6 +1410,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1300,6 +1454,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1337,6 +1498,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1370,6 +1538,10 @@
             "RevisionId": "<uuid:2>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1395,6 +1567,10 @@
             "RevisionId": "<uuid:3>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1427,6 +1603,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1459,6 +1642,10 @@
             "RevisionId": "<uuid:2>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1484,6 +1671,10 @@
             "RevisionId": "<uuid:3>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1499,7 +1690,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_version_lifecycle": {
-    "recorded-date": "30-09-2022, 15:31:40",
+    "recorded-date": "17-02-2023, 11:38:45",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -1520,6 +1711,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1558,6 +1756,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1591,6 +1796,10 @@
             "RevisionId": "<uuid:2>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1625,6 +1834,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1661,6 +1877,13 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1693,6 +1916,13 @@
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1729,6 +1959,13 @@
           "RevisionId": "<uuid:5>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1761,6 +1998,13 @@
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1794,6 +2038,13 @@
         "RevisionId": "<uuid:6>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1830,6 +2081,13 @@
           "RevisionId": "<uuid:5>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -1862,6 +2120,13 @@
         "RevisionId": "<uuid:7>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1893,6 +2158,13 @@
         "RevisionId": "<uuid:7>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -1925,6 +2197,10 @@
             "RevisionId": "<uuid:8>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1950,6 +2226,10 @@
             "RevisionId": "<uuid:5>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -1975,6 +2255,10 @@
             "RevisionId": "<uuid:7>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -2107,7 +2391,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaVersions::test_publish_with_wrong_sha256": {
-    "recorded-date": "30-09-2022, 15:31:45",
+    "recorded-date": "17-02-2023, 11:38:47",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2128,6 +2412,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2166,6 +2457,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -2210,6 +2508,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -2407,7 +2712,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAlias::test_alias_lifecycle": {
-    "recorded-date": "06-10-2022, 16:06:44",
+    "recorded-date": "17-02-2023, 11:38:56",
     "recorded-content": {
       "create_response": {
         "Architectures": [
@@ -2433,6 +2738,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2471,6 +2783,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -2507,6 +2826,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -3113,7 +3439,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_create_tag_on_fn_create": {
-    "recorded-date": "30-09-2022, 15:32:12",
+    "recorded-date": "17-02-2023, 11:39:18",
     "recorded-content": {
       "get_function_result": {
         "Code": {
@@ -3143,6 +3469,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -3170,7 +3503,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_tag_lifecycle": {
-    "recorded-date": "30-09-2022, 15:32:17",
+    "recorded-date": "17-02-2023, 11:39:23",
     "recorded-content": {
       "tag_single_response": {
         "ResponseMetadata": {
@@ -3285,7 +3618,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaTag::test_tag_nonexisting_resource": {
-    "recorded-date": "30-09-2022, 15:32:21",
+    "recorded-date": "17-02-2023, 11:39:27",
     "recorded-content": {
       "pre_delete_get_function": {
         "Code": {
@@ -3315,6 +3648,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -3366,7 +3706,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_exceptions": {
-    "recorded-date": "16-12-2022, 16:20:08",
+    "recorded-date": "17-02-2023, 11:39:54",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -3391,6 +3731,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -3477,7 +3824,7 @@
         "DestinationConfig": {
           "OnFailure": {},
           "OnSuccess": {
-            "Destination": "arn:aws:lambda:<region>:111111111111:function:<resource:4>"
+            "Destination": "arn:aws:lambda:<region>:111111111111:function:<resource:5>"
           }
         },
         "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:$LATEST",
@@ -4016,98 +4363,15 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency_exceptions": {
-    "recorded-date": "30-09-2022, 15:32:42",
-    "recorded-content": {
-      "put_concurrency_unknown_fn": {
-        "Error": {
-          "Code": "ResourceNotFoundException",
-          "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST"
-        },
-        "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST",
-        "Type": "User",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "put_concurrency_unknown_fn_invalid_concurrency": {
-        "Error": {
-          "Code": "ResourceNotFoundException",
-          "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST"
-        },
-        "Message": "Function not found: arn:aws:lambda:<region>:111111111111:function:unknown:$LATEST",
-        "Type": "User",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "put_concurrency_known_fn_concurrency_limit_exceeded": {
-        "Error": {
-          "Code": "InvalidParameterValueException",
-          "Message": "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [100]."
-        },
-        "message": "Specified ReservedConcurrentExecutions for function decreases account's UnreservedConcurrentExecution below its minimum value of [100].",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 400
-        }
-      },
-      "put_0_response": {
-        "ReservedConcurrentExecutions": 0,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "put_1_response": {
-        "ReservedConcurrentExecutions": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      }
-    }
+    "recorded-date": "17-02-2023, 11:39:57",
+    "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaReservedConcurrency::test_function_concurrency": {
-    "recorded-date": "30-09-2022, 15:32:45",
-    "recorded-content": {
-      "put_function_concurrency": {
-        "ReservedConcurrentExecutions": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "get_function_concurrency": {
-        "ReservedConcurrentExecutions": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "delete_function_concurrency": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      },
-      "get_function_concurrency_postdelete": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
+    "recorded-date": "17-02-2023, 11:39:57",
+    "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_aws": {
-    "recorded-date": "21-12-2022, 20:33:13",
+    "recorded-date": "17-02-2023, 11:40:18",
     "recorded-content": {
       "create_lambda": {
         "CreateEventSourceMappingResponse": null,
@@ -4133,6 +4397,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -4158,7 +4429,7 @@
           "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
           "Condition": {
             "ArnLike": {
-              "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+              "AWS:SourceArn": "arn:aws:s3:::<resource:3>"
             }
           }
         },
@@ -4182,7 +4453,7 @@
               "Resource": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>",
               "Condition": {
                 "ArnLike": {
-                  "AWS:SourceArn": "arn:aws:s3:::<resource:2>"
+                  "AWS:SourceArn": "arn:aws:s3:::<resource:3>"
                 }
               }
             }
@@ -4197,7 +4468,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_remove_multi_permissions": {
-    "recorded-date": "21-12-2022, 20:36:23",
+    "recorded-date": "17-02-2023, 11:40:33",
     "recorded-content": {
       "add_permission_1": {
         "Statement": {
@@ -4304,18 +4575,6 @@
           "HTTPStatusCode": 200
         }
       },
-      "remove_permission_exception_revision_id": {
-        "Error": {
-          "Code": "PreconditionFailedException",
-          "Message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id"
-        },
-        "Type": "User",
-        "message": "The Revision Id provided does not match the latest Revision Id. Call the GetFunction/GetAlias API to retrieve the latest Revision Id",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 412
-        }
-      },
       "policy_after_removal_attempt": {
         "Policy": {
           "Version": "2012-10-17",
@@ -4353,7 +4612,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_create_multiple_lambda_permissions": {
-    "recorded-date": "30-09-2022, 15:32:56",
+    "recorded-date": "17-02-2023, 11:40:36",
     "recorded-content": {
       "add_permission_response_1": {
         "Statement": {
@@ -4419,7 +4678,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_lifecycle": {
-    "recorded-date": "21-12-2022, 15:39:04",
+    "recorded-date": "17-02-2023, 11:41:05",
     "recorded-content": {
       "url_creation": {
         "AuthType": "NONE",
@@ -4534,7 +4793,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_environment_variables_fails": {
-    "recorded-date": "30-09-2022, 15:35:03",
+    "recorded-date": "17-02-2023, 11:42:51",
     "recorded-content": {
       "failed_create_fn_result": {
         "Error": {
@@ -4551,7 +4810,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_large_environment_fails_multiple_keys": {
-    "recorded-date": "30-09-2022, 15:35:20",
+    "recorded-date": "17-02-2023, 11:43:08",
     "recorded-content": {
       "failured_create_fn_result_multi_key": {
         "Error": {
@@ -4568,7 +4827,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_lambda_envvars_near_limit_succeeds": {
-    "recorded-date": "30-09-2022, 15:35:23",
+    "recorded-date": "17-02-2023, 11:43:11",
     "recorded-content": {
       "successful_create_fn_result": {
         "CreateEventSourceMappingResponse": null,
@@ -4596,6 +4855,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -4613,7 +4879,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestCodeSigningConfig::test_function_code_signing_config": {
-    "recorded-date": "30-09-2022, 15:35:28",
+    "recorded-date": "17-02-2023, 11:43:16",
     "recorded-content": {
       "create_code_signing_config": {
         "CodeSigningConfig": {
@@ -4916,7 +5182,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings": {
-    "recorded-date": "30-09-2022, 15:35:34",
+    "recorded-date": "17-02-2023, 11:43:17",
     "recorded-content": {
       "acc_settings_modded": {
         "AccountLimit": [
@@ -4938,7 +5204,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventSourceMappings::test_event_source_mapping_exceptions": {
-    "recorded-date": "23-11-2022, 10:09:28",
+    "recorded-date": "17-02-2023, 11:43:39",
     "recorded-content": {
       "get_unknown_uuid": {
         "Error": {
@@ -5694,7 +5960,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_provisioned_concurrency_exceptions": {
-    "recorded-date": "03-10-2022, 08:13:50",
+    "recorded-date": "17-02-2023, 11:40:04",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
@@ -5719,6 +5985,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -5926,14 +6199,14 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaProvisionedConcurrency::test_lambda_provisioned_lifecycle": {
-    "recorded-date": "03-10-2022, 23:22:39",
+    "recorded-date": "17-02-2023, 11:40:09",
     "recorded-content": {
       "publish_version_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "<code-sha256:1>",
-        "CodeSize": "<code-size>",
+        "CodeSha256": "FpPXBDUwLt1SFHQdKkNXDJPy3+MYxnXuK7BVufrmzlk=",
+        "CodeSize": 264,
         "Description": "",
         "Environment": {
           "Variables": {}
@@ -5941,16 +6214,23 @@
         "EphemeralStorage": {
           "Size": 512
         },
-        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
-        "FunctionName": "<function-name:1>",
+        "FunctionArn": "arn:aws:lambda:us-east-1:644798471398:function:lambda_func-f012a158:1",
+        "FunctionName": "lambda_func-f012a158",
         "Handler": "handler.handler",
-        "LastModified": "date",
+        "LastModified": "2023-02-17T10:40:04.850+0000",
         "LastUpdateStatus": "Successful",
         "MemorySize": 128,
         "PackageType": "Zip",
-        "RevisionId": "<uuid:1>",
-        "Role": "arn:aws:iam::111111111111:role/<resource:2>",
+        "RevisionId": "66e16a1d-24fa-4e32-940b-65b4969df09c",
+        "Role": "arn:aws:iam::644798471398:role/lambda-autogenerated-5689708c",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:us-east-1::runtime:07a48df201798d627f2b950f03bb227aab4a655a1d019c3296406f95937e2525"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -5958,114 +6238,41 @@
         },
         "Version": "1",
         "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
+          "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "1207",
+            "content-type": "application/json",
+            "date": "Fri, 17 Feb 2023 10:40:06 GMT",
+            "x-amzn-requestid": "6120238a-bd4e-4c5e-b9c1-8bfe64b1d396"
+          },
+          "HTTPStatusCode": 201,
+          "RequestId": "6120238a-bd4e-4c5e-b9c1-8bfe64b1d396",
+          "RetryAttempts": 0
         }
       },
       "create_alias_result": {
-        "AliasArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:<alias-name>",
+        "AliasArn": "arn:aws:lambda:us-east-1:644798471398:function:lambda_func-f012a158:alias-ff4bbe5c",
         "Description": "",
         "FunctionVersion": "1",
-        "Name": "<alias-name>",
-        "RevisionId": "<uuid:2>",
+        "Name": "alias-ff4bbe5c",
+        "RevisionId": "a4000072-c18e-49fb-aca4-bd4f0aab0056",
         "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 201
-        }
-      },
-      "put_provisioned_on_version": {
-        "AllocatedProvisionedConcurrentExecutions": 0,
-        "AvailableProvisionedConcurrentExecutions": 0,
-        "LastModified": "date",
-        "RequestedProvisionedConcurrentExecutions": 1,
-        "Status": "IN_PROGRESS",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        }
-      },
-      "put_provisioned_on_alias_versionconflict": {
-        "Error": {
-          "Code": "ResourceConflictException",
-          "Message": "Alias can't be used for Provisioned Concurrency configuration on an already Provisioned version"
-        },
-        "Type": "User",
-        "message": "Alias can't be used for Provisioned Concurrency configuration on an already Provisioned version",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      },
-      "delete_provisioned_version": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      },
-      "get_provisioned_version_postdelete": {
-        "Error": {
-          "Code": "ProvisionedConcurrencyConfigNotFoundException",
-          "Message": "No Provisioned Concurrency Config found for this function"
-        },
-        "Type": "User",
-        "message": "No Provisioned Concurrency Config found for this function",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "put_provisioned_on_alias": {
-        "AllocatedProvisionedConcurrentExecutions": 0,
-        "AvailableProvisionedConcurrentExecutions": 0,
-        "LastModified": "date",
-        "RequestedProvisionedConcurrentExecutions": 1,
-        "Status": "IN_PROGRESS",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        }
-      },
-      "put_provisioned_on_version_conflict": {
-        "Error": {
-          "Code": "ResourceConflictException",
-          "Message": "Version is pointed by a Provisioned Concurrency alias"
-        },
-        "Type": "User",
-        "message": "Version is pointed by a Provisioned Concurrency alias",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 409
-        }
-      },
-      "delete_alias_result": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 204
-        }
-      },
-      "get_provisioned_alias_postaliasdelete": {
-        "Error": {
-          "Code": "ResourceNotFoundException",
-          "Message": "Cannot find alias arn: arn:aws:lambda:<region>:111111111111:function:<function-name:1>:<alias-name>"
-        },
-        "Message": "Cannot find alias arn: arn:aws:lambda:<region>:111111111111:function:<function-name:1>:<alias-name>",
-        "Type": "User",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 404
-        }
-      },
-      "list_response_postdeletes": {
-        "ProvisionedConcurrencyConfigs": [],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          "HTTPHeaders": {
+            "connection": "keep-alive",
+            "content-length": "233",
+            "content-type": "application/json",
+            "date": "Fri, 17 Feb 2023 10:40:07 GMT",
+            "x-amzn-requestid": "71379a0d-f93c-4863-9461-08e06654c528"
+          },
+          "HTTPStatusCode": 201,
+          "RequestId": "71379a0d-f93c-4863-9461-08e06654c528",
+          "RetryAttempts": 0
         }
       }
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_oversized_request_create_lambda": {
-    "recorded-date": "03-10-2022, 18:52:49",
+    "recorded-date": "17-02-2023, 11:41:24",
     "recorded-content": {
       "invalid_param_exc": {
         "Error": {
@@ -6109,7 +6316,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_list_paging": {
-    "recorded-date": "21-12-2022, 15:46:10",
+    "recorded-date": "17-02-2023, 11:41:01",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -6134,6 +6341,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "nodejs14.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -6220,7 +6434,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaUrl::test_url_config_exceptions": {
-    "recorded-date": "23-12-2022, 16:10:57",
+    "recorded-date": "17-02-2023, 11:40:55",
     "recorded-content": {
       "fn_version_result": {
         "Architectures": [
@@ -6245,6 +6459,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "nodejs14.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -6647,7 +6868,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_permission_exceptions": {
-    "recorded-date": "22-12-2022, 10:15:01",
+    "recorded-date": "17-02-2023, 11:40:14",
     "recorded-content": {
       "add_permission_fn_qualifier_mismatch": {
         "Error": {
@@ -6818,7 +7039,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSizeLimits::test_oversized_unzipped_lambda": {
-    "recorded-date": "04-10-2022, 12:24:21",
+    "recorded-date": "17-02-2023, 11:42:33",
     "recorded-content": {
       "invalid_param_exc": {
         "Error": {
@@ -6835,7 +7056,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_create_lambda_exceptions": {
-    "recorded-date": "10-02-2023, 21:54:53",
+    "recorded-date": "17-02-2023, 11:34:21",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -6907,7 +7128,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_update_lambda_exceptions": {
-    "recorded-date": "04-10-2022, 18:31:15",
+    "recorded-date": "17-02-2023, 11:34:23",
     "recorded-content": {
       "invalid_role_arn_exc": {
         "Error": {
@@ -6922,10 +7143,10 @@
       "invalid_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value non-existent-runtime at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -6934,10 +7155,10 @@
       "uppercase_runtime_exc": {
         "Error": {
           "Code": "InvalidParameterValueException",
-          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
+          "Message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN"
         },
         "Type": "User",
-        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
+        "message": "Value PYTHON3.9 at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [nodejs12.x, provided, nodejs16.x, nodejs14.x, ruby2.7, java11, dotnet6, go1.x, nodejs18.x, provided.al2, java8, java8.al2, dotnetcore3.1, python3.7, python3.8, python3.9] or be a valid ARN",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
@@ -6946,7 +7167,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaFunction::test_list_functions": {
-    "recorded-date": "06-10-2022, 07:25:34",
+    "recorded-date": "17-02-2023, 11:34:38",
     "recorded-content": {
       "create_response_1": {
         "CreateEventSourceMappingResponse": null,
@@ -6972,6 +7193,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -7010,6 +7238,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -7058,6 +7293,10 @@
             "RevisionId": "<uuid:3>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 30,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -7086,6 +7325,10 @@
             "RevisionId": "<uuid:4>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 30,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -7114,6 +7357,10 @@
             "RevisionId": "<uuid:5>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 30,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -7146,6 +7393,10 @@
             "RevisionId": "<uuid:3>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 30,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -7174,6 +7425,10 @@
             "RevisionId": "<uuid:5>",
             "Role": "arn:aws:iam::111111111111:role/<resource:1>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 30,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -7185,7 +7440,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_exceptions": {
-    "recorded-date": "22-11-2022, 19:12:27",
+    "recorded-date": "17-02-2023, 11:43:48",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -7212,7 +7467,7 @@
       "list_layers_exc_compatibleruntime_invalid": {
         "Error": {
           "Code": "ValidationException",
-          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, java17, nodejs, nodejs4.3, java8.al2, go1.x, go1.9, byol, nodejs10.x, python3.10, java8, nodejs12.x, nodejs8.x, nodejs14.x, nodejs8.9, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, python3.4, ruby2.5, python3.6, python2.7]"
+          "Message": "1 validation error detected: Value 'runtimedoesnotexist' at 'compatibleRuntime' failed to satisfy constraint: Member must satisfy enum value set: [ruby2.6, dotnetcore1.0, python3.7, nodejs8.10, nasa, ruby2.7, python2.7-greengrass, dotnetcore2.0, python3.8, dotnet6, dotnetcore2.1, python3.9, java11, nodejs6.10, provided, dotnetcore3.1, java17, nodejs, nodejs4.3, java8.al2, go1.x, nodejs20.x, go1.9, byol, nodejs10.x, python3.10, java8, nodejs12.x, nodejs8.x, nodejs14.x, nodejs8.9, nodejs16.x, provided.al2, nodejs4.3-edge, nodejs18.x, ruby3.2, python3.4, ruby2.5, python3.6, python2.7]"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -7383,7 +7638,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_lifecycle": {
-    "recorded-date": "22-11-2022, 20:22:40",
+    "recorded-date": "17-02-2023, 11:44:11",
     "recorded-content": {
       "get_fn_result": {
         "Code": {
@@ -7413,6 +7668,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 30,
           "TracingConfig": {
@@ -7448,6 +7710,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -7473,8 +7742,8 @@
         },
         "CreatedDate": "date",
         "Description": "<description>",
-        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>",
-        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
         "LicenseInfo": "<license-info>",
         "Version": 1,
         "ResponseMetadata": {
@@ -7496,8 +7765,8 @@
         },
         "CreatedDate": "date",
         "Description": "<description>",
-        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>",
-        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:2",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:2",
         "LicenseInfo": "<license-info>",
         "Version": 2,
         "ResponseMetadata": {
@@ -7527,7 +7796,7 @@
         "LastUpdateStatusReasonCode": "Creating",
         "Layers": [
           {
-            "Arn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+            "Arn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
             "CodeSize": "<code-size>"
           }
         ],
@@ -7536,6 +7805,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -7567,7 +7843,7 @@
         "LastUpdateStatus": "Successful",
         "Layers": [
           {
-            "Arn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+            "Arn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
             "CodeSize": "<code-size>"
           }
         ],
@@ -7576,6 +7852,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -7601,8 +7884,8 @@
         },
         "CreatedDate": "date",
         "Description": "<description>",
-        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>",
-        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
         "LicenseInfo": "<license-info>",
         "Version": 1,
         "ResponseMetadata": {
@@ -7624,8 +7907,8 @@
         },
         "CreatedDate": "date",
         "Description": "<description>",
-        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>",
-        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
         "LicenseInfo": "<license-info>",
         "Version": 1,
         "ResponseMetadata": {
@@ -7644,7 +7927,7 @@
             ],
             "CreatedDate": "date",
             "Description": "<description>",
-            "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:2",
+            "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:2",
             "LicenseInfo": "<license-info>",
             "Version": 2
           },
@@ -7657,7 +7940,7 @@
             ],
             "CreatedDate": "date",
             "Description": "<description>",
-            "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+            "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
             "LicenseInfo": "<license-info>",
             "Version": 1
           }
@@ -7693,7 +7976,7 @@
         "LastUpdateStatus": "Successful",
         "Layers": [
           {
-            "Arn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:1",
+            "Arn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:1",
             "CodeSize": "<code-size>"
           }
         ],
@@ -7702,6 +7985,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -7740,8 +8030,8 @@
         },
         "CreatedDate": "date",
         "Description": "<description>",
-        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>",
-        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:2>:3",
+        "LayerArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>",
+        "LayerVersionArn": "arn:aws:lambda:<region>:111111111111:layer:<resource:3>:3",
         "LicenseInfo": "<license-info>",
         "Version": 3,
         "ResponseMetadata": {
@@ -7752,7 +8042,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_exceptions": {
-    "recorded-date": "16-01-2023, 14:08:15",
+    "recorded-date": "17-02-2023, 11:44:25",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -7935,7 +8225,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_policy_lifecycle": {
-    "recorded-date": "16-01-2023, 14:12:10",
+    "recorded-date": "17-02-2023, 11:44:31",
     "recorded-content": {
       "publish_result": {
         "CompatibleArchitectures": [
@@ -8063,7 +8353,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaLayer::test_layer_s3_content": {
-    "recorded-date": "21-11-2022, 16:55:19",
+    "recorded-date": "17-02-2023, 11:44:18",
     "recorded-content": {
       "publish_layer_result": {
         "Content": {
@@ -8275,7 +8565,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_crud": {
-    "recorded-date": "30-11-2022, 20:38:27",
+    "recorded-date": "17-02-2023, 11:36:22",
     "recorded-content": {
       "create-image-response": {
         "Architectures": [
@@ -8299,6 +8589,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -8341,6 +8635,10 @@
           "PackageType": "Image",
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -8376,6 +8674,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8424,6 +8726,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8464,6 +8770,10 @@
           "PackageType": "Image",
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -8499,6 +8809,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8513,7 +8827,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_image_and_image_config_crud": {
-    "recorded-date": "30-11-2022, 21:35:01",
+    "recorded-date": "17-02-2023, 11:38:24",
     "recorded-content": {
       "create-image-with-config-response": {
         "Architectures": [
@@ -8549,6 +8863,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -8603,6 +8921,10 @@
           "PackageType": "Image",
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -8650,6 +8972,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8695,6 +9021,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8744,6 +9074,10 @@
           "PackageType": "Image",
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -8788,6 +9122,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:4>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8824,6 +9162,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8864,6 +9206,10 @@
           "PackageType": "Image",
           "RevisionId": "<uuid:6>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -8899,6 +9245,10 @@
         "PackageType": "Image",
         "RevisionId": "<uuid:6>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -8913,7 +9263,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaImages::test_lambda_zip_file_to_image": {
-    "recorded-date": "01-12-2022, 13:34:38",
+    "recorded-date": "17-02-2023, 11:36:41",
     "recorded-content": {
       "create-image-response": {
         "Architectures": [
@@ -8934,6 +9284,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -8972,6 +9329,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -9004,6 +9368,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -9052,6 +9423,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -9084,6 +9462,13 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 3,
         "TracingConfig": {
@@ -9098,7 +9483,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings_total_code_size": {
-    "recorded-date": "07-12-2022, 09:31:14",
+    "recorded-date": "17-02-2023, 11:43:31",
     "recorded-content": {
       "total_code_size_diff_create_function": 276,
       "total_code_size_diff_update_function": 276,
@@ -9107,7 +9492,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaAccountSettings::test_account_settings_total_code_size_config_update": {
-    "recorded-date": "07-12-2022, 09:32:59",
+    "recorded-date": "17-02-2023, 11:43:37",
     "recorded-content": {
       "is_total_code_size_diff_create_function_more_than_200": true,
       "total_code_size_diff_update_function_configuration": 0,
@@ -9115,7 +9500,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_lifecycle": {
-    "recorded-date": "19-12-2022, 14:17:11",
+    "recorded-date": "17-02-2023, 11:39:34",
     "recorded-content": {
       "put_invokeconfig_retries_0": {
         "DestinationConfig": {
@@ -9239,6 +9624,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -9458,7 +9850,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_add_lambda_permission_fields": {
-    "recorded-date": "22-12-2022, 15:46:35",
+    "recorded-date": "17-02-2023, 11:40:29",
     "recorded-content": {
       "add_permission_principal_wildcard": {
         "Statement": {
@@ -9542,9 +9934,9 @@
           "Resource": "arn:aws:lambda:<region>:111111111111:function:<resource:1>",
           "Condition": {
             "StringEquals": {
+              "AWS:SourceAccount": "111111111111",
               "lambda:FunctionUrlAuthType": "NONE",
-              "aws:PrincipalOrgID": "o-1234567890",
-              "AWS:SourceAccount": "111111111111"
+              "aws:PrincipalOrgID": "o-1234567890"
             },
             "ArnLike": {
               "AWS:SourceArn": "arn:aws:s3:::<resource:3>"
@@ -9577,7 +9969,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaPermissions::test_lambda_permission_fn_versioning": {
-    "recorded-date": "16-01-2023, 12:41:51",
+    "recorded-date": "17-02-2023, 11:40:24",
     "recorded-content": {
       "add_permission": {
         "Statement": {
@@ -9649,6 +10041,9 @@
         "RevisionId": "<uuid:2>",
         "Role": "arn:aws:iam::111111111111:role/<resource:3>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:4>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -9692,6 +10087,9 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:3>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:4>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10204,7 +10602,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_basic": {
-    "recorded-date": "06-01-2023, 22:19:13",
+    "recorded-date": "17-02-2023, 11:39:05",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -10230,6 +10628,9 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10276,6 +10677,9 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10329,6 +10733,9 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -10372,6 +10779,9 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10425,6 +10835,9 @@
         "RevisionId": "<uuid:5>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -10468,6 +10881,9 @@
           "RevisionId": "<uuid:6>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10487,7 +10903,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_version_and_alias": {
-    "recorded-date": "13-01-2023, 18:36:42",
+    "recorded-date": "17-02-2023, 11:39:10",
     "recorded-content": {
       "create_function_response_rev1": {
         "CreateEventSourceMappingResponse": null,
@@ -10513,6 +10929,9 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10559,6 +10978,9 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10610,6 +11032,9 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -10653,6 +11078,9 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10697,6 +11125,9 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10752,6 +11183,9 @@
           "RevisionId": "<uuid:4>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10796,6 +11230,9 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
           "SnapStart": {
             "ApplyOn": "None",
             "OptimizationStatus": "Off"
@@ -10838,7 +11275,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaRevisions::test_function_revisions_permissions": {
-    "recorded-date": "06-01-2023, 22:30:27",
+    "recorded-date": "17-02-2023, 11:39:14",
     "recorded-content": {
       "add_permission_revision_exception": {
         "Error": {
@@ -10944,7 +11381,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_exceptions": {
-    "recorded-date": "15-02-2023, 18:01:40",
+    "recorded-date": "17-02-2023, 11:46:20",
     "recorded-content": {
       "create_function_unsupported_snapstart_runtime": {
         "Error": {
@@ -10971,7 +11408,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_lifecycle": {
-    "recorded-date": "15-02-2023, 17:37:32",
+    "recorded-date": "17-02-2023, 11:46:16",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,
@@ -11115,7 +11552,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaSnapStart::test_snapstart_update_function_configuration": {
-    "recorded-date": "15-02-2023, 18:18:14",
+    "recorded-date": "17-02-2023, 11:46:19",
     "recorded-content": {
       "create_function_response": {
         "CreateEventSourceMappingResponse": null,

--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -45,15 +45,12 @@ def snapshot_transformers(snapshot):
 class TestLambdaRuntimesCommon:
     """
     Directly correlates to the structure found in tests.integration.awslambda.functions.common
-
-    each scenario has the following folder structure
-
-    ./common/<scenario>/runtime/
-
-    runtime can either be directly one of the supported runtimes (e.g. in case of version specific compilation instructions) or one of the keys in RUNTIMES_AGGREGATED
-
+    Each scenario has the following folder structure: ./common/<scenario>/runtime/
+    Runtime can either be directly one of the supported runtimes (e.g. in case of version specific compilation instructions) or one of the keys in RUNTIMES_AGGREGATED
+    To selectively execute runtimes, use the runtimes parameter of multiruntime. Example: runtimes=[Runtime.go1_x]
     """
 
+    @pytest.mark.aws_validated
     @pytest.mark.multiruntime(scenario="echo")
     def test_echo_invoke(self, lambda_client, multiruntime_lambda):
         # provided lambdas take a little longer for large payloads, hence timeout to 5s
@@ -130,6 +127,7 @@ class TestLambdaRuntimesCommon:
             "$..CodeSha256",  # works locally but unfortunately still produces a different hash in CI
         ]
     )
+    @pytest.mark.aws_validated
     @pytest.mark.multiruntime(scenario="introspection")
     def test_introspection_invoke(self, lambda_client, multiruntime_lambda, snapshot):
         create_function_result = multiruntime_lambda.create_function(
@@ -167,6 +165,7 @@ class TestLambdaRuntimesCommon:
             "$..CodeSha256",  # works locally but unfortunately still produces a different hash in CI
         ]
     )
+    @pytest.mark.aws_validated
     @pytest.mark.multiruntime(scenario="uncaughtexception")
     def test_uncaught_exception_invoke(self, lambda_client, multiruntime_lambda, snapshot):
         # unfortunately the stack trace is quite unreliable and changes when AWS updates the runtime transparently
@@ -192,9 +191,9 @@ class TestLambdaRuntimesCommon:
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$..CodeSha256",  # works locally but unfortunately still produces a different hash in CI
-            "$..SnapStart",  # FIXME needs to be added to CreateFunction + all snapshots regenerated
         ]
     )
+    @pytest.mark.aws_validated
     # this does only work on al2 lambdas, except provided.al2.
     # Source: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html#runtime-wrapper
     @pytest.mark.multiruntime(

--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -50,6 +50,10 @@ class TestLambdaRuntimesCommon:
     To selectively execute runtimes, use the runtimes parameter of multiruntime. Example: runtimes=[Runtime.go1_x]
     """
 
+    # TODO: refactor builds:
+    # * Remove specific hashes and `touch -t` since we're not actually checking size & hash of the zip files anymore
+    # * Create a generic parametrizable Makefile per runtime (possibly with an option to provide a specific one)
+
     @pytest.mark.aws_validated
     @pytest.mark.multiruntime(scenario="echo")
     def test_echo_invoke(self, lambda_client, multiruntime_lambda):

--- a/tests/integration/awslambda/test_lambda_common.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_common.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs12.x]": {
-    "recorded-date": "23-11-2022, 13:29:54",
+    "recorded-date": "27-02-2023, 15:49:15",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -26,6 +26,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs12.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -130,7 +137,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs14.x]": {
-    "recorded-date": "23-11-2022, 13:29:56",
+    "recorded-date": "27-02-2023, 15:49:18",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -156,6 +163,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs14.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -260,7 +274,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs16.x]": {
-    "recorded-date": "23-11-2022, 13:29:58",
+    "recorded-date": "27-02-2023, 15:49:21",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -286,6 +300,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs16.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -390,7 +411,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.7]": {
-    "recorded-date": "23-11-2022, 13:29:48",
+    "recorded-date": "27-02-2023, 15:49:06",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -416,6 +437,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.7",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -514,7 +542,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.8]": {
-    "recorded-date": "23-11-2022, 13:29:50",
+    "recorded-date": "27-02-2023, 15:49:09",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -540,6 +568,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -644,7 +679,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[python3.9]": {
-    "recorded-date": "23-11-2022, 13:29:52",
+    "recorded-date": "27-02-2023, 15:49:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -670,6 +705,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -774,7 +816,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[ruby2.7]": {
-    "recorded-date": "23-11-2022, 13:30:02",
+    "recorded-date": "27-02-2023, 15:49:28",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -800,6 +842,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "ruby2.7",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -908,7 +957,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8]": {
-    "recorded-date": "23-11-2022, 13:30:25",
+    "recorded-date": "27-02-2023, 15:49:51",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -934,6 +983,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "java8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1038,7 +1094,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java8.al2]": {
-    "recorded-date": "23-11-2022, 13:30:31",
+    "recorded-date": "27-02-2023, 15:50:00",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1064,6 +1120,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "java8.al2",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1166,7 +1229,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[java11]": {
-    "recorded-date": "23-11-2022, 13:30:37",
+    "recorded-date": "27-02-2023, 15:50:19",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1192,6 +1255,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "java11",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1294,13 +1364,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[go1.x]": {
-    "recorded-date": "23-11-2022, 13:31:05",
+    "recorded-date": "27-02-2023, 15:50:42",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "ElaqZ3vc40BIziwnNowuXMWrN3+4NPjLwMCCv1zfykg=",
+        "CodeSha256": "EVxqKUhMTC8LAXQ90Vo5gXZ4gcQO/orXJIYTgwAkMow=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1320,6 +1390,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "go1.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1426,13 +1503,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnet6]": {
-    "recorded-date": "23-11-2022, 13:30:51",
+    "recorded-date": "27-02-2023, 15:50:26",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "EN2qdeZgTKkfpE37f/UE/xEjmT67XROIiGLW4Ubaxbs=",
+        "CodeSha256": "pPNT1m9LVvHF5KD5w6+6D/DiPlGL//7uJyhOHcHcoOE=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1452,6 +1529,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "dotnet6",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1560,13 +1644,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[dotnetcore3.1]": {
-    "recorded-date": "23-11-2022, 13:30:44",
+    "recorded-date": "27-02-2023, 15:50:23",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "dk2zuRfKIAOV3aZPdSvxUKi0pn+l99PNfPZmqHQKgks=",
+        "CodeSha256": "6kJ/nxnpFtFFnAfxqgjvQuueIKv4aH2qFl8qhr3o2Vo=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1586,6 +1670,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "dotnetcore3.1",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1686,13 +1777,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided]": {
-    "recorded-date": "23-11-2022, 13:33:14",
+    "recorded-date": "27-02-2023, 15:50:46",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "Y7ZV7rCjWc7PuVjQhLnuakSFU0AKpeZ51/mOfjGtqw0=",
+        "CodeSha256": "AwbdeLHglRbrp3WlhEE3stQ1MNXdw/2UsN8tYC262as=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1712,6 +1803,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "provided",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1808,13 +1906,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[provided.al2]": {
-    "recorded-date": "23-11-2022, 13:33:17",
+    "recorded-date": "27-02-2023, 15:50:50",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "Y7ZV7rCjWc7PuVjQhLnuakSFU0AKpeZ51/mOfjGtqw0=",
+        "CodeSha256": "AwbdeLHglRbrp3WlhEE3stQ1MNXdw/2UsN8tYC262as=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -1834,6 +1932,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "provided.al2",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1930,7 +2035,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.7]": {
-    "recorded-date": "23-11-2022, 13:33:18",
+    "recorded-date": "27-02-2023, 15:50:53",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -1951,6 +2056,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.7",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -1981,7 +2093,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.8]": {
-    "recorded-date": "23-11-2022, 13:33:20",
+    "recorded-date": "27-02-2023, 15:50:56",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2002,6 +2114,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2032,7 +2151,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[python3.9]": {
-    "recorded-date": "23-11-2022, 13:33:22",
+    "recorded-date": "27-02-2023, 15:50:58",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2053,6 +2172,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2084,7 +2210,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs12.x]": {
-    "recorded-date": "23-11-2022, 13:33:24",
+    "recorded-date": "27-02-2023, 15:51:01",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2105,6 +2231,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs12.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2135,7 +2268,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs14.x]": {
-    "recorded-date": "23-11-2022, 13:33:26",
+    "recorded-date": "27-02-2023, 15:51:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2156,6 +2289,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs14.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2186,7 +2326,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs16.x]": {
-    "recorded-date": "23-11-2022, 13:33:28",
+    "recorded-date": "27-02-2023, 15:51:06",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2207,6 +2347,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs16.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2237,7 +2384,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8]": {
-    "recorded-date": "23-11-2022, 13:33:54",
+    "recorded-date": "27-02-2023, 15:51:22",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2258,6 +2405,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "java8",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2288,7 +2442,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java8.al2]": {
-    "recorded-date": "23-11-2022, 13:34:01",
+    "recorded-date": "27-02-2023, 15:51:30",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2309,6 +2463,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "java8.al2",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2339,7 +2500,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[java11]": {
-    "recorded-date": "23-11-2022, 13:34:07",
+    "recorded-date": "27-02-2023, 15:51:39",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2360,6 +2521,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "java11",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2390,7 +2558,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[ruby2.7]": {
-    "recorded-date": "23-11-2022, 13:33:31",
+    "recorded-date": "27-02-2023, 15:51:12",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2411,6 +2579,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "ruby2.7",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2441,13 +2616,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[go1.x]": {
-    "recorded-date": "23-11-2022, 13:34:29",
+    "recorded-date": "27-02-2023, 15:52:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "SCDyyKP0IKATEQD0LxqsAgguOGEwDlDUReehN6Q04jo=",
+        "CodeSha256": "/HENxf/w1A4pmZiS4KE4hBXNPfJ/oBi/5boLUW40gbM=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2462,6 +2637,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "go1.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2491,13 +2673,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided]": {
-    "recorded-date": "23-11-2022, 13:36:07",
+    "recorded-date": "27-02-2023, 15:52:49",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "xXa38Z7WlUt+krqrOM+f9lrEn9J6mbv34BighGH4ZhY=",
+        "CodeSha256": "mdyx6lX3eKXegmh4CuAtIYkz2zQio3aJPab0U7RUi+g=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2512,6 +2694,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "provided",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2529,7 +2718,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorType": "&alloc::boxed::Box<dyn std::error::Error+core::marker::Sync+core::marker::Send>",
+          "errorType": "&alloc::boxed::Box<dyn core::error::Error + core::marker::Send + core::marker::Sync>",
           "errorMessage": "Error: \"some_error_msg\""
         },
         "StatusCode": 200,
@@ -2541,13 +2730,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[provided.al2]": {
-    "recorded-date": "23-11-2022, 13:36:10",
+    "recorded-date": "27-02-2023, 15:52:52",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "xXa38Z7WlUt+krqrOM+f9lrEn9J6mbv34BighGH4ZhY=",
+        "CodeSha256": "mdyx6lX3eKXegmh4CuAtIYkz2zQio3aJPab0U7RUi+g=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2562,6 +2751,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "provided.al2",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2579,7 +2775,7 @@
         "ExecutedVersion": "$LATEST",
         "FunctionError": "Unhandled",
         "Payload": {
-          "errorType": "&alloc::boxed::Box<dyn std::error::Error+core::marker::Sync+core::marker::Send>",
+          "errorType": "&alloc::boxed::Box<dyn core::error::Error + core::marker::Send + core::marker::Sync>",
           "errorMessage": "Error: \"some_error_msg\""
         },
         "StatusCode": 200,
@@ -2591,13 +2787,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnet6]": {
-    "recorded-date": "23-11-2022, 13:39:29",
+    "recorded-date": "27-02-2023, 15:51:45",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "SRo/CNHtnjkN6EflAqg029GSsLIRRmtwsjCskIu9Ncs=",
+        "CodeSha256": "RMNx39qSLuPzRpcE2Zo1OTMltH+9HJZ5LISmiqSukB0=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2612,6 +2808,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "dotnet6",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2642,13 +2845,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[dotnetcore3.1]": {
-    "recorded-date": "23-11-2022, 13:34:14",
+    "recorded-date": "27-02-2023, 15:51:42",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "o9MV1/KnGpxyzwAx8gRhiXsChrGsEni72ZZJKJhP6lw=",
+        "CodeSha256": "evIqWg7Cz43b2UaEV0G1j2bm0dAVkDzyRRlBK5OY0lY=",
         "CodeSize": "<code-size>",
         "Description": "",
         "EphemeralStorage": {
@@ -2663,6 +2866,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "dotnetcore3.1",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2693,71 +2903,71 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.7]": {
-    "recorded-date": "23-11-2022, 13:25:05",
+    "recorded-date": "27-02-2023, 15:45:48",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.8]": {
-    "recorded-date": "23-11-2022, 13:25:10",
+    "recorded-date": "27-02-2023, 15:45:55",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[python3.9]": {
-    "recorded-date": "23-11-2022, 13:25:15",
+    "recorded-date": "27-02-2023, 15:46:02",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs12.x]": {
-    "recorded-date": "23-11-2022, 13:25:18",
+    "recorded-date": "27-02-2023, 15:46:09",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs14.x]": {
-    "recorded-date": "23-11-2022, 13:25:22",
+    "recorded-date": "27-02-2023, 15:46:20",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs16.x]": {
-    "recorded-date": "23-11-2022, 13:25:26",
+    "recorded-date": "27-02-2023, 15:46:28",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[ruby2.7]": {
-    "recorded-date": "23-11-2022, 13:25:34",
+    "recorded-date": "27-02-2023, 15:46:42",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8]": {
-    "recorded-date": "23-11-2022, 13:26:17",
+    "recorded-date": "27-02-2023, 15:47:00",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java8.al2]": {
-    "recorded-date": "23-11-2022, 13:26:25",
+    "recorded-date": "27-02-2023, 15:47:11",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[java11]": {
-    "recorded-date": "23-11-2022, 13:26:32",
+    "recorded-date": "27-02-2023, 15:47:23",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnetcore3.1]": {
-    "recorded-date": "23-11-2022, 13:27:40",
+    "recorded-date": "27-02-2023, 15:47:29",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[dotnet6]": {
-    "recorded-date": "23-11-2022, 13:28:54",
+    "recorded-date": "27-02-2023, 15:47:36",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[go1.x]": {
-    "recorded-date": "23-11-2022, 13:29:29",
+    "recorded-date": "27-02-2023, 15:48:42",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided]": {
-    "recorded-date": "23-11-2022, 13:29:38",
+    "recorded-date": "27-02-2023, 15:48:52",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[provided.al2]": {
-    "recorded-date": "23-11-2022, 13:29:45",
+    "recorded-date": "27-02-2023, 15:49:03",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_echo_invoke[nodejs18.x]": {
-    "recorded-date": "23-11-2022, 13:25:30",
+    "recorded-date": "27-02-2023, 15:46:35",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_introspection_invoke[nodejs18.x]": {
-    "recorded-date": "23-11-2022, 13:30:00",
+    "recorded-date": "27-02-2023, 15:49:24",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2783,6 +2993,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs18.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2887,7 +3104,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_uncaught_exception_invoke[nodejs18.x]": {
-    "recorded-date": "23-11-2022, 13:33:29",
+    "recorded-date": "27-02-2023, 15:51:10",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
@@ -2908,6 +3125,13 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs18.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Pending",
         "StateReason": "The function is being created.",
         "StateReasonCode": "Creating",
@@ -2938,13 +3162,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs12.x]": {
-    "recorded-date": "09-01-2023, 15:40:22",
+    "recorded-date": "27-02-2023, 15:52:55",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "okIko96ihrSGmEPmnhh46sowBsBdl37dYpXkzQCLABw=",
+        "CodeSha256": "7Kp9bB7d81J5cxZrK9PzbM/luXLmI68YXbXlIbPMMWk=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -2964,6 +3188,9 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs12.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -2984,13 +3211,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs14.x]": {
-    "recorded-date": "09-01-2023, 15:40:24",
+    "recorded-date": "27-02-2023, 15:52:58",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "gfhrdY+Hpo6BL4QWCvD+JiEwJXGjnaqClGvJTQSK1Tg=",
+        "CodeSha256": "1CCL+mA9dhOFe98gl0DP/p5jSStv0+OzxHBZjTdLYwI=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3010,6 +3237,9 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs14.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -3030,13 +3260,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs16.x]": {
-    "recorded-date": "09-01-2023, 15:40:26",
+    "recorded-date": "27-02-2023, 15:53:01",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "W5k3JfmXcqE5YANLxP+oJy48FDb1xNqNzVGY+QFkzDE=",
+        "CodeSha256": "S/Qw+/13v5feqoexcZziFhGCCJuLXYdK/APm/4HirOE=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3056,6 +3286,9 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs16.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"
@@ -3076,13 +3309,13 @@
     }
   },
   "tests/integration/awslambda/test_lambda_common.py::TestLambdaRuntimesCommon::test_runtime_wrapper_invoke[nodejs18.x]": {
-    "recorded-date": "09-01-2023, 15:40:30",
+    "recorded-date": "27-02-2023, 15:53:04",
     "recorded-content": {
       "create_function_result": {
         "Architectures": [
           "x86_64"
         ],
-        "CodeSha256": "NVjeBVHSLYSTQ61qv5jjKkx/C+ZlD65Fp6yKxAXLIWs=",
+        "CodeSha256": "+XDjR2nTpssauodt+UlbzBP7CNWmfoHCl3WidmvnPHc=",
         "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
@@ -3102,6 +3335,9 @@
         "RevisionId": "<uuid:1>",
         "Role": "arn:aws:iam::111111111111:role/<resource:1>",
         "Runtime": "nodejs18.x",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+        },
         "SnapStart": {
           "ApplyOn": "None",
           "OptimizationStatus": "Off"

--- a/tests/integration/awslambda/test_lambda_destinations.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_destinations.snapshot.json
@@ -121,7 +121,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
-    "recorded-date": "01-09-2022, 09:09:20",
+    "recorded-date": "27-02-2023, 16:02:33",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -183,7 +183,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload1]": {
-    "recorded-date": "01-09-2022, 09:12:37",
+    "recorded-date": "27-02-2023, 16:08:45",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -242,7 +242,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDLQ::test_dead_letter_queue": {
-    "recorded-date": "23-11-2022, 21:22:49",
+    "recorded-date": "27-02-2023, 16:00:54",
     "recorded-content": {
       "create_lambda_with_dlq": {
         "CreateEventSourceMappingResponse": null,
@@ -271,6 +271,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:2>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -344,6 +351,13 @@
         "RevisionId": "<uuid:3>",
         "Role": "arn:aws:iam::111111111111:role/<resource:2>",
         "Runtime": "python3.9",
+        "RuntimeVersionConfig": {
+          "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:3>"
+        },
+        "SnapStart": {
+          "ApplyOn": "None",
+          "OptimizationStatus": "Off"
+        },
         "State": "Active",
         "Timeout": 30,
         "TracingConfig": {
@@ -387,7 +401,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_retries": {
-    "recorded-date": "16-12-2022, 09:15:27",
+    "recorded-date": "27-02-2023, 16:12:55",
     "recorded-content": {
       "queue_destination_payload": {
         "Messages": [
@@ -436,7 +450,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_maxeventage": {
-    "recorded-date": "16-12-2022, 11:42:55",
+    "recorded-date": "27-02-2023, 16:14:27",
     "recorded-content": {
       "no_retry_failure_message": {
         "Attributes": {

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py
@@ -17,6 +17,7 @@ from localstack.testing.aws.lambda_utils import (
     lambda_role,
     s3_lambda_permission,
 )
+from localstack.testing.aws.util import is_aws_cloud
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.utils.strings import short_uid
 from localstack.utils.sync import poll_condition, retry
@@ -371,7 +372,9 @@ class TestDynamoDBEventSourceMapping:
             assert res.get("Messages")
             return res
 
-        messages = retry(verify_failure_received, retries=15, sleep=5, sleep_before=5)
+        # It can take ~3 min against AWS until the message is received
+        sleep = 10 if is_aws_cloud() else 5
+        messages = retry(verify_failure_received, retries=15, sleep=sleep, sleep_before=5)
         snapshot.match("destination_queue_messages", messages)
 
     @pytest.mark.aws_validated

--- a/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_integration_dynamodbstreams.snapshot.json
@@ -1,12 +1,8 @@
 {
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping": {
-    "recorded-date": "05-09-2022, 11:16:26",
+    "recorded-date": "27-02-2023, 18:33:49",
     "recorded-content": {
       "create-table-result": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -35,6 +31,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -52,15 +52,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "event_logs": [
         {
@@ -95,13 +95,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_disabled_dynamodb_event_source_mapping": {
-    "recorded-date": "05-09-2022, 11:17:35",
+    "recorded-date": "27-02-2023, 18:34:59",
     "recorded-content": {
       "dynamodb_create_table_result": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -136,6 +132,10 @@
           "TableName": "<resource:2>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_result": {
@@ -153,15 +153,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "update_event_source_mapping_result": {
         "BatchSize": 100,
@@ -178,26 +178,22 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Disabling",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       }
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_deletion_event_source_mapping_with_dynamodb": {
-    "recorded-date": "05-09-2022, 11:18:03",
+    "recorded-date": "27-02-2023, 18:35:29",
     "recorded-content": {
       "create_dynamodb_table_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -232,6 +228,10 @@
           "TableName": "<resource:2>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_result": {
@@ -249,15 +249,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "list_event_source_mapping_result": {
         "EventSourceMappings": [
@@ -291,13 +291,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "05-09-2022, 14:48:19",
+    "recorded-date": "27-02-2023, 18:36:42",
     "recorded-content": {
       "update_table_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -333,6 +329,10 @@
           "TableName": "<resource:2>",
           "TableSizeBytes": 0,
           "TableStatus": "UPDATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -352,15 +352,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "destination_queue_messages": {
         "Messages": [
@@ -402,13 +402,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put10-None-filter0-1]": {
-    "recorded-date": "05-09-2022, 15:50:30",
+    "recorded-date": "27-02-2023, 18:37:56",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -437,6 +433,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -465,15 +465,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [
         {
@@ -544,13 +544,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put11-item_to_put21-filter1-2]": {
-    "recorded-date": "05-09-2022, 15:51:35",
+    "recorded-date": "27-02-2023, 18:39:17",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -579,6 +575,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -608,15 +608,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [
         {
@@ -717,13 +717,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put12-item_to_put22-filter2-1]": {
-    "recorded-date": "05-09-2022, 15:52:28",
+    "recorded-date": "27-02-2023, 18:40:56",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -752,6 +748,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -783,15 +783,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [
         {
@@ -856,13 +856,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put13-item_to_put23-filter3-1]": {
-    "recorded-date": "05-09-2022, 15:53:29",
+    "recorded-date": "27-02-2023, 18:42:11",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -891,6 +887,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -925,15 +925,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [
         {
@@ -998,13 +998,9 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put14-item_to_put24-filter4-0]": {
-    "recorded-date": "05-09-2022, 15:53:48",
+    "recorded-date": "27-02-2023, 18:42:34",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -1033,6 +1029,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -1072,28 +1072,24 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [],
       "lambda-multiple-log-events": []
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put15-item_to_put25-filter5-0]": {
-    "recorded-date": "05-09-2022, 15:54:08",
+    "recorded-date": "27-02-2023, 18:42:58",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -1122,6 +1118,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -1163,28 +1163,24 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [],
       "lambda-multiple-log-events": []
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_event_filter[item_to_put16-item_to_put26-filter6-1]": {
-    "recorded-date": "05-09-2022, 15:55:30",
+    "recorded-date": "27-02-2023, 18:43:59",
     "recorded-content": {
       "table_creation_response": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "TableDescription": {
           "AttributeDefinitions": [
             {
@@ -1213,6 +1209,10 @@
           "TableName": "<resource:1>",
           "TableSizeBytes": 0,
           "TableStatus": "CREATING"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "create_event_source_mapping_response": {
@@ -1249,15 +1249,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:2>"
+        "UUID": "<uuid:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "lambda-log-events": [
         {
@@ -1328,36 +1328,36 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[single-string]": {
-    "recorded-date": "05-09-2022, 15:07:24",
+    "recorded-date": "27-02-2023, 18:44:12",
     "recorded-content": {
       "exception_event_source_creation": {
         "Error": {
           "Code": "InvalidParameterValueException",
           "Message": "Invalid filter pattern definition."
         },
+        "Type": "User",
+        "message": "Invalid filter pattern definition.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
-        },
-        "Type": "User",
-        "message": "Invalid filter pattern definition."
+        }
       }
     }
   },
   "tests/integration/awslambda/test_lambda_integration_dynamodbstreams.py::TestDynamoDBEventSourceMapping::test_dynamodb_invalid_event_filter[[{\"eventName\": [\"INSERT\"=123}]]": {
-    "recorded-date": "05-09-2022, 15:07:34",
+    "recorded-date": "27-02-2023, 18:44:25",
     "recorded-content": {
       "exception_event_source_creation": {
         "Error": {
           "Code": "InvalidParameterValueException",
           "Message": "Invalid filter pattern definition."
         },
+        "Type": "User",
+        "message": "Invalid filter pattern definition.",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 400
-        },
-        "Type": "User",
-        "message": "Invalid filter pattern definition."
+        }
       }
     }
   }

--- a/tests/integration/awslambda/test_lambda_integration_kinesis.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_integration_kinesis.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_integration_kinesis.py::TestKinesisSource::test_create_kinesis_event_source_mapping": {
-    "recorded-date": "31-08-2022, 16:49:34",
+    "recorded-date": "27-02-2023, 16:54:02",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 100,
@@ -17,15 +17,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "LATEST",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>"
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "kinesis_records": {
         "Records": [
@@ -194,7 +194,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_async_invocation": {
-    "recorded-date": "31-08-2022, 17:29:57",
+    "recorded-date": "27-02-2023, 16:55:08",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -211,15 +211,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "LATEST",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>"
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "invocation_events": [
         {
@@ -560,7 +560,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_trim_horizon": {
-    "recorded-date": "31-08-2022, 17:46:37",
+    "recorded-date": "27-02-2023, 16:56:17",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -577,15 +577,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>"
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "invocation_events": [
         {
@@ -1093,7 +1093,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_kinesis.py::TestKinesisSource::test_disable_kinesis_event_source_mapping": {
-    "recorded-date": "01-09-2022, 11:31:14",
+    "recorded-date": "27-02-2023, 16:59:49",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1110,15 +1110,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": -1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "LATEST",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>"
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "invocation_events": [
         {
@@ -1289,7 +1289,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_kinesis.py::TestKinesisSource::test_kinesis_event_source_mapping_with_on_failure_destination_config": {
-    "recorded-date": "01-09-2022, 12:38:29",
+    "recorded-date": "27-02-2023, 17:01:08",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 1,
@@ -1308,15 +1308,15 @@
         "MaximumRecordAgeInSeconds": -1,
         "MaximumRetryAttempts": 1,
         "ParallelizationFactor": 1,
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 202
-        },
         "StartingPosition": "TRIM_HORIZON",
         "State": "Creating",
         "StateTransitionReason": "User action",
         "TumblingWindowInSeconds": 0,
-        "UUID": "<uuid:1>"
+        "UUID": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
       },
       "sqs_payload": {
         "Messages": [

--- a/tests/integration/awslambda/test_lambda_integration_sqs.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_integration_sqs.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_failing_lambda_retries_after_visibility_timeout": {
-    "recorded-date": "31-08-2022, 06:38:19",
+    "recorded-date": "27-02-2023, 17:02:53",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -16,13 +16,13 @@
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
+        "State": "Enabled",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "State": "Enabled",
-        "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:1>"
+        }
       },
       "first_attempt": {
         "Messages": [
@@ -99,7 +99,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_redrive_policy_with_failing_lambda": {
-    "recorded-date": "31-08-2022, 06:38:40",
+    "recorded-date": "27-02-2023, 17:03:26",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -200,7 +200,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_sqs_queue_as_lambda_dead_letter_queue": {
-    "recorded-date": "31-08-2022, 06:41:46",
+    "recorded-date": "27-02-2023, 17:07:25",
     "recorded-content": {
       "lambda-response-dlq-config": {
         "TargetArn": "arn:aws:sqs:<region>:111111111111:<resource:1>"
@@ -239,7 +239,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_report_batch_item_failures": {
-    "recorded-date": "31-08-2022, 06:42:14",
+    "recorded-date": "27-02-2023, 17:07:51",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -249,10 +249,6 @@
         }
       },
       "send_message_batch": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Successful": [
           {
             "Id": "message-1",
@@ -278,7 +274,11 @@
             "MessageId": "<uuid:4>",
             "SequenceNumber": "<sequence-number:4>"
           }
-        ]
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "create_event_source_mapping": {
         "BatchSize": 10,
@@ -289,13 +289,13 @@
         ],
         "LastModified": "datetime",
         "MaximumBatchingWindowInSeconds": 0,
+        "State": "Creating",
+        "StateTransitionReason": "USER_INITIATED",
+        "UUID": "<uuid:5>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 202
-        },
-        "State": "Creating",
-        "StateTransitionReason": "USER_INITIATED",
-        "UUID": "<uuid:5>"
+        }
       },
       "first_invocation": {
         "Messages": [
@@ -529,7 +529,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_report_batch_item_failures_on_lambda_error": {
-    "recorded-date": "31-08-2022, 09:10:51",
+    "recorded-date": "27-02-2023, 17:08:09",
     "recorded-content": {
       "dlq_messages": [
         {
@@ -551,7 +551,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_report_batch_item_failures_invalid_result_json_batch_fails": {
-    "recorded-date": "31-08-2022, 06:43:00",
+    "recorded-date": "27-02-2023, 17:08:39",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -664,7 +664,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::test_report_batch_item_failures_empty_json_batch_succeeds": {
-    "recorded-date": "31-08-2022, 06:43:25",
+    "recorded-date": "27-02-2023, 17:09:08",
     "recorded-content": {
       "get_destination_queue_url": {
         "QueueUrl": "<queue-url:1>",
@@ -712,7 +712,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_event_source_mapping_default_batch_size": {
-    "recorded-date": "09-09-2022, 12:05:11",
+    "recorded-date": "27-02-2023, 17:09:20",
     "recorded-content": {
       "create-event-source-mapping": {
         "BatchSize": 10,
@@ -756,7 +756,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_source_mapping": {
-    "recorded-date": "09-09-2022, 12:15:13",
+    "recorded-date": "27-02-2023, 17:10:13",
     "recorded-content": {
       "create-event-source-mapping-response": {
         "BatchSize": 10,
@@ -801,7 +801,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter0-item_matching0-item_not_matching0]": {
-    "recorded-date": "09-09-2022, 12:22:38",
+    "recorded-date": "27-02-2023, 17:10:46",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -847,8 +847,8 @@
                 "ApproximateFirstReceiveTimestamp": "timestamp"
               },
               "messageAttributes": {},
-              "md5OfMessageAttributes": null,
               "md5OfBody": "<md5-of-body:1>",
+              "md5OfMessageAttributes": null,
               "eventSource": "aws:sqs",
               "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
               "awsRegion": "<region>"
@@ -859,7 +859,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter1-item_matching1-item_not_matching1]": {
-    "recorded-date": "09-09-2022, 12:23:24",
+    "recorded-date": "27-02-2023, 17:11:32",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -918,7 +918,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter2-item_matching2-item_not_matching2]": {
-    "recorded-date": "09-09-2022, 12:24:09",
+    "recorded-date": "27-02-2023, 17:12:15",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -981,7 +981,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter3-item_matching3-item_not_matching3]": {
-    "recorded-date": "09-09-2022, 12:24:53",
+    "recorded-date": "27-02-2023, 17:12:57",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1041,7 +1041,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter4-item_matching4-this is a test string]": {
-    "recorded-date": "09-09-2022, 12:25:39",
+    "recorded-date": "27-02-2023, 17:13:42",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1104,7 +1104,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter5-item_matching5-item_not_matching5]": {
-    "recorded-date": "09-09-2022, 12:26:24",
+    "recorded-date": "27-02-2023, 17:14:29",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1155,8 +1155,8 @@
                 "ApproximateFirstReceiveTimestamp": "timestamp"
               },
               "messageAttributes": {},
-              "md5OfMessageAttributes": null,
               "md5OfBody": "<md5-of-body:1>",
+              "md5OfMessageAttributes": null,
               "eventSource": "aws:sqs",
               "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
               "awsRegion": "<region>"
@@ -1167,7 +1167,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter6-item_matching6-item_not_matching6]": {
-    "recorded-date": "09-09-2022, 12:27:09",
+    "recorded-date": "27-02-2023, 17:15:15",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1232,7 +1232,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_event_filter[filter7-item_matching7-item_not_matching7]": {
-    "recorded-date": "09-09-2022, 12:27:53",
+    "recorded-date": "27-02-2023, 17:16:04",
     "recorded-content": {
       "create_event_source_mapping_response": {
         "BatchSize": 10,
@@ -1292,7 +1292,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[None]": {
-    "recorded-date": "09-09-2022, 12:29:55",
+    "recorded-date": "27-02-2023, 17:16:07",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1309,7 +1309,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[simple string]": {
-    "recorded-date": "09-09-2022, 12:29:57",
+    "recorded-date": "27-02-2023, 17:16:11",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1326,7 +1326,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter2]": {
-    "recorded-date": "09-09-2022, 12:29:59",
+    "recorded-date": "27-02-2023, 17:16:15",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {
@@ -1343,7 +1343,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_integration_sqs.py::TestSQSEventSourceMapping::test_sqs_invalid_event_filter[invalid_filter3]": {
-    "recorded-date": "09-09-2022, 12:30:01",
+    "recorded-date": "27-02-2023, 17:16:18",
     "recorded-content": {
       "create_event_source_mapping_exception": {
         "Error": {

--- a/tests/integration/awslambda/test_lambda_runtimes.py
+++ b/tests/integration/awslambda/test_lambda_runtimes.py
@@ -88,6 +88,8 @@ pytestmark = pytest.mark.skip_snapshot_verify(
         "$..Environment",  # missing
         "$..HTTPStatusCode",  # 201 vs 200
         "$..Layers",
+        "$..CreateFunctionResponse.RuntimeVersionConfig",
+        "$..CreateFunctionResponse.SnapStart",
     ],
 )
 

--- a/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_runtimes.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/awslambda/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs14.x]": {
-    "recorded-date": "09-09-2022, 18:10:07",
+    "recorded-date": "27-02-2023, 17:20:20",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -26,6 +26,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "nodejs14.x",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -55,7 +62,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestNodeJSRuntimes::test_invoke_nodejs_es6_lambda[nodejs16.x]": {
-    "recorded-date": "09-09-2022, 18:10:38",
+    "recorded-date": "27-02-2023, 17:20:39",
     "recorded-content": {
       "creation-result": {
         "CreateEventSourceMappingResponse": null,
@@ -81,6 +88,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "nodejs16.x",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -110,7 +124,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_runtime_with_lib": {
-    "recorded-date": "04-10-2022, 16:33:51",
+    "recorded-date": "27-02-2023, 17:20:55",
     "recorded-content": {
       "create-result-jar-with-lib": {
         "CreateEventSourceMappingResponse": null,
@@ -136,6 +150,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -183,6 +204,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -230,6 +258,13 @@
           "RevisionId": "<uuid:3>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -256,7 +291,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8]": {
-    "recorded-date": "09-09-2022, 18:11:41",
+    "recorded-date": "27-02-2023, 17:20:59",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -270,7 +305,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java8.al2]": {
-    "recorded-date": "09-09-2022, 18:11:55",
+    "recorded-date": "27-02-2023, 17:21:02",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -284,7 +319,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_stream_handler[java11]": {
-    "recorded-date": "09-09-2022, 18:12:09",
+    "recorded-date": "27-02-2023, 17:21:06",
     "recorded-content": {
       "invoke_result": {
         "ExecutedVersion": "$LATEST",
@@ -298,7 +333,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8]": {
-    "recorded-date": "09-09-2022, 18:12:36",
+    "recorded-date": "27-02-2023, 17:21:17",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -324,6 +359,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -354,7 +396,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java8.al2]": {
-    "recorded-date": "09-09-2022, 18:13:01",
+    "recorded-date": "27-02-2023, 17:21:28",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -380,6 +422,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java8.al2",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -410,7 +459,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_serializable_input_object[java11]": {
-    "recorded-date": "09-09-2022, 18:13:26",
+    "recorded-date": "27-02-2023, 17:21:37",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -436,6 +485,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -466,7 +522,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequestCustom-CUSTOM]": {
-    "recorded-date": "09-09-2022, 18:13:51",
+    "recorded-date": "27-02-2023, 17:21:44",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -492,6 +548,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -518,7 +581,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom-INTERFACE]": {
-    "recorded-date": "09-09-2022, 18:14:17",
+    "recorded-date": "27-02-2023, 17:21:51",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -544,6 +607,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -570,7 +640,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestJavaRuntimes::test_java_custom_handler_method_specification[cloud.localstack.sample.LambdaHandlerWithInterfaceAndCustom::handleRequest-INTERFACE]": {
-    "recorded-date": "09-09-2022, 18:14:42",
+    "recorded-date": "27-02-2023, 17:22:03",
     "recorded-content": {
       "create-result": {
         "CreateEventSourceMappingResponse": null,
@@ -596,6 +666,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "java11",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -622,31 +699,31 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.7]": {
-    "recorded-date": "09-09-2022, 18:15:07",
+    "recorded-date": "27-02-2023, 17:22:18",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.8]": {
-    "recorded-date": "09-09-2022, 18:15:34",
+    "recorded-date": "27-02-2023, 17:22:28",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_handler_in_submodule[python3.9]": {
-    "recorded-date": "09-09-2022, 18:15:59",
+    "recorded-date": "27-02-2023, 17:22:41",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.7]": {
-    "recorded-date": "09-09-2022, 18:16:15",
+    "recorded-date": "27-02-2023, 17:22:44",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.8]": {
-    "recorded-date": "09-09-2022, 18:16:32",
+    "recorded-date": "27-02-2023, 17:22:48",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_correct_versions[python3.9]": {
-    "recorded-date": "09-09-2022, 18:16:49",
+    "recorded-date": "27-02-2023, 17:22:51",
     "recorded-content": {}
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.7]": {
-    "recorded-date": "09-09-2022, 18:17:05",
+    "recorded-date": "27-02-2023, 17:22:54",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -672,6 +749,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.7",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -705,7 +789,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.8]": {
-    "recorded-date": "09-09-2022, 18:17:22",
+    "recorded-date": "27-02-2023, 17:22:58",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -731,6 +815,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.8",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",
@@ -764,7 +855,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_runtimes.py::TestPythonRuntimes::test_python_runtime_unhandled_errors[python3.9]": {
-    "recorded-date": "09-09-2022, 18:17:34",
+    "recorded-date": "27-02-2023, 17:23:01",
     "recorded-content": {
       "creation_response": {
         "CreateEventSourceMappingResponse": null,
@@ -790,6 +881,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:1>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:2>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Pending",
           "StateReason": "The function is being created.",
           "StateReasonCode": "Creating",

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -13,6 +13,16 @@ from localstack.utils.strings import to_bytes, to_str
 from localstack.utils.sync import retry, wait_until
 from localstack.utils.testutil import get_lambda_log_events
 
+pytestmark = pytest.mark.skip_snapshot_verify(
+    condition=is_old_provider,
+    paths=[
+        # Generally unsupported in old provider
+        "$..Configuration.RuntimeVersionConfig",
+        "$..Configuration.SnapStart",
+        "$..Versions..SnapStart",
+    ],
+)
+
 
 @pytest.mark.skipif(condition=is_new_provider(), reason="not implemented yet")
 @pytest.mark.aws_validated
@@ -577,6 +587,12 @@ class TestCfnLambdaIntegrations:
             "$..StartingPosition",
             "$..StateTransitionReason",
             "$..Topics",
+            # resource index mismatch but should verify otherwise
+            "$..StreamDescription.StreamArn",
+            "$..StreamDescription.TableName",
+            "$..Table.LatestStreamArn",
+            "$..Table.TableArn",
+            "$..Table.TableName",
         ],
     )
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -587,12 +587,14 @@ class TestCfnLambdaIntegrations:
             "$..StartingPosition",
             "$..StateTransitionReason",
             "$..Topics",
-            # resource index mismatch but should verify otherwise
+            # resource index mismatch due to SnapStart
             "$..StreamDescription.StreamArn",
             "$..StreamDescription.TableName",
             "$..Table.LatestStreamArn",
             "$..Table.TableArn",
             "$..Table.TableName",
+            "$..EventSourceArn",
+            "$..policies..PolicyDocument.Statement..Resource",
         ],
     )
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_lambda.snapshot.json
@@ -1,12 +1,8 @@
 {
   "tests/integration/cloudformation/resources/test_lambda.py::test_cfn_function_url": {
-    "recorded-date": "26-08-2022, 16:45:07",
+    "recorded-date": "27-02-2023, 17:27:12",
     "recorded-content": {
       "url_resource": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "StackResourceDetail": {
           "DriftInformation": {
             "StackResourceDriftStatus": "NOT_CHECKED"
@@ -19,6 +15,10 @@
           "ResourceType": "AWS::Lambda::Url",
           "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
           "StackName": "<stack-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "url_config": {
@@ -38,11 +38,11 @@
           "Message": "The resource you requested does not exist."
         },
         "Message": "The resource you requested does not exist.",
+        "Type": "User",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 404
-        },
-        "Type": "User"
+        }
       },
       "url_config_arn": {
         "AuthType": "NONE",
@@ -66,7 +66,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::test_lambda_alias": {
-    "recorded-date": "26-10-2022, 09:50:41",
+    "recorded-date": "27-02-2023, 17:28:29",
     "recorded-content": {
       "stack_resource_descriptions": {
         "StackResources": [
@@ -138,7 +138,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_permissions": {
-    "recorded-date": "26-10-2022, 09:57:43",
+    "recorded-date": "27-02-2023, 17:34:08",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -233,6 +233,13 @@
           "RevisionId": "<uuid:1>",
           "Role": "arn:aws:iam::111111111111:role/<resource:5>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:6>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -337,7 +344,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_sqs_source": {
-    "recorded-date": "26-10-2022, 10:02:25",
+    "recorded-date": "27-02-2023, 17:38:51",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -457,6 +464,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:4>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:5>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -563,7 +577,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::test_lambda_code_signing_config": {
-    "recorded-date": "25-10-2022, 11:34:43",
+    "recorded-date": "27-02-2023, 17:28:57",
     "recorded-content": {
       "stack_resource_descriptions": {
         "StackResources": [
@@ -608,7 +622,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::test_event_invoke_config": {
-    "recorded-date": "25-10-2022, 11:28:22",
+    "recorded-date": "27-02-2023, 17:30:14",
     "recorded-content": {
       "event_invoke_config": {
         "DestinationConfig": {
@@ -627,7 +641,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::test_lambda_version": {
-    "recorded-date": "26-10-2022, 08:48:16",
+    "recorded-date": "27-02-2023, 17:31:32",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -694,6 +708,10 @@
             "RevisionId": "<uuid:1>",
             "Role": "arn:aws:iam::111111111111:role/<resource:4>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -719,6 +737,10 @@
             "RevisionId": "<uuid:2>",
             "Role": "arn:aws:iam::111111111111:role/<resource:4>",
             "Runtime": "python3.9",
+            "SnapStart": {
+              "ApplyOn": "None",
+              "OptimizationStatus": "Off"
+            },
             "Timeout": 3,
             "TracingConfig": {
               "Mode": "PassThrough"
@@ -756,6 +778,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:4>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:5>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -771,7 +800,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_dynamodb_source": {
-    "recorded-date": "28-10-2022, 15:32:05",
+    "recorded-date": "27-02-2023, 17:42:01",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -828,7 +857,7 @@
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
             "LogicalResourceId": "table8235A42E",
-            "PhysicalResourceId": "<resource:5>",
+            "PhysicalResourceId": "<resource:6>",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::DynamoDB::Table",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
@@ -858,7 +887,7 @@
                     "dynamodb:GetShardIterator"
                   ],
                   "Effect": "Allow",
-                  "Resource": "arn:aws:dynamodb:<region>:111111111111:table/<resource:5>/stream/<resource:2>"
+                  "Resource": "arn:aws:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>"
                 }
               ],
               "Version": "2012-10-17"
@@ -894,6 +923,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:4>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:5>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {
@@ -917,7 +953,7 @@
         "DestinationConfig": {
           "OnFailure": {}
         },
-        "EventSourceArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:5>/stream/<resource:2>",
+        "EventSourceArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>",
         "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:3>",
         "FunctionResponseTypes": [],
         "LastModified": "datetime",
@@ -952,7 +988,7 @@
               "KeyType": "HASH"
             }
           ],
-          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:5>/stream/<resource:2>",
+          "LatestStreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>",
           "LatestStreamLabel": "<resource:2>",
           "ProvisionedThroughput": {
             "NumberOfDecreasesToday": 0,
@@ -963,9 +999,9 @@
             "StreamEnabled": true,
             "StreamViewType": "NEW_AND_OLD_IMAGES"
           },
-          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:5>",
+          "TableArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:6>",
           "TableId": "<uuid:3>",
-          "TableName": "<resource:5>",
+          "TableName": "<resource:6>",
           "TableSizeBytes": 0,
           "TableStatus": "ACTIVE"
         },
@@ -991,11 +1027,11 @@
               "ShardId": "shard-id"
             }
           ],
-          "StreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:5>/stream/<resource:2>",
+          "StreamArn": "arn:aws:dynamodb:<region>:111111111111:table/<resource:6>/stream/<resource:2>",
           "StreamLabel": "<resource:2>",
           "StreamStatus": "ENABLED",
           "StreamViewType": "NEW_AND_OLD_IMAGES",
-          "TableName": "<resource:5>"
+          "TableName": "<resource:6>"
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -1056,7 +1092,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::TestCfnLambdaIntegrations::test_cfn_lambda_kinesis_source": {
-    "recorded-date": "10-11-2022, 19:42:55",
+    "recorded-date": "27-02-2023, 17:44:31",
     "recorded-content": {
       "stack_resources": {
         "StackResources": [
@@ -1183,6 +1219,13 @@
           "RevisionId": "<uuid:2>",
           "Role": "arn:aws:iam::111111111111:role/<resource:4>",
           "Runtime": "python3.9",
+          "RuntimeVersionConfig": {
+            "RuntimeVersionArn": "arn:aws:lambda:<region>::runtime:<resource:5>"
+          },
+          "SnapStart": {
+            "ApplyOn": "None",
+            "OptimizationStatus": "Off"
+          },
           "State": "Active",
           "Timeout": 3,
           "TracingConfig": {


### PR DESCRIPTION
## Contributions

* Add support for [runtime management controls](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-update.html) at API level
* Add support for [SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) at API level
* Add snapshot tests for SnapStart API
* Update all lambda-related snapshot tests due to model updates (only for `aws_validated` tests)
* Add platform flag to docker clients for `build_image`
* Fix Lambda tests on ARM hosts. This enables running Lambda tests on ARM hosts.
* Conditionally skip the concurrency tests if the AWS account has too low limits (improve error messages).

## Limitations

* Runtime management controls use a hard-coded sha256 value (`8eeff65f6809a3ce81507fe733fe09b835899b99481ba22fd75b5a7338290ec1`) instead of inspecting the Docker image.
* Rust builds on ARM (tested on M1 MacBook Pro) are slow (~5 minutes) due to emulation. See Makefile for potential performance improvements.
* The SnapStart tests are a little slow (~1-2min) against AWS

## Breaking changes

* This PR includes model changes in lambda and will break CloudPods for the new lambda provider