### PR TITLE
Add lambda config to ignore architecture

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -645,6 +645,10 @@ LAMBDA_DOCKER_DNS = os.environ.get("LAMBDA_DOCKER_DNS", "").strip()
 # additional flags passed to Lambda Docker run/create commands
 LAMBDA_DOCKER_FLAGS = os.environ.get("LAMBDA_DOCKER_FLAGS", "").strip()
 
+# Enable this flag to run cross-platform compatible lambda functions natively (i.e., Docker selects architecture) and
+# ignore the AWS architectures (i.e., x86_64, arm64) configured for the lambda function.
+LAMBDA_IGNORE_ARCHITECTURE = is_env_true("LAMBDA_IGNORE_ARCHITECTURE")
+
 # prebuild images before execution? Increased cold start time on the tradeoff of increased time until lambda is ACTIVE
 LAMBDA_PREBUILD_IMAGES = is_env_true("LAMBDA_PREBUILD_IMAGES")
 

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -64,15 +64,17 @@ ARCHITECTURE_PLATFORM_MAPPING: dict[Architecture, DockerPlatform] = dict(
 )
 
 
-def docker_platform(lambda_architecture: Architecture) -> DockerPlatform:
+def docker_platform(lambda_architecture: Architecture) -> DockerPlatform | None:
     """
     Convert an AWS Lambda architecture into a Docker platform flag. Examples:
     * docker_platform("x86_64") == "linux/amd64"
     * docker_platform("arm64") == "linux/arm64"
 
     :param lambda_architecture: the instruction set that the function supports
-    :return: Docker platform in the format ``os[/arch[/variant]]``
+    :return: Docker platform in the format ``os[/arch[/variant]]`` or None if configured to ignore the architecture
     """
+    if config.LAMBDA_IGNORE_ARCHITECTURE:
+        return None
     return ARCHITECTURE_PLATFORM_MAPPING[lambda_architecture]
 
 

--- a/localstack/services/awslambda/invocation/docker_runtime_executor.py
+++ b/localstack/services/awslambda/invocation/docker_runtime_executor.py
@@ -50,7 +50,7 @@ COPY aws-lambda-rie {rapid_entrypoint}
 COPY code/ /var/task
 """
 
-PULLED_IMAGES: set[str] = set()
+PULLED_IMAGES: set[(str, DockerPlatform)] = set()
 
 HOT_RELOADING_ENV_VARIABLE = "LOCALSTACK_HOT_RELOADING_PATHS"
 
@@ -380,9 +380,11 @@ class DockerRuntimeExecutor(RuntimeExecutor):
         if function_version.config.code:
             function_version.config.code.prepare_for_execution()
             image_name = resolver.get_image_for_runtime(function_version.config.runtime)
-            if image_name not in PULLED_IMAGES:
-                CONTAINER_CLIENT.pull_image(image_name)
-                PULLED_IMAGES.add(image_name)
+            platform = docker_platform(function_version.config.architectures[0])
+            # Pull image for a given platform upon function creation such that invocations do not time out.
+            if (image_name, platform) not in PULLED_IMAGES:
+                CONTAINER_CLIENT.pull_image(image_name, platform)
+                PULLED_IMAGES.add((image_name, platform))
             if config.LAMBDA_PREBUILD_IMAGES:
                 target_path = function_version.config.code.get_unzipped_code_location()
                 prepare_image(target_path, function_version)

--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-import platform
 from typing import Literal
 
 from localstack.utils.common import to_str
@@ -127,7 +126,3 @@ def is_new_provider():
     return os.environ.get("TEST_TARGET") != "AWS_CLOUD" and os.environ.get(
         "PROVIDER_OVERRIDE_LAMBDA"
     ) in ["asf", "v2"]
-
-
-def is_arm_compatible():
-    return platform.machine() == "arm64"

--- a/localstack/testing/aws/lambda_utils.py
+++ b/localstack/testing/aws/lambda_utils.py
@@ -2,6 +2,7 @@ import json
 import os
 from typing import Literal
 
+from localstack.services.awslambda.lambda_api import use_docker
 from localstack.utils.common import to_str
 from localstack.utils.sync import ShortCircuitWaitException, retry
 from localstack.utils.testutil import get_lambda_log_events
@@ -114,6 +115,14 @@ def _get_lambda_invocation_events(logs_client, function_name, expected_num_event
         return events
 
     return retry(get_events, retries=retries, sleep_before=2)
+
+
+def is_old_local_executor() -> bool:
+    """Returns True if running in local executor mode and False otherwise.
+    The new provider ignores the LAMBDA_EXECUTOR flag and `not use_docker()` covers the fallback case if
+    the Docker socket is not available.
+    """
+    return is_old_provider() and not use_docker()
 
 
 def is_old_provider():

--- a/localstack/utils/platform.py
+++ b/localstack/utils/platform.py
@@ -28,14 +28,21 @@ def is_redhat() -> bool:
     return "rhel" in load_file("/etc/os-release", "")
 
 
+class Arch(str):
+    """LocalStack standardised machine architecture names"""
+
+    amd64 = "amd64"
+    arm64 = "arm64"
+
+
 def standardized_arch(arch: str):
     """
     Returns LocalStack standardised machine architecture name.
     """
     if arch == "x86_64":
-        return "amd64"
+        return Arch.amd64
     if arch == "aarch64":
-        return "arm64"
+        return Arch.arm64
     return arch
 
 
@@ -45,6 +52,11 @@ def get_arch() -> str:
     """
     arch = platform.machine()
     return standardized_arch(arch)
+
+
+def is_arm_compatible() -> bool:
+    """Returns true if the current machine is compatible with ARM instructions and false otherwise."""
+    return get_arch() == Arch.arm64
 
 
 def get_os() -> str:

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -16,7 +16,6 @@ from localstack.services.awslambda.lambda_api import use_docker
 from localstack.testing.aws.lambda_utils import (
     concurrency_update_done,
     get_invoke_init_type,
-    is_arm_compatible,
     is_old_provider,
     update_done,
 )
@@ -27,7 +26,7 @@ from localstack.testing.snapshots.transformer_utility import PATTERN_UUID
 from localstack.utils import files, platform, testutil
 from localstack.utils.files import load_file
 from localstack.utils.http import safe_requests
-from localstack.utils.platform import standardized_arch
+from localstack.utils.platform import is_arm_compatible, standardized_arch
 from localstack.utils.strings import short_uid, to_bytes, to_str
 from localstack.utils.sync import retry, wait_until
 from localstack.utils.testutil import create_lambda_archive

--- a/tests/integration/awslambda/test_lambda.py
+++ b/tests/integration/awslambda/test_lambda.py
@@ -16,6 +16,7 @@ from localstack.services.awslambda.lambda_api import use_docker
 from localstack.testing.aws.lambda_utils import (
     concurrency_update_done,
     get_invoke_init_type,
+    is_old_local_executor,
     is_old_provider,
     update_done,
 )
@@ -380,8 +381,8 @@ class TestLambdaBehavior:
 
     @pytest.mark.skipif(is_old_provider(), reason="unsupported in old provider")
     @pytest.mark.skipif(
-        not use_docker(),
-        reason="Monkeypatching of Docker-related flag not applicable if run locally",
+        is_old_local_executor(),
+        reason="Monkey-patching of Docker flags is not applicable because no new container is spawned",
     )
     @pytest.mark.only_localstack
     def test_ignore_architecture(


### PR DESCRIPTION
Add an environment variable `LAMBDA_IGNORE_ARCHITECTURE` to ignore the architecture (i.e., x86_64 or arm64) of a Lambda function and let Docker select a matching image based on the host operating system and architecture.

## Motivation

* Improve performance by natively running cross-platform compatible lambda functions.
* Facilitate cross-platform testing with different test runners. We might need to introduce pytest markers to indicate compatibility restrictions (e.g., `amd64_only` and `arm64_only`).

## Further changes

* Use standardized `get_arch()` to match `aarch64` platform on Linux
* Move `is_arm_compatible()` to platform utils
* Make the `PULLED_IMAGES` cache platform-aware to prevent running into timeouts upon invocation
