### PR TITLE
Integrate GATEWAY_LISTEN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ volume/
 
 # ANTLR4 ID plugin.
 gen/
+
+# hypothesis pytest plugin
+.hypothesis

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -2,10 +2,6 @@
 
 set -eo pipefail
 shopt -s nullglob
-if [[ ! $EDGE_PORT ]]
-then
-  EDGE_PORT=4566
-fi
 
 # the Dockerfile creates .pro-version file for the pro image and .bigdata-pro-version for the bigdata image.
 # When trying to activate pro features with any other version, a warning is printed.

--- a/bin/localstack-start-docker-dev.sh
+++ b/bin/localstack-start-docker-dev.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-source .venv/bin/activate
+source ${VENV_DIR=.venv}/bin/activate
 
 export LOCALSTACK_VOLUME_DIR=$(pwd)/.filesystem/var/lib/localstack
 export DOCKER_FLAGS="${DOCKER_FLAGS}

--- a/localstack/aws/serving/edge.py
+++ b/localstack/aws/serving/edge.py
@@ -1,9 +1,12 @@
+from typing import List
+
+from localstack.config import HostAndPort
 from localstack.http.hypercorn import GatewayServer
 from localstack.runtime.shutdown import SHUTDOWN_HANDLERS
 from localstack.services.plugins import SERVICE_PLUGINS
 
 
-def serve_gateway(bind_address, port, use_ssl, asynchronous=False):
+def serve_gateway(listen: List[HostAndPort], use_ssl: bool, asynchronous: bool = False):
     """
     Implementation of the edge.do_start_edge_proxy interface to start a Hypercorn server instance serving the
     LocalstackAwsGateway.
@@ -13,7 +16,7 @@ def serve_gateway(bind_address, port, use_ssl, asynchronous=False):
     gateway = LocalstackAwsGateway(SERVICE_PLUGINS)
 
     # start serving gateway
-    server = GatewayServer(gateway, port, bind_address, use_ssl)
+    server = GatewayServer(gateway, listen, use_ssl)
     server.start()
 
     # with the current way the infrastructure is started, this is the easiest way to shut down the server correctly

--- a/localstack/aws/serving/edge.py
+++ b/localstack/aws/serving/edge.py
@@ -6,7 +6,9 @@ from localstack.runtime.shutdown import SHUTDOWN_HANDLERS
 from localstack.services.plugins import SERVICE_PLUGINS
 
 
-def serve_gateway(listen: List[HostAndPort], use_ssl: bool, asynchronous: bool = False):
+def serve_gateway(
+    listen: HostAndPort | List[HostAndPort], use_ssl: bool, asynchronous: bool = False
+):
     """
     Implementation of the edge.do_start_edge_proxy interface to start a Hypercorn server instance serving the
     LocalstackAwsGateway.

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -7,8 +7,7 @@ from typing import Dict, List, Optional, Tuple
 
 from localstack import config
 from localstack.utils.analytics.cli import publish_invocation
-
-from ..utils.json import CustomEncoder
+from localstack.utils.json import CustomEncoder
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict

--- a/localstack/cli/localstack.py
+++ b/localstack/cli/localstack.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Optional, Tuple
 from localstack import config
 from localstack.utils.analytics.cli import publish_invocation
 
+from ..utils.json import CustomEncoder
+
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
@@ -204,7 +206,7 @@ def cmd_config_validate(file: str) -> None:
 def _print_config_json() -> None:
     import json
 
-    console.print(json.dumps(dict(config.collect_config_items())))
+    console.print(json.dumps(dict(config.collect_config_items()), cls=CustomEncoder))
 
 
 def _print_config_pairs() -> None:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -540,7 +540,7 @@ class HostAndPort:
         if isinstance(other, self.__class__):
             return self.host == other.host and self.port == other.port
         elif isinstance(other, str):
-            return self == self.__class__.parse(other)
+            return self == self.parse(other)
         else:
             raise TypeError(f"cannot compare {self.__class__} to {other.__class__}")
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -352,6 +352,7 @@ OVERRIDE_IN_DOCKER = parse_boolean_env("OVERRIDE_IN_DOCKER")
 
 is_in_docker = in_docker()
 is_in_linux = is_linux()
+default_ip = "0.0.0.0" if is_in_docker else "127.0.0.1"
 
 # CLI specific: the configuration profile to load
 CONFIG_PROFILE = os.environ.get("CONFIG_PROFILE", "").strip()
@@ -566,11 +567,6 @@ class HostAndPort:
 def populate_legacy_edge_configuration(
     environment: Mapping[str, str]
 ) -> Tuple[HostAndPort, List[HostAndPort], str, int, int]:
-    if is_in_docker:
-        default_ip = "0.0.0.0"
-    else:
-        default_ip = "127.0.0.1"
-
     localstack_host_raw = environment.get("LOCALSTACK_HOST")
     gateway_listen_raw = environment.get("GATEWAY_LISTEN")
 
@@ -602,7 +598,9 @@ def populate_legacy_edge_configuration(
         for address in gateway_listen_raw.split(","):
             gateway_listen.append(
                 HostAndPort.parse(
-                    address.strip(), default_host=default_ip, default_port=localstack_host.port
+                    address.strip(),
+                    default_host=default_ip,
+                    default_port=localstack_host.port,
                 )
             )
     else:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -583,6 +583,13 @@ class HostAndPort:
 
         return cls(host=host, port=port)
 
+    def is_unprivileged(self) -> Optional[bool]:
+        if self.port is not None:
+            return self.port >= 1024
+
+    def __hash__(self) -> int:
+        return hash((self.host, self.port))
+
     # easier tests
     def __eq__(self, other: "str | HostAndPort") -> bool:
         if isinstance(other, self.__class__):
@@ -1255,10 +1262,12 @@ def external_service_url(service_key, host=None, port=None):
 
 
 def get_edge_port_http():
+    # TODO: update to use gateway_listen
     return EDGE_PORT_HTTP or EDGE_PORT
 
 
 def get_edge_url(localstack_hostname=None, protocol=None):
+    # TODO: update to use gateway_listen
     port = get_edge_port_http()
     protocol = protocol or get_protocol()
     localstack_hostname = localstack_hostname or LOCALSTACK_HOSTNAME

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -504,7 +504,7 @@ class HostAndPort:
         cls,
         input: str,
         default_host: Optional[str] = None,
-        default_port: int = constants.DEFAULT_PORT_EDGE,
+        default_port: Optional[int] = None,
     ) -> "HostAndPort":
         host, port = default_host, default_port
         if ":" in input:
@@ -570,6 +570,7 @@ def populate_legacy_edge_configuration(
         localstack_host = HostAndPort.parse(
             localstack_host,
             default_host=constants.LOCALHOST_HOSTNAME,
+            default_port=constants.DEFAULT_PORT_EDGE,
         )
 
     def legacy_fallback(envar_name: str, default: T) -> T:
@@ -584,7 +585,11 @@ def populate_legacy_edge_configuration(
     if gateway_listen_raw is not None:
         gateway_listen = []
         for address in gateway_listen_raw.split(","):
-            gateway_listen.append(HostAndPort.parse(address.strip(), default_host=default_ip))
+            gateway_listen.append(
+                HostAndPort.parse(
+                    address.strip(), default_host=default_ip, default_port=localstack_host.port
+                )
+            )
     else:
         edge_port = int(environment.get("EDGE_PORT", localstack_host.port))
         edge_port_http = int(environment.get("EDGE_PORT_HTTP", 0))

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -600,7 +600,7 @@ class HostAndPort:
             raise TypeError(f"cannot compare {self.__class__} to {other.__class__}")
 
     def __str__(self) -> str:
-        return f"{self.host}:{self.port}"
+        return f"{self.host}:{self.port}" if self.port is not None else self.host
 
 
 def get_gateway_listen(gateway_listen: str) -> List[HostAndPort]:

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -568,8 +568,8 @@ class HostAndPort:
                 host = hostname.strip()
             try:
                 port = int(port_s)
-            except ValueError:
-                raise ValueError(f"specified port {port_s} not a number")
+            except ValueError as e:
+                raise ValueError(f"specified port {port_s} not a number") from e
         else:
             if input.strip():
                 host = input.strip()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -568,8 +568,8 @@ class HostAndPort:
                 host = hostname.strip()
             try:
                 port = int(port_s)
-            except (ValueError, TypeError):
-                pass
+            except ValueError:
+                raise ValueError(f"specified port {port_s} not a number")
         else:
             if input.strip():
                 host = input.strip()

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -564,7 +564,7 @@ class HostAndPort:
 
 
 def populate_legacy_edge_configuration(
-    environment: Dict[str, str]
+    environment: Mapping[str, str]
 ) -> Tuple[HostAndPort, List[HostAndPort], str, int, int]:
     if is_in_docker:
         default_ip = "0.0.0.0"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1262,12 +1262,10 @@ def external_service_url(service_key, host=None, port=None):
 
 
 def get_edge_port_http():
-    # TODO: update to use gateway_listen
-    return EDGE_PORT_HTTP or EDGE_PORT
+    return GATEWAY_LISTEN[0].port
 
 
 def get_edge_url(localstack_hostname=None, protocol=None):
-    # TODO: update to use gateway_listen
     port = get_edge_port_http()
     protocol = protocol or get_protocol()
     localstack_hostname = localstack_hostname or LOCALSTACK_HOSTNAME

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1261,8 +1261,10 @@ def external_service_url(service_key, host=None, port=None):
     return service_url(service_key, host=host, port=port)
 
 
+# FIXME: we don't separate http and non-http ports any more,
+#        so this function should be removed
 def get_edge_port_http():
-    return GATEWAY_LISTEN[0].port
+    return EDGE_PORT_HTTP or EDGE_PORT
 
 
 def get_edge_url(localstack_hostname=None, protocol=None):

--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -1,7 +1,6 @@
 import asyncio
 import threading
 from asyncio import AbstractEventLoop
-from typing import List
 
 from hypercorn import Config
 from hypercorn.asyncio import serve
@@ -81,7 +80,7 @@ class GatewayServer(HypercornServer):
     exception-handlers.
     """
 
-    def __init__(self, gateway: Gateway, listen: List[HostAndPort], use_ssl: bool = False):
+    def __init__(self, gateway: Gateway, listen: list[HostAndPort], use_ssl: bool = False):
         """
         Creates a new GatewayServer instance.
 
@@ -123,7 +122,7 @@ class ProxyServer(GatewayServer):
     and just forward all incoming requests to a backend.
     """
 
-    def __init__(self, forward_base_url: str, listen: List[HostAndPort], use_ssl: bool = False):
+    def __init__(self, forward_base_url: str, listen: list[HostAndPort], use_ssl: bool = False):
         """
         Creates a new ProxyServer instance.
 

--- a/localstack/http/hypercorn.py
+++ b/localstack/http/hypercorn.py
@@ -1,6 +1,7 @@
 import asyncio
 import threading
 from asyncio import AbstractEventLoop
+from typing import List
 
 from hypercorn import Config
 from hypercorn.asyncio import serve
@@ -9,8 +10,8 @@ from hypercorn.typing import ASGIFramework
 from localstack.aws.gateway import Gateway
 from localstack.aws.handlers.proxy import ProxyHandler
 from localstack.aws.serving.asgi import AsgiGateway
+from localstack.config import HostAndPort
 from localstack.logging.setup import setup_hypercorn_logger
-from localstack.utils.collections import ensure_list
 from localstack.utils.functions import call_safe
 from localstack.utils.serving import Server
 from localstack.utils.ssl import create_ssl_cert, install_predefined_cert_if_available
@@ -80,9 +81,7 @@ class GatewayServer(HypercornServer):
     exception-handlers.
     """
 
-    def __init__(
-        self, gateway: Gateway, port: int, bind_address: str | list[str], use_ssl: bool = False
-    ):
+    def __init__(self, gateway: Gateway, listen: List[HostAndPort], use_ssl: bool = False):
         """
         Creates a new GatewayServer instance.
 
@@ -96,12 +95,12 @@ class GatewayServer(HypercornServer):
         config.h11_pass_raw_headers = True
         setup_hypercorn_logger(config)
 
-        bind_address = ensure_list(bind_address)
-        config.bind = [f"{addr}:{port}" for addr in bind_address]
+        config.bind = [str(host_and_port) for host_and_port in listen]
 
         if use_ssl:
             install_predefined_cert_if_available()
-            _, cert_file_name, key_file_name = create_ssl_cert(serial_number=port)
+            serial_number = listen[0].port
+            _, cert_file_name, key_file_name = create_ssl_cert(serial_number=serial_number)
             config.certfile = cert_file_name
             config.keyfile = key_file_name
 
@@ -124,7 +123,7 @@ class ProxyServer(GatewayServer):
     and just forward all incoming requests to a backend.
     """
 
-    def __init__(self, forward_base_url: str, port: int, bind_address: str, use_ssl: bool = False):
+    def __init__(self, forward_base_url: str, listen: List[HostAndPort], use_ssl: bool = False):
         """
         Creates a new ProxyServer instance.
 
@@ -135,4 +134,4 @@ class ProxyServer(GatewayServer):
         """
         gateway = Gateway()
         gateway.request_handlers.append(ProxyHandler(forward_base_url=forward_base_url))
-        super().__init__(gateway, port, bind_address, use_ssl)
+        super().__init__(gateway, listen, use_ssl)

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -481,7 +481,7 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
             do_start_tcp_proxy(address, asynchronous=asynchronous)
         else:
             # escalate to root
-            run_module_as_root(
+            run_module_as_sudo(
                 module="localstack.services.edge",
                 arguments=["proxy", "--gateway-listen", str(address)],
                 asynchronous=True,
@@ -491,7 +491,9 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
         edge_thread.join()
 
 
-def run_module_as_root(
+# TODO: rename to better represent what is going on, e.g. run_module_as_root
+# but this will break `ext`
+def run_module_as_sudo(
     module: str, arguments: Optional[List[str]] = None, asynchronous=False, env_vars=None
 ):
     # prepare environment

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -529,7 +529,6 @@ def env_vars_to_string(env_vars: Dict) -> str:
     return " ".join(f"{k}='{v}'" for k, v in env_vars.items())
 
 
-# TODO: upstream this into HostAndPort
 def parse_gateway_listen(listen: str) -> List[HostAndPort]:
     addresses = []
     for address in listen.split(","):

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -433,7 +433,7 @@ def do_start_tcp_proxy(
     if target_address is None:
         target_address = HostAndPort(host=config.LOCALHOST_IP, port=constants.DEFAULT_PORT_EDGE)
 
-    src = f"{listen.host}:{listen.port}"
+    src = str(listen)
     dst = f"{config.LOCALHOST_IP}:{target_address.port}"
 
     LOG.debug(f"proxying requests from {src} to {dst}")

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -435,7 +435,11 @@ def start_proxy(
 
         listen = f"{constants.LOCALHOST_IP}:{destination_port}"
     else:
-        listen_hosts = parse_gateway_listen(listen_str)
+        listen_hosts = parse_gateway_listen(
+            listen_str,
+            default_host=constants.LOCALHOST_IP,
+            default_port=constants.DEFAULT_PORT_EDGE,
+        )
         listen = listen_hosts[0]
     return do_start_tcp_proxy(listen, target_address, asynchronous)
 
@@ -461,7 +465,10 @@ def do_start_tcp_proxy(
 
 def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False):
     if listen_str:
-        listen = parse_gateway_listen(listen_str)
+        default_ip = "0.0.0.0" if config.is_in_docker() else "127.0.0.1"
+        listen = parse_gateway_listen(
+            listen_str, default_host=default_ip, default_port=constants.DEFAULT_PORT_EDGE
+        )
     else:
         listen = config.GATEWAY_LISTEN
 
@@ -527,10 +534,10 @@ def env_vars_to_string(env_vars: Dict) -> str:
     return " ".join(f"{k}='{v}'" for k, v in env_vars.items())
 
 
-def parse_gateway_listen(listen: str) -> List[HostAndPort]:
+def parse_gateway_listen(listen: str, default_host: str, default_port: int) -> List[HostAndPort]:
     addresses = []
     for address in listen.split(","):
-        addresses.append(HostAndPort.parse(address))
+        addresses.append(HostAndPort.parse(address, default_host, default_port))
     return addresses
 
 

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -356,7 +356,9 @@ def is_trace_logging_enabled(headers) -> bool:
     return HEADER_LOCALSTACK_ACCOUNT_ID not in headers.keys()
 
 
-def do_start_edge(listen: List[HostAndPort], use_ssl: bool, asynchronous: bool = False):
+def do_start_edge(
+    listen: HostAndPort | List[HostAndPort], use_ssl: bool, asynchronous: bool = False
+):
     from localstack.aws.serving.edge import serve_gateway
 
     return serve_gateway(listen, use_ssl, asynchronous)

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -480,8 +480,6 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
         edge_thread.join()
 
 
-# TODO: rename to better represent what is going on, e.g. run_module_as_root
-# but this will break `ext`
 def run_module_as_sudo(
     module: str, arguments: Optional[List[str]] = None, asynchronous=False, env_vars=None
 ):

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -434,7 +434,7 @@ def do_start_tcp_proxy(
         target_address = HostAndPort(host=config.LOCALHOST_IP, port=constants.DEFAULT_PORT_EDGE)
 
     src = str(listen)
-    dst = f"{config.LOCALHOST_IP}:{target_address.port}"
+    dst = str(target_address)
 
     LOG.debug(f"proxying requests from {src} to {dst}")
 

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import sys
 import threading
-from typing import Callable, Dict, Iterable, List, Optional, Tuple, TypeVar
+from typing import Dict, List, Optional, TypeVar
 
 from requests.models import Response
 
@@ -41,6 +41,7 @@ from localstack.utils.aws.aws_stack import (
     is_internal_call_context,
     set_default_region_in_headers,
 )
+from localstack.utils.collections import split_list_by
 from localstack.utils.functions import empty_context_manager
 from localstack.utils.http import parse_request_data
 from localstack.utils.http import safe_requests as requests
@@ -445,18 +446,6 @@ def do_start_tcp_proxy(
     if not asynchronous:
         proxy.join()
     return proxy
-
-
-def split_list_by(lst: Iterable[T], predicate: Callable[[T], bool]) -> Tuple[List[T], List[T]]:
-    truthy, falsy = [], []
-
-    for item in lst:
-        if predicate(item):
-            truthy.append(item)
-        else:
-            falsy.append(item)
-
-    return truthy, falsy
 
 
 def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False):

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -46,6 +46,7 @@ from localstack.utils.collections import split_list_by
 from localstack.utils.functions import empty_context_manager
 from localstack.utils.http import parse_request_data
 from localstack.utils.http import safe_requests as requests
+from localstack.utils.net import get_free_tcp_port
 from localstack.utils.run import is_root, run
 from localstack.utils.server.http2_server import HTTPErrorResponse
 from localstack.utils.server.proxy_server import start_tcp_proxy
@@ -406,25 +407,37 @@ def ensure_can_use_sudo():
         run("sudo -v", stdin=True)
 
 
-def start_component(component: str, listen_str: str = None):
+def start_component(
+    component: str, listen_str: str | None = None, target_address: str | None = None
+):
     if component == "edge":
         return start_edge(listen_str=listen_str)
     if component == "proxy":
-        return start_proxy(listen_str=listen_str)
+        if target_address is None:
+            raise ValueError("no target address specified")
+
+        default_host = "0.0.0.0" if config.in_docker() else "127.0.0.1"
+        return start_proxy(
+            listen_str=listen_str,
+            target_address=HostAndPort.parse(
+                target_address, default_host=default_host, default_port=constants.DEFAULT_PORT_EDGE
+            ),
+        )
     raise Exception("Unexpected component name '%s' received during start up" % component)
 
 
 def start_proxy(
-    listen_str: str, target_address: Optional[HostAndPort] = None, asynchronous: bool = False
+    listen_str: str, target_address: HostAndPort, asynchronous: bool = False
 ) -> FuncThread:
     """
     Starts a TCP proxy to perform a low-level forwarding of incoming requests.
     The proxy's source port (given as method argument) is bound to the EDGE_BIND_HOST.
     The target IP is always 127.0.0.1.
     The target port is parsed from the EDGE_FORWARD_URL (for compatibility with the legacy edge proxy forwarding).
-    All other parts of the EDGE_FORWARD_URL are _not_ used anymore.
+    All other parts of the EDGE_FORWARD_URL are _not_ used any more.
 
-    :param port: source port
+    :param listen_str: address to listen on
+    :param target_address: target address to proxy requests to
     :param asynchronous: False if the function should join the proxy thread and block until it terminates.
     :return: created thread executing the proxy
     """
@@ -445,11 +458,8 @@ def start_proxy(
 
 
 def do_start_tcp_proxy(
-    listen: HostAndPort, target_address: Optional[HostAndPort] = None, asynchronous: bool = False
+    listen: HostAndPort, target_address: HostAndPort, asynchronous: bool = False
 ) -> FuncThread:
-    if target_address is None:
-        target_address = HostAndPort(host=config.LOCALHOST_IP, port=constants.DEFAULT_PORT_EDGE)
-
     src = str(listen)
     dst = str(target_address)
 
@@ -464,8 +474,8 @@ def do_start_tcp_proxy(
 
 
 def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False):
+    default_ip = "0.0.0.0" if config.in_docker() else "127.0.0.1"
     if listen_str:
-        default_ip = "0.0.0.0" if config.is_in_docker() else "127.0.0.1"
         listen = parse_gateway_listen(
             listen_str, default_host=default_ip, default_port=constants.DEFAULT_PORT_EDGE
         )
@@ -478,19 +488,35 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
     # separate privileged and unprivileged addresses
     unprivileged, privileged = split_list_by(listen, lambda addr: addr.is_unprivileged() or False)
 
+    # check that we are actually started the gateway server
+    if not unprivileged:
+        unprivileged = parse_gateway_listen(
+            f":{get_free_tcp_port()}",
+            default_host=default_ip,
+            default_port=constants.DEFAULT_PORT_EDGE,
+        )
+
     # bind the gateway server to unprivileged addresses
     edge_thread = do_start_edge(unprivileged, use_ssl=use_ssl, asynchronous=True)
 
     # start TCP proxies for the remaining addresses
+    proxy_destination = unprivileged[0]
     for address in privileged:
         if is_root():
             # just start the proxy
-            do_start_tcp_proxy(address, asynchronous=asynchronous)
+            do_start_tcp_proxy(address, target_address=proxy_destination, asynchronous=asynchronous)
         else:
             # escalate to root
+            args = [
+                "proxy",
+                "--gateway-listen",
+                str(address),
+                "--target-address",
+                str(proxy_destination),
+            ]
             run_module_as_sudo(
                 module="localstack.services.edge",
-                arguments=["proxy", "--gateway-listen", str(address)],
+                arguments=args,
                 asynchronous=True,
             )
 
@@ -545,7 +571,8 @@ if __name__ == "__main__":
     logging.basicConfig()
     parser = argparse.ArgumentParser()
     parser.add_argument("component")
-    parser.add_argument("-l", "--gateway-listen", required=False, default=None)
+    parser.add_argument("-l", "--gateway-listen", required=False, type=str)
+    parser.add_argument("-t", "--target-address", required=False, type=str)
     args = parser.parse_args()
 
-    start_component(args.component, args.gateway_listen)
+    start_component(args.component, args.gateway_listen, args.target_address)

--- a/localstack/services/edge.py
+++ b/localstack/services/edge.py
@@ -416,11 +416,12 @@ def start_component(
         if target_address is None:
             raise ValueError("no target address specified")
 
-        default_host = "0.0.0.0" if config.in_docker() else "127.0.0.1"
         return start_proxy(
             listen_str=listen_str,
             target_address=HostAndPort.parse(
-                target_address, default_host=default_host, default_port=constants.DEFAULT_PORT_EDGE
+                target_address,
+                default_host=config.default_ip,
+                default_port=constants.DEFAULT_PORT_EDGE,
             ),
         )
     raise Exception("Unexpected component name '%s' received during start up" % component)
@@ -474,10 +475,9 @@ def do_start_tcp_proxy(
 
 
 def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False):
-    default_ip = "0.0.0.0" if config.in_docker() else "127.0.0.1"
     if listen_str:
         listen = parse_gateway_listen(
-            listen_str, default_host=default_ip, default_port=constants.DEFAULT_PORT_EDGE
+            listen_str, default_host=config.default_ip, default_port=constants.DEFAULT_PORT_EDGE
         )
     else:
         listen = config.GATEWAY_LISTEN
@@ -492,7 +492,7 @@ def start_edge(listen_str: str, use_ssl: bool = True, asynchronous: bool = False
     if not unprivileged:
         unprivileged = parse_gateway_listen(
             f":{get_free_tcp_port()}",
-            default_host=default_ip,
+            default_host=config.default_ip,
             default_port=constants.DEFAULT_PORT_EDGE,
         )
 

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Optional,
@@ -503,3 +504,20 @@ def dict_multi_values(elements: Union[List, Dict]) -> Dict[str, List[Any]]:
         else:
             result_dict[elements[0]] = elements[1:]
     return result_dict
+
+
+ItemType = TypeVar("ItemType")
+
+
+def split_list_by(
+    lst: Iterable[ItemType], predicate: Callable[[ItemType], bool]
+) -> Tuple[List[ItemType], List[ItemType]]:
+    truthy, falsy = [], []
+
+    for item in lst:
+        if predicate(item):
+            truthy.append(item)
+        else:
+            falsy.append(item)
+
+    return truthy, falsy

--- a/localstack/utils/json.py
+++ b/localstack/utils/json.py
@@ -6,6 +6,8 @@ from datetime import date, datetime
 from json import JSONDecodeError
 from typing import Any, Union
 
+from localstack.config import HostAndPort
+
 from .numbers import is_number
 from .strings import to_str
 from .time import timestamp_millis
@@ -19,6 +21,8 @@ class CustomEncoder(json.JSONEncoder):
     def default(self, o):
         import yaml  # leave import here, to avoid breaking our Lambda tests!
 
+        if isinstance(o, HostAndPort):
+            return str(o)
         if isinstance(o, decimal.Decimal):
             if o % 1 > 0:
                 return float(o)

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ test =
     pytest-rerunfailures==10.0
     pytest-tinybird>=0.2.0
     aws-cdk-lib>=2.88.0
+    hypothesis>=6.70.1
 
 # for developing localstack
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,7 +113,6 @@ test =
     pytest-rerunfailures==10.0
     pytest-tinybird>=0.2.0
     aws-cdk-lib>=2.88.0
-    hypothesis>=6.70.1
 
 # for developing localstack
 dev =

--- a/tests/aws/conftest.py
+++ b/tests/aws/conftest.py
@@ -11,7 +11,7 @@ import threading
 
 import pytest
 
-from localstack import config
+from localstack import config, constants
 from localstack.config import is_env_true
 from localstack.constants import ENV_INTERNAL_TEST_RUN
 from localstack.runtime import events
@@ -126,7 +126,7 @@ def run_localstack():
     os.environ[ENV_INTERNAL_TEST_RUN] = "1"
     safe_requests.verify_ssl = False
     config.FORCE_SHUTDOWN = False
-    config.EDGE_BIND_HOST = "0.0.0.0"
+    config.GATEWAY_LISTEN = [config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)]
 
     def watchdog():
         logger.info("waiting stop event")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ import threading
 
 import pytest
 
-from localstack import config
+from localstack import config, constants
 from localstack.config import is_env_true
 from localstack.constants import ENV_INTERNAL_TEST_RUN
 from localstack.runtime import events
@@ -126,7 +126,7 @@ def run_localstack():
     os.environ[ENV_INTERNAL_TEST_RUN] = "1"
     safe_requests.verify_ssl = False
     config.FORCE_SHUTDOWN = False
-    config.EDGE_BIND_HOST = "0.0.0.0"
+    config.GATEWAY_LISTEN = [config.HostAndPort(host="0.0.0.0", port=constants.DEFAULT_PORT_EDGE)]
 
     def watchdog():
         logger.info("waiting stop event")

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -14,6 +14,7 @@ from localstack.aws.connect import (
 from localstack.aws.gateway import Gateway
 from localstack.aws.handlers import add_internal_request_params, add_region_from_header
 from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
+from localstack.config import HostAndPort
 from localstack.http import Response
 from localstack.http.hypercorn import GatewayServer
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header
@@ -33,7 +34,8 @@ class TestClientFactory:
             for handler in request_handlers:
                 gateway.request_handlers.append(handler)
             port = get_free_tcp_port()
-            server = GatewayServer(gateway, port, "127.0.0.1", use_ssl=True)
+            gateway_listen = [HostAndPort(host="127.0.0.1", port=port)]
+            server = GatewayServer(gateway, gateway_listen, use_ssl=True)
             server.start()
             server.wait_is_up(timeout=10)
             return f"http://localhost:{port}"

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -13,8 +13,8 @@ from localstack.aws.connect import (
 )
 from localstack.aws.gateway import Gateway
 from localstack.aws.handlers import add_internal_request_params, add_region_from_header
-from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.config import HostAndPort
+from localstack.constants import TEST_AWS_ACCESS_KEY_ID, TEST_AWS_SECRET_ACCESS_KEY
 from localstack.http import Response
 from localstack.http.hypercorn import GatewayServer
 from localstack.utils.aws.aws_stack import extract_access_key_id_from_auth_header

--- a/tests/unit/aws/test_connect.py
+++ b/tests/unit/aws/test_connect.py
@@ -34,7 +34,7 @@ class TestClientFactory:
             for handler in request_handlers:
                 gateway.request_handlers.append(handler)
             port = get_free_tcp_port()
-            gateway_listen = [HostAndPort(host="127.0.0.1", port=port)]
+            gateway_listen = HostAndPort(host="127.0.0.1", port=port)
             server = GatewayServer(gateway, gateway_listen, use_ssl=True)
             server.start()
             server.wait_is_up(timeout=10)

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -110,8 +110,9 @@ def test_start_host(runner, monkeypatch):
 
 
 def test_status_services(runner, httpserver, monkeypatch):
-    monkeypatch.setattr(config, "EDGE_PORT_HTTP", httpserver.port)
-    monkeypatch.setattr(config, "EDGE_PORT", httpserver.port)
+    monkeypatch.setattr(
+        config, "GATEWAY_LISTEN", [config.HostAndPort("127.0.0.1", httpserver.port)]
+    )
 
     services = {"dynamodb": "starting", "s3": "running"}
     httpserver.expect_request("/_localstack/health", method="GET").respond_with_json(

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -110,9 +110,9 @@ def test_start_host(runner, monkeypatch):
 
 
 def test_status_services(runner, httpserver, monkeypatch):
-    monkeypatch.setattr(
-        config, "GATEWAY_LISTEN", [config.HostAndPort("127.0.0.1", httpserver.port)]
-    )
+    # TODO: legacy API, switch to use GATEWAY_LISTEN in the next step
+    monkeypatch.setattr(config, "EDGE_PORT_HTTP", httpserver.port)
+    monkeypatch.setattr(config, "EDGE_PORT", httpserver.port)
 
     services = {"dynamodb": "starting", "s3": "running"}
     httpserver.expect_request("/_localstack/health", method="GET").respond_with_json(

--- a/tests/unit/http_/test_hypercorn.py
+++ b/tests/unit/http_/test_hypercorn.py
@@ -9,6 +9,7 @@ from werkzeug.wrappers import Request as WerkzeugRequest
 from localstack.aws.api import RequestContext
 from localstack.aws.chain import HandlerChain
 from localstack.aws.gateway import Gateway
+from localstack.config import HostAndPort
 from localstack.http import Response
 from localstack.http.hypercorn import GatewayServer, ProxyServer
 from localstack.utils.net import IP_REGEX, get_free_tcp_port
@@ -33,28 +34,31 @@ def test_gateway_server():
 
     gateway = Gateway()
     gateway.request_handlers.append(echo_request_handler)
-    port = get_free_tcp_port()
-    server = GatewayServer(gateway, port, "127.0.0.1", use_ssl=True)
+    gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
+    server = GatewayServer(gateway, [gateway_listen], use_ssl=True)
     with server_context(server):
         get_response = requests.get(
-            f"https://localhost.localstack.cloud:{port}", data="Let's see if this works..."
+            f"https://localhost.localstack.cloud:{gateway_listen.port}",
+            data="Let's see if this works...",
         )
         assert get_response.text == "Let's see if this works..."
 
 
 def test_proxy_server(httpserver):
     httpserver.expect_request("/base-path/relative-path").respond_with_data("Reached Mock Server.")
-    port = get_free_tcp_port()
-    proxy_server = ProxyServer(httpserver.url_for("/base-path"), port, "127.0.0.1", use_ssl=True)
+    gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
+    proxy_server = ProxyServer(httpserver.url_for("/base-path"), [gateway_listen], use_ssl=True)
     with server_context(proxy_server):
         # Test that only the base path is added by the proxy
         response = requests.get(
-            f"https://localhost.localstack.cloud:{port}/relative-path", data="data"
+            f"https://localhost.localstack.cloud:{gateway_listen.port}/relative-path", data="data"
         )
         assert response.text == "Reached Mock Server."
 
 
 def test_proxy_server_properly_handles_headers(httpserver):
+    gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
+
     def header_echo_handler(request: WerkzeugRequest) -> Response:
         # The proxy needs to preserve multi-value headers in the request to the backend
         headers = Headers(request.headers)
@@ -62,7 +66,7 @@ def test_proxy_server_properly_handles_headers(httpserver):
         assert headers["Multi-Value-Header"] == "Value-1,Value-2"
 
         # The proxy needs to preserve the Host header (some backend systems use the host header to construct Location URLs)
-        assert headers["Host"] == f"localhost.localstack.cloud:{port}"
+        assert headers["Host"] == f"localhost.localstack.cloud:{gateway_listen.port}"
 
         # The proxy needs to correctly set the "X-Forwarded-For" header
         # It contains the previous XFF header, as well as the IP of the machine which sent the request to the proxy
@@ -74,13 +78,12 @@ def test_proxy_server_properly_handles_headers(httpserver):
         return Response(headers=headers)
 
     httpserver.expect_request("").respond_with_handler(header_echo_handler)
-    port = get_free_tcp_port()
-    proxy_server = ProxyServer(httpserver.url_for("/"), port, "127.0.0.1", use_ssl=True)
+    proxy_server = ProxyServer(httpserver.url_for("/"), [gateway_listen], use_ssl=True)
 
     with server_context(proxy_server):
         response = requests.request(
             "GET",
-            f"https://localhost.localstack.cloud:{port}/",
+            f"https://localhost.localstack.cloud:{gateway_listen.port}/",
             headers={"Multi-Value-Header": "Value-1,Value-2", "X-Forwarded-For": "127.0.0.3"},
         )
 
@@ -101,8 +104,8 @@ def test_proxy_server_with_chunked_request(httpserver, httpserver_echo_request_m
         return Response()
 
     httpserver.expect_request("/").respond_with_handler(handler)
-    port = get_free_tcp_port()
-    proxy_server = ProxyServer(httpserver.url_for("/"), port, "127.0.0.1", use_ssl=True)
+    gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
+    proxy_server = ProxyServer(httpserver.url_for("/"), [gateway_listen], use_ssl=True)
 
     def chunk_generator():
         for chunk in chunks:
@@ -110,7 +113,7 @@ def test_proxy_server_with_chunked_request(httpserver, httpserver_echo_request_m
 
     with server_context(proxy_server):
         response = requests.get(
-            f"https://localhost.localstack.cloud:{port}/", data=chunk_generator()
+            f"https://localhost.localstack.cloud:{gateway_listen.port}/", data=chunk_generator()
         )
         assert response
 
@@ -126,11 +129,13 @@ def test_proxy_server_with_streamed_response(httpserver):
         return Response(response=chunk_generator())
 
     httpserver.expect_request("").respond_with_handler(stream_response_handler)
-    port = get_free_tcp_port()
-    proxy_server = ProxyServer(httpserver.url_for("/"), port, "127.0.0.1", use_ssl=True)
+    gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
+    proxy_server = ProxyServer(httpserver.url_for("/"), [gateway_listen], use_ssl=True)
 
     with server_context(proxy_server):
-        with requests.get(f"https://localhost.localstack.cloud:{port}/", stream=True) as r:
+        with requests.get(
+            f"https://localhost.localstack.cloud:{gateway_listen.port}/", stream=True
+        ) as r:
             r.raise_for_status()
             chunk_iterator = r.iter_content(chunk_size=None)
             # TODO Change this assertion to check for each chunk (once the proxy supports that).

--- a/tests/unit/http_/test_hypercorn.py
+++ b/tests/unit/http_/test_hypercorn.py
@@ -35,7 +35,7 @@ def test_gateway_server():
     gateway = Gateway()
     gateway.request_handlers.append(echo_request_handler)
     gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
-    server = GatewayServer(gateway, [gateway_listen], use_ssl=True)
+    server = GatewayServer(gateway, gateway_listen, use_ssl=True)
     with server_context(server):
         get_response = requests.get(
             f"https://localhost.localstack.cloud:{gateway_listen.port}",
@@ -47,7 +47,7 @@ def test_gateway_server():
 def test_proxy_server(httpserver):
     httpserver.expect_request("/base-path/relative-path").respond_with_data("Reached Mock Server.")
     gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
-    proxy_server = ProxyServer(httpserver.url_for("/base-path"), [gateway_listen], use_ssl=True)
+    proxy_server = ProxyServer(httpserver.url_for("/base-path"), gateway_listen, use_ssl=True)
     with server_context(proxy_server):
         # Test that only the base path is added by the proxy
         response = requests.get(
@@ -78,7 +78,7 @@ def test_proxy_server_properly_handles_headers(httpserver):
         return Response(headers=headers)
 
     httpserver.expect_request("").respond_with_handler(header_echo_handler)
-    proxy_server = ProxyServer(httpserver.url_for("/"), [gateway_listen], use_ssl=True)
+    proxy_server = ProxyServer(httpserver.url_for("/"), gateway_listen, use_ssl=True)
 
     with server_context(proxy_server):
         response = requests.request(
@@ -105,7 +105,7 @@ def test_proxy_server_with_chunked_request(httpserver, httpserver_echo_request_m
 
     httpserver.expect_request("/").respond_with_handler(handler)
     gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
-    proxy_server = ProxyServer(httpserver.url_for("/"), [gateway_listen], use_ssl=True)
+    proxy_server = ProxyServer(httpserver.url_for("/"), gateway_listen, use_ssl=True)
 
     def chunk_generator():
         for chunk in chunks:
@@ -130,7 +130,7 @@ def test_proxy_server_with_streamed_response(httpserver):
 
     httpserver.expect_request("").respond_with_handler(stream_response_handler)
     gateway_listen = HostAndPort(host="127.0.0.1", port=get_free_tcp_port())
-    proxy_server = ProxyServer(httpserver.url_for("/"), [gateway_listen], use_ssl=True)
+    proxy_server = ProxyServer(httpserver.url_for("/"), gateway_listen, use_ssl=True)
 
     with server_context(proxy_server):
         with requests.get(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,6 +5,10 @@ from hypothesis import given
 from hypothesis.strategies import integers, sampled_from, text
 
 from localstack import config
+from localstack.config import HostAndPort
+
+HOSTNAME_CHARACTERS = string.ascii_letters + string.digits + "-" + "."
+SAMPLER = sampled_from(HOSTNAME_CHARACTERS)
 
 HOSTNAME_CHARACTERS = string.ascii_letters + string.digits + "-" + "."
 SAMPLER = sampled_from(HOSTNAME_CHARACTERS)
@@ -101,7 +105,7 @@ class TestEdgeVariablesDerivedCorrectly:
         ) = config.populate_legacy_edge_configuration(environment)
 
         assert ls_host == "localhost.localstack.cloud:4566"
-        assert gateway_listen == f"{default_ip}:4566"
+        assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
         assert edge_port == 4566
         assert edge_port_http == 0
         assert edge_bind_host == default_ip
@@ -116,7 +120,7 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert gateway_listen == "192.168.0.1:4566"
+        assert gateway_listen == [HostAndPort(host="192.168.0.1", port=4566)]
         assert edge_port == 4566
         assert edge_port_http == 0
         assert edge_bind_host == "192.168.0.1"
@@ -131,7 +135,7 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert gateway_listen == f"{default_ip}:9999"
+        assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
         assert edge_port == 9999
         assert edge_port_http == 0
         assert edge_bind_host == default_ip
@@ -146,7 +150,7 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert gateway_listen == "192.168.0.1:9999"
+        assert gateway_listen == [HostAndPort(host="192.168.0.1", port=9999)]
         assert edge_port == 9999
         assert edge_port_http == 0
         assert edge_bind_host == "192.168.0.1"
@@ -161,8 +165,8 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert ls_host == "hostname:9999"
-        assert gateway_listen == f"{default_ip}:9999"
+        assert ls_host == HostAndPort(host="hostname", port=9999)
+        assert gateway_listen == [HostAndPort(host=default_ip, port=9999)]
         assert edge_port == 9999
         assert edge_port_http == 0
         assert edge_bind_host == default_ip
@@ -177,8 +181,8 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert ls_host == "foobar:4566"
-        assert gateway_listen == f"{default_ip}:4566"
+        assert ls_host == HostAndPort(host="foobar", port=4566)
+        assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
         assert edge_port == 4566
         assert edge_port_http == 0
         assert edge_bind_host == default_ip
@@ -193,7 +197,10 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert gateway_listen == "0.0.0.0:9999,0.0.0.0:443"
+        assert gateway_listen == [
+            HostAndPort(host="0.0.0.0", port=9999),
+            HostAndPort(host="0.0.0.0", port=443),
+        ]
         # take the first value
         assert edge_port == 9999
         assert edge_port_http == 0
@@ -239,7 +246,7 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert gateway_listen == f"{default_ip}:4566"
+        assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
         assert edge_bind_host == "192.168.0.1"
         assert edge_port == 10101
         assert edge_port_http == 20202

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -274,7 +274,7 @@ class TestEdgeVariablesDerivedCorrectly:
         assert "could not parse hostname" in str(exc_info)
 
     @pytest.mark.parametrize("port", [-1000, 100_000])
-    def test_negative_port(self, port):
+    def test_port_out_of_range(self, port):
         with pytest.raises(ValueError) as exc_info:
             config.HostAndPort.parse(f"localhost:{port}")
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -260,6 +260,12 @@ class TestEdgeVariablesDerivedCorrectly:
         assert h.host == hostname
         assert h.port == port
 
+    def test_invalid_port(self):
+        with pytest.raises(ValueError) as exc_info:
+            config.HostAndPort.parse("0.0.0.0:not-a-port")
+
+        assert "specified port not-a-port not a number" in str(exc_info)
+
     # test edge cases
     def test_empty_hostname(self):
         with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,9 +10,6 @@ from localstack.config import HostAndPort
 HOSTNAME_CHARACTERS = string.ascii_letters + string.digits + "-" + "."
 SAMPLER = sampled_from(HOSTNAME_CHARACTERS)
 
-HOSTNAME_CHARACTERS = string.ascii_letters + string.digits + "-" + "."
-SAMPLER = sampled_from(HOSTNAME_CHARACTERS)
-
 
 class TestProviderConfig:
     def test_provider_default_value(self):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,14 +1,7 @@
-import string
-
 import pytest
-from hypothesis import given
-from hypothesis.strategies import integers, sampled_from, text
 
 from localstack import config
 from localstack.config import HostAndPort
-
-HOSTNAME_CHARACTERS = string.ascii_letters + string.digits + "-" + "."
-SAMPLER = sampled_from(HOSTNAME_CHARACTERS)
 
 
 class TestProviderConfig:
@@ -250,18 +243,6 @@ class TestEdgeVariablesDerivedCorrectly:
         assert edge_bind_host == "192.168.0.1"
         assert edge_port == 10101
         assert edge_port_http == 20202
-
-    # generate random hostnames and ports from within the following criteria:
-    # - hostnames: a-zA-Z0-9-.
-    # - ports: 0-65535
-    @given(text(alphabet=SAMPLER, min_size=1), integers(min_value=0, max_value=2**16 - 1))
-    def test_parsing_hostname_and_ip(self, hostname, port):
-        """
-        Use property-based testing to ensure that "well-behaved" input parses correctly
-        """
-        h = config.HostAndPort.parse(f"{hostname}:{port}")
-        assert h.host == hostname
-        assert h.port == port
 
     def test_invalid_port(self):
         with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -243,7 +243,10 @@ class TestEdgeVariablesDerivedCorrectly:
             edge_port_http,
         ) = config.populate_legacy_edge_configuration(environment)
 
-        assert gateway_listen == [HostAndPort(host=default_ip, port=4566)]
+        assert gateway_listen == [
+            HostAndPort(host=default_ip, port=10101),
+            HostAndPort(host=default_ip, port=20202),
+        ]
         assert edge_bind_host == "192.168.0.1"
         assert edge_port == 10101
         assert edge_port_http == 20202

--- a/tests/unit/test_edge.py
+++ b/tests/unit/test_edge.py
@@ -5,7 +5,7 @@ import requests
 from pytest_httpserver.httpserver import HTTPServer
 from werkzeug.datastructures import Headers
 
-from localstack import config
+from localstack import config, constants
 from localstack.config import HostAndPort
 from localstack.services.edge import get_auth_string, start_proxy
 from localstack.utils.net import get_free_tcp_port
@@ -91,6 +91,7 @@ def test_edge_tcp_proxy_raises_exception_on_invalid_url(monkeypatch):
     with pytest.raises(ValueError):
         start_proxy(
             listen_str=f"127.0.0.1:{port}",
+            target_address=HostAndPort(host="127.0.0.1", port=constants.DEFAULT_PORT_EDGE),
             asynchronous=True,
         ).stop()
 
@@ -102,7 +103,11 @@ def test_edge_tcp_proxy_raises_exception_on_url_without_port(monkeypatch):
     # Start the TCP proxy
     port = get_free_tcp_port()
     with pytest.raises(ValueError):
-        start_proxy(listen_str=f"127.0.0.1:{port}", asynchronous=True).stop()
+        start_proxy(
+            listen_str=f"127.0.0.1:{port}",
+            asynchronous=True,
+            target_address=HostAndPort(host="127.0.0.1", port=constants.DEFAULT_PORT_EDGE),
+        ).stop()
 
 
 def test_edge_tcp_proxy_raises_connection_refused_on_missing_target_server(monkeypatch):


### PR DESCRIPTION
Use GATEWAY_LISTEN to bind hypercorn and TCP proxies

## Changes

- make the localstack-start-docker-env.sh script more system-agnostic (I run NixOS and `/bin/bash` does not exist). Also the `$VENV_DIR` variable was not honoured in the script.
- the hypercorn gateway now takes a list of `HostAndPort` types, which allows binding to multiple addresses
- the `HostAndPort.parse` method is more powerful (i.e. handles parse errors better)
- start the hypercorn gateway for unpriviliged ports and create TCP proxies for priviliged ports, running as sudo if required
- add a special case for our custom json encoder to handle `HostAndPort` instances
