### PR TITLE
Don't source (LOCALSTACK_)HOST in docker entrypoint

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -47,10 +47,12 @@ term_handler() {
   exit 0; # 128 + 15 = 143 -- SIGTERM, but 0 is expected if proper shutdown takes place
 }
 
-# Strip `LOCALSTACK_` prefix in environment variables name (except LOCALSTACK_HOSTNAME)
+# Strip `LOCALSTACK_` prefix in environment variables name (except
+# LOCALSTACK_HOST and LOCALSTACK_HOSTNAME)
 source <(
   env |
   grep -v -e '^LOCALSTACK_HOSTNAME' |
+  grep -v -e '^LOCALSTACK_HOST' |
   grep -v -e '^LOCALSTACK_[[:digit:]]' | # See issue #1387
   sed -ne 's/^LOCALSTACK_\([^=]\+\)=.*/export \1=${LOCALSTACK_\1}/p'
 )


### PR DESCRIPTION
Before this change, the entrypoint script would strip the `LOCALSTACK_` prefix from `LOCALSTACK_HOST` and try to set the `HOST` environment variable to something. This is bad as the `HOST` enviornment variable is reserved for system things, and should not be set.
