### PR TITLE
Add v1 provider aliases for legacy providers

### DIFF
--- a/localstack/services/providers.py
+++ b/localstack/services/providers.py
@@ -152,6 +152,19 @@ def awslambda():
     )
 
 
+@aws_provider(api="lambda", name="v1")
+def awslambda_v1():
+    from localstack.services.awslambda import lambda_starter
+
+    return Service(
+        "lambda",
+        start=lambda_starter.start_lambda,
+        stop=lambda_starter.stop_lambda,
+        check=lambda_starter.check_lambda,
+        lifecycle_hook=lambda_starter.LambdaLifecycleHook(),
+    )
+
+
 @aws_provider(api="lambda", name="asf")
 def awslambda_asf():
     from localstack.services.awslambda.provider import LambdaProvider
@@ -210,6 +223,15 @@ def route53resolver():
 
 @aws_provider(api="s3", name="default")
 def s3():
+    from localstack.services.s3 import s3_listener, s3_starter
+
+    return Service(
+        "s3", listener=s3_listener.UPDATE_S3, start=s3_starter.start_s3, check=s3_starter.check_s3
+    )
+
+
+@aws_provider(api="s3", name="v1")
+def s3_v1():
     from localstack.services.s3 import s3_listener, s3_starter
 
     return Service(
@@ -297,6 +319,19 @@ def events():
 
 @aws_provider()
 def stepfunctions():
+    from localstack.services.stepfunctions.provider import StepFunctionsProvider
+
+    provider = StepFunctionsProvider()
+    return Service.for_provider(
+        provider,
+        dispatch_table_factory=lambda _provider: HttpFallbackDispatcher(
+            _provider, _provider.get_forward_url
+        ),
+    )
+
+
+@aws_provider(api="stepfunctions", name="v1")
+def stepfunctions_v1():
     from localstack.services.stepfunctions.provider import StepFunctionsProvider
 
     provider = StepFunctionsProvider()


### PR DESCRIPTION
Since we currently have been advertising the newer provider implementations as `v2`, users might try to "revert" to the legacy provider by setting the `PROVIDER_OVERRIDE_<svc>` variable to `v1`. Unfortunately this will currently fail since they need to remove the variable completely.

This PR now introduces v1 aliases for the legacy (currently still default) providers with a `v2` provider, i.e. `lambda`, `s3` and `stepfunctions`

cc @bentsku @dfangl 