### PR TITLE
fix flaky CLI tests after startup time improved

### DIFF
--- a/tests/bootstrap/test_cli.py
+++ b/tests/bootstrap/test_cli.py
@@ -70,12 +70,8 @@ class TestCliContainerLifecycle:
             requests.get(get_edge_url() + "/_localstack/health")
 
     def test_wait_timeout_raises_exception(self, runner, container_client):
-        result = runner.invoke(cli, ["start", "-d"])
-        assert result.exit_code == 0
-        assert "starting LocalStack" in result.output
-
+        # assume a wait without start fails
         result = runner.invoke(cli, ["wait", "-t", "0.5"])
-        # one day this test will surely fail ;-)
         assert result.exit_code != 0
 
     def test_logs(self, runner, container_client):


### PR DESCRIPTION
We recently experienced a flake with a CLI test on Python 3.11 in a downstream repo.
The recent changes with the init system further improved the startup time, so I guess the time has come, @thrau! 🚀 🥳 
```
    def test_wait_timeout_raises_exception(self, runner, container_client):
        result = runner.invoke(cli, ["start", "-d"])
        assert result.exit_code == 0
        assert "starting LocalStack" in result.output
    
        result = runner.invoke(cli, ["wait", "-t", "0.5"])
        # one day this test will surely fail ;-)
>       assert result.exit_code != 0
E       assert 0 != 0
E        +  where 0 = <Result okay>.exit_code
```
I verified this locally on my machine with a pre-pulled community image (which is the image being used currently for the CLI tests):
```
$ localstack start -d && localstack wait -t 0.5 && echo $?

     __                     _______ __             __
    / /   ____  _________ _/ / ___// /_____ ______/ /__
   / /   / __ \/ ___/ __ `/ /\__ \/ __/ __ `/ ___/ //_/
  / /___/ /_/ / /__/ /_/ / /___/ / /_/ /_/ / /__/ ,<
 /_____/\____/\___/\__,_/_//____/\__/\__,_/\___/_/|_|

 💻 LocalStack CLI 1.4.1.dev20230215233822

[10:12:39] starting LocalStack in Docker mode 🐳                                                                                                                                                                                                                         
   ...
[10:12:40] detaching                                                                                                                                                                                                                                                      bootstrap.py:694
0
```