### PR TITLE
Support non-standard AWS regions

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -601,7 +601,7 @@ CUSTOM_SSL_CERT_PATH = os.environ.get("CUSTOM_SSL_CERT_PATH", "").strip()
 # Allow non-standard AWS regions
 ALLOW_NONSTANDARD_REGIONS = is_env_true("ALLOW_NONSTANDARD_REGIONS")
 if ALLOW_NONSTANDARD_REGIONS:
-    os.environ["MOTO_ALLOW_NONEXISTENT_REGION"] = True
+    os.environ["MOTO_ALLOW_NONEXISTENT_REGION"] = "true"
 
 # name of the main Docker container
 MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack_main"

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -598,6 +598,11 @@ SKIP_SSL_CERT_DOWNLOAD = is_env_true("SKIP_SSL_CERT_DOWNLOAD")
 # Absolute path to a custom certificate (pem file)
 CUSTOM_SSL_CERT_PATH = os.environ.get("CUSTOM_SSL_CERT_PATH", "").strip()
 
+# Allow non-standard AWS regions
+ALLOW_NONSTANDARD_REGIONS = is_env_true("ALLOW_NONSTANDARD_REGIONS")
+if ALLOW_NONSTANDARD_REGIONS:
+    os.environ["MOTO_ALLOW_NONEXISTENT_REGION"] = True
+
 # name of the main Docker container
 MAIN_CONTAINER_NAME = os.environ.get("MAIN_CONTAINER_NAME", "").strip() or "localstack_main"
 
@@ -913,6 +918,7 @@ MAIN_DOCKER_NETWORK = os.environ.get("MAIN_DOCKER_NETWORK", "") or LAMBDA_DOCKER
 # Make sure to keep this in sync with the above!
 # Note: do *not* include DATA_DIR in this list, as it is treated separately
 CONFIG_ENV_VARS = [
+    "ALLOW_NONSTANDARD_REGIONS",
     "BUCKET_MARKER_LOCAL",
     "CFN_ENABLE_RESOLVE_REFS_IN_MODELS",
     "CUSTOM_SSL_CERT_PATH",

--- a/localstack/services/stores.py
+++ b/localstack/services/stores.py
@@ -303,11 +303,7 @@ class AccountRegionBundle(dict, Generic[BaseStoreType]):
         self._universal = {}
 
     def __getitem__(self, account_id: str) -> RegionBundle[BaseStoreType]:
-        if (
-            config.ALLOW_NONSTANDARD_REGIONS
-            and self.validate
-            and not re.match(r"\d{12}", account_id)
-        ):
+        if self.validate and not re.match(r"\d{12}", account_id):
             raise ValueError(f"'{account_id}' is not a valid AWS account ID")
 
         with self.lock:

--- a/localstack/services/stores.py
+++ b/localstack/services/stores.py
@@ -34,6 +34,7 @@ from collections.abc import Callable
 from threading import RLock
 from typing import Any, Generic, Type, TypeVar, Union
 
+from localstack import config
 from localstack.utils.aws.aws_stack import get_valid_regions_for_service
 
 LOCAL_ATTR_PREFIX = "attr_"
@@ -222,8 +223,11 @@ class RegionBundle(dict, Generic[BaseStoreType]):
         self._universal = universal
 
     def __getitem__(self, region_name) -> BaseStoreType:
-        if self.validate and region_name not in self.valid_regions:
-            # Tip: Try using a valid region or valid service name
+        if (
+            not config.ALLOW_NONSTANDARD_REGIONS
+            and self.validate
+            and region_name not in self.valid_regions
+        ):
             raise ValueError(
                 f"'{region_name}' is not a valid AWS region name for {self.service_name}"
             )
@@ -299,7 +303,11 @@ class AccountRegionBundle(dict, Generic[BaseStoreType]):
         self._universal = {}
 
     def __getitem__(self, account_id: str) -> RegionBundle[BaseStoreType]:
-        if self.validate and not re.match(r"\d{12}", account_id):
+        if (
+            config.ALLOW_NONSTANDARD_REGIONS
+            and self.validate
+            and not re.match(r"\d{12}", account_id)
+        ):
             raise ValueError(f"'{account_id}' is not a valid AWS account ID")
 
         with self.lock:

--- a/tests/integration/test_stores.py
+++ b/tests/integration/test_stores.py
@@ -1,0 +1,17 @@
+import unittest
+
+
+@unittest.mock.patch("localstack.config.ALLOW_NONSTANDARD_REGIONS", True)
+def test_nonstandard_regions(create_boto_client, monkeypatch):
+    """
+    Ensure that non-standard AWS regions can be used vertically.
+    """
+    monkeypatch.setenv("MOTO_ALLOW_NONEXISTENT_REGION", "true")
+
+    # Create a resource in Moto backend
+    ec2_client = create_boto_client("ec2", region_name="uranus-south-1")
+    ec2_client.create_key_pair(KeyName="foo")
+
+    # Create a resource in LocalStack store
+    sqs_client = create_boto_client("sqs", region_name="pluto-central-2a")
+    sqs_client.create_queue(QueueName="bar")

--- a/tests/unit/test_stores.py
+++ b/tests/unit/test_stores.py
@@ -1,6 +1,12 @@
+import unittest
+
 import pytest
 
 from localstack.services.stores import AccountRegionBundle, BaseStore
+
+
+class SampleStore(BaseStore):
+    pass
 
 
 class TestStores:
@@ -141,9 +147,6 @@ class TestStores:
         )
 
     def test_valid_regions(self):
-        class SampleStore(BaseStore):
-            pass
-
         stores = AccountRegionBundle("sns", SampleStore)
         account1 = "696969696969"
 
@@ -156,3 +159,15 @@ class TestStores:
         with pytest.raises(Exception) as exc:
             assert stores[account1]["invalid-region"]
         exc.match("not a valid AWS region")
+
+    @unittest.mock.patch("localstack.config.ALLOW_NONSTANDARD_REGIONS", True)
+    def test_nonstandard_regions(self):
+        stores = AccountRegionBundle("sns", SampleStore)
+        account1 = "696969696969"
+
+        # assert regular and extended regions work
+        assert stores[account1]["us-east-1"]
+        assert stores[account1]["us-gov-west-1"]
+
+        # assert non-standard regions work
+        assert stores[account1]["pluto-south-3"]


### PR DESCRIPTION
Introduces a new config option `ALLOW_NONSTANDARD_REGIONS` which disables strict validation of AWS regions.

Closes https://github.com/localstack/localstack/issues/7993