### PR TITLE
Rename CreateMultipartUploadOutput to InitiateMultipartUploadResult

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -1194,7 +1194,7 @@ class CreateBucketRequest(ServiceRequest):
     ObjectOwnership: Optional[ObjectOwnership]
 
 
-class CreateMultipartUploadOutput(TypedDict, total=False):
+class InitiateMultipartUploadResult(TypedDict, total=False):
     AbortDate: Optional[AbortDate]
     AbortRuleId: Optional[AbortRuleId]
     Bucket: Optional[BucketName]
@@ -3228,7 +3228,7 @@ class S3Api:
         object_lock_legal_hold_status: ObjectLockLegalHoldStatus = None,
         expected_bucket_owner: AccountId = None,
         checksum_algorithm: ChecksumAlgorithm = None,
-    ) -> CreateMultipartUploadOutput:
+    ) -> InitiateMultipartUploadResult:
         raise NotImplementedError
 
     @handler("DeleteBucket")

--- a/localstack/services/s3/provider.py
+++ b/localstack/services/s3/provider.py
@@ -25,7 +25,7 @@ from localstack.aws.api.s3 import (
     CORSConfiguration,
     CreateBucketOutput,
     CreateBucketRequest,
-    CreateMultipartUploadOutput,
+    InitiateMultipartUploadResult,
     CreateMultipartUploadRequest,
     Delete,
     DeleteObjectOutput,
@@ -522,7 +522,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
         self,
         context: RequestContext,
         request: CreateMultipartUploadRequest,
-    ) -> CreateMultipartUploadOutput:
+    ) -> InitiateMultipartUploadResult:
         if not config.S3_SKIP_KMS_KEY_VALIDATION and (sse_kms_key_id := request.get("SSEKMSKeyId")):
             moto_backend = get_moto_s3_backend(context)
             bucket = get_bucket_from_moto(moto_backend, bucket=request["Bucket"])
@@ -536,7 +536,7 @@ class S3Provider(S3Api, ServiceLifecycleHook):
                 StorageClassRequested=storage_class,
             )
 
-        response: CreateMultipartUploadOutput = call_moto(context)
+        response: InitiateMultipartUploadResult = call_moto(context)
         return response
 
     @handler("CompleteMultipartUpload", expand=False)


### PR DESCRIPTION
The response to a CreateMultipartUpload request should contain a root element InitiateMultipartUploadResult. This will align with the AWS API docs and with client libraries that check the root element.

https://github.com/localstack/localstack/issues/8030