### PR TITLE
Fix deletion of file content on snapshot error

### DIFF
--- a/localstack/testing/snapshots/prototype.py
+++ b/localstack/testing/snapshots/prototype.py
@@ -103,8 +103,6 @@ class SnapshotSession:
             with open(self.file_path, "r+") as fd:
                 try:
                     content = fd.read()
-                    fd.seek(0)
-                    fd.truncate()
                     full_state = json.loads(content or "{}")
                     recorded = {
                         "recorded-date": datetime.now().strftime("%d-%m-%Y, %H:%M:%S"),
@@ -112,6 +110,8 @@ class SnapshotSession:
                     }
                     full_state[self.scope_key] = recorded
                     state_to_dump = json.dumps(full_state, indent=2)
+                    fd.seek(0)
+                    fd.truncate()
                     # add line ending to be compatible with pre-commit-hooks (end-of-file-fixer)
                     fd.write(f"{state_to_dump}\n")
                 except Exception as e:


### PR DESCRIPTION
When updating or creating new snapshots, an error when serializing the new snapshot previously lead to the complete removal of the file's content.

By moving `truncate` to after the JSON serialization, an error here will now simply leave the old state as it was instead of leaving behind an empty file.