### PR TITLE
Update PRO image warning

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -7,16 +7,14 @@ then
   EDGE_PORT=4566
 fi
 
-# FIXME: remove with 2.0
-# the Dockerfile creates .pro-version file for the pro image. When trying to activate pro features with any other
-# version, an error is printed.
-if [[ $LOCALSTACK_API_KEY ]] && [[ ! -f /usr/lib/localstack/.pro-version ]]; then
+# the Dockerfile creates .pro-version file for the pro image and .bigdata-pro-version for the bigdata image.
+# When trying to activate pro features with any other version, a warning is printed.
+if [[ $LOCALSTACK_API_KEY ]] && [[ ! -f /usr/lib/localstack/.*pro-version ]]; then
     echo "WARNING"
     echo "============================================================================"
-    echo "  It seems you are using the LocalStack Pro version without using the"
-    echo "  dedicated Pro image."
-    echo "  Future versions will only support running LocalStack Pro with the"
-    echo "  dedicated image."
+    echo "  It seems you are trying to use the LocalStack Pro version without using "
+    echo "  the dedicated Pro image."
+    echo "  LocalStack will only start with community services enabled."
     echo "  To fix this warning, use localstack/localstack-pro instead."
     echo ""
     echo "  See: https://github.com/localstack/localstack/issues/7257"


### PR DESCRIPTION
We will start localstack with community services enabled if the `localstack/localstack` image is used instead of `localstack/localstack-pro`. Also, we have a new version-tag file for the new bigdata tag. This PR adapts the existing warning to consider these changes.