### PR TITLE
add support for asgi lifespan protocol listener in asgi/wsgi bridge

### DIFF
--- a/localstack/aws/serving/asgi.py
+++ b/localstack/aws/serving/asgi.py
@@ -1,14 +1,11 @@
 import asyncio
 import concurrent.futures.thread
 from asyncio import AbstractEventLoop
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 from localstack.aws.gateway import Gateway
 from localstack.aws.serving.wsgi import WsgiGateway
 from localstack.http.asgi import ASGIAdapter, ASGILifespanListener
-
-if TYPE_CHECKING:
-    from hypercorn.typing import ASGIReceiveCallable, ASGISendCallable, HTTPScope
 
 
 class _ThreadPool(concurrent.futures.thread.ThreadPoolExecutor):
@@ -48,8 +45,12 @@ class AsgiGateway:
 
         self.event_loop = event_loop or asyncio.get_event_loop()
         self.executor = _ThreadPool(threads, thread_name_prefix="asgi_gw")
-        self.wsgi = ASGIAdapter(WsgiGateway(gateway), event_loop=event_loop, executor=self.executor)
-        self.lifespan_listener = lifespan_listener or ASGILifespanListener()
+        self.wsgi = ASGIAdapter(
+            WsgiGateway(gateway),
+            event_loop=event_loop,
+            executor=self.executor,
+            lifespan_listener=lifespan_listener,
+        )
         self._closed = False
 
     async def __call__(self, scope, receive, send) -> None:
@@ -63,13 +64,7 @@ class AsgiGateway:
         if self._closed:
             raise RuntimeError("Cannot except new request on closed ASGIGateway")
 
-        if scope["type"] == "http":
-            return await self.wsgi(scope, receive, send)
-
-        if scope["type"] == "lifespan":
-            return await self.handle_lifespan(scope, receive, send)
-
-        raise NotImplementedError(f"{scope['type']} protocol is not implemented")
+        return await self.wsgi(scope, receive, send)
 
     def close(self):
         """
@@ -77,29 +72,3 @@ class AsgiGateway:
         """
         self._closed = True
         self.executor.shutdown(wait=False, cancel_futures=True)
-
-    async def handle_lifespan(
-        self, scope: "HTTPScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
-    ):
-        while True:
-            message = await receive()
-            if message["type"] == "lifespan.startup":
-                try:
-                    await self.event_loop.run_in_executor(
-                        self.executor, self.lifespan_listener.on_startup
-                    )
-                    await send({"type": "lifespan.startup.complete"})
-                except Exception as e:
-                    await send({"type": "lifespan.startup.failed", "message": f"{e}"})
-
-            elif message["type"] == "lifespan.shutdown":
-                try:
-                    await self.event_loop.run_in_executor(
-                        self.executor, self.lifespan_listener.on_shutdown
-                    )
-                    await send({"type": "lifespan.shutdown.complete"})
-                except Exception as e:
-                    await send({"type": "lifespan.shutdown.failed", "message": f"{e}"})
-                return
-            else:
-                return

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -429,18 +429,18 @@ class ASGIAdapter:
                     await self.event_loop.run_in_executor(
                         self.executor, self.lifespan_listener.on_startup
                     )
+                    await send({"type": "lifespan.startup.complete"})
                 except Exception as e:
                     await send({"type": "lifespan.startup.failed", "message": f"{e}"})
 
-                await send({"type": "lifespan.startup.complete"})
             elif message["type"] == "lifespan.shutdown":
                 try:
                     await self.event_loop.run_in_executor(
                         self.executor, self.lifespan_listener.on_shutdown
                     )
+                    await send({"type": "lifespan.shutdown.complete"})
                 except Exception as e:
                     await send({"type": "lifespan.shutdown.failed", "message": f"{e}"})
-                await send({"type": "lifespan.shutdown.complete"})
                 return
             else:
                 return

--- a/localstack/http/asgi.py
+++ b/localstack/http/asgi.py
@@ -309,6 +309,19 @@ class WsgiStartResponse:
             await self.send({"type": "http.response.body", "body": b"", "more_body": False})
 
 
+class ASGILifespanListener:
+    """
+    Simple event handler that is attached to the ASGIAdapter and called on ASGI lifespan events. See
+    https://asgi.readthedocs.io/en/latest/specs/lifespan.html.
+    """
+
+    def on_startup(self):
+        pass
+
+    def on_shutdown(self):
+        pass
+
+
 class ASGIAdapter:
     """
     Adapter to expose a WSGIApplication as an ASGI3Application. This allows you to serve synchronous WSGI applications
@@ -325,10 +338,12 @@ class ASGIAdapter:
         wsgi_app: "WSGIApplication",
         event_loop: AbstractEventLoop = None,
         executor: Executor = None,
+        lifespan_listener: ASGILifespanListener = None,
     ):
         self.wsgi_app = wsgi_app
         self.event_loop = event_loop or asyncio.get_event_loop()
         self.executor = executor
+        self.lifespan_listener = lifespan_listener or ASGILifespanListener()
 
     async def __call__(
         self, scope: "Scope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
@@ -342,6 +357,9 @@ class ASGIAdapter:
         """
         if scope["type"] == "http":
             return await self.handle_http(scope, receive, send)
+
+        if scope["type"] == "lifespan":
+            return await self.handle_lifespan(scope, receive, send)
 
         raise NotImplementedError("Unhandled protocol %s" % scope["type"])
 
@@ -400,6 +418,32 @@ class ASGIAdapter:
                         await response.write(packet)
         finally:
             await response.close()
+
+    async def handle_lifespan(
+        self, scope: "HTTPScope", receive: "ASGIReceiveCallable", send: "ASGISendCallable"
+    ):
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                try:
+                    await self.event_loop.run_in_executor(
+                        self.executor, self.lifespan_listener.on_startup
+                    )
+                except Exception as e:
+                    await send({"type": "lifespan.startup.failed", "message": f"{e}"})
+
+                await send({"type": "lifespan.startup.complete"})
+            elif message["type"] == "lifespan.shutdown":
+                try:
+                    await self.event_loop.run_in_executor(
+                        self.executor, self.lifespan_listener.on_shutdown
+                    )
+                except Exception as e:
+                    await send({"type": "lifespan.shutdown.failed", "message": f"{e}"})
+                await send({"type": "lifespan.shutdown.complete"})
+                return
+            else:
+                return
 
 
 def patch_werkzeug():

--- a/tests/unit/http_/conftest.py
+++ b/tests/unit/http_/conftest.py
@@ -9,7 +9,7 @@ from werkzeug.datastructures import Headers
 from werkzeug.wrappers import Request as WerkzeugRequest
 
 from localstack.http import Response
-from localstack.http.asgi import ASGIAdapter
+from localstack.http.asgi import ASGIAdapter, ASGILifespanListener
 from localstack.http.hypercorn import HypercornServer
 from localstack.utils import net
 from localstack.utils.sync import poll_condition
@@ -45,12 +45,13 @@ def serve_asgi_app():
 
 @pytest.fixture()
 def serve_asgi_adapter(serve_asgi_app):
-    def _create(wsgi_app):
+    def _create(wsgi_app, lifespan_listener: ASGILifespanListener = None):
         loop = asyncio.new_event_loop()
         return serve_asgi_app(
             ASGIAdapter(
                 wsgi_app,
                 event_loop=loop,
+                lifespan_listener=lifespan_listener,
             ),
             event_loop=loop,
         )

--- a/tests/unit/http_/test_asgi.py
+++ b/tests/unit/http_/test_asgi.py
@@ -297,7 +297,7 @@ def test_serve_multiple_apps(serve_asgi_adapter):
     assert result5.text == "ok1"
 
 
-def test_lifespan_startup(serve_asgi_adapter):
+def test_lifespan_listener(serve_asgi_adapter):
 
     events = Queue()
 

--- a/tests/unit/http_/test_asgi.py
+++ b/tests/unit/http_/test_asgi.py
@@ -9,6 +9,8 @@ from typing import List
 import requests
 from werkzeug import Request, Response
 
+from localstack.http.asgi import ASGILifespanListener
+
 LOG = logging.getLogger(__name__)
 
 
@@ -293,3 +295,37 @@ def test_serve_multiple_apps(serve_asgi_adapter):
     result5 = response5_ftr.result(timeout=2)
     assert result5.ok
     assert result5.text == "ok1"
+
+
+def test_lifespan_startup(serve_asgi_adapter):
+
+    events = Queue()
+
+    @Request.application
+    def app(request: Request) -> Response:
+        events.put("request")
+        return Response("ok", 200)
+
+    class LifespanListener(ASGILifespanListener):
+        def on_startup(self):
+            events.put("startup")
+
+        def on_shutdown(self):
+            events.put("shutdown")
+
+    listener = LifespanListener()
+
+    server = serve_asgi_adapter(app, listener)
+
+    assert events.get(timeout=5) == "startup"
+    assert events.qsize() == 0
+
+    assert requests.get(server.url).ok
+
+    assert events.get(timeout=5) == "request"
+    assert events.qsize() == 0
+
+    server.shutdown()
+
+    assert events.get(timeout=5) == "shutdown"
+    assert events.qsize() == 0


### PR DESCRIPTION
This PR adds simple support for the ASGI lifespan protocol for the ASGIAdapter. The change allows you to attach a listener to the ASGIAdapter that can react to lifespan protocol events. See https://asgi.readthedocs.io/en/latest/specs/lifespan.html

This is mostly to get rid of the warning messages that have bothered and mislead some users in issues like #8035

But in the future, we could potentially use this for improving startup/shutdown routines.

The failure case is a bit tedious to test with the fixtures we have, so I decided to skip it for now, since we don't really have a use case for it yet.