### PR TITLE
Ignore publish version code hash if hot-reloading is active

### DIFF
--- a/localstack/services/awslambda/provider.py
+++ b/localstack/services/awslambda/provider.py
@@ -385,7 +385,11 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 Type="User",
             )
         current_hash = current_latest_version.config.code.code_sha256
-        if code_sha256 and current_hash != code_sha256:
+        if (
+            code_sha256
+            and current_hash != code_sha256
+            and not current_latest_version.config.code.is_hot_reloading()
+        ):
             raise InvalidParameterValueException(
                 f"CodeSHA256 ({code_sha256}) is different from current CodeSHA256 in $LATEST ({current_hash}). Please try again with the CodeSHA256 in $LATEST.",
                 Type="User",

--- a/tests/integration/test_firehose.py
+++ b/tests/integration/test_firehose.py
@@ -240,6 +240,7 @@ class TestFirehoseIntegration:
         self,
         firehose_client,
         opensearch_client,
+        opensearch_create_domain,
         kinesis_client,
         kinesis_create_stream,
     ):
@@ -250,10 +251,10 @@ class TestFirehoseIntegration:
         bucket_arn = "arn:aws:s3:::foo"
         delivery_stream_name = f"test-delivery-stream-{short_uid()}"
 
-        opensearch_create_response = opensearch_client.create_domain(
-            DomainName=domain_name, EngineVersion="OpenSearch_2.3"
-        )
-        opensearch_arn = opensearch_create_response["DomainStatus"]["ARN"]
+        opensearch_create_domain(DomainName=domain_name, EngineVersion="OpenSearch_2.3")
+        opensearch_arn = opensearch_client.describe_domain(DomainName=domain_name)["DomainStatus"][
+            "ARN"
+        ]
 
         # create kinesis stream
         kinesis_create_stream(StreamName=stream_name, ShardCount=2)


### PR DESCRIPTION
## Motivation
Some tools, for example serverless, seem to send the local code hash with them when using publish version. This comparison will fail, since hot-reloading code does not have a proper hash (but a placeholder string).

Related comment: https://github.com/localstack/serverless-localstack/pull/215#issuecomment-1488142179

## Changes
* Skip code hash verification if code is hot reloading + test
* Sneaked in a opensearch test update to make sure the cluster is properly terminated after the test