### PR TITLE
Fix lambda destination default retries

### DIFF
--- a/localstack/services/awslambda/invocation/version_manager.py
+++ b/localstack/services/awslambda/invocation/version_manager.py
@@ -576,6 +576,8 @@ class LambdaVersionManager(ServiceEndpoint):
             )
 
             max_retry_attempts = event_invoke_config.maximum_retry_attempts
+            if max_retry_attempts is None:
+                max_retry_attempts = 2  # default
             previous_retry_attempts = queued_invocation.retries
 
             if self.function.reserved_concurrent_executions == 0:

--- a/tests/integration/awslambda/test_lambda_api.py
+++ b/tests/integration/awslambda/test_lambda_api.py
@@ -1764,6 +1764,11 @@ class TestLambdaEventInvokeConfig:
         )
         snapshot.match("put_published_invokeconfig", put_published_invokeconfig)
 
+        get_published_invokeconfig = lambda_client.get_function_event_invoke_config(
+            FunctionName=function_name, Qualifier=publish_version_result["Version"]
+        )
+        snapshot.match("get_published_invokeconfig", get_published_invokeconfig)
+
         # list paging
         list_paging_single = lambda_client.list_function_event_invoke_configs(
             FunctionName=function_name, MaxItems=1

--- a/tests/integration/awslambda/test_lambda_api.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_api.snapshot.json
@@ -9906,7 +9906,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_api.py::TestLambdaEventInvokeConfig::test_lambda_eventinvokeconfig_lifecycle": {
-    "recorded-date": "17-02-2023, 11:39:34",
+    "recorded-date": "22-03-2023, 18:49:13",
     "recorded-content": {
       "put_invokeconfig_retries_0": {
         "DestinationConfig": {
@@ -10061,6 +10061,19 @@
         }
       },
       "put_published_invokeconfig": {
+        "DestinationConfig": {
+          "OnFailure": {},
+          "OnSuccess": {}
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<function-name:1>:1",
+        "LastModified": "datetime",
+        "MaximumEventAgeInSeconds": 120,
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "get_published_invokeconfig": {
         "DestinationConfig": {
           "OnFailure": {},
           "OnSuccess": {}

--- a/tests/integration/awslambda/test_lambda_destinations.py
+++ b/tests/integration/awslambda/test_lambda_destinations.py
@@ -7,7 +7,7 @@ import pytest
 
 from localstack import config
 from localstack.aws.api.lambda_ import Runtime
-from localstack.testing.aws.lambda_utils import is_new_provider, is_old_provider
+from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.testing.aws.util import is_aws_cloud
 from localstack.utils.strings import short_uid, to_bytes, to_str
 from localstack.utils.sync import retry, wait_until
@@ -104,12 +104,6 @@ class TestLambdaDestinationSqs:
             "$..stackTrace",
         ],
     )
-    @pytest.mark.skip_snapshot_verify(
-        condition=is_new_provider,
-        paths=[
-            "$..approximateInvokeCount",  # TODO: retry support
-        ],
-    )
     @pytest.mark.parametrize(
         "payload",
         [
@@ -142,12 +136,12 @@ class TestLambdaDestinationSqs:
         create_lambda_function(
             handler_file=TEST_LAMBDA_PYTHON,
             func_name=lambda_name,
-            libs=TEST_LAMBDA_LIBS,
             role=lambda_su_role,
         )
 
         put_event_invoke_config_response = lambda_client.put_function_event_invoke_config(
             FunctionName=lambda_name,
+            MaximumRetryAttempts=0,
             DestinationConfig={
                 "OnSuccess": {"Destination": queue_arn},
                 "OnFailure": {"Destination": queue_arn},
@@ -162,11 +156,13 @@ class TestLambdaDestinationSqs:
         )
 
         def receive_message():
-            rs = sqs_client.receive_message(QueueUrl=queue_url, MessageAttributeNames=["All"])
+            rs = sqs_client.receive_message(
+                QueueUrl=queue_url, WaitTimeSeconds=2, MessageAttributeNames=["All"]
+            )
             assert len(rs["Messages"]) > 0
             return rs
 
-        receive_message_result = retry(receive_message, retries=120, sleep=3)
+        receive_message_result = retry(receive_message, retries=120, sleep=1)
         snapshot.match("receive_message_result", receive_message_result)
 
     @pytest.mark.skip_snapshot_verify(paths=["$..Body.requestContext.functionArn"])

--- a/tests/integration/awslambda/test_lambda_destinations.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_destinations.snapshot.json
@@ -121,7 +121,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload0]": {
-    "recorded-date": "27-02-2023, 16:02:33",
+    "recorded-date": "22-03-2023, 18:42:11",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -134,6 +134,7 @@
         },
         "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
         "LastModified": "datetime",
+        "MaximumRetryAttempts": 0,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -183,7 +184,7 @@
     }
   },
   "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_assess_lambda_destination_invocation[payload1]": {
-    "recorded-date": "27-02-2023, 16:08:45",
+    "recorded-date": "22-03-2023, 18:42:16",
     "recorded-content": {
       "put_function_event_invoke_config": {
         "DestinationConfig": {
@@ -196,6 +197,7 @@
         },
         "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
         "LastModified": "datetime",
+        "MaximumRetryAttempts": 0,
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -211,7 +213,7 @@
                 "requestId": "<uuid:1>",
                 "functionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
                 "condition": "RetriesExhausted",
-                "approximateInvokeCount": 3
+                "approximateInvokeCount": 1
               },
               "requestPayload": {
                 "raise_error": 1

--- a/tests/integration/awslambda/test_lambda_destinations.snapshot.json
+++ b/tests/integration/awslambda/test_lambda_destinations.snapshot.json
@@ -527,5 +527,64 @@
         "ReceiptHandle": "<receipt-handle:2>"
       }
     }
+  },
+  "tests/integration/awslambda/test_lambda_destinations.py::TestLambdaDestinationSqs::test_lambda_destination_default_retries": {
+    "recorded-date": "22-03-2023, 19:02:29",
+    "recorded-content": {
+      "put_function_event_invoke_config": {
+        "DestinationConfig": {
+          "OnFailure": {
+            "Destination": "arn:aws:sqs:<region>:111111111111:<resource:1>"
+          },
+          "OnSuccess": {
+            "Destination": "arn:aws:sqs:<region>:111111111111:<resource:1>"
+          }
+        },
+        "FunctionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
+        "LastModified": "datetime",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "receive_message_result": {
+        "Messages": [
+          {
+            "Body": {
+              "version": "1.0",
+              "timestamp": "date",
+              "requestContext": {
+                "requestId": "<uuid:1>",
+                "functionArn": "arn:aws:lambda:<region>:111111111111:function:<resource:2>:$LATEST",
+                "condition": "RetriesExhausted",
+                "approximateInvokeCount": 3
+              },
+              "requestPayload": {
+                "raise_error": 1
+              },
+              "responseContext": {
+                "statusCode": 200,
+                "executedVersion": "$LATEST",
+                "functionError": "Unhandled"
+              },
+              "responsePayload": {
+                "errorMessage": "Test exception (this is intentional)",
+                "errorType": "Exception",
+                "stackTrace": [
+                  "  File \"/var/task/handler.py\", line 54, in handler\n    raise Exception(\"Test exception (this is intentional)\")\n"
+                ]
+              }
+            },
+            "MD5OfBody": "<m-d5-of-body:1>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
By default Lambda should retry async event invocations `2` times. We didn't honor this and since max_retry_attempts was `None` this lead to an exception in the spawned thread and therefore was never actually retried.

Example:
```python
lambda_client.put_function_event_invoke_config(FunctionName=function_name, DestinationConfig={"OnSuccess": {"Destination": some_arn}})
```
