### PR TITLE
fix SNS Subscription Filter OR/AND combination on MessageBody

### DIFF
--- a/localstack/services/sns/publisher.py
+++ b/localstack/services/sns/publisher.py
@@ -948,11 +948,13 @@ class SubscriptionFilter:
                     return False
             else:
                 # else, values represents the list of conditions of the filter policy
-                for condition in values:
-                    if not self._evaluate_condition(
+                if not any(
+                    self._evaluate_condition(
                         payload.get(field_name), condition, field_exists=field_name in payload
-                    ):
-                        return False
+                    )
+                    for condition in values
+                ):
+                    return False
 
         return True
 

--- a/tests/integration/test_sns.snapshot.json
+++ b/tests/integration/test_sns.snapshot.json
@@ -2965,7 +2965,7 @@
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[True]": {
-    "recorded-date": "02-01-2023, 20:03:47",
+    "recorded-date": "31-03-2023, 16:57:29",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -2973,7 +2973,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "recv-passed-msg": {
+      "recv-passed-msg-0": {
         "Messages": [
           {
             "Body": {
@@ -2990,11 +2990,29 @@
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
         }
+      },
+      "recv-passed-msg-1": {
+        "Messages": [
+          {
+            "Body": {
+              "object": {
+                "key": "hardcodedvalue"
+              }
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:2>",
+            "ReceiptHandle": "<receipt-handle:2>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
       }
     }
   },
   "tests/integration/test_sns.py::TestSNSProvider::test_filter_policy_on_message_body[False]": {
-    "recorded-date": "02-01-2023, 20:03:59",
+    "recorded-date": "31-03-2023, 16:57:42",
     "recorded-content": {
       "recv-init": {
         "ResponseMetadata": {
@@ -3002,7 +3020,7 @@
           "HTTPStatusCode": 200
         }
       },
-      "recv-passed-msg": {
+      "recv-passed-msg-0": {
         "Messages": [
           {
             "Body": {
@@ -3019,6 +3037,30 @@
             "MD5OfBody": "<md5-hash>",
             "MessageId": "<uuid:2>",
             "ReceiptHandle": "<receipt-handle:1>"
+          }
+        ],
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recv-passed-msg-1": {
+        "Messages": [
+          {
+            "Body": {
+              "Type": "Notification",
+              "MessageId": "<uuid:3>",
+              "TopicArn": "arn:aws:sns:<region>:111111111111:<resource:1>",
+              "Message": "{\"object\": {\"key\": \"hardcodedvalue\"}}",
+              "Timestamp": "date",
+              "SignatureVersion": "1",
+              "Signature": "<signature>",
+              "SigningCertURL": "https://sns.<region>.amazonaws.com/SimpleNotificationService-<signing-cert-file:1>",
+              "UnsubscribeURL": "<unsubscribe-domain>/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:<region>:111111111111:<resource:1>:<resource:2>"
+            },
+            "MD5OfBody": "<md5-hash>",
+            "MessageId": "<uuid:4>",
+            "ReceiptHandle": "<receipt-handle:2>"
           }
         ],
         "ResponseMetadata": {


### PR DESCRIPTION
This issue came up in the support channel, we were not handling OR conditions properly.
We now properly handle combination of OR and AND filters for the `MessageBody` scope. 

I've also added a unit test to properly test the new filter. 

See: https://docs.aws.amazon.com/sns/latest/dg/and-or-logic.html
