### PR TITLE
Fix length check for CloudFormation TemplateBody

### DIFF
--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -143,11 +143,13 @@ class CloudformationProvider(CloudformationApi):
 
         # TODO: test what happens when both TemplateUrl and Body are specified
         state = get_cloudformation_store()
-        api_utils.prepare_template_body(request)  # TODO: avoid mutating request directly
-        if len(request["TemplateBody"]) > 51200:
+        template_body = request.get("TemplateBody") or ""
+        if len(template_body) > 51200:
             raise ValidationError(
-                f'1 validation error detected: Value \'{request["TemplateBody"]}\' at \'templateBody\' failed to satisfy constraint: Member must have length less than or equal to 51200'
+                f'1 validation error detected: Value \'{request["TemplateBody"]}\' at \'templateBody\' '
+                f'failed to satisfy constraint: Member must have length less than or equal to 51200'
             )
+        api_utils.prepare_template_body(request)  # TODO: avoid mutating request directly
 
         template = template_preparer.parse_template(request["TemplateBody"])
         stack_name = template["StackName"] = request.get("StackName")

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -147,7 +147,7 @@ class CloudformationProvider(CloudformationApi):
         if len(template_body) > 51200:
             raise ValidationError(
                 f'1 validation error detected: Value \'{request["TemplateBody"]}\' at \'templateBody\' '
-                f'failed to satisfy constraint: Member must have length less than or equal to 51200'
+                f"failed to satisfy constraint: Member must have length less than or equal to 51200"
             )
         api_utils.prepare_template_body(request)  # TODO: avoid mutating request directly
 

--- a/localstack/services/cloudformation/provider.py
+++ b/localstack/services/cloudformation/provider.py
@@ -147,7 +147,7 @@ class CloudformationProvider(CloudformationApi):
         if len(template_body) > 51200:
             raise ValidationError(
                 f'1 validation error detected: Value \'{request["TemplateBody"]}\' at \'templateBody\' '
-                f"failed to satisfy constraint: Member must have length less than or equal to 51200"
+                "failed to satisfy constraint: Member must have length less than or equal to 51200"
             )
         api_utils.prepare_template_body(request)  # TODO: avoid mutating request directly
 


### PR DESCRIPTION
Small fix in length check for CloudFormation `TemplateBody` - we should only check the length if the body is specified, not if the template is passed via `TemplateURL`. Addresses https://github.com/localstack/localstack/issues/7880 . 

The main use case is also to get a larger sample prepared for the Developer Hub: https://github.com/aws-samples/query-data-in-s3-with-amazon-athena-and-aws-sdk-for-dotnet

/cc @HarshCasper 