### PR TITLE
Fix SortingTransformer for nested input

### DIFF
--- a/localstack/testing/snapshots/transformer.py
+++ b/localstack/testing/snapshots/transformer.py
@@ -227,7 +227,7 @@ class SortingTransformer:
             if k == self.key:
                 if not isinstance(v, list):
                     raise ValueError("SortingTransformer should only be applied to lists.")
-                input_data[k] = sorted(v, key=self.sorting_fn)
+                input_data[k] = sorted(self._transform(v, ctx=ctx), key=self.sorting_fn)
             else:
                 input_data[k] = self._transform(v, ctx=ctx)
         return input_data

--- a/tests/unit/utils/testing/test_transformer.py
+++ b/tests/unit/utils/testing/test_transformer.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from localstack.testing.snapshots.transformer import TransformContext
+from localstack.testing.snapshots.transformer import SortingTransformer, TransformContext
 from localstack.testing.snapshots.transformer_utility import TransformerUtility
 
 
@@ -175,3 +175,34 @@ class TestTransformer:
             }
         }
         assert expected == json.loads(output)
+
+    def test_nested_sorting_transformer(self):
+        input = {
+            "subsegments": [
+                {
+                    "name": "mysubsegment",
+                    "subsegments": [
+                        {"name": "b"},
+                        {"name": "a"},
+                    ],
+                }
+            ],
+        }
+
+        expected = {
+            "subsegments": [
+                {
+                    "name": "mysubsegment",
+                    "subsegments": [
+                        {"name": "a"},
+                        {"name": "b"},
+                    ],
+                }
+            ],
+        }
+
+        transformer = SortingTransformer("subsegments", lambda s: s["name"])
+
+        ctx = TransformContext()
+        output = transformer.transform(input, ctx=ctx)
+        assert output == expected


### PR DESCRIPTION
Fixes a small edge case encountered when writing tests for xray with a SortingTransformer where SubSegments can be nested. The value of the detected entry is now also further transformed.