### PR TITLE
Update apt repositories when installing system dependencies

### DIFF
--- a/.github/workflows/asf-updates.yml
+++ b/.github/workflows/asf-updates.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Set up system wide dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libsasl2-dev jq
 
       - name: Set up Python 3.8

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -137,6 +137,7 @@ jobs:
           terraform_version: 0.13.7
       - name: Set up system wide dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install --allow-downgrades libsasl2-dev jq postgresql-14=14.6-0ubuntu0.22.04.1 postgresql-client postgresql-plpython3
       - name: Cache LocalStack-ext dependencies (venv)
         uses: actions/cache@v2

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Set up system wide dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --allow-downgrades libsasl2-dev jq postgresql-14=14.6-0ubuntu0.22.04.1 postgresql-client postgresql-plpython3
+          sudo apt-get install -y --allow-downgrades libsasl2-dev jq postgresql-14=14.7-0ubuntu0.22.04.1 postgresql-client postgresql-plpython3
       - name: Cache LocalStack-ext dependencies (venv)
         uses: actions/cache@v2
         id: ext-cache


### PR DESCRIPTION
We have to keep the repositories updated or else we potentially get network errors.

Also because of the updated metadata we have to install a later version of postgres. This is unfortunate because it's now a moving target and likely to cause more breakages in the future, but leaving unpinned causes a dependency conflict with postgres-plpython3-14.