### PR TITLE
Fix multiple AWS::Lambda::Permission for single function

### DIFF
--- a/localstack/services/cloudformation/engine/template_deployer.py
+++ b/localstack/services/cloudformation/engine/template_deployer.py
@@ -1161,6 +1161,7 @@ class TemplateDeployer:
 
     def resource_config_differs(self, resource_new):
         """Return whether the given resource properties differ from the existing config (for stack updates)."""
+        # TODO: this is broken for default fields when they're added to the properties in the model
         resource_id = resource_new["LogicalResourceId"]
         resource_old = self.resources[resource_id]
         props_old = resource_old["Properties"]

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -338,6 +338,30 @@ def test_update_lambda_permissions(deploy_cfn_template, lambda_client, sts_clien
     assert new_principal in principal
 
 
+@pytest.mark.aws_validated
+def test_multiple_lambda_permissions_for_singlefn(
+    deploy_cfn_template, cfn_client, lambda_client, snapshot
+):
+    deploy = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/cfn_lambda_permission_multiple.yaml"
+        ),
+        max_wait=240,
+    )
+    fn_name = deploy.outputs["LambdaName"]
+    p1_sid = deploy.outputs["PermissionLambda"]
+    p2_sid = deploy.outputs["PermissionStates"]
+
+    snapshot.add_transformer(snapshot.transform.regex(p1_sid, "<p1-sid>"))
+    snapshot.add_transformer(snapshot.transform.regex(p2_sid, "<p2-sid>"))
+    snapshot.add_transformer(snapshot.transform.regex(fn_name, "<fn-name>"))
+
+    policy = lambda_client.get_policy(FunctionName=fn_name)
+    # load the policy json, so we can properly snapshot it
+    policy["Policy"] = json.loads(policy["Policy"])
+    snapshot.match("policy", policy)
+
+
 class TestCfnLambdaIntegrations:
     @pytest.mark.skip_snapshot_verify(
         paths=[

--- a/tests/integration/cloudformation/resources/test_lambda.py
+++ b/tests/integration/cloudformation/resources/test_lambda.py
@@ -338,6 +338,9 @@ def test_update_lambda_permissions(deploy_cfn_template, lambda_client, sts_clien
     assert new_principal in principal
 
 
+@pytest.mark.skip_snapshot_verify(
+    condition=is_old_provider, paths=["$..PolicyArn", "$..PolicyName", "$..RevisionId"]
+)
 @pytest.mark.aws_validated
 def test_multiple_lambda_permissions_for_singlefn(
     deploy_cfn_template, cfn_client, lambda_client, snapshot
@@ -355,6 +358,7 @@ def test_multiple_lambda_permissions_for_singlefn(
     snapshot.add_transformer(snapshot.transform.regex(p1_sid, "<p1-sid>"))
     snapshot.add_transformer(snapshot.transform.regex(p2_sid, "<p2-sid>"))
     snapshot.add_transformer(snapshot.transform.regex(fn_name, "<fn-name>"))
+    snapshot.add_transformer(SortingTransformer("Statement", lambda s: s["Sid"]))
 
     policy = lambda_client.get_policy(FunctionName=fn_name)
     # load the policy json, so we can properly snapshot it

--- a/tests/integration/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_lambda.snapshot.json
@@ -1355,5 +1355,41 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_lambda.py::test_multiple_lambda_permissions_for_singlefn": {
+    "recorded-date": "09-03-2023, 21:05:29",
+    "recorded-content": {
+      "policy": {
+        "Policy": {
+          "Id": "default",
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "states.amazonaws.com"
+              },
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<fn-name>",
+              "Sid": "<p2-sid>"
+            },
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              },
+              "Resource": "arn:aws:lambda:<region>:111111111111:function:<fn-name>",
+              "Sid": "<p1-sid>"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "RevisionId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/cloudformation/resources/test_lambda.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_lambda.snapshot.json
@@ -1357,7 +1357,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_lambda.py::test_multiple_lambda_permissions_for_singlefn": {
-    "recorded-date": "09-03-2023, 21:05:29",
+    "recorded-date": "09-03-2023, 22:07:56",
     "recorded-content": {
       "policy": {
         "Policy": {
@@ -1367,19 +1367,19 @@
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
               "Principal": {
-                "Service": "states.amazonaws.com"
+                "Service": "lambda.amazonaws.com"
               },
               "Resource": "arn:aws:lambda:<region>:111111111111:function:<fn-name>",
-              "Sid": "<p2-sid>"
+              "Sid": "<p1-sid>"
             },
             {
               "Action": "lambda:InvokeFunction",
               "Effect": "Allow",
               "Principal": {
-                "Service": "lambda.amazonaws.com"
+                "Service": "states.amazonaws.com"
               },
               "Resource": "arn:aws:lambda:<region>:111111111111:function:<fn-name>",
-              "Sid": "<p1-sid>"
+              "Sid": "<p2-sid>"
             }
           ],
           "Version": "2012-10-17"

--- a/tests/integration/templates/cfn_lambda_permission_multiple.yaml
+++ b/tests/integration/templates/cfn_lambda_permission_multiple.yaml
@@ -1,0 +1,65 @@
+Resources:
+  FunctionServiceRole675BB04A:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  Function76856677:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          def handler(event, context):
+              return {"hello": "world"}
+      Role:
+        Fn::GetAtt:
+          - FunctionServiceRole675BB04A
+          - Arn
+      Handler: index.handler
+      Runtime: python3.9
+    DependsOn:
+      - FunctionServiceRole675BB04A
+  FunctionInvoketnlpEgfIKpZyEIAINyVhXFSIfV5EJ7IaMp0cNGOcC4227DF5:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - Function76856677
+          - Arn
+      Principal: states.amazonaws.com
+  FunctionInvokearOgSVH4Ts0qbAOHNp0VMi6g5gzMbVQFH2pumFohAQA578E6CA:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName:
+        Fn::GetAtt:
+          - Function76856677
+          - Arn
+      Principal: lambda.amazonaws.com
+Outputs:
+  LambdaName:
+    Value:
+      Ref: Function76856677
+  LambdaArn:
+    Value:
+      Fn::GetAtt:
+        - Function76856677
+        - Arn
+  PermissionLambda:
+    Value:
+      Ref: FunctionInvokearOgSVH4Ts0qbAOHNp0VMi6g5gzMbVQFH2pumFohAQA578E6CA
+  PermissionStates:
+    Value:
+      Ref: FunctionInvoketnlpEgfIKpZyEIAINyVhXFSIfV5EJ7IaMp0cNGOcC4227DF5


### PR DESCRIPTION
A single lambda function can be associated with multiple `AWS::Lambda::Permission` resources. This was fundamentally incompatible with how the previous fetch_state "worked'. 

## Changes
* Added a test for adding multiple AWS::Lambda::Permission resources for a single function
* Fixed `fetch_state` & physical resource id for `AWS::Lambda::Permission`
* Fixed overwriting `Code` properties in `AWS::Lambda::Function` which lead to unnecessary updates in certain cases