### PR TITLE
fix validator and model check during invocation

### DIFF
--- a/localstack/services/apigateway/helpers.py
+++ b/localstack/services/apigateway/helpers.py
@@ -68,6 +68,8 @@ APIGATEWAY_SQS_DATA_INBOUND_TEMPLATE = (
 # special tag name to allow specifying a custom ID for new REST APIs
 TAG_KEY_CUSTOM_ID = "_custom_id_"
 
+EMPTY_MODEL = "Empty"
+
 # TODO: make the CRUD operations in this file generic for the different model types (authorizes, validators, ...)
 
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -10,6 +10,7 @@ from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway import helpers
 from localstack.services.apigateway.context import ApiInvocationContext
 from localstack.services.apigateway.helpers import (
+    EMPTY_MODEL,
     extract_path_params,
     extract_query_string_params,
     get_cors_response,
@@ -85,9 +86,9 @@ class RequestValidator:
         # if there's no model to validate the body, use the Empty model
         # https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-apigateway.EmptyModel.html
         if not (request_models := resource.get("requestModels")):
-            schema_name = "Empty"
+            schema_name = EMPTY_MODEL
         else:
-            schema_name = request_models.get(APPLICATION_JSON, "Empty")
+            schema_name = request_models.get(APPLICATION_JSON, EMPTY_MODEL)
 
         try:
             model = self.apigateway_client.get_model(
@@ -95,7 +96,6 @@ class RequestValidator:
                 modelName=schema_name,
             )
         except ClientError as e:
-            # This should not happen, as we validate that we cannot delete a Model if it's used
             LOG.exception("An exception occurred while trying to validate the request: %s", e)
             return False
 

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -102,7 +102,7 @@ class RequestValidator:
             validate(instance=json.loads(self.context.data), schema=json.loads(model["schema"]))
             return True
         except ValidationError as e:
-            LOG.warning("failed to validate request body", e)
+            LOG.warning("failed to validate request body %s", e)
             return False
 
     # TODO implement parameters and headers

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -58,11 +58,15 @@ class RequestValidator:
             return True
 
         # check if there is a validator for this request
-        validator = self.apigateway_client.get_request_validator(
-            restApiId=self.context.api_id, requestValidatorId=resource["requestValidatorId"]
-        )
-        if validator is None:
-            return True
+        try:
+            validator = self.apigateway_client.get_request_validator(
+                restApiId=self.context.api_id, requestValidatorId=resource["requestValidatorId"]
+            )
+        except ClientError as e:
+            if "NotFoundException" in e:
+                return True
+
+            raise
 
         # are we validating the body?
         if self.should_validate_body(validator):

--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -82,11 +82,13 @@ class RequestValidator:
         return True
 
     def validate_body(self, resource):
-        # we need a model to validate the body
+        # if there's no model to validate the body, use the Empty model
+        # https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-apigateway.EmptyModel.html
         if "requestModels" not in resource or not resource["requestModels"]:
-            return False
+            schema_name = "Empty"
+        else:
+            schema_name = resource["requestModels"].get(APPLICATION_JSON)
 
-        schema_name = resource["requestModels"].get(APPLICATION_JSON)
         try:
             model = self.apigateway_client.get_model(
                 restApiId=self.context.api_id,

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -61,6 +61,7 @@ from localstack.aws.api.apigateway import (
 from localstack.aws.forwarder import NotImplementedAvoidFallbackError, create_aws_request_context
 from localstack.constants import APPLICATION_JSON
 from localstack.services.apigateway.helpers import (
+    EMPTY_MODEL,
     OpenApiExporter,
     apply_json_patch_safe,
     get_apigateway_store,
@@ -137,7 +138,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         rest_api_container = RestApiContainer(rest_api=response)
         store.rest_apis[result["id"]] = rest_api_container
         # add the 2 default models
-        rest_api_container.models["Empty"] = DEFAULT_EMPTY_MODEL
+        rest_api_container.models[EMPTY_MODEL] = DEFAULT_EMPTY_MODEL
         rest_api_container.models["Error"] = DEFAULT_ERROR_MODEL
 
         return response
@@ -442,7 +443,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         if request_models:
             for content_type, model_name in request_models.items():
                 # FIXME: add Empty model to rest api at creation
-                if model_name == "Empty":
+                if model_name == EMPTY_MODEL:
                     continue
                 if model_name not in rest_api_container.models:
                     raise BadRequestException(f"Invalid model identifier specified: {model_name}")
@@ -521,7 +522,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                 raise BadRequestException("Invalid Request Validator identifier specified")
 
             elif path.startswith("/requestModels/"):
-                if value != "Empty" and value not in rest_api.models:
+                if value != EMPTY_MODEL and value not in rest_api.models:
                     raise BadRequestException(f"Invalid model identifier specified: {value}")
 
             applicable_patch_operations.append(patch_operation)
@@ -1504,7 +1505,7 @@ def to_response_json(model_type, data, api_id=None, self_link=None, id_attr=None
 
 DEFAULT_EMPTY_MODEL = Model(
     id=short_uid()[:6],
-    name="Empty",
+    name=EMPTY_MODEL,
     contentType="application/json",
     description="This is a default empty schema model",
     schema=json.dumps(

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -513,6 +513,11 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                 continue
 
             elif path == "/requestValidatorId" and value not in rest_api.validators:
+                if not value:
+                    # you can remove a requestValidator by passing an empty string as a value
+                    patch_op = {"op": "remove", "path": path, "value": value}
+                    applicable_patch_operations.append(patch_op)
+                    continue
                 raise BadRequestException("Invalid Request Validator identifier specified")
 
             elif path.startswith("/requestModels/"):

--- a/tests/integration/apigateway/conftest.py
+++ b/tests/integration/apigateway/conftest.py
@@ -139,3 +139,17 @@ def create_rest_api_with_integration(
         return api_id
 
     yield _factory
+
+
+@pytest.fixture
+def apigw_redeploy_api(apigateway_client):
+    def _factory(rest_api_id: str, stage_name: str):
+        deployment_id = apigateway_client.create_deployment(restApiId=rest_api_id)["id"]
+
+        apigateway_client.update_stage(
+            restApiId=rest_api_id,
+            stageName=stage_name,
+            patchOperations=[{"op": "replace", "path": "/deploymentId", "value": deployment_id}],
+        )
+
+    return _factory

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -6,7 +6,7 @@ import requests
 from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
 from localstack.utils.aws.arns import parse_arn
 from localstack.utils.strings import short_uid
-from tests.integration.apigateway_fixtures import api_invoke_url
+from tests.integration.apigateway.apigateway_fixtures import api_invoke_url
 from tests.integration.awslambda.test_lambda import TEST_LAMBDA_AWS_PROXY
 
 

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -1,0 +1,167 @@
+import json
+
+import pytest
+import requests
+
+from localstack.services.awslambda.lambda_utils import LAMBDA_RUNTIME_PYTHON39
+from localstack.utils.aws.arns import parse_arn
+from localstack.utils.strings import short_uid
+from tests.integration.apigateway_fixtures import api_invoke_url
+from tests.integration.awslambda.test_lambda import TEST_LAMBDA_AWS_PROXY
+
+
+class TestApiGatewayCommon:
+    """
+    In this class we won't test individual CRUD API calls but how those will affect the integrations and
+    requests/responses from the API.
+    """
+
+    @pytest.mark.aws_validated
+    def test_api_gateway_request_validator(
+        self,
+        apigateway_client,
+        create_lambda_function,
+        create_rest_apigw,
+        lambda_client,
+    ):
+        # TODO: create fixture which will provide basic integrations where we can test behaviour
+        # see once we have more cases how we can regroup functionality into one or several fixtures
+        # example: create a basic echo lambda + integrations + deploy stage
+
+        fn_name = f"test-{short_uid()}"
+        create_lambda_function(
+            func_name=fn_name,
+            handler_file=TEST_LAMBDA_AWS_PROXY,
+            runtime=LAMBDA_RUNTIME_PYTHON39,
+        )
+        lambda_arn = lambda_client.get_function(FunctionName=fn_name)["Configuration"][
+            "FunctionArn"
+        ]
+        parsed_arn = parse_arn(lambda_arn)
+        region = parsed_arn["region"]
+        account_id = parsed_arn["account"]
+
+        api_id, _, root = create_rest_apigw(name="aws lambda api")
+
+        resource_1 = apigateway_client.create_resource(
+            restApiId=api_id, parentId=root, pathPart="test"
+        )["id"]
+
+        resource_id = apigateway_client.create_resource(
+            restApiId=api_id, parentId=resource_1, pathPart="{test}"
+        )["id"]
+
+        validator_id = apigateway_client.create_request_validator(
+            restApiId=api_id,
+            name="test-validator",
+            validateRequestParameters=True,
+            validateRequestBody=True,
+        )["id"]
+
+        apigateway_client.put_method(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            authorizationType="NONE",
+            requestValidatorId=validator_id,
+            requestParameters={"method.request.path.test": True},
+        )
+
+        apigateway_client.put_integration(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            integrationHttpMethod="POST",
+            type="AWS_PROXY",
+            uri=f"arn:aws:apigateway:{region}:lambda:path//2015-03-31/functions/"
+            f"{lambda_arn}/invocations",
+        )
+        apigateway_client.put_method_response(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
+        apigateway_client.put_integration_response(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            statusCode="200",
+        )
+
+        deployment_id = apigateway_client.create_deployment(restApiId=api_id)["id"]
+
+        stage = apigateway_client.create_stage(
+            restApiId=api_id, stageName="local", deploymentId=deployment_id
+        )["stageName"]
+
+        source_arn = f"arn:aws:execute-api:{region}:{account_id}:{api_id}/*/*/test/*"
+
+        lambda_client.add_permission(
+            FunctionName=lambda_arn,
+            StatementId=str(short_uid()),
+            Action="lambda:InvokeFunction",
+            Principal="apigateway.amazonaws.com",
+            SourceArn=source_arn,
+        )
+
+        url = api_invoke_url(api_id, stage=stage, path="/test/value")
+        response = requests.post(url, json={"test": "test"})
+        assert response.ok
+        assert json.loads(response.json()["body"]) == {"test": "test"}
+
+        apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            patchOperations=[
+                {
+                    "op": "add",
+                    "path": "/requestParameters/method.request.path.issuer",
+                    "value": "true",
+                },
+                {
+                    "op": "remove",
+                    "path": "/requestParameters/method.request.path.test",
+                    "value": "true",
+                },
+            ],
+        )
+
+        response = requests.post(url, json={"test": "test"})
+        assert response.ok
+        assert json.loads(response.json()["body"]) == {"test": "test"}
+
+        # create Model schema to validate body
+        apigateway_client.create_model(
+            restApiId=api_id,
+            name="testSchema",
+            contentType="application/json",
+            schema=json.dumps({}),
+        )
+        # then attach the schema to the method
+        apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            patchOperations=[
+                {"op": "add", "path": "/requestModels/application~1json", "value": "testSchema"},
+            ],
+        )
+        # the validator should then check against this schema
+
+        apigateway_client.update_method(
+            restApiId=api_id,
+            resourceId=resource_id,
+            httpMethod="POST",
+            patchOperations=[
+                {
+                    "op": "replace",
+                    "path": "/requestValidatorId",
+                    "value": "",
+                },
+            ],
+        )
+        response = requests.post(url, json={"test": "test"})
+        assert response.ok
+        assert json.loads(response.json()["body"]) == {"test": "test"}

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -1,10 +1,14 @@
 {
   "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
-    "recorded-date": "15-03-2023, 00:42:34",
+    "recorded-date": "15-03-2023, 01:01:50",
     "recorded-content": {
+      "register-lambda": {
+        "fn_arn": "arn:aws:lambda:<region>:111111111111:function:<fn_name:1>",
+        "fn_name": "<fn_name:1>"
+      },
       "deploy-1": {
         "createdDate": "datetime",
-        "id": "ehob5m",
+        "id": "<id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 201
@@ -16,7 +20,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "9qcl57",
+          "cacheNamespace": "5l4d79",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -26,7 +30,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:<fn_name:1>/invocations"
         },
         "methodResponses": {
           "200": {
@@ -36,7 +40,7 @@
         "requestParameters": {
           "method.request.path.issuer": true
         },
-        "requestValidatorId": "f0uyyb",
+        "requestValidatorId": "<request-validator-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -51,7 +55,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "9qcl57",
+          "cacheNamespace": "5l4d79",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -61,7 +65,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:<fn_name:1>/invocations"
         },
         "methodResponses": {
           "200": {
@@ -74,7 +78,7 @@
         "requestParameters": {
           "method.request.path.issuer": true
         },
-        "requestValidatorId": "f0uyyb",
+        "requestValidatorId": "<request-validator-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -86,7 +90,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "9qcl57",
+          "cacheNamespace": "5l4d79",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -96,7 +100,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:<fn_name:1>/invocations"
         },
         "methodResponses": {
           "200": {
@@ -109,7 +113,7 @@
         "requestParameters": {
           "method.request.path.test": true
         },
-        "requestValidatorId": "f0uyyb",
+        "requestValidatorId": "<request-validator-id:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -124,7 +128,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "9qcl57",
+          "cacheNamespace": "5l4d79",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -134,7 +138,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:<fn_name:1>/invocations"
         },
         "methodResponses": {
           "200": {

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -1,14 +1,22 @@
 {
   "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
-    "recorded-date": "14-03-2023, 12:17:22",
+    "recorded-date": "15-03-2023, 00:42:34",
     "recorded-content": {
+      "deploy-1": {
+        "createdDate": "datetime",
+        "id": "ehob5m",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
       "change-request-path-names": {
         "apiKeyRequired": false,
         "authorizationType": "NONE",
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "kx81zt",
+          "cacheNamespace": "9qcl57",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -18,7 +26,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-8a4021bf/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
         },
         "methodResponses": {
           "200": {
@@ -28,11 +36,14 @@
         "requestParameters": {
           "method.request.path.issuer": true
         },
-        "requestValidatorId": "ri5fkc",
+        "requestValidatorId": "f0uyyb",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "missing-required-request-params": {
+        "message": "Missing required request parameters: [issuer]"
       },
       "add-schema": {
         "apiKeyRequired": false,
@@ -40,7 +51,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "kx81zt",
+          "cacheNamespace": "9qcl57",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -50,7 +61,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-8a4021bf/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
         },
         "methodResponses": {
           "200": {
@@ -63,11 +74,49 @@
         "requestParameters": {
           "method.request.path.issuer": true
         },
-        "requestValidatorId": "ri5fkc",
+        "requestValidatorId": "f0uyyb",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "revert-request-path-names": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "9qcl57",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "AWS_PROXY",
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "requestModels": {
+          "application/json": "testSchema"
+        },
+        "requestParameters": {
+          "method.request.path.test": true
+        },
+        "requestValidatorId": "f0uyyb",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "invalid-request-body": {
+        "message": "Invalid request body"
       },
       "remove-validator": {
         "apiKeyRequired": false,
@@ -75,7 +124,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "kx81zt",
+          "cacheNamespace": "9qcl57",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -85,7 +134,7 @@
           "passthroughBehavior": "WHEN_NO_MATCH",
           "timeoutInMillis": 29000,
           "type": "AWS_PROXY",
-          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-8a4021bf/invocations"
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-ae38daf7/invocations"
         },
         "methodResponses": {
           "200": {
@@ -96,7 +145,7 @@
           "application/json": "testSchema"
         },
         "requestParameters": {
-          "method.request.path.issuer": true
+          "method.request.path.test": true
         },
         "ResponseMetadata": {
           "HTTPHeaders": {},

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -1,0 +1,108 @@
+{
+  "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
+    "recorded-date": "14-03-2023, 12:17:22",
+    "recorded-content": {
+      "change-request-path-names": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "kx81zt",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "AWS_PROXY",
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-8a4021bf/invocations"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "requestParameters": {
+          "method.request.path.issuer": true
+        },
+        "requestValidatorId": "ri5fkc",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "add-schema": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "kx81zt",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "AWS_PROXY",
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-8a4021bf/invocations"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "requestModels": {
+          "application/json": "testSchema"
+        },
+        "requestParameters": {
+          "method.request.path.issuer": true
+        },
+        "requestValidatorId": "ri5fkc",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-validator": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "POST",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "kx81zt",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "AWS_PROXY",
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:test-8a4021bf/invocations"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "requestModels": {
+          "application/json": "testSchema"
+        },
+        "requestParameters": {
+          "method.request.path.issuer": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -166,6 +166,14 @@ class ApiGatewayPathsTest(unittest.TestCase):
     def test_request_validate_body_with_no_request_model(self):
         apigateway_client = self._mock_client()
         apigateway_client.get_request_validator.return_value = {"validateRequestBody": True}
+        empty_schema = json.dumps(
+            {
+                "$schema": "http://json-schema.org/draft-04/schema#",
+                "title": "Empty Schema",
+                "type": "object",
+            }
+        )
+        apigateway_client.get_model.return_value = {"schema": empty_schema}
         ctx = ApiInvocationContext("POST", "/", '{"id":"1"}', {})
         ctx.api_id = "deadbeef"
         ctx.resource = {
@@ -177,7 +185,7 @@ class ApiGatewayPathsTest(unittest.TestCase):
             }
         }
         validator = RequestValidator(ctx, apigateway_client)
-        self.assertFalse(validator.is_request_valid())
+        self.assertTrue(validator.is_request_valid())
 
     def test_request_validate_body_with_no_model_for_schema_name(self):
         apigateway_client = self._mock_client()

--- a/tests/unit/test_apigateway.py
+++ b/tests/unit/test_apigateway.py
@@ -186,6 +186,10 @@ class ApiGatewayPathsTest(unittest.TestCase):
         }
         validator = RequestValidator(ctx, apigateway_client)
         self.assertTrue(validator.is_request_valid())
+        apigateway_client.get_request_validator.assert_called_with(
+            restApiId="deadbeef", requestValidatorId="112233"
+        )
+        apigateway_client.get_model.assert_called_with(restApiId="deadbeef", modelName="Empty")
 
     def test_request_validate_body_with_no_model_for_schema_name(self):
         apigateway_client = self._mock_client()


### PR DESCRIPTION
We had a wrong assumption when using a `RequestValidator` and validating the body of a request. If a method did not have a `requestModel` set, we would reject the request. However, AWS uses the default `Empty` model. We now follow the same logic.

We also did not have validation for validators before, and would return an empty response if no validators existed with that ID. Now, in parity with AWS, it raises an exception instead of returning `None`.
However, that case should not happen because it's not possible to delete an existing `RequestValidator` if it's used by a `Method` in AWS. I'll try to implement this behaviour in following PR. 

We needed to change the code in `invocations.py` to reflect the change when checking if a request is valid.

note: created a `test_apigateway_common`, where we could test "integrations", or how different RestAPI resources work together, on a level above the CRUD one. If you have a better name than "common", I'm all ears 😄 

_fixes in part #7842_ 
