### PR TITLE
update s3 tests location in  CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -136,7 +136,7 @@
 /localstack/aws/api/s3/ @bentsku @macnev2013
 /localstack/services/s3/ @bentsku @macnev2013
 /localstack/services/cloudformation/models/s3.py @bentsku @macnev2013
-/tests/integration/test_s3.py @bentsku @macnev2013
+/test/integration/s3/ @bentsku @macnev2013
 /tests/unit/test_s3.py @bentsku @macnev2013
 
 # Secretsmanager

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -5200,7 +5200,7 @@ class TestS3DeepArchive:
         if 'ongoing-request="false"' in response.get("Restore", ""):
             # if the restoring happens in LocalStack (or was fast in AWS) we can retrieve the object
             restore_bucket_name = f"bucket-{short_uid()}"
-            s3_client.create_bucket(Bucket=restore_bucket_name)
+            s3_create_bucket(Bucket=restore_bucket_name)
 
             s3_client.copy_object(
                 CopySource={"Bucket": bucket_name, "Key": object_key},


### PR DESCRIPTION
Just realised I wasn't tagged in a test modification in S3, so as seen with @alexrashed, updating it.

Also using a fixture in the s3 test to not leave a dangling S3 bucket. 