### PR TITLE
Fix test failures for community tests in PRO

### DIFF
--- a/tests/integration/awslambda/test_lambda_common.py
+++ b/tests/integration/awslambda/test_lambda_common.py
@@ -7,6 +7,7 @@ import zipfile
 
 import pytest
 
+from localstack.constants import FALSE_STRINGS
 from localstack.testing.aws.lambda_utils import is_old_provider
 from localstack.testing.snapshots.transformer import KeyValueBasedTransformer
 from localstack.utils.files import cp_r
@@ -247,6 +248,7 @@ class TestLambdaRuntimesCommon:
         assert invocation_result_payload["environment"]["WRAPPER_VAR"] == test_value
 
 
+# TODO: Split this and move to PRO
 @pytest.mark.whitebox
 @pytest.mark.skipif(
     condition=is_old_provider(),
@@ -254,6 +256,11 @@ class TestLambdaRuntimesCommon:
 )
 @pytest.mark.skipif(
     condition=platform.machine() != "x86_64", reason="build process doesn't support arm64 right now"
+)
+@pytest.mark.skipif(
+    condition="LOCALSTACK_API_KEY" in os.environ
+    and str(os.environ.get("DNS_ADDRESS")) not in FALSE_STRINGS,
+    reason="Transparent endpoint injection requires enabled DNS",
 )
 class TestLambdaCallingLocalstack:
     @pytest.mark.multiruntime(

--- a/tests/integration/stepfunctions/legacy/test_stepfunctions_legacy.py
+++ b/tests/integration/stepfunctions/legacy/test_stepfunctions_legacy.py
@@ -142,7 +142,7 @@ STATE_MACHINE_INTRINSIC_FUNCS = {
         "state3": {
             "Type": "Task",
             "Resource": "__tbd__",
-            "ResultSelector": {"payload.$": "$"},
+            "ResultSelector": {"payload.$": "$.Payload"},
             "ResultPath": "$.result_value",
             "End": True,
         },
@@ -417,6 +417,7 @@ class TestStateMachine:
         # clean up
         cleanup(sm_arn, state_machines_before, stepfunctions_client)
 
+    # TODO: validate against AWS
     def test_intrinsic_functions(self, stepfunctions_client):
         if os.environ.get("AWS_DEFAULT_REGION") != "us-east-1":
             pytest.skip("skipping non us-east-1 temporarily")


### PR DESCRIPTION
Fixes community tests with PRO enabled.

- Skip transparent endpoint injection tests when PRO enabled (with lambda v2) and DNS is disabled
- Fix stepfunctions state machine to return correct payload structure.