### PR TITLE
Catch Route53 Record Sets without TTL

### DIFF
--- a/localstack/services/cloudformation/models/route53.py
+++ b/localstack/services/cloudformation/models/route53.py
@@ -38,9 +38,9 @@ class Route53RecordSet(GenericBaseModel):
                 "HealthCheckId",
             ]
             attrs = select_attributes(params, attr_names)
-
-            if isinstance(attrs["TTL"], str):
-                attrs["TTL"] = int(attrs["TTL"])
+            if "TTL" in attrs:
+                if isinstance(attrs["TTL"], str):
+                    attrs["TTL"] = int(attrs["TTL"])
 
             alias_target = attrs.get("AliasTarget", {})
             alias_target["EvaluateTargetHealth"] = alias_target.get("EvaluateTargetHealth", False)


### PR DESCRIPTION
Alias records, for example, should explicitly not have a TTL set, as it's derived from the TTL of the target.


