### PR TITLE
fix CORS issue for CreateBucket and ListBuckets

### DIFF
--- a/localstack/aws/handlers/cors.py
+++ b/localstack/aws/handlers/cors.py
@@ -118,10 +118,6 @@ def should_enforce_self_managed_service(context: RequestContext) -> bool:
     if context.service:
         service_name = context.service.service_name
         if not config.DISABLE_CUSTOM_CORS_S3 and service_name == "s3":
-            # ListBuckets is not concerned by S3 CORS handling, it should follow general LocalStack CORS rules.
-            # we can also check if the path is "/", no need for operation
-            if context.operation and context.operation.name == "ListBuckets":
-                return True
             return False
         if not config.DISABLE_CUSTOM_CORS_APIGATEWAY and service_name == "apigateway":
             is_user_request = (

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -259,6 +259,10 @@ def s3_cors_request_handler(chain: HandlerChain, context: RequestContext, respon
     """
     Handler to add default CORS headers to S3 operations not concerned with CORS configuration
     """
+    # if DISABLE_CUSTOM_CORS_S3 is true, the default CORS handling will take place, so we won't need to do it here
+    if config.LEGACY_S3_PROVIDER or config.DISABLE_CUSTOM_CORS_S3:
+        return
+
     if context.service.service_name != "s3":
         return
 

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Optional, Tuple
 
@@ -17,6 +18,9 @@ from localstack.constants import S3_VIRTUAL_HOSTNAME
 from localstack.http import Request, Response
 from localstack.services.s3.models import BucketCorsIndex
 from localstack.services.s3.utils import S3_VIRTUAL_HOSTNAME_REGEX
+
+# TODO: add more logging statements
+LOG = logging.getLogger(__name__)
 
 _s3_virtual_host_regex = re.compile(S3_VIRTUAL_HOSTNAME_REGEX)
 FAKE_HOST_ID = "9Gjjt1m+cjU4OPvX9O9/8RuvnG41MRb/18Oux2o5H5MY7ISNTlXN+Dz9IG62/ILVxhAGI0qyPfg="
@@ -249,3 +253,24 @@ class S3CorsHandler(Handler):
         except Exception:
             # if we can't parse the request, just set GetObject
             return self._service.operation_model("GetObject")
+
+
+def s3_cors_request_handler(chain: HandlerChain, context: RequestContext, response: Response):
+    """
+    Handler to add default CORS headers to S3 operations not concerned with CORS configuration
+    """
+    if context.service.service_name != "s3":
+        return
+
+    if not context.operation or context.operation.name not in ("ListBuckets", "CreateBucket"):
+        return
+
+    if not config.DISABLE_CORS_CHECKS and not is_origin_allowed_default(context.request.headers):
+        LOG.info(
+            "Blocked CORS request from forbidden origin %s",
+            context.request.headers.get("origin") or context.request.headers.get("referer"),
+        )
+        response.status_code = 403
+        chain.terminate()
+
+    add_default_headers(response_headers=response.headers, request_headers=context.request.headers)

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -98,7 +98,7 @@ from localstack.services.edge import ROUTER
 from localstack.services.moto import call_moto
 from localstack.services.plugins import ServiceLifecycleHook
 from localstack.services.s3 import constants as s3_constants
-from localstack.services.s3.cors import S3CorsHandler
+from localstack.services.s3.cors import S3CorsHandler, s3_cors_request_handler
 from localstack.services.s3.models import S3Store, get_moto_s3_backend, s3_stores
 from localstack.services.s3.notifications import NotificationDispatcher, S3EventNotificationContext
 from localstack.services.s3.presigned_url import (
@@ -1409,5 +1409,6 @@ def apply_moto_patches():
 
 
 def register_custom_handlers():
+    serve_custom_service_request_handlers.append(s3_cors_request_handler)
     serve_custom_service_request_handlers.append(s3_presigned_url_request_handler)
     modify_service_response.append(S3Provider.service, s3_presigned_url_response_handler)


### PR DESCRIPTION
It seems we missed a scenario when creating the new CORS handling for S3:

If we do a `CreateBucket` request not targeting the S3 specific endpoint (like we do from the web app), we cannot know for sure that the request is targeting S3 (it is a simple `PUT` request with a path, nothing else), because the bucket does not exist yet. So, the pre-process handler does not add any headers, and the request is seen as "self-managed" by the default CORS enforcer / enricher because it targets S3, so nobody adds the right headers in the end. 

The solution for now is to let the handler chain execute before handing the request to the skeleton, and if the request is `CreateBucket` or `ListBuckets`, we will use the default LocalStack CORS handling to enrich the response with the right headers, only of the origin is allowed. Otherwise, we will reject the request. At least we won't get any side effect directly in the provider. 

\cc @lukqw, thanks for finding and helping in reproducing the issue! 