### PR TITLE
Unify network configuration with LOCALSTACK_HOST variable

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -612,9 +612,6 @@ SQS_DELAY_PURGE_RETRY = is_env_true("SQS_DELAY_PURGE_RETRY")
 # Used to toggle QueueDeletedRecently errors when re-creating a queue within 60 seconds of deleting it
 SQS_DELAY_RECENTLY_DELETED = is_env_true("SQS_DELAY_RECENTLY_DELETED")
 
-# expose SQS on a specific port externally
-SQS_PORT_EXTERNAL = int(os.environ.get("SQS_PORT_EXTERNAL") or 0)
-
 # Strategy used when creating SQS queue urls. can be "off", "domain", or "path"
 SQS_ENDPOINT_STRATEGY = os.environ.get("SQS_ENDPOINT_STRATEGY", "") or "off"
 
@@ -865,7 +862,6 @@ CONFIG_ENV_VARS = [
     "SQS_DELAY_PURGE_RETRY",
     "SQS_DELAY_RECENTLY_DELETED",
     "SQS_ENDPOINT_STRATEGY",
-    "SQS_PORT_EXTERNAL",
     "STEPFUNCTIONS_LAMBDA_ENDPOINT",
     "SYNCHRONOUS_KINESIS_EVENTS",
     "SYNCHRONOUS_SNS_EVENTS",
@@ -996,9 +992,6 @@ populate_config_env_var_names()
 
 def service_port(service_key: str, external: bool = False) -> int:
     service_key = service_key.lower()
-    if external:
-        if service_key == "sqs" and SQS_PORT_EXTERNAL:
-            return SQS_PORT_EXTERNAL
     if FORWARD_EDGE_INMEM:
         if service_key == "elasticsearch":
             # TODO Elasticsearch domains are a special case - we do not want to route them through

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -355,6 +355,8 @@ HOSTNAME_EXTERNAL = os.environ.get("HOSTNAME_EXTERNAL", "").strip() or LOCALHOST
 # name of the host under which the LocalStack services are available
 LOCALSTACK_HOSTNAME = os.environ.get("LOCALSTACK_HOSTNAME", "").strip() or LOCALHOST
 
+LOCALSTACK_HOST = os.environ.get("LOCALSTACK_HOST", "")
+
 # directory for persisting data (TODO: deprecated, simply use PERSISTENCE=1)
 DATA_DIR = os.environ.get("DATA_DIR", "").strip()
 

--- a/localstack/services/opensearch/provider.py
+++ b/localstack/services/opensearch/provider.py
@@ -169,7 +169,7 @@ def create_cluster(
     # Replacing only 0.0.0.0 here as usage of this bind address mostly means running in docker which is used locally
     # If another bind address is used we want to keep it in the endpoint as this is a conscious user decision to
     # access from another device on the network.
-    status["Endpoint"] = cluster.url.split("://")[-1].replace("0.0.0.0", LOCALSTACK_HOSTNAME)
+    status["Endpoint"] = cluster.endpoint.split("://")[-1].replace("0.0.0.0", LOCALSTACK_HOSTNAME)
     status["EngineVersion"] = engine_version
 
     if cluster.is_up():

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -241,8 +241,7 @@ class SqsQueue:
     def url(self, context: RequestContext) -> str:
         """Return queue URL using the SQS_ENDPOINT_STRATEGY (if configured) or based on the 'Host' request header"""
 
-        host_url = context.request.host_url
-
+        host_definition = localstack_host()
         if config.SQS_ENDPOINT_STRATEGY == "domain":
             # queue.localhost.localstack.cloud:4566/000000000000/my-queue (us-east-1)
             # or us-east-2.queue.localhost.localstack.cloud:4566/000000000000/my-queue
@@ -253,7 +252,9 @@ class SqsQueue:
             host_url = f"{scheme}://{region}queue.{host_definition.host_and_port()}"
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
-            host_url = f"{context.request.host_url}queue/{self.region}"
+            host_url = f"{host_definition.host_and_port()}/queue/{self.region}"
+        else:
+            host_url = host_definition.to_url(context.request.scheme)
 
         return "{host}/{account_id}/{name}".format(
             host=host_url.rstrip("/"),

--- a/localstack/services/sqs/models.py
+++ b/localstack/services/sqs/models.py
@@ -21,7 +21,6 @@ from localstack.aws.api.sqs import (
     ReceiptHandleIsInvalid,
     TagMap,
 )
-from localstack.config import get_protocol
 from localstack.services.sqs import constants as sqs_constants
 from localstack.services.sqs.exceptions import (
     InvalidAttributeValue,
@@ -240,8 +239,7 @@ class SqsQueue:
         return f"arn:aws:sqs:{self.region}:{self.account_id}:{self.name}"
 
     def url(self, context: RequestContext) -> str:
-        """Return queue URL using either SQS_PORT_EXTERNAL (if configured), the SQS_ENDPOINT_STRATEGY (if configured)
-        or based on the 'Host' request header"""
+        """Return queue URL using the SQS_ENDPOINT_STRATEGY (if configured) or based on the 'Host' request header"""
 
         host_url = context.request.host_url
 
@@ -256,12 +254,6 @@ class SqsQueue:
         elif config.SQS_ENDPOINT_STRATEGY == "path":
             # https?://localhost:4566/queue/us-east-1/00000000000/my-queue (us-east-1)
             host_url = f"{context.request.host_url}queue/{self.region}"
-        else:
-            if config.SQS_PORT_EXTERNAL:
-                host_definition = localstack_host(
-                    use_hostname_external=True, custom_port=config.SQS_PORT_EXTERNAL
-                )
-                host_url = f"{get_protocol()}://{host_definition.host_and_port()}"
 
         return "{host}/{account_id}/{name}".format(
             host=host_url.rstrip("/"),

--- a/localstack/testing/pytest/fixtures.py
+++ b/localstack/testing/pytest/fixtures.py
@@ -2008,7 +2008,7 @@ def appsync_create_api(appsync_client):
 
 
 # parameter indicates whether LOCALSTACK_HOST should be set
-@pytest.fixture(params=[False, True])
+@pytest.fixture(params=[False, True], ids=["without-localstack-host", "with-localstack-host"])
 def assert_host_customisation(request, monkeypatch):
     use_localstack_host = request.param
     hostname_external = f"external-host-{short_uid()}"

--- a/localstack/utils/urls.py
+++ b/localstack/utils/urls.py
@@ -1,7 +1,10 @@
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
 from localstack import config, constants
+
+LOG = logging.getLogger(__name__)
 
 
 def path_from_url(url: str) -> str:
@@ -20,6 +23,9 @@ class HostDefinition:
     def host_and_port(self):
         return f"{self.host}:{self.port}"
 
+    def to_url(self, scheme: str) -> str:
+        return f"{scheme}://{self.host}:{self.port}"
+
 
 def localstack_host(
     use_hostname_external: bool = False,
@@ -36,6 +42,13 @@ def localstack_host(
     if custom_port is not None:
         port = custom_port
 
+    # v2 override
+    host_definition = _parse_localstack_host_envar(port)
+    if host_definition is not None:
+        return host_definition
+
+    # deprecation path
+
     host = config.LOCALHOST
     if use_hostname_external:
         host = config.HOSTNAME_EXTERNAL
@@ -45,3 +58,51 @@ def localstack_host(
         host = constants.LOCALHOST_HOSTNAME
 
     return HostDefinition(host=host, port=port)
+
+
+def _parse_localstack_host_envar(custom_port: Optional[int] = None) -> Optional[HostDefinition]:
+    """
+    Parse the LOCALSTACK_HOST environment variable into <hostname>:<port>
+
+    Note: both hostname and port are optional
+
+    If `custom_port` is supplied then this value is used in preference to any defaults set by configuration.
+
+    Examples:
+        - "foobar" | "foobar:" => {"host": "foobar", "port": 4566}
+        - ":10101" => {"host": "localhost.localstack.cloud", "port": 10101}
+        - "foobar:10101" => {"host": "foobar", "port": 10101}
+        - "" => {"host": "localhost.localstack.cloud", "port": 4566} (default/fallback case)
+    """
+    envar_value = config.LOCALSTACK_HOST.strip()
+    if not envar_value:
+        # the user did not set the value
+        return None
+
+    if ":" in envar_value:
+        # the variable contains both hostname and port specification, with either half possibly being default
+        hostname, port_str = envar_value.split(":", 1)
+        if not hostname.strip():
+            # default to localhost.localstack.cloud
+            hostname = constants.LOCALHOST_HOSTNAME
+
+        port = config.EDGE_PORT
+        if port_str.strip():
+            try:
+                port = int(port_str.strip())
+            except (ValueError, TypeError):
+                LOG.warning(
+                    f"invalid port specified: {port_str}, must be an integer; falling back to defaults"
+                )
+        if custom_port is not None:
+            port = custom_port
+
+        definition = HostDefinition(host=hostname, port=port)
+
+    else:
+        # we must just have a hostname
+        hostname = envar_value
+        port = custom_port if custom_port is not None else config.EDGE_PORT
+        definition = HostDefinition(host=hostname, port=port)
+
+    return definition

--- a/tests/integration/test_network_configuration.py
+++ b/tests/integration/test_network_configuration.py
@@ -46,10 +46,7 @@ class TestOpenSearch:
         opensearch_wait_for_cluster(domain_name)
         endpoint = res["DomainStatus"]["Endpoint"]
 
-        if config.is_in_docker:
-            assert_host_customisation(endpoint, use_localhost=True)
-        else:
-            assert_host_customisation(endpoint, custom_host="127.0.0.1")
+        assert_host_customisation(endpoint, use_localhost=True)
 
     def test_path_strategy(
         self, monkeypatch, opensearch_client, opensearch_wait_for_cluster, assert_host_customisation

--- a/tests/integration/test_network_configuration.py
+++ b/tests/integration/test_network_configuration.py
@@ -131,7 +131,6 @@ class TestSQS:
     Test all combinations of:
 
     * endpoint_strategy
-    * sqs_port_external
     * hostname_external
     """
 
@@ -145,20 +144,6 @@ class TestSQS:
 
         assert_host_customisation(queue_url, use_localhost=True)
         assert queue_name in queue_url
-
-    def test_off_strategy_with_external_port(
-        self, monkeypatch, sqs_create_queue, assert_host_customisation
-    ):
-        external_port = 12345
-        monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
-        monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_port)
-
-        queue_name = f"queue-{short_uid()}"
-        queue_url = sqs_create_queue(QueueName=queue_name)
-
-        assert_host_customisation(queue_url, use_hostname_external=True)
-        assert queue_name in queue_url
-        assert f":{external_port}" in queue_url
 
     def test_domain_strategy(self, monkeypatch, sqs_create_queue, assert_host_customisation):
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "domain")

--- a/tests/integration/test_sqs.py
+++ b/tests/integration/test_sqs.py
@@ -1029,15 +1029,13 @@ class TestSqsProvider:
     @pytest.mark.only_localstack
     def test_external_hostname(self, monkeypatch, sqs_client, sqs_create_queue):
         external_host = "external-host"
-        external_port = "12345"
 
         monkeypatch.setattr(config, "SQS_ENDPOINT_STRATEGY", "off")
-        monkeypatch.setattr(config, "SQS_PORT_EXTERNAL", external_port)
         monkeypatch.setattr(config, "HOSTNAME_EXTERNAL", external_host)
 
         queue_url = sqs_create_queue()
 
-        assert f"{external_host}:{external_port}" in queue_url
+        assert external_host in queue_url
 
         message_body = "external_host_test"
         sqs_client.send_message(QueueUrl=queue_url, MessageBody=message_body)

--- a/tests/unit/test_network_configuration.py
+++ b/tests/unit/test_network_configuration.py
@@ -1,0 +1,62 @@
+from localstack import config
+from localstack.utils.strings import short_uid
+from localstack.utils.urls import HostDefinition, localstack_host
+
+
+class TestSuccess:
+    def test_all_defaults(self, monkeypatch):
+        # do not set LOCALSTACK_HOST
+        host_definition = localstack_host()
+
+        assert host_definition == HostDefinition(
+            host="localhost",
+            port=4566,
+        )
+
+    def test_setting_hostname(self, monkeypatch):
+        hostname = f"localstack-host-{short_uid()}"
+        monkeypatch.setattr(config, "LOCALSTACK_HOST", hostname)
+
+        host_definition = localstack_host()
+
+        assert host_definition == HostDefinition(
+            host=hostname,
+            port=4566,
+        )
+
+    def test_setting_port(self, monkeypatch):
+        port = 10101
+        monkeypatch.setattr(config, "LOCALSTACK_HOST", f":{port}")
+        host_definition = localstack_host()
+
+        assert host_definition == HostDefinition(
+            host="localhost.localstack.cloud",
+            port=port,
+        )
+
+    def test_setting_both(self, monkeypatch):
+        hostname = f"localstack_host-{short_uid()}"
+        port = 10101
+        monkeypatch.setattr(config, "LOCALSTACK_HOST", f"{hostname}:{port}")
+
+        host_definition = localstack_host()
+
+        assert host_definition == HostDefinition(
+            host=hostname,
+            port=port,
+        )
+
+
+class TestFailures:
+    def test_invalid_port_integer(self, monkeypatch, caplog):
+        port = "not a port"
+        monkeypatch.setattr(config, "LOCALSTACK_HOST", f":{port}")
+
+        host_definition = localstack_host()
+
+        assert host_definition == HostDefinition(
+            host="localhost.localstack.cloud",
+            port=4566,
+        )
+
+        assert "invalid port specified" in caplog.messages[0]


### PR DESCRIPTION
Use the new `LOCALSTACK_HOST` variable to unify URL returning.
