### PR TITLE
add persistence API integration for community services

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -361,8 +361,11 @@ DATA_DIR = os.environ.get("DATA_DIR", "").strip()
 # whether localstack should persist service state across localstack runs
 PERSISTENCE = is_env_true("PERSISTENCE")
 
-# the save strategy used if `PERSISTENCE=1` (on_shutdown, on_request, scheduled)
-SAVE_STRATEGY = os.environ.get("SAVE_STRATEGY", "").upper()
+# the strategy for loading snapshots from disk when `PERSISTENCE=1` is used (on_startup, on_request, manual)
+SNAPSHOT_LOAD_STRATEGY = os.environ.get("SNAPSHOT_LOAD_STRATEGY", "").upper()
+
+# the strategy saving snapshots to disk when `PERSISTENCE=1` is used (on_shutdown, on_request, scheduled, manual)
+SNAPSHOT_SAVE_STRATEGY = os.environ.get("SNAPSHOT_SAVE_STRATEGY", "").upper()
 
 # whether to clear config.dirs.tmp on startup and shutdown
 CLEAR_TMP_FOLDER = is_env_not_false("CLEAR_TMP_FOLDER")
@@ -836,12 +839,13 @@ CONFIG_ENV_VARS = [
     "PERSISTENCE",
     "PORTS_CHECK_DOCKER_IMAGE",
     "REQUESTS_CA_BUNDLE",
-    "SAVE_STRATEGY",
     "S3_SKIP_SIGNATURE_VALIDATION",
     "S3_SKIP_KMS_KEY_VALIDATION",
     "SERVICES",
     "SKIP_INFRA_DOWNLOADS",
     "SKIP_SSL_CERT_DOWNLOAD",
+    "SNAPSHOT_LOAD_STRATEGY",
+    "SNAPSHOT_SAVE_STRATEGY",
     "SQS_DELAY_PURGE_RETRY",
     "SQS_DELAY_RECENTLY_DELETED",
     "SQS_ENDPOINT_STRATEGY",

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -361,6 +361,9 @@ DATA_DIR = os.environ.get("DATA_DIR", "").strip()
 # whether localstack should persist service state across localstack runs
 PERSISTENCE = is_env_true("PERSISTENCE")
 
+# the save strategy used if `PERSISTENCE=1` (on_shutdown, on_request, scheduled)
+SAVE_STRATEGY = os.environ.get("SAVE_STRATEGY", "").upper()
+
 # whether to clear config.dirs.tmp on startup and shutdown
 CLEAR_TMP_FOLDER = is_env_not_false("CLEAR_TMP_FOLDER")
 
@@ -833,6 +836,7 @@ CONFIG_ENV_VARS = [
     "PERSISTENCE",
     "PORTS_CHECK_DOCKER_IMAGE",
     "REQUESTS_CA_BUNDLE",
+    "SAVE_STRATEGY",
     "S3_SKIP_SIGNATURE_VALIDATION",
     "S3_SKIP_KMS_KEY_VALIDATION",
     "SERVICES",

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -27,6 +27,7 @@ default_log_levels = {
     "localstack.aws.serving.wsgi": logging.WARNING,
     "localstack.request": logging.INFO,
     "localstack.request.internal": logging.WARNING,
+    "localstack.state.inspect": logging.INFO,
 }
 
 trace_log_levels = {
@@ -34,6 +35,7 @@ trace_log_levels = {
     "localstack.aws.serving.wsgi": logging.DEBUG,
     "localstack.request": logging.DEBUG,
     "localstack.request.internal": logging.INFO,
+    "localstack.state.inspect": logging.DEBUG,
 }
 
 trace_internal_log_levels = {

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -100,7 +100,6 @@ from localstack.aws.api.dynamodb import (
 from localstack.aws.forwarder import get_request_forwarder_http
 from localstack.constants import AUTH_CREDENTIAL_REGEX, LOCALHOST, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.http import Response
-from localstack.state import AssetDirectory, StateVisitor
 from localstack.services.dynamodb import server
 from localstack.services.dynamodb.models import DynamoDBStore, dynamodb_stores
 from localstack.services.dynamodb.server import start_dynamodb, wait_for_dynamodb
@@ -116,6 +115,7 @@ from localstack.services.dynamodbstreams.dynamodbstreams_api import (
 )
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
+from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.aws.arns import extract_account_id_from_arn, extract_region_from_arn
 from localstack.utils.aws.aws_stack import get_valid_regions_for_service

--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import logging
+import os.path
 import random
 import re
 import time
@@ -99,6 +100,7 @@ from localstack.aws.api.dynamodb import (
 from localstack.aws.forwarder import get_request_forwarder_http
 from localstack.constants import AUTH_CREDENTIAL_REGEX, LOCALHOST, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.http import Response
+from localstack.state import AssetDirectory, StateVisitor
 from localstack.services.dynamodb import server
 from localstack.services.dynamodb.models import DynamoDBStore, dynamodb_stores
 from localstack.services.dynamodb.server import start_dynamodb, wait_for_dynamodb
@@ -346,6 +348,10 @@ def modify_context_region(context: RequestContext, region: str):
 class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
     def __init__(self):
         self.request_forwarder = get_request_forwarder_http(self.get_forward_url)
+
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(dynamodb_stores)
+        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "dynamodb")))
 
     def on_after_init(self):
         # add response processor specific to ddblocal

--- a/localstack/services/kinesis/provider.py
+++ b/localstack/services/kinesis/provider.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from random import random
 
@@ -28,6 +29,7 @@ from localstack.aws.api.kinesis import (
 from localstack.constants import LOCALHOST
 from localstack.services.kinesis.models import KinesisStore, kinesis_stores
 from localstack.services.plugins import ServiceLifecycleHook
+from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws import arns, aws_stack
 from localstack.utils.time import now_utc
 
@@ -46,6 +48,10 @@ def find_stream_for_consumer(consumer_arn):
 
 
 class KinesisProvider(KinesisApi, ServiceLifecycleHook):
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(kinesis_stores)
+        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "kinesis")))
+
     @staticmethod
     def get_store(account_id: str, region_name: str) -> KinesisStore:
         return kinesis_stores[account_id][region_name]

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -1,10 +1,13 @@
 import logging
+import os
 import re
 import threading
 from datetime import datetime, timezone
 from random import randint
 from typing import Dict, Optional
+from urllib.parse import urlparse
 
+from localstack import config
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.opensearch import (
@@ -55,6 +58,7 @@ from localstack.aws.api.opensearch import (
     NextToken,
     NodeToNodeEncryptionOptions,
     NodeToNodeEncryptionOptionsStatus,
+    OffPeakWindowOptions,
     OpensearchApi,
     OpenSearchPartitionInstanceType,
     OptionState,
@@ -66,6 +70,7 @@ from localstack.aws.api.opensearch import (
     ServiceSoftwareOptions,
     SnapshotOptions,
     SnapshotOptionsStatus,
+    SoftwareUpdateOptions,
     StringList,
     TagList,
     TLSSecurityPolicy,
@@ -88,6 +93,7 @@ from localstack.services.opensearch.cluster_manager import (
     create_cluster_manager,
 )
 from localstack.services.opensearch.models import OpenSearchStore, opensearch_stores
+from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.aws.request_context import get_region_from_request_context
 from localstack.utils.collections import PaginatedList, remove_none_values_from_dict
 from localstack.utils.serving import Server
@@ -400,6 +406,51 @@ class OpensearchProvider(OpensearchApi):
             ), "The region was not given and it could not be extracted from a request context."
         return opensearch_stores[get_aws_account_id()][region]
 
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(opensearch_stores)
+        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "opensearch")))
+        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "elasticsearch")))
+
+    def on_after_state_load(self):
+        """Starts clusters whose metadata has been restored."""
+        for account_id, region_bundle in opensearch_stores.items():
+            for region, store in region_bundle.items():
+                for domain_name, domain_status in store.opensearch_domains.items():
+                    domain_key = DomainKey(domain_name, region, account_id)
+                    if cluster_manager().get(domain_key.arn):
+                        # cluster already restored in previous call to on_after_state_load
+                        continue
+
+                    LOG.info(f"Restoring domain {domain_name} in region {region}.")
+                    try:
+                        preferred_port = None
+                        if config.OPENSEARCH_ENDPOINT_STRATEGY == "port":
+                            # try to parse the previous port to re-use it for the re-created cluster
+                            if "Endpoint" in domain_status:
+                                preferred_port = urlparse(
+                                    f"http://{domain_status['Endpoint']}"
+                                ).port
+
+                        engine_version = domain_status.get("EngineVersion")
+                        domain_endpoint_options = domain_status.get("DomainEndpointOptions", {})
+                        create_cluster(
+                            domain_key, engine_version, domain_endpoint_options, preferred_port
+                        )
+                    except Exception:
+                        LOG.exception(f"Could not restore domain {domain_name} in region {region}.")
+
+    def on_before_state_reset(self):
+        self._stop_clusters()
+
+    def on_before_stop(self):
+        self._stop_clusters()
+
+    def _stop_clusters(self):
+        for account_id, region_bundle in opensearch_stores.items():
+            for region, store in region_bundle.items():
+                for domain_name in store.opensearch_domains.keys():
+                    cluster_manager().remove(DomainKey(domain_name, region, account_id).arn)
+
     def create_domain(
         self,
         context: RequestContext,
@@ -419,6 +470,8 @@ class OpensearchProvider(OpensearchApi):
         advanced_security_options: AdvancedSecurityOptionsInput = None,
         tag_list: TagList = None,
         auto_tune_options: AutoTuneOptionsInput = None,
+        off_peak_window_options: OffPeakWindowOptions = None,
+        software_update_options: SoftwareUpdateOptions = None,
     ) -> CreateDomainResponse:
         store = self.get_store()
 

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -433,8 +433,16 @@ class OpensearchProvider(OpensearchApi):
 
                         engine_version = domain_status.get("EngineVersion")
                         domain_endpoint_options = domain_status.get("DomainEndpointOptions", {})
+                        security_options = SecurityOptions.from_input(
+                            domain_status.get("AdvancedSecurityOptions")
+                        )
+
                         create_cluster(
-                            domain_key, engine_version, domain_endpoint_options, preferred_port
+                            domain_key=domain_key,
+                            engine_version=engine_version,
+                            domain_endpoint_options=domain_endpoint_options,
+                            security_options=security_options,
+                            preferred_port=preferred_port,
                         )
                     except Exception:
                         LOG.exception(f"Could not restore domain {domain_name} in region {region}.")

--- a/localstack/services/redshift/provider.py
+++ b/localstack/services/redshift/provider.py
@@ -1,6 +1,9 @@
+import os
+
 from moto.redshift import responses as redshift_responses
 from moto.redshift.models import redshift_backends
 
+from localstack import config
 from localstack.aws.api import RequestContext, handler
 from localstack.aws.api.redshift import (
     ClusterSecurityGroupMessage,
@@ -8,6 +11,7 @@ from localstack.aws.api.redshift import (
     RedshiftApi,
 )
 from localstack.services.moto import call_moto
+from localstack.state import AssetDirectory, StateVisitor
 from localstack.utils.common import recurse_object
 from localstack.utils.patch import patch
 
@@ -31,6 +35,10 @@ def itemize(fn, data, parent_key=None, *args, **kwargs):
 
 
 class RedshiftProvider(RedshiftApi):
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(redshift_backends)
+        visitor.visit(AssetDirectory(os.path.join(config.dirs.data, "redshift")))
+
     @handler("DescribeClusterSecurityGroups", expand=False)
     def describe_cluster_security_groups(
         self,


### PR DESCRIPTION
This PR uses the persistence API to integrate community services into the persistence lifecycle. It's "basic" because it doesn't fully add restore functionality for every services.
* added `accept_state_visitor` methods to community services that have an asset directory
* added the `SAVE_STRATEGY` variable used by the persistence plugin to the config
* I was able to add the restore functionality for opensearch (tested manually), but not for others. Those will be part of follow-up PRs once we have a good persistence testing setup.
* I also snuck in the two parameters to the opensearch `create_domain`  method that were missing after the last ASF API update /cc @alexrashed 