### PR TITLE
remove use of LEGACY_EDGE_PROXY

### DIFF
--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -354,14 +354,9 @@ def is_trace_logging_enabled(headers) -> bool:
 
 
 def do_start_edge(bind_address, port, use_ssl, asynchronous=False):
-    if config.LEGACY_EDGE_PROXY:
-        serve = do_start_edge_proxy
-    else:
-        from localstack.aws.serving.edge import serve_gateway
+    from localstack.aws.serving.edge import serve_gateway
 
-        serve = serve_gateway
-
-    return serve(bind_address, port, use_ssl, asynchronous)
+    return serve_gateway(bind_address, port, use_ssl, asynchronous)
 
 
 def do_start_edge_proxy(bind_address, port, use_ssl, asynchronous=False):

--- a/localstack/services/s3/s3_listener.py
+++ b/localstack/services/s3/s3_listener.py
@@ -183,10 +183,6 @@ class BackendState:
         backend = get_s3_backend()
         bucket = backend.buckets.get(bucket_name)
         if not bucket:
-            # note: adding a switch here to be able to handle both, moto's MissingBucket with the
-            # legacy edge proxy, as well as our custom CommonServiceException with the new Gateway.
-            if config.LEGACY_EDGE_PROXY:
-                raise MissingBucket()
             raise NoSuchBucket()
         return bucket
 

--- a/localstack/services/s3/s3_starter.py
+++ b/localstack/services/s3/s3_starter.py
@@ -82,8 +82,7 @@ def start_s3(port=None, backend_port=None, asynchronous=None, update_listener=No
 
     apply_patches()
 
-    if not config.LEGACY_EDGE_PROXY:
-        add_gateway_compatibility_handlers()
+    add_gateway_compatibility_handlers()
 
     return start_moto_server(
         key="s3",


### PR DESCRIPTION
This PR removes the immediate use of the `LEGACY_EDGE_PROXY` config flag. Dead code removal can happen at a later point.