### PR TITLE
add ListBuckets into general CORS handling

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -118,6 +118,10 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
     if context.service:
         service_name = context.service.service_name
         if not config.DISABLE_CUSTOM_CORS_S3 and service_name == "s3":
+            # ListBuckets is not concerned by S3 CORS handling, it should follow general LocalStack CORS rules.
+            # we can also check if the path is "/", no need for operation
+            if context.operation and context.operation.name == "ListBuckets":
+                return True
             return False
         if not config.DISABLE_CUSTOM_CORS_APIGATEWAY and service_name == "apigateway":
             is_user_request = (

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -186,10 +186,6 @@ def legacy_rules(request: Request) -> Optional[str]:
 
     # TODO The remaining rules here are special S3 rules - needs to be discussed how these should be handled.
     #      Some are similar to other rules and not that greedy, others are nearly general fallbacks.
-    # This is ListBuckets, at the root path
-    if path == "/":
-        return "s3"
-
     stripped = path.strip("/")
     if method in ["GET", "HEAD"] and stripped:
         # assume that this is an S3 GET request with URL path `/<bucket>/<key ...>`

--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -186,6 +186,10 @@ def legacy_rules(request: Request) -> Optional[str]:
 
     # TODO The remaining rules here are special S3 rules - needs to be discussed how these should be handled.
     #      Some are similar to other rules and not that greedy, others are nearly general fallbacks.
+    # This is ListBuckets, at the root path
+    if path == "/":
+        return "s3"
+
     stripped = path.strip("/")
     if method in ["GET", "HEAD"] and stripped:
         # assume that this is an S3 GET request with URL path `/<bucket>/<key ...>`

--- a/tests/integration/s3/test_s3_cors.py
+++ b/tests/integration/s3/test_s3_cors.py
@@ -126,7 +126,6 @@ class TestS3Cors:
         body = "cors-test"
         response = s3_client.put_object(Bucket=s3_bucket, Key=key, Body=body, ACL="public-read")
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-
         key_url = f"{_bucket_url_vhost(bucket_name=s3_bucket)}/{key}"
         origin = ALLOWED_CORS_ORIGINS[0]
 
@@ -140,6 +139,26 @@ class TestS3Cors:
         assert response.status_code == 200
         assert response.text == body
         assert response.headers["Access-Control-Allow-Origin"] == origin
+
+    @pytest.mark.only_localstack
+    def test_cors_list_buckets(self):
+        # ListBuckets is an operation outside S3 CORS configuration management
+        # it should follow the default rules of LocalStack
+
+        url = f"{config.get_edge_url()}/"
+        origin = ALLOWED_CORS_ORIGINS[0]
+
+        response = requests.options(
+            url, headers={"Origin": origin, "Access-Control-Request-Method": "GET"}
+        )
+        assert response.ok
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+
+        response = requests.get(url, headers={"Origin": origin})
+        assert response.status_code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == origin
+        # assert that we're getting ListBuckets result
+        assert b"<ListAllMyBuckets" in response.content
 
     @pytest.mark.aws_validated
     def test_cors_http_options_non_existent_bucket(self, s3_client, s3_bucket, snapshot):


### PR DESCRIPTION
Currently in the process of trying to create some sample concerning CORS configuration of S3, and making a small sample allowing people to create their own CORS rules for their bucket but still allowing the `app.localstack.cloud` / resource browser to access it, I've encountered an issue with the `ListBuckets` operation. 

S3 is a "self-managed" CORS service, as it can manage the CORS setting of its buckets. However, the `ListBuckets` operation is not configurable, and should be using the default CORS setting of LocalStack. I've added a check in our general CORS handler to not skip setting CORS headers if the operation is `ListBuckets`. 

While creating the test, I've also found that if you try to access `http://localhost:4566`, it should return `ListBuckets`, but our service name parser does not recognise the request as it's not signed.
Funnily, in AWS, if you do the same and try to access `s3.amazonaws.com` which is the default URL for `ListBuckets` in `us-east-1` without signing the request, you get redirected to https://aws.amazon.com/s3/.

If you use `s3.localhost.localstack.cloud` without signing the request, you'll get the response for `ListBuckets` because of the host matching.
Should we match on the path being `/` as a sign of an S3 request?
