### PR TITLE
Add scenario tests with Fundamental level for Stepfunctions

### DIFF
--- a/tests/integration/stepfunctions/v2/scenarios/templates/path-based-on-data.yaml
+++ b/tests/integration/stepfunctions/v2/scenarios/templates/path-based-on-data.yaml
@@ -1,0 +1,108 @@
+Resources:
+  statemachineRole52044F93:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::FindInMap:
+                  - ServiceprincipalMap
+                  - Ref: AWS::Region
+                  - states
+        Version: "2012-10-17"
+  statemachineC5962F3E:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - statemachineRole52044F93
+          - Arn
+      DefinitionString: '{"StartAt":"Choice State","States":{"Choice State":{"Type":"Choice","Choices":[{"Not":{"Variable":"$.type","StringEquals":"Private"},"Next":"NEXT_STATE_ONE"},{"Variable":"$.value","NumericEquals":0,"Next":"NEXT_STATE_TWO"},{"And":[{"Variable":"$.value","NumericGreaterThanEquals":20},{"Variable":"$.value","NumericLessThan":30}],"Next":"NEXT_STATE_TWO"}],"Default":"DEFAULT_STATE"},"DEFAULT_STATE":{"Type":"Pass","End":true},"NEXT_STATE_ONE":{"Type":"Pass","End":true},"NEXT_STATE_TWO":{"Type":"Pass","End":true}}}'
+    DependsOn:
+      - statemachineRole52044F93
+Outputs:
+  StateMachineArn:
+    Value:
+      Ref: statemachineC5962F3E
+  StateMachineName:
+    Value:
+      Fn::GetAtt:
+        - statemachineC5962F3E
+        - Name
+  RoleArn:
+    Value:
+      Fn::GetAtt:
+        - statemachineRole52044F93
+        - Arn
+  RoleName:
+    Value:
+      Ref: statemachineRole52044F93
+Mappings:
+  ServiceprincipalMap:
+    af-south-1:
+      states: states.af-south-1.amazonaws.com
+    ap-east-1:
+      states: states.ap-east-1.amazonaws.com
+    ap-northeast-1:
+      states: states.ap-northeast-1.amazonaws.com
+    ap-northeast-2:
+      states: states.ap-northeast-2.amazonaws.com
+    ap-northeast-3:
+      states: states.ap-northeast-3.amazonaws.com
+    ap-south-1:
+      states: states.ap-south-1.amazonaws.com
+    ap-south-2:
+      states: states.ap-south-2.amazonaws.com
+    ap-southeast-1:
+      states: states.ap-southeast-1.amazonaws.com
+    ap-southeast-2:
+      states: states.ap-southeast-2.amazonaws.com
+    ap-southeast-3:
+      states: states.ap-southeast-3.amazonaws.com
+    ca-central-1:
+      states: states.ca-central-1.amazonaws.com
+    cn-north-1:
+      states: states.cn-north-1.amazonaws.com
+    cn-northwest-1:
+      states: states.cn-northwest-1.amazonaws.com
+    eu-central-1:
+      states: states.eu-central-1.amazonaws.com
+    eu-north-1:
+      states: states.eu-north-1.amazonaws.com
+    eu-south-1:
+      states: states.eu-south-1.amazonaws.com
+    eu-south-2:
+      states: states.eu-south-2.amazonaws.com
+    eu-west-1:
+      states: states.eu-west-1.amazonaws.com
+    eu-west-2:
+      states: states.eu-west-2.amazonaws.com
+    eu-west-3:
+      states: states.eu-west-3.amazonaws.com
+    me-central-1:
+      states: states.me-central-1.amazonaws.com
+    me-south-1:
+      states: states.me-south-1.amazonaws.com
+    sa-east-1:
+      states: states.sa-east-1.amazonaws.com
+    us-east-1:
+      states: states.us-east-1.amazonaws.com
+    us-east-2:
+      states: states.us-east-2.amazonaws.com
+    us-gov-east-1:
+      states: states.us-gov-east-1.amazonaws.com
+    us-gov-west-1:
+      states: states.us-gov-west-1.amazonaws.com
+    us-iso-east-1:
+      states: states.amazonaws.com
+    us-iso-west-1:
+      states: states.amazonaws.com
+    us-isob-east-1:
+      states: states.amazonaws.com
+    us-west-1:
+      states: states.us-west-1.amazonaws.com
+    us-west-2:
+      states: states.us-west-2.amazonaws.com

--- a/tests/integration/stepfunctions/v2/scenarios/templates/step-functions-calling-api-gateway.yaml
+++ b/tests/integration/stepfunctions/v2/scenarios/templates/step-functions-calling-api-gateway.yaml
@@ -1,0 +1,387 @@
+Resources:
+  waitFnServiceRole0216D1B5:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  waitFnF267ED7D:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import json
+
+
+          def handler(event, context):
+              print(event)
+
+              body = json.loads(event["body"])
+
+              if body["fail"]:
+                  return {
+                      "statusCode": 200,
+                      "body": json.dumps({"errors": ["Errors.Failure"]})
+                  }
+
+              return {
+                  "statusCode": 200,
+                  "body": json.dumps({"hello": "world"})
+              }
+      Role:
+        Fn::GetAtt:
+          - waitFnServiceRole0216D1B5
+          - Arn
+      Handler: index.handler
+      Runtime: python3.9
+    DependsOn:
+      - waitFnServiceRole0216D1B5
+  waitFnEventInvokeConfig11670229:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName:
+        Ref: waitFnF267ED7D
+      Qualifier: $LATEST
+      MaximumRetryAttempts: 0
+  apiC8550315:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: api
+  apiCloudWatchRoleAC81D93E:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: apigateway.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  apiAccount57E28B43:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn:
+        Fn::GetAtt:
+          - apiCloudWatchRoleAC81D93E
+          - Arn
+    DependsOn:
+      - apiC8550315
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  apiDeployment149F1294de73d8965f6482f8e9c53d63c8688161:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId:
+        Ref: apiC8550315
+      Description: Automatically created by the RestApi construct
+    DependsOn:
+      - apiproxyANY7F13F09C
+      - apiproxy4EA44110
+      - apiANYB3DF8C3C
+  apiDeploymentStagedev96712F43:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      RestApiId:
+        Ref: apiC8550315
+      DeploymentId:
+        Ref: apiDeployment149F1294de73d8965f6482f8e9c53d63c8688161
+      StageName: dev
+    DependsOn:
+      - apiAccount57E28B43
+  apiproxy4EA44110:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId:
+        Fn::GetAtt:
+          - apiC8550315
+          - RootResourceId
+      PathPart: "{proxy+}"
+      RestApiId:
+        Ref: apiC8550315
+  apiproxyANYApiPermissionStepFunctionsCallingApiGatewayapi087EEC13ANYproxyAAE92B1A:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - waitFnF267ED7D
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: apiC8550315
+            - /
+            - Ref: apiDeploymentStagedev96712F43
+            - /*/*
+  apiproxyANYApiPermissionTestStepFunctionsCallingApiGatewayapi087EEC13ANYproxy4CE90A2A:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - waitFnF267ED7D
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: apiC8550315
+            - /test-invoke-stage/*/*
+  apiproxyANY7F13F09C:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId:
+        Ref: apiproxy4EA44110
+      RestApiId:
+        Ref: apiC8550315
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - ":apigateway:"
+              - Ref: AWS::Region
+              - :lambda:path/2015-03-31/functions/
+              - Fn::GetAtt:
+                  - waitFnF267ED7D
+                  - Arn
+              - /invocations
+  apiANYApiPermissionStepFunctionsCallingApiGatewayapi087EEC13ANYC9378D12:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - waitFnF267ED7D
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: apiC8550315
+            - /
+            - Ref: apiDeploymentStagedev96712F43
+            - /*/
+  apiANYApiPermissionTestStepFunctionsCallingApiGatewayapi087EEC13ANY9D250CDE:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - waitFnF267ED7D
+          - Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn:
+        Fn::Join:
+          - ""
+          - - "arn:"
+            - Ref: AWS::Partition
+            - ":execute-api:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":"
+            - Ref: apiC8550315
+            - /test-invoke-stage/*/
+  apiANYB3DF8C3C:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      HttpMethod: ANY
+      ResourceId:
+        Fn::GetAtt:
+          - apiC8550315
+          - RootResourceId
+      RestApiId:
+        Ref: apiC8550315
+      AuthorizationType: NONE
+      Integration:
+        IntegrationHttpMethod: POST
+        Type: AWS_PROXY
+        Uri:
+          Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - ":apigateway:"
+              - Ref: AWS::Region
+              - :lambda:path/2015-03-31/functions/
+              - Fn::GetAtt:
+                  - waitFnF267ED7D
+                  - Arn
+              - /invocations
+  statemachineRole52044F93:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::FindInMap:
+                  - ServiceprincipalMap
+                  - Ref: AWS::Region
+                  - states
+        Version: "2012-10-17"
+  statemachineC5962F3E:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - statemachineRole52044F93
+          - Arn
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - '{"StartAt":"Add Pet to Store","States":{"Add Pet to Store":{"Next":"Pet was Added Successfully?","Type":"Task","Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::apigateway:invoke","Parameters":{"ApiEndpoint":"
+            - Ref: apiC8550315
+            - .execute-api.
+            - Ref: AWS::Region
+            - "."
+            - Ref: AWS::URLSuffix
+            - '","Method":"POST","Stage":"dev","RequestBody.$":"$","AuthType":"NO_AUTH"}},"Pet was Added Successfully?":{"Type":"Choice","Choices":[{"Variable":"$.ResponseBody.errors","IsPresent":true,"Next":"Failure"}],"Default":"Success"},"Success":{"Type":"Succeed"},"Failure":{"Type":"Fail"}}}'
+    DependsOn:
+      - statemachineRole52044F93
+Outputs:
+  apiEndpoint9349E63C:
+    Value:
+      Fn::Join:
+        - ""
+        - - https://
+          - Ref: apiC8550315
+          - .execute-api.
+          - Ref: AWS::Region
+          - "."
+          - Ref: AWS::URLSuffix
+          - /
+          - Ref: apiDeploymentStagedev96712F43
+          - /
+  StateMachineArn:
+    Value:
+      Ref: statemachineC5962F3E
+  StateMachineName:
+    Value:
+      Fn::GetAtt:
+        - statemachineC5962F3E
+        - Name
+  RoleArn:
+    Value:
+      Fn::GetAtt:
+        - statemachineRole52044F93
+        - Arn
+  RoleName:
+    Value:
+      Ref: statemachineRole52044F93
+Mappings:
+  ServiceprincipalMap:
+    af-south-1:
+      states: states.af-south-1.amazonaws.com
+    ap-east-1:
+      states: states.ap-east-1.amazonaws.com
+    ap-northeast-1:
+      states: states.ap-northeast-1.amazonaws.com
+    ap-northeast-2:
+      states: states.ap-northeast-2.amazonaws.com
+    ap-northeast-3:
+      states: states.ap-northeast-3.amazonaws.com
+    ap-south-1:
+      states: states.ap-south-1.amazonaws.com
+    ap-south-2:
+      states: states.ap-south-2.amazonaws.com
+    ap-southeast-1:
+      states: states.ap-southeast-1.amazonaws.com
+    ap-southeast-2:
+      states: states.ap-southeast-2.amazonaws.com
+    ap-southeast-3:
+      states: states.ap-southeast-3.amazonaws.com
+    ca-central-1:
+      states: states.ca-central-1.amazonaws.com
+    cn-north-1:
+      states: states.cn-north-1.amazonaws.com
+    cn-northwest-1:
+      states: states.cn-northwest-1.amazonaws.com
+    eu-central-1:
+      states: states.eu-central-1.amazonaws.com
+    eu-north-1:
+      states: states.eu-north-1.amazonaws.com
+    eu-south-1:
+      states: states.eu-south-1.amazonaws.com
+    eu-south-2:
+      states: states.eu-south-2.amazonaws.com
+    eu-west-1:
+      states: states.eu-west-1.amazonaws.com
+    eu-west-2:
+      states: states.eu-west-2.amazonaws.com
+    eu-west-3:
+      states: states.eu-west-3.amazonaws.com
+    me-central-1:
+      states: states.me-central-1.amazonaws.com
+    me-south-1:
+      states: states.me-south-1.amazonaws.com
+    sa-east-1:
+      states: states.sa-east-1.amazonaws.com
+    us-east-1:
+      states: states.us-east-1.amazonaws.com
+    us-east-2:
+      states: states.us-east-2.amazonaws.com
+    us-gov-east-1:
+      states: states.us-gov-east-1.amazonaws.com
+    us-gov-west-1:
+      states: states.us-gov-west-1.amazonaws.com
+    us-iso-east-1:
+      states: states.amazonaws.com
+    us-iso-west-1:
+      states: states.amazonaws.com
+    us-isob-east-1:
+      states: states.amazonaws.com
+    us-west-1:
+      states: states.us-west-1.amazonaws.com
+    us-west-2:
+      states: states.us-west-2.amazonaws.com

--- a/tests/integration/stepfunctions/v2/scenarios/templates/wait-for-callback.yaml
+++ b/tests/integration/stepfunctions/v2/scenarios/templates/wait-for-callback.yaml
@@ -1,0 +1,238 @@
+Resources:
+  queue276F7297:
+    Type: AWS::SQS::Queue
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  waitFnServiceRole0216D1B5:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  waitFnServiceRoleDefaultPolicy76952F54:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - sqs:ReceiveMessage
+              - sqs:ChangeMessageVisibility
+              - sqs:GetQueueUrl
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - queue276F7297
+                - Arn
+          - Action:
+              - states:SendTaskSuccess
+              - states:SendTaskFailure
+              - states:SendTaskHeartbeat
+            Effect: Allow
+            Resource:
+              Ref: statemachineC5962F3E
+        Version: "2012-10-17"
+      PolicyName: waitFnServiceRoleDefaultPolicy76952F54
+      Roles:
+        - Ref: waitFnServiceRole0216D1B5
+  waitFnF267ED7D:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          import json
+          import os
+
+          import boto3
+
+
+          def create_client(svc_name: str):
+              if "LOCALSTACK_HOSTNAME" in os.environ:
+                  return boto3.client(
+                      svc_name, endpoint_url=f"http://{os.environ['LOCALSTACK_HOSTNAME']}:{os.environ['EDGE_PORT']}"
+                  )
+              else:
+                  return boto3.client(svc_name)
+
+
+          sfn_client = create_client("stepfunctions")
+
+
+          def handler(event, context):
+              print(event)
+
+              records = event["Records"]
+              record = records[0]
+              data = json.loads(record["body"])
+
+              if data["ShouldFail"] == "yes":
+                  sfn_client.send_task_failure(taskToken=data["TaskToken"], error="IntentionalFail", cause="Intentional failure")
+              else:
+                  sfn_client.send_task_success(taskToken=data["TaskToken"], output=json.dumps({"message": "Successfully executed lambda"}))
+      Role:
+        Fn::GetAtt:
+          - waitFnServiceRole0216D1B5
+          - Arn
+      Handler: index.handler
+      Runtime: python3.9
+    DependsOn:
+      - waitFnServiceRoleDefaultPolicy76952F54
+      - waitFnServiceRole0216D1B5
+  waitFnEventInvokeConfig11670229:
+    Type: AWS::Lambda::EventInvokeConfig
+    Properties:
+      FunctionName:
+        Ref: waitFnF267ED7D
+      Qualifier: $LATEST
+      MaximumRetryAttempts: 0
+  waitFnSqsEventSourceWaitForCallbackqueue5A0C181CF1A9D0B1:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      FunctionName:
+        Ref: waitFnF267ED7D
+      BatchSize: 1
+      EventSourceArn:
+        Fn::GetAtt:
+          - queue276F7297
+          - Arn
+  statemachineRole52044F93:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::FindInMap:
+                  - ServiceprincipalMap
+                  - Ref: AWS::Region
+                  - states
+        Version: "2012-10-17"
+  statemachineRoleDefaultPolicy9AE064E2:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: sqs:SendMessage
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - queue276F7297
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: statemachineRoleDefaultPolicy9AE064E2
+      Roles:
+        - Ref: statemachineRole52044F93
+  statemachineC5962F3E:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - statemachineRole52044F93
+          - Arn
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - '{"StartAt":"Start Task And Wait For Callback","States":{"Start Task And Wait For Callback":{"Next":"Succeed State","Catch":[{"ErrorEquals":["States.ALL"],"Next":"Fail State"}],"Type":"Task","Resource":"arn:'
+            - Ref: AWS::Partition
+            - :states:::sqs:sendMessage.waitForTaskToken","Parameters":{"QueueUrl":"
+            - Ref: queue276F7297
+            - '","MessageBody":{"MessageTitle":"Task started by Step Functions. Waiting for callback with task token.","ShouldFail.$":"$.shouldfail","TaskToken.$":"$$.Task.Token"}}},"Succeed State":{"Type":"Succeed"},"Fail State":{"Type":"Fail"}}}'
+    DependsOn:
+      - statemachineRoleDefaultPolicy9AE064E2
+      - statemachineRole52044F93
+Outputs:
+  StateMachineArn:
+    Value:
+      Ref: statemachineC5962F3E
+  StateMachineName:
+    Value:
+      Fn::GetAtt:
+        - statemachineC5962F3E
+        - Name
+  RoleArn:
+    Value:
+      Fn::GetAtt:
+        - statemachineRole52044F93
+        - Arn
+  RoleName:
+    Value:
+      Ref: statemachineRole52044F93
+Mappings:
+  ServiceprincipalMap:
+    af-south-1:
+      states: states.af-south-1.amazonaws.com
+    ap-east-1:
+      states: states.ap-east-1.amazonaws.com
+    ap-northeast-1:
+      states: states.ap-northeast-1.amazonaws.com
+    ap-northeast-2:
+      states: states.ap-northeast-2.amazonaws.com
+    ap-northeast-3:
+      states: states.ap-northeast-3.amazonaws.com
+    ap-south-1:
+      states: states.ap-south-1.amazonaws.com
+    ap-south-2:
+      states: states.ap-south-2.amazonaws.com
+    ap-southeast-1:
+      states: states.ap-southeast-1.amazonaws.com
+    ap-southeast-2:
+      states: states.ap-southeast-2.amazonaws.com
+    ap-southeast-3:
+      states: states.ap-southeast-3.amazonaws.com
+    ca-central-1:
+      states: states.ca-central-1.amazonaws.com
+    cn-north-1:
+      states: states.cn-north-1.amazonaws.com
+    cn-northwest-1:
+      states: states.cn-northwest-1.amazonaws.com
+    eu-central-1:
+      states: states.eu-central-1.amazonaws.com
+    eu-north-1:
+      states: states.eu-north-1.amazonaws.com
+    eu-south-1:
+      states: states.eu-south-1.amazonaws.com
+    eu-south-2:
+      states: states.eu-south-2.amazonaws.com
+    eu-west-1:
+      states: states.eu-west-1.amazonaws.com
+    eu-west-2:
+      states: states.eu-west-2.amazonaws.com
+    eu-west-3:
+      states: states.eu-west-3.amazonaws.com
+    me-central-1:
+      states: states.me-central-1.amazonaws.com
+    me-south-1:
+      states: states.me-south-1.amazonaws.com
+    sa-east-1:
+      states: states.sa-east-1.amazonaws.com
+    us-east-1:
+      states: states.us-east-1.amazonaws.com
+    us-east-2:
+      states: states.us-east-2.amazonaws.com
+    us-gov-east-1:
+      states: states.us-gov-east-1.amazonaws.com
+    us-gov-west-1:
+      states: states.us-gov-west-1.amazonaws.com
+    us-iso-east-1:
+      states: states.amazonaws.com
+    us-iso-west-1:
+      states: states.amazonaws.com
+    us-isob-east-1:
+      states: states.amazonaws.com
+    us-west-1:
+      states: states.us-west-1.amazonaws.com
+    us-west-2:
+      states: states.us-west-2.amazonaws.com

--- a/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py
+++ b/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py
@@ -1,0 +1,137 @@
+import json
+import os.path
+from pathlib import Path
+from typing import Any, TypedDict
+
+import pytest
+
+from localstack.aws.api.stepfunctions import ExecutionStatus
+from localstack.utils.sync import wait_until
+
+THIS_FOLDER = Path(os.path.dirname(__file__))
+
+
+class RunConfig(TypedDict):
+    name: str
+    input: Any
+    terminal_state: ExecutionStatus | None
+
+
+class TestFundamental:
+    @staticmethod
+    def _record_execution(stepfunctions_client, snapshot, statemachine_arn, run_config: RunConfig):
+        """
+        This pattern is used throughout all stepfunctions scenario tests.
+        It starts a single state machine execution and snapshots all related information for the execution.
+        Make sure the "name" in the run_config is unique in the run.
+        """
+        name = run_config["name"]
+        start_execution_result = stepfunctions_client.start_execution(
+            stateMachineArn=statemachine_arn, input=json.dumps(run_config["input"])
+        )
+        execution_arn = start_execution_result["executionArn"]
+        execution_id = execution_arn.split(":")[-1]
+        snapshot.add_transformer(snapshot.transform.regex(execution_id, f"<execution-id-{name}>"))
+        snapshot.match(f"{name}__start_execution_result", start_execution_result)
+        describe_ex = stepfunctions_client.describe_execution(executionArn=execution_arn)
+        snapshot.match(f"{name}__describe_ex", describe_ex)
+
+        def execution_done():
+            # wait until execution is successful (or a different terminal state)
+            return (
+                stepfunctions_client.describe_execution(executionArn=execution_arn)["status"]
+                != ExecutionStatus.RUNNING
+            )
+
+        wait_until(execution_done)
+        describe_ex_done = stepfunctions_client.describe_execution(executionArn=execution_arn)
+        snapshot.match(f"{name}__describe_ex_done", describe_ex_done)
+        execution_history = stepfunctions_client.get_execution_history(executionArn=execution_arn)
+        snapshot.match(f"{name}__execution_history", execution_history)
+
+        assert_state = run_config.get("terminal_state")
+        if assert_state:
+            assert describe_ex_done["status"] == assert_state
+
+    @pytest.mark.aws_validated
+    def test_path_based_on_data(self, deploy_cfn_template, stepfunctions_client, snapshot):
+        """
+        Based on the "path-based-on-data" sample workflow on serverlessland.com
+
+        choice state with 3 paths
+        1. input "type" is not "Private"
+        2. value is >= 20 and < 30
+        3. default path
+        """
+        deployment = deploy_cfn_template(
+            template_path=os.path.join(THIS_FOLDER, "./templates/path-based-on-data.yaml")
+        )
+        statemachine_arn = deployment.outputs["StateMachineArn"]
+        statemachine_name = deployment.outputs["StateMachineName"]
+        role_name = deployment.outputs["RoleName"]
+        snapshot.add_transformer(snapshot.transform.regex(role_name, "<role-name>"))
+        snapshot.add_transformer(
+            snapshot.transform.regex(statemachine_name, "<state-machine-name>")
+        )
+
+        describe_statemachine = stepfunctions_client.describe_state_machine(
+            stateMachineArn=statemachine_arn
+        )
+        snapshot.match("describe_statemachine", describe_statemachine)
+
+        run_configs = [
+            {
+                "name": "first_path",
+                "input": {"type": "Public", "value": 3},
+                "terminal_state": ExecutionStatus.SUCCEEDED,
+            },
+            {
+                "name": "second_path",
+                "input": {"type": "Private", "value": 25},
+                "terminal_state": ExecutionStatus.SUCCEEDED,
+            },
+            {
+                "name": "default_path",
+                "input": {"type": "Private", "value": 3},
+                "terminal_state": ExecutionStatus.SUCCEEDED,
+            },
+        ]
+
+        for run_config in run_configs:
+            self._record_execution(stepfunctions_client, snapshot, statemachine_arn, run_config)
+
+    def test_simple_retry(self, deploy_cfn_template):
+        """
+        Based on the "simple-retry" sample workflow on serverlessland.com
+        """
+        raise Exception("TODO")
+
+    def test_synchronous_job(self, deploy_cfn_template):
+        """
+        Based on the "synchronous-job" sample workflow on serverlessland.com
+        """
+        raise Exception("TODO")
+
+    def test_wait_for_callback(self, deploy_cfn_template):
+        """
+        Based on the "wait-for-callback" sample workflow on serverlessland.com
+        """
+        raise Exception("TODO")
+
+    def test_batch_lambda_cdk(self, deploy_cfn_template):
+        """
+        Based on the "batch-lambda-cdk" sample workflow on serverlessland.com
+        """
+        raise Exception("TODO")
+
+    def test_request_response_cdk(self, deploy_cfn_template):
+        """
+        Based on the "request-response-cdk" sample workflow on serverlessland.com
+        """
+        raise Exception("TODO")
+
+    def test_step_functions_calling_api_gateway(self, deploy_cfn_template):
+        """
+        Based on the "step-functions-calling-api-gateway" sample workflow on serverlessland.com
+        """
+        raise Exception("TODO")

--- a/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py
+++ b/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py
@@ -18,6 +18,10 @@ class RunConfig(TypedDict):
     terminal_state: ExecutionStatus | None
 
 
+@pytest.mark.skipif(
+    condition=not is_old_provider() and os.environ.get("TEST_TARGET") != "AWS_CLOUD",
+    reason="Not supported yet.",
+)
 @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..tracingConfiguration"])
 class TestFundamental:
     @staticmethod

--- a/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
+++ b/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_path_based_on_data": {
-    "recorded-date": "03-03-2023, 07:48:10",
+    "recorded-date": "03-03-2023, 10:04:07",
     "recorded-content": {
       "describe_statemachine": {
         "creationDate": "datetime",
@@ -72,32 +72,6 @@
       "first_path__start_execution_result": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
         "startDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "first_path__describe_ex": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
-        "input": {
-          "type": "Public",
-          "value": 3
-        },
-        "inputDetails": {
-          "included": true
-        },
-        "name": "<execution-id-first_path>",
-        "output": {
-          "type": "Public",
-          "value": 3
-        },
-        "outputDetails": {
-          "included": true
-        },
-        "startDate": "datetime",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
-        "stopDate": "datetime",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -240,32 +214,6 @@
           "HTTPStatusCode": 200
         }
       },
-      "second_path__describe_ex": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
-        "input": {
-          "type": "Private",
-          "value": 25
-        },
-        "inputDetails": {
-          "included": true
-        },
-        "name": "<execution-id-second_path>",
-        "output": {
-          "type": "Private",
-          "value": 25
-        },
-        "outputDetails": {
-          "included": true
-        },
-        "startDate": "datetime",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
-        "stopDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "second_path__describe_ex_done": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
         "input": {
@@ -403,32 +351,6 @@
           "HTTPStatusCode": 200
         }
       },
-      "default_path__describe_ex": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
-        "input": {
-          "type": "Private",
-          "value": 3
-        },
-        "inputDetails": {
-          "included": true
-        },
-        "name": "<execution-id-default_path>",
-        "output": {
-          "type": "Private",
-          "value": 3
-        },
-        "outputDetails": {
-          "included": true
-        },
-        "startDate": "datetime",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
-        "stopDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
       "default_path__describe_ex_done": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
         "input": {
@@ -551,6 +473,462 @@
             "previousEventId": 5,
             "timestamp": "timestamp",
             "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_wait_for_callback": {
+    "recorded-date": "03-03-2023, 09:50:43",
+    "recorded-content": {
+      "describe_statemachine": {
+        "creationDate": "datetime",
+        "definition": {
+          "StartAt": "Start Task And Wait For Callback",
+          "States": {
+            "Start Task And Wait For Callback": {
+              "Next": "Succeed State",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Next": "Fail State"
+                }
+              ],
+              "Type": "Task",
+              "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+              "Parameters": {
+                "QueueUrl": "<queue-url:1>",
+                "MessageBody": {
+                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
+                  "ShouldFail.$": "$.shouldfail",
+                  "TaskToken.$": "$$.Task.Token"
+                }
+              }
+            },
+            "Succeed State": {
+              "Type": "Succeed"
+            },
+            "Fail State": {
+              "Type": "Fail"
+            }
+          }
+        },
+        "loggingConfiguration": {
+          "includeExecutionData": false,
+          "level": "OFF"
+        },
+        "name": "<state-machine-name>",
+        "roleArn": "arn:aws:iam::111111111111:role/<role-name>",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "ACTIVE",
+        "tracingConfiguration": {
+          "enabled": false
+        },
+        "type": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "success__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-success>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "success__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-success>",
+        "input": {
+          "shouldfail": "no"
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-success>",
+        "output": {
+          "message": "Successfully executed lambda"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "success__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "shouldfail": "no"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "shouldfail": "no"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start Task And Wait For Callback"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "QueueUrl": "<queue-url:1>",
+                "MessageBody": {
+                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
+                  "ShouldFail": "no",
+                  "TaskToken": "<task-token:1>"
+                }
+              },
+              "region": "<region>",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSubmittedEventDetails": {
+              "output": {
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "Content-Length": [
+                      "378"
+                    ],
+                    "Date": "<date>",
+                    "Content-Type": [
+                      "text/xml"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "Content-Length": "378",
+                    "Content-Type": "text/xml",
+                    "Date": "<date>",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSubmitted"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "taskSucceededEventDetails": {
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "Start Task And Wait For Callback",
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateEnteredEventDetails": {
+              "input": {
+                "message": "Successfully executed lambda"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Succeed State"
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateEntered"
+          },
+          {
+            "id": 9,
+            "previousEventId": 8,
+            "stateExitedEventDetails": {
+              "name": "Succeed State",
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 10,
+            "previousEventId": 9,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "failure__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-failure>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "failure__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-failure>",
+        "input": {
+          "shouldfail": "yes"
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-failure>",
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "FAILED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "failure__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "shouldfail": "yes"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "shouldfail": "yes"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start Task And Wait For Callback"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "QueueUrl": "<queue-url:1>",
+                "MessageBody": {
+                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
+                  "ShouldFail": "yes",
+                  "TaskToken": "<task-token:2>"
+                }
+              },
+              "region": "<region>",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSubmittedEventDetails": {
+              "output": {
+                "MD5OfMessageBody": "<m-d5-of-message-body:2>",
+                "MessageId": "<uuid:3>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:4>"
+                    ],
+                    "Content-Length": [
+                      "378"
+                    ],
+                    "Date": "<date>",
+                    "Content-Type": [
+                      "text/xml"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "Content-Length": "378",
+                    "Content-Type": "text/xml",
+                    "Date": "<date>",
+                    "x-amzn-RequestId": "<uuid:4>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:4>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSubmitted"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "taskFailedEventDetails": {
+              "cause": "Intentional failure",
+              "error": "IntentionalFail",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "Start Task And Wait For Callback",
+              "output": {
+                "Error": "IntentionalFail",
+                "Cause": "Intentional failure"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "IntentionalFail",
+                "Cause": "Intentional failure"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Fail State"
+            },
+            "timestamp": "timestamp",
+            "type": "FailStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {},
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
           }
         ],
         "ResponseMetadata": {

--- a/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
+++ b/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
@@ -1,0 +1,563 @@
+{
+  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_path_based_on_data": {
+    "recorded-date": "03-03-2023, 07:48:10",
+    "recorded-content": {
+      "describe_statemachine": {
+        "creationDate": "datetime",
+        "definition": {
+          "StartAt": "Choice State",
+          "States": {
+            "Choice State": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Not": {
+                    "Variable": "$.type",
+                    "StringEquals": "Private"
+                  },
+                  "Next": "NEXT_STATE_ONE"
+                },
+                {
+                  "Variable": "$.value",
+                  "NumericEquals": 0,
+                  "Next": "NEXT_STATE_TWO"
+                },
+                {
+                  "And": [
+                    {
+                      "Variable": "$.value",
+                      "NumericGreaterThanEquals": 20
+                    },
+                    {
+                      "Variable": "$.value",
+                      "NumericLessThan": 30
+                    }
+                  ],
+                  "Next": "NEXT_STATE_TWO"
+                }
+              ],
+              "Default": "DEFAULT_STATE"
+            },
+            "DEFAULT_STATE": {
+              "Type": "Pass",
+              "End": true
+            },
+            "NEXT_STATE_ONE": {
+              "Type": "Pass",
+              "End": true
+            },
+            "NEXT_STATE_TWO": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        "loggingConfiguration": {
+          "includeExecutionData": false,
+          "level": "OFF"
+        },
+        "name": "<state-machine-name>",
+        "roleArn": "arn:aws:iam::111111111111:role/<role-name>",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "ACTIVE",
+        "tracingConfiguration": {
+          "enabled": false
+        },
+        "type": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__describe_ex": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
+        "input": {
+          "type": "Public",
+          "value": 3
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-first_path>",
+        "output": {
+          "type": "Public",
+          "value": 3
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
+        "input": {
+          "type": "Public",
+          "value": 3
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-first_path>",
+        "output": {
+          "type": "Public",
+          "value": 3
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "type": "Public",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Public",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Choice State"
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Choice State",
+              "output": {
+                "type": "Public",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Public",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "NEXT_STATE_ONE"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "NEXT_STATE_ONE",
+              "output": {
+                "type": "Public",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "type": "Public",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__describe_ex": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
+        "input": {
+          "type": "Private",
+          "value": 25
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-second_path>",
+        "output": {
+          "type": "Private",
+          "value": 25
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
+        "input": {
+          "type": "Private",
+          "value": 25
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-second_path>",
+        "output": {
+          "type": "Private",
+          "value": 25
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 25
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 25
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Choice State"
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Choice State",
+              "output": {
+                "type": "Private",
+                "value": 25
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 25
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "NEXT_STATE_TWO"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "NEXT_STATE_TWO",
+              "output": {
+                "type": "Private",
+                "value": 25
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "type": "Private",
+                "value": 25
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__describe_ex": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
+        "input": {
+          "type": "Private",
+          "value": 3
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-default_path>",
+        "output": {
+          "type": "Private",
+          "value": 3
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
+        "input": {
+          "type": "Private",
+          "value": 3
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-default_path>",
+        "output": {
+          "type": "Private",
+          "value": 3
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Choice State"
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Choice State",
+              "output": {
+                "type": "Private",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "DEFAULT_STATE"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "DEFAULT_STATE",
+              "output": {
+                "type": "Private",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "type": "Private",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
+++ b/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
@@ -1,6 +1,945 @@
 {
+  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_path_based_on_data": {
+    "recorded-date": "04-03-2023, 10:00:55",
+    "recorded-content": {
+      "describe_statemachine": {
+        "creationDate": "datetime",
+        "definition": {
+          "StartAt": "Choice State",
+          "States": {
+            "Choice State": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Not": {
+                    "Variable": "$.type",
+                    "StringEquals": "Private"
+                  },
+                  "Next": "NEXT_STATE_ONE"
+                },
+                {
+                  "Variable": "$.value",
+                  "NumericEquals": 0,
+                  "Next": "NEXT_STATE_TWO"
+                },
+                {
+                  "And": [
+                    {
+                      "Variable": "$.value",
+                      "NumericGreaterThanEquals": 20
+                    },
+                    {
+                      "Variable": "$.value",
+                      "NumericLessThan": 30
+                    }
+                  ],
+                  "Next": "NEXT_STATE_TWO"
+                }
+              ],
+              "Default": "DEFAULT_STATE"
+            },
+            "DEFAULT_STATE": {
+              "Type": "Pass",
+              "End": true
+            },
+            "NEXT_STATE_ONE": {
+              "Type": "Pass",
+              "End": true
+            },
+            "NEXT_STATE_TWO": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        "loggingConfiguration": {
+          "includeExecutionData": false,
+          "level": "OFF"
+        },
+        "name": "<state-machine-name>",
+        "roleArn": "arn:aws:iam::111111111111:role/<role-name>",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "ACTIVE",
+        "tracingConfiguration": {
+          "enabled": false
+        },
+        "type": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
+        "input": {
+          "type": "Public",
+          "value": 3
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-first_path>",
+        "output": {
+          "type": "Public",
+          "value": 3
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_path__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "type": "Public",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Public",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Choice State"
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Choice State",
+              "output": {
+                "type": "Public",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Public",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "NEXT_STATE_ONE"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "NEXT_STATE_ONE",
+              "output": {
+                "type": "Public",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "type": "Public",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
+        "input": {
+          "type": "Private",
+          "value": 25
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-second_path>",
+        "output": {
+          "type": "Private",
+          "value": 25
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "second_path__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 25
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 25
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Choice State"
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Choice State",
+              "output": {
+                "type": "Private",
+                "value": 25
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 25
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "NEXT_STATE_TWO"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "NEXT_STATE_TWO",
+              "output": {
+                "type": "Private",
+                "value": 25
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "type": "Private",
+                "value": 25
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
+        "input": {
+          "type": "Private",
+          "value": 3
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-default_path>",
+        "output": {
+          "type": "Private",
+          "value": 3
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "default_path__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Choice State"
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "stateExitedEventDetails": {
+              "name": "Choice State",
+              "output": {
+                "type": "Private",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "stateEnteredEventDetails": {
+              "input": {
+                "type": "Private",
+                "value": 3
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "DEFAULT_STATE"
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateEntered"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "stateExitedEventDetails": {
+              "name": "DEFAULT_STATE",
+              "output": {
+                "type": "Private",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "PassStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "type": "Private",
+                "value": 3
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 6,
+            "previousEventId": 5,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_wait_for_callback": {
+    "recorded-date": "04-03-2023, 10:05:28",
+    "recorded-content": {
+      "describe_statemachine": {
+        "creationDate": "datetime",
+        "definition": {
+          "StartAt": "Start Task And Wait For Callback",
+          "States": {
+            "Start Task And Wait For Callback": {
+              "Next": "Succeed State",
+              "Catch": [
+                {
+                  "ErrorEquals": [
+                    "States.ALL"
+                  ],
+                  "Next": "Fail State"
+                }
+              ],
+              "Type": "Task",
+              "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+              "Parameters": {
+                "QueueUrl": "<queue-url:1>",
+                "MessageBody": {
+                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
+                  "ShouldFail.$": "$.shouldfail",
+                  "TaskToken.$": "$$.Task.Token"
+                }
+              }
+            },
+            "Succeed State": {
+              "Type": "Succeed"
+            },
+            "Fail State": {
+              "Type": "Fail"
+            }
+          }
+        },
+        "loggingConfiguration": {
+          "includeExecutionData": false,
+          "level": "OFF"
+        },
+        "name": "<state-machine-name>",
+        "roleArn": "arn:aws:iam::111111111111:role/<role-name>",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "ACTIVE",
+        "tracingConfiguration": {
+          "enabled": false
+        },
+        "type": "STANDARD",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "success__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-success>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "success__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-success>",
+        "input": {
+          "shouldfail": "no"
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-success>",
+        "output": {
+          "message": "Successfully executed lambda"
+        },
+        "outputDetails": {
+          "included": true
+        },
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "SUCCEEDED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "success__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "shouldfail": "no"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "shouldfail": "no"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start Task And Wait For Callback"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "QueueUrl": "<queue-url:1>",
+                "MessageBody": {
+                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
+                  "ShouldFail": "no",
+                  "TaskToken": "<task-token:1>"
+                }
+              },
+              "region": "<region>",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSubmittedEventDetails": {
+              "output": {
+                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
+                "MessageId": "<uuid:1>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:2>"
+                    ],
+                    "Content-Length": [
+                      "378"
+                    ],
+                    "Date": "<date>",
+                    "Content-Type": [
+                      "text/xml"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "Content-Length": "378",
+                    "Content-Type": "text/xml",
+                    "Date": "<date>",
+                    "x-amzn-RequestId": "<uuid:2>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:2>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSubmitted"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "taskSucceededEventDetails": {
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSucceeded"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "Start Task And Wait For Callback",
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateEnteredEventDetails": {
+              "input": {
+                "message": "Successfully executed lambda"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Succeed State"
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateEntered"
+          },
+          {
+            "id": 9,
+            "previousEventId": 8,
+            "stateExitedEventDetails": {
+              "name": "Succeed State",
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "message": "Successfully executed lambda"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 10,
+            "previousEventId": 9,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "failure__start_execution_result": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-failure>",
+        "startDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "failure__describe_ex_done": {
+        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-failure>",
+        "input": {
+          "shouldfail": "yes"
+        },
+        "inputDetails": {
+          "included": true
+        },
+        "name": "<execution-id-failure>",
+        "startDate": "datetime",
+        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
+        "status": "FAILED",
+        "stopDate": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "failure__execution_history": {
+        "events": [
+          {
+            "executionStartedEventDetails": {
+              "input": {
+                "shouldfail": "yes"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
+            },
+            "id": 1,
+            "previousEventId": 0,
+            "timestamp": "timestamp",
+            "type": "ExecutionStarted"
+          },
+          {
+            "id": 2,
+            "previousEventId": 0,
+            "stateEnteredEventDetails": {
+              "input": {
+                "shouldfail": "yes"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Start Task And Wait For Callback"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateEntered"
+          },
+          {
+            "id": 3,
+            "previousEventId": 2,
+            "taskScheduledEventDetails": {
+              "parameters": {
+                "QueueUrl": "<queue-url:1>",
+                "MessageBody": {
+                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
+                  "ShouldFail": "yes",
+                  "TaskToken": "<task-token:2>"
+                }
+              },
+              "region": "<region>",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskScheduled"
+          },
+          {
+            "id": 4,
+            "previousEventId": 3,
+            "taskStartedEventDetails": {
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStarted"
+          },
+          {
+            "id": 5,
+            "previousEventId": 4,
+            "taskSubmittedEventDetails": {
+              "output": {
+                "MD5OfMessageBody": "<m-d5-of-message-body:2>",
+                "MessageId": "<uuid:3>",
+                "SdkHttpMetadata": {
+                  "AllHttpHeaders": {
+                    "x-amzn-RequestId": [
+                      "<uuid:4>"
+                    ],
+                    "Content-Length": [
+                      "378"
+                    ],
+                    "Date": "<date>",
+                    "Content-Type": [
+                      "text/xml"
+                    ]
+                  },
+                  "HttpHeaders": {
+                    "Content-Length": "378",
+                    "Content-Type": "text/xml",
+                    "Date": "<date>",
+                    "x-amzn-RequestId": "<uuid:4>"
+                  },
+                  "HttpStatusCode": 200
+                },
+                "SdkResponseMetadata": {
+                  "RequestId": "<uuid:4>"
+                }
+              },
+              "outputDetails": {
+                "truncated": false
+              },
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskSubmitted"
+          },
+          {
+            "id": 6,
+            "previousEventId": 5,
+            "taskFailedEventDetails": {
+              "cause": "Intentional failure",
+              "error": "IntentionalFail",
+              "resource": "sendMessage.waitForTaskToken",
+              "resourceType": "sqs"
+            },
+            "timestamp": "timestamp",
+            "type": "TaskFailed"
+          },
+          {
+            "id": 7,
+            "previousEventId": 6,
+            "stateExitedEventDetails": {
+              "name": "Start Task And Wait For Callback",
+              "output": {
+                "Error": "IntentionalFail",
+                "Cause": "Intentional failure"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "TaskStateExited"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Error": "IntentionalFail",
+                "Cause": "Intentional failure"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Fail State"
+            },
+            "timestamp": "timestamp",
+            "type": "FailStateEntered"
+          },
+          {
+            "executionFailedEventDetails": {},
+            "id": 9,
+            "previousEventId": 8,
+            "timestamp": "timestamp",
+            "type": "ExecutionFailed"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
   "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_step_functions_calling_api_gateway": {
-    "recorded-date": "03-03-2023, 15:19:42",
+    "recorded-date": "04-03-2023, 10:06:48",
     "recorded-content": {
       "describe_statemachine": {
         "creationDate": "datetime",

--- a/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
+++ b/tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.snapshot.json
@@ -1,520 +1,39 @@
 {
-  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_path_based_on_data": {
-    "recorded-date": "03-03-2023, 10:04:07",
+  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_step_functions_calling_api_gateway": {
+    "recorded-date": "03-03-2023, 15:19:42",
     "recorded-content": {
       "describe_statemachine": {
         "creationDate": "datetime",
         "definition": {
-          "StartAt": "Choice State",
+          "StartAt": "Add Pet to Store",
           "States": {
-            "Choice State": {
+            "Add Pet to Store": {
+              "Next": "Pet was Added Successfully?",
+              "Type": "Task",
+              "Resource": "arn:aws:states:::apigateway:invoke",
+              "Parameters": {
+                "ApiEndpoint": "<api-endpoint:1>",
+                "Method": "POST",
+                "Stage": "dev",
+                "RequestBody.$": "$",
+                "AuthType": "NO_AUTH"
+              }
+            },
+            "Pet was Added Successfully?": {
               "Type": "Choice",
               "Choices": [
                 {
-                  "Not": {
-                    "Variable": "$.type",
-                    "StringEquals": "Private"
-                  },
-                  "Next": "NEXT_STATE_ONE"
-                },
-                {
-                  "Variable": "$.value",
-                  "NumericEquals": 0,
-                  "Next": "NEXT_STATE_TWO"
-                },
-                {
-                  "And": [
-                    {
-                      "Variable": "$.value",
-                      "NumericGreaterThanEquals": 20
-                    },
-                    {
-                      "Variable": "$.value",
-                      "NumericLessThan": 30
-                    }
-                  ],
-                  "Next": "NEXT_STATE_TWO"
+                  "Variable": "$.ResponseBody.errors",
+                  "IsPresent": true,
+                  "Next": "Failure"
                 }
               ],
-              "Default": "DEFAULT_STATE"
+              "Default": "Success"
             },
-            "DEFAULT_STATE": {
-              "Type": "Pass",
-              "End": true
-            },
-            "NEXT_STATE_ONE": {
-              "Type": "Pass",
-              "End": true
-            },
-            "NEXT_STATE_TWO": {
-              "Type": "Pass",
-              "End": true
-            }
-          }
-        },
-        "loggingConfiguration": {
-          "includeExecutionData": false,
-          "level": "OFF"
-        },
-        "name": "<state-machine-name>",
-        "roleArn": "arn:aws:iam::111111111111:role/<role-name>",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "ACTIVE",
-        "tracingConfiguration": {
-          "enabled": false
-        },
-        "type": "STANDARD",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "first_path__start_execution_result": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
-        "startDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "first_path__describe_ex_done": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-first_path>",
-        "input": {
-          "type": "Public",
-          "value": 3
-        },
-        "inputDetails": {
-          "included": true
-        },
-        "name": "<execution-id-first_path>",
-        "output": {
-          "type": "Public",
-          "value": 3
-        },
-        "outputDetails": {
-          "included": true
-        },
-        "startDate": "datetime",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
-        "stopDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "first_path__execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "type": "Public",
-                "value": 3
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "type": "Public",
-                "value": 3
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Choice State"
-            },
-            "timestamp": "timestamp",
-            "type": "ChoiceStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "stateExitedEventDetails": {
-              "name": "Choice State",
-              "output": {
-                "type": "Public",
-                "value": 3
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "ChoiceStateExited"
-          },
-          {
-            "id": 4,
-            "previousEventId": 3,
-            "stateEnteredEventDetails": {
-              "input": {
-                "type": "Public",
-                "value": 3
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "NEXT_STATE_ONE"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "stateExitedEventDetails": {
-              "name": "NEXT_STATE_ONE",
-              "output": {
-                "type": "Public",
-                "value": 3
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "type": "Public",
-                "value": 3
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 6,
-            "previousEventId": 5,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "second_path__start_execution_result": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
-        "startDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "second_path__describe_ex_done": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-second_path>",
-        "input": {
-          "type": "Private",
-          "value": 25
-        },
-        "inputDetails": {
-          "included": true
-        },
-        "name": "<execution-id-second_path>",
-        "output": {
-          "type": "Private",
-          "value": 25
-        },
-        "outputDetails": {
-          "included": true
-        },
-        "startDate": "datetime",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
-        "stopDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "second_path__execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "type": "Private",
-                "value": 25
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "type": "Private",
-                "value": 25
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Choice State"
-            },
-            "timestamp": "timestamp",
-            "type": "ChoiceStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "stateExitedEventDetails": {
-              "name": "Choice State",
-              "output": {
-                "type": "Private",
-                "value": 25
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "ChoiceStateExited"
-          },
-          {
-            "id": 4,
-            "previousEventId": 3,
-            "stateEnteredEventDetails": {
-              "input": {
-                "type": "Private",
-                "value": 25
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "NEXT_STATE_TWO"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "stateExitedEventDetails": {
-              "name": "NEXT_STATE_TWO",
-              "output": {
-                "type": "Private",
-                "value": 25
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "type": "Private",
-                "value": 25
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 6,
-            "previousEventId": 5,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "default_path__start_execution_result": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
-        "startDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "default_path__describe_ex_done": {
-        "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-default_path>",
-        "input": {
-          "type": "Private",
-          "value": 3
-        },
-        "inputDetails": {
-          "included": true
-        },
-        "name": "<execution-id-default_path>",
-        "output": {
-          "type": "Private",
-          "value": 3
-        },
-        "outputDetails": {
-          "included": true
-        },
-        "startDate": "datetime",
-        "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
-        "stopDate": "datetime",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "default_path__execution_history": {
-        "events": [
-          {
-            "executionStartedEventDetails": {
-              "input": {
-                "type": "Private",
-                "value": 3
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "roleArn": "arn:aws:iam::111111111111:role/<role-name>"
-            },
-            "id": 1,
-            "previousEventId": 0,
-            "timestamp": "timestamp",
-            "type": "ExecutionStarted"
-          },
-          {
-            "id": 2,
-            "previousEventId": 0,
-            "stateEnteredEventDetails": {
-              "input": {
-                "type": "Private",
-                "value": 3
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "Choice State"
-            },
-            "timestamp": "timestamp",
-            "type": "ChoiceStateEntered"
-          },
-          {
-            "id": 3,
-            "previousEventId": 2,
-            "stateExitedEventDetails": {
-              "name": "Choice State",
-              "output": {
-                "type": "Private",
-                "value": 3
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "ChoiceStateExited"
-          },
-          {
-            "id": 4,
-            "previousEventId": 3,
-            "stateEnteredEventDetails": {
-              "input": {
-                "type": "Private",
-                "value": 3
-              },
-              "inputDetails": {
-                "truncated": false
-              },
-              "name": "DEFAULT_STATE"
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateEntered"
-          },
-          {
-            "id": 5,
-            "previousEventId": 4,
-            "stateExitedEventDetails": {
-              "name": "DEFAULT_STATE",
-              "output": {
-                "type": "Private",
-                "value": 3
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "timestamp": "timestamp",
-            "type": "PassStateExited"
-          },
-          {
-            "executionSucceededEventDetails": {
-              "output": {
-                "type": "Private",
-                "value": 3
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
-            "id": 6,
-            "previousEventId": 5,
-            "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
-          }
-        ],
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
-  "tests/integration/stepfunctions/v2/scenarios/test_sfn_scenarios.py::TestFundamental::test_wait_for_callback": {
-    "recorded-date": "03-03-2023, 09:50:43",
-    "recorded-content": {
-      "describe_statemachine": {
-        "creationDate": "datetime",
-        "definition": {
-          "StartAt": "Start Task And Wait For Callback",
-          "States": {
-            "Start Task And Wait For Callback": {
-              "Next": "Succeed State",
-              "Catch": [
-                {
-                  "ErrorEquals": [
-                    "States.ALL"
-                  ],
-                  "Next": "Fail State"
-                }
-              ],
-              "Type": "Task",
-              "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
-              "Parameters": {
-                "QueueUrl": "<queue-url:1>",
-                "MessageBody": {
-                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
-                  "ShouldFail.$": "$.shouldfail",
-                  "TaskToken.$": "$$.Task.Token"
-                }
-              }
-            },
-            "Succeed State": {
+            "Success": {
               "Type": "Succeed"
             },
-            "Fail State": {
+            "Failure": {
               "Type": "Fail"
             }
           }
@@ -547,21 +66,15 @@
       "success__describe_ex_done": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-success>",
         "input": {
-          "shouldfail": "no"
+          "fail": true
         },
         "inputDetails": {
           "included": true
         },
         "name": "<execution-id-success>",
-        "output": {
-          "message": "Successfully executed lambda"
-        },
-        "outputDetails": {
-          "included": true
-        },
         "startDate": "datetime",
         "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "SUCCEEDED",
+        "status": "FAILED",
         "stopDate": "datetime",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -573,7 +86,7 @@
           {
             "executionStartedEventDetails": {
               "input": {
-                "shouldfail": "no"
+                "fail": true
               },
               "inputDetails": {
                 "truncated": false
@@ -590,12 +103,12 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "shouldfail": "no"
+                "fail": true
               },
               "inputDetails": {
                 "truncated": false
               },
-              "name": "Start Task And Wait For Callback"
+              "name": "Add Pet to Store"
             },
             "timestamp": "timestamp",
             "type": "TaskStateEntered"
@@ -605,16 +118,17 @@
             "previousEventId": 2,
             "taskScheduledEventDetails": {
               "parameters": {
-                "QueueUrl": "<queue-url:1>",
-                "MessageBody": {
-                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
-                  "ShouldFail": "no",
-                  "TaskToken": "<task-token:1>"
+                "ApiEndpoint": "<api-endpoint:1>",
+                "Method": "POST",
+                "Stage": "dev",
+                "AuthType": "NO_AUTH",
+                "RequestBody": {
+                  "fail": true
                 }
               },
               "region": "<region>",
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
+              "resource": "invoke",
+              "resourceType": "apigateway"
             },
             "timestamp": "timestamp",
             "type": "TaskScheduled"
@@ -623,8 +137,8 @@
             "id": 4,
             "previousEventId": 3,
             "taskStartedEventDetails": {
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
+              "resource": "invoke",
+              "resourceType": "apigateway"
             },
             "timestamp": "timestamp",
             "type": "TaskStarted"
@@ -632,67 +146,80 @@
           {
             "id": 5,
             "previousEventId": 4,
-            "taskSubmittedEventDetails": {
-              "output": {
-                "MD5OfMessageBody": "<m-d5-of-message-body:1>",
-                "MessageId": "<uuid:1>",
-                "SdkHttpMetadata": {
-                  "AllHttpHeaders": {
-                    "x-amzn-RequestId": [
-                      "<uuid:2>"
-                    ],
-                    "Content-Length": [
-                      "378"
-                    ],
-                    "Date": "<date>",
-                    "Content-Type": [
-                      "text/xml"
-                    ]
-                  },
-                  "HttpHeaders": {
-                    "Content-Length": "378",
-                    "Content-Type": "text/xml",
-                    "Date": "<date>",
-                    "x-amzn-RequestId": "<uuid:2>"
-                  },
-                  "HttpStatusCode": 200
-                },
-                "SdkResponseMetadata": {
-                  "RequestId": "<uuid:2>"
-                }
-              },
-              "outputDetails": {
-                "truncated": false
-              },
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskSubmitted"
-          },
-          {
-            "id": 6,
-            "previousEventId": 5,
             "taskSucceededEventDetails": {
               "output": {
-                "message": "Successfully executed lambda"
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "30"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "errors": [
+                    "Errors.Failure"
+                  ]
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
               "outputDetails": {
                 "truncated": false
               },
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
+              "resource": "invoke",
+              "resourceType": "apigateway"
             },
             "timestamp": "timestamp",
             "type": "TaskSucceeded"
           },
           {
-            "id": 7,
-            "previousEventId": 6,
+            "id": 6,
+            "previousEventId": 5,
             "stateExitedEventDetails": {
-              "name": "Start Task And Wait For Callback",
+              "name": "Add Pet to Store",
               "output": {
-                "message": "Successfully executed lambda"
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "30"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "errors": [
+                    "Errors.Failure"
+                  ]
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
               "outputDetails": {
                 "truncated": false
@@ -702,48 +229,137 @@
             "type": "TaskStateExited"
           },
           {
-            "id": 8,
-            "previousEventId": 7,
+            "id": 7,
+            "previousEventId": 6,
             "stateEnteredEventDetails": {
               "input": {
-                "message": "Successfully executed lambda"
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "30"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "errors": [
+                    "Errors.Failure"
+                  ]
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
               "inputDetails": {
                 "truncated": false
               },
-              "name": "Succeed State"
+              "name": "Pet was Added Successfully?"
             },
             "timestamp": "timestamp",
-            "type": "SucceedStateEntered"
+            "type": "ChoiceStateEntered"
+          },
+          {
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "Pet was Added Successfully?",
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "30"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "errors": [
+                    "Errors.Failure"
+                  ]
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
           },
           {
             "id": 9,
             "previousEventId": 8,
-            "stateExitedEventDetails": {
-              "name": "Succeed State",
-              "output": {
-                "message": "Successfully executed lambda"
+            "stateEnteredEventDetails": {
+              "input": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "30"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "errors": [
+                    "Errors.Failure"
+                  ]
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
-              "outputDetails": {
+              "inputDetails": {
                 "truncated": false
-              }
+              },
+              "name": "Failure"
             },
             "timestamp": "timestamp",
-            "type": "SucceedStateExited"
+            "type": "FailStateEntered"
           },
           {
-            "executionSucceededEventDetails": {
-              "output": {
-                "message": "Successfully executed lambda"
-              },
-              "outputDetails": {
-                "truncated": false
-              }
-            },
+            "executionFailedEventDetails": {},
             "id": 10,
             "previousEventId": 9,
             "timestamp": "timestamp",
-            "type": "ExecutionSucceeded"
+            "type": "ExecutionFailed"
           }
         ],
         "ResponseMetadata": {
@@ -762,15 +378,46 @@
       "failure__describe_ex_done": {
         "executionArn": "arn:aws:states:<region>:111111111111:execution:<state-machine-name>:<execution-id-failure>",
         "input": {
-          "shouldfail": "yes"
+          "fail": false
         },
         "inputDetails": {
           "included": true
         },
         "name": "<execution-id-failure>",
+        "output": {
+          "Headers": {
+            "Connection": [
+              "keep-alive"
+            ],
+            "Content-Length": [
+              "18"
+            ],
+            "Content-Type": [
+              "application/json"
+            ],
+            "Date": "date",
+            "Via": "via",
+            "x-amz-apigw-id": "x-amz-apigw-id",
+            "X-Amz-Cf-Id": "x--amz--cf--id",
+            "X-Amz-Cf-Pop": "x--amz--cf--pop",
+            "x-amzn-RequestId": "x-amzn--request-id",
+            "X-Amzn-Trace-Id": "x--amzn--trace--id",
+            "X-Cache": [
+              "Miss from cloudfront"
+            ]
+          },
+          "ResponseBody": {
+            "hello": "world"
+          },
+          "StatusCode": 200,
+          "StatusText": "OK"
+        },
+        "outputDetails": {
+          "included": true
+        },
         "startDate": "datetime",
         "stateMachineArn": "arn:aws:states:<region>:111111111111:stateMachine:<state-machine-name>",
-        "status": "FAILED",
+        "status": "SUCCEEDED",
         "stopDate": "datetime",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -782,7 +429,7 @@
           {
             "executionStartedEventDetails": {
               "input": {
-                "shouldfail": "yes"
+                "fail": false
               },
               "inputDetails": {
                 "truncated": false
@@ -799,12 +446,12 @@
             "previousEventId": 0,
             "stateEnteredEventDetails": {
               "input": {
-                "shouldfail": "yes"
+                "fail": false
               },
               "inputDetails": {
                 "truncated": false
               },
-              "name": "Start Task And Wait For Callback"
+              "name": "Add Pet to Store"
             },
             "timestamp": "timestamp",
             "type": "TaskStateEntered"
@@ -814,16 +461,17 @@
             "previousEventId": 2,
             "taskScheduledEventDetails": {
               "parameters": {
-                "QueueUrl": "<queue-url:1>",
-                "MessageBody": {
-                  "MessageTitle": "Task started by Step Functions. Waiting for callback with task token.",
-                  "ShouldFail": "yes",
-                  "TaskToken": "<task-token:2>"
+                "ApiEndpoint": "<api-endpoint:1>",
+                "Method": "POST",
+                "Stage": "dev",
+                "AuthType": "NO_AUTH",
+                "RequestBody": {
+                  "fail": false
                 }
               },
               "region": "<region>",
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
+              "resource": "invoke",
+              "resourceType": "apigateway"
             },
             "timestamp": "timestamp",
             "type": "TaskScheduled"
@@ -832,8 +480,8 @@
             "id": 4,
             "previousEventId": 3,
             "taskStartedEventDetails": {
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
+              "resource": "invoke",
+              "resourceType": "apigateway"
             },
             "timestamp": "timestamp",
             "type": "TaskStarted"
@@ -841,64 +489,76 @@
           {
             "id": 5,
             "previousEventId": 4,
-            "taskSubmittedEventDetails": {
+            "taskSucceededEventDetails": {
               "output": {
-                "MD5OfMessageBody": "<m-d5-of-message-body:2>",
-                "MessageId": "<uuid:3>",
-                "SdkHttpMetadata": {
-                  "AllHttpHeaders": {
-                    "x-amzn-RequestId": [
-                      "<uuid:4>"
-                    ],
-                    "Content-Length": [
-                      "378"
-                    ],
-                    "Date": "<date>",
-                    "Content-Type": [
-                      "text/xml"
-                    ]
-                  },
-                  "HttpHeaders": {
-                    "Content-Length": "378",
-                    "Content-Type": "text/xml",
-                    "Date": "<date>",
-                    "x-amzn-RequestId": "<uuid:4>"
-                  },
-                  "HttpStatusCode": 200
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
                 },
-                "SdkResponseMetadata": {
-                  "RequestId": "<uuid:4>"
-                }
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
               "outputDetails": {
                 "truncated": false
               },
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
+              "resource": "invoke",
+              "resourceType": "apigateway"
             },
             "timestamp": "timestamp",
-            "type": "TaskSubmitted"
+            "type": "TaskSucceeded"
           },
           {
             "id": 6,
             "previousEventId": 5,
-            "taskFailedEventDetails": {
-              "cause": "Intentional failure",
-              "error": "IntentionalFail",
-              "resource": "sendMessage.waitForTaskToken",
-              "resourceType": "sqs"
-            },
-            "timestamp": "timestamp",
-            "type": "TaskFailed"
-          },
-          {
-            "id": 7,
-            "previousEventId": 6,
             "stateExitedEventDetails": {
-              "name": "Start Task And Wait For Callback",
+              "name": "Add Pet to Store",
               "output": {
-                "Error": "IntentionalFail",
-                "Cause": "Intentional failure"
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
               "outputDetails": {
                 "truncated": false
@@ -908,27 +568,203 @@
             "type": "TaskStateExited"
           },
           {
-            "id": 8,
-            "previousEventId": 7,
+            "id": 7,
+            "previousEventId": 6,
             "stateEnteredEventDetails": {
               "input": {
-                "Error": "IntentionalFail",
-                "Cause": "Intentional failure"
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
               },
               "inputDetails": {
                 "truncated": false
               },
-              "name": "Fail State"
+              "name": "Pet was Added Successfully?"
             },
             "timestamp": "timestamp",
-            "type": "FailStateEntered"
+            "type": "ChoiceStateEntered"
           },
           {
-            "executionFailedEventDetails": {},
+            "id": 8,
+            "previousEventId": 7,
+            "stateExitedEventDetails": {
+              "name": "Pet was Added Successfully?",
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "ChoiceStateExited"
+          },
+          {
             "id": 9,
             "previousEventId": 8,
+            "stateEnteredEventDetails": {
+              "input": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "inputDetails": {
+                "truncated": false
+              },
+              "name": "Success"
+            },
             "timestamp": "timestamp",
-            "type": "ExecutionFailed"
+            "type": "SucceedStateEntered"
+          },
+          {
+            "id": 10,
+            "previousEventId": 9,
+            "stateExitedEventDetails": {
+              "name": "Success",
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "timestamp": "timestamp",
+            "type": "SucceedStateExited"
+          },
+          {
+            "executionSucceededEventDetails": {
+              "output": {
+                "Headers": {
+                  "Connection": [
+                    "keep-alive"
+                  ],
+                  "Content-Length": [
+                    "18"
+                  ],
+                  "Content-Type": [
+                    "application/json"
+                  ],
+                  "Date": "date",
+                  "Via": "via",
+                  "x-amz-apigw-id": "x-amz-apigw-id",
+                  "X-Amz-Cf-Id": "x--amz--cf--id",
+                  "X-Amz-Cf-Pop": "x--amz--cf--pop",
+                  "x-amzn-RequestId": "x-amzn--request-id",
+                  "X-Amzn-Trace-Id": "x--amzn--trace--id",
+                  "X-Cache": [
+                    "Miss from cloudfront"
+                  ]
+                },
+                "ResponseBody": {
+                  "hello": "world"
+                },
+                "StatusCode": 200,
+                "StatusText": "OK"
+              },
+              "outputDetails": {
+                "truncated": false
+              }
+            },
+            "id": 11,
+            "previousEventId": 10,
+            "timestamp": "timestamp",
+            "type": "ExecutionSucceeded"
           }
         ],
         "ResponseMetadata": {


### PR DESCRIPTION
Adds tests based on workflow samples from [serverlessland.com](https://serverlessland.com/workflows?type=Standard&simplicity=1+-+Fundamental)

- [x] path-based-on-data
- [x] wait-for-callback
- [x] step-functions-calling-api-gateway


I've had to drop a lot of the samples since they were a poor fit (either too complicated or too simple and some of them didn't even properly allow testing all paths defined in the workflow definition). The rest were all simplified/fixed.

All tests are designed to be able to take a single CloudFormation template as an input with lambda code & workflow definitions being included in-line in the template.
