### PR TITLE
fix client metadata to always return an empty string for api_key

### DIFF
--- a/localstack/utils/analytics/metadata.py
+++ b/localstack/utils/analytics/metadata.py
@@ -48,7 +48,7 @@ def read_client_metadata() -> ClientMetadata:
     return ClientMetadata(
         session_id=get_session_id(),
         machine_id=get_machine_id(),
-        api_key=read_api_key_safe(),
+        api_key=read_api_key_safe() or "",  # api key should not be None
         system=get_system(),
         version=get_version_string(),
         is_ci=os.getenv("CI") is not None,


### PR DESCRIPTION
in #7693 we changed the behavior of `read_client_metadata` to return `None` as key if pro is not available. previously it was always an empty string. our data schema, unfortunately, as api key as a non-nullable field, so this leads to rows landing in quarantine. 