### PR TITLE
create separate cache directory for cli

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -161,7 +161,7 @@ class Directories:
         from localstack.utils import files
 
         tmp_dir = os.path.join(tempfile.gettempdir(), "localstack-cli")
-        cache_dir = (files.cache_dir() / "cli").absolute()
+        cache_dir = (files.get_user_cache_dir()).absolute() / "localstack-cli"
 
         return Directories(
             static_libs=None,

--- a/localstack/utils/files.py
+++ b/localstack/utils/files.py
@@ -36,19 +36,33 @@ def parse_config_file(file_or_str: str, single_section: bool = True) -> Dict:
     return result
 
 
-def cache_dir() -> Path:
+def get_user_cache_dir() -> Path:
+    """
+    Returns the path of the user's cache dir (e.g., ~/.cache on Linux, or ~/Library/Caches on Mac).
+
+    :return: a Path pointing to the platform-specific cache dir of the user
+    """
     from localstack.utils.platform import is_linux, is_mac_os, is_windows
 
     if is_windows():
-        return Path(os.path.expandvars(r"%LOCALAPPDATA%\cache\localstack"))
+        return Path(os.path.expandvars(r"%LOCALAPPDATA%\cache"))
     if is_mac_os():
-        return Path.home() / "Library" / "Caches" / "localstack"
+        return Path.home() / "Library" / "Caches"
     if is_linux():
         string_path = os.environ.get("XDG_CACHE_HOME")
         if string_path and os.path.isabs(string_path):
             return Path(string_path)
     # Use the common place to store caches in Linux as a default
-    return Path.home() / ".cache" / "localstack"
+    return Path.home() / ".cache"
+
+
+def cache_dir() -> Path:
+    """
+    Returns the cache dir for localstack (e.g., ~/.cache/localstack)
+
+    :return: a Path pointing to the localstack cache dir
+    """
+    return get_user_cache_dir() / "localstack"
 
 
 def save_file(file, content, append=False, permissions=None):


### PR DESCRIPTION
This PR adds a separate cache dir for the CLI. I saw errors in the log:

```
[16:16:34] starting LocalStack in Docker mode 🐳                                                                                                                                                  localstack.py:142
2023-03-29T16:16:34.656  WARN --- [  MainThread] localstack.utils.functions : error calling function save: [Errno 13] Permission denied: '/home/thomas/.cache/localstack/cli'
```

because `/home/thomas/.cache/localstack` is created by the container. So instead, we now have `/home/thomas/.cache/localstack-cli` which is managed by the cli and won't have permission errors.