### PR TITLE
add fix for CLI tests to properly set CLI context 

### DIFF
--- a/tests/bootstrap/conftest.py
+++ b/tests/bootstrap/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from localstack import config
+
+
+@pytest.fixture(autouse=True)
+def _setup_cli_environment(monkeypatch):
+    # normally we are setting LOCALSTACK_CLI in localstack/cli/main.py, which is not actually run in the tests
+    monkeypatch.setenv("LOCALSTACK_CLI", "1")
+    monkeypatch.setattr(config, "dirs", config.Directories.for_cli())

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -17,10 +17,7 @@ from localstack.utils.run import run, to_str
 
 
 @pytest.fixture
-def runner(monkeypatch):
-    # normally we are setting LOCALSTACK_CLI in localstack/cli/main.py, which is not actually run in the tests
-    monkeypatch.setenv("LOCALSTACK_CLI", "1")
-    monkeypatch.setattr(config, "dirs", config.Directories.for_cli())
+def runner():
     return CliRunner()
 
 

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -17,7 +17,9 @@ from localstack.utils.run import run, to_str
 
 
 @pytest.fixture
-def runner():
+def runner(monkeypatch):
+    # normally we are setting LOCALSTACK_CLI in localstack/cli/main.py, which is not actually run in the tests
+    monkeypatch.setenv("LOCALSTACK_CLI", "1")
     return CliRunner()
 
 

--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -20,6 +20,7 @@ from localstack.utils.run import run, to_str
 def runner(monkeypatch):
     # normally we are setting LOCALSTACK_CLI in localstack/cli/main.py, which is not actually run in the tests
     monkeypatch.setenv("LOCALSTACK_CLI", "1")
+    monkeypatch.setattr(config, "dirs", config.Directories.for_cli())
     return CliRunner()
 
 


### PR DESCRIPTION
without setting `LOCALSTACK_CLI=1`, the config.dirs are not set to the CLI directories, but the the host-mode directories using `.filesystem`.

https://github.com/localstack/localstack/blob/a12e673130f5a5c77f6f9a2049d7bfe7bff960a4/localstack/config.py#L1096-L1103

we are setting `LOCALSTACK_CLI=1` here, but this is never called in the tests:

https://github.com/localstack/localstack/blob/a12e673130f5a5c77f6f9a2049d7bfe7bff960a4/localstack/cli/main.py#L4-L6
