### PR TITLE
set 'trylast' for pytest-teardown that writes the collected metrics

### DIFF
--- a/localstack/testing/pytest/metric_collection.py
+++ b/localstack/testing/pytest/metric_collection.py
@@ -38,7 +38,7 @@ def pytest_sessionstart(session: "Session") -> None:
         writer.writerow(Metric.RAW_DATA_HEADER)
 
 
-@pytest.hookimpl()
+@pytest.hookimpl(trylast=True)
 def pytest_runtest_teardown(item: "Item", nextitem: Optional["Item"]) -> None:
     node_id = item.nodeid
     xfail = False


### PR DESCRIPTION
With the new coverage docs we also show which tests called certain operations.

The automated workflow update in the docs repo reveals that there is a subset of tests changing for every run. 
This is likely due to a wrong recording of the raw-metrics. 

The raw-metrics are recorded and written to a CSV in the teardown of the test case:
* each api call recorded will be considered to belong to that test
* the metrics-collection array will be reset after writing the records to the CSV
* but there might be other tear-down actions afterwards - which would then be considered being part of the next test

This PR adds the `trylast` flag to the `pytest_runtest_teardown` which could help making the recorded test metrics more stable. 
