### PR TITLE
Cfn::IAM::Policy update

### DIFF
--- a/tests/integration/cloudformation/resources/test_iam.py
+++ b/tests/integration/cloudformation/resources/test_iam.py
@@ -83,7 +83,7 @@ def test_policy_attachments(
 
 
 @pytest.mark.aws_validated
-def test_iam_policy_role_attachments(deploy_cfn_template, snapshot, iam_client):
+def test_update_inline_policy(deploy_cfn_template, snapshot, iam_client):
 
     snapshot.add_transformer(snapshot.transform.iam_api())
     policy_name = f"policy-{short_uid()}"

--- a/tests/integration/cloudformation/resources/test_iam.py
+++ b/tests/integration/cloudformation/resources/test_iam.py
@@ -88,8 +88,7 @@ def test_update_inline_policy(deploy_cfn_template, snapshot, iam_client):
     snapshot.add_transformer(snapshot.transform.iam_api())
     policy_name = f"policy-{short_uid()}"
     user_name = f"user-{short_uid()}"
-    role_name = f"user-{short_uid()}"
-    group_name = f"user-{short_uid()}"
+    role_name = f"role-{short_uid()}"
 
     stack = deploy_cfn_template(
         template_path=os.path.join(
@@ -99,22 +98,17 @@ def test_update_inline_policy(deploy_cfn_template, snapshot, iam_client):
             "PolicyName": policy_name,
             "UserName": user_name,
             "RoleName": role_name,
-            "GroupName": group_name,
         },
     )
 
     user_inline_policy_response = iam_client.get_user_policy(
         UserName=user_name, PolicyName=policy_name
     )
-    group_inline_policy_resource = iam_client.get_group_policy(
-        GroupName=group_name, PolicyName=policy_name
-    )
     role_inline_policy_resource = iam_client.get_role_policy(
         RoleName=role_name, PolicyName=policy_name
     )
 
     snapshot.match("user_inline_policy", user_inline_policy_response)
-    snapshot.match("group_inline_policy", group_inline_policy_resource)
     snapshot.match("role_inline_policy", role_inline_policy_resource)
 
     deploy_cfn_template(
@@ -125,7 +119,6 @@ def test_update_inline_policy(deploy_cfn_template, snapshot, iam_client):
             "PolicyName": policy_name,
             "UserName": user_name,
             "RoleName": role_name,
-            "GroupName": group_name,
         },
         stack_name=stack.stack_name,
         is_update=True,
@@ -134,15 +127,11 @@ def test_update_inline_policy(deploy_cfn_template, snapshot, iam_client):
     user_updated_inline_policy_response = iam_client.get_user_policy(
         UserName=user_name, PolicyName=policy_name
     )
-    group_updated_inline_policy_resource = iam_client.get_group_policy(
-        GroupName=group_name, PolicyName=policy_name
-    )
     role_updated_inline_policy_resource = iam_client.get_role_policy(
         RoleName=role_name, PolicyName=policy_name
     )
 
     snapshot.match("user_updated_inline_policy", user_updated_inline_policy_response)
-    snapshot.match("group_updated_inline_policy", group_updated_inline_policy_resource)
     snapshot.match("role_updated_inline_policy", role_updated_inline_policy_resource)
 
 

--- a/tests/integration/cloudformation/resources/test_iam.py
+++ b/tests/integration/cloudformation/resources/test_iam.py
@@ -81,6 +81,19 @@ def test_policy_attachments(
     policy = json.loads(policy) if isinstance(policy, str) else policy
     assert policy["Statement"][0]["Principal"] == {"Service": "elasticbeanstalk.amazonaws.com"}
 
+@pytest.mark.aws_validated
+def test_iam_policy_role_attachments(deploy_cfn_template, iam_client, snapshot):
+    snapshot.add_transformer(snapshot.transform.iam_api())
+    snapshot.add_transformer(snapshot.transform.cloudformation_api())
+
+    stack = deploy_cfn_template(
+        template_path=os.path.join(
+            os.path.dirname(__file__), "../../templates/iam_policy_role.yaml"
+        ),
+    )
+
+    snapshot.match("outputs", stack.outputs)
+
 
 @pytest.mark.aws_validated
 @pytest.mark.skip_snapshot_verify(paths=["$..User.Tags"])

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -69,7 +69,131 @@
     }
   },
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_policy_role_attachments": {
-    "recorded-date": "31-03-2023, 19:57:32",
-    "recorded-content": {}
+    "recorded-date": "01-04-2023, 13:05:01",
+    "recorded-content": {
+      "user_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-3096d6c3",
+        "UserName": "<user-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "group_inline_policy": {
+        "GroupName": "user-13980818",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-3096d6c3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-3096d6c3",
+        "RoleName": "user-8faf5135",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "user_updated_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-3096d6c3",
+        "UserName": "<user-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "group_updated_inline_policy": {
+        "GroupName": "user-13980818",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-3096d6c3",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role_updated_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-3096d6c3",
+        "RoleName": "user-8faf5135",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -1,24 +1,24 @@
 {
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_username_defaultname": {
-    "recorded-date": "31-05-2022, 11:29:45",
+    "recorded-date": "30-03-2023, 13:58:47",
     "recorded-content": {
       "get_iam_user": {
         "User": {
-          "Path": "/",
-          "UserName": "<user-name:1>",
-          "UserId": "<user-id:1>",
           "Arn": "arn:aws:iam::111111111111:user/<user-name:1>",
-          "CreateDate": "datetime"
+          "CreateDate": "datetime",
+          "Path": "/",
+          "UserId": "<user-id:1>",
+          "UserName": "<user-name:1>"
         },
         "ResponseMetadata": {
-          "HTTPStatusCode": 200,
-          "HTTPHeaders": {}
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
         }
       }
     }
   },
   "tests/integration/cloudformation/resources/test_iam.py::test_managed_policy_with_empty_resource": {
-    "recorded-date": "05-09-2022, 10:01:53",
+    "recorded-date": "30-03-2023, 14:30:51",
     "recorded-content": {
       "outputs": {
         "PolicyArn": "arn:aws:iam::111111111111:policy/<resource:1>",
@@ -48,7 +48,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_user_access_key": {
-    "recorded-date": "06-01-2023, 11:55:42",
+    "recorded-date": "30-03-2023, 14:00:28",
     "recorded-content": {
       "key_outputs": {
         "AccessKeyId": "<key-id:1>",
@@ -63,15 +63,13 @@
       "access_key_updated": {
         "AccessKeyId": "<key-id:1>",
         "CreateDate": "datetime",
-        "Status": "Inactive",
-        "UserName": "<user-name:1>"
-      },
-      "access_key_serial_updated": {
-        "AccessKeyId": "<key-id:2>",
-        "CreateDate": "datetime",
-        "Status": "Inactive",
+        "Status": "Active",
         "UserName": "<user-name:1>"
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_iam.py::test_iam_policy_role_attachments": {
+    "recorded-date": "30-03-2023, 14:35:02",
+    "recorded-content": {}
   }
 }

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -68,136 +68,8 @@
       }
     }
   },
-  "tests/integration/cloudformation/resources/test_iam.py::test_iam_policy_role_attachments": {
-    "recorded-date": "01-04-2023, 13:05:01",
-    "recorded-content": {
-      "user_inline_policy": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:PutObject",
-                "s3:ListBucket"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-3096d6c3",
-        "UserName": "<user-name:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "group_inline_policy": {
-        "GroupName": "user-13980818",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject",
-                "s3:PutObject"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-3096d6c3",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "role_inline_policy": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-3096d6c3",
-        "RoleName": "user-8faf5135",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "user_updated_inline_policy": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:PutObject"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-3096d6c3",
-        "UserName": "<user-name:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "group_updated_inline_policy": {
-        "GroupName": "user-13980818",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-3096d6c3",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "role_updated_inline_policy": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:ListBucket"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-3096d6c3",
-        "RoleName": "user-8faf5135",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      }
-    }
-  },
   "tests/integration/cloudformation/resources/test_iam.py::test_update_inline_policy": {
-    "recorded-date": "03-04-2023, 08:31:37",
+    "recorded-date": "03-04-2023, 21:22:23",
     "recorded-content": {
       "user_inline_policy": {
         "PolicyDocument": {
@@ -213,29 +85,8 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-a1184df9",
+        "PolicyName": "policy-f367081c",
         "UserName": "<user-name:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "group_inline_policy": {
-        "GroupName": "user-9ee18e30",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject",
-                "s3:PutObject"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-a1184df9",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -255,8 +106,8 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-a1184df9",
-        "RoleName": "user-813d953c",
+        "PolicyName": "policy-f367081c",
+        "RoleName": "role-cfca663d",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -275,28 +126,8 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-a1184df9",
+        "PolicyName": "policy-f367081c",
         "UserName": "<user-name:1>",
-        "ResponseMetadata": {
-          "HTTPHeaders": {},
-          "HTTPStatusCode": 200
-        }
-      },
-      "group_updated_inline_policy": {
-        "GroupName": "user-9ee18e30",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject"
-              ],
-              "Effect": "Allow",
-              "Resource": "*"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "policy-a1184df9",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -315,8 +146,8 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-a1184df9",
-        "RoleName": "user-813d953c",
+        "PolicyName": "policy-f367081c",
+        "RoleName": "role-cfca663d",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -69,7 +69,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_iam.py::test_iam_policy_role_attachments": {
-    "recorded-date": "30-03-2023, 14:35:02",
+    "recorded-date": "31-03-2023, 19:57:32",
     "recorded-content": {}
   }
 }

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -69,7 +69,7 @@
     }
   },
   "tests/integration/cloudformation/resources/test_iam.py::test_update_inline_policy": {
-    "recorded-date": "03-04-2023, 21:22:23",
+    "recorded-date": "03-04-2023, 23:59:36",
     "recorded-content": {
       "user_inline_policy": {
         "PolicyDocument": {
@@ -85,7 +85,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-f367081c",
+        "PolicyName": "policy-212b7d59",
         "UserName": "<user-name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -106,8 +106,8 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-f367081c",
-        "RoleName": "role-cfca663d",
+        "PolicyName": "policy-212b7d59",
+        "RoleName": "role-3fe0e29e",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200
@@ -126,7 +126,7 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-f367081c",
+        "PolicyName": "policy-212b7d59",
         "UserName": "<user-name:1>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
@@ -146,8 +146,8 @@
           ],
           "Version": "2012-10-17"
         },
-        "PolicyName": "policy-f367081c",
-        "RoleName": "role-cfca663d",
+        "PolicyName": "policy-212b7d59",
+        "RoleName": "role-3fe0e29e",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/integration/cloudformation/resources/test_iam.snapshot.json
+++ b/tests/integration/cloudformation/resources/test_iam.snapshot.json
@@ -195,5 +195,133 @@
         }
       }
     }
+  },
+  "tests/integration/cloudformation/resources/test_iam.py::test_update_inline_policy": {
+    "recorded-date": "03-04-2023, 08:31:37",
+    "recorded-content": {
+      "user_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutObject",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-a1184df9",
+        "UserName": "<user-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "group_inline_policy": {
+        "GroupName": "user-9ee18e30",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-a1184df9",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-a1184df9",
+        "RoleName": "user-813d953c",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "user_updated_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:PutObject"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-a1184df9",
+        "UserName": "<user-name:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "group_updated_inline_policy": {
+        "GroupName": "user-9ee18e30",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-a1184df9",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "role_updated_inline_policy": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:ListBucket"
+              ],
+              "Effect": "Allow",
+              "Resource": "*"
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "PolicyName": "policy-a1184df9",
+        "RoleName": "user-813d953c",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/integration/templates/iam_policy_role.yaml
+++ b/tests/integration/templates/iam_policy_role.yaml
@@ -2,9 +2,6 @@ Parameters:
   UserName:
     Type: String
     Default: "RandomUser"
-  GroupName:
-    Type: String
-    Default: "RandomGroup"
   RoleName:
     Type: String
     Default: "RandomRole"
@@ -16,10 +13,6 @@ Resources:
     Type: "AWS::IAM::User"
     Properties:
       UserName: !Ref UserName
-  MyGroup:
-    Type: "AWS::IAM::Group"
-    Properties:
-      GroupName: !Ref GroupName
   MyRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -47,20 +40,6 @@ Resources:
             Resource: "*"
       Users:
         - Ref: MyUser
-  GroupPolicy:
-    Type: "AWS::IAM::Policy"
-    Properties:
-      PolicyName: !Ref PolicyName
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "s3:GetObject"
-              - "s3:PutObject"
-            Resource: "*"
-      Groups:
-        - Ref: MyGroup
   RolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/tests/integration/templates/iam_policy_role.yaml
+++ b/tests/integration/templates/iam_policy_role.yaml
@@ -1,0 +1,23 @@
+Resources:
+  MyS3Policy:
+    Type: "AWS::IAM::Policy"
+    Properties:
+      PolicyName: "S3AccessPolicy"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Action:
+              - "s3:GetObject"
+              - "s3:PutObject"
+              - "s3:ListBucket"
+            Resource: "*"
+      Roles:
+        - "MyRole"
+        - "AnotherRole"
+      Users:
+        - "MyUser"
+        - "AnotherUser"
+      Groups:
+        - "MyGroup"
+        - "AnotherGroup"

--- a/tests/integration/templates/iam_policy_updated_role.yaml
+++ b/tests/integration/templates/iam_policy_updated_role.yaml
@@ -2,9 +2,6 @@ Parameters:
   UserName:
     Type: String
     Default: "RandomUser"
-  GroupName:
-    Type: String
-    Default: "RandomGroup"
   RoleName:
     Type: String
     Default: "RandomRole"
@@ -16,10 +13,6 @@ Resources:
     Type: "AWS::IAM::User"
     Properties:
       UserName: !Ref UserName
-  MyGroup:
-    Type: "AWS::IAM::Group"
-    Properties:
-      GroupName: !Ref GroupName
   MyRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -46,19 +39,6 @@ Resources:
             Resource: "*"
       Users:
         - Ref: MyUser
-  GroupPolicy:
-    Type: "AWS::IAM::Policy"
-    Properties:
-      PolicyName: !Ref PolicyName
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "s3:GetObject"
-            Resource: "*"
-      Groups:
-        - Ref: MyGroup
   RolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:

--- a/tests/integration/templates/iam_policy_updated_role.yaml
+++ b/tests/integration/templates/iam_policy_updated_role.yaml
@@ -43,7 +43,6 @@ Resources:
           - Effect: "Allow"
             Action:
               - "s3:PutObject"
-              - "s3:ListBucket"
             Resource: "*"
       Users:
         - Ref: MyUser
@@ -57,7 +56,6 @@ Resources:
           - Effect: "Allow"
             Action:
               - "s3:GetObject"
-              - "s3:PutObject"
             Resource: "*"
       Groups:
         - Ref: MyGroup
@@ -70,7 +68,6 @@ Resources:
         Statement:
           - Effect: "Allow"
             Action:
-              - "s3:GetObject"
               - "s3:ListBucket"
             Resource: "*"
       Roles:


### PR DESCRIPTION
As requested by @pinzon in #7963 implement support for the Update operation on IAM policy. I was working on it along with the help of @pinzon. After a few discussions, we decided to make a test that would create a policy for the user/group/role and again deploy a template to update it.  I also tried a test where we are making use of `put_user_policy` for the same user, and that also works fine.

Performing this operation on the current implementation of Cfn::IAM models works perfectly fine. So, I think we can conclude that the current implementation supports the Update operation. 

What do you think @thrau @pinzon ?