### PR TITLE
Ignore empty provider overrides

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -1226,7 +1226,7 @@ class ServiceProviderConfig(Mapping[str, str]):
         if env is None:
             env = os.environ
         for key, value in env.items():
-            if key.startswith(self.override_prefix):
+            if key.startswith(self.override_prefix) and value:
                 self.set_provider(key[len(self.override_prefix) :].lower().replace("_", "-"), value)
 
     def get_provider(self, service: str) -> str:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -47,6 +47,16 @@ class TestProviderConfig:
         provider_config.load_from_environment()
         assert provider_config.get_provider("sqs") == override_value
 
+    def test_empty_provider_config_override(self, monkeypatch):
+        default_value = "default_value"
+        override_value = ""
+        provider_config = config.ServiceProviderConfig(default_value=default_value)
+        monkeypatch.setenv("PROVIDER_OVERRIDE_S3", override_value)
+        monkeypatch.setenv("PROVIDER_OVERRIDE_LAMBDA", override_value)
+        provider_config.load_from_environment()
+        assert provider_config.get_provider("s3") == default_value
+        assert provider_config.get_provider("lambda") == default_value
+
     def test_bulk_set_if_not_exists(self):
         default_value = "default_value"
         custom_value = "custom_value"


### PR DESCRIPTION
Currently, when explicitly setting `""` for provider overrides (e.g., `PROVIDER_OVERRIDE_S3=""`) the ServiceProviderConfig assumes that a provider with the name `""` (i.e. an empty string) is requested. This happens, e.g., in the `bin/test-in-docker.sh` script and leads to `NotImplementedError`s. 
Since we can safely assume that we won't create new provider variants with the explicit name of an empty string, we can ignore all falsey values for provider overrides and thus assume a selection of the default provider. 

This PR also adds a unit test to verify this new behavior.

/cc @bentsku 