### PR TITLE
refactor SNS store to facilitate lookups

### DIFF
--- a/localstack/services/sns/models.py
+++ b/localstack/services/sns/models.py
@@ -88,11 +88,13 @@ class SnsSubscription(TypedDict):
 
 
 class SnsStore(BaseStore):
-    # maps topic ARN to topic's subscriptions
-    sns_subscriptions: Dict[str, List[SnsSubscription]] = LocalAttribute(default=dict)
+    # maps topic ARN to subscriptions ARN
+    topic_subscriptions: Dict[str, List[str]] = LocalAttribute(default=dict)
+    # maps subscription ARN to SnsSubscription
+    subscriptions: Dict[str, SnsSubscription] = LocalAttribute(default=dict)
 
-    # maps subscription ARN to subscription status
-    subscription_status: Dict[str, Dict] = LocalAttribute(default=dict)
+    # maps topic Arn to subscription validation token to subscription ARN
+    subscription_tokens: Dict[str, Dict[str, str]] = LocalAttribute(default=dict)
 
     # maps topic ARN to list of tags
     sns_tags: Dict[str, List[Dict]] = LocalAttribute(default=dict)
@@ -105,6 +107,15 @@ class SnsStore(BaseStore):
 
     # filter policy are stored as JSON string in subscriptions, store the decoded result Dict
     subscription_filter_policy: Dict[subscriptionARN, Dict] = LocalAttribute(default=dict)
+
+    def get_topic_subscriptions(self, topic_arn: str) -> List[SnsSubscription]:
+        topic_subscriptions = self.topic_subscriptions.get(topic_arn, [])
+        subscriptions = [
+            subscription
+            for subscription_arn in topic_subscriptions
+            if (subscription := self.subscriptions.get(subscription_arn))
+        ]
+        return subscriptions
 
 
 sns_stores = AccountRegionBundle("sns", SnsStore)

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -80,7 +80,7 @@ from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.sns import constants as sns_constants
-from localstack.services.sns.models import SnsMessage, SnsStore, SnsSubscription, sns_stores
+from localstack.services.sns.models import SnsMessage, SnsStore, sns_stores
 from localstack.services.sns.publisher import (
     PublishDispatcher,
     SnsBatchPublishContext,
@@ -88,6 +88,7 @@ from localstack.services.sns.publisher import (
 )
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import parse_arn
+from localstack.utils.collections import select_from_typed_dict
 from localstack.utils.strings import short_uid
 
 # set up logger
@@ -107,8 +108,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         register_sns_api_resource(ROUTER)
 
     @staticmethod
-    def get_store() -> SnsStore:
-        return sns_stores[get_aws_account_id()][aws_stack.get_region()]
+    def get_store(account_id: str = None, region: str = None) -> SnsStore:
+        return sns_stores[account_id or get_aws_account_id()][region or aws_stack.get_region()]
 
     @staticmethod
     def _get_moto_backend(context: RequestContext) -> SNSBackend:
@@ -127,8 +128,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
     def check_if_phone_number_is_opted_out(
         self, context: RequestContext, phone_number: PhoneNumber
     ) -> CheckIfPhoneNumberIsOptedOutResponse:
-        moto_response = call_moto(context)
-        return CheckIfPhoneNumberIsOptedOutResponse(**moto_response)
+        moto_response: CheckIfPhoneNumberIsOptedOutResponse = call_moto(context)
+        return moto_response
 
     def create_sms_sandbox_phone_number(
         self,
@@ -148,33 +149,32 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
     def get_endpoint_attributes(
         self, context: RequestContext, endpoint_arn: String
     ) -> GetEndpointAttributesResponse:
-        moto_response = call_moto(context)
-        return GetEndpointAttributesResponse(**moto_response)
+        moto_response: GetEndpointAttributesResponse = call_moto(context)
+        return moto_response
 
     def get_platform_application_attributes(
         self, context: RequestContext, platform_application_arn: String
     ) -> GetPlatformApplicationAttributesResponse:
         moto_response = call_moto(context)
-        # TODO: filter response to not include credentials
-        return GetPlatformApplicationAttributesResponse(**moto_response)
+        return select_from_typed_dict(GetPlatformApplicationAttributesResponse, moto_response)
 
     def get_sms_attributes(
         self, context: RequestContext, attributes: ListString = None
     ) -> GetSMSAttributesResponse:
-        moto_response = call_moto(context)
-        return GetSMSAttributesResponse(**moto_response)
+        moto_response: GetSMSAttributesResponse = call_moto(context)
+        return moto_response
 
     def get_sms_sandbox_account_status(
         self, context: RequestContext
     ) -> GetSMSSandboxAccountStatusResult:
-        moto_response = call_moto(context)
-        return GetSMSSandboxAccountStatusResult(**moto_response)
+        moto_response: GetSMSSandboxAccountStatusResult = call_moto(context)
+        return moto_response
 
     def list_endpoints_by_platform_application(
         self, context: RequestContext, platform_application_arn: String, next_token: String = None
     ) -> ListEndpointsByPlatformApplicationResponse:
-        moto_response = call_moto(context)
-        return ListEndpointsByPlatformApplicationResponse(**moto_response)
+        moto_response: ListEndpointsByPlatformApplicationResponse = call_moto(context)
+        return moto_response
 
     def list_origination_numbers(
         self,
@@ -182,38 +182,38 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         next_token: nextToken = None,
         max_results: MaxItemsListOriginationNumbers = None,
     ) -> ListOriginationNumbersResult:
-        moto_response = call_moto(context)
-        return ListOriginationNumbersResult(**moto_response)
+        moto_response: ListOriginationNumbersResult = call_moto(context)
+        return moto_response
 
     def list_phone_numbers_opted_out(
         self, context: RequestContext, next_token: String = None
     ) -> ListPhoneNumbersOptedOutResponse:
-        moto_response = call_moto(context)
-        return ListPhoneNumbersOptedOutResponse(**moto_response)
+        moto_response: ListPhoneNumbersOptedOutResponse = call_moto(context)
+        return moto_response
 
     def list_platform_applications(
         self, context: RequestContext, next_token: String = None
     ) -> ListPlatformApplicationsResponse:
-        moto_response = call_moto(context)
-        return ListPlatformApplicationsResponse(**moto_response)
+        moto_response: ListPlatformApplicationsResponse = call_moto(context)
+        return moto_response
 
     def list_sms_sandbox_phone_numbers(
         self, context: RequestContext, next_token: nextToken = None, max_results: MaxItems = None
     ) -> ListSMSSandboxPhoneNumbersResult:
-        moto_response = call_moto(context)
-        return ListSMSSandboxPhoneNumbersResult(**moto_response)
+        moto_response: ListSMSSandboxPhoneNumbersResult = call_moto(context)
+        return moto_response
 
     def list_subscriptions_by_topic(
         self, context: RequestContext, topic_arn: topicARN, next_token: nextToken = None
     ) -> ListSubscriptionsByTopicResponse:
-        moto_response = call_moto(context)
-        return ListSubscriptionsByTopicResponse(**moto_response)
+        moto_response: ListSubscriptionsByTopicResponse = call_moto(context)
+        return moto_response
 
     def list_topics(
         self, context: RequestContext, next_token: nextToken = None
     ) -> ListTopicsResponse:
-        moto_response = call_moto(context)
-        return ListTopicsResponse(**moto_response)
+        moto_response: ListTopicsResponse = call_moto(context)
+        return moto_response
 
     def opt_in_phone_number(
         self, context: RequestContext, phone_number: PhoneNumber
@@ -286,8 +286,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 "The batch request contains more entries than permissible."
             )
 
-        store = self.get_store()
-        if topic_arn not in store.sns_subscriptions:
+        store = self.get_store(account_id=context.account_id, region=context.region)
+        if topic_arn not in store.topic_subscriptions:
             raise NotFoundException(
                 "Topic does not exist",
             )
@@ -313,7 +313,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     )
 
         # TODO: implement SNS MessageDeduplicationId and ContentDeduplication checks
-        response = {"Successful": [], "Failed": []}
+        response: PublishBatchResponse = {"Successful": [], "Failed": []}
         for entry in publish_batch_request_entries:
             message_attributes = entry.get("MessageAttributes", {})
             if message_attributes:
@@ -350,7 +350,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         )
         self._publisher.publish_batch_to_topic(publish_ctx, topic_arn)
 
-        return PublishBatchResponse(**response)
+        return response
 
     def set_subscription_attributes(
         self,
@@ -359,7 +359,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         attribute_name: attributeName,
         attribute_value: attributeValue = None,
     ) -> None:
-        sub = get_subscription_by_arn(subscription_arn)
+        store = self.get_store(account_id=context.account_id, region=context.region)
+        sub = store.subscriptions.get(subscription_arn)
         if not sub:
             raise NotFoundException("Subscription does not exist")
 
@@ -377,7 +378,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             raise
 
         if attribute_name == "FilterPolicy":
-            store = self.get_store()
+            store = self.get_store(account_id=context.account_id, region=context.region)
             store.subscription_filter_policy[subscription_arn] = json.loads(attribute_value)
 
         sub[attribute_name] = attribute_value
@@ -389,36 +390,37 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         token: String,
         authenticate_on_unsubscribe: authenticateOnUnsubscribe = None,
     ) -> ConfirmSubscriptionResponse:
-        store = self.get_store()
-        sub_arn = None
-        # TODO: this is false, we validate only one sub and not all for topic
-        #  WRITE AWS VALIDATED TEST FOR IT
-        for k, v in store.subscription_status.items():
-            if v.get("Token") == token and v["TopicArn"] == topic_arn:
-                v["Status"] = "Subscribed"
-                sub_arn = k
-        for k, v in store.sns_subscriptions.items():
-            for i in v:
-                if i["TopicArn"] == topic_arn:
-                    i["PendingConfirmation"] = "false"
-                    i["ConfirmationWasAuthenticated"] = "true"
+        # TODO: validate format on the token (seems to be 288 hex chars)
+        store = self.get_store(account_id=context.account_id, region=context.region)
+        topic_tokens = store.subscription_tokens.get(topic_arn, {})
 
-        return ConfirmSubscriptionResponse(SubscriptionArn=sub_arn)
+        subscription_arn = topic_tokens.pop(token, None)
+        if not subscription_arn:
+            raise InvalidParameterException("Invalid parameter: Token")
+
+        subscription = store.subscriptions.get(subscription_arn)
+        subscription["PendingConfirmation"] = "false"
+        subscription["ConfirmationWasAuthenticated"] = "true"
+
+        return ConfirmSubscriptionResponse(SubscriptionArn=subscription_arn)
 
     def untag_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName, tag_keys: TagKeyList
     ) -> UntagResourceResponse:
         call_moto(context)
+        # TODO: probably get the account_id and region from the `resource_arn`
         store = self.get_store()
-        store.sns_tags[resource_arn] = [
-            t for t in _get_tags(resource_arn) if t["Key"] not in tag_keys
-        ]
+        existing_tags = store.sns_tags.setdefault(resource_arn, [])
+        store.sns_tags[resource_arn] = [t for t in existing_tags if t["Key"] not in tag_keys]
         return UntagResourceResponse()
 
     def list_tags_for_resource(
         self, context: RequestContext, resource_arn: AmazonResourceName
     ) -> ListTagsForResourceResponse:
-        return ListTagsForResourceResponse(Tags=_get_tags(resource_arn))
+        # TODO: probably get the account_id and region from the `resource_arn`
+        store = self.get_store()
+        tags = store.sns_tags.setdefault(resource_arn, [])
+        return ListTagsForResourceResponse(Tags=tags)
 
     def delete_platform_application(
         self, context: RequestContext, platform_application_arn: String
@@ -436,8 +438,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         # list of possible values: ADM, Baidu, APNS, APNS_SANDBOX, GCM, MPNS, WNS
         # each platform has a specific way to handle credentials
         # this can also be used for dispatching message to the right platform
-        moto_response = call_moto(context)
-        return CreatePlatformApplicationResponse(**moto_response)
+        moto_response: CreatePlatformApplicationResponse = call_moto(context)
+        return moto_response
 
     def create_platform_endpoint(
         self,
@@ -468,41 +470,38 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
     def unsubscribe(self, context: RequestContext, subscription_arn: subscriptionARN) -> None:
         call_moto(context)
-        store = self.get_store()
+        store = self.get_store(account_id=context.account_id, region=context.region)
 
-        def should_be_kept(current_subscription: SnsSubscription, target_subscription_arn: str):
-            if current_subscription["SubscriptionArn"] != target_subscription_arn:
-                return True
+        # pop the subscription at the end, to avoid race condition by iterating over the topic subscriptions
+        subscription = store.subscriptions.get(subscription_arn)
+        # TODO: can it be None? or moto raises an error?
+        if subscription["Protocol"] in ["http", "https"]:
+            # TODO: actually validate this (re)subscribe behaviour somehow (localhost.run?)
+            #  we might need to save the sub token in the store
+            subscription_token = short_uid()
+            message_ctx = SnsMessage(
+                type="UnsubscribeConfirmation",
+                token=subscription_token,
+                message=f"You have chosen to deactivate subscription {subscription_arn}.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+            )
+            publish_ctx = SnsPublishContext(
+                message=message_ctx, store=store, request_headers=context.request.headers
+            )
+            self._publisher.publish_to_topic_subscriber(
+                publish_ctx,
+                topic_arn=subscription["TopicArn"],
+                subscription_arn=subscription_arn,
+            )
 
-            if current_subscription["Protocol"] in ["http", "https"]:
-                # TODO: actually validate this (re)subscribe behaviour somehow (localhost.run?)
-                #  we might need to save the sub token in the store
-                subscription_token = short_uid()
-                message_ctx = SnsMessage(
-                    type="UnsubscribeConfirmation",
-                    token=subscription_token,
-                    message=f"You have chosen to deactivate subscription {target_subscription_arn}.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
-                )
-                publish_ctx = SnsPublishContext(
-                    message=message_ctx, store=store, request_headers=context.request.headers
-                )
-                self._publisher.publish_to_topic_subscriber(
-                    publish_ctx,
-                    topic_arn=current_subscription["TopicArn"],
-                    subscription_arn=target_subscription_arn,
-                )
-
-            return False
-
-        for topic_arn, existing_subs in store.sns_subscriptions.items():
-            store.sns_subscriptions[topic_arn] = [
-                sub for sub in existing_subs if should_be_kept(sub, subscription_arn)
-            ]
+        store.topic_subscriptions[subscription["TopicArn"]].remove(subscription_arn)
+        store.subscription_filter_policy.pop(subscription_arn, None)
+        store.subscriptions.pop(subscription_arn, None)
 
     def get_subscription_attributes(
         self, context: RequestContext, subscription_arn: subscriptionARN
     ) -> GetSubscriptionAttributesResponse:
-        sub = get_subscription_by_arn(subscription_arn)
+        store = self.get_store(account_id=context.account_id, region=context.region)
+        sub = store.subscriptions.get(subscription_arn)
         if not sub:
             raise NotFoundException(f"Subscription with arn {subscription_arn} not found")
         removed_attrs = ["sqs_queue_url"]
@@ -517,8 +516,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
     def list_subscriptions(
         self, context: RequestContext, next_token: nextToken = None
     ) -> ListSubscriptionsResponse:
-        moto_response = call_moto(context)
-        return ListSubscriptionsResponse(**moto_response)
+        moto_response: ListSubscriptionsResponse = call_moto(context)
+        return moto_response
 
     def publish(
         self,
@@ -593,7 +592,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         if message_attributes:
             validate_message_attributes(message_attributes)
 
-        store = self.get_store()
+        store = self.get_store(account_id=context.account_id, region=context.region)
 
         if not phone_number:
             if is_endpoint_publish:
@@ -603,7 +602,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                         "Invalid parameter: TargetArn Reason: No endpoint found for the target arn specified"
                     )
             else:
-                if topic_or_target_arn not in store.sns_subscriptions:
+                if topic_or_target_arn not in store.topic_subscriptions:
                     raise NotFoundException(
                         "Topic does not exist",
                     )
@@ -681,17 +680,14 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         moto_response = call_moto(context)
         subscription_arn = moto_response.get("SubscriptionArn")
 
-        store = self.get_store()
-        topic_subs = store.sns_subscriptions[topic_arn] = (
-            store.sns_subscriptions.get(topic_arn) or []
-        )
+        store = self.get_store(account_id=context.account_id, region=context.region)
+
         # An endpoint may only be subscribed to a topic once. Subsequent
         # subscribe calls do nothing (subscribe is idempotent).
-        for existing_topic_subscription in topic_subs:
-            if existing_topic_subscription.get("Endpoint") == endpoint:
-                return SubscribeResponse(
-                    SubscriptionArn=existing_topic_subscription["SubscriptionArn"]
-                )
+        for existing_topic_subscription in store.topic_subscriptions[topic_arn]:
+            sub = store.subscriptions.get(existing_topic_subscription, {})
+            if sub.get("Endpoint") == endpoint:
+                return SubscribeResponse(SubscriptionArn=sub["SubscriptionArn"])
 
         subscription = {
             # http://docs.aws.amazon.com/cli/latest/reference/sns/get-subscription-attributes.html
@@ -710,15 +706,14 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                     attributes["FilterPolicy"]
                 )
 
-        topic_subs.append(subscription)
+        store.subscriptions[subscription_arn] = subscription
+        store.topic_subscriptions[topic_arn].append(subscription_arn)
 
-        if subscription_arn not in store.subscription_status:
-            store.subscription_status[subscription_arn] = {}
-
+        # store the token and subscription arn
         subscription_token = short_uid()
-        store.subscription_status[subscription_arn].update(
-            {"TopicArn": topic_arn, "Token": subscription_token, "Status": "Not Subscribed"}
-        )
+        topic_tokens = store.subscription_tokens.setdefault(topic_arn, {})
+        topic_tokens[subscription_token] = subscription_arn
+
         # Send out confirmation message for HTTP(S), fix for https://github.com/localstack/localstack/issues/881
         if protocol in ["http", "https"]:
             message_ctx = SnsMessage(
@@ -737,7 +732,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         elif protocol in ["sqs", "lambda"]:
             # Auto-confirm sqs and lambda subscriptions for now
             # TODO: revisit for multi-account
-            self.confirm_subscription(context, topic_arn, subscription_token)
+            subscription["PendingConfirmation"] = "false"
+            subscription["ConfirmationWasAuthenticated"] = "true"
         return SubscribeResponse(SubscriptionArn=subscription_arn)
 
     def tag_resource(
@@ -753,9 +749,9 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         store = self.get_store()
         existing_tags = store.sns_tags.get(resource_arn, [])
 
-        def existing_tag_index(item):
+        def existing_tag_index(_item):
             for idx, tag in enumerate(existing_tags):
-                if item["Key"] == tag["Key"]:
+                if _item["Key"] == tag["Key"]:
                     return idx
             return None
 
@@ -771,9 +767,13 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
     def delete_topic(self, context: RequestContext, topic_arn: topicARN) -> None:
         call_moto(context)
-        store = self.get_store()
-        store.sns_subscriptions.pop(topic_arn, None)
+        store = self.get_store(account_id=context.account_id, region=context.region)
+        topic_subscriptions = store.topic_subscriptions.pop(topic_arn, [])
+        for topic_sub in topic_subscriptions:
+            store.subscriptions.pop(topic_sub, None)
+
         store.sns_tags.pop(topic_arn, None)
+        store.subscription_tokens.pop(topic_arn, None)
 
     def create_topic(
         self,
@@ -784,7 +784,7 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
         data_protection_policy: attributeValue = None,
     ) -> CreateTopicResponse:
         moto_response = call_moto(context)
-        store = self.get_store()
+        store = self.get_store(account_id=context.account_id, region=context.region)
         topic_arn = moto_response["TopicArn"]
         tag_resource_success = extract_tags(topic_arn, tags, True, store)
         if not tag_resource_success:
@@ -793,26 +793,8 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
             )
         if tags:
             self.tag_resource(context=context, resource_arn=topic_arn, tags=tags)
-        store.sns_subscriptions[topic_arn] = store.sns_subscriptions.get(topic_arn) or []
+        store.topic_subscriptions[topic_arn] = store.topic_subscriptions.get(topic_arn) or []
         return CreateTopicResponse(TopicArn=topic_arn)
-
-
-def get_subscription_by_arn(sub_arn):
-    store = SnsProvider.get_store()
-    # TODO maintain separate map instead of traversing all items
-    # how to deprecate the store without breaking pods/persistence
-    for key, subscriptions in store.sns_subscriptions.items():
-        for sub in subscriptions:
-            if sub["SubscriptionArn"] == sub_arn:
-                return sub
-
-
-def _get_tags(topic_arn):
-    store = SnsProvider.get_store()
-    if topic_arn not in store.sns_tags:
-        store.sns_tags[topic_arn] = []
-
-    return store.sns_tags[topic_arn]
 
 
 def is_raw_message_delivery(susbcriber):
@@ -940,11 +922,12 @@ def validate_message_attribute_name(name: str) -> None:
                 )
 
 
-def extract_tags(topic_arn, tags, is_create_topic_request, store):
+def extract_tags(
+    topic_arn: str, tags: TagList, is_create_topic_request: bool, store: SnsStore
+) -> bool:
     existing_tags = list(store.sns_tags.get(topic_arn, []))
-    existing_sub = store.sns_subscriptions.get(topic_arn, None)
     # if this is none there is nothing to check
-    if existing_sub is not None:
+    if topic_arn in store.topic_subscriptions:
         if tags is None:
             tags = []
         for tag in tags:

--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -729,9 +729,12 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
                 topic_arn=topic_arn,
                 subscription_arn=subscription_arn,
             )
-        elif protocol in ["sqs", "lambda"]:
-            # Auto-confirm sqs and lambda subscriptions for now
+        elif protocol not in ["email", "email-json"]:
+            # Only HTTP(S) and email subscriptions are not auto validated
+            # Except if the endpoint and the topic are not in the same AWS account, then you'd need to manually confirm
+            # the subscription with the token
             # TODO: revisit for multi-account
+            # TODO: test with AWS for email & email-json confirmation message
             subscription["PendingConfirmation"] = "false"
             subscription["ConfirmationWasAuthenticated"] = "true"
         return SubscribeResponse(SubscriptionArn=subscription_arn)

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -1068,7 +1068,12 @@ class PublishDispatcher:
         Validate that the message should be relayed to the subscriber, depending on the filter policy and the
         subscription status
         """
-        if not subscriber["PendingConfirmation"] == "false":
+        # FIXME: for now, send to email even if not confirmed, as we do not send the token to confirm to email
+        # subscriptions
+        if (
+            not subscriber["PendingConfirmation"] == "false"
+            and "email" not in subscriber["Protocol"]
+        ):
             return
 
         subscriber_arn = subscriber["SubscriptionArn"]

--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -512,9 +512,7 @@ class ApplicationTopicPublisher(TopicPublisher):
     def _publish(self, context: SnsPublishContext, subscriber: SnsSubscription):
         endpoint_arn = subscriber["Endpoint"]
         message = self.prepare_message(context.message, subscriber)
-        cache = context.store.platform_endpoint_messages[endpoint_arn] = (
-            context.store.platform_endpoint_messages.get(endpoint_arn) or []
-        )
+        cache = context.store.platform_endpoint_messages.setdefault(endpoint_arn, [])
         cache.append(message)
 
         if (
@@ -654,9 +652,7 @@ class ApplicationEndpointPublisher(EndpointPublisher):
 
     def _publish(self, context: SnsPublishContext, endpoint: str):
         message = self.prepare_message(context.message, endpoint)
-        cache = context.store.platform_endpoint_messages[endpoint] = (
-            context.store.platform_endpoint_messages.get(endpoint) or []
-        )
+        cache = context.store.platform_endpoint_messages.setdefault(endpoint, [])
         cache.append(message)
 
         if (
@@ -1063,13 +1059,20 @@ class PublishDispatcher:
         self.executor.shutdown(wait=False)
 
     def _should_publish(
-        self, store: SnsStore, message_ctx: SnsMessage, subscriber: SnsSubscription
+        self,
+        subscription_filter_policy: dict[str, dict],
+        message_ctx: SnsMessage,
+        subscriber: SnsSubscription,
     ):
         """
-        Validate that the message should be relayed to the subscriber, depending on the filter policy
+        Validate that the message should be relayed to the subscriber, depending on the filter policy and the
+        subscription status
         """
+        if not subscriber["PendingConfirmation"] == "false":
+            return
+
         subscriber_arn = subscriber["SubscriptionArn"]
-        filter_policy = store.subscription_filter_policy.get(subscriber_arn)
+        filter_policy = subscription_filter_policy.get(subscriber_arn)
         if not filter_policy:
             return True
         # default value is `MessageAttributes`
@@ -1085,9 +1088,9 @@ class PublishDispatcher:
                 )
 
     def publish_to_topic(self, ctx: SnsPublishContext, topic_arn: str) -> None:
-        subscriptions = ctx.store.sns_subscriptions.get(topic_arn, [])
+        subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:
-            if self._should_publish(ctx.store, ctx.message, subscriber):
+            if self._should_publish(ctx.store.subscription_filter_policy, ctx.message, subscriber):
                 notifier = self.topic_notifiers[subscriber["Protocol"]]
                 LOG.debug(
                     "Topic '%s' publishing '%s' to subscribed '%s' with protocol '%s' (subscription '%s')",
@@ -1100,7 +1103,7 @@ class PublishDispatcher:
                 self.executor.submit(notifier.publish, context=ctx, subscriber=subscriber)
 
     def publish_batch_to_topic(self, ctx: SnsBatchPublishContext, topic_arn: str) -> None:
-        subscriptions = ctx.store.sns_subscriptions.get(topic_arn, [])
+        subscriptions = ctx.store.get_topic_subscriptions(topic_arn)
         for subscriber in subscriptions:
             protocol = subscriber["Protocol"]
             notifier = self.batch_topic_notifiers.get(protocol)
@@ -1111,7 +1114,9 @@ class PublishDispatcher:
                 filtered_messages = [
                     message
                     for message in ctx.messages
-                    if self._should_publish(ctx.store, message, subscriber)
+                    if self._should_publish(
+                        ctx.store.subscription_filter_policy, message, subscriber
+                    )
                 ]
                 if not filtered_messages:
                     LOG.debug(
@@ -1149,7 +1154,9 @@ class PublishDispatcher:
                 # if no batch support, fall back to sending them sequentially
                 notifier = self.topic_notifiers[subscriber["Protocol"]]
                 for message in ctx.messages:
-                    if self._should_publish(ctx.store, message, subscriber):
+                    if self._should_publish(
+                        ctx.store.subscription_filter_policy, message, subscriber
+                    ):
                         individual_ctx = SnsPublishContext(
                             message=message, store=ctx.store, request_headers=ctx.request_headers
                         )
@@ -1195,18 +1202,17 @@ class PublishDispatcher:
         :param subscription_arn: the ARN of the subscriber
         :return: None
         """
-        subscriptions: List[SnsSubscription] = ctx.store.sns_subscriptions.get(topic_arn, [])
-        for subscriber in subscriptions:
-            if subscriber["SubscriptionArn"] == subscription_arn:
-                notifier = self.topic_notifiers[subscriber["Protocol"]]
-                LOG.debug(
-                    "Topic '%s' publishing '%s' to subscribed '%s' with protocol '%s' (Id='%s', Subscription='%s')",
-                    topic_arn,
-                    ctx.message.type,
-                    subscription_arn,
-                    subscriber["Protocol"],
-                    ctx.message.message_id,
-                    subscriber.get("Endpoint"),
-                )
-                self.executor.submit(notifier.publish, context=ctx, subscriber=subscriber)
-                return
+        subscriber = ctx.store.subscriptions.get(subscription_arn)
+        if not subscriber:
+            return
+        notifier = self.topic_notifiers[subscriber["Protocol"]]
+        LOG.debug(
+            "Topic '%s' publishing '%s' to subscribed '%s' with protocol '%s' (Id='%s', Subscription='%s')",
+            topic_arn,
+            ctx.message.type,
+            subscription_arn,
+            subscriber["Protocol"],
+            ctx.message.message_id,
+            subscriber.get("Endpoint"),
+        )
+        self.executor.submit(notifier.publish, context=ctx, subscriber=subscriber)

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -528,6 +528,11 @@ class TestSNSProvider:
         fake_arn = f"{topic_arn}-fake"
         message = "This is a test message"
 
+        # test to send a message with no subscribers
+        response = sns_client.publish(TopicArn=topic_arn, Message=message)
+        snapshot.match("success", response)
+
+        # test to send to a nonexistent topic
         with pytest.raises(ClientError) as e:
             sns_client.publish(TopicArn=fake_arn, Message=message)
 
@@ -1055,34 +1060,72 @@ class TestSNSProvider:
         number_of_endpoints = 4
 
         servers = []
+        try:
+            for _ in range(number_of_endpoints):
+                server = HTTPServer()
+                server.start()
+                servers.append(server)
+                server.expect_request("/").respond_with_handler(handler)
+                http_endpoint = server.url_for("/")
+                wait_for_port_open(http_endpoint)
 
-        for _ in range(number_of_endpoints):
-            server = HTTPServer()
-            server.start()
-            servers.append(server)
-            server.expect_request("/").respond_with_handler(handler)
-            http_endpoint = server.url_for("/")
-            wait_for_port_open(http_endpoint)
+                sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint)
 
-            sns_subscription(TopicArn=topic_arn, Protocol="http", Endpoint=http_endpoint)
+            # fetch subscription information
+            subscription_list = sns_client.list_subscriptions_by_topic(TopicArn=topic_arn)
+            assert subscription_list["ResponseMetadata"]["HTTPStatusCode"] == 200
+            assert (
+                len(subscription_list["Subscriptions"]) == number_of_endpoints
+            ), f"unexpected number of subscriptions {subscription_list}"
 
-        # fetch subscription information
-        subscription_list = sns_client.list_subscriptions_by_topic(TopicArn=topic_arn)
-        assert subscription_list["ResponseMetadata"]["HTTPStatusCode"] == 200
-        assert (
-            len(subscription_list["Subscriptions"]) == number_of_endpoints
-        ), f"unexpected number of subscriptions {subscription_list}"
+            tokens = []
+            for _ in range(number_of_endpoints):
+                request = _requests.get(timeout=2)
+                request_data = request.get_json(True)
+                tokens.append(request_data["Token"])
+                assert request_data["TopicArn"] == topic_arn
 
-        for _ in range(number_of_endpoints):
-            request = _requests.get(timeout=2)
-            assert request.get_json(True)["TopicArn"] == topic_arn
+            with pytest.raises(queue.Empty):
+                # make sure only four requests are received
+                _requests.get(timeout=1)
 
-        with pytest.raises(queue.Empty):
-            # make sure only four requests are received
-            _requests.get(timeout=1)
+            # assert the first subscription is pending confirmation
+            sub_1 = subscription_list["Subscriptions"][0]
+            sub_1_attrs = sns_client.get_subscription_attributes(
+                SubscriptionArn=sub_1["SubscriptionArn"]
+            )
+            assert sub_1_attrs["Attributes"]["PendingConfirmation"] == "true"
 
-        for server in servers:
-            server.stop()
+            # assert the second subscription is pending confirmation
+            sub_2 = subscription_list["Subscriptions"][1]
+            sub_2_attrs = sns_client.get_subscription_attributes(
+                SubscriptionArn=sub_2["SubscriptionArn"]
+            )
+            assert sub_2_attrs["Attributes"]["PendingConfirmation"] == "true"
+
+            # confirm the first subscription
+            response = sns_client.confirm_subscription(TopicArn=topic_arn, Token=tokens[0])
+            # assert the confirmed subscription is the first one
+            assert response["SubscriptionArn"] == sub_1["SubscriptionArn"]
+
+            # assert the first subscription is confirmed
+            sub_1_attrs = sns_client.get_subscription_attributes(
+                SubscriptionArn=sub_1["SubscriptionArn"]
+            )
+            assert sub_1_attrs["Attributes"]["PendingConfirmation"] == "false"
+
+            # assert the second subscription is NOT confirmed
+            sub_2_attrs = sns_client.get_subscription_attributes(
+                SubscriptionArn=sub_2["SubscriptionArn"]
+            )
+            assert sub_2_attrs["Attributes"]["PendingConfirmation"] == "true"
+
+        finally:
+            subscription_list = sns_client.list_subscriptions_by_topic(TopicArn=topic_arn)
+            for subscription in subscription_list["Subscriptions"]:
+                sns_client.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+            for server in servers:
+                server.stop()
 
     @pytest.mark.only_localstack
     def test_publish_sms_endpoint(self, sns_client, sns_create_topic, sns_subscription):
@@ -3379,6 +3422,35 @@ class TestSNSProvider:
         )
         # there should be no messages in this queue
         snapshot.match("messages-with-filter-after-publish-filtered", response_after_publish_filter)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=["$.invalid-token.Error.Message"]  # validate the token shape
+    )
+    def test_sns_confirm_subscription_wrong_token(self, sns_client, sns_create_topic, snapshot):
+        topic_arn = sns_create_topic()["TopicArn"]
+
+        with pytest.raises(ClientError) as e:
+            wrong_topic = topic_arn[:-1] + "i"
+            sns_client.confirm_subscription(
+                TopicArn=wrong_topic,
+                Token="51b2ff3edb475b7d91550e0ab6edf0c1de2a34e6ebaf6c2262a001bcb7e051c43aa00022ceecce70bd2a67b2042da8d8eb47fef7a4e4e942d23e7fa56146b9ee35da040b4b8af564cc4184a7391c834cb75d75c22981f776ad1ce8805e9bab29da2329985337bb8095627907b46c8577c8440556b6f86582a954758026f41fc62041c4b3f67b0f5921232b5dae5aaca1",
+            )
+
+        snapshot.match("topic-not-exists", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            sns_client.confirm_subscription(TopicArn=topic_arn, Token="randomtoken")
+
+        snapshot.match("invalid-token", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            sns_client.confirm_subscription(
+                TopicArn=topic_arn,
+                Token="51b2ff3edb475b7d91550e0ab6edf0c1de2a34e6ebaf6c2262a001bcb7e051c43aa00022ceecce70bd2a67b2042da8d8eb47fef7a4e4e942d23e7fa56146b9ee35da040b4b8af564cc4184a7391c834cb75d75c22981f776ad1ce8805e9bab29da2329985337bb8095627907b46c8577c8440556b6f86582a954758026f41fc62041c4b3f67b0f5921232b5dae5aaca1",
+            )
+
+        snapshot.match("token-not-exists", e.value.response)
 
 
 class TestSNSPublishDelivery:

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3349,5 +3349,34 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_subscribe_sms_endpoint": {
+    "recorded-date": "05-03-2023, 15:29:28",
+    "recorded-content": {
+      "subscribe-sms-endpoint": {
+        "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "subscribe-sms-attrs": {
+        "Attributes": {
+          "ConfirmationWasAuthenticated": "true",
+          "Endpoint": "+123123123",
+          "Owner": "111111111111",
+          "PendingConfirmation": "false",
+          "Protocol": "sms",
+          "RawMessageDelivery": "false",
+          "SubscriptionArn": "arn:aws:sns:<region>:111111111111:<resource:2>:<resource:1>",
+          "SubscriptionPrincipal": "<sub-principal>",
+          "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:2>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -597,8 +597,15 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_unknown_topic_publish": {
-    "recorded-date": "09-08-2022, 11:30:15",
+    "recorded-date": "04-03-2023, 21:35:42",
     "recorded-content": {
+      "success": {
+        "MessageId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "error": {
         "Error": {
           "Code": "NotFound",
@@ -3301,6 +3308,44 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_sns_confirm_subscription_wrong_token": {
+    "recorded-date": "04-03-2023, 21:28:49",
+    "recorded-content": {
+      "topic-not-exists": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Token",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "invalid-token": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid token",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "token-not-exists": {
+        "Error": {
+          "Code": "InvalidParameter",
+          "Message": "Invalid parameter: Token",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
         }
       }
     }


### PR DESCRIPTION
As we're currently working on persistence, I'd like to refactor the SNS store to facilitate lookup and have its data structures more aligned with how we are using them in the provider and to how AWS stores them.

Added some validations where I had questions on how AWS would behave. 