### PR TITLE
Add cache for common functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,12 +196,12 @@ jobs:
                 command: |
                   find tests/integration/awslambda/functions/common -type f -path '**/src/**' -not -path '*/.*' | xargs sha256sum > /tmp/common-functions-checksums
             - restore_cache:
-                key: common-functions-{{ arch }}-{{ checksum "/tmp/common-functions-checksums" }}
+                key: common-functions-{{ checksum "/tmp/common-functions-checksums" }}
             - run:
                 name: pre-build lambda common test packages
                 command: ./scripts/build_common_test_functions.sh `pwd`/tests/integration/awslambda/functions/common
             - save_cache:
-                key: common-functions-{{ arch }}-{{ checksum "/tmp/common-functions-checksums" }}
+                key: common-functions-{{ checksum "/tmp/common-functions-checksums" }}
                 paths:
                   - "tests/integration/awslambda/functions/common"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,6 @@ jobs:
                 name: compute-src-hashes
                 command: |
                   find tests/integration/awslambda/functions/common -type f -path '**/src/**' -not -path '*/.*' | xargs sha256sum > /tmp/common-functions-checksums
-                  cat /tmp/common-functions-checksums
             - restore_cache:
                 key: common-functions-{{ arch }}-{{ checksum "/tmp/common-functions-checksums" }}
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,8 +192,19 @@ jobs:
             equal: [ "amd64", << parameters.platform >>]
           steps:
             - run:
+                name: compute-src-hashes
+                command: |
+                  find tests/integration/awslambda/functions/common -type f -path '**/src/**' -not -path '*/.*' | xargs sha256sum > /tmp/common-functions-checksums
+                  cat /tmp/common-functions-checksums
+            - restore_cache:
+                key: common-functions-{{ arch }}-{{ checksum "/tmp/common-functions-checksums" }}
+            - run:
                 name: pre-build lambda common test packages
                 command: ./scripts/build_common_test_functions.sh `pwd`/tests/integration/awslambda/functions/common
+            - save_cache:
+                key: common-functions-{{ arch }}-{{ checksum "/tmp/common-functions-checksums" }}
+                paths:
+                  - "tests/integration/awslambda/functions/common"
       - run:
           name: Run integration tests
           # circleci split returns newline separated list, so `tr` is necessary to prevent problems in the Makefile


### PR DESCRIPTION
Adds a cache to the common functions to avoid building them every build.
Uses a file with a list of all hashes of hash-key-files as hash-key (so hashing the file full of hashes), as CircleCI does not support hashing multiple files (via a glob or something) sadly.
Reduces amd64 build time by about 10 minutes.