### PR TITLE
add tracing for handler chain

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -1,6 +1,9 @@
+from localstack import config
 from localstack.aws import handlers
+from localstack.aws.chain import HandlerChain
 from localstack.aws.handlers.metric_handler import MetricHandler
 from localstack.aws.handlers.service_plugin import ServiceLoader
+from localstack.aws.trace import TracingHandlerChain
 from localstack.services.plugins import SERVICE_PLUGINS, ServiceManager, ServicePluginManager
 from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
 
@@ -70,6 +73,13 @@ class LocalstackAwsGateway(Gateway):
                 metric_collector.update_metric_collection,
             ]
         )
+
+    def new_chain(self) -> HandlerChain:
+        if config.DEBUG_HANDLER_CHAIN:
+            return TracingHandlerChain(
+                self.request_handlers, self.response_handlers, self.exception_handlers
+            )
+        return super().new_chain()
 
 
 def main():

--- a/localstack/aws/trace.py
+++ b/localstack/aws/trace.py
@@ -1,0 +1,345 @@
+import dataclasses
+import inspect
+import logging
+import time
+from typing import Any, Callable
+
+from werkzeug.datastructures import Headers
+
+from localstack.http import Response
+from localstack.utils.patch import Patch, Patches
+
+from .api import RequestContext
+from .chain import ExceptionHandler, Handler, HandlerChain
+
+LOG = logging.getLogger(__name__)
+
+
+class Action:
+    """
+    Encapsulates something that the handler performed on the request context, request, or response objects.
+    """
+
+    name: str
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self):
+        return self.name
+
+
+class SetAttributeAction(Action):
+    """
+    The handler set an attribute of the request context or something else.
+    """
+
+    key: str
+    value: Any | None
+
+    def __init__(self, key: str, value: Any | None = None):
+        super().__init__("set")
+        self.key = key
+        self.value = value
+
+    def __repr__(self):
+        if self.value is None:
+            return f"set {self.key}"
+        return f"set {self.key} = {self.value!r}"
+
+
+class ModifyHeadersAction(Action):
+    """
+    The handler modified headers in some way, either adding, updating, or removing headers.
+    """
+
+    def __init__(self, name: str, before: Headers, after: Headers):
+        super().__init__(name)
+        self.before = before
+        self.after = after
+
+    @property
+    def header_actions(self) -> list[Action]:
+        after = self.after
+        before = self.before
+
+        actions = []
+
+        headers_set = dict(set(after.items()) - set(before.items()))
+        headers_removed = {k: v for k, v in before.items() if k not in after}
+
+        for k, v in headers_set.items():
+            actions.append(Action(f"set '{k}: {v}'"))
+        for k, v in headers_removed.items():
+            actions.append(Action(f"del '{k}: {v}'"))
+
+        return actions
+
+
+@dataclasses.dataclass
+class HandlerTrace:
+    handler: Handler
+    """The handler"""
+    duration_ms: float
+    """The runtime duration of the handler in milliseconds"""
+    actions: list[Action]
+    """The actions the handler chain performed"""
+
+    @property
+    def handler_module(self):
+        return self.handler.__module__
+
+    @property
+    def handler_name(self):
+        if inspect.isfunction(self.handler):
+            return self.handler.__name__
+        else:
+            return self.handler.__class__.__name__
+
+
+def _log_method_call(name: str, actions: list[Action]):
+    """Creates a wrapper around the original method `_fn`. It appends an action to the `actions`
+    list indicating that the function was called and then returns the original function."""
+
+    def _proxy(self, _fn, *args, **kwargs):
+        actions.append(Action(f"call {name}"))
+        return _fn(*args, **kwargs)
+
+    return _proxy
+
+
+class TracingHandlerBase:
+    """
+    This class is a Handler that records a trace of the execution of another request handler. It has two
+    attributes: `trace`, which stores the tracing information, and `delegate`, which is the handler or
+    exception handler that will be traced.
+    """
+
+    trace: HandlerTrace | None
+    delegate: Handler | ExceptionHandler
+
+    def __init__(self, delegate: Handler | ExceptionHandler):
+        self.trace = None
+        self.delegate = delegate
+
+    def do_trace_call(
+        self, fn: Callable, chain: HandlerChain, context: RequestContext, response: Response
+    ):
+        """
+        Wraps the function call with the tracing functionality and records a HandlerTrace.
+
+        The method determines changes made by the request handler to specific aspects of the request.
+        Changes made to the request context and the response headers/status by the request handler are then
+        examined, and appropriate actions are added to the `actions` list of the trace.
+
+        :param fn: which is the function to be traced, which is the request/response/exception handler
+        :param chain: the handler chain
+        :param context: the request context
+        :param response: the response object
+        """
+        then = time.perf_counter()
+
+        actions = []
+
+        prev_context = dict(context.__dict__)
+        prev_stopped = chain.stopped
+        prev_request_identity = id(context.request)
+        prev_terminated = chain.terminated
+        prev_request_headers = context.request.headers.copy()
+        prev_response_headers = response.headers.copy()
+        prev_response_status = response.status_code
+
+        # add patches to log invocations or certain functions
+        patches = Patches(
+            [
+                Patch.function(
+                    context.request.get_data,
+                    _log_method_call("request.get_data", actions),
+                ),
+                Patch.function(
+                    context.request._load_form_data,
+                    _log_method_call("request._load_form_data", actions),
+                ),
+                Patch.function(
+                    response.get_data,
+                    _log_method_call("response.get_data", actions),
+                ),
+            ]
+        )
+        patches.apply()
+
+        try:
+            return fn()
+        finally:
+            now = time.perf_counter()
+            # determine some basic things the handler changed in the context
+            patches.undo()
+
+            # chain
+            if chain.stopped and not prev_stopped:
+                actions.append(Action("stop chain"))
+            if chain.terminated and not prev_terminated:
+                actions.append(Action("terminate chain"))
+
+            # request contex
+            if context.region and not prev_context.get("region"):
+                actions.append(SetAttributeAction("region", context.region))
+            if context.account_id and not prev_context.get("account_id"):
+                actions.append(SetAttributeAction("account_id", context.account_id))
+            if context.service and not prev_context.get("service"):
+                actions.append(SetAttributeAction("service", context.service.service_name))
+            if context.operation and not prev_context.get("operation"):
+                actions.append(SetAttributeAction("operation", context.operation.name))
+            if context.service_request and not prev_context.get("service_request"):
+                actions.append(SetAttributeAction("service_request"))
+            if context.service_response and not prev_context.get("service_response"):
+                actions.append(SetAttributeAction("service_response"))
+
+            # request
+            if id(context.request) != prev_request_identity:
+                actions.append(Action("replaced request object"))
+
+            # response
+            if response.status_code != prev_response_status:
+                actions.append(SetAttributeAction("response stats_code", response.status_code))
+            if context.request.headers != prev_request_headers:
+                actions.append(
+                    ModifyHeadersAction(
+                        "modify request headers",
+                        prev_request_headers,
+                        context.request.headers.copy(),
+                    )
+                )
+            if response.headers != prev_response_headers:
+                actions.append(
+                    ModifyHeadersAction(
+                        "modify response headers", prev_response_headers, response.headers.copy()
+                    )
+                )
+
+            self.trace = HandlerTrace(
+                handler=self.delegate, duration_ms=(now - then) * 1000, actions=actions
+            )
+
+
+class TracingHandler(Handler, TracingHandlerBase):
+    delegate: Handler
+
+    def __init__(self, delegate: Handler):
+        super().__init__(delegate)
+
+    def __call__(self, chain: HandlerChain, context: RequestContext, response: Response):
+        def _call():
+            return self.delegate(chain, context, response)
+
+        return self.do_trace_call(_call, chain, context, response)
+
+
+class TracingExceptionHandler(ExceptionHandler, TracingHandlerBase):
+    delegate: ExceptionHandler
+
+    def __init__(self, delegate: ExceptionHandler):
+        super().__init__(delegate)
+
+    def __call__(
+        self, chain: HandlerChain, exception: Exception, context: RequestContext, response: Response
+    ):
+        def _call():
+            return self.delegate(chain, exception, context, response)
+
+        return self.do_trace_call(_call, chain, context, response)
+
+
+class TracingHandlerChain(HandlerChain):
+    """
+    DebuggingHandlerChain - A subclass of HandlerChain for logging and tracing handlers.
+
+    Attributes:
+    - duration (float): Total time taken for handling request in milliseconds.
+    - request_handler_traces (list[HandlerTrace]): List of request handler traces.
+    - response_handler_traces (list[HandlerTrace]): List of response handler traces.
+    - exception_handler_traces (list[HandlerTrace]): List of exception handler traces.
+
+    Methods:
+    - handle(context: RequestContext, response: Response):
+    - _call_response_handlers(response): .
+    - _call_exception_handlers(e, response): Overrides HandlerChain's _call_exception_handlers method and adds tracing handler to exception handlers.
+    - _log_report(): Logs the trace report in the format specified.
+    """
+
+    duration: float
+    request_handler_traces: list[HandlerTrace]
+    response_handler_traces: list[HandlerTrace]
+    exception_handler_traces: list[HandlerTrace]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request_handler_traces = []
+        self.response_handler_traces = []
+        self.exception_handler_traces = []
+
+    def handle(self, context: RequestContext, response: Response):
+        """Overrides HandlerChain's handle method and adds tracing handler to request handlers. Logs the trace
+        report with request and response details."""
+        then = time.perf_counter()
+        try:
+            self.request_handlers = [TracingHandler(handler) for handler in self.request_handlers]
+            return super().handle(context, response)
+        finally:
+            self.duration = (time.perf_counter() - then) * 1000
+            self.request_handler_traces = [handler.trace for handler in self.request_handlers]
+            self._log_report()
+
+    def _call_response_handlers(self, response):
+        self.response_handlers = [TracingHandler(handler) for handler in self.response_handlers]
+        try:
+            return super()._call_response_handlers(response)
+        finally:
+            self.response_handler_traces = [handler.trace for handler in self.response_handlers]
+
+    def _call_exception_handlers(self, e, response):
+        self.exception_handlers = [
+            TracingExceptionHandler(handler) for handler in self.exception_handlers
+        ]
+        try:
+            return super()._call_exception_handlers(e, response)
+        finally:
+            self.exception_handler_traces = [handler.trace for handler in self.exception_handlers]
+
+    def _log_report(self):
+        report = []
+        request = self.context.request
+        response = self.response
+
+        def _append_traces(traces: list[HandlerTrace]):
+            """Format and appends a list of traces to the report, and recursively append the trace's
+            actions (if any)."""
+
+            for trace in traces:
+                if trace is None:
+                    continue
+
+                report.append(
+                    f"{trace.handler_module:43s} {trace.handler_name:30s} {trace.duration_ms:8.2f}ms"
+                )
+                _append_actions(trace.actions, 46)
+
+        def _append_actions(actions: list[Action], indent: int):
+            for action in actions:
+                report.append((" " * indent) + f"- {action!r}")
+
+                if isinstance(action, ModifyHeadersAction):
+                    _append_actions(action.header_actions, indent + 2)
+
+        report.append(f"request:  {request.method} {request.url}")
+        report.append(f"response: {response.status_code}")
+        report.append("---- request handlers " + ("-" * 63))
+        _append_traces(self.request_handler_traces)
+        report.append("---- response handlers " + ("-" * 63))
+        _append_traces(self.response_handler_traces)
+        report.append("---- exception handlers " + ("-" * 63))
+        _append_traces(self.exception_handler_traces)
+        # Add a separator and total duration value to the end of the report
+        report.append(f"{'=' * 68} total {self.duration:8.2f}ms")
+
+        LOG.info("handler chain trace report:\n%s\n%s", "=" * 85, "\n".join(report))

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -477,6 +477,9 @@ DISABLE_PREFLIGHT_PROCESSING = is_env_true("DISABLE_PREFLIGHT_PROCESSING")
 DISABLE_EVENTS = is_env_true("DISABLE_EVENTS")
 DEBUG_ANALYTICS = is_env_true("DEBUG_ANALYTICS")
 
+# whether to log fine-grained debugging information for the handler chain
+DEBUG_HANDLER_CHAIN = is_env_true("DEBUG_HANDLER_CHAIN")
+
 # whether to eagerly start services
 EAGER_SERVICE_LOADING = is_env_true("EAGER_SERVICE_LOADING")
 
@@ -781,6 +784,7 @@ CONFIG_ENV_VARS = [
     "CFN_ENABLE_RESOLVE_REFS_IN_MODELS",
     "CUSTOM_SSL_CERT_PATH",
     "DEBUG",
+    "DEBUG_HANDLER_CHAIN",
     "DEFAULT_REGION",
     "DEVELOP",
     "DEVELOP_PORT",


### PR DESCRIPTION
This PR targets localstack developers and adds tracing functionality to debug the handler chain.
I think this can be useful for work that involves a lot of debugging in the HTTP framework (thinking APIGW, S3, CORS, Lambda, issues with request streaming, ...) :eyes: @bentsku @alexrashed @calvernaz @dfangl @dominikschubert 

You can enable this behavior by setting `DEBUG_HANDLER_CHAIN=1` 

By wrapping handlers and recording before/after state of the context, request, and response object, we can report in quite a detailed way what the handler did to the request/response.
This includes
* attributes set on the context, like the service or operation
* which headers where modified
* whether pesky get_data methods were called on request/response objects

I'm sure there are better/more generic ways of implementing it than the way I did, but I feel for a first iteration it's OK. 
Here are some examples of how the report looks like. I know they're not super pretty - happy for suggestions.

calling a non-implemented operation:

```
=====================================================================================
request:  POST http://localhost:4566/
response: 501
---- request handlers ---------------------------------------------------------------
localstack.aws.handlers.legacy              push_request_context               0.13ms
localstack.aws.handlers.metric_handler      method                             0.08ms
localstack.aws.chain                        CompositeHandler                   0.08ms
localstack.aws.handlers.service             ServiceNameParser                  9.69ms
                                              - set service = 'lightsail'
                                              - modify request headers
                                                - set 'x-localstack-tgt-api: lightsail'
localstack.aws.handlers.cors                CorsEnforcer                       0.10ms
localstack.aws.handlers.codec               ContentDecoder                     0.09ms
localstack.aws.handlers.internal            LocalstackResourceHandler          0.20ms
localstack.aws.handlers.legacy              DefaultListenerHandler             0.08ms
localstack.aws.handlers.legacy              EdgeRouterHandler                  0.11ms
localstack.aws.handlers.auth                MissingAuthHeaderInjector          0.10ms
localstack.aws.handlers.region              RegionContextEnricher              0.43ms
                                              - set region = 'us-east-1'
localstack.aws.handlers.auth                AccountIdEnricher                  0.44ms
                                              - set account_id = '000000000000'
                                              - modify request headers
                                                - set 'x-moto-account-id: 000000000000'
localstack.aws.handlers.internal_requests   InternalRequestParamsEnricher      0.09ms
localstack.aws.handlers.service             ServiceRequestParser               0.57ms
                                              - call request.get_data
                                              - call request._load_form_data
                                              - call request.get_data
                                              - set operation = 'GetBundles'
localstack.aws.handlers.metric_handler      method                             0.09ms
localstack.aws.chain                        CompositeHandler                   0.08ms
localstack.aws.handlers.service_plugin      ServiceLoader                      0.13ms
---- response handlers ---------------------------------------------------------------
localstack.aws.handlers.service             ServiceResponseHandlers            0.09ms
localstack.aws.handlers.service             ServiceResponseParser              0.09ms
localstack.aws.handlers.legacy              set_close_connection_header        0.10ms
                                              - modify response headers
                                                - set 'Connection: close'
localstack.aws.chain                        CompositeResponseHandler           0.09ms
localstack.aws.handlers.cors                CorsResponseEnricher               0.26ms
                                              - modify response headers
                                                - set 'Access-Control-Allow-Methods: HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH'
                                                - set 'Access-Control-Allow-Origin: *'
                                                - set 'Access-Control-Expose-Headers: etag,x-amz-version-id'
                                                - set 'Access-Control-Allow-Headers: authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request'
localstack.aws.handlers.logging             ResponseLogger                     0.29ms
localstack.aws.handlers.analytics           ServiceRequestCounter              0.66ms
localstack.aws.handlers.legacy              pop_request_context                0.13ms
localstack.aws.handlers.metric_handler      method                             0.11ms
---- exception handlers ---------------------------------------------------------------
localstack.aws.handlers.logging             ExceptionLogger                    0.70ms
localstack.aws.handlers.service             ServiceExceptionSerializer         5.00ms
                                              - set response stats_code = 501
                                              - modify response headers
                                                - set 'Content-Length: 220'
                                                - set 'x-amzn-requestid: OU72LH39VYZ3NUXXBGQNBONTIELQN10G783JHGP2JW46Q78DLE37'
                                                - set 'X-Amzn-Errortype: InternalFailure'
                                                - set 'Content-Type: application/json'
localstack.aws.handlers.fallback            InternalFailureHandler             0.14ms
==================================================================== total    21.37ms
```


calling `awslocal opensearch list-domain-names`
```
=====================================================================================
request:  GET http://localhost:4566/2021-01-01/domain
response: 200
---- request handlers ---------------------------------------------------------------
localstack.aws.handlers.legacy              push_request_context               0.19ms
localstack.aws.handlers.metric_handler      method                             0.09ms
localstack.aws.chain                        CompositeHandler                   0.06ms
localstack.aws.handlers.service             ServiceNameParser                  1.68ms
                                              - set service = 'opensearch'
                                              - modify request headers
                                                - set 'x-localstack-tgt-api: opensearch'
localstack.aws.handlers.cors                CorsEnforcer                       0.09ms
localstack.aws.handlers.codec               ContentDecoder                     0.08ms
localstack.aws.handlers.internal            LocalstackResourceHandler          0.13ms
localstack.aws.handlers.legacy              DefaultListenerHandler             0.07ms
localstack.aws.handlers.legacy              EdgeRouterHandler                  0.08ms
localstack.aws.handlers.auth                MissingAuthHeaderInjector          0.07ms
localstack.aws.handlers.region              RegionContextEnricher              0.09ms
                                              - set region = 'us-east-1'
localstack.aws.handlers.auth                AccountIdEnricher                  0.09ms
                                              - set account_id = '000000000000'
                                              - modify request headers
                                                - set 'x-moto-account-id: 000000000000'
localstack.aws.handlers.internal_requests   InternalRequestParamsEnricher      0.07ms
localstack.aws.handlers.service             ServiceRequestParser              55.38ms
                                              - call request.get_data
                                              - call request._load_form_data
                                              - set operation = 'ListDomainNames'
localstack.aws.handlers.metric_handler      method                             0.09ms
localstack.aws.chain                        CompositeHandler                   0.07ms
localstack.aws.handlers.service_plugin      ServiceLoader                     57.39ms
localstack.aws.handlers.service             ServiceRequestRouter             116.85ms
                                              - set service_response
                                              - modify response headers
                                                - set 'x-amz-request-id: OP0F0433URHYVS47YDAN1RCGNSZS3XBYXICYAG056R738O6Q2LJP'
                                                - set 'Content-Length: 19'
                                                - set 'x-amzn-requestid: KC0F54NE4YMTBHGW35N7UUECL0WPI0N8Q2TDF9DTLK55JEX1Y1DM'
localstack.aws.handlers.fallback            EmptyResponseHandler               0.10ms
---- response handlers ---------------------------------------------------------------
localstack.aws.handlers.service             ServiceResponseHandlers            0.08ms
localstack.aws.handlers.service             ServiceResponseParser              0.08ms
localstack.aws.handlers.legacy              set_close_connection_header        0.09ms
                                              - modify response headers
                                                - set 'Connection: close'
localstack.aws.chain                        CompositeResponseHandler           0.08ms
localstack.aws.handlers.cors                CorsResponseEnricher               0.15ms
                                              - modify response headers
                                                - set 'Access-Control-Allow-Methods: HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH'
                                                - set 'Access-Control-Allow-Origin: *'
                                                - set 'Access-Control-Expose-Headers: etag,x-amz-version-id'
                                                - set 'Access-Control-Allow-Headers: authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request'
localstack.aws.handlers.logging             ResponseLogger                     0.26ms
localstack.aws.handlers.analytics           ServiceRequestCounter              0.12ms
localstack.aws.handlers.legacy              pop_request_context                0.13ms
localstack.aws.handlers.metric_handler      method                             0.11ms
---- exception handlers ---------------------------------------------------------------
==================================================================== total   234.82ms
```

calling the health endpoint

```
=====================================================================================
request:  GET http://localhost:4566/_localstack/health
response: 200
---- request handlers ---------------------------------------------------------------
localstack.aws.handlers.legacy              push_request_context               0.11ms
localstack.aws.handlers.metric_handler      method                             0.07ms
localstack.aws.chain                        CompositeHandler                   0.05ms
localstack.aws.handlers.service             ServiceNameParser                  0.58ms
localstack.aws.handlers.cors                CorsEnforcer                       0.07ms
localstack.aws.handlers.codec               ContentDecoder                     0.06ms
localstack.aws.handlers.internal            LocalstackResourceHandler          1.63ms
                                              - stop chain
                                              - modify response headers
                                                - set 'Content-Length: 872'
                                                - set 'Content-Type: application/json'
---- response handlers ---------------------------------------------------------------
localstack.aws.handlers.service             ServiceResponseHandlers            0.06ms
localstack.aws.handlers.service             ServiceResponseParser              0.06ms
localstack.aws.handlers.legacy              set_close_connection_header        0.07ms
                                              - modify response headers
                                                - set 'Connection: close'
localstack.aws.chain                        CompositeResponseHandler           0.06ms
localstack.aws.handlers.cors                CorsResponseEnricher               0.12ms
                                              - modify response headers
                                                - set 'Access-Control-Allow-Methods: HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH'
                                                - set 'Access-Control-Allow-Origin: *'
                                                - set 'Access-Control-Expose-Headers: etag,x-amz-version-id'
                                                - set 'Access-Control-Allow-Headers: authorization,cache-control,content-length,content-md5,content-type,etag,location,x-amz-acl,x-amz-content-sha256,x-amz-date,x-amz-request-id,x-amz-security-token,x-amz-tagging,x-amz-target,x-amz-user-agent,x-amz-version-id,x-amzn-requestid,x-localstack-target,amz-sdk-invocation-id,amz-sdk-request'
localstack.aws.handlers.logging             ResponseLogger                     0.07ms
localstack.aws.handlers.analytics           ServiceRequestCounter              0.07ms
localstack.aws.handlers.legacy              pop_request_context                0.08ms
localstack.aws.handlers.metric_handler      method                             0.07ms
---- exception handlers ---------------------------------------------------------------
==================================================================== total     3.78ms
```