### PR TITLE
7910 support having a grant with the same name on different keys

### DIFF
--- a/localstack/services/kms/models.py
+++ b/localstack/services/kms/models.py
@@ -8,7 +8,7 @@ import struct
 import uuid
 from collections import namedtuple
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
@@ -517,8 +517,8 @@ class KmsStore(BaseStore):
     #
     # maps grant ids to grants
     grants: Dict[str, KmsGrant] = LocalAttribute(default=dict)
-    # maps from grant names (used for idempotency) to grant ids
-    grant_names: Dict[str, str] = LocalAttribute(default=dict)
+    # maps from (grant names (used for idempotency), key id) to grant ids
+    grant_names: Dict[Tuple[str, str], str] = LocalAttribute(default=dict)
     # maps grant tokens to grant ids
     grant_tokens: Dict[str, str] = LocalAttribute(default=dict)
 


### PR DESCRIPTION
This change addresses this issue https://github.com/localstack/localstack/issues/7910
Previously, due to the `grant_names` only mapping from grant name to grant ID, it was impossible to have more than one grant with the same name across keys. By including the key ID in the mapping, it becomes possible. 

I've added a unit test to demonstrate the fix works, and allows this grant to be created on both keys. 

If any extra test coverage would help, just point me in the right direction!