### PR TITLE
implement apigw Model validation if in use by a Method

### DIFF
--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -30,12 +30,10 @@ class RestApiContainer:
     documentation_parts: Dict[str, DocumentationPart]
     # not used yet, still in moto
     gateway_responses: Dict[str, GatewayResponse]
-    # not used yet, still in moto
+    # maps Model name -> Model
     models: Dict[str, Model]
     # maps ResourceId of a Resource to its children ResourceIds
     resource_children: Dict[str, List[str]]
-    # maps ModelId to Resource methods using it
-    models_in_use: Dict[str, List[str]]
 
     def __init__(self, rest_api: RestApi):
         self.rest_api = rest_api
@@ -45,7 +43,6 @@ class RestApiContainer:
         self.gateway_responses = {}
         self.models = {}
         self.resource_children = {}
-        self.models_in_use = {}
 
 
 class ApiGatewayStore(BaseStore):

--- a/localstack/services/apigateway/models.py
+++ b/localstack/services/apigateway/models.py
@@ -34,6 +34,8 @@ class RestApiContainer:
     models: Dict[str, Model]
     # maps ResourceId of a Resource to its children ResourceIds
     resource_children: Dict[str, List[str]]
+    # maps ModelId to Resource methods using it
+    models_in_use: Dict[str, List[str]]
 
     def __init__(self, rest_api: RestApi):
         self.rest_api = rest_api
@@ -43,6 +45,7 @@ class RestApiContainer:
         self.gateway_responses = {}
         self.models = {}
         self.resource_children = {}
+        self.models_in_use = {}
 
 
 class ApiGatewayStore(BaseStore):

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -453,8 +453,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         response: Method = call_moto(context)
         remove_empty_attributes_from_method(response)
 
-        # TODO: validate path format
-        method_path = f"/{moto_rest_api.resources[resource_id].get_path()}{http_method}"
+        method_path = f"{moto_rest_api.resources[resource_id].get_path()}/{http_method}"
         for model_name in models_to_add:
             paths_for_model = rest_api_container.models_in_use.setdefault(model_name, [])
             paths_for_model.append(method_path)
@@ -550,8 +549,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
 
         models_after_patch = set(moto_method.request_models.values())
         if models_before_patch != models_after_patch:
-            # TODO: validate path format
-            method_path = f"/{moto_resource.get_path()}{http_method}"
+            method_path = f"{moto_resource.get_path()}/{http_method}"
             to_remove = models_before_patch - models_after_patch
             for model_name in to_remove:
                 in_use = rest_api.models_in_use.get(model_name)
@@ -1358,7 +1356,7 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         models_in_use = store.rest_apis[rest_api_id].models_in_use
         if in_use := models_in_use.get(model_name):
             raise ConflictException(
-                f"Cannot delete model '{model_name}', is referenced in method request: {in_use[0]}"
+                f"Cannot delete model '{model_name}', is referenced in method request: {in_use[-1]}"
             )
 
         store.rest_apis[rest_api_id].models.pop(model_name, None)

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -487,8 +487,6 @@ class ApigatewayProvider(ApigatewayApi, ServiceLifecycleHook):
         applicable_patch_operations = []
         modifying_auth_type = False
         modified_authorizer_id = False
-        models_before_patch = set(moto_method.request_models.values())
-
         moto_request_models = moto_method.request_models or {}
         models_before_patch = set(moto_request_models.values())
         for patch_operation in patch_operations:

--- a/localstack/services/apigateway/provider.py
+++ b/localstack/services/apigateway/provider.py
@@ -1453,15 +1453,6 @@ def is_variable_path(path_part: str) -> bool:
     return path_part.startswith("{") and path_part.endswith("}")
 
 
-def mark_model_in_use(
-    rest_api: RestApiContainer, model_name: str, resource_path: str, http_method: str
-):
-    # TODO: refactor into function for more resources to add (RequestValidator has the same functionality)
-    paths_for_model = rest_api.models_in_use.setdefault(model_name, [])
-    # TODO: need to reconstruct full path from here, validate
-    paths_for_model.append(f"/{resource_path}{http_method}")
-
-
 def create_custom_context(
     context: RequestContext, action: str, parameters: ServiceRequest
 ) -> RequestContext:

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -844,6 +844,12 @@ class TestApiGatewayApi:
         snapshot.match("req-params-same-name", e.value.response)
 
     @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$.delete-model-used-by-2-method.Error.Message",
+            "$.delete-model-used-by-2-method.message",  # we can't guarantee the last method will be the same as AWS
+        ]
+    )
     def test_put_method_model(
         self,
         apigateway_client,

--- a/tests/integration/apigateway/test_apigateway_api.py
+++ b/tests/integration/apigateway/test_apigateway_api.py
@@ -788,6 +788,14 @@ class TestApiGatewayApi:
         )
         snapshot.match("del-base-method-response", del_base_method_response)
 
+        with pytest.raises(ClientError) as e:
+            apigateway_client.get_method(restApiId=api_id, resourceId=root_id, httpMethod="ANY")
+        snapshot.match("get-deleted-method-response", e.value.response)
+
+        with pytest.raises(ClientError) as e:
+            apigateway_client.delete_method(restApiId=api_id, resourceId=root_id, httpMethod="ANY")
+        snapshot.match("delete-deleted-method-response", e.value.response)
+
     @pytest.mark.aws_validated
     def test_method_request_parameters(
         self,
@@ -938,6 +946,16 @@ class TestApiGatewayApi:
         with pytest.raises(ClientError) as e:
             apigateway_client.delete_model(restApiId=api_id, modelName="MySchemaTwo")
         snapshot.match("delete-model-used-by-method-1", e.value.response)
+
+        # delete the Method using MySchemaTwo
+        delete_method = apigateway_client.delete_method(
+            restApiId=api_id, resourceId=root_id, httpMethod="ANY"
+        )
+        snapshot.match("delete-method-using-model-2", delete_method)
+
+        # assert we can now delete MySchemaTwo
+        delete_model = apigateway_client.delete_model(restApiId=api_id, modelName="MySchemaTwo")
+        snapshot.match("delete-model-unused-2", delete_model)
 
     @pytest.mark.aws_validated
     def test_put_method_validation(

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1855,5 +1855,88 @@
         }
       }
     }
+  },
+  "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_model": {
+    "recorded-date": "14-03-2023, 02:42:49",
+    "recorded-content": {
+      "create-model": {
+        "contentType": "application/json",
+        "id": "<id:1>",
+        "name": "<name:1>",
+        "schema": {
+          "title": "<name:1>",
+          "type": "object"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "create-model-2": {
+        "contentType": "application/json",
+        "id": "<id:2>",
+        "name": "<name:1>Two",
+        "schema": {
+          "title": "<name:1>Two",
+          "type": "object"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "put-method-request-models": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "<name:1>"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "delete-model-used": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "update-method-model": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "<name:1>Two"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-model-unused": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
+        }
+      },
+      "delete-model-used-2": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      }
+    }
   }
 }

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1857,7 +1857,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_model": {
-    "recorded-date": "14-03-2023, 02:42:49",
+    "recorded-date": "15-03-2023, 02:12:34",
     "recorded-content": {
       "create-model": {
         "contentType": "application/json",
@@ -1927,6 +1927,49 @@
         }
       },
       "delete-model-used-2": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"
+        },
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "put-method-2-request-models": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "requestModels": {
+          "application/json": "<name:1>Two"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 201
+        }
+      },
+      "delete-model-used-by-2-method": {
+        "Error": {
+          "Code": "ConflictException",
+          "Message": "Cannot delete model '<name:1>Two', is referenced in method request: /test/ANY"
+        },
+        "message": "Cannot delete model '<name:1>Two', is referenced in method request: /test/ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 409
+        }
+      },
+      "update-method-model-2": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "ANY",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-model-used-by-method-1": {
         "Error": {
           "Code": "ConflictException",
           "Message": "Cannot delete model '<name:1>Two', is referenced in method request: //ANY"

--- a/tests/integration/apigateway/test_apigateway_api.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_api.snapshot.json
@@ -1175,7 +1175,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_method_lifecycle": {
-    "recorded-date": "24-02-2023, 19:17:18",
+    "recorded-date": "15-03-2023, 12:06:26",
     "recorded-content": {
       "put-base-method-response": {
         "apiKeyRequired": false,
@@ -1199,6 +1199,28 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 204
+        }
+      },
+      "get-deleted-method-response": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "delete-deleted-method-response": {
+        "Error": {
+          "Code": "NotFoundException",
+          "Message": "Invalid Method identifier specified"
+        },
+        "message": "Invalid Method identifier specified",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }
@@ -1857,7 +1879,7 @@
     }
   },
   "tests/integration/apigateway/test_apigateway_api.py::TestApiGatewayApi::test_put_method_model": {
-    "recorded-date": "15-03-2023, 02:12:34",
+    "recorded-date": "15-03-2023, 12:12:59",
     "recorded-content": {
       "create-model": {
         "contentType": "application/json",
@@ -1978,6 +2000,18 @@
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 409
+        }
+      },
+      "delete-method-using-model-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "delete-model-unused-2": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 202
         }
       }
     }


### PR DESCRIPTION
This PR implements the validation when deleting a `Model` resource: it will check if it's in use in any Method of the RestAPI, and it is, will reject the call. This allows us to not have any integration calling a non existing Model anymore. 

This logic will also be applied to `RequestValidator`, and maybe some other resources. We will extract the logic then into something more general when applying it to other resources. 