### PR TITLE
Fix cloudformation get template

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -336,6 +336,7 @@ class CloudformationProvider(CloudformationApi):
 
         return GetTemplateOutput(
             TemplateBody=json.dumps(stack.latest_template_raw()),
+            StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
         )
 
     @handler("GetTemplateSummary", expand=False)

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -334,17 +334,16 @@ class CloudformationProvider(CloudformationApi):
         if not stack:
             return stack_not_found_error(stack_name)
 
+        template_body = None
         try:
             json.loads(stack.template)
-            return GetTemplateOutput(
-                TemplateBody=json.dumps(stack.latest_template_raw()),
-                StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
-            )
+            template_body = json.dumps(stack.latest_template_raw())
         except Exception:
-            return GetTemplateOutput(
-                TemplateBody=stack.template_body,
-                StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
-            )
+            template_body = stack.template_body
+        return GetTemplateOutput(
+            TemplateBody=template_body,
+            StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
+        )
 
     @handler("GetTemplateSummary", expand=False)
     def get_template_summary(

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -334,10 +334,17 @@ class CloudformationProvider(CloudformationApi):
         if not stack:
             return stack_not_found_error(stack_name)
 
-        return GetTemplateOutput(
-            TemplateBody=json.dumps(stack.latest_template_raw()),
-            StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
-        )
+        try:
+            json.loads(stack.template)
+            return GetTemplateOutput(
+                TemplateBody=json.dumps(stack.latest_template_raw()),
+                StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
+            )
+        except Exception:
+            return GetTemplateOutput(
+                TemplateBody=stack.template_body,
+                StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
+            )
 
     @handler("GetTemplateSummary", expand=False)
     def get_template_summary(

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -335,8 +335,7 @@ class CloudformationProvider(CloudformationApi):
             return stack_not_found_error(stack_name)
 
         return GetTemplateOutput(
-            TemplateBody=stack.template_body,
-            StagesAvailable=[TemplateStage.Original, TemplateStage.Processed],
+            TemplateBody=json.dumps(stack.latest_template_raw()),
         )
 
     @handler("GetTemplateSummary", expand=False)

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -90,6 +90,9 @@ class TestStacksApi:
         )
         snapshot.match("template_processed", template_processed)
 
+        template_body = cfn_client.get_template(StackName=stack.stack_id)
+        snapshot.match("template_body", template_body)
+        
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=["$..ParameterValue", "$..PhysicalResourceId", "$..Capabilities"]

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -92,7 +92,7 @@ class TestStacksApi:
 
         template_body = cfn_client.get_template(StackName=stack.stack_id)
         snapshot.match("template_body", template_body)
-        
+
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
         paths=["$..ParameterValue", "$..PhysicalResourceId", "$..Capabilities"]

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -66,6 +66,9 @@ class TestStacksApi:
 
     @pytest.mark.aws_validated
     @pytest.mark.parametrize("fileformat", ["yaml", "json"])
+    @pytest.mark.skip_snapshot_verify(
+        paths=["$..TemplateBody.ChangeSetName", "$..TemplateBody.StackName"]
+    )
     def test_get_template(self, cfn_client, deploy_cfn_template, snapshot, fileformat):
         snapshot.add_transformer(snapshot.transform.cloudformation_api())
 

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -83,18 +83,22 @@ class TestStacksApi:
         describe_stacks = cfn_client.describe_stacks(StackName=stack.stack_id)
         snapshot.match("describe_stacks", describe_stacks)
 
-        template_original = cfn_client.get_template(
-            StackName=stack.stack_id, TemplateStage="Original"
-        )
-        snapshot.match("template_original", template_original)
+        if fileformat == "json":
 
-        template_processed = cfn_client.get_template(
-            StackName=stack.stack_id, TemplateStage="Processed"
-        )
-        snapshot.match("template_processed", template_processed)
+            template_original = cfn_client.get_template(
+                StackName=stack.stack_id, TemplateStage="Original"
+            )
+            snapshot.match("template_original", template_original)
 
-        template_body = cfn_client.get_template(StackName=stack.stack_id)
-        snapshot.match("template_body", template_body)
+            template_processed = cfn_client.get_template(
+                StackName=stack.stack_id, TemplateStage="Processed"
+            )
+            snapshot.match("template_processed", template_processed)
+
+            template_body = cfn_client.get_template(
+                StackName=stack.stack_id, TemplateStage="Processed"
+            )
+            snapshot.match("template_body", template_body)
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/cloudformation/api/test_stacks.py
+++ b/tests/integration/cloudformation/api/test_stacks.py
@@ -83,22 +83,20 @@ class TestStacksApi:
         describe_stacks = cfn_client.describe_stacks(StackName=stack.stack_id)
         snapshot.match("describe_stacks", describe_stacks)
 
-        if fileformat == "json":
+        template_original = cfn_client.get_template(
+            StackName=stack.stack_id, TemplateStage="Original"
+        )
+        snapshot.match("template_original", template_original)
 
-            template_original = cfn_client.get_template(
-                StackName=stack.stack_id, TemplateStage="Original"
-            )
-            snapshot.match("template_original", template_original)
+        template_processed = cfn_client.get_template(
+            StackName=stack.stack_id, TemplateStage="Processed"
+        )
+        snapshot.match("template_processed", template_processed)
 
-            template_processed = cfn_client.get_template(
-                StackName=stack.stack_id, TemplateStage="Processed"
-            )
-            snapshot.match("template_processed", template_processed)
-
-            template_body = cfn_client.get_template(
-                StackName=stack.stack_id, TemplateStage="Processed"
-            )
-            snapshot.match("template_body", template_body)
+        template_default = cfn_client.get_template(
+            StackName=stack.stack_id,
+        )
+        snapshot.match("template_default", template_default)
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -27,7 +27,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[yaml]": {
-    "recorded-date": "06-03-2023, 22:19:22",
+    "recorded-date": "07-03-2023, 00:44:41",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [
@@ -63,44 +63,11 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
-      },
-      "template_original": {
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "template_processed": {
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "template_body": {
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[json]": {
-    "recorded-date": "06-03-2023, 22:19:39",
+    "recorded-date": "07-03-2023, 00:44:58",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_special_chars": {
-    "recorded-date": "05-08-2022, 13:03:43",
+    "recorded-date": "02-03-2023, 22:20:03",
     "recorded-content": {
       "describe_stack": {
         "Capabilities": [
@@ -27,13 +27,9 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[yaml]": {
-    "recorded-date": "11-08-2022, 10:55:10",
+    "recorded-date": "02-03-2023, 22:20:04",
     "recorded-content": {
       "describe_stacks": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Stacks": [
           {
             "Capabilities": [
@@ -62,40 +58,93 @@
             "StackStatus": "CREATE_COMPLETE",
             "Tags": []
           }
-        ]
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "template_original": {
+        "TemplateBody": {
+          "ChangeSetName": "<change-set-name:1>",
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          },
+          "StackName": "<stack-name:1>"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
+        }
       },
       "template_processed": {
+        "TemplateBody": {
+          "ChangeSetName": "<change-set-name:1>",
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          },
+          "StackName": "<stack-name:1>"
+        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "template_body": {
+        "TemplateBody": {
+          "ChangeSetName": "<change-set-name:1>",
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          },
+          "StackName": "<stack-name:1>"
         },
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[json]": {
-    "recorded-date": "11-08-2022, 10:55:35",
+    "recorded-date": "02-03-2023, 22:20:05",
     "recorded-content": {
       "describe_stacks": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Stacks": [
           {
             "Capabilities": [
@@ -124,18 +173,15 @@
             "StackStatus": "CREATE_COMPLETE",
             "Tags": []
           }
-        ]
-      },
-      "template_original": {
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
+        }
+      },
+      "template_original": {
         "TemplateBody": {
+          "ChangeSetName": "<change-set-name:1>",
           "Outputs": {
             "TopicName": {
               "Value": {
@@ -150,19 +196,17 @@
             "topic69831491": {
               "Type": "AWS::SNS::Topic"
             }
-          }
+          },
+          "StackName": "<stack-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "template_processed": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
-        "StagesAvailable": [
-          "Original",
-          "Processed"
-        ],
         "TemplateBody": {
+          "ChangeSetName": "<change-set-name:1>",
           "Outputs": {
             "TopicName": {
               "Value": {
@@ -177,13 +221,43 @@
             "topic69831491": {
               "Type": "AWS::SNS::Topic"
             }
-          }
+          },
+          "StackName": "<stack-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "template_body": {
+        "TemplateBody": {
+          "ChangeSetName": "<change-set-name:1>",
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          },
+          "StackName": "<stack-name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_update_resources": {
-    "recorded-date": "30-08-2022, 00:13:26",
+    "recorded-date": "02-03-2023, 22:20:07",
     "recorded-content": {
       "stack_created": {
         "Capabilities": [
@@ -203,7 +277,7 @@
         "Parameters": [
           {
             "ParameterKey": "ApiName",
-            "ParameterValue": "test_12395eb4"
+            "ParameterValue": "test_31f97efe"
           }
         ],
         "RollbackConfiguration": {},
@@ -213,6 +287,11 @@
         "Tags": []
       },
       "stack_updated": {
+        "Capabilities": [
+          "CAPABILITY_AUTO_EXPAND",
+          "CAPABILITY_IAM",
+          "CAPABILITY_NAMED_IAM"
+        ],
         "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -225,7 +304,7 @@
         "Parameters": [
           {
             "ParameterKey": "ApiName",
-            "ParameterValue": "test_5a3df175"
+            "ParameterValue": "test_f13a06f5"
           }
         ],
         "RollbackConfiguration": {},
@@ -235,10 +314,6 @@
         "Tags": []
       },
       "stack_resources": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "StackResources": [
           {
             "DriftInformation": {
@@ -257,19 +332,23 @@
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
             "LogicalResourceId": "Bucket",
-            "PhysicalResourceId": "<stack-name:1>-bucket-10xf2vf1pqap8",
+            "PhysicalResourceId": "<stack-name:1>-bucket-5979c4ab",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::S3::Bucket",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ]
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_list_events_after_deployment": {
-    "recorded-date": "05-10-2022, 13:33:55",
+    "recorded-date": "02-03-2023, 22:20:11",
     "recorded-content": {
       "events": {
         "StackEvents": [
@@ -278,7 +357,6 @@
             "LogicalResourceId": "<stack-name:1>",
             "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "ResourceStatus": "REVIEW_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
@@ -289,48 +367,7 @@
             "LogicalResourceId": "<stack-name:1>",
             "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
-            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "topic123-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "topic123",
-            "PhysicalResourceId": "",
-            "ResourceProperties": {
-              "TopicName": "<resource:2>"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "topic123-CREATE_IN_PROGRESS-date",
-            "LogicalResourceId": "topic123",
-            "PhysicalResourceId": "arn:aws:sns:<region>:111111111111:<resource:2>",
-            "ResourceProperties": {
-              "TopicName": "<resource:2>"
-            },
-            "ResourceStatus": "CREATE_IN_PROGRESS",
-            "ResourceStatusReason": "Resource creation Initiated",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "topic123-CREATE_COMPLETE-date",
-            "LogicalResourceId": "topic123",
-            "PhysicalResourceId": "arn:aws:sns:<region>:111111111111:<resource:2>",
-            "ResourceProperties": {
-              "TopicName": "<resource:2>"
-            },
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -344,6 +381,16 @@
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "<uuid:4>",
+            "LogicalResourceId": "topic123",
+            "PhysicalResourceId": "arn:aws:sns:<region>:111111111111:<resource:2>",
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
           }
         ],
         "ResponseMetadata": {
@@ -354,7 +401,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_lifecycle": {
-    "recorded-date": "11-10-2022, 13:34:32",
+    "recorded-date": "02-03-2023, 22:20:01",
     "recorded-content": {
       "creation": {
         "Capabilities": [
@@ -442,7 +489,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_updating_an_updated_stack_sets_status": {
-    "recorded-date": "02-12-2022, 11:19:41",
+    "recorded-date": "02-03-2023, 22:20:14",
     "recorded-content": {
       "describe-result": {
         "Stacks": [
@@ -463,12 +510,12 @@
             "NotificationARNs": [],
             "Parameters": [
               {
-                "ParameterKey": "Topic2Name",
-                "ParameterValue": "topic-2"
-              },
-              {
                 "ParameterKey": "Topic1Name",
                 "ParameterValue": "topic-1"
+              },
+              {
+                "ParameterKey": "Topic2Name",
+                "ParameterValue": "topic-2"
               },
               {
                 "ParameterKey": "Topic3Name",
@@ -490,7 +537,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_update_termination_protection": {
-    "recorded-date": "04-01-2023, 16:23:22",
+    "recorded-date": "02-03-2023, 22:20:16",
     "recorded-content": {
       "describe-stack-1": {
         "Stacks": [
@@ -565,7 +612,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_events_resource_types": {
-    "recorded-date": "15-02-2023, 10:46:53",
+    "recorded-date": "02-03-2023, 22:20:17",
     "recorded-content": {
       "resource_types": [
         "AWS::CloudFormation::Stack",

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_description_special_chars": {
-    "recorded-date": "02-03-2023, 22:20:03",
+    "recorded-date": "05-08-2022, 13:03:43",
     "recorded-content": {
       "describe_stack": {
         "Capabilities": [
@@ -27,9 +27,13 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[yaml]": {
-    "recorded-date": "02-03-2023, 22:20:04",
+    "recorded-date": "11-08-2022, 10:55:10",
     "recorded-content": {
       "describe_stacks": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
         "Stacks": [
           {
             "Capabilities": [
@@ -58,93 +62,40 @@
             "StackStatus": "CREATE_COMPLETE",
             "Tags": []
           }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+        ]
       },
       "template_original": {
-        "TemplateBody": {
-          "ChangeSetName": "<change-set-name:1>",
-          "Outputs": {
-            "TopicName": {
-              "Value": {
-                "Fn::GetAtt": [
-                  "topic69831491",
-                  "TopicName"
-                ]
-              }
-            }
-          },
-          "Resources": {
-            "topic69831491": {
-              "Type": "AWS::SNS::Topic"
-            }
-          },
-          "StackName": "<stack-name:1>"
-        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
       },
       "template_processed": {
-        "TemplateBody": {
-          "ChangeSetName": "<change-set-name:1>",
-          "Outputs": {
-            "TopicName": {
-              "Value": {
-                "Fn::GetAtt": [
-                  "topic69831491",
-                  "TopicName"
-                ]
-              }
-            }
-          },
-          "Resources": {
-            "topic69831491": {
-              "Type": "AWS::SNS::Topic"
-            }
-          },
-          "StackName": "<stack-name:1>"
-        },
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      },
-      "template_body": {
-        "TemplateBody": {
-          "ChangeSetName": "<change-set-name:1>",
-          "Outputs": {
-            "TopicName": {
-              "Value": {
-                "Fn::GetAtt": [
-                  "topic69831491",
-                  "TopicName"
-                ]
-              }
-            }
-          },
-          "Resources": {
-            "topic69831491": {
-              "Type": "AWS::SNS::Topic"
-            }
-          },
-          "StackName": "<stack-name:1>"
         },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[json]": {
-    "recorded-date": "02-03-2023, 22:20:05",
+    "recorded-date": "11-08-2022, 10:55:35",
     "recorded-content": {
       "describe_stacks": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
         "Stacks": [
           {
             "Capabilities": [
@@ -173,15 +124,18 @@
             "StackStatus": "CREATE_COMPLETE",
             "Tags": []
           }
-        ],
+        ]
+      },
+      "template_original": {
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        }
-      },
-      "template_original": {
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
         "TemplateBody": {
-          "ChangeSetName": "<change-set-name:1>",
           "Outputs": {
             "TopicName": {
               "Value": {
@@ -196,17 +150,19 @@
             "topic69831491": {
               "Type": "AWS::SNS::Topic"
             }
-          },
-          "StackName": "<stack-name:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          }
         }
       },
       "template_processed": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
         "TemplateBody": {
-          "ChangeSetName": "<change-set-name:1>",
           "Outputs": {
             "TopicName": {
               "Value": {
@@ -221,43 +177,13 @@
             "topic69831491": {
               "Type": "AWS::SNS::Topic"
             }
-          },
-          "StackName": "<stack-name:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "template_body": {
-        "TemplateBody": {
-          "ChangeSetName": "<change-set-name:1>",
-          "Outputs": {
-            "TopicName": {
-              "Value": {
-                "Fn::GetAtt": [
-                  "topic69831491",
-                  "TopicName"
-                ]
-              }
-            }
-          },
-          "Resources": {
-            "topic69831491": {
-              "Type": "AWS::SNS::Topic"
-            }
-          },
-          "StackName": "<stack-name:1>"
-        },
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
+          }
         }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_update_resources": {
-    "recorded-date": "02-03-2023, 22:20:07",
+    "recorded-date": "30-08-2022, 00:13:26",
     "recorded-content": {
       "stack_created": {
         "Capabilities": [
@@ -277,7 +203,7 @@
         "Parameters": [
           {
             "ParameterKey": "ApiName",
-            "ParameterValue": "test_31f97efe"
+            "ParameterValue": "test_12395eb4"
           }
         ],
         "RollbackConfiguration": {},
@@ -287,11 +213,6 @@
         "Tags": []
       },
       "stack_updated": {
-        "Capabilities": [
-          "CAPABILITY_AUTO_EXPAND",
-          "CAPABILITY_IAM",
-          "CAPABILITY_NAMED_IAM"
-        ],
         "ChangeSetId": "arn:aws:cloudformation:<region>:111111111111:changeSet/<resource:3>",
         "CreationTime": "datetime",
         "DisableRollback": false,
@@ -304,7 +225,7 @@
         "Parameters": [
           {
             "ParameterKey": "ApiName",
-            "ParameterValue": "test_f13a06f5"
+            "ParameterValue": "test_5a3df175"
           }
         ],
         "RollbackConfiguration": {},
@@ -314,6 +235,10 @@
         "Tags": []
       },
       "stack_resources": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        },
         "StackResources": [
           {
             "DriftInformation": {
@@ -332,23 +257,19 @@
               "StackResourceDriftStatus": "NOT_CHECKED"
             },
             "LogicalResourceId": "Bucket",
-            "PhysicalResourceId": "<stack-name:1>-bucket-5979c4ab",
+            "PhysicalResourceId": "<stack-name:1>-bucket-10xf2vf1pqap8",
             "ResourceStatus": "CREATE_COMPLETE",
             "ResourceType": "AWS::S3::Bucket",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:2>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
           }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
+        ]
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_list_events_after_deployment": {
-    "recorded-date": "02-03-2023, 22:20:11",
+    "recorded-date": "05-10-2022, 13:33:55",
     "recorded-content": {
       "events": {
         "StackEvents": [
@@ -357,6 +278,7 @@
             "LogicalResourceId": "<stack-name:1>",
             "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "ResourceStatus": "REVIEW_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
@@ -367,7 +289,48 @@
             "LogicalResourceId": "<stack-name:1>",
             "PhysicalResourceId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "User Initiated",
             "ResourceType": "AWS::CloudFormation::Stack",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "topic123-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "topic123",
+            "PhysicalResourceId": "",
+            "ResourceProperties": {
+              "TopicName": "<resource:2>"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "topic123-CREATE_IN_PROGRESS-date",
+            "LogicalResourceId": "topic123",
+            "PhysicalResourceId": "arn:aws:sns:<region>:111111111111:<resource:2>",
+            "ResourceProperties": {
+              "TopicName": "<resource:2>"
+            },
+            "ResourceStatus": "CREATE_IN_PROGRESS",
+            "ResourceStatusReason": "Resource creation Initiated",
+            "ResourceType": "AWS::SNS::Topic",
+            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
+            "StackName": "<stack-name:1>",
+            "Timestamp": "timestamp"
+          },
+          {
+            "EventId": "topic123-CREATE_COMPLETE-date",
+            "LogicalResourceId": "topic123",
+            "PhysicalResourceId": "arn:aws:sns:<region>:111111111111:<resource:2>",
+            "ResourceProperties": {
+              "TopicName": "<resource:2>"
+            },
+            "ResourceStatus": "CREATE_COMPLETE",
+            "ResourceType": "AWS::SNS::Topic",
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
@@ -381,16 +344,6 @@
             "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
             "StackName": "<stack-name:1>",
             "Timestamp": "timestamp"
-          },
-          {
-            "EventId": "<uuid:4>",
-            "LogicalResourceId": "topic123",
-            "PhysicalResourceId": "arn:aws:sns:<region>:111111111111:<resource:2>",
-            "ResourceStatus": "CREATE_COMPLETE",
-            "ResourceType": "AWS::SNS::Topic",
-            "StackId": "arn:aws:cloudformation:<region>:111111111111:stack/<stack-name:1>/<resource:1>",
-            "StackName": "<stack-name:1>",
-            "Timestamp": "timestamp"
           }
         ],
         "ResponseMetadata": {
@@ -401,7 +354,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_stack_lifecycle": {
-    "recorded-date": "02-03-2023, 22:20:01",
+    "recorded-date": "11-10-2022, 13:34:32",
     "recorded-content": {
       "creation": {
         "Capabilities": [
@@ -489,7 +442,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_updating_an_updated_stack_sets_status": {
-    "recorded-date": "02-03-2023, 22:20:14",
+    "recorded-date": "02-12-2022, 11:19:41",
     "recorded-content": {
       "describe-result": {
         "Stacks": [
@@ -510,12 +463,12 @@
             "NotificationARNs": [],
             "Parameters": [
               {
-                "ParameterKey": "Topic1Name",
-                "ParameterValue": "topic-1"
-              },
-              {
                 "ParameterKey": "Topic2Name",
                 "ParameterValue": "topic-2"
+              },
+              {
+                "ParameterKey": "Topic1Name",
+                "ParameterValue": "topic-1"
               },
               {
                 "ParameterKey": "Topic3Name",
@@ -537,7 +490,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_update_termination_protection": {
-    "recorded-date": "02-03-2023, 22:20:16",
+    "recorded-date": "04-01-2023, 16:23:22",
     "recorded-content": {
       "describe-stack-1": {
         "Stacks": [
@@ -612,7 +565,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::test_events_resource_types": {
-    "recorded-date": "02-03-2023, 22:20:17",
+    "recorded-date": "15-02-2023, 10:46:53",
     "recorded-content": {
       "resource_types": [
         "AWS::CloudFormation::Stack",

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -27,7 +27,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[yaml]": {
-    "recorded-date": "07-03-2023, 00:44:41",
+    "recorded-date": "07-03-2023, 20:44:51",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [
@@ -63,11 +63,44 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "template_original": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "template_processed": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "template_default": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[json]": {
-    "recorded-date": "07-03-2023, 00:44:58",
+    "recorded-date": "07-03-2023, 20:45:19",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [
@@ -158,7 +191,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "template_body": {
+      "template_default": {
         "StagesAvailable": [
           "Original",
           "Processed"

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -27,13 +27,9 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[yaml]": {
-    "recorded-date": "11-08-2022, 10:55:10",
+    "recorded-date": "03-03-2023, 22:53:35",
     "recorded-content": {
       "describe_stacks": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Stacks": [
           {
             "Capabilities": [
@@ -62,40 +58,51 @@
             "StackStatus": "CREATE_COMPLETE",
             "Tags": []
           }
-        ]
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "template_original": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "StagesAvailable": [
           "Original",
           "Processed"
         ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       },
       "template_processed": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "StagesAvailable": [
           "Original",
           "Processed"
         ],
-        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n"
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "template_body": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": "Resources:\n  topic69831491:\n    Type: AWS::SNS::Topic\nOutputs:\n  TopicName:\n    Value:\n      Fn::GetAtt:\n        - topic69831491\n        - TopicName\n",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[json]": {
-    "recorded-date": "11-08-2022, 10:55:35",
+    "recorded-date": "03-03-2023, 22:53:53",
     "recorded-content": {
       "describe_stacks": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "Stacks": [
           {
             "Capabilities": [
@@ -124,13 +131,13 @@
             "StackStatus": "CREATE_COMPLETE",
             "Tags": []
           }
-        ]
-      },
-      "template_original": {
+        ],
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
-        },
+        }
+      },
+      "template_original": {
         "StagesAvailable": [
           "Original",
           "Processed"
@@ -151,13 +158,13 @@
               "Type": "AWS::SNS::Topic"
             }
           }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       },
       "template_processed": {
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        },
         "StagesAvailable": [
           "Original",
           "Processed"
@@ -178,6 +185,37 @@
               "Type": "AWS::SNS::Topic"
             }
           }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "template_body": {
+        "StagesAvailable": [
+          "Original",
+          "Processed"
+        ],
+        "TemplateBody": {
+          "Outputs": {
+            "TopicName": {
+              "Value": {
+                "Fn::GetAtt": [
+                  "topic69831491",
+                  "TopicName"
+                ]
+              }
+            }
+          },
+          "Resources": {
+            "topic69831491": {
+              "Type": "AWS::SNS::Topic"
+            }
+          }
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }

--- a/tests/integration/cloudformation/api/test_stacks.snapshot.json
+++ b/tests/integration/cloudformation/api/test_stacks.snapshot.json
@@ -27,7 +27,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[yaml]": {
-    "recorded-date": "03-03-2023, 22:53:35",
+    "recorded-date": "06-03-2023, 22:19:22",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [
@@ -100,7 +100,7 @@
     }
   },
   "tests/integration/cloudformation/api/test_stacks.py::TestStacksApi::test_get_template[json]": {
-    "recorded-date": "03-03-2023, 22:53:53",
+    "recorded-date": "06-03-2023, 22:19:39",
     "recorded-content": {
       "describe_stacks": {
         "Stacks": [


### PR DESCRIPTION
Fix for issue #7657 

Now the get-template response for the command with created stack-name "test-stack": 
`awslocal cloudformation get-template --stack-name test-stack` returns

``` {
    "TemplateBody": {
        "Resources": {
            "topic69831491": {
                "Type": "AWS::SNS::Topic"
            }
        },
        "Outputs": {
            "TopicName": {
                "Value": {
                    "Fn::GetAtt": [
                        "topic69831491",
                        "TopicName"
                    ]
                }
            }
        },
        "StackName": "test-stack",
        "ChangeSetName": "awscli-cloudformation-package-deploy-1678120472"
    },
    "StagesAvailable": [
        "Original",
        "Processed"
    ]
}
```