### PR TITLE
Remove extra slash in SQS path strategy

### DIFF
--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -252,7 +252,7 @@ class SqsQueue:
             host_url = f"{scheme}://{region}queue.{constants.LOCALHOST_HOSTNAME}:{config.EDGE_PORT}"
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
-            host_url = f"{context.request.host_url}/queue/{self.region}"
+            host_url = f"{context.request.host_url}queue/{self.region}"
         else:
             if config.SQS_PORT_EXTERNAL:
                 host_url = external_service_url("sqs")

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -3097,6 +3097,14 @@ class TestSqsQueryApi:
         assert response.ok
         assert "foobar" in response.text
 
+    def test_queue_url_format_path_strategy(self, sqs_create_queue, monkeypatch):
+        monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "path")
+        queue_name = f"path_queue_{short_uid()}"
+        queue_url = sqs_create_queue(QueueName=queue_name)
+        assert (
+            f"localhost:4566/queue/{get_region()}/{get_aws_account_id()}/{queue_name}" in queue_url
+        )
+
     @pytest.mark.aws_validated
     def test_overwrite_queue_url_in_params(self, sqs_create_queue, sqs_http_client):
         # here, queue1 url simply serves as AWS endpoint but we pass queue2 url in the request arg


### PR DESCRIPTION
This PR removes a duplicate slash when creating the queue url under the `path` endpoint strategy
