### PR TITLE
fix signal handling in localstack-supervisor

### DIFF
--- a/bin/localstack-supervisor
+++ b/bin/localstack-supervisor
@@ -3,7 +3,7 @@
 localstack. This can be used on the host or in the docker-entrypoint.sh.
 
 The supervisor behaves as follows:
-* SIGHUP to supervisor will terminate the localstack instance and then start a new process
+* SIGUSR1 to supervisor will terminate the localstack instance and then start a new process
 * SIGTERM to supervisor will terminate the localstack instance and then return
 * if the localstack instance exits, then the supervisor exits with the same exit code.
 
@@ -141,7 +141,7 @@ def main():
     #  yet setting this to a no-op also worked. since we couldn't really figure out what was going on, we just
     #  translate SIGINT to SIGTERM for the localstack process.
     signal.signal(signal.SIGINT, _terminate_localstack)
-    signal.signal(signal.SIGHUP, _restart_localstack)
+    signal.signal(signal.SIGUSR1, _restart_localstack)
 
     # sets the supervisor PID so localstack can signal to it more easily
     os.environ["SUPERVISOR_PID"] = str(os.getpid())

--- a/bin/localstack-supervisor
+++ b/bin/localstack-supervisor
@@ -137,6 +137,10 @@ def main():
 
     signal.signal(signal.SIGALRM, _raise_alarm_exception)
     signal.signal(signal.SIGTERM, _terminate_localstack)
+    # TODO investigate: when we tried to forward SIGINT to LS, for some reason SIGINT was raised twice in LS
+    #  yet setting this to a no-op also worked. since we couldn't really figure out what was going on, we just
+    #  translate SIGINT to SIGTERM for the localstack process.
+    signal.signal(signal.SIGINT, _terminate_localstack)
     signal.signal(signal.SIGHUP, _restart_localstack)
 
     # sets the supervisor PID so localstack can signal to it more easily
@@ -169,8 +173,6 @@ def main():
                 continue
             else:
                 break
-    except KeyboardInterrupt:
-        pass
     finally:
         log("exiting")
 

--- a/localstack/services/infra.py
+++ b/localstack/services/infra.py
@@ -333,7 +333,7 @@ def check_aws_credentials():
 
 def signal_supervisor_restart():
     if pid := os.environ.get("SUPERVISOR_PID"):
-        os.kill(int(pid), signal.SIGHUP)
+        os.kill(int(pid), signal.SIGUSR1)
     else:
         LOG.warning("could not signal supervisor to restart localstack")
 


### PR DESCRIPTION
@dfangl noticed that SIGINT is not terminating localstack correctly in docker. this PR makes sure that SIGINT to the supervisor is translated into a SIGTERM to localstack. we tried to forward SIGINT but couldn't quite figure it out. left a todo in there for future daniel and thomas :P

We also now use SIGUSR1 instead of SIGHUP to restart LS, to avoid restarting when the shell is closed (it will now just be ignored. We could start terminating, we can discuss if this is expected).

/cc @alexrashed 