### PR TITLE
add check for FakeDeleteMarker in case of versioned bucket

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -180,6 +180,7 @@ X_Amz_Expires = int
 HttpMethod = str
 ResourceType = str
 MissingHeaderName = str
+Method = str
 
 
 class AnalyticsS3ExportFileFormat(str):
@@ -752,6 +753,14 @@ class InvalidStorageClass(ServiceException):
     sender_fault: bool = False
     status_code: int = 400
     StorageClassRequested: Optional[StorageClass]
+
+
+class MethodNotAllowed(ServiceException):
+    code: str = "MethodNotAllowed"
+    sender_fault: bool = False
+    status_code: int = 405
+    Method: Optional[Method]
+    ResourceType: Optional[ResourceType]
 
 
 AbortDate = datetime

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -791,6 +791,40 @@
       "op": "move",
       "from": "/shapes/ListObjectsOutput",
       "path": "/shapes/ListBucketResult"
+    },
+    {
+      "op": "add",
+      "path": "/shapes/Method",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ResourceType",
+      "value": {
+        "type": "string"
+      }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/MethodNotAllowed",
+      "value": {
+        "type": "structure",
+        "members": {
+          "Method": {
+            "shape": "Method"
+          },
+          "ResourceType": {
+            "shape": "ResourceType"
+          }
+        },
+        "error": {
+          "httpStatusCode": 405
+        },
+        "documentation": "<p>The specified method is not allowed against this resource.</p>",
+        "exception": true
+      }
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1059,7 +1059,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["Checksum"] = {f"Checksum{checksum_algorithm.upper()}": checksum}  # noqa
 
         response["LastModified"] = key.last_modified
-        if key.version_id:
+
+        if bucket in self.get_store().bucket_versioning_status:
             response["VersionId"] = key.version_id
 
         if key.multipart:

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -344,13 +344,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
     def get_object(self, context: RequestContext, request: GetObjectRequest) -> GetObjectOutput:
         key = request["Key"]
         bucket = request["Bucket"]
-        if is_object_expired(context, bucket=bucket, key=key):
+        version_id = request.get("VersionId")
+        if is_object_expired(context, bucket=bucket, key=key, version_id=version_id):
             # TODO: old behaviour was deleting key instantly if expired. AWS cleans up only once a day generally
             # see if we need to implement a feature flag
             # but you can still HeadObject on it and you get the expiry time
-            ex = NoSuchKey("The specified key does not exist.")
-            ex.Key = key
-            raise ex
+            raise NoSuchKey("The specified key does not exist.", Key=key)
 
         response: GetObjectOutput = call_moto(context)
         # check for the presence in the response, might be fixed by moto one day
@@ -363,7 +362,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         moto_backend = get_moto_s3_backend(context)
         moto_bucket = get_bucket_from_moto(moto_backend, bucket=bucket)
-        key_object = get_key_from_moto_bucket(moto_bucket, key=key)
+        key_object = get_key_from_moto_bucket(moto_bucket, key=key, version_id=version_id)
 
         if not config.S3_SKIP_KMS_KEY_VALIDATION and key_object.kms_key_id:
             validate_kms_key_id(kms_key=key_object.kms_key_id, bucket=moto_bucket)
@@ -390,6 +389,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: PutObjectRequest,
     ) -> PutObjectOutput:
+        # TODO: it seems AWS uses AES256 encryption by default now, starting January 5th 2023
+        # note: etag do not change after encryption
+        # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html
         if checksum_algorithm := request.get("ChecksumAlgorithm"):
             verify_checksum(checksum_algorithm, context.request.data, request)
 
@@ -412,6 +414,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         # moto interprets the Expires in query string for presigned URL as an Expires header and use it for the object
         # we set it to the correctly parsed value in Request, else we remove it from moto metadata
+        # we are getting the last set key here so no need for versionId when getting the key
         key_object = get_key_from_moto_bucket(moto_bucket, key=request["Key"])
         if expires := request.get("Expires"):
             key_object.set_expiry(expires)
@@ -453,12 +456,17 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         context: RequestContext,
         request: DeleteObjectRequest,
     ) -> DeleteObjectOutput:
-
+        # TODO: implement DeleteMarker response
         if request["Bucket"] not in self.get_store().bucket_notification_configs:
             return call_moto(context)
 
+        # TODO: we do not differentiate between deleting a key and creating a DeleteMarker in a versioned bucket
+        # for the event (s3:ObjectRemoved:Delete / s3:ObjectRemoved:DeleteMarkerCreated)
+        # it always s3:ObjectRemoved:Delete for now
         # create the notification context before deleting the object, to be able to retrieve its properties
-        s3_notification_ctx = S3EventNotificationContext.from_request_context(context)
+        s3_notification_ctx = S3EventNotificationContext.from_request_context(
+            context, version_id=request.get("VersionId")
+        )
 
         response: DeleteObjectOutput = call_moto(context)
         self._notify(context, s3_notification_ctx)
@@ -476,14 +484,19 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         expected_bucket_owner: AccountId = None,
         checksum_algorithm: ChecksumAlgorithm = None,
     ) -> DeleteResult:
+        # TODO: implement DeleteMarker response
         objects: List[ObjectIdentifier] = delete.get("Objects")
         deleted_objects = {}
         quiet = delete.get("Quiet", False)
-        for object in objects:
-            key = object["Key"]
+        for object_data in objects:
+            key = object_data["Key"]
             # create the notification context before deleting the object, to be able to retrieve its properties
+            # TODO: test format of notification if the key is a DeleteMarker
             s3_notification_ctx = S3EventNotificationContext.from_request_context(
-                context, key_name=key, allow_non_existing_key=True
+                context,
+                key_name=key,
+                version_id=object_data.get("VersionId"),
+                allow_non_existing_key=True,
             )
 
             deleted_objects[key] = s3_notification_ctx
@@ -845,8 +858,12 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             validate_acl_acp(acp)
 
         moto_backend = get_moto_s3_backend(context)
+        # TODO: rework the delete marker handling
         key = get_key_from_moto_bucket(
-            get_bucket_from_moto(moto_backend, bucket=request["Bucket"]), key=request["Key"]
+            moto_bucket=get_bucket_from_moto(moto_backend, bucket=request["Bucket"]),
+            key=request["Key"],
+            version_id=request.get("VersionId"),
+            raise_if_delete_marker_method="PUT",
         )
         acl = key.acl
 
@@ -967,6 +984,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             key_name = key_name.replace("${filename}", context.request.files["file"].filename)
 
         moto_backend = get_moto_s3_backend(context)
+        # TODO: add concept of VersionId
         key = get_key_from_moto_bucket(
             get_bucket_from_moto(moto_backend, bucket=bucket), key=key_name
         )
@@ -1014,7 +1032,13 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         bucket_name = request["Bucket"]
         moto_backend = get_moto_s3_backend(context)
         bucket = get_bucket_from_moto(moto_backend, bucket_name)
-        key = get_key_from_moto_bucket(moto_bucket=bucket, key=request["Key"])
+        # TODO: rework the delete marker handling
+        key = get_key_from_moto_bucket(
+            moto_bucket=bucket,
+            key=request["Key"],
+            version_id=request.get("VersionId"),
+            raise_if_delete_marker_method="GET",
+        )
 
         object_attrs = request.get("ObjectAttributes", [])
         response = GetObjectAttributesOutput()
@@ -1035,8 +1059,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             response["Checksum"] = {f"Checksum{checksum_algorithm.upper()}": checksum}  # noqa
 
         response["LastModified"] = key.last_modified
-        if version_id := request.get("VersionId"):
-            response["VersionId"] = version_id
+        if key.version_id:
+            response["VersionId"] = key.version_id
 
         if key.multipart:
             response["ObjectParts"] = GetObjectAttributesParts(
@@ -1207,10 +1231,12 @@ def validate_website_configuration(website_config: WebsiteConfiguration) -> None
                 )
 
 
-def is_object_expired(context: RequestContext, bucket: BucketName, key: ObjectKey) -> bool:
+def is_object_expired(
+    context: RequestContext, bucket: BucketName, key: ObjectKey, version_id: str = None
+) -> bool:
     moto_backend = get_moto_s3_backend(context)
     moto_bucket = get_bucket_from_moto(moto_backend, bucket)
-    key_object = get_key_from_moto_bucket(moto_bucket, key)
+    key_object = get_key_from_moto_bucket(moto_bucket, key, version_id=version_id)
     return is_key_expired(key_object=key_object)
 
 

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1060,7 +1060,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
 
         response["LastModified"] = key.last_modified
 
-        if bucket in self.get_store().bucket_versioning_status:
+        if bucket_name in self.get_store().bucket_versioning_status:
             response["VersionId"] = key.version_id
 
         if key.multipart:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -691,8 +691,6 @@ class TestS3:
         condition=LEGACY_S3_PROVIDER,
         reason="currently not implemented in moto, see https://github.com/localstack/localstack/issues/6217",
     )
-    # parser issue in https://github.com/localstack/localstack/issues/6422 because moto returns wrong response
-    # TODO test versioned KEY
     def test_get_object_attributes(self, s3_client, s3_bucket, snapshot, s3_multipart_upload):
         s3_client.put_object(Bucket=s3_bucket, Key="data.txt", Body=b"69\n420\n")
         response = s3_client.get_object_attributes(
@@ -3279,7 +3277,7 @@ class TestS3:
             Key=key_name,
             ObjectAttributes=["StorageClass"],
         )
-        snapshot.match("put-object-storage-class", response)
+        snapshot.match("get-object-storage-class", response)
 
     @pytest.mark.aws_validated
     @pytest.mark.xfail(

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -723,6 +723,55 @@ class TestS3:
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..ServerSideEncryption",
+            "$..DeleteMarker",
+        ]
+    )
+    @pytest.mark.xfail(
+        condition=LEGACY_S3_PROVIDER,
+        reason="currently not implemented in moto, see https://github.com/localstack/localstack/issues/6217",
+    )
+    def test_get_object_attributes_versioned(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        s3_client.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        key = "key-attrs-versioned"
+        put_obj_1 = s3_client.put_object(Bucket=s3_bucket, Key=key, Body=b"69\n420\n")
+        snapshot.match("put-obj-v1", put_obj_1)
+
+        put_obj_2 = s3_client.put_object(Bucket=s3_bucket, Key=key, Body=b"version 2")
+        snapshot.match("put-obj-v2", put_obj_2)
+
+        response = s3_client.get_object_attributes(
+            Bucket=s3_bucket,
+            Key=key,
+            ObjectAttributes=["StorageClass", "ETag", "ObjectSize", "ObjectParts", "Checksum"],
+        )
+        snapshot.match("object-attrs", response)
+
+        response = s3_client.delete_object(Bucket=s3_bucket, Key=key)
+        snapshot.match("delete-key", response)
+
+        with pytest.raises(ClientError) as e:
+            s3_client.get_object_attributes(
+                Bucket=s3_bucket,
+                Key=key,
+                ObjectAttributes=["StorageClass", "ETag", "ObjectSize"],
+            )
+        snapshot.match("deleted-object-attrs", e.value.response)
+
+        response = s3_client.get_object_attributes(
+            Bucket=s3_bucket,
+            Key=key,
+            VersionId=put_obj_1["VersionId"],
+            ObjectAttributes=["StorageClass", "ETag", "ObjectSize"],
+        )
+        snapshot.match("get-object-attrs-v1", response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
         condition=is_old_provider, paths=["$..VersionId", "$..Error.RequestID"]
     )
     def test_multipart_and_list_parts(self, s3_client, s3_bucket, snapshot):
@@ -1823,6 +1872,67 @@ class TestS3:
 
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(
+        path=[
+            "$..Deleted..VersionId",  # we cannot guarantee order nor we can sort it
+            "$..Delimiter",
+            "$..EncodingType",
+            "$..VersionIdMarker",
+        ]
+    )
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..VersionId"])
+    def test_delete_keys_in_versioned_bucket(self, s3_client, s3_bucket, snapshot):
+        # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        s3_client.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        object_key = "test-key-versioned"
+        s3_client.put_object(Bucket=s3_bucket, Key=object_key, Body="something")
+        s3_client.put_object(Bucket=s3_bucket, Key=object_key, Body="something-v2")
+
+        response = s3_client.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-objects-v2", response)
+
+        # delete objects
+        response = s3_client.delete_objects(
+            Bucket=s3_bucket,
+            Delete={
+                "Objects": [{"Key": object_key}],
+            },
+        )
+        snapshot.match("delete-object", response)
+
+        response = s3_client.list_object_versions(Bucket=s3_bucket)
+        snapshot.match("list-object-version", response)
+
+        # delete objects with version
+        versions_to_delete = [
+            {"Key": version["Key"], "VersionId": version["VersionId"]}
+            for version in response["Versions"]
+        ]
+        response = s3_client.delete_objects(
+            Bucket=s3_bucket,
+            Delete={"Objects": versions_to_delete},
+        )
+        snapshot.match("delete-object-version", response)
+
+        response = s3_client.list_objects_v2(Bucket=s3_bucket)
+        snapshot.match("list-objects-v2-after-delete", response)
+
+        response = s3_client.list_object_versions(Bucket=s3_bucket)
+        snapshot.match("list-object-version-after-delete", response)
+
+        delete_marker = response["DeleteMarkers"][0]
+        response = s3_client.delete_objects(
+            Bucket=s3_bucket,
+            Delete={
+                "Objects": [{"Key": delete_marker["Key"], "VersionId": delete_marker["VersionId"]}]
+            },
+        )
+        snapshot.match("delete-object-delete-marker", response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
         paths=["$..Error.RequestID"]
     )  # fixme RequestID not in AWS response
     def test_delete_non_existing_keys_in_non_existing_bucket(self, s3_client, snapshot):
@@ -1833,6 +1943,40 @@ class TestS3:
             )
         assert "NoSuchBucket" == e.value.response["Error"]["Code"]
         snapshot.match("error-non-existent-bucket", e.value.response)
+
+    @pytest.mark.aws_validated
+    @pytest.mark.skip_snapshot_verify(
+        paths=[
+            "$..ServerSideEncryption",
+            "$..Deleted..DeleteMarker",  # TODO: missing from response, not implemented in moto
+            "$..Deleted..DeleteMarkerVersionId",
+        ]
+    )
+    @pytest.mark.skip_snapshot_verify(condition=is_old_provider, paths=["$..VersionId"])
+    def test_put_object_acl_on_delete_marker(self, s3_client, s3_bucket, snapshot):
+        # see https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        s3_client.put_bucket_versioning(
+            Bucket=s3_bucket, VersioningConfiguration={"Status": "Enabled"}
+        )
+        object_key = "test-key-versioned"
+        put_obj_1 = s3_client.put_object(Bucket=s3_bucket, Key=object_key, Body="something")
+        snapshot.match("put-obj-1", put_obj_1)
+        put_obj_2 = s3_client.put_object(Bucket=s3_bucket, Key=object_key, Body="something-v2")
+        snapshot.match("put-obj-2", put_obj_2)
+
+        # delete objects
+        response = s3_client.delete_objects(
+            Bucket=s3_bucket,
+            Delete={
+                "Objects": [{"Key": object_key}],
+            },
+        )
+        snapshot.match("delete-object", response)
+
+        with pytest.raises(ClientError) as e:
+            s3_client.put_object_acl(Bucket=s3_bucket, Key=object_key, ACL="public-read")
+        snapshot.match("key-delete-marker", e.value.response)
 
     @pytest.mark.aws_validated
     def test_s3_request_payer(self, s3_client, s3_bucket, snapshot):

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5011,5 +5011,276 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_delete_keys_in_versioned_bucket": {
+    "recorded-date": "24-03-2023, 01:25:18",
+    "recorded-content": {
+      "list-objects-v2": {
+        "Contents": [
+          {
+            "ETag": "\"d28473b5c0d7abeb397551aa2fe42be7\"",
+            "Key": "test-key-versioned",
+            "LastModified": "datetime",
+            "Size": 12,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object": {
+        "Deleted": [
+          {
+            "DeleteMarker": true,
+            "DeleteMarkerVersionId": "<version-id:1>",
+            "Key": "test-key-versioned"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version": {
+        "DeleteMarkers": [
+          {
+            "IsLatest": true,
+            "Key": "test-key-versioned",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "VersionId": "<version-id:1>"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "VersionIdMarker": "",
+        "Versions": [
+          {
+            "ETag": "\"d28473b5c0d7abeb397551aa2fe42be7\"",
+            "IsLatest": false,
+            "Key": "test-key-versioned",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 12,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:2>"
+          },
+          {
+            "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+            "IsLatest": false,
+            "Key": "test-key-versioned",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "Size": 9,
+            "StorageClass": "STANDARD",
+            "VersionId": "<version-id:3>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object-version": {
+        "Deleted": [
+          {
+            "Key": "test-key-versioned",
+            "VersionId": "<version-id:3>"
+          },
+          {
+            "Key": "test-key-versioned",
+            "VersionId": "<version-id:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-after-delete": {
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 0,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-object-version-after-delete": {
+        "DeleteMarkers": [
+          {
+            "IsLatest": true,
+            "Key": "test-key-versioned",
+            "LastModified": "datetime",
+            "Owner": {
+              "DisplayName": "<display-name>",
+              "ID": "<owner-id>"
+            },
+            "VersionId": "<version-id:1>"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "",
+        "VersionIdMarker": "",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object-delete-marker": {
+        "Deleted": [
+          {
+            "DeleteMarker": true,
+            "DeleteMarkerVersionId": "<version-id:1>",
+            "Key": "test-key-versioned",
+            "VersionId": "<version-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_put_object_acl_on_delete_marker": {
+    "recorded-date": "24-03-2023, 00:28:23",
+    "recorded-content": {
+      "put-obj-1": {
+        "ETag": "\"437b930db84b8079c2dd804a71936b5f\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-2": {
+        "ETag": "\"d28473b5c0d7abeb397551aa2fe42be7\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-object": {
+        "Deleted": [
+          {
+            "DeleteMarker": true,
+            "DeleteMarkerVersionId": "0wvrZJFm5uVT3UZ3qpFOZ_MCcWInT.TR",
+            "Key": "test-key-versioned"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "key-delete-marker": {
+        "Error": {
+          "Code": "MethodNotAllowed",
+          "Message": "The specified method is not allowed against this resource.",
+          "Method": "PUT",
+          "ResourceType": "DeleteMarker"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 405
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_get_object_attributes_versioned": {
+    "recorded-date": "24-03-2023, 01:39:11",
+    "recorded-content": {
+      "put-obj-v1": {
+        "ETag": "\"e92499db864217242396e8ef766079a9\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "put-obj-v2": {
+        "ETag": "\"d4ca1ed7571e2e7b1f1c375bd50fa220\"",
+        "ServerSideEncryption": "AES256",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "object-attrs": {
+        "ETag": "d4ca1ed7571e2e7b1f1c375bd50fa220",
+        "LastModified": "datetime",
+        "ObjectSize": 9,
+        "StorageClass": "STANDARD",
+        "VersionId": "<version-id:2>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "delete-key": {
+        "DeleteMarker": true,
+        "VersionId": "<version-id:3>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 204
+        }
+      },
+      "deleted-object-attrs": {
+        "Error": {
+          "Code": "NoSuchKey",
+          "Key": "key-attrs-versioned",
+          "Message": "The specified key does not exist."
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
+        }
+      },
+      "get-object-attrs-v1": {
+        "ETag": "e92499db864217242396e8ef766079a9",
+        "LastModified": "datetime",
+        "ObjectSize": 7,
+        "StorageClass": "STANDARD",
+        "VersionId": "<version-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -4308,9 +4308,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD]": {
-    "recorded-date": "16-01-2023, 18:02:54",
+    "recorded-date": "24-03-2023, 03:44:20",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "STANDARD",
         "ResponseMetadata": {
@@ -4321,9 +4321,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[STANDARD_IA]": {
-    "recorded-date": "16-01-2023, 18:01:59",
+    "recorded-date": "24-03-2023, 03:44:22",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "STANDARD_IA",
         "ResponseMetadata": {
@@ -4334,9 +4334,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER]": {
-    "recorded-date": "16-01-2023, 18:02:01",
+    "recorded-date": "24-03-2023, 03:44:24",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "GLACIER",
         "ResponseMetadata": {
@@ -4347,9 +4347,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[GLACIER_IR]": {
-    "recorded-date": "16-01-2023, 18:02:04",
+    "recorded-date": "24-03-2023, 03:44:26",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "GLACIER_IR",
         "ResponseMetadata": {
@@ -4360,9 +4360,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[REDUCED_REDUNDANCY]": {
-    "recorded-date": "16-01-2023, 18:02:06",
+    "recorded-date": "24-03-2023, 03:44:29",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "REDUCED_REDUNDANCY",
         "ResponseMetadata": {
@@ -4373,9 +4373,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[ONEZONE_IA]": {
-    "recorded-date": "16-01-2023, 18:02:09",
+    "recorded-date": "24-03-2023, 03:44:31",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "ONEZONE_IA",
         "ResponseMetadata": {
@@ -4386,9 +4386,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[INTELLIGENT_TIERING]": {
-    "recorded-date": "16-01-2023, 18:02:11",
+    "recorded-date": "24-03-2023, 03:44:33",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "INTELLIGENT_TIERING",
         "ResponseMetadata": {
@@ -4399,9 +4399,9 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_put_object_storage_class[DEEP_ARCHIVE]": {
-    "recorded-date": "16-01-2023, 18:02:13",
+    "recorded-date": "24-03-2023, 03:44:35",
     "recorded-content": {
-      "put-object-storage-class": {
+      "get-object-storage-class": {
         "LastModified": "datetime",
         "StorageClass": "DEEP_ARCHIVE",
         "ResponseMetadata": {


### PR DESCRIPTION
While looking at the tests run, I realised we were encountering issue when doing test cleanup. 

Trace:
```python
2023-03-23T21:22:27.7599773Z Traceback (most recent call last):
2023-03-23T21:22:27.7600672Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/chain.py", line 90, in handle
2023-03-23T21:22:27.7601377Z     handler(self, self.context, response)
2023-03-23T21:22:27.7602178Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/handlers/service.py", line 122, in __call__
2023-03-23T21:22:27.7602712Z     handler(chain, context, response)
2023-03-23T21:22:27.7603397Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/handlers/service.py", line 92, in __call__
2023-03-23T21:22:27.7603934Z     skeleton_response = self.skeleton.invoke(context)
2023-03-23T21:22:27.7604622Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/skeleton.py", line 153, in invoke
2023-03-23T21:22:27.7605130Z     return self.dispatch_request(context, instance)
2023-03-23T21:22:27.7605835Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/skeleton.py", line 165, in dispatch_request
2023-03-23T21:22:27.7606339Z     result = handler(context, instance) or {}
2023-03-23T21:22:27.7607016Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/forwarder.py", line 60, in _call
2023-03-23T21:22:27.7607483Z     return handler(context, req)
2023-03-23T21:22:27.7608151Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/aws/skeleton.py", line 117, in __call__
2023-03-23T21:22:27.7608616Z     return self.fn(*args, **kwargs)
2023-03-23T21:22:27.7609473Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/services/s3/provider.py", line 485, in delete_objects
2023-03-23T21:22:27.7610083Z     s3_notification_ctx = S3EventNotificationContext.from_request_context(
2023-03-23T21:22:27.7610903Z   File "/home/runner/work/localstack-ext/localstack-ext/localstack/localstack/services/s3/notifications.py", line 127, in from_request_context
2023-03-23T21:22:27.7611457Z     key_etag=key.etag.strip('"'),
2023-03-23T21:22:27.7612135Z AttributeError: 'FakeDeleteMarker' object has no attribute 'etag'
2023-03-23T21:22:27.7613013Z 2023-03-23T21:22:27.760  INFO --- [   asgi_gw_2] localstack.request.aws     : AWS s3.DeleteObjects => 500 (InternalError)
```

After some reproductions, I could reproduce the issue when the bucket is versioned, which we, it turns out, don't support very well. While migrating the S3 provider, we did not account very much for the concept of `VersionId`, and we did not have tests covering it (not a single operation was done with `VersionId` parameter).

So I've added some checks and fixed some direct usages of moto `FakeKey` object which can be `FakeDeleteMarker`, a case we didn't account for. We can fix a lot more when using versioned bucket, but at least now we shouldn't raise direct `AttributeError`. 

Concerning notifications, we do not support `s3:ObjectRemoved:DeleteMarkerCreated` at the moment and we will send a `s3:ObjectRemoved:Delete` instead, but this will need a bit of refactoring in the notification handling (in the map determining the service operation, it would depend if the bucket is versioned or not and if we delete a key or delete a key version). 

I guess we can see this as a bandaid, we don't implement versioned buckets in a better way for now (except for `PutObjectAcl`), but at least we don't raise exceptions linked to that. We will need to come back to this to better support the use case with some usage numbers.

Sources:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjectVersions.html
https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types
