### PR TITLE
Fix AttributeError for custom S3 handler

### DIFF
--- a/localstack/services/s3/presigned_url.py
+++ b/localstack/services/s3/presigned_url.py
@@ -224,7 +224,7 @@ def s3_presigned_url_request_handler(_: HandlerChain, context: RequestContext, _
     Handler to validate S3 presigned URL. Checks the validity of the request signature, and raises an error if
     `S3_SKIP_SIGNATURE_VALIDATION` is set to False
     """
-    if context.service.service_name != "s3":
+    if not context.service or context.service.service_name != "s3":
         return
 
     if not is_presigned_url_request(context):


### PR DESCRIPTION
This PR fixes the `AttributeError: 'NoneType' object has no attribute 'service_name'` error occurring when doing any pod operation after the initialization of the S3 provider.

I am simply adding a guard clause for `context.service` being None, similar to the other S3 handler for CORS (`s3_cors_request_handler`).

The error can be simply reproduced with:
```
awslocal s3 mb s3://localstack-bucket
localstack pod save file://my-pod
```