### PR TITLE
fix APIGW request validation with empty request body

### DIFF
--- a/localstack/services/apigateway/invocations.py
+++ b/localstack/services/apigateway/invocations.py
@@ -100,7 +100,10 @@ class RequestValidator:
             return False
 
         try:
-            validate(instance=json.loads(self.context.data), schema=json.loads(model["schema"]))
+            # if the body is empty, replace it with an empty JSON body
+            validate(
+                instance=json.loads(self.context.data or "{}"), schema=json.loads(model["schema"])
+            )
             return True
         except ValidationError as e:
             LOG.warning("failed to validate request body %s", e)

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -81,36 +81,37 @@ class TestApiGatewayCommon:
             validateRequestBody=True,
         )["id"]
 
-        apigateway_client.put_method(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            authorizationType="NONE",
-            requestValidatorId=validator_id,
-            requestParameters={"method.request.path.test": True},
-        )
+        for http_method in ("GET", "POST"):
+            apigateway_client.put_method(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=http_method,
+                authorizationType="NONE",
+                requestValidatorId=validator_id,
+                requestParameters={"method.request.path.test": True},
+            )
 
-        apigateway_client.put_integration(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            integrationHttpMethod="POST",
-            type="AWS_PROXY",
-            uri=f"arn:aws:apigateway:{region}:lambda:path//2015-03-31/functions/"
-            f"{lambda_arn}/invocations",
-        )
-        apigateway_client.put_method_response(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            statusCode="200",
-        )
-        apigateway_client.put_integration_response(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            statusCode="200",
-        )
+            apigateway_client.put_integration(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=http_method,
+                integrationHttpMethod="POST",
+                type="AWS_PROXY",
+                uri=f"arn:aws:apigateway:{region}:lambda:path//2015-03-31/functions/"
+                f"{lambda_arn}/invocations",
+            )
+            apigateway_client.put_method_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=http_method,
+                statusCode="200",
+            )
+            apigateway_client.put_integration_response(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=http_method,
+                statusCode="200",
+            )
 
         stage_name = "local"
         deploy_1 = apigateway_client.create_deployment(restApiId=api_id, stageName=stage_name)
@@ -130,6 +131,10 @@ class TestApiGatewayCommon:
         response = requests.post(url, json={"test": "test"})
         assert response.ok
         assert json.loads(response.json()["body"]) == {"test": "test"}
+
+        # GET request with an empty body
+        response_get = requests.get(url)
+        assert response_get.ok
 
         response = apigateway_client.update_method(
             restApiId=api_id,
@@ -175,17 +180,23 @@ class TestApiGatewayCommon:
                 }
             ),
         )
-        # then attach the schema to the method
-        response = apigateway_client.update_method(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            patchOperations=[
-                {"op": "add", "path": "/requestModels/application~1json", "value": "testSchema"},
-            ],
-        )
-        snapshot.match("add-schema", response)
+        # then attach the schema to the methods
+        for http_method in ("GET", "POST"):
+            response = apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=http_method,
+                patchOperations=[
+                    {
+                        "op": "add",
+                        "path": "/requestModels/application~1json",
+                        "value": "testSchema",
+                    },
+                ],
+            )
+            snapshot.match(f"add-schema-{http_method}", response)
 
+        # revert the path validation for POST method
         response = apigateway_client.update_method(
             restApiId=api_id,
             resourceId=resource_id,
@@ -212,23 +223,36 @@ class TestApiGatewayCommon:
         assert response.status_code == 400
         snapshot.match("invalid-request-body", response.json())
 
-        # remove the validator from the method
-        response = apigateway_client.update_method(
-            restApiId=api_id,
-            resourceId=resource_id,
-            httpMethod="POST",
-            patchOperations=[
-                {
-                    "op": "replace",
-                    "path": "/requestValidatorId",
-                    "value": "",
-                },
-            ],
-        )
-        snapshot.match("remove-validator", response)
+        # GET request with an empty body
+        response_get = requests.get(url)
+        assert response_get.status_code == 400
+
+        # GET request with an empty body, content type JSON
+        response_get = requests.get(url, headers={"Content-Type": "application/json"})
+        assert response_get.status_code == 400
+
+        # remove the validator from the methods
+        for http_method in ("GET", "POST"):
+            response = apigateway_client.update_method(
+                restApiId=api_id,
+                resourceId=resource_id,
+                httpMethod=http_method,
+                patchOperations=[
+                    {
+                        "op": "replace",
+                        "path": "/requestValidatorId",
+                        "value": "",
+                    },
+                ],
+            )
+            snapshot.match(f"remove-validator-{http_method}", response)
 
         apigw_redeploy_api(rest_api_id=api_id, stage_name=stage_name)
 
         response = requests.post(url, json={"test": "test"})
         assert response.ok
         assert json.loads(response.json()["body"]) == {"test": "test"}
+
+        # GET request with an empty body
+        response_get = requests.get(url)
+        assert response_get.ok

--- a/tests/integration/apigateway/test_apigateway_common.py
+++ b/tests/integration/apigateway/test_apigateway_common.py
@@ -20,7 +20,6 @@ class TestApiGatewayCommon:
     @pytest.mark.skip_snapshot_verify(
         paths=[
             "$.invalid-request-body.Type",
-            "$..methodIntegration.cacheNamespace",
             "$..methodIntegration.integrationResponses",
             "$..methodIntegration.passthroughBehavior",
             "$..methodIntegration.requestParameters",
@@ -42,6 +41,7 @@ class TestApiGatewayCommon:
         snapshot.add_transformers_list(
             [
                 snapshot.transform.key_value("requestValidatorId"),
+                snapshot.transform.key_value("cacheNamespace"),
                 snapshot.transform.key_value("id"),  # deployment id
                 snapshot.transform.key_value("fn_name"),  # lambda name
                 snapshot.transform.key_value("fn_arn"),  # lambda arn
@@ -246,6 +246,7 @@ class TestApiGatewayCommon:
                 ],
             )
             snapshot.match(f"remove-validator-{http_method}", response)
+            print(response)
 
         apigw_redeploy_api(rest_api_id=api_id, stage_name=stage_name)
 

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/integration/apigateway/test_apigateway_common.py::TestApiGatewayCommon::test_api_gateway_request_validator": {
-    "recorded-date": "15-03-2023, 01:01:50",
+    "recorded-date": "20-03-2023, 17:18:54",
     "recorded-content": {
       "register-lambda": {
         "fn_arn": "arn:aws:lambda:<region>:111111111111:function:<fn_name:1>",
@@ -20,7 +20,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "5l4d79",
+          "cacheNamespace": "nygb1k",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -49,13 +49,48 @@
       "missing-required-request-params": {
         "message": "Missing required request parameters: [issuer]"
       },
-      "add-schema": {
+      "add-schema-GET": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "nygb1k",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "AWS_PROXY",
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:<fn_name:1>/invocations"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "requestModels": {
+          "application/json": "testSchema"
+        },
+        "requestParameters": {
+          "method.request.path.test": true
+        },
+        "requestValidatorId": "<request-validator-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "add-schema-POST": {
         "apiKeyRequired": false,
         "authorizationType": "NONE",
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "5l4d79",
+          "cacheNamespace": "nygb1k",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -90,7 +125,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "5l4d79",
+          "cacheNamespace": "nygb1k",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -122,13 +157,47 @@
       "invalid-request-body": {
         "message": "Invalid request body"
       },
-      "remove-validator": {
+      "remove-validator-GET": {
+        "apiKeyRequired": false,
+        "authorizationType": "NONE",
+        "httpMethod": "GET",
+        "methodIntegration": {
+          "cacheKeyParameters": [],
+          "cacheNamespace": "nygb1k",
+          "httpMethod": "POST",
+          "integrationResponses": {
+            "200": {
+              "statusCode": "200"
+            }
+          },
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "timeoutInMillis": 29000,
+          "type": "AWS_PROXY",
+          "uri": "arn:aws:apigateway:<region>:lambda:path//2015-03-31/functions/arn:aws:lambda:<region>:111111111111:function:<fn_name:1>/invocations"
+        },
+        "methodResponses": {
+          "200": {
+            "statusCode": "200"
+          }
+        },
+        "requestModels": {
+          "application/json": "testSchema"
+        },
+        "requestParameters": {
+          "method.request.path.test": true
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "remove-validator-POST": {
         "apiKeyRequired": false,
         "authorizationType": "NONE",
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "5l4d79",
+          "cacheNamespace": "nygb1k",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {

--- a/tests/integration/apigateway/test_apigateway_common.snapshot.json
+++ b/tests/integration/apigateway/test_apigateway_common.snapshot.json
@@ -20,7 +20,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "nygb1k",
+          "cacheNamespace": "<cache-namespace:1>",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -55,7 +55,7 @@
         "httpMethod": "GET",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "nygb1k",
+          "cacheNamespace": "<cache-namespace:1>",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -90,7 +90,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "nygb1k",
+          "cacheNamespace": "<cache-namespace:1>",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -125,7 +125,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "nygb1k",
+          "cacheNamespace": "<cache-namespace:1>",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -163,7 +163,7 @@
         "httpMethod": "GET",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "nygb1k",
+          "cacheNamespace": "<cache-namespace:1>",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {
@@ -197,7 +197,7 @@
         "httpMethod": "POST",
         "methodIntegration": {
           "cacheKeyParameters": [],
-          "cacheNamespace": "nygb1k",
+          "cacheNamespace": "<cache-namespace:1>",
           "httpMethod": "POST",
           "integrationResponses": {
             "200": {


### PR DESCRIPTION
Following #7842, we were missing a step in the validation: if the request body was empty, we should consider the request body as an empty JSON object to allow the validation to take effect, and not throw an error for invalid JSON.

I've extended the existing test for the request validator integration to add the `GET` method, and test with a request with no request body. 