### PR TITLE
add runtime hook that runs on pro infra startup

### DIFF
--- a/localstack/runtime/hooks.py
+++ b/localstack/runtime/hooks.py
@@ -6,6 +6,7 @@ from plugin import PluginManager, plugin
 HOOKS_CONFIGURE_LOCALSTACK_CONTAINER = "localstack.hooks.configure_localstack_container"
 HOOKS_ON_INFRA_READY = "localstack.hooks.on_infra_ready"
 HOOKS_ON_INFRA_START = "localstack.hooks.on_infra_start"
+HOOKS_ON_PRO_INFRA_START = "localstack.hooks.on_pro_infra_start"
 HOOKS_ON_INFRA_SHUTDOWN = "localstack.hooks.on_infra_shutdown"
 HOOKS_PREPARE_HOST = "localstack.hooks.prepare_host"
 
@@ -77,6 +78,9 @@ prepare_host = hook_spec(HOOKS_PREPARE_HOST)
 
 on_infra_start = hook_spec(HOOKS_ON_INFRA_START)
 """Hooks that are executed right before starting the LocalStack infrastructure."""
+
+on_pro_infra_start = hook_spec(HOOKS_ON_PRO_INFRA_START)
+"""Hooks that are executed after on_infra_start hooks, and only if LocalStack pro has been activated."""
 
 on_infra_ready = hook_spec(HOOKS_ON_INFRA_READY)
 """Hooks that are execute after all startup hooks have been executed, and the LocalStack infrastructure has become


### PR DESCRIPTION
Adds a runtime hook used in pro and plugins that is only run when pro is activated. This makes it easier to hook in functionality that's conditionally after license activation. 