### PR TITLE
Skip lambda nodejs18 extra cert snapshot verify

### DIFF
--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -122,6 +122,8 @@ class TestLambdaRuntimesCommon:
             "$..environment._AWS_XRAY_DAEMON_PORT",
             "$..environment._LAMBDA_TELEMETRY_LOG_FD",  # Only java8, dotnetcore3.1, dotnet6, go1.x
             "$..environment._X_AMZN_TRACE_ID",
+            # Only nodejs18.x (AWS: /etc/pki/tls/certs/ca-bundle.crt, LS: /var/runtime/ca-cert.pem)
+            "$..environment.NODE_EXTRA_CA_CERTS",
             "$..environment.AWS_EXECUTION_ENV",  # Only rust runtime
             "$..environment.LD_LIBRARY_PATH",  # Only rust runtime (additional /var/lang/bin)
             "$..environment.PATH",  # Only rust runtime (additional /var/lang/bin)


### PR DESCRIPTION
Greenify pipeline: Fixes a suddenly failing test case for the new lambda provider `tests.integration.awslambda.test_lambda_common.TestLambdaRuntimesCommon.test_introspection_invoke[nodejs18.x]`
https://app.circleci.com/pipelines/github/localstack/localstack/12943/workflows/a0a0ec66-a580-472f-8ae7-66a573f3a2d6/jobs/93952

Quickfix skips snapshot validation for the environment variable `NODE_EXTRA_CA_CERTS` (only occurs for nodjs18 runtime)


## Follow up

- [ ] Check whether we need to set `NODE_EXTRA_CA_CERTS` explicitly to ensure runtime parity for the Nodejs18 runtime.