### PR TITLE
Add config option to override used lambda init version

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -845,6 +845,9 @@ LAMBDA_DEV_PORT_EXPOSE = is_env_true("LAMBDA_DEV_PORT_EXPOSE")
 
 # DEV: only applies to new lambda provider. All LAMBDA_INIT_* configuration are for LS developers only.
 # There are NO stability guarantees, and they may break at any time.
+
+# DEV: Release version of https://github.com/localstack/lambda-runtime-init overriding the current default
+LAMBDA_INIT_RELEASE_VERSION = os.environ.get("LAMBDA_INIT_RELEASE_VERSION")
 # DEV: 0 (default) Enable for mounting of RIE init binary and delve debugger
 LAMBDA_INIT_DEBUG = is_env_true("LAMBDA_INIT_DEBUG")
 # DEV: path to RIE init binary (e.g., var/rapid/init)
@@ -1014,6 +1017,7 @@ CONFIG_ENV_VARS = [
     "LAMBDA_INIT_DELVE_PORT",
     "LAMBDA_INIT_POST_INVOKE_WAIT",
     "LAMBDA_INIT_USER",
+    "LAMBDA_INIT_RELEASE_VERSION",
     "LAMBDA_RUNTIME_IMAGE_MAPPING",
     "LAMBDA_JAVA_OPTS",
     "LAMBDA_REMOTE_DOCKER",

--- a/localstack/services/awslambda/packages.py
+++ b/localstack/services/awslambda/packages.py
@@ -3,6 +3,7 @@ import platform
 import stat
 from typing import List
 
+from localstack import config
 from localstack.packages import DownloadInstaller, InstallTarget, Package, PackageInstaller
 from localstack.packages.core import ArchiveDownloadAndExtractInstaller, SystemNotSupportedException
 from localstack.utils.platform import get_arch
@@ -10,6 +11,7 @@ from localstack.utils.platform import get_arch
 LAMBDA_RUNTIME_INIT_URL = "https://github.com/localstack/lambda-runtime-init/releases/download/{version}/aws-lambda-rie-{arch}"
 
 LAMBDA_RUNTIME_DEFAULT_VERSION = "v0.1.16-pre"
+LAMBDA_RUNTIME_VERSION = config.LAMBDA_INIT_RELEASE_VERSION or LAMBDA_RUNTIME_DEFAULT_VERSION
 
 # GO Lambda runtime
 GO_RUNTIME_VERSION = "0.4.0"
@@ -17,11 +19,11 @@ GO_RUNTIME_DOWNLOAD_URL_TEMPLATE = "https://github.com/localstack/awslamba-go-ru
 
 
 class AWSLambdaRuntimePackage(Package):
-    def __init__(self, default_version: str = LAMBDA_RUNTIME_DEFAULT_VERSION):
+    def __init__(self, default_version: str = LAMBDA_RUNTIME_VERSION):
         super().__init__(name="AwsLambda", default_version=default_version)
 
     def get_versions(self) -> List[str]:
-        return [LAMBDA_RUNTIME_DEFAULT_VERSION]
+        return [LAMBDA_RUNTIME_VERSION]
 
     def _get_installer(self, version: str) -> PackageInstaller:
         return AWSLambdaRuntimePackageInstaller(name="awslambda-runtime", version=version)


### PR DESCRIPTION
Adds the `LAMBDA_INIT_RELEASE_VERSION` config variable. This value will override the default version which was previously hard-coded in the lambda service. We still only really support a 1-1 mapping of localstack version to init version (always whatever is set as `LAMBDA_RUNTIME_DEFAULT_VERSION` at the time of the localstack release), but sometimes it's helpful to test an existing container with a newer released init version without updating localstack first.