### PR TITLE
Dynamically determine ports check Docker image to avoid duplicate download

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -17,7 +17,6 @@ from localstack.constants import (
     DEFAULT_LAMBDA_CONTAINER_REGISTRY,
     DEFAULT_SERVICE_PORTS,
     DEFAULT_VOLUME_DIR,
-    DOCKER_IMAGE_NAME,
     ENV_INTERNAL_TEST_COLLECT_METRIC,
     ENV_INTERNAL_TEST_RUN,
     FALSE_STRINGS,
@@ -401,9 +400,7 @@ DOCKER_CMD = os.environ.get("DOCKER_CMD", "").strip() or "docker"
 LEGACY_DOCKER_CLIENT = is_env_true("LEGACY_DOCKER_CLIENT")
 
 # Docker image to use when starting up containers for port checks
-PORTS_CHECK_DOCKER_IMAGE = (
-    os.environ.get("PORTS_CHECK_DOCKER_IMAGE", "").strip() or DOCKER_IMAGE_NAME
-)
+PORTS_CHECK_DOCKER_IMAGE = os.environ.get("PORTS_CHECK_DOCKER_IMAGE", "").strip()
 
 # whether to forward edge requests in-memory (instead of via proxy servers listening on backend ports)
 # TODO: this will likely become the default and may get removed in the future

--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import platform
 import random
-import threading
 from typing import List, Optional
 
 from localstack import config
@@ -13,8 +12,8 @@ from localstack.utils.container_utils.container_client import (
     VolumeInfo,
 )
 from localstack.utils.net import PortNotAvailableException, PortRange
+from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import to_str
-from localstack.utils.sync import synchronized
 
 LOG = logging.getLogger(__name__)
 
@@ -24,15 +23,6 @@ PORT_START = 0
 PORT_END = 65536
 RANDOM_PORT_START = 1024
 RANDOM_PORT_END = 65536
-
-
-class _State:
-    """simple container to encapsulate the runtime state (lazily loaded)"""
-
-    # name of the Docker image to use for ports checks
-    ports_check_docker_image: Optional[str] = None
-    # lock used to determine the ports check Docker image
-    ports_check_docker_image_lock: threading.RLock = threading.RLock()
 
 
 def is_docker_sdk_installed() -> bool:
@@ -229,29 +219,25 @@ def reserve_available_container_port(
     )
 
 
-@synchronized(_State.ports_check_docker_image_lock)
+@singleton_factory
 def _get_ports_check_docker_image() -> str:
     """
     Determine the Docker image to use for Docker port availability checks.
     Uses either PORTS_CHECK_DOCKER_IMAGE (if configured), or otherwise inspects the running container's image.
     """
-    if not _State.ports_check_docker_image:
-        if config.PORTS_CHECK_DOCKER_IMAGE:
-            # explicit configuration takes precedence
-            _docker_image = config.PORTS_CHECK_DOCKER_IMAGE
-        elif not config.is_in_docker:
-            # use default image for host mode
-            _docker_image = DOCKER_IMAGE_NAME
-        else:
-            try:
-                # inspect the running container to determine the image
-                container = DOCKER_CLIENT.inspect_container(get_current_container_id())
-                _docker_image = container["Config"]["Image"]
-            except Exception:
-                # fall back to using the default Docker image
-                _docker_image = DOCKER_IMAGE_NAME
-        _State.ports_check_docker_image = _docker_image
-    return _State.ports_check_docker_image
+    if config.PORTS_CHECK_DOCKER_IMAGE:
+        # explicit configuration takes precedence
+        return config.PORTS_CHECK_DOCKER_IMAGE
+    if not config.is_in_docker:
+        # use default image for host mode
+        return DOCKER_IMAGE_NAME
+    try:
+        # inspect the running container to determine the image
+        container = DOCKER_CLIENT.inspect_container(get_current_container_id())
+        return container["Config"]["Image"]
+    except Exception:
+        # fall back to using the default Docker image
+        return DOCKER_IMAGE_NAME
 
 
 DOCKER_CLIENT: ContainerClient = create_docker_client()

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -1385,13 +1385,22 @@ class TestDockerPermissions:
         assert security_opt == inspect_result["HostConfig"]["SecurityOpt"]
 
 
+@pytest.fixture
+def set_ports_check_image_alpine(monkeypatch):
+    """Set the ports check Docker image to 'alpine', to avoid pulling the larger localstack image in the tests"""
+
+    def _get_ports_check_docker_image():
+        return "alpine"
+
+    monkeypatch.setattr(
+        docker_utils, "_get_ports_check_docker_image", _get_ports_check_docker_image
+    )
+
+
 class TestDockerPorts:
-    def test_reserve_container_port(self, docker_client, monkeypatch):
+    def test_reserve_container_port(self, docker_client, set_ports_check_image_alpine):
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")
-
-        monkeypatch.setattr(config, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
-        monkeypatch.setattr(docker_utils._State, "ports_check_docker_image", None)
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)
@@ -1417,12 +1426,9 @@ class TestDockerPorts:
         assert container_port_can_be_bound(port)
         assert not is_port_available_for_containers(port)
 
-    def test_container_port_can_be_bound(self, docker_client, monkeypatch):
+    def test_container_port_can_be_bound(self, docker_client, set_ports_check_image_alpine):
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")
-
-        monkeypatch.setattr(config, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
-        monkeypatch.setattr(docker_utils._State, "ports_check_docker_image", None)
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -10,6 +10,7 @@ import pytest
 
 from localstack import config
 from localstack.config import in_docker
+from localstack.utils import docker_utils
 from localstack.utils.common import is_ipv4_address, save_file, short_uid, to_str
 from localstack.utils.container_utils.container_client import (
     AccessDenied,
@@ -1390,6 +1391,7 @@ class TestDockerPorts:
             pytest.skip("Running test only for one Docker executor")
 
         monkeypatch.setattr(config, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
+        monkeypatch.setattr(docker_utils._State, "ports_check_docker_image", None)
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)
@@ -1420,6 +1422,7 @@ class TestDockerPorts:
             pytest.skip("Running test only for one Docker executor")
 
         monkeypatch.setattr(config, "PORTS_CHECK_DOCKER_IMAGE", "alpine")
+        monkeypatch.setattr(docker_utils._State, "ports_check_docker_image", None)
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)


### PR DESCRIPTION
Dynamically determine ports check Docker image to avoid duplicate image download.

Currently, the default image we're using for the port availability checks is `localstack/localstack` (unless configured manually via `PORTS_CHECK_DOCKER_IMAGE`). For Pro users (`localstack/localstack-pro`), this means that potentially an additional image would be downloaded at runtime. 

This hasn't been an issue so far (as the images were aliases), but is now becoming relevant for the upcoming image split in v2.