### PR TITLE
add dynamic check of origin for CORS

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -76,7 +76,7 @@ ALLOWED_CORS_RESPONSE_HEADERS = [
 ]
 
 
-def _get_allowed_cors_internal_domains() -> Set[int]:
+def _get_allowed_cors_internal_domains() -> Set[str]:
     """
     Construct the list of allowed internal domains for CORS enforcement purposes
     Defined as function to allow easier testing with monkeypatch of config values

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -112,7 +112,7 @@ def _get_allowed_cors_origins() -> List[str]:
     # Add allowed origins for localhost domains, using different protocol/port combinations.
     # If a different port is configured for EDGE_PORT_HTTP, add it to allowed origins as well
     for protocol in {"http", "https"}:
-        for port in _ALLOWED_INTERNAL_PORTS:
+        for port in _get_allowed_cors_ports():
             result.append(f"{protocol}://{LOCALHOST}:{port}")
             result.append(f"{protocol}://{LOCALHOST_HOSTNAME}:{port}")
 

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -3,7 +3,7 @@ A set of handlers which handle Cross Origin Resource Sharing (CORS).
 """
 import logging
 import re
-from typing import List
+from typing import List, Set
 from urllib.parse import urlparse
 
 from flask_cors.core import (
@@ -20,6 +20,7 @@ from localstack.config import EXTRA_CORS_ALLOWED_HEADERS, EXTRA_CORS_EXPOSE_HEAD
 from localstack.http import Response
 
 from ...constants import LOCALHOST, LOCALHOST_HOSTNAME, PATH_USER_REQUEST
+from ...utils.bootstrap import log_duration
 from ..api import RequestContext
 from ..chain import Handler, HandlerChain
 
@@ -75,6 +76,28 @@ ALLOWED_CORS_RESPONSE_HEADERS = [
 ]
 
 
+def _get_allowed_cors_internal_domains() -> Set[int]:
+    """
+    Construct the list of allowed internal domains for CORS enforcement purposes
+    Defined as function to allow easier testing with monkeypatch of config values
+    """
+    return {LOCALHOST, LOCALHOST_HOSTNAME, config.HOSTNAME_EXTERNAL}
+
+
+_ALLOWED_INTERNAL_DOMAINS = _get_allowed_cors_internal_domains()
+
+
+def _get_allowed_cors_ports() -> Set[int]:
+    """
+    Construct the list of allowed ports for CORS enforcement purposes
+    Defined as function to allow easier testing with monkeypatch of config values
+    """
+    return set([config.EDGE_PORT] + ([config.EDGE_PORT_HTTP] if config.EDGE_PORT_HTTP else []))
+
+
+_ALLOWED_INTERNAL_PORTS = _get_allowed_cors_ports()
+
+
 def _get_allowed_cors_origins() -> List[str]:
     """Construct the list of allowed origins for CORS enforcement purposes"""
     result = [
@@ -88,9 +111,8 @@ def _get_allowed_cors_origins() -> List[str]:
     ]
     # Add allowed origins for localhost domains, using different protocol/port combinations.
     # If a different port is configured for EDGE_PORT_HTTP, add it to allowed origins as well
-    _ports = set([config.EDGE_PORT] + ([config.EDGE_PORT_HTTP] if config.EDGE_PORT_HTTP else []))
     for protocol in {"http", "https"}:
-        for port in _ports:
+        for port in _ALLOWED_INTERNAL_PORTS:
             result.append(f"{protocol}://{LOCALHOST}:{port}")
             result.append(f"{protocol}://{LOCALHOST_HOSTNAME}:{port}")
 
@@ -102,6 +124,14 @@ def _get_allowed_cors_origins() -> List[str]:
 
 # allowed origins used for CORS / CSRF checks
 ALLOWED_CORS_ORIGINS = _get_allowed_cors_origins()
+
+# allowed dynamic internal origin
+# must follow the same pattern with 3 matching group, group 2 being the domain and group 3 the port
+# TODO: might need to match/group the scheme also?
+DYNAMIC_INTERNAL_ORIGINS = (
+    re.compile("(.*)\\.s3-website\\.(.[^:]*)(:[0-9]{2,5})?"),
+    re.compile("(.*)\\.cloudfront\\.(.[^:]*)(:[0-9]{2,5})?"),
+)
 
 
 def should_enforce_self_managed_service(context: RequestContext) -> bool:
@@ -166,11 +196,25 @@ class CorsEnforcer(Handler):
         return True
 
     @staticmethod
+    @log_duration(min_ms=0)
     def _is_in_allowed_origins(allowed_origins: List[str], origin: str) -> bool:
         """Returns true if the `origin` is in the `allowed_origins`."""
         for allowed_origin in allowed_origins:
             if allowed_origin == "*" or origin == allowed_origin:
                 return True
+
+        # the cost of adding one a dynamic origin will around 4us on my local machine
+        # but performance wise, this is not very heavy because most of the regular requests will match above
+        # this would be executed mostly when rejecting or actually using content served by CloudFront or S3 website
+        for dynamic_origin in DYNAMIC_INTERNAL_ORIGINS:
+            match = dynamic_origin.match(origin)
+            if (
+                match
+                and (match.group(2) in _ALLOWED_INTERNAL_DOMAINS)
+                and (not (port := match.group(3)) or int(port[1:]) in _ALLOWED_INTERNAL_PORTS)
+            ):
+                return True
+
         return False
 
 

--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -16,13 +16,11 @@ from flask_cors.core import (
 from werkzeug.datastructures import Headers
 
 from localstack import config
+from localstack.aws.api import RequestContext
+from localstack.aws.chain import Handler, HandlerChain
 from localstack.config import EXTRA_CORS_ALLOWED_HEADERS, EXTRA_CORS_EXPOSE_HEADERS
+from localstack.constants import LOCALHOST, LOCALHOST_HOSTNAME, PATH_USER_REQUEST
 from localstack.http import Response
-
-from ...constants import LOCALHOST, LOCALHOST_HOSTNAME, PATH_USER_REQUEST
-from ...utils.bootstrap import log_duration
-from ..api import RequestContext
-from ..chain import Handler, HandlerChain
 
 LOG = logging.getLogger(__name__)
 
@@ -196,15 +194,13 @@ class CorsEnforcer(Handler):
         return True
 
     @staticmethod
-    @log_duration(min_ms=0)
     def _is_in_allowed_origins(allowed_origins: List[str], origin: str) -> bool:
         """Returns true if the `origin` is in the `allowed_origins`."""
         for allowed_origin in allowed_origins:
             if allowed_origin == "*" or origin == allowed_origin:
                 return True
 
-        # the cost of adding one a dynamic origin will around 4us on my local machine
-        # but performance wise, this is not very heavy because most of the regular requests will match above
+        # performance wise, this is not very heavy because most of the regular requests will match above
         # this would be executed mostly when rejecting or actually using content served by CloudFront or S3 website
         for dynamic_origin in DYNAMIC_INTERNAL_ORIGINS:
             match = dynamic_origin.match(origin)

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,12 +1,16 @@
+from werkzeug.datastructures import Headers
+
 from localstack import config
-from localstack.aws.handlers.cors import _get_allowed_cors_origins
+
+# from localstack.aws.handlers.cors import _get_allowed_cors_origins, CorsEnforcer
+from localstack.aws.handlers import cors
 
 
 def test_allowed_cors_origins_different_ports_and_protocols(monkeypatch):
     # test allowed origins for default config (edge port 4566)
     monkeypatch.setattr(config, "EDGE_PORT", 4566)
     monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)
-    origins = _get_allowed_cors_origins()
+    origins = cors._get_allowed_cors_origins()
     assert "http://localhost:4566" in origins
     assert "http://localhost.localstack.cloud:4566" in origins
     assert "https://localhost.localstack.cloud:443" not in origins
@@ -14,7 +18,64 @@ def test_allowed_cors_origins_different_ports_and_protocols(monkeypatch):
     # test allowed origins for extended config (HTTPS edge port 443, HTTP edge port 4566)
     monkeypatch.setattr(config, "EDGE_PORT", 443)
     monkeypatch.setattr(config, "EDGE_PORT_HTTP", 4566)
-    origins = _get_allowed_cors_origins()
+    origins = cors._get_allowed_cors_origins()
     assert "http://localhost:4566" in origins
     assert "http://localhost.localstack.cloud:4566" in origins
     assert "https://localhost.localstack.cloud:443" in origins
+
+
+def test_dynamic_allowed_cors_origins(monkeypatch):
+    assert _origin_allowed("http://test.s3-website.localhost.localstack.cloud")
+    assert _origin_allowed("https://test.s3-website.localhost.localstack.cloud")
+    assert _origin_allowed("http://test.cloudfront.localhost.localstack.cloud")
+
+    assert not _origin_allowed("https://test.appsync.localhost.localstack.cloud")
+    assert not _origin_allowed("https://testcloudfront.localhost.localstack.cloud")
+    assert not _origin_allowed("http://test.cloudfront.custom-domain.com")
+
+
+def test_dynamic_allowed_cors_origins_different_ports(monkeypatch):
+    # test dynamic allowed origins for default config (edge port 4566)
+    monkeypatch.setattr(config, "EDGE_PORT", 4566)
+    monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)
+    # monkeypatch.setattr(config, "EXTRA_CORS_ALLOWED_ORIGINS", f"https://{test_domain}")
+    monkeypatch.setattr(cors, "_ALLOWED_INTERNAL_PORTS", cors._get_allowed_cors_ports())
+    # monkeypatch.setattr(cors, "ALLOWED_CORS_ORIGINS", cors._get_allowed_cors_origins())
+
+    assert _origin_allowed("http://test.s3-website.localhost.localstack.cloud:4566")
+    assert _origin_allowed("http://test.s3-website.localhost.localstack.cloud")
+    assert _origin_allowed("https://test.s3-website.localhost.localstack.cloud:4566")
+    assert _origin_allowed("https://test.s3-website.localhost.localstack.cloud")
+    assert _origin_allowed("http://test.cloudfront.localhost.localstack.cloud")
+
+    assert not _origin_allowed("https://test.cloudfront.localhost.localstack.cloud:443")
+    assert not _origin_allowed("http://test.cloudfront.localhost.localstack.cloud:123")
+
+    # test allowed origins for extended config (HTTPS edge port 443, HTTP edge port 4566)
+    monkeypatch.setattr(config, "EDGE_PORT", 443)
+    monkeypatch.setattr(config, "EDGE_PORT_HTTP", 4566)
+    monkeypatch.setattr(cors, "_ALLOWED_INTERNAL_PORTS", cors._get_allowed_cors_ports())
+
+    assert _origin_allowed("https://test.cloudfront.localhost.localstack.cloud:443")
+
+
+def test_dynamic_allowed_cors_origins_different_domains(monkeypatch):
+    # test dynamic allowed origins for default config (edge port 4566)
+    monkeypatch.setattr(config, "EDGE_PORT", 4566)
+    monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)
+    monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", "my-custom-domain.com")
+
+    monkeypatch.setattr(
+        cors, "_ALLOWED_INTERNAL_DOMAINS", cors._get_allowed_cors_internal_domains()
+    )
+
+    assert _origin_allowed("http://test.cloudfront.my-custom-domain.com")
+    assert _origin_allowed("http://test.s3-website.my-custom-domain.com:4566")
+
+    assert not _origin_allowed("http://test.s3-website.my-wrong-domain.com")
+    assert not _origin_allowed("http://test.s3-website.my-wrong-domain.com:4566")
+
+
+def _origin_allowed(url) -> bool:
+    headers = Headers({"Origin": url})
+    return cors.CorsEnforcer.is_cors_origin_allowed(headers)

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,8 +1,6 @@
 from werkzeug.datastructures import Headers
 
 from localstack import config
-
-# from localstack.aws.handlers.cors import _get_allowed_cors_origins, CorsEnforcer
 from localstack.aws.handlers import cors
 
 
@@ -38,9 +36,7 @@ def test_dynamic_allowed_cors_origins_different_ports(monkeypatch):
     # test dynamic allowed origins for default config (edge port 4566)
     monkeypatch.setattr(config, "EDGE_PORT", 4566)
     monkeypatch.setattr(config, "EDGE_PORT_HTTP", 0)
-    # monkeypatch.setattr(config, "EXTRA_CORS_ALLOWED_ORIGINS", f"https://{test_domain}")
     monkeypatch.setattr(cors, "_ALLOWED_INTERNAL_PORTS", cors._get_allowed_cors_ports())
-    # monkeypatch.setattr(cors, "ALLOWED_CORS_ORIGINS", cors._get_allowed_cors_origins())
 
     assert _origin_allowed("http://test.s3-website.localhost.localstack.cloud:4566")
     assert _origin_allowed("http://test.s3-website.localhost.localstack.cloud")


### PR DESCRIPTION
This is a follow up from #7554, from an idea proposed by @whummer ([in this comment](https://github.com/localstack/localstack/pull/7554#discussion_r1086872025)) , with dynamic handling of CORS origin for web resource served by LocalStack.
This is not mergeable as is, as it still has some logging regarding performance, but I'd like to have some comments / opinions.

### Scenario:

LocalStack is serving a resource meant to be accessed from the browser (CloudFront or S3 website).

But this resource needs to access LocalStack resources as well. Right now, the only way is to set the environment variables of LocalStack to allow the Origin (let’s say, `http://<bucket>.s3-website.localhost.localstack.cloud:4566`).


### Fix

This PR adds a dynamic check of the origin, to validate if it follows some regex matching 2 service domains known for serving content accessible from a user browser (thus enforcing CORS).  We can then add a regex for every resource subdomain in that situation. 

The performance right now is around 4µs on my local machine when a request would be either rejected or matching `s3-website` or `cloudfront`. The performance would not be affected for most requests, as we either don't match CORS because of no `Origin` header, or the request is normally allowed. 

\cc @whummer @dfangl @alexrashed 
