### PR TITLE
fix openapi 3.0 security schemes import

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -554,7 +554,9 @@ def import_api_from_openapi_spec(
         security_schemes = path_payload.get("security")
         for security_scheme in security_schemes:
             for security_scheme_name, _ in security_scheme.items():
-                security_definitions = body.get("securityDefinitions") or {}
+                security_definitions = body.get("securityDefinitions") or body.get(
+                    "components", {}
+                ).get("securitySchemes", {})
                 if security_scheme_name in security_definitions:
                     security_config = security_definitions.get(security_scheme_name)
                     aws_apigateway_authorizer = security_config.get(

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -1958,6 +1958,27 @@ def create_rest_apigw():
 
 
 @pytest.fixture
+def create_rest_apigw_openapi():
+    rest_apis = []
+
+    def _create_apigateway_function(**kwargs):
+        region_name = kwargs.pop("region_name", None)
+        apigateway_client = _client("apigateway", region_name)
+
+        response = apigateway_client.import_rest_api(**kwargs)
+        api_id = response.get("id")
+        rest_apis.append((api_id, region_name))
+        return api_id, response
+
+    yield _create_apigateway_function
+
+    for rest_api_id, region_name in rest_apis:
+        with contextlib.suppress(Exception):
+            apigateway_client = _client("apigateway", region_name)
+            apigateway_client.delete_rest_api(restApiId=rest_api_id)
+
+
+@pytest.fixture
 def appsync_create_api(appsync_client):
     graphql_apis = []
 


### PR DESCRIPTION
Fix to handle OpenAPI 3.0 security schemes object - https://swagger.io/specification/v3/#security-scheme-object

Terraform sample: https://github.com/localstack/localstack-terraform-samples/tree/master/apigateway-openapi-3.0-import