### PR TITLE
fix race condition in service plugin loading

### DIFF
--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -16,7 +16,7 @@ from localstack.state import StateLifecycleHook, StateVisitable, StateVisitor
 from localstack.utils.bootstrap import get_enabled_apis, log_duration
 from localstack.utils.functions import call_safe
 from localstack.utils.net import wait_for_port_status
-from localstack.utils.sync import poll_condition
+from localstack.utils.sync import SynchronizedDefaultDict, poll_condition
 
 # set up logger
 LOG = logging.getLogger(__name__)
@@ -245,7 +245,7 @@ class ServiceContainer:
 class ServiceManager:
     def __init__(self) -> None:
         super().__init__()
-        self._services = {}
+        self._services: Dict[str, ServiceContainer] = {}
         self._mutex = threading.RLock()
 
     def get_service_container(self, name: str) -> Optional[ServiceContainer]:
@@ -454,6 +454,11 @@ class ServicePluginManager(ServiceManager):
         self._api_provider_specs = None
         self.provider_config = provider_config or config.SERVICE_PROVIDER_CONFIG
 
+        # locks used to make sure plugin loading is thread safe - will be cleared after single use
+        self._plugin_load_locks: Dict[str, threading.RLock] = SynchronizedDefaultDict(
+            threading.RLock
+        )
+
     def get_active_provider(self, service: str) -> str:
         """
         Get configured provider for a given service
@@ -542,24 +547,32 @@ class ServicePluginManager(ServiceManager):
         return ServiceState.AVAILABLE
 
     def get_service_container(self, name: str) -> Optional[ServiceContainer]:
-        container = super().get_service_container(name)
-        if container:
+        if container := self._services.get(name):
             return container
 
         if not self.exists(name):
             return None
 
-        # this is where we start lazy loading. we now know the PluginSpec for the API exists,
-        # but the ServiceContainer has not been created
-        plugin = self._load_service_plugin(name)
-        if not plugin or not plugin.service:
-            return None
+        load_lock = self._plugin_load_locks[name]
+        with load_lock:
+            # check once again to avoid race conditions
+            if container := self._services.get(name):
+                return container
 
-        with self._mutex:
-            if plugin.service.name() not in self._services:
-                super().add_service(plugin.service)
+            # this is where we start lazy loading. we now know the PluginSpec for the API exists,
+            # but the ServiceContainer has not been created.
+            # this control path will be executed once per service
+            plugin = self._load_service_plugin(name)
+            if not plugin or not plugin.service:
+                return None
 
-        return super().get_service_container(name)
+            with self._mutex:
+                if plugin.service.name() not in self._services:
+                    super().add_service(plugin.service)
+
+            del self._plugin_load_locks[name]  # we only needed the service lock once
+
+            return self._services.get(name)
 
     @property
     def api_provider_specs(self) -> Dict[str, List[str]]:

--- a/localstack/services/plugins.py
+++ b/localstack/services/plugins.py
@@ -567,8 +567,7 @@ class ServicePluginManager(ServiceManager):
                 return None
 
             with self._mutex:
-                if plugin.service.name() not in self._services:
-                    super().add_service(plugin.service)
+                super().add_service(plugin.service)
 
             del self._plugin_load_locks[name]  # we only needed the service lock once
 

--- a/tests/unit/services/test_plugins.py
+++ b/tests/unit/services/test_plugins.py
@@ -1,0 +1,71 @@
+import threading
+from queue import Queue
+
+from localstack.services.plugins import ServicePluginManager
+from localstack.services.sqs.provider import SqsProvider
+
+
+class TestServicePluginManager:
+    def test_get_service_calls_init_hook_once(self, monkeypatch):
+        manager = ServicePluginManager()
+
+        calls_to_on_after_init = []
+
+        def _on_after_init(_self):
+            calls_to_on_after_init.append(_self)
+
+        monkeypatch.setattr(SqsProvider, "on_after_init", _on_after_init)
+
+        s1 = manager.get_service("sqs")
+        s2 = manager.get_service("sqs")
+
+        assert s1 is s2, "instantiated two different services"
+        assert len(calls_to_on_after_init) == 1, "on_after_init should be called once"
+
+    def test_concurrent_get_service_calls_init_hook_once(self, monkeypatch):
+        manager = ServicePluginManager()
+
+        calls_to_get_service = Queue()
+        calls_to_on_after_init = []
+
+        def _call_get_service():
+            service = manager.get_service("sqs")
+            calls_to_get_service.put(service)
+
+        def _on_after_init(_self):
+            calls_to_on_after_init.append(_self)
+
+        monkeypatch.setattr(SqsProvider, "on_after_init", _on_after_init)
+
+        threading.Thread(target=_call_get_service).start()
+        threading.Thread(target=_call_get_service).start()
+
+        s1 = calls_to_get_service.get()
+        s2 = calls_to_get_service.get()
+
+        assert s1 is s2, "instantiated two different services"
+        assert len(calls_to_on_after_init) == 1, "on_after_init should be called once"
+
+    def test_nested_concurrent_get_service_calls_init_hook_once(self, monkeypatch):
+        manager = ServicePluginManager()
+
+        calls_to_get_service = Queue()
+        calls_to_on_after_init = []
+
+        def _call_get_service():
+            service = manager.get_service("sqs")
+            calls_to_get_service.put(service)
+
+        def _on_after_init(_self):
+            calls_to_on_after_init.append(_self)
+            threading.Thread(target=_call_get_service).start()
+
+        monkeypatch.setattr(SqsProvider, "on_after_init", _on_after_init)
+
+        threading.Thread(target=_call_get_service).start()
+
+        s1 = calls_to_get_service.get()
+        s2 = calls_to_get_service.get()
+
+        assert s1 is s2, "instantiated two different services"
+        assert len(calls_to_on_after_init) == 1, "on_after_init should be called once"


### PR DESCRIPTION
This PR fixes a race condition in the service plugin loading, where multiple concurrent calls to `service_manager.require(...)` could lead to Service plugins being instantiated more than once, and subsequently `on_after_init` being called multiple times, whose implementation often mutates global state.

We haven't seen this manifest yet, other an exception in the logs when running `tests/integration/test_terraform.py::TestTerraform::test_bucket_exists`:

```
2023-03-24T17:22:07.962 ERROR --- [   asgi_gw_5] localstack.utils.functions : error calling function on_after_init
Traceback (most recent call last):
  File "/opt/code/localstack/localstack/utils/functions.py", line 41, in call_safe
    return func(*args, **kwargs)
  File "/opt/code/localstack/localstack/services/apigateway/provider.py", line 97, in on_after_init
    apply_patches()
  File "/opt/code/localstack/localstack/services/apigateway/patches.py", line 270, in apply_patches
    def get_rest_api(self, function_id):
  File "/opt/code/localstack/localstack/utils/patch.py", line 170, in wrapper
    fn.patch = Patch.function(target, fn, pass_target=pass_target)
  File "/opt/code/localstack/localstack/utils/patch.py", line 96, in function
    return Patch(obj, name, new)
  File "/opt/code/localstack/localstack/utils/patch.py", line 56, in __init__
    self.old = getattr(self.obj, name)
AttributeError: module 'localstack.services.apigateway.patches' has no attribute 'get_rest_api'
```

which was an obscure indicator that `on_after_init` was called twice.

The PR introduces a locking mechanism that makes sure that, while the service is being loaded and instantiated, other calls to `require` of the same service block. The `SynchronizedDefaultDict(RLock)` pattern is helpful here - and we make sure we delete the locks after using them (we only need them once).