### PR TITLE
fix config.dirs usage in the CLI

### DIFF
--- a/localstack/aws/protocol/service_router.py
+++ b/localstack/aws/protocol/service_router.py
@@ -282,15 +282,14 @@ def resolve_conflicts(candidates: Set[str], request: Request):
         return "rds"
 
 
-def determine_aws_service_name(
-    request: Request, services: ServiceCatalog = get_service_catalog()
-) -> Optional[str]:
+def determine_aws_service_name(request: Request, services: ServiceCatalog = None) -> Optional[str]:
     """
     Tries to determine the name of the AWS service an incoming request is targeting.
     :param request: to determine the target service name of
     :param services: service catalog (can be handed in for caching purposes)
     :return: service name string (or None if the targeting service could not be determined exactly)
     """
+    services = services or get_service_catalog()
     signing_name, target_prefix, operation, host, path = _extract_service_indicators(request)
     candidates = set()
 

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -56,6 +56,10 @@ def localstack(debug, profile):
     if not os.environ.get("LOCALSTACK_VOLUME_DIR", "").strip():
         config.VOLUME_DIR = str(cache_dir() / "volume")
 
+    # FIXME: at some point we should remove the use of `config.dirs` for the CLI,
+    #  see https://github.com/localstack/localstack/pull/7906
+    config.dirs.for_cli().mkdirs()
+
 
 @localstack.group(name="config", help="Inspect your LocalStack configuration")
 def localstack_config():

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -143,6 +143,11 @@ def cmd_start(docker: bool, host: bool, no_banner: bool, detached: bool):
         console.rule("LocalStack Runtime Log (press [bold][yellow]CTRL-C[/yellow][/bold] to quit)")
 
     if host:
+        # from here we abandon the regular CLI control path and start treating the process like a localstack
+        # runtime process
+        os.environ["LOCALSTACK_CLI"] = "0"
+        config.dirs = config.init_directories()
+
         try:
             bootstrap.start_infra_locally()
         except ImportError:

--- a/localstack/cli/main.py
+++ b/localstack/cli/main.py
@@ -1,3 +1,9 @@
+import os
+
+# indicate to the environment we are starting from the CLI
+os.environ["LOCALSTACK_CLI"] = "1"
+
+
 def main():
     # config profiles are the first thing that need to be loaded
     from .profiles import set_profile_from_sys_argv

--- a/localstack/cli/main.py
+++ b/localstack/cli/main.py
@@ -1,11 +1,11 @@
 import os
 
-# indicate to the environment we are starting from the CLI
-os.environ["LOCALSTACK_CLI"] = "1"
-
 
 def main():
-    # config profiles are the first thing that need to be loaded
+    # indicate to the environment we are starting from the CLI
+    os.environ["LOCALSTACK_CLI"] = "1"
+
+    # config profiles are the first thing that need to be loaded (especially before localstack.config!)
     from .profiles import set_profile_from_sys_argv
 
     set_profile_from_sys_argv()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -59,9 +59,6 @@ class Directories:
     init: str
     logs: str
 
-    # these are the folders mounted into the container by default when the CLI is used
-    default_bind_mounts = ["var_libs", "cache", "tmp", "data", "init", "logs"]
-
     def __init__(
         self,
         static_libs: str,

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -150,10 +150,10 @@ class Directories:
         """Returns directories used for when running localstack CLI commands from the host system. Unlike
         ``for_container``, these here need to be cross-platform. Ideally, this should not be needed at all,
         because the localstack runtime and CLI do not share any control paths. There are a handful of
-        situations where directories or files may be created lazily for CLI commands. `mkdirs` should
-        certainly never be called with these directories. Some paths are intentionally set to None to
-        provoke errors if these paths are used from the CLI - which they shouldn't. This is a symptom of
-        not having a clear separation between CLI/runtime code, which will be a future project."""
+        situations where directories or files may be created lazily for CLI commands. Some paths are
+        intentionally set to None to provoke errors if these paths are used from the CLI - which they
+        shouldn't. This is a symptom of not having a clear separation between CLI/runtime code, which will
+        be a future project."""
         import tempfile
 
         from localstack.utils import files

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -24,7 +24,6 @@ from localstack.constants import (
     LOCALHOST_IP,
     LOCALSTACK_ROOT_FOLDER,
     LOG_LEVELS,
-    MODULE_MAIN_PATH,
     TRACE_LOG_LEVELS,
     TRUE_STRINGS,
 )
@@ -150,60 +149,31 @@ class Directories:
         )
 
     @staticmethod
-    def legacy_from_config():
-        """Returns Localstack directory paths from the config/environment variables defined by the config."""
-        # Note that the entries should be unique, as further downstream in docker_utils.py we're removing
-        # duplicate host paths in the volume mounts via `dict(mount_volumes)`.
+    def for_cli() -> "Directories":
+        """Returns directories used for when running localstack CLI commands from the host system. Unlike
+        ``for_container``, these here need to be cross-platform. Ideally, this should not be needed at all,
+        because the localstack runtime and CLI do not share any control paths. There are a handful of
+        situations where directories or files may be created lazily for CLI commands. `mkdirs` should
+        certainly never be called with these directories. Some paths are intentionally set to None to
+        provoke errors if these paths are used from the CLI - which they shouldn't. This is a symptom of
+        not having a clear separation between CLI/runtime code, which will be a future project."""
+        import tempfile
 
-        # legacy config variables inlined
-        INSTALL_DIR_INFRA = os.path.join(MODULE_MAIN_PATH, "infra")
-        # ephemeral cache dir that persists across reboots
-        CACHE_DIR = os.environ.get("CACHE_DIR", os.path.join(TMP_FOLDER, "cache")).strip()
-        # libs cache dir that persists across reboots
-        VAR_LIBS_DIR = os.environ.get("VAR_LIBS_DIR", os.path.join(TMP_FOLDER, "var_libs")).strip()
+        from localstack.utils import files
+
+        tmp_dir = os.path.join(tempfile.gettempdir(), "localstack-cli")
+        cache_dir = (files.cache_dir() / "cli").absolute()
 
         return Directories(
-            static_libs=INSTALL_DIR_INFRA,
-            var_libs=VAR_LIBS_DIR,
-            cache=CACHE_DIR,
-            tmp=TMP_FOLDER,  # TODO: should inherit from root value for /var/lib/localstack (e.g., MOUNT_ROOT)
-            functions=HOST_TMP_FOLDER,  # TODO: rename variable/consider a volume
-            data=DATA_DIR,
-            config=CONFIG_DIR,
-            init=None,  # TODO: introduce environment variable
-            logs=TMP_FOLDER,  # TODO: add variable
-        )
-
-    @staticmethod
-    def legacy_for_container() -> "Directories":
-        """
-        Returns Localstack directory paths as they are defined within the container. Everything shared and writable
-        lives in /var/lib/localstack or /tmp/localstack.
-
-        :returns: Directories object
-        """
-        # only set CONTAINER_VAR_LIBS_FOLDER/CONTAINER_CACHE_FOLDER inside the container to redirect var_libs/cache to
-        # another directory to avoid override by host mount
-        var_libs = (
-            os.environ.get("CONTAINER_VAR_LIBS_FOLDER", "").strip() or "/tmp/localstack/var_libs"
-        )
-        cache = os.environ.get("CONTAINER_CACHE_FOLDER", "").strip() or "/tmp/localstack/cache"
-        tmp = (
-            os.environ.get("CONTAINER_TMP_FOLDER", "").strip() or "/tmp/localstack"
-        )  # TODO: discuss movement to /var/lib/localstack/tmp
-        data_dir = os.environ.get("CONTAINER_DATA_DIR_FOLDER", "").strip() or (
-            DATA_DIR if in_docker() else "/tmp/localstack_data"
-        )  # TODO: move to /var/lib/localstack/data
-        return Directories(
-            static_libs=os.path.join(MODULE_MAIN_PATH, "infra"),
-            var_libs=var_libs,
-            cache=cache,
-            tmp=tmp,
-            functions=HOST_TMP_FOLDER,  # TODO: move to /var/lib/localstack/tmp
-            data=data_dir,
-            config=None,  # config directory is host-only
-            logs="/tmp/localstack/logs",
-            init="/docker-entrypoint-initaws.d",
+            static_libs=None,
+            var_libs=None,
+            cache=str(cache_dir),  # used by analytics metadata
+            tmp=tmp_dir,
+            functions=None,
+            data=os.path.join(tmp_dir, "state"),  # used by localstack_ext config TODO: remove
+            logs=os.path.join(tmp_dir, "logs"),  # used for container logs
+            config=None,  # in the context of the CLI, config.CONFIG_DIR should be used
+            init=None,
         )
 
     def mkdirs(self):
@@ -1094,11 +1064,12 @@ SERVICE_PROVIDER_CONFIG.load_from_environment()
 
 
 def init_directories() -> Directories:
-    # FIXME: should also consider when the config.py is loaded from the CLI which does not necessarily imply
-    #  host mode. this may prove quite tricky to do.
     if is_in_docker:
         return Directories.for_container()
     else:
+        if is_env_true("LOCALSTACK_CLI"):
+            return Directories.for_cli()
+
         return Directories.for_host()
 
 

--- a/localstack/constants.py
+++ b/localstack/constants.py
@@ -154,8 +154,7 @@ API_ENDPOINT = os.environ.get("API_ENDPOINT") or "https://api.localstack.cloud/v
 # new analytics API endpoint
 ANALYTICS_API = os.environ.get("ANALYTICS_API") or "https://analytics.localstack.cloud/v1"
 
-# environment variable to indicates that this process is running the Web UI
-LOCALSTACK_WEB_PROCESS = "LOCALSTACK_WEB_PROCESS"
+# environment variable to indicates this process should run the localstack infrastructure
 LOCALSTACK_INFRA_PROCESS = "LOCALSTACK_INFRA_PROCESS"
 
 # default AWS region us-east-1

--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -22,7 +22,7 @@ from localstack.utils.container_utils.container_client import (
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import DOCKER_CLIENT
-from localstack.utils.files import cache_dir, chmod_r, mkdir
+from localstack.utils.files import cache_dir, mkdir
 from localstack.utils.functions import call_safe
 from localstack.utils.run import run, to_str
 from localstack.utils.serving import Server
@@ -54,13 +54,6 @@ API_COMPOSITES = {
     ],
     "cognito": ["cognito-idp", "cognito-identity"],
 }
-
-# main container name determined via "docker inspect"
-MAIN_CONTAINER_NAME_CACHED = None
-
-# environment variable that indicates that we're executing in
-# the context of the script that starts the Docker container
-ENV_SCRIPT_STARTING_DOCKER = "LS_SCRIPT_STARTING_DOCKER"
 
 
 def log_duration(name=None, min_ms=500):
@@ -516,21 +509,6 @@ def prepare_docker_start():
 
     if DOCKER_CLIENT.is_container_running(container_name):
         raise ContainerExists('LocalStack container named "%s" is already running' % container_name)
-    if config.dirs.tmp != config.dirs.functions and not config.LAMBDA_REMOTE_DOCKER:
-        # Logger is not initialized at this point, so the warning is displayed via print
-        print(
-            f"WARNING: The detected temp folder for localstack ({config.dirs.tmp}) is not equal to the "
-            f"HOST_TMP_FOLDER environment variable set ({config.dirs.functions})."
-        )
-
-    os.environ[ENV_SCRIPT_STARTING_DOCKER] = "1"
-
-    # make sure temp folder exists
-    mkdir(config.dirs.tmp)
-    try:
-        chmod_r(config.dirs.tmp, 0o777)
-    except Exception:
-        pass
 
 
 def configure_container(container: LocalstackContainer):


### PR DESCRIPTION

This PR adds a band-aid to a long-standing issue that `config.dirs` is used when running CLI commands.

This caused localstack to create the `.filesystem` directory in the Python path, which was originally just designed for executing host mode in developer environments, even when simply using the CLI.

```
 % locate .filesystem     
/home/thomas/.pyenv/versions/3.10.9/lib/python3.10/site-packages/.filesystem
/home/thomas/workspace/localstack/localstack/.filesystem
/home/thomas/workspace/localstack/localstack-ext/.venv/lib/python3.10/site-packages/.filesystem
```

Because the CLI and the runtime share control paths, there are situations where values from `config.dirs` are used to  create directories or files, even though they may not make sense in the context of the CLI.

* `dirs.cache` is used by the analytics metadata (cache machine id file), and was used by the `get_service_catalog` call (now removed)
* `dirs.data` is used by `localstack_ext.config` (this will be removed)
* `dirs.logs` is used as target to put the logs of the docker run command when starting localstack
* `dirs.tmp` should be removed now, but left it in there just in case

There is now a special control path that populates `config.dirs` deliberately with values that make the above examples work without the `.filesystem` directory.
To reduce the number of calls to `config.dirs`, I also removed some unused code from the startup procedure.

Once the old edge proxy logic is removed, we can more easily split up `infra.py` and therefore `bootstrap.py`, which will hopefuly also make it easier to separate out the CLI code.
