### PR TITLE
re-add mkdirs call before starting localstack docker container

### DIFF
--- a/localstack/utils/bootstrap.py
+++ b/localstack/utils/bootstrap.py
@@ -510,6 +510,8 @@ def prepare_docker_start():
     if DOCKER_CLIENT.is_container_running(container_name):
         raise ContainerExists('LocalStack container named "%s" is already running' % container_name)
 
+    config.dirs.mkdirs()
+
 
 def configure_container(container: LocalstackContainer):
     """


### PR DESCRIPTION
Looks like something is still not quite right with the directories and the way they are initialized depending on the environment.
The log files from the CLI tests in master suggest that some directories are again not created properly. 

```
[Errno 2] No such file or directory: \'/var/lib/localstack/tmp/localstack_main_container.log\'\n
```

It's not clear to me why the file is `/var/lib/localstack/tmp/localstack_main_container.log` - it should not be `/var/lib/localstack` when starting the cli. need to investigate further and clean this up, but adding this band-aid for now.

log output from the test (very easy to read :grimacing: )

```
FAILED tests/bootstrap/test_cli.py::TestCliContainerLifecycle::test_start_cli_within_container - localstack.utils.container_utils.container_client.ContainerException: ('Docker process returned with errorcode 1', b'\n     __                     _______ __             __\n    / /   ____  _________ _/ / ___// /_____ ______/ /__\n   / /   / __ \\/ ___/ __ `/ /\\__ \\/ __/ __ `/ ___/ //_/\n  / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<\n /_____/\\____/\\___/\\__,_/_//____/\\__/\\__,_/\\___/_/|_|\n\n \xf0\x9f\x92\xbb LocalStack CLI 2.0.0.dev\n\n[20:56:54] starting LocalStack in Docker mode \xf0\x9f\x90\xb3               localstack.py:142\n           preparing environment                                bootstrap.py:629\n           configuring container                                bootstrap.py:637\n', b'Traceback (most recent call last):\n  File "/opt/code/localstack/bin/localstack", line 23, in <module>\n    main()\n  File "/opt/code/localstack/bin/localstack", line 19, in main\n    main.main()\n  File "/opt/code/localstack/localstack/cli/main.py", line 17, in main\n    cli()\n  File "/opt/code/localstack/localstack/cli/plugin.py", line 15, in __call__\n    self.group(*args, **kwargs)\n  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__\n    return self.main(*args, **kwargs)\n  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/click/core.py", line 1055, in main\n    rv = self.invoke(ctx)\n  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke\n    return _process_result(sub_ctx.command.invoke(sub_ctx))\n  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n  File "/opt/code/localstack/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke\n    return __callback(*args, **kwargs)\n  File "/opt/code/localstack/localstack/utils/analytics/cli.py", line 66, in publisher_wrapper\n    return fn(*args, **kwargs)\n  File "/opt/code/localstack/localstack/cli/localstack.py", line 166, in cmd_start\n    bootstrap.start_infra_in_docker_detached(console)\n  File "/opt/code/localstack/localstack/utils/bootstrap.py", line 641, in start_infra_in_docker_detached\n    container.truncate_log()\n  File "/opt/code/localstack/localstack/utils/bootstrap.py", line 454, in truncate_log\n    with open(self.logfile, "wb") as fd:\nFileNotFoundError: [Errno 2] No such file or directory: \'/var/lib/localstack/tmp/localstack_main_container.log\'\n')
```