### PR TITLE
Update default container name from localstack_main to localstack-main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VENV_DIR ?= .venv
 PIP_CMD ?= pip3
 TEST_PATH ?= .
 PYTEST_LOGLEVEL ?=
-MAIN_CONTAINER_NAME ?= localstack_main
+MAIN_CONTAINER_NAME ?= localstack-main
 
 MAJOR_VERSION = $(shell echo ${IMAGE_TAG} | cut -d '.' -f1)
 MINOR_VERSION = $(shell echo ${IMAGE_TAG} | cut -d '.' -f2)

--- a/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
+++ b/doc/external_services_integration/kafka_self_managed_cluster/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - KAFKA_BROKERS=kafka:29092
 
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     network_mode: bridge
     ports:

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack-pro  # required for Pro
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/docker-compose-pro.yml
+++ b/docker-compose-pro.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
     image: localstack/localstack-pro  # required for Pro
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -490,7 +490,7 @@ SKIP_SSL_CERT_DOWNLOAD = is_env_true("SKIP_SSL_CERT_DOWNLOAD")
 CUSTOM_SSL_CERT_PATH = os.environ.get("CUSTOM_SSL_CERT_PATH", "").strip()
 
 # name of the main Docker container
-MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack_main"
+MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack-main"
 
 # the latest commit id of the repository when the docker image was created
 LOCALSTACK_BUILD_GIT_HASH = os.environ.get("LOCALSTACK_BUILD_GIT_HASH", "").strip() or None

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -104,7 +104,7 @@ def test_validate_config(runner, monkeypatch, tmp_path):
         """version: "3.3"
 services:
   localstack:
-    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack-main}"
     image: localstack/localstack
     network_mode: bridge
     ports:

--- a/tests/unit/test_dockerclient.py
+++ b/tests/unit/test_dockerclient.py
@@ -27,7 +27,7 @@ class TestDockerClient:
         mock_container = {
             "ID": "00000000a1",
             "Image": "localstack/localstack",
-            "Names": "localstack_main",
+            "Names": "localstack-main",
             "Labels": "authors=LocalStack Contributors",
             "State": "running",
         }
@@ -50,16 +50,16 @@ class TestDockerClient:
 
     @patch("localstack.utils.container_utils.docker_cmd_client.run")
     def test_container_status(self, run_mock):
-        test_output = "Up 2 minutes - localstack_main"
+        test_output = "Up 2 minutes - localstack-main"
         run_mock.return_value = test_output
         docker_client = CmdDockerClient()
-        status = docker_client.get_container_status("localstack_main")
+        status = docker_client.get_container_status("localstack-main")
         assert status == DockerContainerStatus.UP
-        run_mock.return_value = "Exited (0) 1 minute ago - localstack_main"
-        status = docker_client.get_container_status("localstack_main")
+        run_mock.return_value = "Exited (0) 1 minute ago - localstack-main"
+        status = docker_client.get_container_status("localstack-main")
         assert status == DockerContainerStatus.DOWN
         run_mock.return_value = "STATUS    NAME"
-        status = docker_client.get_container_status("localstack_main")
+        status = docker_client.get_container_status("localstack-main")
         assert status == DockerContainerStatus.NON_EXISTENT
 
 


### PR DESCRIPTION
Docker can use a container name for DNS resolution, but hostnames cannot include underscores.

This change sets the default container name in the documentation to localstack-main to allow it to be used as a hostname.
