### PR TITLE
fix APIGW UpdateMethod authorizer validation

### DIFF
--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -471,6 +471,8 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         store = get_apigateway_store(account_id=context.account_id, region=context.region)
         rest_api = store.rest_apis[rest_api_id]
         applicable_patch_operations = []
+        modifying_auth_type = False
+        modified_authorizer_id = False
         for patch_operation in patch_operations:
             op = patch_operation.get("op")
             path = patch_operation.get("path")
@@ -493,10 +495,10 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
             if path == "/authorizationType" and value in ("CUSTOM", "COGNITO_USER_POOLS"):
                 # TODO: test with 2 operations adding this
-                raise BadRequestException(
-                    "Invalid authorizer ID specified. "
-                    "Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
-                )
+                modifying_auth_type = True
+
+            elif path == "/authorizerId":
+                modified_authorizer_id = value
 
             if any(
                 path.startswith(s_path) for s_path in ("/apiKeyRequired", "/requestParameters/")
@@ -513,6 +515,13 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
                     raise BadRequestException(f"Invalid model identifier specified: {value}")
 
             applicable_patch_operations.append(patch_operation)
+
+        if modifying_auth_type:
+            if not modified_authorizer_id or modified_authorizer_id not in rest_api.authorizers:
+                raise BadRequestException(
+                    "Invalid authorizer ID specified. "
+                    "Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
+                )
 
         # TODO: test with multiple patch operations which would not be compatible between each other
         _patch_api_gateway_entity(moto_method, applicable_patch_operations)

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1321,7 +1321,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method": {
-    "recorded-date": "25-02-2023, 18:10:42",
+    "recorded-date": "13-03-2023, 23:24:55",
     "recorded-content": {
       "put-method-response": {
         "apiKeyRequired": false,
@@ -1363,9 +1363,27 @@
           "HTTPStatusCode": 200
         }
       },
+      "update-method-replace-authorizer": {
+        "apiKeyRequired": true,
+        "authorizationType": "CUSTOM",
+        "authorizerId": "<authorizer-id:1>",
+        "httpMethod": "ANY",
+        "operationName": "ReplacedOperationName",
+        "requestModels": {
+          "application/json": "Empty"
+        },
+        "requestParameters": {
+          "method.request.querystring.optional": false
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
       "update-method-remove": {
         "apiKeyRequired": true,
-        "authorizationType": "AWS_IAM",
+        "authorizationType": "CUSTOM",
+        "authorizerId": "<authorizer-id:1>",
         "httpMethod": "ANY",
         "operationName": "ReplacedOperationName",
         "ResponseMetadata": {

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1321,7 +1321,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method": {
-    "recorded-date": "13-03-2023, 23:24:55",
+    "recorded-date": "13-03-2023, 23:31:44",
     "recorded-content": {
       "put-method-response": {
         "apiKeyRequired": false,
@@ -1394,7 +1394,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_update_method_validation": {
-    "recorded-date": "02-03-2023, 16:58:33",
+    "recorded-date": "13-03-2023, 23:36:56",
     "recorded-content": {
       "wrong-rest-api": {
         "Error": {
@@ -1490,6 +1490,26 @@
         }
       },
       "wrong-auth-type": {
+        "Error": {
+          "Code": "BadRequestException",
+          "Message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."
+        },
+        "message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer.",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "skip-auth-id-with-wrong-type": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "wrong-auth-id": {
         "Error": {
           "Code": "BadRequestException",
           "Message": "Invalid authorizer ID specified. Setting the authorization type to CUSTOM or COGNITO_USER_POOLS requires a valid authorizer."


### PR DESCRIPTION
Follow up from #7749, it seems the validation was lacking and a bit too restrictive while updating Authorizers-related fields. I've added more AWS tests, this should solve our Pro pipeline (tested locally and it works).