### PR TITLE
Extend docker/net utils to allow port checks for UDP ports

### DIFF
--- a/localstack/utils/docker_utils.py
+++ b/localstack/utils/docker_utils.py
@@ -6,12 +6,13 @@ from typing import List, Optional
 
 from localstack import config
 from localstack.constants import DEFAULT_VOLUME_DIR, DOCKER_IMAGE_NAME
+from localstack.utils.collections import ensure_list
 from localstack.utils.container_utils.container_client import (
     ContainerClient,
     PortMappings,
     VolumeInfo,
 )
-from localstack.utils.net import PortNotAvailableException, PortRange
+from localstack.utils.net import Port, PortNotAvailableException, PortRange
 from localstack.utils.objects import singleton_factory
 from localstack.utils.strings import to_str
 
@@ -131,16 +132,23 @@ def get_host_path_for_path_in_docker(path):
     return path
 
 
-def container_port_can_be_bound(port: int) -> bool:
-    """Determine whether a port can be bound by Docker containers"""
-    ports = PortMappings()
-    ports.add(port, port)
+def container_ports_can_be_bound(ports: int | Port | list[int | Port]) -> bool:
+    """Determine whether a given list of ports can be bound by Docker containers
+
+    :param ports: single port or list of ports to check
+    :return: True iff all ports can be bound
+    """
+    port_mappings = PortMappings()
+    ports = ensure_list(ports)
+    for port in ports:
+        port = Port.wrap(port)
+        port_mappings.add(port.port, port.port, protocol=port.protocol)
     try:
         result = DOCKER_CLIENT.run_container(
             _get_ports_check_docker_image(),
             entrypoint="",
             command=["echo", "test123"],
-            ports=ports,
+            ports=port_mappings,
             remove=True,
         )
     except Exception as e:
@@ -161,14 +169,15 @@ class _DockerPortRange(PortRange):
     PortRange which checks whether the port can be bound on the host instead of inside the container.
     """
 
-    def _try_reserve_port(self, port: int, duration: int) -> int:
+    def _try_reserve_port(self, port: int | Port, duration: int) -> int:
         """Checks if the given port is currently not reserved."""
-        if not self.is_port_reserved(port) and container_port_can_be_bound(port):
+        port = Port.wrap(port)
+        if not self.is_port_reserved(port) and container_ports_can_be_bound(port):
             # reserve the port for a short period of time
             self._ports_cache[port] = "__reserved__"
             if duration:
                 self._ports_cache.set_expiry(port, duration)
-            return port
+            return port.port
         else:
             raise PortNotAvailableException(f"The given port ({port}) is already reserved.")
 
@@ -176,33 +185,37 @@ class _DockerPortRange(PortRange):
 reserved_docker_ports = _DockerPortRange(PORT_START, PORT_END)
 
 
-def is_port_available_for_containers(port: int) -> bool:
+def is_port_available_for_containers(port: int | Port) -> bool:
     """Check whether the given port can be bound by containers and is not currently reserved"""
-    return not is_container_port_reserved(port) and container_port_can_be_bound(port)
+    return not is_container_port_reserved(port) and container_ports_can_be_bound(port)
 
 
-def reserve_container_port(port: int, duration: int = None):
+def reserve_container_port(port: int | Port, duration: int = None):
     """Reserve the given container port for a short period of time"""
     reserved_docker_ports.reserve_port(port, duration=duration)
 
 
-def is_container_port_reserved(port: int) -> bool:
+def is_container_port_reserved(port: int | Port) -> bool:
     """Return whether the given container port is currently reserved"""
+    port = Port.wrap(port)
     return reserved_docker_ports.is_port_reserved(port)
 
 
 def reserve_available_container_port(
-    duration: int = None, port_start: int = None, port_end: int = None
+    duration: int = None, port_start: int = None, port_end: int = None, protocol: str = None
 ) -> int:
     """Determine and reserve a port that can then be bound by a Docker container"""
+
+    protocol = protocol or "tcp"
 
     def _random_port():
         port = None
         while not port or reserved_docker_ports.is_port_reserved(port):
-            port = random.randint(
+            port_number = random.randint(
                 RANDOM_PORT_START if port_start is None else port_start,
                 RANDOM_PORT_END if port_end is None else port_end,
             )
+            port = Port(port=port_number, protocol=protocol)
         return port
 
     retries = 10
@@ -210,7 +223,7 @@ def reserve_available_container_port(
         port = _random_port()
         try:
             reserve_container_port(port, duration=duration)
-            return port
+            return port.port
         except PortNotAvailableException as e:
             LOG.debug("Could not bind port %s, trying the next one: %s", port, e)
 

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -3,7 +3,7 @@ import re
 import socket
 import threading
 from contextlib import closing
-from typing import List, Optional, Union
+from typing import Any, List, MutableMapping, NamedTuple, Optional, Union
 from urllib.parse import urlparse
 
 import dns.resolver
@@ -18,6 +18,22 @@ LOG = logging.getLogger(__name__)
 IP_REGEX = (
     r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
 )
+
+
+class Port(NamedTuple):
+    """Represents a network port, with port number and protocol (TCP/UDP)"""
+
+    port: int
+    """the port number"""
+    protocol: str
+    """network protocol name (usually 'tcp' or 'udp')"""
+
+    @classmethod
+    def wrap(cls, port: Union[int, "Port"]) -> "Port":
+        """Return the given port as a Port object, using 'tcp' as the default protocol."""
+        if isinstance(port, Port):
+            return port
+        return Port(port=port, protocol="tcp")
 
 
 def is_port_open(
@@ -88,7 +104,7 @@ def is_port_open(
 def wait_for_port_open(
     port: int, http_path: str = None, expect_success=True, retries=10, sleep_time=0.5
 ):
-    """Ping the given network port until it becomes available (for a given number of retries).
+    """Ping the given TCP network port until it becomes available (for a given number of retries).
     If 'http_path' is set, make a GET request to this path and assert a non-error response."""
     return wait_for_port_status(
         port,
@@ -120,7 +136,7 @@ def wait_for_port_status(
     sleep_time=0.5,
     expect_closed=False,
 ):
-    """Ping the given network port until it becomes (un)available (for a given number of retries)."""
+    """Ping the given TCP network port until it becomes (un)available (for a given number of retries)."""
 
     def check():
         status = is_port_open(port, http_path=http_path, expect_success=expect_success)
@@ -133,28 +149,37 @@ def wait_for_port_status(
     return retry(check, sleep=sleep_time, retries=retries)
 
 
-def port_can_be_bound(port: int) -> bool:
-    """Return whether a local port can be bound to. Note that this is a stricter check
+def port_can_be_bound(port: int | Port) -> bool:
+    """
+    Return whether a local port (TCP or UDP) can be bound to. Note that this is a stricter check
     than is_port_open(...) above, as is_port_open() may return False if the port is
-    not accessible (i.e., does not respond), yet cannot be bound to."""
+    not accessible (i.e., does not respond), yet cannot be bound to.
+    """
     try:
-        tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        tcp.bind(("", port))
+        port = Port.wrap(port)
+        if port.protocol == "tcp":
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        elif port.protocol == "udp":
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        else:
+            LOG.debug("Unsupported network protocol '%s' for port check", port.protocol)
+            return False
+        sock.bind(("", port.port))
         return True
     except Exception:
         return False
 
 
-def get_free_tcp_port(blacklist: List[int] = None) -> int:
-    blacklist = blacklist or []
+def get_free_tcp_port(blocklist: List[int] = None) -> int:
+    blocklist = blocklist or []
     for i in range(10):
         tcp = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         tcp.bind(("", 0))
         addr, port = tcp.getsockname()
         tcp.close()
-        if port not in blacklist:
+        if port not in blocklist:
             return port
-    raise Exception("Unable to determine free TCP port with blacklist %s" % blacklist)
+    raise Exception(f"Unable to determine free TCP port with blocklist {blocklist}")
 
 
 def resolve_hostname(hostname: str) -> Optional[str]:
@@ -193,12 +218,14 @@ class PortRange:
 
     def __init__(self, start: int, end: int):
         # cache for locally available ports (ports are reserved for a short period of a few seconds)
-        self._ports_cache = CustomExpiryTTLCache(maxsize=100, ttl=6)
+        self._ports_cache: MutableMapping[Port, Any] = CustomExpiryTTLCache(maxsize=100, ttl=6)
         self._ports_lock = threading.RLock()
         self.start = start
         self.end = end
 
-    def reserve_port(self, port: int = None, duration: int = None) -> int:
+    def reserve_port(
+        self, port: Optional[int | Port] = None, duration: Optional[int] = None
+    ) -> int:
         """
         Reserves the given port (if it is still free). If the given port is None, it reserves a free port from the
         configured port range for external services. If a port is given, it has to be within the configured
@@ -209,7 +236,8 @@ class PortRange:
                     reserved, or if the given port is none and there is no free port in the configured service range.
         """
         ports_range = range(self.start, self.end)
-        if port is not None and port not in ports_range:
+        port = Port.wrap(port) if port is not None else port
+        if port is not None and port.port not in ports_range:
             raise PortNotAvailableException(
                 f"The requested port ({port}) is not in the port range ({ports_range})."
             )
@@ -228,16 +256,18 @@ class PortRange:
             list(self._ports_cache.keys()),
         )
 
-    def is_port_reserved(self, port: int) -> bool:
+    def is_port_reserved(self, port: int | Port) -> bool:
+        port = Port.wrap(port)
         return self._ports_cache.get(port) is not None
 
-    def _try_reserve_port(self, port: int, duration: int) -> int:
+    def _try_reserve_port(self, port: int | Port, duration: int) -> int:
         """Checks if the given port is currently not reserved and can be bound."""
+        port = Port.wrap(port)
         if not self.is_port_reserved(port) and port_can_be_bound(port):
             # reserve the port for a short period of time
             self._ports_cache[port] = "__reserved__"
             if duration:
                 self._ports_cache.set_expiry(port, duration)
-            return port
+            return port.port
         else:
             raise PortNotAvailableException(f"The given port ({port}) is already reserved.")

--- a/localstack/utils/net.py
+++ b/localstack/utils/net.py
@@ -29,11 +29,15 @@ class Port(NamedTuple):
     """network protocol name (usually 'tcp' or 'udp')"""
 
     @classmethod
-    def wrap(cls, port: Union[int, "Port"]) -> "Port":
+    def wrap(cls, port: "IntOrPort") -> "Port":
         """Return the given port as a Port object, using 'tcp' as the default protocol."""
         if isinstance(port, Port):
             return port
         return Port(port=port, protocol="tcp")
+
+
+# simple helper type to encapsulate int/Port argument types
+IntOrPort = Union[int, Port]
 
 
 def is_port_open(
@@ -149,7 +153,7 @@ def wait_for_port_status(
     return retry(check, sleep=sleep_time, retries=retries)
 
 
-def port_can_be_bound(port: int | Port) -> bool:
+def port_can_be_bound(port: IntOrPort) -> bool:
     """
     Return whether a local port (TCP or UDP) can be bound to. Note that this is a stricter check
     than is_port_open(...) above, as is_port_open() may return False if the port is
@@ -223,9 +227,7 @@ class PortRange:
         self.start = start
         self.end = end
 
-    def reserve_port(
-        self, port: Optional[int | Port] = None, duration: Optional[int] = None
-    ) -> int:
+    def reserve_port(self, port: Optional[IntOrPort] = None, duration: Optional[int] = None) -> int:
         """
         Reserves the given port (if it is still free). If the given port is None, it reserves a free port from the
         configured port range for external services. If a port is given, it has to be within the configured
@@ -256,11 +258,11 @@ class PortRange:
             list(self._ports_cache.keys()),
         )
 
-    def is_port_reserved(self, port: int | Port) -> bool:
+    def is_port_reserved(self, port: IntOrPort) -> bool:
         port = Port.wrap(port)
         return self._ports_cache.get(port) is not None
 
-    def _try_reserve_port(self, port: int | Port, duration: int) -> int:
+    def _try_reserve_port(self, port: IntOrPort, duration: int) -> int:
         """Checks if the given port is currently not reserved and can be bound."""
         port = Port.wrap(port)
         if not self.is_port_reserved(port) and port_can_be_bound(port):

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -85,12 +85,17 @@ def start_ssl_proxy(
     target_ssl=False,
     client_cert_key: Tuple[str, str] = None,
     asynchronous: bool = False,
+    bind_address: str = None,
 ):
     """Start a proxy server that accepts SSL requests and forwards requests to a backend (either SSL or non-SSL)"""
 
     def _run(*args):
         return _do_start_ssl_proxy(
-            port, target, target_ssl=target_ssl, client_cert_key=client_cert_key
+            port,
+            target,
+            target_ssl=target_ssl,
+            client_cert_key=client_cert_key,
+            bind_address=bind_address,
         )
 
     if not asynchronous:

--- a/localstack/utils/server/proxy_server.py
+++ b/localstack/utils/server/proxy_server.py
@@ -85,17 +85,12 @@ def start_ssl_proxy(
     target_ssl=False,
     client_cert_key: Tuple[str, str] = None,
     asynchronous: bool = False,
-    bind_address: str = None,
 ):
     """Start a proxy server that accepts SSL requests and forwards requests to a backend (either SSL or non-SSL)"""
 
     def _run(*args):
         return _do_start_ssl_proxy(
-            port,
-            target,
-            target_ssl=target_ssl,
-            client_cert_key=client_cert_key,
-            bind_address=bind_address,
+            port, target, target_ssl=target_ssl, client_cert_key=client_cert_key
         )
 
     if not asynchronous:

--- a/tests/integration/docker_utils/test_docker.py
+++ b/tests/integration/docker_utils/test_docker.py
@@ -27,13 +27,13 @@ from localstack.utils.container_utils.container_client import (
 )
 from localstack.utils.container_utils.docker_cmd_client import CmdDockerClient
 from localstack.utils.docker_utils import (
-    container_port_can_be_bound,
+    container_ports_can_be_bound,
     is_container_port_reserved,
     is_port_available_for_containers,
     reserve_available_container_port,
     reserve_container_port,
 )
-from localstack.utils.net import PortNotAvailableException, get_free_tcp_port
+from localstack.utils.net import Port, PortNotAvailableException, get_free_tcp_port
 
 ContainerInfo = NamedTuple(
     "ContainerInfo",
@@ -1397,15 +1397,17 @@ def set_ports_check_image_alpine(monkeypatch):
     )
 
 
+@pytest.mark.parametrize("protocol", [None, "tcp", "udp"])
 class TestDockerPorts:
-    def test_reserve_container_port(self, docker_client, set_ports_check_image_alpine):
+    def test_reserve_container_port(self, docker_client, set_ports_check_image_alpine, protocol):
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")
 
         # reserve available container port
-        port = reserve_available_container_port(duration=1)
+        port = reserve_available_container_port(duration=1, protocol=protocol)
+        port = Port(port, protocol or "tcp")
         assert is_container_port_reserved(port)
-        assert container_port_can_be_bound(port)
+        assert container_ports_can_be_bound(port)
         assert not is_port_available_for_containers(port)
 
         # reservation should fail immediately after
@@ -1418,22 +1420,24 @@ class TestDockerPorts:
         assert is_port_available_for_containers(port)
         reserve_container_port(port, duration=1)
         assert is_container_port_reserved(port)
-        assert container_port_can_be_bound(port)
+        assert container_ports_can_be_bound(port)
 
         # reservation should work on privileged port
         port = reserve_available_container_port(duration=1, port_start=1, port_end=1024)
         assert is_container_port_reserved(port)
-        assert container_port_can_be_bound(port)
+        assert container_ports_can_be_bound(port)
         assert not is_port_available_for_containers(port)
 
-    def test_container_port_can_be_bound(self, docker_client, set_ports_check_image_alpine):
+    def test_container_port_can_be_bound(
+        self, docker_client, set_ports_check_image_alpine, protocol
+    ):
         if isinstance(docker_client, CmdDockerClient):
             pytest.skip("Running test only for one Docker executor")
 
         # reserve available container port
         port = reserve_available_container_port(duration=1)
         start_time = datetime.datetime.now()
-        assert container_port_can_be_bound(port)
+        assert container_ports_can_be_bound(port)
         assert not is_port_available_for_containers(port)
 
         # run test container with port exposed
@@ -1449,11 +1453,11 @@ class TestDockerPorts:
             detach=True,
         )
         # assert that port can no longer be bound by new containers
-        assert not container_port_can_be_bound(port)
+        assert not container_ports_can_be_bound(port)
 
         # remove container, assert that port can be bound again
         docker_client.remove_container(name, force=True)
-        assert container_port_can_be_bound(port)
+        assert container_ports_can_be_bound(port)
         delta = (datetime.datetime.now() - start_time).total_seconds()
         if delta <= 1:
             time.sleep(1.01 - delta)

--- a/tests/unit/utils/test_net_utils.py
+++ b/tests/unit/utils/test_net_utils.py
@@ -1,8 +1,10 @@
+import socket
+
 import pytest as pytest
 
 from localstack.constants import LOCALHOST
 from localstack.utils.common import short_uid
-from localstack.utils.net import resolve_hostname
+from localstack.utils.net import Port, port_can_be_bound, resolve_hostname
 
 
 @pytest.mark.skip_offline
@@ -10,3 +12,24 @@ def test_resolve_hostname():
     assert "127." in resolve_hostname(LOCALHOST)
     assert resolve_hostname("example.com")
     assert resolve_hostname(f"non-existing-host-{short_uid()}") is None
+
+
+@pytest.mark.parametrize("protocol", ["tcp", "udp"])
+def test_port_open(protocol):
+
+    if protocol == "tcp":
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    else:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    # bind socket
+    sock.bind(("", 0))
+    addr, port = sock.getsockname()
+
+    # assert that port cannot be bound
+    port = Port(port, protocol=protocol)
+    assert not port_can_be_bound(port)
+
+    # close socket, assert that port can be bound
+    sock.close()
+    assert port_can_be_bound(port)


### PR DESCRIPTION
Extend docker/net utils to allow port checks for UDP ports. Addresses an issue from a support channel where starting up the LS container fails due to UDP port 53 already being bound. 

This PR extends `container_ports_can_be_bound(..)` to allow us to make port availability checks also for UDP ports, which will allow us to selectively add the port bind for UDP port 53, based on availability.

Tried to make the changes minimally invasive, and backwards-compatible. Ports can be specified as an `int` (in which case we assume TCP as the default protocol), or as a `Port` instance that contains the protocol explicitly.

The existing `TestDockerPorts` test has been parameterized to also cover UDP ports, and a new simple test has been added to cover the UDP-based logic for `port_can_be_bound(..)`.

Debatable whether this is a new feature or a fix 🤷 - but since it addresses a support case, arguably this could still be considered for the pre v2 merges (despite the feature freeze). To be discussed..

/cc @simonrw @dfangl 