### PR TITLE
Fix lambda urls when persistence is enabled

### DIFF
--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -223,6 +223,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
 
     def on_after_state_load(self):
         self.lambda_service = LambdaService()
+        self.router.lambda_service = self.lambda_service
 
         # TODO: provisioned concurrency
         for account_id, account_bundle in lambda_stores.items():


### PR DESCRIPTION
## Problem
We currently set a new lambda service on state restore, but this service is not injected into the url router.

## Changes
* Set the new lambda service into the router after state restore
* Fix internal state of version managers