### PR TITLE
Cleanup after non-standard region tests

### DIFF
--- a/tests/integration/test_stores.py
+++ b/tests/integration/test_stores.py
@@ -1,7 +1,7 @@
 from localstack.utils.strings import short_uid
 
 
-def test_nonstandard_regions(monkeypatch, create_boto_client, sqs_create_queue):
+def test_nonstandard_regions(monkeypatch, create_boto_client):
     """
     Ensure that non-standard AWS regions can be used vertically.
     """

--- a/tests/integration/test_stores.py
+++ b/tests/integration/test_stores.py
@@ -1,17 +1,22 @@
-import unittest
+from localstack.utils.strings import short_uid
 
 
-@unittest.mock.patch("localstack.config.ALLOW_NONSTANDARD_REGIONS", True)
-def test_nonstandard_regions(create_boto_client, monkeypatch):
+def test_nonstandard_regions(monkeypatch, create_boto_client, sqs_create_queue):
     """
     Ensure that non-standard AWS regions can be used vertically.
     """
     monkeypatch.setenv("MOTO_ALLOW_NONEXISTENT_REGION", "true")
+    monkeypatch.setattr("localstack.config.ALLOW_NONSTANDARD_REGIONS", True)
 
     # Create a resource in Moto backend
     ec2_client = create_boto_client("ec2", region_name="uranus-south-1")
-    ec2_client.create_key_pair(KeyName="foo")
+    key_name = f"k-{short_uid()}"
+    ec2_client.create_key_pair(KeyName=key_name)
+    assert ec2_client.describe_key_pairs(KeyNames=[key_name])
 
     # Create a resource in LocalStack store
     sqs_client = create_boto_client("sqs", region_name="pluto-central-2a")
-    sqs_client.create_queue(QueueName="bar")
+    queue_name = f"q-{short_uid()}"
+    sqs_client.create_queue(QueueName=queue_name)
+    queue_url = sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+    sqs_client.delete_queue(QueueUrl=queue_url)


### PR DESCRIPTION
Since #7997, there were errors in tests as follows:

https://github.com/localstack/localstack/actions/runs/4567644230/jobs/8061685484#step:18:23986
```
  File "/home/runner/work/localstack/localstack/localstack-ext/.venv/lib/python3.10/site-packages/moto/utilities/aws_headers.py", line 64, in _wrapper
    response = f(*args, **kwargs)
  File "/home/runner/work/localstack/localstack/localstack-ext/.venv/lib/python3.10/site-packages/moto/cloudwatch/responses.py", line 173, in put_metric_data
    self.cloudwatch_backend.put_metric_data(namespace, metric_data)
  File "/home/runner/work/localstack/localstack/localstack-ext/.venv/lib/python3.10/site-packages/moto/cloudwatch/responses.py", line 28, in cloudwatch_backend
    return cloudwatch_backends[self.current_account][self.region]
  File "/home/runner/work/localstack/localstack/localstack-ext/.venv/lib/python3.10/site-packages/moto/core/base_backend.py", line 247, in __getitem__
    return super().__getitem__(region_name)
KeyError: 'pluto-central-2a'
```

`tests.integration.test_stores` which created the SQS queue in non-standard region `pluto-central-2a` uses monkeypatch to enable `MOTO_ALLOW_NONEXISTENT_REGION` in Moto. SQS creates threads to post certain metrics to Cloudwatch. After the test ends, monkeypatch would disable `MOTO_ALLOW_NONEXISTENT_REGION`, but the said thread continues to attempt to put the Cloudwatch metric in that region.

The proper long-term solution is not to use monkeypatch and instead set the env var before LS initialises. However our test framework doesn't support this atm.