### PR TITLE
fix SNS FIFO DLQ + add SequenceNumber to FIFO

### DIFF
--- a/tests/integration/test_sns.py
+++ b/tests/integration/test_sns.py
@@ -1421,8 +1421,6 @@ class TestSNSProvider:
             "$.topic-attrs.Attributes.DeliveryPolicy",
             "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
             "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
-            "$..Messages..Attributes.SequenceNumber",
-            "$..Successful..SequenceNumber",  # not added, need to be managed by SNS, different from SQS received
         ]
     )
     @pytest.mark.parametrize("content_based_deduplication", [True, False])
@@ -1554,12 +1552,9 @@ class TestSNSProvider:
             "$.topic-attrs.Attributes.DeliveryPolicy",
             "$.topic-attrs.Attributes.EffectiveDeliveryPolicy",
             "$.topic-attrs.Attributes.Policy.Statement..Action",  # SNS:Receive is added by moto but not returned in AWS
-            "$..Messages..Attributes.SequenceNumber",
-            "$..Successful..SequenceNumber",  # not added, need to be managed by SNS, different from SQS received
         ]
     )
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
-    @pytest.mark.xfail(reason="DLQ behaviour for FIFO topic does not work yet")
     def test_publish_fifo_batch_messages_to_dlq(
         self,
         sns_client,
@@ -1881,15 +1876,6 @@ class TestSNSProvider:
         assert len(subscriptions_by_topic["Subscriptions"]) == 0
 
     @pytest.mark.aws_validated
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Messages..Body.SignatureVersion",  # TODO: apparently, messages are not signed in fifo topics
-            "$..Messages..Body.Signature",
-            "$..Messages..Body.SigningCertURL",
-            "$..Messages..Body.SequenceNumber",
-            "$..Messages..Attributes.SequenceNumber",
-        ]
-    )
     @pytest.mark.parametrize("content_based_deduplication", [True, False])
     def test_message_to_fifo_sqs(
         self,
@@ -3295,14 +3281,6 @@ class TestSNSProvider:
 
     @pytest.mark.aws_validated
     @pytest.mark.parametrize("raw_message_delivery", [True, False])
-    @pytest.mark.skip_snapshot_verify(
-        paths=[
-            "$..Messages..Body.SignatureVersion",  # TODO: apparently, messages are not signed in fifo topics
-            "$..Messages..Body.Signature",
-            "$..Messages..Body.SigningCertURL",
-            "$..Messages..Body.SequenceNumber",
-        ]
-    )
     def test_publish_to_fifo_topic_to_sqs_queue_no_content_dedup(
         self,
         sns_client,


### PR DESCRIPTION
This PR adds the ability to pass a failed message from a FIFO topic down to a FIFO queue. It was failing before because we would not pass the required attributes needed for a FIFO queue, namely `MessageGroupId` and optionally `MessageDeduplicationId`.

I've also removed some snapshot skipping by adding the `SequenceNumber` attributes to messages published on FIFO topics. Needed to add a field on `SnsMessage`, not very clean to pass the context there, but it feels like the only solution to be able to return that `SequenceNumber` to the `PublishBatch` operation response, it needs to be pre-defined before actually creating the message body. 

I already added the test for this behaviour, so I just removed the `xfail` mark.  