### PR TITLE
fix GetObjectTagging and GetBucketTagging format

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -3495,7 +3495,7 @@ class S3Api:
     @handler("GetBucketTagging")
     def get_bucket_tagging(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
-    ) -> GetBucketTaggingOutput:
+    ) -> Tagging:
         raise NotImplementedError
 
     @handler("GetBucketVersioning")
@@ -3607,7 +3607,7 @@ class S3Api:
         version_id: ObjectVersionId = None,
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
-    ) -> GetObjectTaggingOutput:
+    ) -> Tagging:
         raise NotImplementedError
 
     @handler("GetObjectTorrent")

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -851,6 +851,16 @@
       "op": "move",
       "from": "/shapes/ListMultipartUploadsOutput",
       "path": "/shapes/ListMultipartUploadsResult"
+    },
+    {
+      "op": "replace",
+      "path": "/operations/GetObjectTagging/output/shape",
+      "value": "Tagging"
+    },
+    {
+      "op": "replace",
+      "path": "/operations/GetBucketTagging/output/shape",
+      "value": "Tagging"
     }
   ]
 }

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -620,6 +620,9 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self, context: RequestContext, request: GetObjectTaggingRequest
     ) -> GetObjectTaggingOutput:
         response: GetObjectTaggingOutput = call_moto(context)
+        # FIXME: because of an issue with the serializer, we cannot return the VersionId for now
+        # the specs give a GetObjectTaggingOutput but the real return tag is `Tagging` which already exists as a shape
+        # we can't add the VersionId for now
         if (
             "VersionId" in response
             and request["Bucket"] not in self.get_store().bucket_versioning_status


### PR DESCRIPTION
No need to introduce this one anymore, same issue as always. Extending #7983

I think we need to create a small script to test every single S3 operations to check for the XML of the response, and not only what boto returns, or check the documentation of every operation. 

This addresses #8019 

Format in the docs:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectTagging.html#API_GetObjectTagging_ResponseElements

Format from botocore specs:
https://github.com/boto/botocore/blob/a77b1766b2e34a55b3c9d3aed89a8d2376a8eed6/botocore/data/s3/2006-03-01/service-2.json#L4920-L4935
