### PR TITLE
fix: dynamodb restart

### DIFF
--- a/localstack/services/dynamodb/provider.py
+++ b/localstack/services/dynamodb/provider.py
@@ -362,13 +362,13 @@ class DynamoDBProvider(DynamodbApi, ServiceLifecycleHook):
 
     def on_before_state_reset(self):
         self.server.stop_dynamodb()
-        self.server = DynamodbServer()
 
     def on_before_state_load(self):
         self.server.stop_dynamodb()
         self.server = DynamodbServer()
 
     def on_after_state_reset(self):
+        self.server = DynamodbServer()
         self.server.start_dynamodb()
 
     def on_after_state_load(self):


### PR DESCRIPTION
This PR fixes the restart of DynamoDB. 

I noticed this issue when working to re-enable the cloud pods tests. I likely introduced this regression in https://github.com/localstack/localstack/pull/7827.

In a nutshell, we were creating the assets directory in the `on_before_state_reset()` hook and deleting it when calling the visitor. This PR moves the creation to the server to the `on_after_state_reset()` hook.

One can simply test it by creating some resources and calling the endpoint with `curl -X POST http://localhost:4566/_localstack/state/reset`

