### PR TITLE
add test for ListObjectsV2 + fix config flag

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -2354,35 +2354,6 @@ class ListObjectsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
-class Object(TypedDict, total=False):
-    Key: Optional[ObjectKey]
-    LastModified: Optional[LastModified]
-    ETag: Optional[ETag]
-    ChecksumAlgorithm: Optional[ChecksumAlgorithmList]
-    Size: Optional[Size]
-    StorageClass: Optional[ObjectStorageClass]
-    Owner: Optional[Owner]
-
-
-ObjectList = List[Object]
-
-
-class ListObjectsV2Output(TypedDict, total=False):
-    IsTruncated: Optional[IsTruncated]
-    Contents: Optional[ObjectList]
-    Name: Optional[BucketName]
-    Prefix: Optional[Prefix]
-    Delimiter: Optional[Delimiter]
-    MaxKeys: Optional[MaxKeys]
-    CommonPrefixes: Optional[CommonPrefixList]
-    EncodingType: Optional[EncodingType]
-    KeyCount: Optional[KeyCount]
-    ContinuationToken: Optional[Token]
-    NextContinuationToken: Optional[NextToken]
-    StartAfter: Optional[StartAfter]
-    BucketRegion: Optional[BucketRegion]
-
-
 class ListObjectsV2Request(ServiceRequest):
     Bucket: BucketName
     Delimiter: Optional[Delimiter]
@@ -2493,6 +2464,17 @@ class NotificationConfigurationDeprecated(TypedDict, total=False):
     CloudFunctionConfiguration: Optional[CloudFunctionConfiguration]
 
 
+class Object(TypedDict, total=False):
+    Key: Optional[ObjectKey]
+    LastModified: Optional[LastModified]
+    ETag: Optional[ETag]
+    ChecksumAlgorithm: Optional[ChecksumAlgorithmList]
+    Size: Optional[Size]
+    StorageClass: Optional[ObjectStorageClass]
+    Owner: Optional[Owner]
+
+
+ObjectList = List[Object]
 UserMetadata = List[MetadataEntry]
 
 
@@ -3094,8 +3076,6 @@ class ListAllMyBucketsResult(TypedDict, total=False):
 
 class ListBucketResult(TypedDict, total=False):
     IsTruncated: Optional[IsTruncated]
-    Marker: Optional[Marker]
-    NextMarker: Optional[NextMarker]
     Contents: Optional[ObjectList]
     Name: Optional[BucketName]
     Prefix: Optional[Prefix]
@@ -3103,6 +3083,12 @@ class ListBucketResult(TypedDict, total=False):
     MaxKeys: Optional[MaxKeys]
     CommonPrefixes: Optional[CommonPrefixList]
     EncodingType: Optional[EncodingType]
+    KeyCount: Optional[KeyCount]
+    ContinuationToken: Optional[Token]
+    NextContinuationToken: Optional[NextToken]
+    StartAfter: Optional[StartAfter]
+    Marker: Optional[Marker]
+    NextMarker: Optional[NextMarker]
     BucketRegion: Optional[BucketRegion]
 
 
@@ -3771,7 +3757,7 @@ class S3Api:
         start_after: StartAfter = None,
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
-    ) -> ListObjectsV2Output:
+    ) -> ListBucketResult:
         raise NotImplementedError
 
     @handler("ListParts")

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -90,24 +90,6 @@
     },
     {
       "op": "add",
-      "path": "/shapes/ListObjectsOutput/members/BucketRegion",
-      "value": {
-        "shape": "BucketRegion",
-        "location": "header",
-        "locationName": "x-amz-bucket-region"
-      }
-    },
-    {
-      "op": "add",
-      "path": "/shapes/ListObjectsV2Output/members/BucketRegion",
-      "value": {
-        "shape": "BucketRegion",
-        "location": "header",
-        "locationName": "x-amz-bucket-region"
-      }
-    },
-    {
-      "op": "add",
       "path": "/operations/PutBucketPolicy/http/responseCode",
       "value": 204
     },
@@ -789,8 +771,37 @@
     },
     {
       "op": "move",
-      "from": "/shapes/ListObjectsOutput",
+      "from": "/shapes/ListObjectsV2Output",
       "path": "/shapes/ListBucketResult"
+    },
+    {
+      "op": "remove",
+      "path": "/shapes/ListObjectsOutput"
+    },
+    {
+        "op": "add",
+        "path": "/shapes/ListBucketResult/members/Marker",
+        "value": {
+            "shape": "Marker",
+            "documentation": "<p>Indicates where in the bucket listing begins. Marker is included in the response if it was sent with the request.</p>"
+        }
+    },
+    {
+        "op": "add",
+        "path": "/shapes/ListBucketResult/members/NextMarker",
+        "value": {
+            "shape": "NextMarker",
+            "documentation": "<p>When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMarker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys.</p>"
+        }
+    },
+    {
+      "op": "add",
+      "path": "/shapes/ListBucketResult/members/BucketRegion",
+      "value": {
+        "shape": "BucketRegion",
+        "location": "header",
+        "locationName": "x-amz-bucket-region"
+      }
     },
     {
       "op": "add",
@@ -825,6 +836,11 @@
         "documentation": "<p>The specified method is not allowed against this resource.</p>",
         "exception": true
       }
+    },
+    {
+      "op": "replace",
+      "path": "/operations/ListObjectsV2/output/shape",
+      "value": "ListBucketResult"
     }
   ]
 }

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -366,11 +366,6 @@ USE_SSL = is_env_true("USE_SSL")
 # whether to use the legacy edge proxy or the newer Gateway/HandlerChain framework
 LEGACY_EDGE_PROXY = is_env_true("LEGACY_EDGE_PROXY")
 
-# Forces to use S3 ASF provider, while not loading -ext (does not have asf provider)
-# TODO: will need to discuss the best way to do this with -ext, this is temporary for testing
-if not os.environ.get("PROVIDER_OVERRIDE_S3"):
-    os.environ["PROVIDER_OVERRIDE_S3"] = "asf"
-
 # whether legacy s3 is enabled
 LEGACY_S3_PROVIDER = os.environ.get("PROVIDER_OVERRIDE_S3", "") == "legacy"
 

--- a/localstack/services/s3/cors.py
+++ b/localstack/services/s3/cors.py
@@ -263,7 +263,7 @@ def s3_cors_request_handler(chain: HandlerChain, context: RequestContext, respon
     if config.LEGACY_S3_PROVIDER or config.DISABLE_CUSTOM_CORS_S3:
         return
 
-    if context.service.service_name != "s3":
+    if not context.service or context.service.service_name != "s3":
         return
 
     if not context.operation or context.operation.name not in ("ListBuckets", "CreateBucket"):

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -57,7 +57,6 @@ from localstack.aws.api.s3 import (
     InvalidStorageClass,
     ListBucketResult,
     ListObjectsRequest,
-    ListObjectsV2Output,
     ListObjectsV2Request,
     MissingSecurityHeader,
     NoSuchBucket,
@@ -310,8 +309,8 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self,
         context: RequestContext,
         request: ListObjectsV2Request,
-    ) -> ListObjectsV2Output:
-        response: ListObjectsV2Output = call_moto(context)
+    ) -> ListBucketResult:
+        response: ListBucketResult = call_moto(context)
 
         encoding_type = request.get("EncodingType")
         if "EncodingType" not in response and encoding_type:

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -660,6 +660,25 @@ class TestS3:
             )
             snapshot.match(f"list-object-version-{param['Id']}", response)
 
+    def test_list_objects_v2_with_prefix(self, s3_client, s3_bucket, snapshot):
+        snapshot.add_transformer(snapshot.transform.s3_api())
+        keys = ["test/foo/bar/123" "test/foo/bar/456", "test/bar/foo/123"]
+        for key in keys:
+            s3_client.put_object(Bucket=s3_bucket, Key=key, Body=b"content 123")
+
+        response = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix="test/", EncodingType="url")
+        snapshot.match("list-objects-v2-1", response)
+
+        response = s3_client.list_objects_v2(
+            Bucket=s3_bucket, Prefix="test/foo", EncodingType="url"
+        )
+        snapshot.match("list-objects-v2-2", response)
+
+        response = s3_client.list_objects_v2(
+            Bucket=s3_bucket, Prefix="test/foo/bar", EncodingType="url"
+        )
+        snapshot.match("list-objects-v2-3", response)
+
     @pytest.mark.aws_validated
     @pytest.mark.skip_snapshot_verify(condition=is_old_provider, path="$..Error.BucketName")
     def test_get_object_no_such_bucket(self, s3_client, snapshot):

--- a/tests/integration/s3/test_s3.py
+++ b/tests/integration/s3/test_s3.py
@@ -660,6 +660,7 @@ class TestS3:
             )
             snapshot.match(f"list-object-version-{param['Id']}", response)
 
+    @pytest.mark.aws_validated
     def test_list_objects_v2_with_prefix(self, s3_client, s3_bucket, snapshot):
         snapshot.add_transformer(snapshot.transform.s3_api())
         keys = ["test/foo/bar/123" "test/foo/bar/456", "test/bar/foo/123"]

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -2542,7 +2542,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_head_object_fields": {
-    "recorded-date": "21-09-2022, 13:54:45",
+    "recorded-date": "28-03-2023, 15:37:16",
     "recorded-content": {
       "head-object": {
         "AcceptRanges": "bytes",
@@ -2551,9 +2551,20 @@
         "ETag": "\"e8dc4081b13434b45189a720b77b6818\"",
         "LastModified": "datetime",
         "Metadata": {},
+        "ServerSideEncryption": "AES256",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
+        }
+      },
+      "head-object-404": {
+        "Error": {
+          "Code": "404",
+          "Message": "Not Found"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 404
         }
       }
     }
@@ -5338,7 +5349,7 @@
     }
   },
   "tests/integration/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix": {
-    "recorded-date": "28-03-2023, 12:30:57",
+    "recorded-date": "28-03-2023, 13:54:02",
     "recorded-content": {
       "list-objects-v2-1": {
         "Contents": [

--- a/tests/integration/s3/test_s3.snapshot.json
+++ b/tests/integration/s3/test_s3.snapshot.json
@@ -5282,5 +5282,134 @@
         }
       }
     }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix[None]": {
+    "recorded-date": "28-03-2023, 12:25:25",
+    "recorded-content": {}
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix[/]": {
+    "recorded-date": "28-03-2023, 12:25:27",
+    "recorded-content": {
+      "list-objects-v2": {
+        "CommonPrefixes": [
+          {
+            "Prefix": "test/foo/"
+          }
+        ],
+        "Delimiter": "/",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix[%2F]": {
+    "recorded-date": "28-03-2023, 12:25:30",
+    "recorded-content": {
+      "list-objects-v2": {
+        "Contents": [
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "Delimiter": "%252F",
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
+  },
+  "tests/integration/s3/test_s3.py::TestS3::test_list_objects_v2_with_prefix": {
+    "recorded-date": "28-03-2023, 12:30:57",
+    "recorded-content": {
+      "list-objects-v2-1": {
+        "Contents": [
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/bar/foo/123",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          },
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123test/foo/bar/456",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 2,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-2": {
+        "Contents": [
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123test/foo/bar/456",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/foo",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "list-objects-v2-3": {
+        "Contents": [
+          {
+            "ETag": "\"0d9fa06a66933b40f615f530e59edd6b\"",
+            "Key": "test/foo/bar/123test/foo/bar/456",
+            "LastModified": "datetime",
+            "Size": 11,
+            "StorageClass": "STANDARD"
+          }
+        ],
+        "EncodingType": "url",
+        "IsTruncated": false,
+        "KeyCount": 1,
+        "MaxKeys": 1000,
+        "Name": "<bucket-name:1>",
+        "Prefix": "test/foo/bar",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
It seemed we had an issue with `ListObjectsV2` and Glue. Once again, the specs were not right about the root tag of the XML response of S3. However, the responses for `ListObjects` and `ListObjectsV2` are using the same root tag `ListBucketResult` so we must merge the two wrongly named "containers" in the specs into one for both operation. 

Also, I've realized that we merged this from our old S3 migration branch:
```python
# Forces to use S3 ASF provider, while not loading -ext (does not have asf provider)
# TODO: will need to discuss the best way to do this with -ext, this is temporary for testing
if not os.environ.get("PROVIDER_OVERRIDE_S3"):
    os.environ["PROVIDER_OVERRIDE_S3"] = "asf"
```

So, removing it. 
Also, thanks @silv-io for the hours long debugging session we've had to find this issue 😄 