### PR TITLE
fix S3 response xml root tag names

### DIFF
--- a/localstack/aws/api/s3/__init__.py
+++ b/localstack/aws/api/s3/__init__.py
@@ -1372,6 +1372,32 @@ class DeleteObjectTaggingRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
+class Error(TypedDict, total=False):
+    Key: Optional[ObjectKey]
+    VersionId: Optional[ObjectVersionId]
+    Code: Optional[Code]
+    Message: Optional[Message]
+
+
+Errors = List[Error]
+
+
+class DeletedObject(TypedDict, total=False):
+    Key: Optional[ObjectKey]
+    VersionId: Optional[ObjectVersionId]
+    DeleteMarker: Optional[DeleteMarker]
+    DeleteMarkerVersionId: Optional[DeleteMarkerVersionId]
+
+
+DeletedObjects = List[DeletedObject]
+
+
+class DeleteObjectsOutput(TypedDict, total=False):
+    Deleted: Optional[DeletedObjects]
+    RequestCharged: Optional[RequestCharged]
+    Errors: Optional[Errors]
+
+
 class DeleteObjectsRequest(ServiceRequest):
     Bucket: BucketName
     Delete: Delete
@@ -1385,16 +1411,6 @@ class DeleteObjectsRequest(ServiceRequest):
 class DeletePublicAccessBlockRequest(ServiceRequest):
     Bucket: BucketName
     ExpectedBucketOwner: Optional[AccountId]
-
-
-class DeletedObject(TypedDict, total=False):
-    Key: Optional[ObjectKey]
-    VersionId: Optional[ObjectVersionId]
-    DeleteMarker: Optional[DeleteMarker]
-    DeleteMarkerVersionId: Optional[DeleteMarkerVersionId]
-
-
-DeletedObjects = List[DeletedObject]
 
 
 class ReplicationTimeValue(TypedDict, total=False):
@@ -1438,18 +1454,8 @@ class EndEvent(TypedDict, total=False):
     pass
 
 
-class Error(TypedDict, total=False):
-    Key: Optional[ObjectKey]
-    VersionId: Optional[ObjectVersionId]
-    Code: Optional[Code]
-    Message: Optional[Message]
-
-
 class ErrorDocument(TypedDict, total=False):
     Key: ObjectKey
-
-
-Errors = List[Error]
 
 
 class EventBridgeConfiguration(TypedDict, total=False):
@@ -2262,6 +2268,39 @@ class ListBucketMetricsConfigurationsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
+class ListBucketsOutput(TypedDict, total=False):
+    Buckets: Optional[Buckets]
+    Owner: Optional[Owner]
+
+
+class MultipartUpload(TypedDict, total=False):
+    UploadId: Optional[MultipartUploadId]
+    Key: Optional[ObjectKey]
+    Initiated: Optional[Initiated]
+    StorageClass: Optional[StorageClass]
+    Owner: Optional[Owner]
+    Initiator: Optional[Initiator]
+    ChecksumAlgorithm: Optional[ChecksumAlgorithm]
+
+
+MultipartUploadList = List[MultipartUpload]
+
+
+class ListMultipartUploadsOutput(TypedDict, total=False):
+    Bucket: Optional[BucketName]
+    KeyMarker: Optional[KeyMarker]
+    UploadIdMarker: Optional[UploadIdMarker]
+    NextKeyMarker: Optional[NextKeyMarker]
+    Prefix: Optional[Prefix]
+    Delimiter: Optional[Delimiter]
+    NextUploadIdMarker: Optional[NextUploadIdMarker]
+    MaxUploads: Optional[MaxUploads]
+    IsTruncated: Optional[IsTruncated]
+    Uploads: Optional[MultipartUploadList]
+    CommonPrefixes: Optional[CommonPrefixList]
+    EncodingType: Optional[EncodingType]
+
+
 class ListMultipartUploadsRequest(ServiceRequest):
     Bucket: BucketName
     Delimiter: Optional[Delimiter]
@@ -2315,6 +2354,33 @@ class ListObjectVersionsRequest(ServiceRequest):
     ExpectedBucketOwner: Optional[AccountId]
 
 
+class Object(TypedDict, total=False):
+    Key: Optional[ObjectKey]
+    LastModified: Optional[LastModified]
+    ETag: Optional[ETag]
+    ChecksumAlgorithm: Optional[ChecksumAlgorithmList]
+    Size: Optional[Size]
+    StorageClass: Optional[ObjectStorageClass]
+    Owner: Optional[Owner]
+
+
+ObjectList = List[Object]
+
+
+class ListObjectsOutput(TypedDict, total=False):
+    IsTruncated: Optional[IsTruncated]
+    Marker: Optional[Marker]
+    NextMarker: Optional[NextMarker]
+    Contents: Optional[ObjectList]
+    Name: Optional[BucketName]
+    Prefix: Optional[Prefix]
+    Delimiter: Optional[Delimiter]
+    MaxKeys: Optional[MaxKeys]
+    CommonPrefixes: Optional[CommonPrefixList]
+    EncodingType: Optional[EncodingType]
+    BucketRegion: Optional[BucketRegion]
+
+
 class ListObjectsRequest(ServiceRequest):
     Bucket: BucketName
     Delimiter: Optional[Delimiter]
@@ -2324,6 +2390,22 @@ class ListObjectsRequest(ServiceRequest):
     Prefix: Optional[Prefix]
     RequestPayer: Optional[RequestPayer]
     ExpectedBucketOwner: Optional[AccountId]
+
+
+class ListObjectsV2Output(TypedDict, total=False):
+    IsTruncated: Optional[IsTruncated]
+    Contents: Optional[ObjectList]
+    Name: Optional[BucketName]
+    Prefix: Optional[Prefix]
+    Delimiter: Optional[Delimiter]
+    MaxKeys: Optional[MaxKeys]
+    CommonPrefixes: Optional[CommonPrefixList]
+    EncodingType: Optional[EncodingType]
+    KeyCount: Optional[KeyCount]
+    ContinuationToken: Optional[Token]
+    NextContinuationToken: Optional[NextToken]
+    StartAfter: Optional[StartAfter]
+    BucketRegion: Optional[BucketRegion]
 
 
 class ListObjectsV2Request(ServiceRequest):
@@ -2389,19 +2471,6 @@ class MetadataEntry(TypedDict, total=False):
     Value: Optional[MetadataValue]
 
 
-class MultipartUpload(TypedDict, total=False):
-    UploadId: Optional[MultipartUploadId]
-    Key: Optional[ObjectKey]
-    Initiated: Optional[Initiated]
-    StorageClass: Optional[StorageClass]
-    Owner: Optional[Owner]
-    Initiator: Optional[Initiator]
-    ChecksumAlgorithm: Optional[ChecksumAlgorithm]
-
-
-MultipartUploadList = List[MultipartUpload]
-
-
 class QueueConfiguration(TypedDict, total=False):
     Id: Optional[NotificationId]
     QueueArn: QueueArn
@@ -2449,17 +2518,6 @@ class NotificationConfigurationDeprecated(TypedDict, total=False):
     CloudFunctionConfiguration: Optional[CloudFunctionConfiguration]
 
 
-class Object(TypedDict, total=False):
-    Key: Optional[ObjectKey]
-    LastModified: Optional[LastModified]
-    ETag: Optional[ETag]
-    ChecksumAlgorithm: Optional[ChecksumAlgorithmList]
-    Size: Optional[Size]
-    StorageClass: Optional[ObjectStorageClass]
-    Owner: Optional[Owner]
-
-
-ObjectList = List[Object]
 UserMetadata = List[MetadataEntry]
 
 
@@ -3020,12 +3078,6 @@ class HeadBucketOutput(TypedDict, total=False):
     BucketContentType: Optional[BucketContentType]
 
 
-class DeleteResult(TypedDict, total=False):
-    Deleted: Optional[DeletedObjects]
-    RequestCharged: Optional[RequestCharged]
-    Errors: Optional[Errors]
-
-
 class PostObjectRequest(ServiceRequest):
     Body: Optional[IO[Body]]
     Bucket: BucketName
@@ -3052,44 +3104,6 @@ class PostResponse(TypedDict, total=False):
     SSEKMSEncryptionContext: Optional[SSEKMSEncryptionContext]
     BucketKeyEnabled: Optional[BucketKeyEnabled]
     RequestCharged: Optional[RequestCharged]
-
-
-class ListAllMyBucketsResult(TypedDict, total=False):
-    Buckets: Optional[Buckets]
-    Owner: Optional[Owner]
-
-
-class ListBucketResult(TypedDict, total=False):
-    IsTruncated: Optional[IsTruncated]
-    Contents: Optional[ObjectList]
-    Name: Optional[BucketName]
-    Prefix: Optional[Prefix]
-    Delimiter: Optional[Delimiter]
-    MaxKeys: Optional[MaxKeys]
-    CommonPrefixes: Optional[CommonPrefixList]
-    EncodingType: Optional[EncodingType]
-    KeyCount: Optional[KeyCount]
-    ContinuationToken: Optional[Token]
-    NextContinuationToken: Optional[NextToken]
-    StartAfter: Optional[StartAfter]
-    Marker: Optional[Marker]
-    NextMarker: Optional[NextMarker]
-    BucketRegion: Optional[BucketRegion]
-
-
-class ListMultipartUploadsResult(TypedDict, total=False):
-    Bucket: Optional[BucketName]
-    KeyMarker: Optional[KeyMarker]
-    UploadIdMarker: Optional[UploadIdMarker]
-    NextKeyMarker: Optional[NextKeyMarker]
-    Prefix: Optional[Prefix]
-    Delimiter: Optional[Delimiter]
-    NextUploadIdMarker: Optional[NextUploadIdMarker]
-    MaxUploads: Optional[MaxUploads]
-    IsTruncated: Optional[IsTruncated]
-    Uploads: Optional[MultipartUploadList]
-    CommonPrefixes: Optional[CommonPrefixList]
-    EncodingType: Optional[EncodingType]
 
 
 class S3Api:
@@ -3357,7 +3371,7 @@ class S3Api:
         bypass_governance_retention: BypassGovernanceRetention = None,
         expected_bucket_owner: AccountId = None,
         checksum_algorithm: ChecksumAlgorithm = None,
-    ) -> DeleteResult:
+    ) -> DeleteObjectsOutput:
         raise NotImplementedError
 
     @handler("DeletePublicAccessBlock")
@@ -3495,7 +3509,7 @@ class S3Api:
     @handler("GetBucketTagging")
     def get_bucket_tagging(
         self, context: RequestContext, bucket: BucketName, expected_bucket_owner: AccountId = None
-    ) -> Tagging:
+    ) -> GetBucketTaggingOutput:
         raise NotImplementedError
 
     @handler("GetBucketVersioning")
@@ -3607,7 +3621,7 @@ class S3Api:
         version_id: ObjectVersionId = None,
         expected_bucket_owner: AccountId = None,
         request_payer: RequestPayer = None,
-    ) -> Tagging:
+    ) -> GetObjectTaggingOutput:
         raise NotImplementedError
 
     @handler("GetObjectTorrent")
@@ -3695,7 +3709,7 @@ class S3Api:
     def list_buckets(
         self,
         context: RequestContext,
-    ) -> ListAllMyBucketsResult:
+    ) -> ListBucketsOutput:
         raise NotImplementedError
 
     @handler("ListMultipartUploads")
@@ -3710,7 +3724,7 @@ class S3Api:
         prefix: Prefix = None,
         upload_id_marker: UploadIdMarker = None,
         expected_bucket_owner: AccountId = None,
-    ) -> ListMultipartUploadsResult:
+    ) -> ListMultipartUploadsOutput:
         raise NotImplementedError
 
     @handler("ListObjectVersions")
@@ -3740,7 +3754,7 @@ class S3Api:
         prefix: Prefix = None,
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
-    ) -> ListBucketResult:
+    ) -> ListObjectsOutput:
         raise NotImplementedError
 
     @handler("ListObjectsV2")
@@ -3757,7 +3771,7 @@ class S3Api:
         start_after: StartAfter = None,
         request_payer: RequestPayer = None,
         expected_bucket_owner: AccountId = None,
-    ) -> ListBucketResult:
+    ) -> ListObjectsV2Output:
         raise NotImplementedError
 
     @handler("ListParts")

--- a/localstack/aws/spec-patches.json
+++ b/localstack/aws/spec-patches.json
@@ -192,38 +192,6 @@
       }
     },
     {
-      "op": "remove",
-      "path": "/shapes/DeleteObjectsOutput"
-    },
-    {
-      "op": "add",
-      "path": "/shapes/DeleteResult",
-      "value": {
-        "type": "structure",
-        "members": {
-          "Deleted": {
-            "shape": "DeletedObjects",
-            "documentation": "<p>Container element for a successful delete. It identifies the object that was successfully deleted.</p>"
-          },
-          "RequestCharged": {
-            "shape": "RequestCharged",
-            "location": "header",
-            "locationName": "x-amz-request-charged"
-          },
-          "Errors": {
-            "shape": "Errors",
-            "documentation": "<p>Container for a failed delete action that describes the object that Amazon S3 attempted to delete and the error it encountered.</p>",
-            "locationName": "Error"
-          }
-        }
-      }
-    },
-    {
-      "op": "replace",
-      "path": "/operations/DeleteObjects/output/shape",
-      "value": "DeleteResult"
-    },
-    {
       "op": "add",
       "path": "/shapes/RestoreObjectOutputStatusCode",
       "value": {
@@ -755,48 +723,17 @@
       }
     },
     {
-      "op": "move",
-      "from": "/shapes/ListBucketsOutput",
-      "path": "/shapes/ListAllMyBucketsResult"
-    },
-    {
-        "op": "replace",
-        "path": "/operations/ListBuckets/output/shape",
-        "value": "ListAllMyBucketsResult"
-    },
-    {
-      "op": "replace",
-      "path": "/operations/ListObjects/output/shape",
-      "value": "ListBucketResult"
-    },
-    {
-      "op": "move",
-      "from": "/shapes/ListObjectsV2Output",
-      "path": "/shapes/ListBucketResult"
-    },
-    {
-      "op": "remove",
-      "path": "/shapes/ListObjectsOutput"
-    },
-    {
-        "op": "add",
-        "path": "/shapes/ListBucketResult/members/Marker",
-        "value": {
-            "shape": "Marker",
-            "documentation": "<p>Indicates where in the bucket listing begins. Marker is included in the response if it was sent with the request.</p>"
-        }
-    },
-    {
-        "op": "add",
-        "path": "/shapes/ListBucketResult/members/NextMarker",
-        "value": {
-            "shape": "NextMarker",
-            "documentation": "<p>When response is truncated (the IsTruncated element value in the response is true), you can use the key name in this field as marker in the subsequent request to get next set of objects. Amazon S3 lists objects in alphabetical order Note: This element is returned only if you have delimiter request parameter specified. If response does not include the NextMarker and it is truncated, you can use the value of the last Key in the response as the marker in the subsequent request to get the next set of object keys.</p>"
-        }
+      "op": "add",
+      "path": "/shapes/ListObjectsOutput/members/BucketRegion",
+      "value": {
+        "shape": "BucketRegion",
+        "location": "header",
+        "locationName": "x-amz-bucket-region"
+      }
     },
     {
       "op": "add",
-      "path": "/shapes/ListBucketResult/members/BucketRegion",
+      "path": "/shapes/ListObjectsV2Output/members/BucketRegion",
       "value": {
         "shape": "BucketRegion",
         "location": "header",
@@ -836,31 +773,6 @@
         "documentation": "<p>The specified method is not allowed against this resource.</p>",
         "exception": true
       }
-    },
-    {
-      "op": "replace",
-      "path": "/operations/ListObjectsV2/output/shape",
-      "value": "ListBucketResult"
-    },
-    {
-      "op": "replace",
-      "path": "/operations/ListMultipartUploads/output/shape",
-      "value": "ListMultipartUploadsResult"
-    },
-    {
-      "op": "move",
-      "from": "/shapes/ListMultipartUploadsOutput",
-      "path": "/shapes/ListMultipartUploadsResult"
-    },
-    {
-      "op": "replace",
-      "path": "/operations/GetObjectTagging/output/shape",
-      "value": "Tagging"
-    },
-    {
-      "op": "replace",
-      "path": "/operations/GetBucketTagging/output/shape",
-      "value": "Tagging"
     }
   ]
 }


### PR DESCRIPTION
So following #8021, #7983 and #7545, I've investigated and made a list of all S3 operations with a different root node name than the specs. Basically, 41 of 44 operations returning an XML body do not follow the specs. Here's the list:
❌: wrong name, 🟠: fixed by patches, ✅: right from the specs
| | Operation | Spec shape | Root tag
|-|-|-|-|
| ❌| CompleteMultipartUpload | CompleteMultipartUploadOutput | CompleteMultipartUploadResult
| ❌| CopyObject | CopyObjectOutput | CopyObjectResult
| ❌| CreateMultipartUpload | CreateMultipartUploadOutput | InitiateMultipartUploadResult
| 🟠| DeleteObjects | DeleteObjectsOutput | DeleteResult
| ❌| GetBucketAccelerateConfiguration | GetBucketAccelerateConfigurationOutput | AccelerateConfiguration
| ❌| GetBucketAcl | GetBucketAclOutput | AccessControlPolicy
| ❌| GetBucketAnalyticsConfiguration | GetBucketAnalyticsConfigurationOutput | AnalyticsConfiguration
| ❌| GetBucketCors | GetBucketCorsOutput | CORSConfiguration
| ❌| GetBucketEncryption | GetBucketEncryptionOutput | ServerSideEncryptionConfiguration
| ❌| GetBucketIntelligentTieringConfiguration | GetBucketIntelligentTieringConfigurationOutput | IntelligentTieringConfiguration
| ❌| GetBucketInventoryConfiguration | GetBucketInventoryConfigurationOutput | InventoryConfiguration
| ❌| GetBucketLifecycle | GetBucketLifecycleOutput | LifecycleConfiguration
| ❌| GetBucketLifecycleConfiguration | GetBucketLifecycleConfigurationOutput | LifecycleConfiguration
| - | GetBucketLocation | GetBucketLocationOutput | LocationConstraint
| ❌| GetBucketLogging | GetBucketLoggingOutput | BucketLoggingStatus
| ❌| GetBucketMetricsConfiguration | GetBucketMetricsConfigurationOutput | MetricsConfiguration
| ❌| GetBucketNotification | NotificationConfigurationDeprecated | NotificationConfiguration
| ✅| GetBucketNotificationConfiguration | NotificationConfiguration | NotificationConfiguration
| ❌| GetBucketOwnershipControls | GetBucketOwnershipControlsOutput | OwnershipControls
| ❌| GetBucketPolicyStatus | GetBucketPolicyStatusOutput | PolicyStatus
| ❌| GetBucketReplication | GetBucketReplicationOutput | ReplicationConfiguration
| ❌| GetBucketRequestPayment | GetBucketRequestPaymentOutput | RequestPaymentConfiguration
| 🟠| GetBucketTagging | GetBucketTaggingOutput | Tagging
| ❌| GetBucketVersioning | GetBucketVersioningOutput | VersioningConfiguration
| ❌| GetBucketWebsite | GetBucketWebsiteOutput | WebsiteConfiguration
| ❌| GetObjectAcl | GetObjectAclOutput | AccessControlPolicy
| ✅| GetObjectAttributes | GetObjectAttributesOutput | GetObjectAttributesOutput
| ❌| GetObjectLegalHold | GetObjectLegalHoldOutput | LegalHold
| ❌| GetObjectLockConfiguration | GetObjectLockConfigurationOutput | ObjectLockConfiguration
| ❌| GetObjectRetention | GetObjectRetentionOutput | Retention
| 🟠| GetObjectTagging | GetObjectTaggingOutput | Tagging
| ❌| GetPublicAccessBlock | GetPublicAccessBlockOutput | PublicAccessBlockConfiguration
| ❌| ListBucketAnalyticsConfigurations | ListBucketAnalyticsConfigurationsOutput | ListBucketAnalyticsConfigurationResult
| ✅| ListBucketIntelligentTieringConfigurations | ListBucketIntelligentTieringConfigurationsOutput | ListBucketIntelligentTieringConfigurationsOutput
| ❌| ListBucketInventoryConfigurations | ListBucketInventoryConfigurationsOutput | ListInventoryConfigurationsResult
| ❌| ListBucketMetricsConfigurations | ListBucketMetricsConfigurationsOutput | ListMetricsConfigurationsResult
| 🟠| ListBuckets | ListBucketsOutput | ListAllMyBucketsResult
| 🟠| ListMultipartUploads | ListMultipartUploadsOutput | ListMultipartUploadsResult
| 🟠| ListObjects | ListObjectsOutput | ListBucketResult
| 🟠| ListObjectsV2 | ListObjectsV2Output | ListBucketResult
| ❌| ListObjectVersions | ListObjectVersionsOutput | ListVersionsResult
| ❌| ListParts | ListPartsOutput | ListPartsResult
| - | SelectObjectContent | SelectObjectContentOutput | Payload
| ❌| UploadPartCopy | UploadPartCopyOutput | CopyPartResult

Note: I've removed `GetBucketLocation` as it's a special case with no root node wrapper, and `SelectObjectContent` as it's a streaming response.

This PR implements a fix by directly renaming the root node while still taking advantages of the specs. Previously, modifying the specs would also have effects on the parser where, for example, the shape would already exists (see `GetBucketTagging` and `GetObjectTagging`, both returns a root node with `Tagging` name but the shape is different). Now we can still differentiate for each operations. 

Now, the issue is systematic testing of those operations. I'm confident the new root node names are the right ones, but it would be nice to have replicable tests against AWS. We already have a test in place (`tests.integration.s3.test_s3.TestS3.test_response_structure`) testing some operations (and we can see that removing the patches didn't make the test fail as the new serializer part is now taking care of it).
However, as 41 of 44 operations needs to be tested for their XML response, this makes it a bit difficult as you would need to setup the resources to be able to query them afterwards (ex. `GetBucketCorsConfiguration` would need a configuration to be able to be queried). 

would fix #8030