### PR TITLE
Fix: Alias name validator

### DIFF
--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -712,6 +712,7 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
     def create_alias(self, context: RequestContext, request: CreateAliasRequest) -> None:
         store = self._get_store(context)
         alias_name = request["AliasName"]
+        validate_alias_name(alias_name)
         if alias_name in store.aliases:
             alias_arn = store.aliases.get(alias_name).metadata["AliasArn"]
             # AWS itself uses AliasArn instead of AliasName in this exception.

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -59,6 +59,16 @@ class TestKMS:
         return sts_client.get_caller_identity()["Arn"]
 
     @pytest.mark.aws_validated
+    def test_create_alias(self, kms_create_alias, kms_create_key, snapshot):
+
+        alias_name = f"{short_uid()}"
+        alias_key_id = kms_create_key()["KeyId"]
+        with pytest.raises(Exception) as e:
+            kms_create_alias(AliasName=alias_name, TargetKeyId=alias_key_id)
+
+        snapshot.match("create_alias", e.value.response)
+
+    @pytest.mark.aws_validated
     def test_create_key(self, kms_client_for_region, kms_create_key, sts_client, snapshot):
         region = "us-east-1"
         kms_client = kms_client_for_region(region)

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -389,5 +389,20 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_create_alias": {
+    "recorded-date": "11-03-2023, 13:11:50",
+    "recorded-content": {
+      "create_alias": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Alias must start with the prefix \"alias/\". Please see https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/unit/test_kms.py
+++ b/tests/unit/test_kms.py
@@ -1,0 +1,9 @@
+import pytest
+
+from localstack.services.kms.models import validate_alias_name
+
+
+def test_alias_name_validator():
+
+    with pytest.raises(Exception):
+        validate_alias_name("test-alias")


### PR DESCRIPTION
This PR is for the fix of issue #7494 
Initially, there was no validation on alias names done to create an alias. I have added the Alias name validation which would raise a ValidationException if the given alias name doesn't start with "alias/"

@bentsku You can review this.