### PR TITLE
fix SNS storing lambda invocation logs + improve parity

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -37,7 +37,7 @@ from localstack.utils.aws.aws_responses import create_sqs_system_attributes
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
 from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.objects import not_none_or
-from localstack.utils.strings import long_uid, md5, to_bytes, to_str
+from localstack.utils.strings import long_uid, md5, to_bytes
 from localstack.utils.time import timestamp_millis
 
 LOG = logging.getLogger(__name__)
@@ -180,11 +180,13 @@ class LambdaTopicPublisher(TopicPublisher):
             )
             status_code = inv_result.get("StatusCode")
             payload = inv_result.get("Payload")
-
             if payload:
                 delivery = {
                     "statusCode": status_code,
-                    "providerResponse": to_str(payload.read()),
+                    # TODO: normally, this is the lambda RequestId (invocation id)
+                    # but we don't get it from the response, this could change if we set the RequestId when we receive
+                    # the request instead of when sending the response. For now, mock it with a random UUID
+                    "providerResponse": json.dumps({"lambdaRequestId": long_uid()}),
                 }
                 store_delivery_log(context.message, subscriber, success=True, delivery=delivery)
 
@@ -834,13 +836,15 @@ def store_delivery_log(
     message_context: SnsMessage, subscriber: SnsSubscription, success: bool, delivery: dict = None
 ):
     """Store the delivery logs in CloudWatch"""
+    # TODO: this is enabled by default in LocalStack, but not in AWS
+    # TODO: validate format of `delivery` for each Publisher
     log_group_name = subscriber.get("TopicArn", "").replace("arn:aws:", "").replace(":", "/")
     log_stream_name = long_uid()
     invocation_time = int(time.time() * 1000)
 
     delivery = not_none_or(delivery, {})
-    delivery["deliveryId"] = (long_uid(),)
-    delivery["destination"] = (subscriber.get("Endpoint", ""),)
+    delivery["deliveryId"] = long_uid()
+    delivery["destination"] = subscriber.get("Endpoint", "")
     delivery["dwellTimeMs"] = 200
     if not success:
         delivery["attemps"] = 1

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -37,7 +37,7 @@ from localstack.utils.aws.aws_responses import create_sqs_system_attributes
 from localstack.utils.aws.dead_letter_queue import sns_error_to_dead_letter_queue
 from localstack.utils.cloudwatch.cloudwatch_util import store_cloudwatch_logs
 from localstack.utils.objects import not_none_or
-from localstack.utils.strings import long_uid, md5, to_bytes
+from localstack.utils.strings import long_uid, md5, to_bytes, to_str
 from localstack.utils.time import timestamp_millis
 
 LOG = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ class LambdaTopicPublisher(TopicPublisher):
             if payload:
                 delivery = {
                     "statusCode": status_code,
-                    "providerResponse": payload.read(),
+                    "providerResponse": to_str(payload.read()),
                 }
                 store_delivery_log(context.message, subscriber, success=True, delivery=delivery)
 

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3208,5 +3208,101 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSPublishDelivery::test_delivery_lambda": {
+    "recorded-date": "01-03-2023, 14:56:10",
+    "recorded-content": {
+      "get-topic-attrs": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false
+            }
+          },
+          "LambdaSuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/<resource:1>",
+          "LambdaSuccessFeedbackSampleRate": "100",
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:aws:sns:<region>:111111111111:<resource:2>",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delivery-events": {
+        "events": [
+          {
+            "ingestionTime": "timestamp",
+            "message": {
+              "delivery": {
+                "deliveryId": "<uuid:1>",
+                "destination": "arn:aws:lambda:<region>:111111111111:function:<resource:3>",
+                "dwellTimeMs": "<time-ms>",
+                "providerResponse": {
+                  "lambdaRequestId": "<uuid:2>"
+                },
+                "statusCode": 202
+              },
+              "notification": {
+                "messageId": "<uuid:3>",
+                "messageMD5Sum": "764569e58f53ea8b6404f6fa7fc0247f",
+                "timestamp": "timestamp",
+                "topicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+              },
+              "status": "SUCCESS"
+            },
+            "timestamp": "timestamp"
+          }
+        ],
+        "nextBackwardToken": "<next-backward-token:1>",
+        "nextForwardToken": "<next-forward-token:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR fixes #7768, a regression introduced by remove a call to `json_safe` on the payload.
However, there was no payload to get here, because the lambda invocation is asynchronous. The parity was wrong here, and it's nice to be able to introduce additional behaviour in SNS.
I've introduced a test by retrieving CloudWatch logs for this particular scenario and improved parity.

We would still need to check parity for all other "Publisher" (SQS, Kinesis, HTTP and Platform application endpoint), to see how they store their logs. See https://docs.aws.amazon.com/sns/latest/dg/sns-topic-attributes.html

We will also need to add a conditional on storing the logs, as they should be enabled first. 

Note: I'll introduce a scenario fixture regarding setting up the logs for Success/Failure in SNS when introducing the next parity check for another publisher!