### PR TITLE
Fix error with threads not having _target attributes

### DIFF
--- a/localstack/testing/pytest/detect_thread_leakage.py
+++ b/localstack/testing/pytest/detect_thread_leakage.py
@@ -23,8 +23,10 @@ def pytest_unconfigure(config):
             "line_no": frame.f_code.co_firstlineno,
             "frame_traceback": traceback.format_stack(frame),
             "thread_name": thread.name,
-            "thread_target": repr(thread._target),
-            "thread_target_file": inspect.getfile(thread._target) if thread._target else None,
+            "thread_target": repr(thread._target) if hasattr(thread, "_target") else None,
+            "thread_target_file": inspect.getfile(thread._target)
+            if hasattr(thread, "_target") and thread._target
+            else None,
         }
         for frame, thread in thread_frames
         if frame


### PR DESCRIPTION
## Motivation
Master build is currently red due to some threads not having the _target attribute, and the thread leakage detection therefore failing.

## Changes
Check if a thread has the _target attribute before accessing it, otherwise just print `None`.