### PR TITLE
Fix transformation of falsy values in KeyValueBasedTransformer

### DIFF
--- a/localstack/testing/snapshots/transformer.py
+++ b/localstack/testing/snapshots/transformer.py
@@ -169,7 +169,7 @@ class RegexTransformer:
 class KeyValueBasedTransformer:
     def __init__(
         self,
-        match_fn: Callable[[str, str], Optional[str]],
+        match_fn: Callable[[str, Any], Optional[str]],
         replacement: str,
         replace_reference: bool = True,
     ):
@@ -179,7 +179,7 @@ class KeyValueBasedTransformer:
 
     def transform(self, input_data: dict, *, ctx: TransformContext) -> dict:
         for k, v in input_data.items():
-            if match_result := self.match_fn(k, v):
+            if (match_result := self.match_fn(k, v)) is not None:
                 if self.replace_reference:
                     _register_serialized_reference_replacement(
                         ctx, reference_value=match_result, replacement=self.replacement

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -8846,7 +8846,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -8891,7 +8891,7 @@
             "x86_64"
           ],
           "CodeSha256": "<code-sha256:1>",
-          "CodeSize": 0,
+          "CodeSize": "<code-size>",
           "Description": "",
           "Environment": {
             "Variables": {
@@ -8930,7 +8930,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -8980,7 +8980,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:2>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9026,7 +9026,7 @@
             "x86_64"
           ],
           "CodeSha256": "<code-sha256:2>",
-          "CodeSize": 0,
+          "CodeSize": "<code-size>",
           "Description": "",
           "Environment": {
             "Variables": {
@@ -9065,7 +9065,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:2>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9108,7 +9108,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9165,7 +9165,7 @@
             "x86_64"
           ],
           "CodeSha256": "<code-sha256:1>",
-          "CodeSize": 0,
+          "CodeSize": "<code-size>",
           "Description": "",
           "Environment": {
             "Variables": {
@@ -9216,7 +9216,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9266,7 +9266,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9321,7 +9321,7 @@
             "x86_64"
           ],
           "CodeSha256": "<code-sha256:1>",
-          "CodeSize": 0,
+          "CodeSize": "<code-size>",
           "Description": "",
           "Environment": {
             "Variables": {
@@ -9369,7 +9369,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9416,7 +9416,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {
@@ -9462,7 +9462,7 @@
             "x86_64"
           ],
           "CodeSha256": "<code-sha256:1>",
-          "CodeSize": 0,
+          "CodeSize": "<code-size>",
           "Description": "",
           "Environment": {
             "Variables": {
@@ -9501,7 +9501,7 @@
           "x86_64"
         ],
         "CodeSha256": "<code-sha256:1>",
-        "CodeSize": 0,
+        "CodeSize": "<code-size>",
         "Description": "",
         "Environment": {
           "Variables": {

--- a/tests/unit/utils/testing/test_transformer.py
+++ b/tests/unit/utils/testing/test_transformer.py
@@ -46,6 +46,26 @@ class TestTransformer:
 
         assert json.loads(tmp) == expected_key_value_reference
 
+    def test_key_value_replacement_with_falsy_value(self):
+        input = {
+            "hello": "world",
+            "somenumber": 0,
+        }
+
+        key_value = TransformerUtility.key_value(
+            "somenumber", "placeholder", reference_replacement=False
+        )
+
+        expected_key_value = {
+            "hello": "world",
+            "somenumber": "placeholder",
+        }
+
+        copied = copy.deepcopy(input)
+        ctx = TransformContext()
+        assert key_value.transform(copied, ctx=ctx) == expected_key_value
+        assert ctx.serialized_replacements == []
+
     @pytest.mark.parametrize("type", ["key_value", "jsonpath"])
     def test_replacement_with_reference(self, type):
         input = {


### PR DESCRIPTION
Encountered this issue when I was trying to replace a number that flaked between 0 and non-0

## Changes
* Explicitly check for `None` with matched result