### PR TITLE
ignore scheduled rules when processing put_events

### DIFF
--- a/localstack/services/events/provider.py
+++ b/localstack/services/events/provider.py
@@ -491,8 +491,12 @@ def events_handler_put_events(self):
         event = event_envelope["event"]
         event_bus = event.get("EventBusName") or DEFAULT_EVENT_BUS_NAME
 
-        matchine_rules = [r for r in event_rules.values() if r.event_bus_name == event_bus]
-        if not matchine_rules:
+        matching_rules = [
+            r
+            for r in event_rules.values()
+            if r.event_bus_name == event_bus and not r.scheduled_expression
+        ]
+        if not matching_rules:
             continue
 
         formatted_event = {
@@ -508,7 +512,7 @@ def events_handler_put_events(self):
         }
 
         targets = []
-        for rule in matchine_rules:
+        for rule in matching_rules:
             if filter_event_based_on_event_format(self, rule.name, formatted_event):
                 targets.extend(self.events_backend.list_targets_by_rule(rule.name)["Targets"])
 

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1638,3 +1638,51 @@ class TestEvents:
                 {"Id": target_id, "Arn": queue_arn, "InputPath": "$.detail"},
             ],
         )
+
+    @pytest.mark.aws_validated
+    def test_should_ignore_schedules_for_put_event(
+        self, create_lambda_function, lambda_client, events_client, logs_client
+    ):
+        """Regression test for https://github.com/localstack/localstack/issues/7847"""
+        fn_name = f"test-event-fn-{short_uid()}"
+        create_lambda_function(
+            func_name=fn_name,
+            handler_file=TEST_LAMBDA_PYTHON_ECHO,
+            runtime=Runtime.python3_9,
+            client=lambda_client,
+        )
+
+        lambda_client.add_permission(
+            FunctionName=fn_name,
+            StatementId="AllowFnInvokeStatement",
+            Action="lambda:InvokeFunction",
+            Principal="events.amazonaws.com",
+        )
+
+        fn_arn = lambda_client.get_function(FunctionName=fn_name)["Configuration"]["FunctionArn"]
+        events_client.put_rule(
+            Name="ScheduledLambda", ScheduleExpression="rate(1 minute)"
+        )  # every minute, can't go lower than that
+        events_client.put_targets(
+            Rule="ScheduledLambda", Targets=[{"Id": "calllambda1", "Arn": fn_arn}]
+        )
+
+        events_client.put_events(
+            Entries=[
+                {
+                    "Source": "MySource",
+                    "DetailType": "CustomType",
+                    "Detail": json.dumps({"message": "manually invoked"}),
+                }
+            ]
+        )
+
+        def check_invocation():
+            events_after = logs_client.filter_log_events(logGroupName=f"/aws/lambda/{fn_name}")
+            # the custom sent event should NOT trigger the lambda (!)
+            assert len([e for e in events_after["events"] if "START" in e["message"]]) >= 1
+            assert (
+                len([e for e in events_after["events"] if "manually invoked" in e["message"]]) == 0
+            )
+
+        retry(check_invocation, sleep=5, retries=15)


### PR DESCRIPTION
Addresses #7847

Since scheduled events don't have a pattern and it defaults to a "{}" pattern, they were always unintentionally triggering the targets of the scheduled event rule when calling `put_events` (which should only consider pattern-based event rules).

To fix this we now ignore any rules that have a `scheduled_expression` set (which would otherwise default to None).  