### PR TITLE
fix scheduler start/stop for persistence

### DIFF
--- a/localstack/services/cloudwatch/alarm_scheduler.py
+++ b/localstack/services/cloudwatch/alarm_scheduler.py
@@ -37,7 +37,7 @@ class AlarmScheduler:
         """
         super().__init__()
         self.scheduler = Scheduler()
-        self.thread = threading.Thread(target=self.scheduler.run)
+        self.thread = threading.Thread(target=self.scheduler.run, name="cloudwatch-scheduler")
         self.thread.start()
         self.scheduled_alarms = {}
 


### PR DESCRIPTION
CloudWatch is using a scheduler, that should check if an alarm state should change periodically.

* The scheduler should be restarted and check all existing metric-alarms for the `on_*_load` scenario.
* The scheduler should also be restarted for the `on_*_reset` scenario
