### PR TITLE
Implement basic persistence for lambda v2

### DIFF
--- a/localstack/services/awslambda/invocation/lambda_models.py
+++ b/localstack/services/awslambda/invocation/lambda_models.py
@@ -82,6 +82,7 @@ IMAGE_MAPPING = {
 SNAP_START_SUPPORTED_RUNTIMES = [Runtime.java11]
 
 
+# TODO: maybe we should make this more "transient" by always initializing to Pending and *not* persisting it?
 @dataclasses.dataclass(frozen=True)
 class VersionState:
     state: State
@@ -518,11 +519,6 @@ class ServiceEndpoint(abc.ABC):
         :param executor_id: Executor ID this error report is for
         """
         raise NotImplementedError()
-
-
-@dataclasses.dataclass
-class EventSourceMapping:
-    ...
 
 
 @dataclasses.dataclass(frozen=True)

--- a/localstack/services/awslambda/invocation/lambda_service.py
+++ b/localstack/services/awslambda/invocation/lambda_service.py
@@ -111,7 +111,7 @@ class LambdaService:
 
         return version_manager
 
-    def create_function_version(self, function_version: FunctionVersion) -> None:
+    def create_function_version(self, function_version: FunctionVersion) -> Future[None]:
         """
         Creates a new function version (manager), and puts it in the startup dict
 
@@ -130,7 +130,7 @@ class LambdaService:
                 function_arn=qualified_arn, function_version=function_version, lambda_service=self
             )
             self.lambda_starting_versions[qualified_arn] = version_manager
-        self.task_executor.submit(version_manager.start)
+        return self.task_executor.submit(version_manager.start)
 
     def publish_version(self, function_version: FunctionVersion):
         """
@@ -238,7 +238,7 @@ class LambdaService:
             )
         )
 
-    def update_version(self, new_version: FunctionVersion) -> None:
+    def update_version(self, new_version: FunctionVersion) -> Future[None]:
         """
         Updates a given version. Will perform a rollover, so the old version will be active until the new one is ready
         to be invoked

--- a/localstack/services/awslambda/invocation/models.py
+++ b/localstack/services/awslambda/invocation/models.py
@@ -1,7 +1,7 @@
+from localstack.aws.api.lambda_ import EventSourceMappingConfiguration
 from localstack.services.awslambda.invocation.lambda_models import (
     AccountSettings,
     CodeSigningConfig,
-    EventSourceMapping,
     Function,
     Layer,
 )
@@ -13,7 +13,7 @@ class LambdaStore(BaseStore):
     functions: dict[str, Function] = LocalAttribute(default=dict)
 
     # maps EventSourceMapping UUIDs to the respective EventSourceMapping
-    event_source_mappings: dict[str, EventSourceMapping] = LocalAttribute(default=dict)
+    event_source_mappings: dict[str, EventSourceMappingConfiguration] = LocalAttribute(default=dict)
 
     # maps CodeSigningConfig ARNs to the respective CodeSigningConfig
     code_signing_configs: dict[str, CodeSigningConfig] = LocalAttribute(default=dict)
@@ -25,4 +25,4 @@ class LambdaStore(BaseStore):
     settings: AccountSettings = LocalAttribute(default=AccountSettings)
 
 
-lambda_stores = AccountRegionBundle[LambdaStore]("lambda", LambdaStore)
+lambda_stores = AccountRegionBundle("lambda", LambdaStore)

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -253,9 +253,9 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                                 exc_info=True,
                             )
 
-                    # Restore event source listeners
-                    for esm in state.event_source_mappings.values():
-                        EventSourceListener.start_listeners_for_asf(esm, self.lambda_service)
+                # Restore event source listeners
+                for esm in state.event_source_mappings.values():
+                    EventSourceListener.start_listeners_for_asf(esm, self.lambda_service)
 
     def on_after_init(self):
         self.router.register_routes()

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -187,6 +187,7 @@ from localstack.services.awslambda.layerfetcher.layer_fetcher import LayerFetche
 from localstack.services.awslambda.urlrouter import FunctionUrlRouter
 from localstack.services.edge import ROUTER
 from localstack.services.plugins import ServiceLifecycleHook
+from localstack.state import StateVisitor
 from localstack.utils.aws import aws_stack
 from localstack.utils.aws.arns import extract_service_from_arn
 from localstack.utils.collections import PaginatedList
@@ -203,12 +204,19 @@ LAMBDA_TAG_LIMIT_PER_RESOURCE = 50
 LAMBDA_LAYERS_LIMIT_PER_FUNCTION = 5
 
 
+@dataclasses.dataclass
+class LambdaPersistenceContext:
+    # TODO: extend for more detailed comparisons
+    functions_pre_restore: list[str] = dataclasses.field(default_factory=list)
+
+
 class LambdaProvider(LambdaApi, ServiceLifecycleHook):
     lambda_service: LambdaService
     create_fn_lock: threading.RLock
     create_layer_lock: threading.RLock
     router: FunctionUrlRouter
     layer_fetcher: LayerFetcher | None
+    lambda_persistence_context: LambdaPersistenceContext
 
     def __init__(self) -> None:
         self.lambda_service = LambdaService()
@@ -217,6 +225,48 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         self.router = FunctionUrlRouter(ROUTER, self.lambda_service)
         self.layer_fetcher = None
         lambda_hooks.inject_layer_fetcher.run(self)
+        self.lambda_persistence_context = LambdaPersistenceContext()
+
+    def accept_state_visitor(self, visitor: StateVisitor):
+        visitor.visit(lambda_stores)
+
+    def on_before_state_load(self):
+        for account_id, account_bundle in lambda_stores.items():
+            for region_name, state in account_bundle.items():
+                for fn in state.functions.values():
+                    self.lambda_persistence_context.functions_pre_restore.append(
+                        fn.latest().id.unqualified_arn()
+                    )
+
+    def on_after_state_load(self):
+        # TODO: provisioned concurrency
+        # TODO: detect new versions
+        # TODO: detect changes
+        for account_id, account_bundle in lambda_stores.items():
+            for region_name, state in account_bundle.items():
+                for fn in state.functions.values():
+                    # only restore functions that have been loaded and were not in the store before
+                    if (
+                        fn.latest().id.unqualified_arn()
+                        not in self.lambda_persistence_context.functions_pre_restore
+                    ):
+                        for fn_version in fn.versions.values():
+                            # restore the "Pending" state for every function version and start it
+                            new_state = VersionState(
+                                state=State.Pending,
+                                code=StateReasonCode.Creating,
+                                reason="The function is being created.",
+                            )
+                            new_config = dataclasses.replace(fn_version.config, state=new_state)
+                            new_version = dataclasses.replace(fn_version, config=new_config)
+                            fn.versions[fn_version.id.qualifier] = new_version
+                            self.lambda_service.create_function_version(fn_version)
+
+                            # Restore event source listeners
+                            for esm in state.event_source_mappings.values():
+                                EventSourceListener.start_listeners_for_asf(
+                                    esm, self.lambda_service
+                                )
 
     def on_after_init(self):
         self.router.register_routes()

--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -232,32 +232,26 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         for account_id, account_bundle in lambda_stores.items():
             for region_name, state in account_bundle.items():
                 for fn in state.functions.values():
-                    # only start functions that don't have a version manager yet
-                    try:
-                        self.lambda_service.get_lambda_version_manager(
-                            fn.latest().id.qualified_arn()
-                        )
-                    except ValueError:
-                        for fn_version in fn.versions.values():
-                            # restore the "Pending" state for every function version and start it
-                            try:
-                                new_state = VersionState(
-                                    state=State.Pending,
-                                    code=StateReasonCode.Creating,
-                                    reason="The function is being created.",
-                                )
-                                new_config = dataclasses.replace(fn_version.config, state=new_state)
-                                new_version = dataclasses.replace(fn_version, config=new_config)
-                                fn.versions[fn_version.id.qualifier] = new_version
-                                self.lambda_service.create_function_version(fn_version).result(
-                                    timeout=5
-                                )
-                            except Exception:
-                                LOG.warning(
-                                    "Failed to restore function version %s",
-                                    fn_version.id.qualified_arn(),
-                                    exc_info=True,
-                                )
+                    for fn_version in fn.versions.values():
+                        # restore the "Pending" state for every function version and start it
+                        try:
+                            new_state = VersionState(
+                                state=State.Pending,
+                                code=StateReasonCode.Creating,
+                                reason="The function is being created.",
+                            )
+                            new_config = dataclasses.replace(fn_version.config, state=new_state)
+                            new_version = dataclasses.replace(fn_version, config=new_config)
+                            fn.versions[fn_version.id.qualifier] = new_version
+                            self.lambda_service.create_function_version(fn_version).result(
+                                timeout=5
+                            )
+                        except Exception:
+                            LOG.warning(
+                                "Failed to restore function version %s",
+                                fn_version.id.qualified_arn(),
+                                exc_info=True,
+                            )
 
                     # Restore event source listeners
                     for esm in state.event_source_mappings.values():


### PR DESCRIPTION
Adds a first iteration on basic persistence for the new lambda v2 provider.

## Changes

- Start loaded lambda function versions. => Detects lambdas that need to start by checking if they have a VersionManager assigned
- Start event source listeners (note: restoring a dynamodbstreams event source mapping is currently broken because the dynamodbstreams provider doesn't properly support persistence yet) => test skipped for now


## Left to do (in a later PR)
- Implement state reset
- Implement restore for provisioned concurrency (Depends on https://github.com/localstack/localstack/pull/7881)
