### PR TITLE
KMS: Fix double hashing during sign/verify operations

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -8,13 +8,12 @@ import struct
 import uuid
 from collections import namedtuple
 from dataclasses import dataclass
-from hashlib import sha256
 from typing import Dict, List
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization as crypto_serialization
-from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa, utils
 
 from localstack.aws.accounts import get_aws_account_id
 from localstack.aws.api import CommonServiceException
@@ -229,16 +228,14 @@ class KmsKey:
     def decrypt(self, ciphertext: Ciphertext) -> bytes:
         return decrypt(self.crypto_key.key_material, ciphertext.ciphertext, ciphertext.iv)
 
-    def _get_digest(self, data: bytes) -> bytes:
-        return sha256(data).digest()
-
     def sign(
         self, data: bytes, message_type: MessageType, signing_algorithm: SigningAlgorithmSpec
     ) -> bytes:
-        kwargs = self._construct_sign_verify_kwargs(signing_algorithm)
-        if message_type != MessageType.DIGEST:
-            data = self._get_digest(data)
-        return self.crypto_key.key.sign(data=data, **kwargs)
+        kwargs = self._construct_sign_verify_kwargs(signing_algorithm, message_type)
+        try:
+            return self.crypto_key.key.sign(data=data, **kwargs)
+        except ValueError as exc:
+            raise ValidationException(str(exc))
 
     def verify(
         self,
@@ -247,27 +244,34 @@ class KmsKey:
         signing_algorithm: SigningAlgorithmSpec,
         signature: bytes,
     ) -> bool:
-        kwargs = self._construct_sign_verify_kwargs(signing_algorithm)
-        if message_type != MessageType.DIGEST:
-            data = self._get_digest(data)
+        kwargs = self._construct_sign_verify_kwargs(signing_algorithm, message_type)
         try:
             self.crypto_key.key.public_key().verify(signature=signature, data=data, **kwargs)
             return True
+        except ValueError as exc:
+            raise ValidationException(str(exc))
         except InvalidSignature:
             # AWS itself raises this exception without any additional message.
             raise KMSInvalidSignatureException()
 
-    def _construct_sign_verify_kwargs(self, signing_algorithm: SigningAlgorithmSpec) -> Dict:
+    def _construct_sign_verify_kwargs(
+        self, signing_algorithm: SigningAlgorithmSpec, message_type: MessageType
+    ) -> Dict:
         kwargs = {}
 
         if "SHA_256" in signing_algorithm:
-            kwargs["algorithm"] = hashes.SHA256()
+            hasher = hashes.SHA256()
         elif "SHA_384" in signing_algorithm:
-            kwargs["algorithm"] = hashes.SHA384()
+            hasher = hashes.SHA384()
         elif "SHA_512" in signing_algorithm:
-            kwargs["algorithm"] = hashes.SHA512()
+            hasher = hashes.SHA512()
         else:
-            LOG.warning("Unsupported hash type in SigningAlgorithm '%s'", signing_algorithm)
+            LOG.exception("Unsupported hash type in SigningAlgorithm '%s'", signing_algorithm)
+
+        if message_type == MessageType.DIGEST:
+            kwargs["algorithm"] = utils.Prehashed(hasher)
+        else:
+            kwargs["algorithm"] = hasher
 
         if signing_algorithm.startswith("ECDSA"):
             kwargs["signature_algorithm"] = ec.ECDSA(algorithm=kwargs.pop("algorithm", None))
@@ -278,7 +282,7 @@ class KmsKey:
                 kwargs["padding"] = padding.PKCS1v15()
             elif "PSS" in signing_algorithm:
                 kwargs["padding"] = padding.PSS(
-                    mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH
+                    mgf=padding.MGF1(hasher), salt_length=padding.PSS.MAX_LENGTH
                 )
             else:
                 LOG.warning("Unsupported padding in SigningAlgorithm '%s'", signing_algorithm)

--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -266,7 +266,9 @@ class KmsKey:
         elif "SHA_512" in signing_algorithm:
             hasher = hashes.SHA512()
         else:
-            LOG.exception("Unsupported hash type in SigningAlgorithm '%s'", signing_algorithm)
+            raise ValidationException(
+                f"Unsupported hash type in SigningAlgorithm '{signing_algorithm}'"
+            )
 
         if message_type == MessageType.DIGEST:
             kwargs["algorithm"] = utils.Prehashed(hasher)

--- a/localstack/services/kms/provider.py
+++ b/localstack/services/kms/provider.py
@@ -532,7 +532,6 @@ class KmsProvider(KmsApi, ServiceLifecycleHook):
         result.pop("Plaintext")
         return GenerateDataKeyWithoutPlaintextResponse(**result)
 
-    # Currently LocalStack only calculates SHA256 digests no matter what the signing algorithm is.
     @handler("Sign", expand=False)
     def sign(self, context: RequestContext, request: SignRequest) -> SignResponse:
         key = self._get_key(context, request.get("KeyId"))

--- a/localstack/services/kms/utils.py
+++ b/localstack/services/kms/utils.py
@@ -1,0 +1,6 @@
+def get_hash_algorithm(signing_algorithm: str) -> str:
+    """
+    Return the hashing algorithm for a given signing algorithm.
+    eg. "RSASSA_PSS_SHA_512" -> "SHA_512"
+    """
+    return "_".join(signing_algorithm.rsplit(sep="_", maxsplit=-2)[-2:])

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import json
 from datetime import datetime
 from random import getrandbits
@@ -9,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.serialization import load_der_public_key
 
 from localstack.aws.accounts import get_aws_account_id
+from localstack.services.kms.utils import get_hash_algorithm
 from localstack.testing.pytest.fixtures import _client
 from localstack.utils.strings import short_uid
 
@@ -384,53 +387,112 @@ class TestKMS:
         assert result.get("KeyId")
 
     @pytest.mark.aws_validated
-    @pytest.mark.parametrize("key_type", ["rsa", "ecc"])
-    def test_sign_verify(self, kms_client, key_type, kms_create_key):
-        key_spec = "RSA_2048" if key_type == "rsa" else "ECC_NIST_P256"
-        result = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)
-        key_id = result["KeyId"]
-        # The Message parameter for Sign contains either a message itself, or a signature of a message. It is
-        # MessageType parameter that specifies one of the two cases. Unfortunately, at some point our code was
-        # ignoring the MessageType setting, so both types of message were getting treated the same way. Want to have
-        # a test to make sure that is no longer the case.
-        #
-        # The following string is 32 bytes, the same length as SHA256 digests we use for message signatures. So KMS
-        # accepts the string both as a plaintext message and a signature. As a result - we can use the same string as
-        # Message with different settings for MessageType to see if the outcome is different.
+    @pytest.mark.parametrize(
+        "key_spec,sign_algo",
+        [
+            ("RSA_2048", "RSASSA_PSS_SHA_256"),
+            ("RSA_2048", "RSASSA_PSS_SHA_384"),
+            ("RSA_2048", "RSASSA_PSS_SHA_512"),
+            ("RSA_4096", "RSASSA_PKCS1_V1_5_SHA_256"),
+            ("RSA_4096", "RSASSA_PKCS1_V1_5_SHA_512"),
+            ("ECC_NIST_P256", "ECDSA_SHA_256"),
+            ("ECC_NIST_P256", "ECDSA_SHA_384"),
+            ("ECC_SECG_P256K1", "ECDSA_SHA_256"),
+            ("ECC_SECG_P256K1", "ECDSA_SHA_512"),
+        ],
+    )
+    def test_sign_verify(self, kms_client, kms_create_key, key_spec, sign_algo):
+        hash_algo = get_hash_algorithm(sign_algo)
+        hasher = getattr(hashlib, hash_algo.replace("_", "").lower())
+
+        plaintext = b"test message !%$@ 1234567890"
+        digest = hasher(plaintext).digest()
+
+        key_id = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec=key_spec)["KeyId"]
+
+        kwargs = {"KeyId": key_id, "SigningAlgorithm": sign_algo}
+
+        bad_signature = kms_client.sign(MessageType="RAW", Message="bad", **kwargs)["Signature"]
+        bad_message = b"bad message 321"
+
+        # Ensure raw messages can be signed and verified
+        signature = kms_client.sign(MessageType="RAW", Message=plaintext, **kwargs)["Signature"]
+        assert kms_client.verify(
+            MessageType="RAW", Signature=signature, Message=plaintext, **kwargs
+        )["SignatureValid"]
+
+        # Ensure pre-hashed messages can be signed and verified
+        signature = kms_client.sign(MessageType="DIGEST", Message=digest, **kwargs)["Signature"]
+        assert kms_client.verify(
+            MessageType="DIGEST", Signature=signature, Message=digest, **kwargs
+        )["SignatureValid"]
+
+        # Ensure bad digest raises during signing
+        with pytest.raises(ClientError) as exc:
+            kms_client.sign(MessageType="DIGEST", Message=plaintext, **kwargs)
+        assert exc.match("ValidationException")
+
+        # Ensure bad signature raises during verify
+        with pytest.raises(ClientError) as exc:
+            kms_client.verify(
+                MessageType="RAW", Signature=bad_signature, Message=plaintext, **kwargs
+            )
+        assert exc.match("KMSInvalidSignatureException")
+
+        # Ensure bad message raises during verify
+        with pytest.raises(ClientError) as exc:
+            kms_client.verify(MessageType="RAW", Signature=signature, Message=bad_message, **kwargs)
+        assert exc.match("KMSInvalidSignatureException")
+
+        # Ensure bad digest raises during verify
+        with pytest.raises(ClientError) as exc:
+            kms_client.verify(
+                MessageType="DIGEST", Signature=signature, Message=bad_message, **kwargs
+            )
+        assert exc.match("ValidationException")
+
+    def test_invalid_key_usage(self, kms_client, kms_create_key):
+        key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec="RSA_4096")["KeyId"]
+        with pytest.raises(ClientError) as exc:
+            kms_client.sign(
+                MessageType="RAW",
+                Message="hello",
+                KeyId=key_id,
+                SigningAlgorithm="RSASSA_PSS_SHA_256",
+            )
+        assert exc.match("InvalidKeyUsageException")
+
+        key_id = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_4096")["KeyId"]
+        with pytest.raises(ClientError) as exc:
+            kms_client.encrypt(
+                MessageType="RAW",
+                Plaintext="hello",
+                KeyId=key_id,
+                EncryptionAlgorithm="RSAES_OAEP_SHA_256",
+            )
+        assert exc.match("InvalidKeyUsageException")
+
+    @pytest.mark.parametrize(
+        "key_spec,algo",
+        [
+            ("SYMMETRIC_DEFAULT", "SYMMETRIC_DEFAULT"),
+            ("RSA_2048", "RSAES_OAEP_SHA_256"),
+            ("ECC_NIST_P256", "RSAES_OAEP_SHA_1"),
+            ("ECC_SECG_P256K1", "RSAES_OAEP_SHA_256"),
+            # ("HMAC_256", "SYMMETRIC_DEFAULT"),  # currently not supported in LocalStack
+            # ("SM2", "SM2PKE"),  # currently not supported in LocalStack
+        ],
+    )
+    def test_encrypt_decrypt(self, kms_client, kms_create_key, key_spec, algo):
+        key_id = kms_create_key(KeyUsage="ENCRYPT_DECRYPT", KeySpec=key_spec)["KeyId"]
         message = b"test message 123 !%$@ 1234567890"
-        algo = "RSASSA_PSS_SHA_256" if key_type == "rsa" else "ECDSA_SHA_256"
-        kwargs = {"KeyId": key_id, "Message": message, "SigningAlgorithm": algo}
-
-        signature_for_plaintext = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
-        signature_for_digest = kms_client.sign(MessageType="DIGEST", **kwargs)["Signature"]
-        assert signature_for_plaintext != signature_for_digest
-
-        # These following blocks basically test that MessageType="DIGEST" results in a different outcome
-        # from the default MessageType="RAW". As long as both Sign and Verify are called with the same MessageType,
-        # everything should work, while if this parameter mismatches between such two calls - the verifications is
-        # supposed to fail.
-        #
-        # There is a possibility that I do not understand how digests work, so can't write better tests. If we have
-        # any issues with the digests - know that the current approach is not a calculated design, but rather a guess.
-        signature = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
-        assert kms_client.verify(MessageType="RAW", Signature=signature, **kwargs)["SignatureValid"]
-
-        signature = kms_client.sign(MessageType="RAW", **kwargs)["Signature"]
-        with pytest.raises(kms_client.exceptions.KMSInvalidSignatureException):
-            assert not kms_client.verify(MessageType="DIGEST", Signature=signature, **kwargs)[
-                "SignatureValid"
-            ]
-
-        signature = kms_client.sign(MessageType="DIGEST", **kwargs)["Signature"]
-        with pytest.raises(kms_client.exceptions.KMSInvalidSignatureException):
-            assert not kms_client.verify(MessageType="RAW", Signature=signature, **kwargs)[
-                "SignatureValid"
-            ]
-
-        signature = kms_client.sign(MessageType="DIGEST", **kwargs)["Signature"]
-        assert kms_client.verify(MessageType="DIGEST", Signature=signature, **kwargs)[
-            "SignatureValid"
-        ]
+        ciphertext = kms_client.encrypt(
+            KeyId=key_id, Plaintext=base64.b64encode(message), EncryptionAlgorithm=algo
+        )["CiphertextBlob"]
+        plaintext = kms_client.decrypt(
+            KeyId=key_id, CiphertextBlob=ciphertext, EncryptionAlgorithm=algo
+        )["Plaintext"]
+        assert base64.b64decode(plaintext) == message
 
     @pytest.mark.aws_validated
     def test_get_public_key(self, kms_client, kms_create_key):

--- a/tests/integration/test_kms.py
+++ b/tests/integration/test_kms.py
@@ -465,7 +465,6 @@ class TestKMS:
         key_id = kms_create_key(KeyUsage="SIGN_VERIFY", KeySpec="RSA_4096")["KeyId"]
         with pytest.raises(ClientError) as exc:
             kms_client.encrypt(
-                MessageType="RAW",
                 Plaintext="hello",
                 KeyId=key_id,
                 EncryptionAlgorithm="RSAES_OAEP_SHA_256",

--- a/tests/integration/test_kms.snapshot.json
+++ b/tests/integration/test_kms.snapshot.json
@@ -404,5 +404,357 @@
         }
       }
     }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[RSA_2048-RSASSA_PSS_SHA_256]": {
+    "recorded-date": "16-03-2023, 19:16:06",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/a48829a6-6127-494e-be9a-4a62a4021caa",
+        "Signature": "b'\\n\\x89\\x92\\xef\\xe3\\xd2d\\xfb\\x9a\\xc27\\x04\\xef\\x92e\\xa1\\xc9\\x86\\x919\\xb8\\xd5\\x0f\\x1d\\x1bv\\xe2\\xe5\\x13@=Ql\\x02\\xfeh\\x1dPEX*\\x93\\x05\\xe7\\xde\\xa9\\xa5\\x01\\xc3z#\\x81U\\xf1B\\xf4^\\xc6\\xb9VI\\x988\\xa4l\\x0e\\xb8\\x81\\xf4\\xb7\\xb3D\\xe3:\\xceN\"\\xd9\\xcb\\xf6\\xd6\\x1b\\xaf#\\xdf\\x14yh\\xb9\\xde RrD\\x12\\x1e\\xac\\xdewbkp\\x97\\xe7{__J\\xde\\xf5\\x9c\\xca.\\xadAg\\xe2\\xf3\\x8fPT\\x82\\x14\\x19LoW\\xc5\\xf3\\x7f\\xe3a\\x1a+\\xd6p7\\xd9\\x0c\\xa9\\xf7w\\x10<\\xef\\xdb\\xe1\\xb8\\xbc\\xed\\x82.o\\xd4h\\x1c\\xb6]\\xa20\\xe5V\\x1b\\xc3\\x1c*+r=\\xc4\\x8b\\tXp\\x91!Y^L\\xbaN\\xa7\\x97\\xd0\\xd1R\\xfb\\xd3\\xae`\\xa7\\x993[\\xfa\\xd5\\x8c_J\\xcak\\xab\\xbew\\xa6\\x88\\xb6B\\x90(vG\\x14\\x1b \\r\\xf9\\xdd\\xe0B\\xd5KJ/\\xa2\\xa0[\\r\\xfc\\x97\\xfe\\xb6\\xee0\\x89\\x8e\\x94\\xc4,i\\xc60\\x01]E\\xfd\\xf7\\x93i\\x17ois\\xbeZ&'",
+        "SigningAlgorithm": "RSASSA_PSS_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/a48829a6-6127-494e-be9a-4a62a4021caa",
+        "SignatureValid": true,
+        "SigningAlgorithm": "RSASSA_PSS_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm RSASSA_PSS_SHA_256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[RSA_2048-RSASSA_PSS_SHA_384]": {
+    "recorded-date": "16-03-2023, 19:16:11",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/61a7c49e-2004-4c31-bcf4-bd819d31440a",
+        "Signature": "b'\\x97;\\x90\\xff\\xe5\\x99\\n)gH\\xb9_bin\\r\\x9c\\xb9d\\x86\\x85\\x03=\\xb2\\x1b\\x87\\xb7\\xaa:\\x92)\\x82K/\\x926\\xbb\\x7f\\xfd\\t\\xc0 \\r\\xa8\\x95\\xc9\\xca\\x86\\x8ct\\'\\x7f&\\xb5\\xa8k\\x89\\xfa\\xa1\\xe6\\x8d\\xf7\\x98\\xa3OS\\x15\\xfc\\xcb\\xad\\x05\\x19\\xae\\x99\\xd2xn;\\xb5\\xc6Xj\\x9e9\\xfbGW\\x85\\xb3\\xe8)\\xde\\x1aF\\x13>&}2\\x94\\xe8\\x0c\\xdc\\xa0\\x074\\xad\\xebGY\\xf2\\xacPra\\xbb#\\x1c\\xd0y\\x15\\n\\xfb$%\\xe1\\x81-\\xf5\"\\xe1\\xfb\\x88)sd\\x8e\\xcc\\x15<Z\\x1e0\\x14\\x1e\\x89|b/VG\\xbb\\t\\xa5\\xf1GR\\x91F\\x94L\\x95\\x90\\x19\\xb3H\\x9c]\\xb1\\'\\x1c\\x84\\xa3\\x1a0^8\\x9al\\xc4>\\x89\\xddT=*\\xd4\\xe1\\x94\\xdd\\x07E\\xc9\\xedh\\xc3\\xe6/84\\x90u\\x83\\xbf\\xa3SZ\\x89\\xbba8\\x01`\\xfeO\\rq\\xc9\\x89s\\x9a\\x06\\x82w\\x03\\x90]\\x8e\\xd8~\\x04\\x19Q\\xf3\\x1d\\xa7\\xef\\x1b\\x1c\\xa8\\xadB*\\x11\\xf2W\\x0c\\x0c\\x13\\xe0\\x1f0\\x03\\x93\\xb8\\xd7'",
+        "SigningAlgorithm": "RSASSA_PSS_SHA_384",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/61a7c49e-2004-4c31-bcf4-bd819d31440a",
+        "SignatureValid": true,
+        "SigningAlgorithm": "RSASSA_PSS_SHA_384",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm RSASSA_PSS_SHA_384."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[RSA_2048-RSASSA_PSS_SHA_512]": {
+    "recorded-date": "16-03-2023, 19:16:17",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/06b4c944-ad4a-4908-9bbd-ae04a2a6e7b5",
+        "Signature": "b'=\"h\\x0c\\xa3L\\xae\\xe7\\xf6\\xe7\\xf4e\\x0f\\\\\\'\\x8c\\xaa)5\\xd1\\xdb^\\xa7Gd\\xd3\\xb3\\x88A\\xdc\\xbb\\xf9\\xa1\\x16\\xfd\\x94\\xbar\\xd8\\x80\\xeaw\\xfb#\\x9b\\xa6\\xad\\xe2\\x98*\\x19\\x18\\xd7F\\xc4\\x14\\xa3\\xde\\x1ej\\xf7\\x1bV\\x9b\\xf2G1W_\\x84\\x8e*\\x02,\\xd2\"\\x93\\x1f2\\x9cD\\x99\\x02=g\\xd9p\\x83\\xd8\\xac]\\x97\\xba\\xd4\\'Xw\\x9f+\\xd5\\xd3\\xfd\\xc6\\x99\\'\\xac.\\xcfd`\\x83>X\\x92\\xf8\\x03=I\\xa3\\x86\\x99\\x86\\x98f`\\xfd\\x9d*\\x1a\\xd7c<\\x8a\\xee\\x90\\xd0\\xf0\\xd1@\\xda8\\x9d\\xa7 *{\\xa7\\xd9\\x87pQ\\xf6\\xfc\\xd5\\xfb4\\xfe\\xc5\\x0f\\xef\\xc0*\\xb8\\x83\\xe1\\xda\\xdaG\\xb0)\\x18\\xf3b\\xe3B\\xa8\\xd6\\x04\\xdd\\xc4}\\xf5\\x03\\xde\\x16jz\\xdch7\\xb6k\\xbf\\xb3\\xd3\\xac\\xe7\\xab\\xf4j\\xbb\\x8b\\x92v7\\xca\\xb7\\xadu\\x9cF\\xec\\xb3r}\\xe4\\xff\\x1c%\\xd3\\x9a\\x1c[\\xf3\\xa2\\xc1\\xf5\\xee\\x18\\t\\xb4\\xde\\xf5\\xcc\\x8cc\\xc3\\x86f5>&\\xc7\\xcb\\x16\\xb9\\xbfR6:\\x01\\xb7\\x83\\xcc\\xe3w'",
+        "SigningAlgorithm": "RSASSA_PSS_SHA_512",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/06b4c944-ad4a-4908-9bbd-ae04a2a6e7b5",
+        "SignatureValid": true,
+        "SigningAlgorithm": "RSASSA_PSS_SHA_512",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm RSASSA_PSS_SHA_512."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[RSA_4096-RSASSA_PKCS1_V1_5_SHA_256]": {
+    "recorded-date": "16-03-2023, 19:16:22",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/5a258bda-6cc5-4028-9c1d-f75335874b66",
+        "Signature": "b\"\\x90\\xf6\\xf7\\xac~W\\x0c\\x9d\\xb5\\x1e\\x9f#D\\x86\\xf1\\xbe+\\x96\\x06\\xac\\xd7\\xe5\\xd5\\x9d\\xbe\\xc5\\xf84m)D#f\\xd8#\\x9e\\x14\\xef\\x1f\\xfe\\xfc\\x9fq\\xb3\\xc8\\xbb-\\x07\\xcd\\x84kq-V\\xcd\\x8eq(\\xf9\\xb3S\\x11\\xff\\xf35\\x8e1\\xa6\\xaeW[W\\xc3j%\\x0c\\xf0\\xa0\\xe1\\xe5amr\\xc2&\\x05\\xa5\\xdc\\xc3\\x96\\xceCM\\x0b\\xca\\xed6\\xeaB\\x91\\xbc \\xf8Ri\\xbc\\x1f2l-\\x0e\\xb3\\xaa>@D8\\xe2A\\xbd\\x19\\x02\\xf9\\x13\\xa5\\x94U\\xa4\\r\\xdd\\xea\\xa0\\x9d@5\\x8a\\xcb\\xc9\\x98\\x96\\x16B\\xd1R\\x9d%\\x9e\\xb9&<\\xbc\\xd9\\xe0@K\\x7f\\x04\\xf1l\\xb6$1S\\xc0\\xb7g,A\\x86uzN\\x01\\xe6f\\x8b\\xc7\\xc8g\\x91!Qv\\xe7\\x07\\xbcc=G\\xb5<{\\x8c\\x0e\\x13\\xdb}\\xa7\\xfbk&\\xd7\\x08\\xd1\\xd0l\\xdc\\x89U\\xfd\\xa2\\xf8v\\x84\\xf0\\xf3\\x0e\\x1d\\xdfY\\xe9C]I\\x93\\xb7\\xd4\\xd5!\\x99\\x04\\xf8\\xb6#\\xaf\\x86\\xd4\\xd8\\x05\\x1ek\\x19\\x9a8\\x02\\xb31\\x15\\x07\\xeePI\\xba3\\xf9\\xdck\\x11:b\\xf4\\x90K\\x14\\x12\\xa5\\xaf\\xa3\\x9b\\x8an-\\xcc\\x1flsJn}\\x13\\\\\\x94\\xe6\\xe6\\x99\\xd8\\x97^\\xd8\\xc6\\xb4\\xf6QO\\xf9\\xeb\\t\\xc3\\xe6`\\xbdYu0\\x01\\x9a]\\xa1\\x0e\\xf7O\\xc9!\\x9a\\x0catT\\x05\\xe8\\xb0\\x9f\\xdd\\x87Ed_-^W\\xdc\\xe1\\xf9I\\xf5\\xd7\\x9e\\xa3\\x04\\x14v\\x8d\\x8fY\\xa9\\xf8\\xe2\\xbc\\xda\\xf9#\\x9fM\\x9c/\\xc0\\xf7\\xc8\\xb7\\tx\\x02\\xef\\x82\\x1b\\x0c8P\\xea\\x12-\\xea\\xdb!(\\x993\\x06\\xb8\\xc3\\x8f0\\xeb\\xbf\\xa7[\\x95\\xb5\\xdf\\x05\\x11QY%,\\xac2\\x90t\\xdd\\xbef+'\\xabu\\xa5\\xc0\\xfb3\\x90\\xd6\\xb4.\\xb1\\x9d;\\x97\\xab\\x01Z*\\xeb\\xf1\\x89&fZz\\xd3C\\xc3\\xae\\xf8BJ\\xc5OO\\x90\\xa8f(\\xc5\\x01\\xcd\\xe4^!?\\x93\\xc25h[\\xdf\\xff\\x9bc\\xbb\\x02\\xaaW9\\x8f\\xc7\\xe5\\xcd\\xea\\xdb\\x11\\x00\\x10\\xc4^\\xe0\\x7fY\\x85L\\x18\\xd4&\\xa9\\x93\\xb8\\xf1\\xd1\\xf0B\\xcf\\x80\\x1aP\\x96\\x01\\xb3\\xbf!\\x87\\n\\xe1/\\x98~\\xf3\\xab\\x0bv\\x86\\xa3(\"",
+        "SigningAlgorithm": "RSASSA_PKCS1_V1_5_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/5a258bda-6cc5-4028-9c1d-f75335874b66",
+        "SignatureValid": true,
+        "SigningAlgorithm": "RSASSA_PKCS1_V1_5_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm RSASSA_PKCS1_V1_5_SHA_256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[RSA_4096-RSASSA_PKCS1_V1_5_SHA_512]": {
+    "recorded-date": "16-03-2023, 19:16:27",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/eff26b7e-b63b-4018-8cc8-a8939720aaa5",
+        "Signature": "b'Ge\\x16\\x1c\\xa4?\\xa3\\xdf\\x04\\x97\\xe3~\\xdd9dU\\x0fk\\\\\\n\\xed\\xa4\\x16\\x0b\\xde\\xbb\\xebR\\xcf>\\xe3\\x8fkk\\xb4d\\xcf\\xc7\\xa2\\xc6KKJ\\xff.R\\x07\\xb0\\xa1\\xdf\\xf7\\x9d\\xae\\x04\\xc5\\x7f`\\'{\\xad\\xf2\\xb0\\xce`\\x01\\xa8\\x17\\xe6?\\xc89\\xd6\\xe1[\\x9b>\\xc4\\x92\\xeah\\x02a\\x17}/\\xc0\\xbd%V\\xeb\\x1c\\x02-\\xf6T\\x80/\\xf0\\xacq\\xe9e\\x90\\xef\\xfe/d\\x11\\xe2G\\xd8\\x0c\\x8bf\\x84n\\xa2\\xfcx\\r\\n\\xd1K\\xcd\\x953\\x04V\\xe4\\xfbJ|\\xb0\\x83\\xbbM\\xca\\xe4\\x0c\\x9aw\\x1aE\\x98\\x1e\\x07!\\xeeA&]:vU}\\xcd$\\xfa\\x13\\xb6jju\\xe7\\x87\\xe3p(\\x00\\x1eJ\\xc1\\x01\\xcd\\x1a\\xfb\\x9c0\\xae\\xdd\\xe0\\xc6j\\x8cc\\xe3\\xb69\\xd2:\\xf7\\xbc\\xc0K/8\\x800/\\xef\\x15\\x08\\xe7\\x91w\\x1a\\x1d\\xfc\\xd8\\x8e+u%=ow\\x04\\x870v\\xb4\\xc4.\\xc9\\xe5\\xb9\\xd3o\\xc0\\x86d\\x90\\x03\\x81\\xa5\\xb1\\xec/\\xb6\\xb9\\x18\\xc6\\x05\\xb1\\xbb\\x00c\\xb6\\xe9\\x87l\\xc1E\\xa2\\'\\xbb\\x052L\\xeap7g\\x82\\x91\\xffT\\xb8\\x1c\\xc4kfY\\xe1\\x96/\\x7fl\\x9d\\xc8=2\\xad\\xe3\\xdd\\xf9sQ\\x85\\x17i\\xb2\\xac\\xad5i\\xc6\\xf6-=}\\xb1\\x9a\\xea\\xf0&\\xcc>\\xfb_\\x9fJ\\x03\\x90\\xbd\\x1a\\xf3\\xe2\\x1f#\\x8a\\xa5\\x85\\x88\\x8e\\xee\\xa7\\xac\\x11\\xa7\\xa9\\xbf\\xc6\\xa1\\xc7\\xa2\\x14F\\xc0\\x08\\xb4\\x9aN+\\ny\\x059/\\x12!q\\xb3d\\x83p\\x81\\x02e\\xca\\x1b\\xff\\x881\\x84\\x9a\\x91:\\nS\"\\xc1i\\x95\\x0cG\\xcc\\xb19\\xe8\\xd98\\xa5\\xbce\"\\x1eu\\x83W\\x96\\x9d\\xe2.\\xc6bB\\xb0\\xd8\\xee<g\\x0c N\\xaf\\xb5l\\x1e$N\\x8a\\xcdy G\\x01z\\x0f\\xc6\\xaa\\xfa\\xf8\\xf3\\x87\\x17\\x1b\\xdcG\\xcc\\xe0;\\x07\\x15\\x01\\xd0JZ\\x92\\t\\xe4^\\x01H\\x88\\x01\\xd6,!\\x9a]\\xd0C\\xbf\\xdcwW\\x141\\xec\\xb7\\x92\\xbd\\xf7\\xab\\x85\\x87\\xcd\\xadd\\x89\\xff\\xc7Wi0\\x04\\xfd\\x1c\\xc2\\xe30\\xe7\\xe9\\xd2\\x0b^`\\x88\\xb2\\x16e\\xac\\xe8\\x07\\x01\\xb0\\x00[K\\xdbI\\xb5Aq\\x06\\xe8\\xbc\\xc3x\\x8d+'",
+        "SigningAlgorithm": "RSASSA_PKCS1_V1_5_SHA_512",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/eff26b7e-b63b-4018-8cc8-a8939720aaa5",
+        "SignatureValid": true,
+        "SigningAlgorithm": "RSASSA_PKCS1_V1_5_SHA_512",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm RSASSA_PKCS1_V1_5_SHA_512."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P256-ECDSA_SHA_256]": {
+    "recorded-date": "16-03-2023, 19:16:32",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/96221c2a-786a-492b-a529-a7c8e369855a",
+        "Signature": "b'0D\\x02 4$#\\xd4\\x01-\\xa6\\xc6j;\\x85\\x84\\\\\\xe0\\xd3\\x99+\\x9f\\xacC\\xd9\\xc2$\\xd0\\x02B\\x07\\x9d\\x00\\xb7\\x02\\x06\\x02 _>=\\x9aSIbB\\x9f\\xc1\\xd5\\x9c\\x17\\xec\\x1d\\xdc\\xb4\\xfc\\x99K\\xae\\x97\\x83@\\xb3\\xe1\\x01\\xa1\\xcaK\\x9f\\xc9'",
+        "SigningAlgorithm": "ECDSA_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/96221c2a-786a-492b-a529-a7c8e369855a",
+        "SignatureValid": true,
+        "SigningAlgorithm": "ECDSA_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm ECDSA_SHA_256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P256-ECDSA_SHA_384]": {
+    "recorded-date": "16-03-2023, 18:57:59",
+    "recorded-content": {}
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_SECG_P256K1-ECDSA_SHA_256]": {
+    "recorded-date": "16-03-2023, 19:16:44",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/cea25e34-9edd-45d0-9afb-2731d9b16a53",
+        "Signature": "b'0E\\x02!\\x00\\xf1\\x18\\xa3\\x87\\xc3\\xf9\\xa9\\xadQ}\\xcb\\xa6c\\x044\\x92\\x15f\\xa4\\x002\\xb3D\\x03\\x84\\xd4mK\\xde\\xfcM\\x17\\x02 KC\\xae\\xec\\x92.\\x18\\x93=\\xc3\\x04\\xa4O\\xf6\\n\\xb5l%\\x13sp\\x82`\\x00\\xe3\\xc6\\xb2?\\xa0\\xd1\\xdb\\x01'",
+        "SigningAlgorithm": "ECDSA_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/cea25e34-9edd-45d0-9afb-2731d9b16a53",
+        "SignatureValid": true,
+        "SigningAlgorithm": "ECDSA_SHA_256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm ECDSA_SHA_256."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_SECG_P256K1-ECDSA_SHA_512]": {
+    "recorded-date": "16-03-2023, 18:58:07",
+    "recorded-content": {}
+  },
+  "tests/integration/test_kms.py::TestKMS::test_sign_verify[ECC_NIST_P384-ECDSA_SHA_384]": {
+    "recorded-date": "16-03-2023, 19:16:39",
+    "recorded-content": {
+      "signature": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/ac2cd4e4-ec13-448a-b48f-a92ec5efe59e",
+        "Signature": "b'0e\\x020p\\xdc\\xb9\\xa3\\xec=6_V\\x86\\x0e\\xcd\\xd1\\x10\\x9az\\xb2:\\xc5\\xd6\\xfd\\xc2\\xdc\\xf1\\x06\\xf8pS\\xc6\\x1c\\xb4\\xcf\\xd1\\xd5<\\xcbA%\\xb7{\\x10\\xd9\\x17\\xdd\\xb1\"\\xfe\\x98\\x021\\x00\\xe8c\\xe9\\x92\\x10?\\xe6\\x83\\xa7\\xe1\\x0e\\xae\\xf4\\x89<\\x0f\\x9eq\\xb3L\\xabz\\x15\\x11DX\\x7f\\xbc\\x0bx\\x84\\xf7\\x17\\xc19q\\xdc\\xba\\xa3r\\x88\\x1a\\xa9\\xa7\\xb9j\\xc9\\xc3'",
+        "SigningAlgorithm": "ECDSA_SHA_384",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "verification": {
+        "KeyId": "arn:aws:kms:<region>:111111111111:key/ac2cd4e4-ec13-448a-b48f-a92ec5efe59e",
+        "SignatureValid": true,
+        "SigningAlgorithm": "ECDSA_SHA_384",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "bad-digest": {
+        "Error": {
+          "Code": "ValidationException",
+          "Message": "Digest is invalid length for algorithm ECDSA_SHA_384."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      },
+      "bad-signature": {
+        "Error": {
+          "Code": "KMSInvalidSignatureException",
+          "Message": ""
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR is based on investigation done by @paullallier in https://github.com/localstack/localstack/issues/6815#issuecomment-1458573903

LocalStack KMS Sign and Verify operations were double hashing the message payloads. This PR reworks these operations to rely on `cryptography` to perform hashing if required based on the value of `MessageType` argument.

The integration tests are also refactored to make the correct assertions.

Also checked that signatures produced by KMS:Sign can be correctly verified with OpenSSL (i.e. outside of the KMS:Verify operation).
```
$ cat msg.txt
hello world

$ awslocal kms create-key --key-spec RSA_4096 --key-usage SIGN_VERIFY

{
    "KeyMetadata": {
        "AWSAccountId": "000000000000",
        "KeyId": "54ec6e0d-7356-4b08-897c-26eb7b134939",
        "Arn": "arn:aws:kms:us-east-1:000000000000:key/54ec6e0d-7356-4b08-897c-26eb7b134939",
        "CreationDate": "2023-03-15T23:06:05.913720+05:30",
        "Enabled": true,
        "Description": "",
        "KeyUsage": "SIGN_VERIFY",
        "KeyState": "Enabled",
        "Origin": "AWS_KMS",
        "KeyManager": "CUSTOMER",
        "CustomerMasterKeySpec": "RSA_4096",
        "KeySpec": "RSA_4096",
        "SigningAlgorithms": [
            "RSASSA_PKCS1_V1_5_SHA_256",
            "RSASSA_PKCS1_V1_5_SHA_384",
            "RSASSA_PKCS1_V1_5_SHA_512",
            "RSASSA_PSS_SHA_256",
            "RSASSA_PSS_SHA_384",
            "RSASSA_PSS_SHA_512"
        ],
        "MultiRegion": false
    }
}

$ awslocal kms get-public-key --key-id 54ec6e0d-7356-4b08-897c-26eb7b134939 --output text --query PublicKey | base64 -d > pubkey.der

$ openssl rsa -pubin -inform DER     -outform PEM -in pubkey.der     -pubout -out pubkey.pem
writing RSA key

$ awslocal kms sign --key-id 54ec6e0d-7356-4b08-897c-26eb7b134939 --message-type RAW --message fileb://msg.txt --signing-algorithm RSASSA_PKCS1_V1_5_SHA_512 --output text --query Signature | base64 -d > sig.sig

$ openssl dgst -sha512     -verify pubkey.pem     -signature sig.sig msg.txt
Verified OK
```

Supersedes https://github.com/localstack/localstack/pull/7817

Fixes https://github.com/localstack/localstack/issues/6815, https://github.com/localstack/localstack/issues/7158