### PR TITLE
Dont abort when failed to decode logs that contains multibyte characters

### DIFF
--- a/localstack/services/awslambda/lambda_executors.py
+++ b/localstack/services/awslambda/lambda_executors.py
@@ -889,7 +889,10 @@ class LambdaExecutorReuseContainers(LambdaExecutorContainers):
             LogType="Tail",
         )
 
-        log_output = base64.b64decode(response.get("LogResult") or b"").decode("utf-8")
+        # Decode may fail when log is cut off at 4kbytes if it contains multi-byte characters
+        log_output = base64.b64decode(response.get("LogResult") or b"").decode(
+            "utf-8", errors="replace"
+        )
         result = response["Payload"].read().decode("utf-8")
 
         if "FunctionError" in response:


### PR DESCRIPTION
fix: https://github.com/localstack/localstack/issues/7940

This PR allows for correct handling of lambda runs that output more than 4000 bytes, including multibyte characters.