### PR TITLE
fix sns unsubscribe to be idempotent

### DIFF
--- a/localstack/services/sns/provider.py
+++ b/localstack/services/sns/provider.py
@@ -480,7 +480,11 @@ class SnsProvider(SnsApi, ServiceLifecycleHook):
 
         # pop the subscription at the end, to avoid race condition by iterating over the topic subscriptions
         subscription = store.subscriptions.get(subscription_arn)
-        # TODO: can it be None? or moto raises an error?
+
+        if not subscription:
+            # unsubscribe is idempotent, so unsubscribing from a non-existing topic does nothing
+            return
+
         if subscription["Protocol"] in ["http", "https"]:
             # TODO: actually validate this (re)subscribe behaviour somehow (localhost.run?)
             #  we might need to save the sub token in the store

--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -190,6 +190,24 @@ class TestSNSProvider:
         snapshot.match("exception", e.value.response)
 
     @pytest.mark.aws_validated
+    def test_unsubscribe_from_non_existing_subscription(
+        self,
+        sns_client,
+        sns_create_topic,
+        sqs_create_queue,
+        sqs_client,
+        sns_create_sqs_subscription,
+        snapshot,
+    ):
+        topic_arn = sns_create_topic()["TopicArn"]
+        queue_url = sqs_create_queue()
+        subscription = sns_create_sqs_subscription(topic_arn=topic_arn, queue_url=queue_url)
+        sns_client.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+        # unsubscribing a second time
+        response = sns_client.unsubscribe(SubscriptionArn=subscription["SubscriptionArn"])
+        snapshot.match("empty-unsubscribe", response)
+
+    @pytest.mark.aws_validated
     def test_attribute_raw_subscribe(
         self,
         sqs_client,

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -3452,5 +3452,16 @@
         }
       }
     }
+  },
+  "tests/integration/test_sns.py::TestSNSProvider::test_unsubscribe_from_non_existing_subscription": {
+    "recorded-date": "17-03-2023, 19:35:30",
+    "recorded-content": {
+      "empty-unsubscribe": {
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Small fix that makes sure there's no exception when sns unsubscribe is called twice (which happens a decent amount of times in tests).

Logs had quite a few of these errors:
```
2023-03-17T16:38:29.4143947Z ------------------------------ live log teardown -------------------------------
2023-03-17T16:38:29.4144724Z 2023-03-17T16:38:29.412 ERROR --- [   asgi_gw_3] localstack.aws.handlers.logging : exception during call chain
2023-03-17T16:38:29.4146180Z Traceback (most recent call last):
2023-03-17T16:38:29.4146706Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/chain.py", line 90, in handle
2023-03-17T16:38:29.4147135Z     handler(self, self.context, response)
2023-03-17T16:38:29.4147637Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/handlers/service.py", line 122, in __call__
2023-03-17T16:38:29.4148043Z     handler(chain, context, response)
2023-03-17T16:38:29.4148523Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/handlers/service.py", line 92, in __call__
2023-03-17T16:38:29.4148972Z     skeleton_response = self.skeleton.invoke(context)
2023-03-17T16:38:29.4149483Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/skeleton.py", line 153, in invoke
2023-03-17T16:38:29.4149933Z     return self.dispatch_request(context, instance)
2023-03-17T16:38:29.4150443Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/skeleton.py", line 165, in dispatch_request
2023-03-17T16:38:29.4150877Z     result = handler(context, instance) or {}
2023-03-17T16:38:29.4151347Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/forwarder.py", line 60, in _call
2023-03-17T16:38:29.4151737Z     return handler(context, req)
2023-03-17T16:38:29.4152197Z   File "/home/runner/work/localstack/localstack/localstack/localstack/aws/skeleton.py", line 117, in __call__
2023-03-17T16:38:29.4152577Z     return self.fn(*args, **kwargs)
2023-03-17T16:38:29.4153072Z   File "/home/runner/work/localstack/localstack/localstack/localstack/services/sns/provider.py", line 484, in unsubscribe
2023-03-17T16:38:29.4153525Z     if subscription["Protocol"] in ["http", "https"]:
2023-03-17T16:38:29.4154012Z TypeError: 'NoneType' object is not subscriptable
2023-03-17T16:38:29.4170528Z 2023-03-17T16:38:29.416  INFO --- [   asgi_gw_3] localstack.request.aws     : AWS sns.Unsubscribe => 500 (InternalError)
```