### PR TITLE
fix response structure for S3 ListMultipartUploads

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2262,34 +2262,6 @@ class ListBucketMetricsConfigurationsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
-class MultipartUpload(TypedDict, total=False):
-    UploadId: Optional[MultipartUploadId]
-    Key: Optional[ObjectKey]
-    Initiated: Optional[Initiated]
-    StorageClass: Optional[StorageClass]
-    Owner: Optional[Owner]
-    Initiator: Optional[Initiator]
-    ChecksumAlgorithm: Optional[ChecksumAlgorithm]
-
-
-MultipartUploadList = List[MultipartUpload]
-
-
-class ListMultipartUploadsOutput(TypedDict, total=False):
-    Bucket: Optional[BucketName]
-    KeyMarker: Optional[KeyMarker]
-    UploadIdMarker: Optional[UploadIdMarker]
-    NextKeyMarker: Optional[NextKeyMarker]
-    Prefix: Optional[Prefix]
-    Delimiter: Optional[Delimiter]
-    NextUploadIdMarker: Optional[NextUploadIdMarker]
-    MaxUploads: Optional[MaxUploads]
-    IsTruncated: Optional[IsTruncated]
-    Uploads: Optional[MultipartUploadList]
-    CommonPrefixes: Optional[CommonPrefixList]
-    EncodingType: Optional[EncodingType]
-
-
 class ListMultipartUploadsRequest(ServiceRequest):
     Bucket: BucketName
     Delimiter: Optional[Delimiter]
@@ -2415,6 +2387,19 @@ class ListPartsRequest(ServiceRequest):
 class MetadataEntry(TypedDict, total=False):
     Name: Optional[MetadataKey]
     Value: Optional[MetadataValue]
+
+
+class MultipartUpload(TypedDict, total=False):
+    UploadId: Optional[MultipartUploadId]
+    Key: Optional[ObjectKey]
+    Initiated: Optional[Initiated]
+    StorageClass: Optional[StorageClass]
+    Owner: Optional[Owner]
+    Initiator: Optional[Initiator]
+    ChecksumAlgorithm: Optional[ChecksumAlgorithm]
+
+
+MultipartUploadList = List[MultipartUpload]
 
 
 class QueueConfiguration(TypedDict, total=False):
@@ -3092,6 +3077,21 @@ class ListBucketResult(TypedDict, total=False):
     BucketRegion: Optional[BucketRegion]
 
 
+class ListMultipartUploadsResult(TypedDict, total=False):
+    Bucket: Optional[BucketName]
+    KeyMarker: Optional[KeyMarker]
+    UploadIdMarker: Optional[UploadIdMarker]
+    NextKeyMarker: Optional[NextKeyMarker]
+    Prefix: Optional[Prefix]
+    Delimiter: Optional[Delimiter]
+    NextUploadIdMarker: Optional[NextUploadIdMarker]
+    MaxUploads: Optional[MaxUploads]
+    IsTruncated: Optional[IsTruncated]
+    Uploads: Optional[MultipartUploadList]
+    CommonPrefixes: Optional[CommonPrefixList]
+    EncodingType: Optional[EncodingType]
+
+
 class S3Api:
 
     service = "s3"
@@ -3710,7 +3710,7 @@ class S3Api:
         prefix: Prefix = None,
         upload_id_marker: UploadIdMarker = None,
         expected_bucket_owner: AccountId = None,
-    ) -> ListMultipartUploadsOutput:
+    ) -> ListMultipartUploadsResult:
         raise NotImplementedError
 
     @handler("ListObjectVersions")

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -841,6 +841,16 @@
       "op": "replace",
       "path": "/operations/ListObjectsV2/output/shape",
       "value": "ListBucketResult"
+    },
+    {
+      "op": "replace",
+      "path": "/operations/ListMultipartUploads/output/shape",
+      "value": "ListMultipartUploadsResult"
+    },
+    {
+      "op": "move",
+      "from": "/shapes/ListMultipartUploadsOutput",
+      "path": "/shapes/ListMultipartUploadsResult"
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 from typing import IO, Dict, List
@@ -56,9 +57,12 @@ from localstack.aws.api.s3 import (
     InvalidPartOrder,
     InvalidStorageClass,
     ListBucketResult,
+    ListMultipartUploadsRequest,
+    ListMultipartUploadsResult,
     ListObjectsRequest,
     ListObjectsV2Request,
     MissingSecurityHeader,
+    MultipartUpload,
     NoSuchBucket,
     NoSuchKey,
     NoSuchLifecycleConfiguration,
@@ -85,6 +89,7 @@ from localstack.aws.api.s3 import (
     RequestPayer,
     S3Api,
     SkipValidation,
+    StorageClass,
 )
 from localstack.aws.api.s3 import Type as GranteeType
 from localstack.aws.api.s3 import WebsiteConfiguration
@@ -554,6 +559,60 @@ class S3Provider(S3Api, ServiceLifecycleHook):
             "Location"
         ] = f'{get_full_default_bucket_location(request["Bucket"])}{response["Key"]}'
         self._notify(context)
+        return response
+
+    @handler("ListMultipartUploads", expand=False)
+    def list_multipart_uploads(
+        self,
+        context: RequestContext,
+        request: ListMultipartUploadsRequest,
+    ) -> ListMultipartUploadsResult:
+
+        try:
+            response: ListMultipartUploadsResult = call_moto(context)
+        except NotImplementedError:
+            # TODO: implement KeyMarker and UploadIdMarker (using sort)
+            # implement Delimiter and MaxUploads
+            # see https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html
+            bucket = request["Bucket"]
+            moto_backend = get_moto_s3_backend(context)
+            multiparts = list(moto_backend.get_all_multiparts(bucket).values())
+            if (prefix := request.get("Prefix")) is not None:
+                multiparts = [upload for upload in multiparts if upload.key_name.startswith(prefix)]
+
+            # TODO: this is taken from moto template, hardcoded strings.
+            uploads = [
+                MultipartUpload(
+                    Key=upload.key_name,
+                    UploadId=upload.id,
+                    Initiator={
+                        "ID": f"arn:aws:iam::{context.account_id}:user/user1-11111a31-17b5-4fb7-9df5-b111111f13de",
+                        "DisplayName": "user1-11111a31-17b5-4fb7-9df5-b111111f13de",
+                    },
+                    Owner={
+                        "ID": "75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a",
+                        "DisplayName": "webfile",
+                    },
+                    StorageClass=StorageClass.STANDARD,  # hardcoded in moto
+                    Initiated=datetime.datetime.now(),  # hardcoded in moto
+                )
+                for upload in multiparts
+            ]
+
+            response = ListMultipartUploadsResult(
+                Bucket=request["Bucket"],
+                MaxUploads=request.get("MaxUploads") or 1000,
+                IsTruncated=False,
+                Uploads=uploads,
+                UploadIdMarker=request.get("UploadIdMarker") or "",
+                KeyMarker=request.get("KeyMarker") or "",
+            )
+
+            if "Delimiter" in request:
+                response["Delimiter"] = request["Delimiter"]
+
+            # TODO: add NextKeyMarker and NextUploadIdMarker to response once implemented
+
         return response
 
     @handler("GetObjectTagging", expand=False)

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -3383,6 +3383,13 @@ class TestS3:
         resp_dict = xmltodict.parse(resp.content)
         assert "ListBucketResult" in resp_dict
 
+        # Lists all multipart uploads in a bucket
+        bucket_url = f"{_bucket_url(s3_bucket)}?uploads"
+        resp = s3_http_client.get(bucket_url, headers=headers)
+        assert b'<?xml version="1.0" encoding="UTF-8"?>\n' in get_xml_content(resp.content)
+        resp_dict = xmltodict.parse(resp.content)
+        assert "ListMultipartUploadsResult" in resp_dict
+
         location_constraint_url = f"{bucket_url}?location"
         resp = s3_http_client.get(location_constraint_url, headers=headers)
         assert b'<?xml version="1.0" encoding="UTF-8"?>\n' in get_xml_content(resp.content)

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5496,5 +5496,116 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_list_multipart_uploads_parameters": {
+    "recorded-date": "28-03-2023, 18:16:25",
+    "recorded-content": {
+      "create-multipart": {
+        "Bucket": "bucket",
+        "Key": "test-multipart-uploads-parameters",
+        "ServerSideEncryption": "AES256",
+        "UploadId": "<upload-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "upload-part": {
+        "ETag": "\"098f6bcd4621d373cade4e832627b4f6\"",
+        "ServerSideEncryption": "AES256",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-uploads-basic": {
+        "Bucket": "bucket",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "test-multipart-uploads-parameters",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "Key": "test-multipart-uploads-parameters",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-uploads-max-uploads": {
+        "Bucket": "bucket",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1,
+        "NextKeyMarker": "test-multipart-uploads-parameters",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "Key": "test-multipart-uploads-parameters",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-uploads-delimiter": {
+        "Bucket": "bucket",
+        "Delimiter": "/",
+        "IsTruncated": false,
+        "KeyMarker": "",
+        "MaxUploads": 1000,
+        "NextKeyMarker": "test-multipart-uploads-parameters",
+        "NextUploadIdMarker": "<upload-id:1>",
+        "UploadIdMarker": "",
+        "Uploads": [
+          {
+            "Initiated": "datetime",
+            "Initiator": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "Key": "test-multipart-uploads-parameters",
+            "Owner": {
+              "DisplayName": "display-name",
+              "ID": "i-d"
+            },
+            "StorageClass": "STANDARD",
+            "UploadId": "<upload-id:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This is a follow up from #7545, a user reported an issue in our Community Slack. The test is AWS validated, and once again the specs were not compliant with what S3 really returns. 

We also reapply the logic that was in a patch previously set, moto would have raised an error if using some request parameters that were not implemented. It would raise a `NotImplemented` exception. The previous provider was swallowing the exception and letting it pass anyway without applying the parameters. We can keep the same behaviour for now and come back later and actually implement the right behaviour. 

related: #7981, https://github.com/localstack/docs/pull/539

\cc @steffyP 