### PR TITLE
Configure cosmetic and functional variables with LOCALSTACK_HOST and GATEWAY_LISTEN

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -317,10 +317,15 @@ DEFAULT_REGION = (
 )
 
 # expose services on a specific host externally
+# DEPRECATED:  since v2.0.0 as we are moving to LOCALSTACK_HOST
 HOSTNAME_EXTERNAL = os.environ.get("HOSTNAME_EXTERNAL", "").strip() or LOCALHOST
 
 # name of the host under which the LocalStack services are available
+# DEPRECATED: if the user sets this since v2.0.0 as we are moving to LOCALSTACK_HOST
 LOCALSTACK_HOSTNAME = os.environ.get("LOCALSTACK_HOSTNAME", "").strip() or LOCALHOST
+
+# configuration of hostnames the user can use to access LocalStack
+LOCALSTACK_HOST = os.environ.get("LOCALSTACK_HOST")
 
 # directory for persisting data (TODO: deprecated, simply use PERSISTENCE=1)
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -433,7 +433,6 @@ def populate_legacy_edge_configuration(
     # populate LOCALSTACK_HOST first since EDGE_BIND may be derived from LOCALSTACK_HOST
     localstack_host = localstack_host_raw
     if localstack_host is None:
-        localstack_host = f"{default_ip}:4566"
         localstack_host = f"{constants.LOCALHOST_HOSTNAME}:{constants.DEFAULT_PORT_EDGE}"
 
     def parse_edge_bind(value: str) -> str:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -454,13 +454,8 @@ def populate_legacy_edge_configuration(
         port = int(localstack_host.split(":")[-1])
         edge_bind = f"{default_ip}:{port}"
     else:
-        if "," in edge_bind:
-            components = edge_bind.split(",")
-            edge_bind = ",".join([parse_edge_bind(component.strip()) for component in components])
-        else:
-            # if the user specifies a port
-            # e.g. ":4566" should become "<default_ip>:4566"
-            edge_bind = parse_edge_bind(edge_bind)
+        components = edge_bind.split(",")
+        edge_bind = ",".join([parse_edge_bind(component.strip()) for component in components])
 
     assert edge_bind is not None
     assert localstack_host is not None

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -427,10 +427,10 @@ def populate_legacy_edge_configuration(
         default_ip = "127.0.0.1"
 
     localstack_host_raw = environment.get("LOCALSTACK_HOST")
-    edge_bind_raw = environment.get("EDGE_BIND")
+    edge_bind_raw = environment.get("GATEWAY_LISTEN")
 
     # new for v2
-    # populate LOCALSTACK_HOST first since EDGE_BIND may be derived from LOCALSTACK_HOST
+    # populate LOCALSTACK_HOST first since GATEWAY_LISTEN may be derived from LOCALSTACK_HOST
     localstack_host = localstack_host_raw
     if localstack_host is None:
         localstack_host = f"{constants.LOCALHOST_HOSTNAME}:{constants.DEFAULT_PORT_EDGE}"
@@ -467,7 +467,7 @@ def populate_legacy_edge_configuration(
 
         return result
 
-    # derive legacy variables from EDGE_BIND unless EDGE_BIND is not given and
+    # derive legacy variables from GATEWAY_LISTEN unless GATEWAY_LISTEN is not given and
     # legacy variables are
     edge_bind_host = legacy_fallback("EDGE_BIND_HOST", get_edge_bind(edge_bind)[0].host)
     edge_port = int(legacy_fallback("EDGE_PORT", get_edge_bind(edge_bind)[0].port))
@@ -507,7 +507,7 @@ def get_edge_bind(edge_bind: str) -> List[HostAndPort]:
     # -- Edge configuration
     # Main configuration of the listen address of the hypercorn proxy. Of the form
     # <ip_address>:<port>(,<ip_address>:port>)*
-    EDGE_BIND,
+    GATEWAY_LISTEN,
     # -- Legacy variables
     EDGE_BIND_HOST,
     EDGE_PORT,

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -501,6 +501,9 @@ EDGE_BIND_HOST = edge_bind()[0].host
 EDGE_PORT = edge_bind()[0].port
 EDGE_PORT_HTTP = EDGE_PORT
 
+# optional target URL to forward all edge requests to
+EDGE_FORWARD_URL = os.environ.get("EDGE_FORWARD_URL", "").strip()
+
 # IP of the docker bridge used to enable access between containers
 DOCKER_BRIDGE_IP = os.environ.get("DOCKER_BRIDGE_IP", "").strip()
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -454,6 +454,9 @@ def populate_legacy_edge_configuration(
         gateway_listen = f"{default_ip}:{port}"
     else:
         components = gateway_listen.split(",")
+        if len(components) > 1:
+            LOG.warning("multiple GATEWAY_LISTEN addresses are not currently supported")
+
         gateway_listen = ",".join(
             [parse_gateway_listen(component.strip()) for component in components]
         )

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -147,6 +147,18 @@ DEPRECATIONS = [
         "1.4.0",
         "This feature will not be supported in the future. Please remove this environment variable.",
     ),
+    # Since 2.0.0 - HOSTNAME_EXTERNAL will be replaced with LOCALSTACK_HOST
+    EnvVarDeprecation(
+        "HOSTNAME_EXTERNAL",
+        "2.0.0",
+        "This configuration will be migrated to LOCALSTACK_HOST",
+    ),
+    # Since 2.0.0 - LOCALSTAKCK_HOST will be replaced with LOCALSTACK_HOST
+    EnvVarDeprecation(
+        "LOCALSTACK_HOSTNAME",
+        "2.0.0",
+        "This configuration will be migrated to LOCALSTACK_HOST",
+    ),
 ]
 
 

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -153,11 +153,29 @@ DEPRECATIONS = [
         "2.0.0",
         "This configuration will be migrated to LOCALSTACK_HOST",
     ),
-    # Since 2.0.0 - LOCALSTAKCK_HOST will be replaced with LOCALSTACK_HOST
+    # Since 2.0.0 - LOCALSTACK_HOST will be replaced with LOCALSTACK_HOST
     EnvVarDeprecation(
         "LOCALSTACK_HOSTNAME",
         "2.0.0",
         "This configuration will be migrated to LOCALSTACK_HOST",
+    ),
+    # Since 2.0.0 - redefined as EDGE_BIND
+    EnvVarDeprecation(
+        "EDGE_BIND_HOST",
+        "2.0.0",
+        "This configuration will be migrated to EDGE_BIND",
+    ),
+    # Since 2.0.0 - redefined as EDGE_BIND
+    EnvVarDeprecation(
+        "EDGE_PORT",
+        "2.0.0",
+        "This configuration will be migrated to EDGE_BIND",
+    ),
+    # Since 2.0.0 - redefined as EDGE_BIND
+    EnvVarDeprecation(
+        "EDGE_PORT_HTTP",
+        "2.0.0",
+        "This configuration will be migrated to EDGE_BIND",
     ),
 ]
 

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -159,23 +159,23 @@ DEPRECATIONS = [
         "2.0.0",
         "This configuration will be migrated to LOCALSTACK_HOST",
     ),
-    # Since 2.0.0 - redefined as EDGE_BIND
+    # Since 2.0.0 - redefined as GATEWAY_LISTEN
     EnvVarDeprecation(
         "EDGE_BIND_HOST",
         "2.0.0",
-        "This configuration will be migrated to EDGE_BIND",
+        "This configuration will be migrated to GATEWAY_LISTEN",
     ),
-    # Since 2.0.0 - redefined as EDGE_BIND
+    # Since 2.0.0 - redefined as GATEWAY_LISTEN
     EnvVarDeprecation(
         "EDGE_PORT",
         "2.0.0",
-        "This configuration will be migrated to EDGE_BIND",
+        "This configuration will be migrated to GATEWAY_LISTEN",
     ),
-    # Since 2.0.0 - redefined as EDGE_BIND
+    # Since 2.0.0 - redefined as GATEWAY_LISTEN
     EnvVarDeprecation(
         "EDGE_PORT_HTTP",
         "2.0.0",
-        "This configuration will be migrated to EDGE_BIND",
+        "This configuration will be migrated to GATEWAY_LISTEN",
     ),
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     cryptography
     dill==0.3.2
     dnspython>=1.16.0
-    localstack-client>=1.37
+    localstack-client>=2.0
     plux>=1.3.1
     psutil>=5.4.8,<6.0.0
     python-dotenv>=0.19.1

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -164,16 +164,14 @@ class TestEdgeVariablesDerivedCorrectly:
             return "127.0.0.1"
 
     def test_defaults(self, default_ip):
+        environment = {}
         (
             ls_host,
             edge_bind,
             edge_bind_host,
             edge_port,
             edge_port_http,
-        ) = config.populate_legacy_edge_configuration(
-            localstack_host_raw=None,
-            edge_bind_raw=None,
-        )
+        ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == "localhost.localstack.cloud:4566"
         assert edge_bind == f"{default_ip}:4566"
@@ -182,16 +180,14 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == default_ip
 
     def test_custom_hostname(self):
+        environment = {"EDGE_BIND": "192.168.0.1"}
         (
             _,
             edge_bind,
             edge_bind_host,
             edge_port,
             edge_port_http,
-        ) = config.populate_legacy_edge_configuration(
-            localstack_host_raw=None,
-            edge_bind_raw="192.168.0.1",
-        )
+        ) = config.populate_legacy_edge_configuration(environment)
 
         assert edge_bind == "192.168.0.1:4566"
         assert edge_port == 4566
@@ -199,16 +195,14 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == "192.168.0.1"
 
     def test_custom_port(self, default_ip):
+        environment = {"EDGE_BIND": ":9999"}
         (
             _,
             edge_bind,
             edge_bind_host,
             edge_port,
             edge_port_http,
-        ) = config.populate_legacy_edge_configuration(
-            localstack_host_raw=None,
-            edge_bind_raw=":9999",
-        )
+        ) = config.populate_legacy_edge_configuration(environment)
 
         assert edge_bind == f"{default_ip}:9999"
         assert edge_port == 9999
@@ -216,16 +210,14 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == default_ip
 
     def test_custom_host_and_port(self):
+        environment = {"EDGE_BIND": "192.168.0.1:9999"}
         (
             _,
             edge_bind,
             edge_bind_host,
             edge_port,
             edge_port_http,
-        ) = config.populate_legacy_edge_configuration(
-            localstack_host_raw=None,
-            edge_bind_raw="192.168.0.1:9999",
-        )
+        ) = config.populate_legacy_edge_configuration(environment)
 
         assert edge_bind == "192.168.0.1:9999"
         assert edge_port == 9999
@@ -233,16 +225,14 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == "192.168.0.1"
 
     def test_localstack_host_overrides_edge_variables(self, default_ip):
+        environment = {"LOCALSTACK_HOST": "hostname:9999"}
         (
             ls_host,
             edge_bind,
             edge_bind_host,
             edge_port,
             edge_port_http,
-        ) = config.populate_legacy_edge_configuration(
-            localstack_host_raw="hostname:9999",
-            edge_bind_raw=None,
-        )
+        ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == "hostname:9999"
         assert edge_bind == f"{default_ip}:9999"
@@ -251,16 +241,14 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == default_ip
 
     def test_edge_bind_multiple_addresses(self):
+        environment = {"EDGE_BIND": "0.0.0.0:9999,0.0.0.0:443"}
         (
             _,
             edge_bind,
             edge_bind_host,
             edge_port,
             edge_port_http,
-        ) = config.populate_legacy_edge_configuration(
-            localstack_host_raw=None,
-            edge_bind_raw="0.0.0.0:9999,0.0.0.0:443",
-        )
+        ) = config.populate_legacy_edge_configuration(environment)
 
         assert edge_bind == "0.0.0.0:9999,0.0.0.0:443"
         # take the first value
@@ -293,3 +281,22 @@ class TestEdgeVariablesDerivedCorrectly:
 
         expected = [config.HostAndPort(host=host, port=port) for (host, port) in hosts_and_ports]
         assert res == expected
+
+    def test_legacy_variables_override_if_given(self, default_ip):
+        environment = {
+            "EDGE_BIND_HOST": "192.168.0.1",
+            "EDGE_PORT": "10101",
+            "EDGE_PORT_HTTP": "20202",
+        }
+        (
+            _,
+            edge_bind,
+            edge_bind_host,
+            edge_port,
+            edge_port_http,
+        ) = config.populate_legacy_edge_configuration(environment)
+
+        assert edge_bind == f"{default_ip}:4566"
+        assert edge_bind_host == "192.168.0.1"
+        assert edge_port == 10101
+        assert edge_port_http == 20202

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from contextlib import contextmanager
 from typing import Any, Dict
 
@@ -140,21 +139,6 @@ class TestEdgeVariablesDerivedCorrectly:
     tests run after these ones to import the wrong config. Instead, we test the
     function that populates the configuration variables.
     """
-
-    @pytest.fixture
-    def configure_environment(self, monkeypatch):
-        def inner(**envars):
-            import importlib
-
-            for name, value in envars.items():
-                monkeypatch.setenv(name, value)
-
-            del sys.modules["localstack.config"]
-            cfg = importlib.import_module("localstack.config")
-
-            return cfg
-
-        return inner
 
     @pytest.fixture
     def default_ip(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,10 +130,10 @@ class TestEdgeVariablesDerivedCorrectly:
     * EDGE_PORT_HTTP
     * EDGE_BIND_HOST
 
-    from EDGE_BIND (name TBD). We are also ensuring the configuration behaves
+    from GATEWAY_LISTEN. We are also ensuring the configuration behaves
     well with LOCALSTACK_HOST, i.e. if LOCALSTACK_HOST is supplied and
-    EDGE_BIND is not, then we should propagate LOCALSTACK_HOST configuration
-    into EDGE_BIND.
+    GATEWAY_LISTEN is not, then we should propagate LOCALSTACK_HOST configuration
+    into GATEWAY_LISTEN.
 
     Implementation note: monkeypatching the config module is hard, and causes
     tests run after these ones to import the wrong config. Instead, we test the
@@ -164,7 +164,7 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == default_ip
 
     def test_custom_hostname(self):
-        environment = {"EDGE_BIND": "192.168.0.1"}
+        environment = {"GATEWAY_LISTEN": "192.168.0.1"}
         (
             _,
             edge_bind,
@@ -179,7 +179,7 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == "192.168.0.1"
 
     def test_custom_port(self, default_ip):
-        environment = {"EDGE_BIND": ":9999"}
+        environment = {"GATEWAY_LISTEN": ":9999"}
         (
             _,
             edge_bind,
@@ -194,7 +194,7 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == default_ip
 
     def test_custom_host_and_port(self):
-        environment = {"EDGE_BIND": "192.168.0.1:9999"}
+        environment = {"GATEWAY_LISTEN": "192.168.0.1:9999"}
         (
             _,
             edge_bind,
@@ -225,7 +225,7 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == default_ip
 
     def test_edge_bind_multiple_addresses(self):
-        environment = {"EDGE_BIND": "0.0.0.0:9999,0.0.0.0:443"}
+        environment = {"GATEWAY_LISTEN": "0.0.0.0:9999,0.0.0.0:443"}
         (
             _,
             edge_bind,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -151,14 +151,14 @@ class TestEdgeVariablesDerivedCorrectly:
         environment = {}
         (
             ls_host,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == "localhost.localstack.cloud:4566"
-        assert edge_bind == f"{default_ip}:4566"
+        assert gateway_listen == f"{default_ip}:4566"
         assert edge_port == 4566
         assert edge_port_http == 4566
         assert edge_bind_host == default_ip
@@ -167,13 +167,13 @@ class TestEdgeVariablesDerivedCorrectly:
         environment = {"GATEWAY_LISTEN": "192.168.0.1"}
         (
             _,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert edge_bind == "192.168.0.1:4566"
+        assert gateway_listen == "192.168.0.1:4566"
         assert edge_port == 4566
         assert edge_port_http == 4566
         assert edge_bind_host == "192.168.0.1"
@@ -182,13 +182,13 @@ class TestEdgeVariablesDerivedCorrectly:
         environment = {"GATEWAY_LISTEN": ":9999"}
         (
             _,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert edge_bind == f"{default_ip}:9999"
+        assert gateway_listen == f"{default_ip}:9999"
         assert edge_port == 9999
         assert edge_port_http == 9999
         assert edge_bind_host == default_ip
@@ -197,13 +197,13 @@ class TestEdgeVariablesDerivedCorrectly:
         environment = {"GATEWAY_LISTEN": "192.168.0.1:9999"}
         (
             _,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert edge_bind == "192.168.0.1:9999"
+        assert gateway_listen == "192.168.0.1:9999"
         assert edge_port == 9999
         assert edge_port_http == 9999
         assert edge_bind_host == "192.168.0.1"
@@ -212,29 +212,29 @@ class TestEdgeVariablesDerivedCorrectly:
         environment = {"LOCALSTACK_HOST": "hostname:9999"}
         (
             ls_host,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == "hostname:9999"
-        assert edge_bind == f"{default_ip}:9999"
+        assert gateway_listen == f"{default_ip}:9999"
         assert edge_port == 9999
         assert edge_port_http == 9999
         assert edge_bind_host == default_ip
 
-    def test_edge_bind_multiple_addresses(self):
+    def test_gateway_listen_multiple_addresses(self):
         environment = {"GATEWAY_LISTEN": "0.0.0.0:9999,0.0.0.0:443"}
         (
             _,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert edge_bind == "0.0.0.0:9999,0.0.0.0:443"
+        assert gateway_listen == "0.0.0.0:9999,0.0.0.0:443"
         # take the first value
         assert edge_port == 9999
         assert edge_port_http == 9999
@@ -260,8 +260,8 @@ class TestEdgeVariablesDerivedCorrectly:
             ),
         ],
     )
-    def test_edge_bind_parsed(self, input, hosts_and_ports):
-        res = config.get_edge_bind(input)
+    def test_gateway_listen_parsed(self, input, hosts_and_ports):
+        res = config.get_gateway_listen(input)
 
         expected = [config.HostAndPort(host=host, port=port) for (host, port) in hosts_and_ports]
         assert res == expected
@@ -274,13 +274,13 @@ class TestEdgeVariablesDerivedCorrectly:
         }
         (
             _,
-            edge_bind,
+            gateway_listen,
             edge_bind_host,
             edge_port,
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert edge_bind == f"{default_ip}:4566"
+        assert gateway_listen == f"{default_ip}:4566"
         assert edge_bind_host == "192.168.0.1"
         assert edge_port == 10101
         assert edge_port_http == 20202


### PR DESCRIPTION
We are switching to using `LOCALSTACK_HOST` and `GATEWAY_LISTEN` to configure LocalStack.

## Variable types

These variables are split into two types: _cosmetic_ and _functional_. Cosmetic are purely used as hostnames in returned URLs or addresses by LocalStack. LocalStack does not use these variables to configure services.

_functional_ variables are used to configure the networking stack of LocalStack.

## Roles

* `LOCALSTACK_HOST`: (cosmetic) this variable is interpolated into URLs and addresses. It has the form `<hostname>:<port>` and defaults to `localhost.localstack.cloud:4566`.
* `GATEWAY_LISTEN`: (functional) this configures the bind addresses of LocalStack. It has the form `<ip address>:<port>(,<ip address>:<port>)*` and defaults to `127.0.0.1:4566` on the host and `0.0.0.0:4566` in docker.

## `GATEWAY_LISTEN` advantages

Since `GATEWAY_LISTEN` supports multiple addresses (separated by `,`) we can provide configuration for pro users who wish to use SSL e.g. `GATEWAY_LISTEN=0.0.0.0:4566,0.0.0.0:443`.

## Legacy configuration

Existing configuration of the system is maintained with the existing legacy variables (`EDGE_PORT`, `EDGE_PORT_HTTP` and `EDGE_BIND_HOST`) as these are now derived from `GATEWAY_LISTEN` if absent. Some examples:

* `GATEWAY_LISTEN`: "" -> `EDGE_PORT=4566`,`EDGE_PORT_HTTP=4566`,`EDGE_BIND_HOST=127.0.0.1/0.0.0.0`
* `GATEWAY_LISTEN=0.0.0.0:9999` -> `EDGE_PORT=9999`,`EDGE_PORT_HTTP=9999`,`EDGE_BIND_HOST=0.0.0.0`

If `GATEWAY_LISTEN` is not given but legacy variables are, they pick up the supplied values rather than inheriting the default `GATEWAY_LISTEN`.

If `GATEWAY_LISTEN` includes multiple values, the first will be used to configure our `hypercorn` listener, and the rest will be transparent proxies (implementation in future PR).

Legacy variables have been marked as deprecated:
* `LOCALSTACK_HOSTNAME`
* `HOSTNAME_EXTERNAL`
* `EDGE_PORT`
* `EDGE_PORT_HTTP`
* `EDGE_BIND_HOST`

[Design document](https://www.notion.so/localstack/Networking-sync-9f34c512d964469689eff9e815281238)