### PR TITLE
add sqs lambda event source listener test for message attributes

### DIFF
--- a/tests/integration/awslambda/test_lambda_integration_sqs.py
+++ b/tests/integration/awslambda/test_lambda_integration_sqs.py
@@ -161,6 +161,94 @@ def test_failing_lambda_retries_after_visibility_timeout(
 
 @pytest.mark.skip_snapshot_verify(
     paths=[
+        # AWS returns empty lists for these values, even though they are not implemented yet
+        # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html
+        "$..stringListValues",
+        "$..binaryListValues",
+    ]
+)
+def test_message_body_and_attributes_passed_correctly(
+    create_lambda_function,
+    lambda_client,
+    sqs_client,
+    sqs_create_queue,
+    sqs_queue_arn,
+    lambda_su_role,
+    snapshot,
+    cleanups,
+):
+    # create queue used in the lambda to send events to (to verify lambda was invoked)
+    destination_queue_name = f"destination-queue-{short_uid()}"
+    destination_url = sqs_create_queue(QueueName=destination_queue_name)
+    snapshot.match(
+        "get_destination_queue_url", sqs_client.get_queue_url(QueueName=destination_queue_name)
+    )
+
+    # timeout in seconds, used for both the lambda and the queue visibility timeout
+    retry_timeout = 5
+    retries = 2
+
+    # set up lambda function
+    function_name = f"lambda-{short_uid()}"
+    create_lambda_function(
+        func_name=function_name,
+        handler_file=LAMBDA_SQS_INTEGRATION_FILE,
+        runtime=LAMBDA_RUNTIME_PYTHON38,
+        role=lambda_su_role,
+        timeout=retry_timeout,  # timeout needs to be <= than visibility timeout
+    )
+
+    # create dlq for event source queue
+    event_dlq_url = sqs_create_queue(QueueName=f"event-dlq-{short_uid()}")
+    event_dlq_arn = sqs_queue_arn(event_dlq_url)
+
+    # create event source queue
+    event_source_url = sqs_create_queue(
+        QueueName=f"source-queue-{short_uid()}",
+        Attributes={
+            # the visibility timeout is implicitly also the time between retries
+            "VisibilityTimeout": str(retry_timeout),
+            "RedrivePolicy": json.dumps(
+                {"deadLetterTargetArn": event_dlq_arn, "maxReceiveCount": retries}
+            ),
+        },
+    )
+    event_source_arn = sqs_queue_arn(event_source_url)
+
+    # wire everything with the event source mapping
+    mapping_uuid = lambda_client.create_event_source_mapping(
+        EventSourceArn=event_source_arn,
+        FunctionName=function_name,
+        BatchSize=1,
+    )["UUID"]
+    cleanups.append(lambda: lambda_client.delete_event_source_mapping(UUID=mapping_uuid))
+    _await_event_source_mapping_enabled(lambda_client, mapping_uuid)
+
+    # trigger lambda with a message and pass the result destination url. the event format is expected by the
+    # lambda_sqs_integration.py lambda.
+    event = {"destination": destination_url, "fail_attempts": 0}
+    sqs_client.send_message(
+        QueueUrl=event_source_url,
+        MessageBody=json.dumps(event),
+        MessageAttributes={
+            "Title": {"DataType": "String", "StringValue": "The Whistler"},
+            "Author": {"DataType": "String", "StringValue": "John Grisham"},
+            "WeeksOn": {"DataType": "Number", "StringValue": "6"},
+        },
+    )
+
+    # now wait for the first invocation result which is expected to fail
+    response = sqs_client.receive_message(
+        QueueUrl=destination_url,
+        WaitTimeSeconds=15,
+        MaxNumberOfMessages=1,
+    )
+    assert "Messages" in response
+    snapshot.match("first_attempt", response)
+
+
+@pytest.mark.skip_snapshot_verify(
+    paths=[
         "$..ParallelizationFactor",
         "$..LastProcessingResult",
         "$..Topics",

--- a/tests/integration/awslambda/test_lambda_integration_sqs.py
+++ b/tests/integration/awslambda/test_lambda_integration_sqs.py
@@ -167,6 +167,7 @@ def test_failing_lambda_retries_after_visibility_timeout(
         "$..binaryListValues",
     ]
 )
+@pytest.mark.aws_validated
 def test_message_body_and_attributes_passed_correctly(
     create_lambda_function,
     lambda_client,

--- a/tests/integration/awslambda/test_lambda_integration_sqs.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_integration_sqs.snapshot.json
@@ -1358,5 +1358,73 @@
         }
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_integration_sqs.py::test_message_body_and_attributes_passed_correctly": {
+    "recorded-date": "17-03-2023, 17:04:06",
+    "recorded-content": {
+      "get_destination_queue_url": {
+        "QueueUrl": "<queue-url:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "first_attempt": {
+        "Messages": [
+          {
+            "Body": {
+              "error": null,
+              "event": {
+                "Records": [
+                  {
+                    "messageId": "<uuid:1>",
+                    "receiptHandle": "<receipt-handle:2>",
+                    "body": "{\"destination\": \"<queue-url:1>\", \"fail_attempts\": 0}",
+                    "attributes": {
+                      "ApproximateReceiveCount": "1",
+                      "SentTimestamp": "timestamp",
+                      "SenderId": "sender-id",
+                      "ApproximateFirstReceiveTimestamp": "timestamp"
+                    },
+                    "messageAttributes": {
+                      "WeeksOn": {
+                        "stringValue": "6",
+                        "stringListValues": [],
+                        "binaryListValues": [],
+                        "dataType": "Number"
+                      },
+                      "Author": {
+                        "stringValue": "John Grisham",
+                        "stringListValues": [],
+                        "binaryListValues": [],
+                        "dataType": "String"
+                      },
+                      "Title": {
+                        "stringValue": "The Whistler",
+                        "stringListValues": [],
+                        "binaryListValues": [],
+                        "dataType": "String"
+                      }
+                    },
+                    "md5OfMessageAttributes": "d25a6aea97eb8f585bfa92d314504a92",
+                    "md5OfBody": "<md5-of-body:1>",
+                    "eventSource": "aws:sqs",
+                    "eventSourceARN": "arn:aws:sqs:<region>:111111111111:<resource:1>",
+                    "awsRegion": "<region>"
+                  }
+                ]
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR adds a test to verify #7897. Basically it's just a normal "let the lambda echo the SQS message into another SQS queue and fetch it" test, but i added message attributes explicitly.

The test didn't really reproduce the issue, but it's useful as regression test I suppose. The only difference I could find is that AWS adds empty values for `stringListValues` and `binaryListValues` of message attributes, but 1) [those are not implemented in AWS](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html), and 2) these empty values only show up when using the event source mapper, not in SQS in general. :thinking: :shrug: 

```
  "Author": {
    "stringValue": "John Grisham",
    "stringListValues": [],
    "binaryListValues": [],
    "dataType": "String"
  },
```

in localstack that would be
```
  "Author": {
    "stringValue": "John Grisham",
    "dataType": "String"
  },
```